### PR TITLE
Fix peak memory usage not being saved to the logfile

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -559,7 +559,7 @@ for step in range(args.num_iterations + 1):
     print0(f"step:{step+1}/{args.num_iterations} train_loss:{train_loss.item():.4f} train_time:{approx_time:.0f}ms step_avg:{approx_time/timed_steps:.2f}ms")
 
 if master_process:
-    print(f"peak memory consumption: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB")
+    print0(f"peak memory consumption: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB")
 
 # -------------------------------------------------------------------------
 # clean up nice


### PR DESCRIPTION
Super simple, just lets us see the peak memory usage from past model runs at the end of the logfile (ran into this today, so just fixing it real quick!)