### PR TITLE
Fix readme to call `data/cached_fineweb10B.py 10` in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Note: an NVIDIA driver must already be installed on the system (useful if only t
 
 ```bash
 sudo docker build -t modded-nanogpt .
-sudo docker run -it --rm --gpus all -v $(pwd):/modded-nanogpt modded-nanogpt python data/cached_fineweb10B.py 18
+sudo docker run -it --rm --gpus all -v $(pwd):/modded-nanogpt modded-nanogpt python data/cached_fineweb10B.py 10
 sudo docker run -it --rm --gpus all -v $(pwd):/modded-nanogpt modded-nanogpt sh run.sh
 ```
 ---


### PR DESCRIPTION
As running outside docker is called with 10 files 
https://github.com/KellerJordan/modded-nanogpt/blob/f75897d7424458f169c95050ea7fbbe40ada20f1/README.md?plain=1#L36
And logs seem to do so too
https://github.com/KellerJordan/modded-nanogpt/blob/f75897d7424458f169c95050ea7fbbe40ada20f1/records/121024_MFUTweaks/04df8c70-2462-4b6c-9e49-c7589b321a81.txt#L666

Having lots of fun with this repo and the cifar speedrun! Great work, love the hackability of it! Trying to run some tests on my own and will PR tiny things if I see them. 
