### PR TITLE
Correcting gradient accumulation in the training section

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -546,15 +546,18 @@ for step in range(args.num_iterations + 1):
             with model.no_sync(): # there's no need to sync gradients every accumulation step
                 # forward pass
                 loss = model(x, y, attn_blocksize=attn_blocksize)
+                # advance the dataset for the next batch
+                x, y = train_loader.next_batch()
                 # backward pass
                 loss.backward()
         else: # just sync on the last step
             # forward pass
-            loss = model(x, y, attn_blocksize=attn_blocksize)           
+            loss = model(x, y, attn_blocksize=attn_blocksize)      
+            # advance the dataset for the next batch
+            x, y = train_loader.next_batch()     
             # backward pass
             loss.backward()
         train_loss = loss.detach()
-        x, y = train_loader.next_batch()  
     for p in model.parameters():
         p.grad /= train_accumulation_steps
     # momentum warmup for Muon

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -542,17 +542,19 @@ for step in range(args.num_iterations + 1):
     # --------------- TRAINING SECTION BEGIN -----------------
     model.train()
     for i in range(1, train_accumulation_steps+1):
-        # forward pass
-        loss = model(x, y, attn_blocksize=attn_blocksize)
-        train_loss = loss.detach()
-        # advance the dataset for the next batch
-        x, y = train_loader.next_batch()
-        # backward pass
         if i < train_accumulation_steps:
             with model.no_sync(): # there's no need to sync gradients every accumulation step
+                # forward pass
+                loss = model(x, y, attn_blocksize=attn_blocksize)
+                # backward pass
                 loss.backward()
-        else:
-            loss.backward() # just sync on the last step
+        else: # just sync on the last step
+            # forward pass
+            loss = model(x, y, attn_blocksize=attn_blocksize)           
+            # backward pass
+            loss.backward()
+        train_loss = loss.detach()
+        x, y = train_loader.next_batch()  
     for p in model.parameters():
         p.grad /= train_accumulation_steps
     # momentum warmup for Muon


### PR DESCRIPTION
Putting the forward pass within the no_sync() context along with the backward pass; otherwise gradients will still be synchronized. For details, check this from the PyTorch repo: https://github.com/pytorch/pytorch/blob/main/torch/nn/parallel/distributed.py#L1427