### PR TITLE
(Failed) Experiment: Use a well-initialized bias for output layer

### DIFF
--- a/_logs/bias-3e010137-10fc-46f7-a68b-7649ff13cc7d.txt
+++ b/_logs/bias-3e010137-10fc-46f7-a68b-7649ff13cc7d.txt
@@ -1,0 +1,2201 @@
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+import contextlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import torch.distributed as dist
+import torch._inductor.config as config
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.nn.attention.flex_attention import BlockMask, flex_attention #KoszarskyB
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps):
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert len(G.shape) == 2
+    a, b, c = (3.4445, -4.7750,  2.0315)
+    X = G.bfloat16()
+    if G.size(0) > G.size(1):
+        X = X.T
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm() + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A # adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+    
+    if G.size(0) > G.size(1):
+        X = X.T
+    return X
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Some warnings:
+    - This optimizer assumes that all parameters passed in are 2D.
+    - It should not be used for the embedding layer, the final fully connected layer, or any {0,1}-D
+    parameters; those should all be optimized by a standard method (e.g., AdamW).
+    - To use it with 4D convolutional filters, it works well to just flatten their last 3 dimensions.
+    - We believe it is unlikely to work well for training with small batch size.
+    - We believe it may not work well for finetuning pretrained models, but we haven't tested this.
+    - We have not yet tried this optimizer for training scenarios larger than NanoGPT (124M).
+
+    Arguments:
+        lr: The learning rate used by the internal SGD.
+        momentum: The momentum used by the internal SGD.
+        nesterov: Whether to use Nesterov-style momentum in the internal SGD. (recommended)
+        ns_steps: The number of Newton-Schulz iteration steps to use.
+    """
+    def __init__(self, params, lr=0.02, momentum=0.95, nesterov=True, ns_steps=5):
+        self.world_size = int(os.environ['WORLD_SIZE'])
+        self.rank = int(os.environ['RANK'])
+        defaults = dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps)
+        params = list(params)
+        assert all(isinstance(p, torch.Tensor) for p in params)
+        sizes = {p.numel() for p in params}
+        param_groups = [
+            {
+                'params': [p for p in params if p.numel() == size],
+                'update_buffer': [
+                    torch.empty(size, device='cuda', dtype=torch.bfloat16)
+                    for _ in range(self.world_size)
+                ],
+            }
+            for size in sizes
+        ]
+        super().__init__(param_groups, defaults)
+
+    def step(self):
+
+        for group in self.param_groups:
+
+            lr = group['lr']
+            momentum = group['momentum']
+            nesterov = group['nesterov']
+            ns_steps = group['ns_steps']
+            update_buffers = group['update_buffer']
+            # generate weight updates in distributed fashion
+            params = group['params']
+            assert len(params) % self.world_size == 0
+            handle = None
+            params_world = None
+            def update_prev():
+                if params_world is None:
+                    return
+                assert handle is not None
+                handle.wait()
+                for p_world, g_world in zip(params_world, update_buffers):
+                    p_world.data.add_(
+                        g_world.view_as(p_world),
+                        alpha=-lr * max(1, p_world.size(0) / p_world.size(1)) ** 0.5,
+                    )
+            for base_i in range(len(params))[::self.world_size]:
+                p = params[base_i + self.rank]
+                g = p.grad
+                assert g is not None
+                state = self.state[p]
+                if 'momentum_buffer' not in state:
+                    state['momentum_buffer'] = torch.zeros_like(g)
+                buf = state['momentum_buffer']
+                buf.lerp_(g, 1 - momentum)
+                g = g.lerp_(buf, momentum) if nesterov else buf
+                g = zeropower_via_newtonschulz5(g, steps=ns_steps).flatten()
+                update_prev()
+                handle = dist.all_gather(update_buffers, g, async_op=True)
+                params_world = params[base_i : base_i + self.world_size]
+            update_prev()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the GPT-2 model
+
+def norm(x):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+
+    def __init__(self, in_features, out_features, bias=False):
+        super().__init__(in_features, out_features, bias)
+
+    def forward(self, x):
+        return F.linear(
+            x,
+            self.weight.to(x.dtype),
+            None if self.bias is None else self.bias.to(x.dtype)
+        )
+
+class Rotary(torch.nn.Module):
+
+    def __init__(self, dim, base=10000):
+        super().__init__()
+        self.register_buffer('inv_freq', (1 / base) ** (torch.arange(0, dim, 2) / dim))
+        self.seq_len_cached = None
+        self.cos_cached = None
+        self.sin_cached = None
+
+    def forward(self, x):
+        seq_len = x.shape[1]
+        if seq_len != self.seq_len_cached:
+            t = torch.arange(seq_len, device=x.device)
+            freqs = torch.outer(t, self.inv_freq)
+            self.seq_len_cached = seq_len
+            self.cos_cached = freqs.cos()
+            self.sin_cached = freqs.sin()
+        cos, sin = self.cos_cached[None, :, None, :], self.sin_cached[None, :, None, :]
+        # apply_rotary_emb(x, cos, sin)
+        x1, x2 = x.chunk(2, dim=3)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x)
+
+class CausalSelfAttention(nn.Module):
+
+    def __init__(self, dim, num_heads):
+        super().__init__()
+        assert dim % num_heads == 0
+        self.num_heads = num_heads
+        self.c_q = CastedLinear(dim, dim)
+        self.c_k = CastedLinear(dim, dim)
+        self.c_v = CastedLinear(dim, dim)
+        self.lambdas = nn.Parameter(torch.tensor([0.5, 0.5]))
+        self.rotary = Rotary(dim // num_heads) # dim // num_heads = head_dim
+        self.c_proj = CastedLinear(dim, dim)
+        self.c_proj.weight.data.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x, vi, block_mask):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q = self.c_q(x).view(B, T, self.num_heads, -1)
+        k = self.c_k(x).view(B, T, self.num_heads, -1)
+        v = self.c_v(x).view(B, T, self.num_heads, -1)
+        v = self.lambdas[0] * v + self.lambdas[1] * vi.view_as(v) # @KoszarskyB & @Grad62304977
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, enable_gqa=True)
+        y = y.transpose(1, 2).contiguous().view_as(x) # re-assemble all head outputs side by side
+        y = self.c_proj(y)
+        return y
+
+class MLP(nn.Module):
+
+    def __init__(self, dim):
+        super().__init__()
+        self.c_fc   = CastedLinear(dim, 4 * dim)
+        self.c_proj = CastedLinear(4 * dim, dim)
+        self.c_proj.weight.data.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x):
+        x = self.c_fc(x)
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = self.c_proj(x)
+        return x
+
+class Block(nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+        self.attn = CausalSelfAttention(config.model_dim, config.num_heads)
+        self.mlp = MLP(config.model_dim)
+        self.lambdas = nn.Parameter(torch.tensor([1., 0.]))
+
+    def forward(self, x, vi, x0, block_mask):
+        x = self.lambdas[0] * x + self.lambdas[1] * x0
+        x = x + self.attn(norm(x), vi, block_mask)
+        x = x + self.mlp(norm(x))
+        return x
+
+class ValueEmbedding(nn.Module):
+    def __init__(self, config: "GPTConfig"):
+        super().__init__()
+        self.embed = nn.ModuleList([
+            nn.Embedding(config.vocab_size, config.model_dim)
+            for _ in range(6)
+        ])
+
+    def forward(self, inputs) -> "list[torch.Tensor]":
+        ve = [emb(inputs) for emb in self.embed]
+        ve += reversed(ve)
+        return ve
+
+# -----------------------------------------------------------------------------
+# The main GPT-2 model
+
+@dataclass
+class GPTConfig:
+    vocab_size : int = 50304
+    num_layers : int = 12
+    num_heads : int = 6 # head dim 128 suggested by @Grad62304977
+    model_dim : int = 768
+
+class GPT(nn.Module):
+
+    def __init__(self, config: GPTConfig):
+        super().__init__()
+        self.num_layers = config.num_layers
+
+        # U-net design by @brendanh0gan
+        self.num_encoder_layers = config.num_layers // 2 # Half of the layers for encoder
+        self.num_decoder_layers = config.num_layers - self.num_encoder_layers # Remaining for decoder
+        # Add learnable skip connection weights for decoder layers
+        self.skip_weights = nn.Parameter(torch.ones(self.num_decoder_layers))
+
+        self.embed = nn.Embedding(config.vocab_size, config.model_dim)
+        self.blocks = nn.ModuleList([Block(config) for _ in range(config.num_layers)])
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual learning
+        # U-net structure on token value embeddings by @leloykun
+        self.value_embeds = ValueEmbedding(config)
+        self.lm_head = CastedLinear(config.model_dim, config.vocab_size, bias=True)
+        self.lm_head.weight.data.zero_() # @Grad62304977
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        targets: torch.Tensor,
+        sliding_window_num_blocks: torch.Tensor,
+    ):
+        BLOCK_SIZE = 128
+        seq_len = len(inputs)
+        assert seq_len % BLOCK_SIZE == 0
+        total_num_blocks = seq_len // BLOCK_SIZE
+        assert inputs.ndim == 1
+        docs = (inputs == 50256).cumsum(0)
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_mask: torch.Tensor):
+            num_blocks = dense_mask.sum(dim=-1, dtype=torch.int32)
+            indices = dense_mask.argsort(dim=-1, descending=True, stable=True).to(torch.int32)
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        def create_doc_swc_block_mask(sliding_window_num_blocks: torch.Tensor):
+            kv_idx = block_idx = torch.arange(total_num_blocks, dtype=torch.int32, device="cuda")
+            q_idx = block_idx[:, None]
+            causal_bm = q_idx >= kv_idx
+            causal_full_bm = q_idx > kv_idx
+            window_bm = q_idx - kv_idx < sliding_window_num_blocks
+            window_full_bm = window_bm
+            # document_bm = (docs_low[q_idx] <= docs_high[kv_idx]) & (docs_low[kv_idx] <= docs_high[q_idx])
+            document_bm = (docs_low[:, None] <= docs_high) & (docs_low <= docs_high[:, None])
+            document_full_bm = (docs_low[:, None] == docs_high) & (docs_low == docs_high[:, None])
+            nonzero_bm = causal_bm & window_bm & document_bm
+            full_bm  = causal_full_bm & window_full_bm & document_full_bm
+            kv_num_blocks, kv_indices = dense_to_ordered(nonzero_bm ^ full_bm)
+            full_kv_num_blocks, full_kv_indices = dense_to_ordered(full_bm)
+            return BlockMask.from_kv_blocks(
+                kv_num_blocks,
+                kv_indices,
+                full_kv_num_blocks,
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+
+        block_mask = create_doc_swc_block_mask(sliding_window_num_blocks)
+
+        # forward the GPT model itself
+        x = self.embed(inputs[None]) # token embeddings of shape (b, t, model_dim)
+        x = norm(x) # @Grad62304977
+        x0 = x
+        ve = self.value_embeds(inputs)
+        ve_enc, ve_dec = ve[:self.num_encoder_layers], ve[self.num_encoder_layers:]
+
+        # Store outputs for U-Net skip connections
+        skip_connections = []
+        # Encoder pass - process only the first half of the blocks
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, ve_enc[i], x0, block_mask)
+            skip_connections.append(x)
+        # Decoder pass - process the remaining blocks with weighted skip connections
+        for i in range(self.num_decoder_layers):
+            x = x + self.skip_weights[i] * skip_connections.pop()
+            # U-net structure on token value embeddings by @leloykun
+            x = self.blocks[self.num_encoder_layers + i](x, ve_dec[i], x0, block_mask)
+
+        x = norm(x)
+        logits = self.lm_head(x)
+        logits = 30 * torch.tanh(logits / 30) # @Grad62304977
+        logits = logits.float()
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
+        return loss
+
+# -----------------------------------------------------------------------------
+# Our own simple Distributed Data Loader
+
+def _peek_data_shard(file: Path):
+    # only reads the header, returns header data
+    # header is 256 int32
+    header = torch.from_file(f"{file}", False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    return int(header[2]) # number of tokens (claimed)
+
+def _load_data_shard(path: Path, num_tokens):
+    with path.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header?"
+    return tokens
+
+class DistributedDataLoader:
+    def __init__(self, filename_pattern, seq_len, process_rank, num_processes):
+        self.process_rank = process_rank
+        self.num_processes = num_processes
+        self.seq_len = seq_len
+
+        # glob files that match the pattern
+        self.files = sorted(Path.cwd().glob(filename_pattern))
+        assert len(self.files) > 0, f"did not find any files that match the pattern {filename_pattern}"
+
+        # load and validate all data shards, count number of tokens in total
+        self.files_num_tokens = [_peek_data_shard(file) for file in self.files]
+        assert min(self.files_num_tokens) >= num_processes * seq_len + 1
+        self.total_num_tokens = sum(self.files_num_tokens)
+
+        self.reset()
+
+    def reset(self):
+        self.current_shard = -1
+        self.advance()
+
+    def advance(self): # advance to next data shard
+        self.current_shard = (self.current_shard + 1) % len(self.files)
+        self.current_position = self.process_rank * self.seq_len
+        self.tokens = _load_data_shard(self.files[self.current_shard], self.files_num_tokens[self.current_shard])
+
+    def next_batch(self):
+        batch_size = self.seq_len * self.num_processes
+        buf = self.tokens[self.current_position:self.current_position+self.seq_len+1]
+        # host side async is sufficient;
+        # no performance improvement was observed when introducing a separate stream.
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # inputs
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # targets
+        # advance current position and load next shard if necessary
+        self.current_position += batch_size
+        if self.current_position + batch_size + 1 >= len(self.tokens):
+            self.advance()
+        return inputs, targets
+
+def set_output_layer_bias(model, dataloader, n_batches):
+    # Use token prevalence to initialize output layer bias & avoid initial shock to network of having to find it.
+    t0 = time.perf_counter()
+    num_vocab = model.lm_head.bias.size(0)
+    for i in range(n_batches):
+        _, targets_train = dataloader.next_batch()
+        if i == 0:
+            total_counts = torch.zeros(num_vocab, dtype=torch.int32, device=targets_train.device)
+        ids, counts = torch.unique(targets_train, sorted=True, return_counts=True)
+        total_counts[ids] += counts
+
+    target_probs = total_counts / total_counts.sum()
+    target_probs = (target_probs + 1e-12)
+    target_probs = target_probs / target_probs.sum()
+
+    with torch.no_grad():
+        model.lm_head.bias.copy_(target_probs.log())
+
+    old_init_loss = torch.tensor(1 / num_vocab).log().item()
+    new_init_loss = (target_probs * target_probs.log()).sum().item()
+    total_time = time.perf_counter() - t0
+    print0(f"Centered output layer, initial loss {old_init_loss:.3f} => {new_init_loss:.3f} ({total_time:.1f}s)")
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data hyperparams
+    input_bin : str = 'data/fineweb10B/fineweb_train_*.bin' # input .bin to train on
+    input_val_bin : str = 'data/fineweb10B/fineweb_val_*.bin' # input .bin to eval validation loss on
+    # optimization hyperparams
+    batch_size : int = 8 # batch size, in sequences, across all devices
+    sequence_length : int = 64*1024 # sequence length, in tokens
+    num_iterations : int = 1480 # number of iterations to run
+    warmup_iters : int = 0
+    cooldown_iters : int = 600 # number of iterations of linear warmup/cooldown for triangular or trapezoidal schedule
+    weight_decay : float = 0
+    # evaluation and logging hyperparams
+    val_loss_every : int = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    val_tokens : int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+args = Hyperparameters()
+
+# set up DDP (distributed data parallel). torchrun sets this env variable
+ddp_rank = int(os.environ['RANK'])
+ddp_local_rank = int(os.environ['LOCAL_RANK'])
+ddp_world_size = int(os.environ['WORLD_SIZE'])
+assert torch.cuda.is_available()
+device = torch.device(f'cuda:{ddp_local_rank}')
+torch.cuda.set_device(device)
+print(f'using device: {device}')
+dist.init_process_group(backend='nccl', device_id=device)
+dist.barrier()
+master_process = (ddp_rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = uuid.uuid4()
+    Path('logs').mkdir(exist_ok=True)
+    # logdir = Path('logs') / f'{run_id}'
+    # logdir.mkdir()
+    logfile = Path('logs') / f'{run_id}.txt'
+    print(logfile.stem)
+    # create the log file
+    with logfile.open('w') as f:
+        # begin the log by printing this file (the Python code)
+        print(code, file=f)
+        print('=' * 100, file=f)
+def print0(s, logonly=False):
+    if master_process:
+        with logfile.open('a') as f:
+            if not logonly:
+                print(s)
+            print(s, file=f)
+# log information about the hardware/software environment this is running on
+# and print the full `nvidia-smi` to file
+print0(f'Running python {sys.version}')
+print0(f'Running pytorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}\nnvidia-smi:')
+import subprocess
+result = subprocess.run(['nvidia-smi'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+print0(f'{result.stdout}', logonly=True)
+print0('='*100, logonly=True)
+
+# calculate the number of steps to take in the val loop.
+assert args.val_tokens % (args.sequence_length * ddp_world_size) == 0
+val_steps = args.val_tokens // (args.sequence_length * ddp_world_size)
+# calculate the steps of gradient accumulation required to attain the desired global batch size.
+assert args.batch_size % (ddp_world_size) == 0
+train_accumulation_steps = args.batch_size // ddp_world_size
+
+# load tokens
+train_loader = DistributedDataLoader(args.input_bin, args.sequence_length, ddp_rank, ddp_world_size)
+val_loader = DistributedDataLoader(args.input_val_bin, args.sequence_length, ddp_rank, ddp_world_size)
+print0(f"Training DataLoader: total number of tokens: {train_loader.total_num_tokens} across {len(train_loader.files)} files")
+print0(f"Validation DataLoader: total number of tokens: {val_loader.total_num_tokens} across {len(val_loader.files)} files")
+print0('='*100, logonly=True)
+inputs_train, targets_train = train_loader.next_batch()
+
+# there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency. suggested to me by @Grad62304977.
+# this originates from Karpathy's experiments.
+num_vocab = 50304
+model = GPT(GPTConfig(vocab_size=num_vocab, num_layers=12, num_heads=6, model_dim=768))
+model = model.cuda().bfloat16()
+for m in model.modules():
+    if isinstance(m, CastedLinear):
+        m.float()
+if hasattr(config, "coordinate_descent_tuning"):
+    config.coordinate_descent_tuning = True # suggested by @Chillee
+
+set_output_layer_bias(model, train_loader, n_batches=100)
+
+model = torch.compile(model)
+# here we wrap model into DDP container
+model = DDP(model, device_ids=[ddp_local_rank], broadcast_buffers=False, gradient_as_bucket_view=True)
+raw_model = model.module # always contains the "raw" unwrapped model
+
+# init the optimizer(s)
+embed_params = [*raw_model.embed.parameters(), *raw_model.value_embeds.parameters()]
+optimizer1 = torch.optim.Adam(embed_params, lr=0.6, betas=(0.8, 0.95), fused=True)
+optimizer2 = torch.optim.Adam([raw_model.lm_head.weight, raw_model.lm_head.bias], lr=0.008, betas=(0.8, 0.95), fused=True)
+params = list(raw_model.blocks.parameters())
+matrix_params = [p for p in params if p.ndim == 2]
+scalar_params = [p for p in params if p.ndim < 2] + [raw_model.skip_weights]
+optimizer3 = Muon(matrix_params, lr=0.05, momentum=0.95)
+optimizer4 = torch.optim.Adam(scalar_params, lr=0.04, betas=(0.8, 0.95), fused=True)
+optimizers = [optimizer1, optimizer2, optimizer3, optimizer4]
+# learning rate decay scheduler (linear warmup and cooldown)
+def get_lr(it):
+    assert it <= args.num_iterations
+    # 1) linear warmup for warmup_iters steps
+    if it < args.warmup_iters:
+        return (it+1) / args.warmup_iters
+    # 2) constant lr for a while
+    elif it < args.num_iterations - args.cooldown_iters:
+        return 1.0
+    # 3) linear cooldown
+    else:
+        decay_ratio = (args.num_iterations - it) / args.cooldown_iters
+        return decay_ratio
+schedulers = [torch.optim.lr_scheduler.LambdaLR(opt, get_lr) for opt in optimizers]
+
+sliding_window_num_blocks = torch.tensor(1, dtype=torch.int32, device="cuda")
+sw_num_blocks_prev = 1
+# Start training loop
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+for step in range(args.num_iterations + 1):
+    last_step = (step == args.num_iterations)
+    # This effectively ignores timing first 10 steps, which are slower for weird reasons.
+    # Alternately, and slightly more correctly in terms of benchmarking, we could do 10
+    # steps with dummy data first, and then re-initialize the model and reset the loader.
+    if step == 10:
+        training_time_ms = 0
+        t0 = time.perf_counter()
+    timed_steps = float('nan') if step <= 11 else (step - 10) + 1 # <= 11 to avoid bug in val
+
+    # Linearly increase the sliding window size over training in chunks of 128 from 128 -> 1856. By @fernbear.bsky.social
+    frac_done = step / args.num_iterations # training progress
+    sw_num_blocks = int(((1 - frac_done) * 128 + frac_done * 1856) // 128)
+    if sw_num_blocks != sw_num_blocks_prev:
+        sliding_window_num_blocks.copy_(sw_num_blocks, non_blocking=True)
+        sw_num_blocks_prev = sw_num_blocks
+
+    # once in a while evaluate the validation dataset
+    if (last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)):
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        # run validation batches
+        model.eval()
+        val_loader.reset()
+        val_loss = 0.0
+        for _ in range(val_steps):
+            with torch.no_grad():
+                inputs_val, targets_val = val_loader.next_batch()
+                val_loss += model(inputs_val, targets_val, sliding_window_num_blocks)
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        val_loss /= val_steps
+        # log val loss to console and to logfile
+        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    # uncomment if you want to save any checkpoints
+    #save_every = 1000
+    #if master_process and (last_step or (save_every > 0 and step % save_every == 0)):
+    #    # stop the clock
+    #    torch.cuda.synchronize()
+    #    training_time_ms += 1000 * (time.perf_counter() - t0)
+    #    # save the state of the training process
+    #    log = dict(step=step, code=code, model=raw_model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+    #    torch.save(log, 'logs/%s/state_step%06d.pt' % (run_id, step))
+    #    # start the clock again
+    #    torch.cuda.synchronize()
+    #    t0 = time.perf_counter()
+
+    # bit confusing: we want to make sure to eval on 0th iteration
+    # but also after the very last iteration. so we loop for step <= num_iterations
+    # instead of just < num_iterations (one extra due to <=), only to do
+    # the validation/sampling one last time, and then we break right here as we're done.
+    if last_step:
+        break
+
+    # --------------- TRAINING SECTION BEGIN -----------------
+    model.train()
+    for i in range(1, train_accumulation_steps + 1):
+        with contextlib.ExitStack() as stack:
+            if i < train_accumulation_steps: # there's no need to sync gradients every accumulation step
+                stack.enter_context(model.no_sync())
+            if step >= 5:
+                stack.enter_context(torch.compiler.set_stance(skip_guard_eval_unsafe=True))
+            model(inputs_train, targets_train, sliding_window_num_blocks).backward()
+            inputs_train, targets_train = train_loader.next_batch()
+    if train_accumulation_steps != 1:
+        for p in model.parameters():
+            p.grad /= train_accumulation_steps
+    # momentum warmup for Muon
+    frac = min(step/300, 1)
+    for group in optimizer3.param_groups:
+        group['momentum'] = (1 - frac) * 0.85 + frac * 0.95
+    # step the optimizers and schedulers
+    for opt, sched in zip(optimizers, schedulers):
+        opt.step()
+        sched.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # --------------- TRAINING SECTION END -------------------
+    # everything that follows now is just diagnostics, prints, logging, etc.
+    approx_time = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{args.num_iterations} train_time:{approx_time:.0f}ms step_avg:{approx_time/timed_steps:.2f}ms")
+
+print0(f"peak memory consumption: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB")
+
+# -------------------------------------------------------------------------
+# clean up nice
+dist.destroy_process_group()
+
+====================================================================================================
+Running python 3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
+Running pytorch 2.6.0.dev20241203+cu124 compiled for CUDA 12.4
+nvidia-smi:
+Thu Dec 26 08:02:06 2024       
++---------------------------------------------------------------------------------------+
+| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.4     |
+|-----------------------------------------+----------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
+|                                         |                      |               MIG M. |
+|=========================================+======================+======================|
+|   0  NVIDIA H100 PCIe               On  | 00000000:00:07.0 Off |                    0 |
+| N/A   39C    P0              81W / 350W |   4162MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   1  NVIDIA H100 PCIe               On  | 00000000:00:08.0 Off |                    0 |
+| N/A   44C    P0              86W / 350W |    923MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   2  NVIDIA H100 PCIe               On  | 00000000:00:09.0 Off |                    0 |
+| N/A   37C    P0              81W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   3  NVIDIA H100 PCIe               On  | 00000000:00:0A.0 Off |                    0 |
+| N/A   38C    P0              79W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   4  NVIDIA H100 PCIe               On  | 00000000:00:0B.0 Off |                    0 |
+| N/A   37C    P0              77W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   5  NVIDIA H100 PCIe               On  | 00000000:00:0C.0 Off |                    0 |
+| N/A   36C    P0              77W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   6  NVIDIA H100 PCIe               On  | 00000000:00:0D.0 Off |                    0 |
+| N/A   43C    P0              83W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   7  NVIDIA H100 PCIe               On  | 00000000:00:0E.0 Off |                    0 |
+| N/A   38C    P0              78W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+                                                                                         
++---------------------------------------------------------------------------------------+
+| Processes:                                                                            |
+|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
+|        ID   ID                                                             Usage      |
+|=======================================================================================|
++---------------------------------------------------------------------------------------+
+
+====================================================================================================
+Training DataLoader: total number of tokens: 1000000000 across 10 files
+Validation DataLoader: total number of tokens: 100000000 across 1 files
+====================================================================================================
+Centered output layer, initial loss -10.826 => -7.657 (0.1s)
+step:0/1480 val_loss:7.7109 train_time:0ms step_avg:nanms
+step:1/1480 train_time:42113ms step_avg:nanms
+step:2/1480 train_time:42524ms step_avg:nanms
+step:3/1480 train_time:42772ms step_avg:nanms
+step:4/1480 train_time:43028ms step_avg:nanms
+step:5/1480 train_time:43285ms step_avg:nanms
+step:6/1480 train_time:43541ms step_avg:nanms
+step:7/1480 train_time:43793ms step_avg:nanms
+step:8/1480 train_time:44049ms step_avg:nanms
+step:9/1480 train_time:44307ms step_avg:nanms
+step:10/1480 train_time:44566ms step_avg:nanms
+step:11/1480 train_time:251ms step_avg:nanms
+step:12/1480 train_time:504ms step_avg:nanms
+step:13/1480 train_time:762ms step_avg:253.89ms
+step:14/1480 train_time:1018ms step_avg:254.57ms
+step:15/1480 train_time:1273ms step_avg:254.60ms
+step:16/1480 train_time:1529ms step_avg:254.81ms
+step:17/1480 train_time:1783ms step_avg:254.74ms
+step:18/1480 train_time:2041ms step_avg:255.12ms
+step:19/1480 train_time:2301ms step_avg:255.67ms
+step:20/1480 train_time:2557ms step_avg:255.68ms
+step:21/1480 train_time:2813ms step_avg:255.70ms
+step:22/1480 train_time:3069ms step_avg:255.78ms
+step:23/1480 train_time:3324ms step_avg:255.68ms
+step:24/1480 train_time:3581ms step_avg:255.81ms
+step:25/1480 train_time:3841ms step_avg:256.06ms
+step:26/1480 train_time:4100ms step_avg:256.24ms
+step:27/1480 train_time:4357ms step_avg:256.32ms
+step:28/1480 train_time:4613ms step_avg:256.26ms
+step:29/1480 train_time:4869ms step_avg:256.27ms
+step:30/1480 train_time:5124ms step_avg:256.18ms
+step:31/1480 train_time:5382ms step_avg:256.29ms
+step:32/1480 train_time:5641ms step_avg:256.40ms
+step:33/1480 train_time:5901ms step_avg:256.55ms
+step:34/1480 train_time:6158ms step_avg:256.59ms
+step:35/1480 train_time:6415ms step_avg:256.60ms
+step:36/1480 train_time:6672ms step_avg:256.61ms
+step:37/1480 train_time:6925ms step_avg:256.49ms
+step:38/1480 train_time:7182ms step_avg:256.50ms
+step:39/1480 train_time:7442ms step_avg:256.61ms
+step:40/1480 train_time:7702ms step_avg:256.73ms
+step:41/1480 train_time:7960ms step_avg:256.76ms
+step:42/1480 train_time:8215ms step_avg:256.73ms
+step:43/1480 train_time:8472ms step_avg:256.72ms
+step:44/1480 train_time:8726ms step_avg:256.65ms
+step:45/1480 train_time:8983ms step_avg:256.67ms
+step:46/1480 train_time:9240ms step_avg:256.68ms
+step:47/1480 train_time:9501ms step_avg:256.79ms
+step:48/1480 train_time:9758ms step_avg:256.80ms
+step:49/1480 train_time:10015ms step_avg:256.80ms
+step:50/1480 train_time:10273ms step_avg:256.81ms
+step:51/1480 train_time:10530ms step_avg:256.82ms
+step:52/1480 train_time:10784ms step_avg:256.77ms
+step:53/1480 train_time:11042ms step_avg:256.80ms
+step:54/1480 train_time:11302ms step_avg:256.87ms
+step:55/1480 train_time:11561ms step_avg:256.90ms
+step:56/1480 train_time:11818ms step_avg:256.90ms
+step:57/1480 train_time:12074ms step_avg:256.89ms
+step:58/1480 train_time:12330ms step_avg:256.88ms
+step:59/1480 train_time:12584ms step_avg:256.82ms
+step:60/1480 train_time:12843ms step_avg:256.85ms
+step:61/1480 train_time:13102ms step_avg:256.90ms
+step:62/1480 train_time:13358ms step_avg:256.89ms
+step:63/1480 train_time:13619ms step_avg:256.96ms
+step:64/1480 train_time:13875ms step_avg:256.95ms
+step:65/1480 train_time:14129ms step_avg:256.88ms
+step:66/1480 train_time:14385ms step_avg:256.88ms
+step:67/1480 train_time:14643ms step_avg:256.89ms
+step:68/1480 train_time:14903ms step_avg:256.95ms
+step:69/1480 train_time:15161ms step_avg:256.97ms
+step:70/1480 train_time:15419ms step_avg:256.98ms
+step:71/1480 train_time:15675ms step_avg:256.97ms
+step:72/1480 train_time:15930ms step_avg:256.94ms
+step:73/1480 train_time:16185ms step_avg:256.91ms
+step:74/1480 train_time:16442ms step_avg:256.91ms
+step:75/1480 train_time:16702ms step_avg:256.96ms
+step:76/1480 train_time:16961ms step_avg:256.99ms
+step:77/1480 train_time:17218ms step_avg:256.99ms
+step:78/1480 train_time:17474ms step_avg:256.97ms
+step:79/1480 train_time:17730ms step_avg:256.96ms
+step:80/1480 train_time:17985ms step_avg:256.93ms
+step:81/1480 train_time:18243ms step_avg:256.95ms
+step:82/1480 train_time:18503ms step_avg:256.99ms
+step:83/1480 train_time:18762ms step_avg:257.02ms
+step:84/1480 train_time:19019ms step_avg:257.02ms
+step:85/1480 train_time:19277ms step_avg:257.02ms
+step:86/1480 train_time:19532ms step_avg:257.00ms
+step:87/1480 train_time:19786ms step_avg:256.96ms
+step:88/1480 train_time:20043ms step_avg:256.96ms
+step:89/1480 train_time:20304ms step_avg:257.02ms
+step:90/1480 train_time:20562ms step_avg:257.02ms
+step:91/1480 train_time:20820ms step_avg:257.04ms
+step:92/1480 train_time:21076ms step_avg:257.02ms
+step:93/1480 train_time:21331ms step_avg:257.00ms
+step:94/1480 train_time:21586ms step_avg:256.98ms
+step:95/1480 train_time:21843ms step_avg:256.98ms
+step:96/1480 train_time:22105ms step_avg:257.03ms
+step:97/1480 train_time:22363ms step_avg:257.05ms
+step:98/1480 train_time:22621ms step_avg:257.06ms
+step:99/1480 train_time:22880ms step_avg:257.08ms
+step:100/1480 train_time:23137ms step_avg:257.08ms
+step:101/1480 train_time:23395ms step_avg:257.08ms
+step:102/1480 train_time:23651ms step_avg:257.08ms
+step:103/1480 train_time:23907ms step_avg:257.07ms
+step:104/1480 train_time:24166ms step_avg:257.09ms
+step:105/1480 train_time:24423ms step_avg:257.08ms
+step:106/1480 train_time:24682ms step_avg:257.10ms
+step:107/1480 train_time:24940ms step_avg:257.11ms
+step:108/1480 train_time:25197ms step_avg:257.12ms
+step:109/1480 train_time:25455ms step_avg:257.12ms
+step:110/1480 train_time:25713ms step_avg:257.13ms
+step:111/1480 train_time:25971ms step_avg:257.14ms
+step:112/1480 train_time:26230ms step_avg:257.16ms
+step:113/1480 train_time:26491ms step_avg:257.20ms
+step:114/1480 train_time:26750ms step_avg:257.21ms
+step:115/1480 train_time:27009ms step_avg:257.23ms
+step:116/1480 train_time:27270ms step_avg:257.26ms
+step:117/1480 train_time:27531ms step_avg:257.30ms
+step:118/1480 train_time:27790ms step_avg:257.32ms
+step:119/1480 train_time:28050ms step_avg:257.34ms
+step:120/1480 train_time:28309ms step_avg:257.35ms
+step:121/1480 train_time:28569ms step_avg:257.38ms
+step:122/1480 train_time:28830ms step_avg:257.41ms
+step:123/1480 train_time:29089ms step_avg:257.43ms
+step:124/1480 train_time:29348ms step_avg:257.44ms
+step:125/1480 train_time:29609ms step_avg:257.47ms
+step:125/1480 val_loss:4.3719 train_time:29736ms step_avg:258.57ms
+step:126/1480 train_time:29870ms step_avg:257.50ms
+step:127/1480 train_time:30131ms step_avg:257.53ms
+step:128/1480 train_time:30391ms step_avg:257.55ms
+step:129/1480 train_time:30653ms step_avg:257.59ms
+step:130/1480 train_time:30913ms step_avg:257.61ms
+step:131/1480 train_time:31173ms step_avg:257.63ms
+step:132/1480 train_time:31432ms step_avg:257.64ms
+step:133/1480 train_time:31692ms step_avg:257.66ms
+step:134/1480 train_time:31953ms step_avg:257.68ms
+step:135/1480 train_time:32213ms step_avg:257.70ms
+step:136/1480 train_time:32471ms step_avg:257.71ms
+step:137/1480 train_time:32732ms step_avg:257.73ms
+step:138/1480 train_time:32992ms step_avg:257.75ms
+step:139/1480 train_time:33252ms step_avg:257.77ms
+step:140/1480 train_time:33511ms step_avg:257.77ms
+step:141/1480 train_time:33771ms step_avg:257.79ms
+step:142/1480 train_time:34030ms step_avg:257.80ms
+step:143/1480 train_time:34292ms step_avg:257.84ms
+step:144/1480 train_time:34553ms step_avg:257.86ms
+step:145/1480 train_time:34812ms step_avg:257.86ms
+step:146/1480 train_time:35072ms step_avg:257.88ms
+step:147/1480 train_time:35331ms step_avg:257.89ms
+step:148/1480 train_time:35592ms step_avg:257.92ms
+step:149/1480 train_time:35853ms step_avg:257.94ms
+step:150/1480 train_time:36112ms step_avg:257.95ms
+step:151/1480 train_time:36372ms step_avg:257.96ms
+step:152/1480 train_time:36632ms step_avg:257.97ms
+step:153/1480 train_time:36893ms step_avg:257.99ms
+step:154/1480 train_time:37152ms step_avg:258.00ms
+step:155/1480 train_time:37413ms step_avg:258.02ms
+step:156/1480 train_time:37672ms step_avg:258.02ms
+step:157/1480 train_time:37933ms step_avg:258.04ms
+step:158/1480 train_time:38191ms step_avg:258.05ms
+step:159/1480 train_time:38453ms step_avg:258.07ms
+step:160/1480 train_time:38713ms step_avg:258.08ms
+step:161/1480 train_time:38971ms step_avg:258.09ms
+step:162/1480 train_time:39234ms step_avg:258.12ms
+step:163/1480 train_time:39495ms step_avg:258.14ms
+step:164/1480 train_time:39757ms step_avg:258.17ms
+step:165/1480 train_time:40021ms step_avg:258.20ms
+step:166/1480 train_time:40284ms step_avg:258.23ms
+step:167/1480 train_time:40545ms step_avg:258.25ms
+step:168/1480 train_time:40809ms step_avg:258.28ms
+step:169/1480 train_time:41070ms step_avg:258.30ms
+step:170/1480 train_time:41330ms step_avg:258.31ms
+step:171/1480 train_time:41592ms step_avg:258.34ms
+step:172/1480 train_time:41851ms step_avg:258.34ms
+step:173/1480 train_time:42111ms step_avg:258.35ms
+step:174/1480 train_time:42371ms step_avg:258.36ms
+step:175/1480 train_time:42632ms step_avg:258.37ms
+step:176/1480 train_time:42893ms step_avg:258.39ms
+step:177/1480 train_time:43156ms step_avg:258.42ms
+step:178/1480 train_time:43416ms step_avg:258.43ms
+step:179/1480 train_time:43678ms step_avg:258.45ms
+step:180/1480 train_time:43943ms step_avg:258.49ms
+step:181/1480 train_time:44206ms step_avg:258.51ms
+step:182/1480 train_time:44468ms step_avg:258.53ms
+step:183/1480 train_time:44730ms step_avg:258.56ms
+step:184/1480 train_time:44991ms step_avg:258.57ms
+step:185/1480 train_time:45255ms step_avg:258.60ms
+step:186/1480 train_time:45518ms step_avg:258.63ms
+step:187/1480 train_time:45779ms step_avg:258.64ms
+step:188/1480 train_time:46043ms step_avg:258.67ms
+step:189/1480 train_time:46306ms step_avg:258.70ms
+step:190/1480 train_time:46568ms step_avg:258.71ms
+step:191/1480 train_time:46831ms step_avg:258.73ms
+step:192/1480 train_time:47092ms step_avg:258.75ms
+step:193/1480 train_time:47354ms step_avg:258.77ms
+step:194/1480 train_time:47616ms step_avg:258.78ms
+step:195/1480 train_time:47874ms step_avg:258.78ms
+step:196/1480 train_time:48135ms step_avg:258.79ms
+step:197/1480 train_time:48397ms step_avg:258.81ms
+step:198/1480 train_time:48661ms step_avg:258.84ms
+step:199/1480 train_time:48927ms step_avg:258.87ms
+step:200/1480 train_time:49190ms step_avg:258.89ms
+step:201/1480 train_time:49450ms step_avg:258.90ms
+step:202/1480 train_time:49710ms step_avg:258.91ms
+step:203/1480 train_time:49972ms step_avg:258.92ms
+step:204/1480 train_time:50232ms step_avg:258.93ms
+step:205/1480 train_time:50493ms step_avg:258.94ms
+step:206/1480 train_time:50754ms step_avg:258.95ms
+step:207/1480 train_time:51017ms step_avg:258.97ms
+step:208/1480 train_time:51282ms step_avg:259.00ms
+step:209/1480 train_time:51545ms step_avg:259.02ms
+step:210/1480 train_time:51808ms step_avg:259.04ms
+step:211/1480 train_time:52068ms step_avg:259.05ms
+step:212/1480 train_time:52331ms step_avg:259.06ms
+step:213/1480 train_time:52594ms step_avg:259.08ms
+step:214/1480 train_time:52856ms step_avg:259.10ms
+step:215/1480 train_time:53118ms step_avg:259.11ms
+step:216/1480 train_time:53384ms step_avg:259.14ms
+step:217/1480 train_time:53646ms step_avg:259.16ms
+step:218/1480 train_time:53908ms step_avg:259.17ms
+step:219/1480 train_time:54169ms step_avg:259.18ms
+step:220/1480 train_time:54430ms step_avg:259.19ms
+step:221/1480 train_time:54693ms step_avg:259.21ms
+step:222/1480 train_time:54961ms step_avg:259.25ms
+step:223/1480 train_time:55232ms step_avg:259.30ms
+step:224/1480 train_time:55495ms step_avg:259.32ms
+step:225/1480 train_time:55764ms step_avg:259.37ms
+step:226/1480 train_time:56031ms step_avg:259.40ms
+step:227/1480 train_time:56297ms step_avg:259.43ms
+step:228/1480 train_time:56566ms step_avg:259.48ms
+step:229/1480 train_time:56832ms step_avg:259.51ms
+step:230/1480 train_time:57099ms step_avg:259.54ms
+step:231/1480 train_time:57366ms step_avg:259.58ms
+step:232/1480 train_time:57633ms step_avg:259.61ms
+step:233/1480 train_time:57898ms step_avg:259.63ms
+step:234/1480 train_time:58167ms step_avg:259.68ms
+step:235/1480 train_time:58433ms step_avg:259.70ms
+step:236/1480 train_time:58699ms step_avg:259.73ms
+step:237/1480 train_time:58968ms step_avg:259.77ms
+step:238/1480 train_time:59233ms step_avg:259.79ms
+step:239/1480 train_time:59500ms step_avg:259.83ms
+step:240/1480 train_time:59768ms step_avg:259.86ms
+step:241/1480 train_time:60033ms step_avg:259.88ms
+step:242/1480 train_time:60299ms step_avg:259.91ms
+step:243/1480 train_time:60568ms step_avg:259.95ms
+step:244/1480 train_time:60833ms step_avg:259.97ms
+step:245/1480 train_time:61102ms step_avg:260.01ms
+step:246/1480 train_time:61369ms step_avg:260.04ms
+step:247/1480 train_time:61633ms step_avg:260.06ms
+step:248/1480 train_time:61900ms step_avg:260.08ms
+step:249/1480 train_time:62169ms step_avg:260.12ms
+step:250/1480 train_time:62433ms step_avg:260.14ms
+step:250/1480 val_loss:3.9992 train_time:62563ms step_avg:260.68ms
+step:251/1480 train_time:62703ms step_avg:260.18ms
+step:252/1480 train_time:62972ms step_avg:260.21ms
+step:253/1480 train_time:63239ms step_avg:260.24ms
+step:254/1480 train_time:63508ms step_avg:260.28ms
+step:255/1480 train_time:63773ms step_avg:260.30ms
+step:256/1480 train_time:64043ms step_avg:260.34ms
+step:257/1480 train_time:64311ms step_avg:260.37ms
+step:258/1480 train_time:64577ms step_avg:260.39ms
+step:259/1480 train_time:64848ms step_avg:260.44ms
+step:260/1480 train_time:65114ms step_avg:260.46ms
+step:261/1480 train_time:65383ms step_avg:260.49ms
+step:262/1480 train_time:65649ms step_avg:260.51ms
+step:263/1480 train_time:65916ms step_avg:260.54ms
+step:264/1480 train_time:66184ms step_avg:260.57ms
+step:265/1480 train_time:66451ms step_avg:260.59ms
+step:266/1480 train_time:66716ms step_avg:260.61ms
+step:267/1480 train_time:66985ms step_avg:260.64ms
+step:268/1480 train_time:67250ms step_avg:260.66ms
+step:269/1480 train_time:67516ms step_avg:260.68ms
+step:270/1480 train_time:67783ms step_avg:260.70ms
+step:271/1480 train_time:68050ms step_avg:260.73ms
+step:272/1480 train_time:68316ms step_avg:260.75ms
+step:273/1480 train_time:68582ms step_avg:260.77ms
+step:274/1480 train_time:68849ms step_avg:260.79ms
+step:275/1480 train_time:69113ms step_avg:260.80ms
+step:276/1480 train_time:69381ms step_avg:260.83ms
+step:277/1480 train_time:69649ms step_avg:260.86ms
+step:278/1480 train_time:69914ms step_avg:260.87ms
+step:279/1480 train_time:70181ms step_avg:260.89ms
+step:280/1480 train_time:70449ms step_avg:260.92ms
+step:281/1480 train_time:70714ms step_avg:260.94ms
+step:282/1480 train_time:70981ms step_avg:260.96ms
+step:283/1480 train_time:71250ms step_avg:260.99ms
+step:284/1480 train_time:71516ms step_avg:261.01ms
+step:285/1480 train_time:71784ms step_avg:261.03ms
+step:286/1480 train_time:72049ms step_avg:261.05ms
+step:287/1480 train_time:72314ms step_avg:261.06ms
+step:288/1480 train_time:72581ms step_avg:261.08ms
+step:289/1480 train_time:72849ms step_avg:261.11ms
+step:290/1480 train_time:73113ms step_avg:261.12ms
+step:291/1480 train_time:73382ms step_avg:261.15ms
+step:292/1480 train_time:73650ms step_avg:261.17ms
+step:293/1480 train_time:73913ms step_avg:261.18ms
+step:294/1480 train_time:74181ms step_avg:261.20ms
+step:295/1480 train_time:74449ms step_avg:261.22ms
+step:296/1480 train_time:74714ms step_avg:261.24ms
+step:297/1480 train_time:74982ms step_avg:261.26ms
+step:298/1480 train_time:75249ms step_avg:261.28ms
+step:299/1480 train_time:75513ms step_avg:261.29ms
+step:300/1480 train_time:75782ms step_avg:261.32ms
+step:301/1480 train_time:76048ms step_avg:261.33ms
+step:302/1480 train_time:76314ms step_avg:261.35ms
+step:303/1480 train_time:76581ms step_avg:261.37ms
+step:304/1480 train_time:76848ms step_avg:261.39ms
+step:305/1480 train_time:77114ms step_avg:261.40ms
+step:306/1480 train_time:77381ms step_avg:261.42ms
+step:307/1480 train_time:77650ms step_avg:261.45ms
+step:308/1480 train_time:77913ms step_avg:261.45ms
+step:309/1480 train_time:78182ms step_avg:261.48ms
+step:310/1480 train_time:78449ms step_avg:261.50ms
+step:311/1480 train_time:78715ms step_avg:261.51ms
+step:312/1480 train_time:78983ms step_avg:261.53ms
+step:313/1480 train_time:79250ms step_avg:261.55ms
+step:314/1480 train_time:79513ms step_avg:261.55ms
+step:315/1480 train_time:79781ms step_avg:261.58ms
+step:316/1480 train_time:80049ms step_avg:261.60ms
+step:317/1480 train_time:80314ms step_avg:261.61ms
+step:318/1480 train_time:80581ms step_avg:261.63ms
+step:319/1480 train_time:80849ms step_avg:261.65ms
+step:320/1480 train_time:81114ms step_avg:261.66ms
+step:321/1480 train_time:81381ms step_avg:261.67ms
+step:322/1480 train_time:81649ms step_avg:261.69ms
+step:323/1480 train_time:81915ms step_avg:261.71ms
+step:324/1480 train_time:82182ms step_avg:261.73ms
+step:325/1480 train_time:82450ms step_avg:261.74ms
+step:326/1480 train_time:82714ms step_avg:261.75ms
+step:327/1480 train_time:82983ms step_avg:261.78ms
+step:328/1480 train_time:83250ms step_avg:261.79ms
+step:329/1480 train_time:83515ms step_avg:261.80ms
+step:330/1480 train_time:83783ms step_avg:261.82ms
+step:331/1480 train_time:84051ms step_avg:261.84ms
+step:332/1480 train_time:84320ms step_avg:261.86ms
+step:333/1480 train_time:84591ms step_avg:261.89ms
+step:334/1480 train_time:84866ms step_avg:261.93ms
+step:335/1480 train_time:85133ms step_avg:261.95ms
+step:336/1480 train_time:85406ms step_avg:261.98ms
+step:337/1480 train_time:85673ms step_avg:262.00ms
+step:338/1480 train_time:85947ms step_avg:262.03ms
+step:339/1480 train_time:86220ms step_avg:262.07ms
+step:340/1480 train_time:86491ms step_avg:262.09ms
+step:341/1480 train_time:86762ms step_avg:262.12ms
+step:342/1480 train_time:87032ms step_avg:262.14ms
+step:343/1480 train_time:87304ms step_avg:262.18ms
+step:344/1480 train_time:87574ms step_avg:262.20ms
+step:345/1480 train_time:87847ms step_avg:262.23ms
+step:346/1480 train_time:88120ms step_avg:262.26ms
+step:347/1480 train_time:88391ms step_avg:262.29ms
+step:348/1480 train_time:88663ms step_avg:262.32ms
+step:349/1480 train_time:88932ms step_avg:262.34ms
+step:350/1480 train_time:89203ms step_avg:262.36ms
+step:351/1480 train_time:89474ms step_avg:262.39ms
+step:352/1480 train_time:89747ms step_avg:262.42ms
+step:353/1480 train_time:90020ms step_avg:262.45ms
+step:354/1480 train_time:90292ms step_avg:262.48ms
+step:355/1480 train_time:90562ms step_avg:262.50ms
+step:356/1480 train_time:90831ms step_avg:262.52ms
+step:357/1480 train_time:91103ms step_avg:262.54ms
+step:358/1480 train_time:91372ms step_avg:262.56ms
+step:359/1480 train_time:91645ms step_avg:262.59ms
+step:360/1480 train_time:91913ms step_avg:262.61ms
+step:361/1480 train_time:92188ms step_avg:262.64ms
+step:362/1480 train_time:92457ms step_avg:262.66ms
+step:363/1480 train_time:92728ms step_avg:262.69ms
+step:364/1480 train_time:92998ms step_avg:262.71ms
+step:365/1480 train_time:93270ms step_avg:262.73ms
+step:366/1480 train_time:93541ms step_avg:262.76ms
+step:367/1480 train_time:93814ms step_avg:262.78ms
+step:368/1480 train_time:94086ms step_avg:262.81ms
+step:369/1480 train_time:94352ms step_avg:262.82ms
+step:370/1480 train_time:94625ms step_avg:262.85ms
+step:371/1480 train_time:94892ms step_avg:262.86ms
+step:372/1480 train_time:95168ms step_avg:262.89ms
+step:373/1480 train_time:95434ms step_avg:262.90ms
+step:374/1480 train_time:95708ms step_avg:262.93ms
+step:375/1480 train_time:95975ms step_avg:262.95ms
+step:375/1480 val_loss:3.8241 train_time:96107ms step_avg:263.31ms
+step:376/1480 train_time:96249ms step_avg:262.97ms
+step:377/1480 train_time:96517ms step_avg:262.99ms
+step:378/1480 train_time:96788ms step_avg:263.01ms
+step:379/1480 train_time:97056ms step_avg:263.02ms
+step:380/1480 train_time:97328ms step_avg:263.05ms
+step:381/1480 train_time:97595ms step_avg:263.06ms
+step:382/1480 train_time:97869ms step_avg:263.09ms
+step:383/1480 train_time:98136ms step_avg:263.10ms
+step:384/1480 train_time:98411ms step_avg:263.13ms
+step:385/1480 train_time:98682ms step_avg:263.15ms
+step:386/1480 train_time:98952ms step_avg:263.17ms
+step:387/1480 train_time:99225ms step_avg:263.20ms
+step:388/1480 train_time:99494ms step_avg:263.21ms
+step:389/1480 train_time:99769ms step_avg:263.24ms
+step:390/1480 train_time:100036ms step_avg:263.25ms
+step:391/1480 train_time:100310ms step_avg:263.28ms
+step:392/1480 train_time:100584ms step_avg:263.31ms
+step:393/1480 train_time:100853ms step_avg:263.32ms
+step:394/1480 train_time:101125ms step_avg:263.35ms
+step:395/1480 train_time:101395ms step_avg:263.36ms
+step:396/1480 train_time:101668ms step_avg:263.39ms
+step:397/1480 train_time:101935ms step_avg:263.40ms
+step:398/1480 train_time:102209ms step_avg:263.42ms
+step:399/1480 train_time:102484ms step_avg:263.45ms
+step:400/1480 train_time:102754ms step_avg:263.47ms
+step:401/1480 train_time:103026ms step_avg:263.49ms
+step:402/1480 train_time:103295ms step_avg:263.51ms
+step:403/1480 train_time:103570ms step_avg:263.54ms
+step:404/1480 train_time:103837ms step_avg:263.55ms
+step:405/1480 train_time:104110ms step_avg:263.57ms
+step:406/1480 train_time:104384ms step_avg:263.60ms
+step:407/1480 train_time:104653ms step_avg:263.61ms
+step:408/1480 train_time:104926ms step_avg:263.63ms
+step:409/1480 train_time:105195ms step_avg:263.65ms
+step:410/1480 train_time:105470ms step_avg:263.68ms
+step:411/1480 train_time:105738ms step_avg:263.69ms
+step:412/1480 train_time:106010ms step_avg:263.71ms
+step:413/1480 train_time:106278ms step_avg:263.72ms
+step:414/1480 train_time:106551ms step_avg:263.74ms
+step:415/1480 train_time:106819ms step_avg:263.75ms
+step:416/1480 train_time:107089ms step_avg:263.77ms
+step:417/1480 train_time:107359ms step_avg:263.78ms
+step:418/1480 train_time:107629ms step_avg:263.80ms
+step:419/1480 train_time:107897ms step_avg:263.81ms
+step:420/1480 train_time:108171ms step_avg:263.83ms
+step:421/1480 train_time:108443ms step_avg:263.85ms
+step:422/1480 train_time:108712ms step_avg:263.86ms
+step:423/1480 train_time:108984ms step_avg:263.88ms
+step:424/1480 train_time:109253ms step_avg:263.90ms
+step:425/1480 train_time:109526ms step_avg:263.92ms
+step:426/1480 train_time:109795ms step_avg:263.93ms
+step:427/1480 train_time:110069ms step_avg:263.95ms
+step:428/1480 train_time:110337ms step_avg:263.96ms
+step:429/1480 train_time:110609ms step_avg:263.98ms
+step:430/1480 train_time:110878ms step_avg:263.99ms
+step:431/1480 train_time:111150ms step_avg:264.01ms
+step:432/1480 train_time:111417ms step_avg:264.02ms
+step:433/1480 train_time:111689ms step_avg:264.04ms
+step:434/1480 train_time:111958ms step_avg:264.05ms
+step:435/1480 train_time:112230ms step_avg:264.07ms
+step:436/1480 train_time:112500ms step_avg:264.08ms
+step:437/1480 train_time:112771ms step_avg:264.10ms
+step:438/1480 train_time:113041ms step_avg:264.12ms
+step:439/1480 train_time:113312ms step_avg:264.13ms
+step:440/1480 train_time:113586ms step_avg:264.15ms
+step:441/1480 train_time:113856ms step_avg:264.17ms
+step:442/1480 train_time:114130ms step_avg:264.19ms
+step:443/1480 train_time:114405ms step_avg:264.21ms
+step:444/1480 train_time:114677ms step_avg:264.23ms
+step:445/1480 train_time:114952ms step_avg:264.26ms
+step:446/1480 train_time:115229ms step_avg:264.29ms
+step:447/1480 train_time:115501ms step_avg:264.30ms
+step:448/1480 train_time:115774ms step_avg:264.33ms
+step:449/1480 train_time:116050ms step_avg:264.35ms
+step:450/1480 train_time:116324ms step_avg:264.37ms
+step:451/1480 train_time:116595ms step_avg:264.39ms
+step:452/1480 train_time:116872ms step_avg:264.42ms
+step:453/1480 train_time:117145ms step_avg:264.43ms
+step:454/1480 train_time:117419ms step_avg:264.46ms
+step:455/1480 train_time:117692ms step_avg:264.48ms
+step:456/1480 train_time:117968ms step_avg:264.50ms
+step:457/1480 train_time:118238ms step_avg:264.52ms
+step:458/1480 train_time:118513ms step_avg:264.54ms
+step:459/1480 train_time:118787ms step_avg:264.56ms
+step:460/1480 train_time:119057ms step_avg:264.57ms
+step:461/1480 train_time:119331ms step_avg:264.59ms
+step:462/1480 train_time:119607ms step_avg:264.62ms
+step:463/1480 train_time:119878ms step_avg:264.63ms
+step:464/1480 train_time:120152ms step_avg:264.65ms
+step:465/1480 train_time:120428ms step_avg:264.68ms
+step:466/1480 train_time:120700ms step_avg:264.69ms
+step:467/1480 train_time:120974ms step_avg:264.71ms
+step:468/1480 train_time:121250ms step_avg:264.74ms
+step:469/1480 train_time:121522ms step_avg:264.75ms
+step:470/1480 train_time:121797ms step_avg:264.78ms
+step:471/1480 train_time:122074ms step_avg:264.80ms
+step:472/1480 train_time:122350ms step_avg:264.83ms
+step:473/1480 train_time:122628ms step_avg:264.85ms
+step:474/1480 train_time:122904ms step_avg:264.88ms
+step:475/1480 train_time:123174ms step_avg:264.89ms
+step:476/1480 train_time:123451ms step_avg:264.92ms
+step:477/1480 train_time:123726ms step_avg:264.94ms
+step:478/1480 train_time:123997ms step_avg:264.95ms
+step:479/1480 train_time:124273ms step_avg:264.98ms
+step:480/1480 train_time:124550ms step_avg:265.00ms
+step:481/1480 train_time:124827ms step_avg:265.02ms
+step:482/1480 train_time:125098ms step_avg:265.04ms
+step:483/1480 train_time:125372ms step_avg:265.06ms
+step:484/1480 train_time:125650ms step_avg:265.08ms
+step:485/1480 train_time:125920ms step_avg:265.10ms
+step:486/1480 train_time:126195ms step_avg:265.11ms
+step:487/1480 train_time:126473ms step_avg:265.14ms
+step:488/1480 train_time:126748ms step_avg:265.16ms
+step:489/1480 train_time:127020ms step_avg:265.18ms
+step:490/1480 train_time:127294ms step_avg:265.20ms
+step:491/1480 train_time:127571ms step_avg:265.22ms
+step:492/1480 train_time:127845ms step_avg:265.24ms
+step:493/1480 train_time:128119ms step_avg:265.26ms
+step:494/1480 train_time:128391ms step_avg:265.27ms
+step:495/1480 train_time:128669ms step_avg:265.30ms
+step:496/1480 train_time:128940ms step_avg:265.31ms
+step:497/1480 train_time:129212ms step_avg:265.32ms
+step:498/1480 train_time:129487ms step_avg:265.34ms
+step:499/1480 train_time:129758ms step_avg:265.35ms
+step:500/1480 train_time:130032ms step_avg:265.37ms
+step:500/1480 val_loss:3.7067 train_time:130164ms step_avg:265.64ms
+step:501/1480 train_time:130307ms step_avg:265.39ms
+step:502/1480 train_time:130584ms step_avg:265.41ms
+step:503/1480 train_time:130860ms step_avg:265.44ms
+step:504/1480 train_time:131131ms step_avg:265.45ms
+step:505/1480 train_time:131407ms step_avg:265.47ms
+step:506/1480 train_time:131682ms step_avg:265.49ms
+step:507/1480 train_time:131955ms step_avg:265.50ms
+step:508/1480 train_time:132229ms step_avg:265.52ms
+step:509/1480 train_time:132504ms step_avg:265.54ms
+step:510/1480 train_time:132779ms step_avg:265.56ms
+step:511/1480 train_time:133053ms step_avg:265.57ms
+step:512/1480 train_time:133328ms step_avg:265.59ms
+step:513/1480 train_time:133605ms step_avg:265.62ms
+step:514/1480 train_time:133875ms step_avg:265.63ms
+step:515/1480 train_time:134150ms step_avg:265.64ms
+step:516/1480 train_time:134428ms step_avg:265.67ms
+step:517/1480 train_time:134705ms step_avg:265.69ms
+step:518/1480 train_time:134978ms step_avg:265.71ms
+step:519/1480 train_time:135251ms step_avg:265.72ms
+step:520/1480 train_time:135527ms step_avg:265.74ms
+step:521/1480 train_time:135802ms step_avg:265.76ms
+step:522/1480 train_time:136075ms step_avg:265.77ms
+step:523/1480 train_time:136349ms step_avg:265.79ms
+step:524/1480 train_time:136626ms step_avg:265.81ms
+step:525/1480 train_time:136898ms step_avg:265.82ms
+step:526/1480 train_time:137171ms step_avg:265.84ms
+step:527/1480 train_time:137446ms step_avg:265.85ms
+step:528/1480 train_time:137720ms step_avg:265.87ms
+step:529/1480 train_time:137992ms step_avg:265.88ms
+step:530/1480 train_time:138267ms step_avg:265.90ms
+step:531/1480 train_time:138544ms step_avg:265.92ms
+step:532/1480 train_time:138815ms step_avg:265.93ms
+step:533/1480 train_time:139089ms step_avg:265.95ms
+step:534/1480 train_time:139366ms step_avg:265.97ms
+step:535/1480 train_time:139643ms step_avg:265.99ms
+step:536/1480 train_time:139919ms step_avg:266.01ms
+step:537/1480 train_time:140192ms step_avg:266.02ms
+step:538/1480 train_time:140467ms step_avg:266.04ms
+step:539/1480 train_time:140741ms step_avg:266.05ms
+step:540/1480 train_time:141015ms step_avg:266.07ms
+step:541/1480 train_time:141290ms step_avg:266.08ms
+step:542/1480 train_time:141567ms step_avg:266.10ms
+step:543/1480 train_time:141842ms step_avg:266.12ms
+step:544/1480 train_time:142114ms step_avg:266.13ms
+step:545/1480 train_time:142388ms step_avg:266.15ms
+step:546/1480 train_time:142664ms step_avg:266.16ms
+step:547/1480 train_time:142937ms step_avg:266.18ms
+step:548/1480 train_time:143210ms step_avg:266.19ms
+step:549/1480 train_time:143485ms step_avg:266.21ms
+step:550/1480 train_time:143759ms step_avg:266.22ms
+step:551/1480 train_time:144035ms step_avg:266.24ms
+step:552/1480 train_time:144310ms step_avg:266.25ms
+step:553/1480 train_time:144587ms step_avg:266.28ms
+step:554/1480 train_time:144867ms step_avg:266.30ms
+step:555/1480 train_time:145146ms step_avg:266.32ms
+step:556/1480 train_time:145427ms step_avg:266.35ms
+step:557/1480 train_time:145702ms step_avg:266.37ms
+step:558/1480 train_time:145978ms step_avg:266.38ms
+step:559/1480 train_time:146253ms step_avg:266.40ms
+step:560/1480 train_time:146531ms step_avg:266.42ms
+step:561/1480 train_time:146809ms step_avg:266.44ms
+step:562/1480 train_time:147085ms step_avg:266.46ms
+step:563/1480 train_time:147363ms step_avg:266.48ms
+step:564/1480 train_time:147640ms step_avg:266.50ms
+step:565/1480 train_time:147916ms step_avg:266.51ms
+step:566/1480 train_time:148190ms step_avg:266.53ms
+step:567/1480 train_time:148470ms step_avg:266.55ms
+step:568/1480 train_time:148745ms step_avg:266.57ms
+step:569/1480 train_time:149025ms step_avg:266.59ms
+step:570/1480 train_time:149301ms step_avg:266.61ms
+step:571/1480 train_time:149575ms step_avg:266.62ms
+step:572/1480 train_time:149850ms step_avg:266.64ms
+step:573/1480 train_time:150129ms step_avg:266.66ms
+step:574/1480 train_time:150406ms step_avg:266.68ms
+step:575/1480 train_time:150684ms step_avg:266.70ms
+step:576/1480 train_time:150964ms step_avg:266.72ms
+step:577/1480 train_time:151242ms step_avg:266.74ms
+step:578/1480 train_time:151516ms step_avg:266.75ms
+step:579/1480 train_time:151792ms step_avg:266.77ms
+step:580/1480 train_time:152068ms step_avg:266.79ms
+step:581/1480 train_time:152346ms step_avg:266.80ms
+step:582/1480 train_time:152626ms step_avg:266.83ms
+step:583/1480 train_time:152902ms step_avg:266.84ms
+step:584/1480 train_time:153173ms step_avg:266.85ms
+step:585/1480 train_time:153450ms step_avg:266.87ms
+step:586/1480 train_time:153728ms step_avg:266.89ms
+step:587/1480 train_time:154005ms step_avg:266.91ms
+step:588/1480 train_time:154287ms step_avg:266.93ms
+step:589/1480 train_time:154563ms step_avg:266.95ms
+step:590/1480 train_time:154841ms step_avg:266.97ms
+step:591/1480 train_time:155116ms step_avg:266.98ms
+step:592/1480 train_time:155392ms step_avg:267.00ms
+step:593/1480 train_time:155669ms step_avg:267.01ms
+step:594/1480 train_time:155947ms step_avg:267.03ms
+step:595/1480 train_time:156225ms step_avg:267.05ms
+step:596/1480 train_time:156500ms step_avg:267.06ms
+step:597/1480 train_time:156782ms step_avg:267.09ms
+step:598/1480 train_time:157059ms step_avg:267.11ms
+step:599/1480 train_time:157336ms step_avg:267.12ms
+step:600/1480 train_time:157612ms step_avg:267.14ms
+step:601/1480 train_time:157888ms step_avg:267.15ms
+step:602/1480 train_time:158168ms step_avg:267.18ms
+step:603/1480 train_time:158444ms step_avg:267.19ms
+step:604/1480 train_time:158719ms step_avg:267.20ms
+step:605/1480 train_time:158995ms step_avg:267.22ms
+step:606/1480 train_time:159272ms step_avg:267.24ms
+step:607/1480 train_time:159549ms step_avg:267.25ms
+step:608/1480 train_time:159829ms step_avg:267.27ms
+step:609/1480 train_time:160105ms step_avg:267.29ms
+step:610/1480 train_time:160383ms step_avg:267.30ms
+step:611/1480 train_time:160660ms step_avg:267.32ms
+step:612/1480 train_time:160942ms step_avg:267.34ms
+step:613/1480 train_time:161220ms step_avg:267.36ms
+step:614/1480 train_time:161495ms step_avg:267.38ms
+step:615/1480 train_time:161769ms step_avg:267.39ms
+step:616/1480 train_time:162047ms step_avg:267.40ms
+step:617/1480 train_time:162327ms step_avg:267.43ms
+step:618/1480 train_time:162602ms step_avg:267.44ms
+step:619/1480 train_time:162878ms step_avg:267.45ms
+step:620/1480 train_time:163157ms step_avg:267.47ms
+step:621/1480 train_time:163430ms step_avg:267.48ms
+step:622/1480 train_time:163708ms step_avg:267.50ms
+step:623/1480 train_time:163986ms step_avg:267.51ms
+step:624/1480 train_time:164263ms step_avg:267.53ms
+step:625/1480 train_time:164545ms step_avg:267.55ms
+step:625/1480 val_loss:3.6328 train_time:164680ms step_avg:267.77ms
+step:626/1480 train_time:164824ms step_avg:267.57ms
+step:627/1480 train_time:165104ms step_avg:267.59ms
+step:628/1480 train_time:165382ms step_avg:267.61ms
+step:629/1480 train_time:165659ms step_avg:267.62ms
+step:630/1480 train_time:165937ms step_avg:267.64ms
+step:631/1480 train_time:166211ms step_avg:267.65ms
+step:632/1480 train_time:166486ms step_avg:267.66ms
+step:633/1480 train_time:166764ms step_avg:267.68ms
+step:634/1480 train_time:167040ms step_avg:267.69ms
+step:635/1480 train_time:167317ms step_avg:267.71ms
+step:636/1480 train_time:167595ms step_avg:267.72ms
+step:637/1480 train_time:167869ms step_avg:267.73ms
+step:638/1480 train_time:168146ms step_avg:267.75ms
+step:639/1480 train_time:168425ms step_avg:267.77ms
+step:640/1480 train_time:168705ms step_avg:267.79ms
+step:641/1480 train_time:168985ms step_avg:267.80ms
+step:642/1480 train_time:169265ms step_avg:267.82ms
+step:643/1480 train_time:169541ms step_avg:267.84ms
+step:644/1480 train_time:169823ms step_avg:267.86ms
+step:645/1480 train_time:170104ms step_avg:267.88ms
+step:646/1480 train_time:170382ms step_avg:267.90ms
+step:647/1480 train_time:170660ms step_avg:267.91ms
+step:648/1480 train_time:170941ms step_avg:267.93ms
+step:649/1480 train_time:171224ms step_avg:267.96ms
+step:650/1480 train_time:171498ms step_avg:267.97ms
+step:651/1480 train_time:171777ms step_avg:267.98ms
+step:652/1480 train_time:172055ms step_avg:268.00ms
+step:653/1480 train_time:172331ms step_avg:268.01ms
+step:654/1480 train_time:172606ms step_avg:268.02ms
+step:655/1480 train_time:172885ms step_avg:268.04ms
+step:656/1480 train_time:173164ms step_avg:268.06ms
+step:657/1480 train_time:173443ms step_avg:268.07ms
+step:658/1480 train_time:173721ms step_avg:268.09ms
+step:659/1480 train_time:174004ms step_avg:268.11ms
+step:660/1480 train_time:174283ms step_avg:268.13ms
+step:661/1480 train_time:174568ms step_avg:268.15ms
+step:662/1480 train_time:174846ms step_avg:268.17ms
+step:663/1480 train_time:175125ms step_avg:268.19ms
+step:664/1480 train_time:175405ms step_avg:268.20ms
+step:665/1480 train_time:175684ms step_avg:268.22ms
+step:666/1480 train_time:175967ms step_avg:268.24ms
+step:667/1480 train_time:176246ms step_avg:268.26ms
+step:668/1480 train_time:176525ms step_avg:268.28ms
+step:669/1480 train_time:176806ms step_avg:268.29ms
+step:670/1480 train_time:177085ms step_avg:268.31ms
+step:671/1480 train_time:177367ms step_avg:268.33ms
+step:672/1480 train_time:177644ms step_avg:268.34ms
+step:673/1480 train_time:177924ms step_avg:268.36ms
+step:674/1480 train_time:178204ms step_avg:268.38ms
+step:675/1480 train_time:178482ms step_avg:268.39ms
+step:676/1480 train_time:178765ms step_avg:268.42ms
+step:677/1480 train_time:179045ms step_avg:268.43ms
+step:678/1480 train_time:179324ms step_avg:268.45ms
+step:679/1480 train_time:179606ms step_avg:268.47ms
+step:680/1480 train_time:179887ms step_avg:268.49ms
+step:681/1480 train_time:180168ms step_avg:268.51ms
+step:682/1480 train_time:180447ms step_avg:268.52ms
+step:683/1480 train_time:180726ms step_avg:268.54ms
+step:684/1480 train_time:181006ms step_avg:268.56ms
+step:685/1480 train_time:181285ms step_avg:268.57ms
+step:686/1480 train_time:181568ms step_avg:268.59ms
+step:687/1480 train_time:181847ms step_avg:268.61ms
+step:688/1480 train_time:182126ms step_avg:268.62ms
+step:689/1480 train_time:182406ms step_avg:268.64ms
+step:690/1480 train_time:182687ms step_avg:268.66ms
+step:691/1480 train_time:182969ms step_avg:268.68ms
+step:692/1480 train_time:183249ms step_avg:268.69ms
+step:693/1480 train_time:183527ms step_avg:268.71ms
+step:694/1480 train_time:183808ms step_avg:268.72ms
+step:695/1480 train_time:184086ms step_avg:268.74ms
+step:696/1480 train_time:184367ms step_avg:268.76ms
+step:697/1480 train_time:184644ms step_avg:268.77ms
+step:698/1480 train_time:184926ms step_avg:268.79ms
+step:699/1480 train_time:185207ms step_avg:268.81ms
+step:700/1480 train_time:185485ms step_avg:268.82ms
+step:701/1480 train_time:185767ms step_avg:268.84ms
+step:702/1480 train_time:186047ms step_avg:268.85ms
+step:703/1480 train_time:186325ms step_avg:268.87ms
+step:704/1480 train_time:186606ms step_avg:268.88ms
+step:705/1480 train_time:186885ms step_avg:268.90ms
+step:706/1480 train_time:187165ms step_avg:268.92ms
+step:707/1480 train_time:187444ms step_avg:268.93ms
+step:708/1480 train_time:187725ms step_avg:268.95ms
+step:709/1480 train_time:188005ms step_avg:268.96ms
+step:710/1480 train_time:188284ms step_avg:268.98ms
+step:711/1480 train_time:188565ms step_avg:268.99ms
+step:712/1480 train_time:188846ms step_avg:269.01ms
+step:713/1480 train_time:189125ms step_avg:269.03ms
+step:714/1480 train_time:189404ms step_avg:269.04ms
+step:715/1480 train_time:189685ms step_avg:269.06ms
+step:716/1480 train_time:189968ms step_avg:269.08ms
+step:717/1480 train_time:190245ms step_avg:269.09ms
+step:718/1480 train_time:190522ms step_avg:269.10ms
+step:719/1480 train_time:190803ms step_avg:269.12ms
+step:720/1480 train_time:191085ms step_avg:269.13ms
+step:721/1480 train_time:191365ms step_avg:269.15ms
+step:722/1480 train_time:191644ms step_avg:269.16ms
+step:723/1480 train_time:191924ms step_avg:269.18ms
+step:724/1480 train_time:192203ms step_avg:269.19ms
+step:725/1480 train_time:192485ms step_avg:269.21ms
+step:726/1480 train_time:192767ms step_avg:269.23ms
+step:727/1480 train_time:193045ms step_avg:269.24ms
+step:728/1480 train_time:193323ms step_avg:269.25ms
+step:729/1480 train_time:193604ms step_avg:269.27ms
+step:730/1480 train_time:193883ms step_avg:269.28ms
+step:731/1480 train_time:194167ms step_avg:269.30ms
+step:732/1480 train_time:194445ms step_avg:269.31ms
+step:733/1480 train_time:194727ms step_avg:269.33ms
+step:734/1480 train_time:195005ms step_avg:269.34ms
+step:735/1480 train_time:195286ms step_avg:269.36ms
+step:736/1480 train_time:195568ms step_avg:269.38ms
+step:737/1480 train_time:195846ms step_avg:269.39ms
+step:738/1480 train_time:196126ms step_avg:269.40ms
+step:739/1480 train_time:196408ms step_avg:269.42ms
+step:740/1480 train_time:196685ms step_avg:269.43ms
+step:741/1480 train_time:196967ms step_avg:269.45ms
+step:742/1480 train_time:197245ms step_avg:269.46ms
+step:743/1480 train_time:197524ms step_avg:269.47ms
+step:744/1480 train_time:197804ms step_avg:269.49ms
+step:745/1480 train_time:198086ms step_avg:269.50ms
+step:746/1480 train_time:198368ms step_avg:269.52ms
+step:747/1480 train_time:198645ms step_avg:269.53ms
+step:748/1480 train_time:198925ms step_avg:269.55ms
+step:749/1480 train_time:199204ms step_avg:269.56ms
+step:750/1480 train_time:199483ms step_avg:269.57ms
+step:750/1480 val_loss:3.5784 train_time:199620ms step_avg:269.76ms
+step:751/1480 train_time:199766ms step_avg:269.59ms
+step:752/1480 train_time:200045ms step_avg:269.60ms
+step:753/1480 train_time:200324ms step_avg:269.62ms
+step:754/1480 train_time:200606ms step_avg:269.63ms
+step:755/1480 train_time:200885ms step_avg:269.64ms
+step:756/1480 train_time:201166ms step_avg:269.66ms
+step:757/1480 train_time:201444ms step_avg:269.67ms
+step:758/1480 train_time:201726ms step_avg:269.69ms
+step:759/1480 train_time:202005ms step_avg:269.70ms
+step:760/1480 train_time:202284ms step_avg:269.71ms
+step:761/1480 train_time:202565ms step_avg:269.73ms
+step:762/1480 train_time:202845ms step_avg:269.74ms
+step:763/1480 train_time:203126ms step_avg:269.76ms
+step:764/1480 train_time:203406ms step_avg:269.77ms
+step:765/1480 train_time:203684ms step_avg:269.78ms
+step:766/1480 train_time:203967ms step_avg:269.80ms
+step:767/1480 train_time:204245ms step_avg:269.81ms
+step:768/1480 train_time:204522ms step_avg:269.82ms
+step:769/1480 train_time:204804ms step_avg:269.83ms
+step:770/1480 train_time:205084ms step_avg:269.85ms
+step:771/1480 train_time:205366ms step_avg:269.86ms
+step:772/1480 train_time:205648ms step_avg:269.88ms
+step:773/1480 train_time:205927ms step_avg:269.89ms
+step:774/1480 train_time:206208ms step_avg:269.91ms
+step:775/1480 train_time:206487ms step_avg:269.92ms
+step:776/1480 train_time:206766ms step_avg:269.93ms
+step:777/1480 train_time:207048ms step_avg:269.95ms
+step:778/1480 train_time:207328ms step_avg:269.96ms
+step:779/1480 train_time:207607ms step_avg:269.97ms
+step:780/1480 train_time:207886ms step_avg:269.98ms
+step:781/1480 train_time:208167ms step_avg:270.00ms
+step:782/1480 train_time:208450ms step_avg:270.01ms
+step:783/1480 train_time:208735ms step_avg:270.03ms
+step:784/1480 train_time:209015ms step_avg:270.05ms
+step:785/1480 train_time:209301ms step_avg:270.07ms
+step:786/1480 train_time:209583ms step_avg:270.08ms
+step:787/1480 train_time:209867ms step_avg:270.10ms
+step:788/1480 train_time:210149ms step_avg:270.11ms
+step:789/1480 train_time:210428ms step_avg:270.13ms
+step:790/1480 train_time:210707ms step_avg:270.14ms
+step:791/1480 train_time:210986ms step_avg:270.15ms
+step:792/1480 train_time:211267ms step_avg:270.16ms
+step:793/1480 train_time:211545ms step_avg:270.17ms
+step:794/1480 train_time:211828ms step_avg:270.19ms
+step:795/1480 train_time:212111ms step_avg:270.20ms
+step:796/1480 train_time:212392ms step_avg:270.22ms
+step:797/1480 train_time:212678ms step_avg:270.24ms
+step:798/1480 train_time:212962ms step_avg:270.26ms
+step:799/1480 train_time:213242ms step_avg:270.27ms
+step:800/1480 train_time:213524ms step_avg:270.28ms
+step:801/1480 train_time:213805ms step_avg:270.30ms
+step:802/1480 train_time:214085ms step_avg:270.31ms
+step:803/1480 train_time:214370ms step_avg:270.33ms
+step:804/1480 train_time:214651ms step_avg:270.34ms
+step:805/1480 train_time:214928ms step_avg:270.35ms
+step:806/1480 train_time:215209ms step_avg:270.36ms
+step:807/1480 train_time:215494ms step_avg:270.38ms
+step:808/1480 train_time:215774ms step_avg:270.39ms
+step:809/1480 train_time:216058ms step_avg:270.41ms
+step:810/1480 train_time:216342ms step_avg:270.43ms
+step:811/1480 train_time:216624ms step_avg:270.44ms
+step:812/1480 train_time:216906ms step_avg:270.46ms
+step:813/1480 train_time:217189ms step_avg:270.47ms
+step:814/1480 train_time:217466ms step_avg:270.48ms
+step:815/1480 train_time:217754ms step_avg:270.50ms
+step:816/1480 train_time:218039ms step_avg:270.52ms
+step:817/1480 train_time:218318ms step_avg:270.53ms
+step:818/1480 train_time:218604ms step_avg:270.55ms
+step:819/1480 train_time:218885ms step_avg:270.56ms
+step:820/1480 train_time:219163ms step_avg:270.57ms
+step:821/1480 train_time:219443ms step_avg:270.58ms
+step:822/1480 train_time:219725ms step_avg:270.60ms
+step:823/1480 train_time:220006ms step_avg:270.61ms
+step:824/1480 train_time:220287ms step_avg:270.62ms
+step:825/1480 train_time:220567ms step_avg:270.63ms
+step:826/1480 train_time:220846ms step_avg:270.64ms
+step:827/1480 train_time:221125ms step_avg:270.66ms
+step:828/1480 train_time:221406ms step_avg:270.67ms
+step:829/1480 train_time:221688ms step_avg:270.68ms
+step:830/1480 train_time:221967ms step_avg:270.69ms
+step:831/1480 train_time:222247ms step_avg:270.70ms
+step:832/1480 train_time:222527ms step_avg:270.71ms
+step:833/1480 train_time:222807ms step_avg:270.73ms
+step:834/1480 train_time:223087ms step_avg:270.74ms
+step:835/1480 train_time:223373ms step_avg:270.76ms
+step:836/1480 train_time:223659ms step_avg:270.77ms
+step:837/1480 train_time:223943ms step_avg:270.79ms
+step:838/1480 train_time:224223ms step_avg:270.80ms
+step:839/1480 train_time:224506ms step_avg:270.82ms
+step:840/1480 train_time:224785ms step_avg:270.83ms
+step:841/1480 train_time:225066ms step_avg:270.84ms
+step:842/1480 train_time:225347ms step_avg:270.85ms
+step:843/1480 train_time:225627ms step_avg:270.86ms
+step:844/1480 train_time:225909ms step_avg:270.87ms
+step:845/1480 train_time:226189ms step_avg:270.89ms
+step:846/1480 train_time:226470ms step_avg:270.90ms
+step:847/1480 train_time:226747ms step_avg:270.90ms
+step:848/1480 train_time:227027ms step_avg:270.92ms
+step:849/1480 train_time:227308ms step_avg:270.93ms
+step:850/1480 train_time:227587ms step_avg:270.94ms
+step:851/1480 train_time:227872ms step_avg:270.95ms
+step:852/1480 train_time:228153ms step_avg:270.97ms
+step:853/1480 train_time:228440ms step_avg:270.98ms
+step:854/1480 train_time:228724ms step_avg:271.00ms
+step:855/1480 train_time:229006ms step_avg:271.01ms
+step:856/1480 train_time:229285ms step_avg:271.02ms
+step:857/1480 train_time:229567ms step_avg:271.04ms
+step:858/1480 train_time:229850ms step_avg:271.05ms
+step:859/1480 train_time:230130ms step_avg:271.06ms
+step:860/1480 train_time:230409ms step_avg:271.07ms
+step:861/1480 train_time:230688ms step_avg:271.08ms
+step:862/1480 train_time:230967ms step_avg:271.09ms
+step:863/1480 train_time:231247ms step_avg:271.10ms
+step:864/1480 train_time:231528ms step_avg:271.11ms
+step:865/1480 train_time:231807ms step_avg:271.12ms
+step:866/1480 train_time:232088ms step_avg:271.13ms
+step:867/1480 train_time:232367ms step_avg:271.14ms
+step:868/1480 train_time:232648ms step_avg:271.15ms
+step:869/1480 train_time:232927ms step_avg:271.16ms
+step:870/1480 train_time:233207ms step_avg:271.17ms
+step:871/1480 train_time:233489ms step_avg:271.18ms
+step:872/1480 train_time:233766ms step_avg:271.19ms
+step:873/1480 train_time:234045ms step_avg:271.20ms
+step:874/1480 train_time:234328ms step_avg:271.21ms
+step:875/1480 train_time:234608ms step_avg:271.22ms
+step:875/1480 val_loss:3.5303 train_time:234743ms step_avg:271.38ms
+step:876/1480 train_time:234888ms step_avg:271.23ms
+step:877/1480 train_time:235169ms step_avg:271.24ms
+step:878/1480 train_time:235453ms step_avg:271.26ms
+step:879/1480 train_time:235732ms step_avg:271.27ms
+step:880/1480 train_time:236013ms step_avg:271.28ms
+step:881/1480 train_time:236304ms step_avg:271.30ms
+step:882/1480 train_time:236586ms step_avg:271.31ms
+step:883/1480 train_time:236869ms step_avg:271.33ms
+step:884/1480 train_time:237151ms step_avg:271.34ms
+step:885/1480 train_time:237438ms step_avg:271.36ms
+step:886/1480 train_time:237724ms step_avg:271.37ms
+step:887/1480 train_time:238005ms step_avg:271.39ms
+step:888/1480 train_time:238289ms step_avg:271.40ms
+step:889/1480 train_time:238571ms step_avg:271.41ms
+step:890/1480 train_time:238856ms step_avg:271.43ms
+step:891/1480 train_time:239135ms step_avg:271.44ms
+step:892/1480 train_time:239428ms step_avg:271.46ms
+step:893/1480 train_time:239724ms step_avg:271.49ms
+step:894/1480 train_time:240005ms step_avg:271.50ms
+step:895/1480 train_time:240285ms step_avg:271.51ms
+step:896/1480 train_time:240565ms step_avg:271.52ms
+step:897/1480 train_time:240847ms step_avg:271.53ms
+step:898/1480 train_time:241128ms step_avg:271.54ms
+step:899/1480 train_time:241412ms step_avg:271.55ms
+step:900/1480 train_time:241697ms step_avg:271.57ms
+step:901/1480 train_time:241979ms step_avg:271.58ms
+step:902/1480 train_time:242260ms step_avg:271.59ms
+step:903/1480 train_time:242549ms step_avg:271.61ms
+step:904/1480 train_time:242836ms step_avg:271.63ms
+step:905/1480 train_time:243125ms step_avg:271.65ms
+step:906/1480 train_time:243409ms step_avg:271.66ms
+step:907/1480 train_time:243692ms step_avg:271.67ms
+step:908/1480 train_time:243974ms step_avg:271.69ms
+step:909/1480 train_time:244264ms step_avg:271.71ms
+step:910/1480 train_time:244545ms step_avg:271.72ms
+step:911/1480 train_time:244827ms step_avg:271.73ms
+step:912/1480 train_time:245109ms step_avg:271.74ms
+step:913/1480 train_time:245397ms step_avg:271.76ms
+step:914/1480 train_time:245683ms step_avg:271.77ms
+step:915/1480 train_time:245968ms step_avg:271.79ms
+step:916/1480 train_time:246251ms step_avg:271.80ms
+step:917/1480 train_time:246541ms step_avg:271.82ms
+step:918/1480 train_time:246827ms step_avg:271.84ms
+step:919/1480 train_time:247110ms step_avg:271.85ms
+step:920/1480 train_time:247392ms step_avg:271.86ms
+step:921/1480 train_time:247673ms step_avg:271.87ms
+step:922/1480 train_time:247961ms step_avg:271.89ms
+step:923/1480 train_time:248244ms step_avg:271.90ms
+step:924/1480 train_time:248528ms step_avg:271.91ms
+step:925/1480 train_time:248811ms step_avg:271.92ms
+step:926/1480 train_time:249089ms step_avg:271.93ms
+step:927/1480 train_time:249369ms step_avg:271.94ms
+step:928/1480 train_time:249658ms step_avg:271.96ms
+step:929/1480 train_time:249949ms step_avg:271.98ms
+step:930/1480 train_time:250230ms step_avg:271.99ms
+step:931/1480 train_time:250510ms step_avg:272.00ms
+step:932/1480 train_time:250798ms step_avg:272.02ms
+step:933/1480 train_time:251083ms step_avg:272.03ms
+step:934/1480 train_time:251367ms step_avg:272.04ms
+step:935/1480 train_time:251649ms step_avg:272.05ms
+step:936/1480 train_time:251931ms step_avg:272.06ms
+step:937/1480 train_time:252212ms step_avg:272.07ms
+step:938/1480 train_time:252491ms step_avg:272.08ms
+step:939/1480 train_time:252780ms step_avg:272.10ms
+step:940/1480 train_time:253066ms step_avg:272.11ms
+step:941/1480 train_time:253349ms step_avg:272.13ms
+step:942/1480 train_time:253628ms step_avg:272.13ms
+step:943/1480 train_time:253910ms step_avg:272.14ms
+step:944/1480 train_time:254190ms step_avg:272.15ms
+step:945/1480 train_time:254475ms step_avg:272.17ms
+step:946/1480 train_time:254764ms step_avg:272.18ms
+step:947/1480 train_time:255048ms step_avg:272.20ms
+step:948/1480 train_time:255330ms step_avg:272.21ms
+step:949/1480 train_time:255613ms step_avg:272.22ms
+step:950/1480 train_time:255900ms step_avg:272.23ms
+step:951/1480 train_time:256188ms step_avg:272.25ms
+step:952/1480 train_time:256469ms step_avg:272.26ms
+step:953/1480 train_time:256750ms step_avg:272.27ms
+step:954/1480 train_time:257036ms step_avg:272.28ms
+step:955/1480 train_time:257318ms step_avg:272.29ms
+step:956/1480 train_time:257601ms step_avg:272.31ms
+step:957/1480 train_time:257885ms step_avg:272.32ms
+step:958/1480 train_time:258167ms step_avg:272.33ms
+step:959/1480 train_time:258453ms step_avg:272.34ms
+step:960/1480 train_time:258737ms step_avg:272.35ms
+step:961/1480 train_time:259023ms step_avg:272.37ms
+step:962/1480 train_time:259306ms step_avg:272.38ms
+step:963/1480 train_time:259587ms step_avg:272.39ms
+step:964/1480 train_time:259867ms step_avg:272.40ms
+step:965/1480 train_time:260149ms step_avg:272.41ms
+step:966/1480 train_time:260434ms step_avg:272.42ms
+step:967/1480 train_time:260720ms step_avg:272.43ms
+step:968/1480 train_time:261003ms step_avg:272.45ms
+step:969/1480 train_time:261288ms step_avg:272.46ms
+step:970/1480 train_time:261567ms step_avg:272.47ms
+step:971/1480 train_time:261847ms step_avg:272.47ms
+step:972/1480 train_time:262129ms step_avg:272.48ms
+step:973/1480 train_time:262409ms step_avg:272.49ms
+step:974/1480 train_time:262690ms step_avg:272.50ms
+step:975/1480 train_time:262977ms step_avg:272.51ms
+step:976/1480 train_time:263265ms step_avg:272.53ms
+step:977/1480 train_time:263548ms step_avg:272.54ms
+step:978/1480 train_time:263839ms step_avg:272.56ms
+step:979/1480 train_time:264126ms step_avg:272.58ms
+step:980/1480 train_time:264409ms step_avg:272.59ms
+step:981/1480 train_time:264689ms step_avg:272.59ms
+step:982/1480 train_time:264971ms step_avg:272.60ms
+step:983/1480 train_time:265252ms step_avg:272.61ms
+step:984/1480 train_time:265534ms step_avg:272.62ms
+step:985/1480 train_time:265823ms step_avg:272.64ms
+step:986/1480 train_time:266107ms step_avg:272.65ms
+step:987/1480 train_time:266388ms step_avg:272.66ms
+step:988/1480 train_time:266672ms step_avg:272.67ms
+step:989/1480 train_time:266965ms step_avg:272.69ms
+step:990/1480 train_time:267251ms step_avg:272.71ms
+step:991/1480 train_time:267542ms step_avg:272.72ms
+step:992/1480 train_time:267829ms step_avg:272.74ms
+step:993/1480 train_time:268115ms step_avg:272.75ms
+step:994/1480 train_time:268400ms step_avg:272.76ms
+step:995/1480 train_time:268683ms step_avg:272.78ms
+step:996/1480 train_time:268967ms step_avg:272.79ms
+step:997/1480 train_time:269250ms step_avg:272.80ms
+step:998/1480 train_time:269536ms step_avg:272.81ms
+step:999/1480 train_time:269827ms step_avg:272.83ms
+step:1000/1480 train_time:270116ms step_avg:272.84ms
+step:1000/1480 val_loss:3.4681 train_time:270262ms step_avg:272.99ms
+step:1001/1480 train_time:270408ms step_avg:272.86ms
+step:1002/1480 train_time:270703ms step_avg:272.89ms
+step:1003/1480 train_time:270993ms step_avg:272.90ms
+step:1004/1480 train_time:271274ms step_avg:272.91ms
+step:1005/1480 train_time:271561ms step_avg:272.93ms
+step:1006/1480 train_time:271844ms step_avg:272.94ms
+step:1007/1480 train_time:272130ms step_avg:272.95ms
+step:1008/1480 train_time:272411ms step_avg:272.96ms
+step:1009/1480 train_time:272693ms step_avg:272.97ms
+step:1010/1480 train_time:272975ms step_avg:272.97ms
+step:1011/1480 train_time:273260ms step_avg:272.99ms
+step:1012/1480 train_time:273546ms step_avg:273.00ms
+step:1013/1480 train_time:273837ms step_avg:273.02ms
+step:1014/1480 train_time:274125ms step_avg:273.03ms
+step:1015/1480 train_time:274409ms step_avg:273.04ms
+step:1016/1480 train_time:274693ms step_avg:273.05ms
+step:1017/1480 train_time:274985ms step_avg:273.07ms
+step:1018/1480 train_time:275276ms step_avg:273.09ms
+step:1019/1480 train_time:275561ms step_avg:273.10ms
+step:1020/1480 train_time:275844ms step_avg:273.11ms
+step:1021/1480 train_time:276130ms step_avg:273.13ms
+step:1022/1480 train_time:276412ms step_avg:273.13ms
+step:1023/1480 train_time:276697ms step_avg:273.15ms
+step:1024/1480 train_time:276985ms step_avg:273.16ms
+step:1025/1480 train_time:277270ms step_avg:273.17ms
+step:1026/1480 train_time:277548ms step_avg:273.18ms
+step:1027/1480 train_time:277832ms step_avg:273.19ms
+step:1028/1480 train_time:278122ms step_avg:273.20ms
+step:1029/1480 train_time:278409ms step_avg:273.22ms
+step:1030/1480 train_time:278692ms step_avg:273.23ms
+step:1031/1480 train_time:278987ms step_avg:273.25ms
+step:1032/1480 train_time:279268ms step_avg:273.26ms
+step:1033/1480 train_time:279557ms step_avg:273.27ms
+step:1034/1480 train_time:279844ms step_avg:273.29ms
+step:1035/1480 train_time:280129ms step_avg:273.30ms
+step:1036/1480 train_time:280416ms step_avg:273.31ms
+step:1037/1480 train_time:280705ms step_avg:273.32ms
+step:1038/1480 train_time:280990ms step_avg:273.34ms
+step:1039/1480 train_time:281273ms step_avg:273.35ms
+step:1040/1480 train_time:281558ms step_avg:273.36ms
+step:1041/1480 train_time:281850ms step_avg:273.37ms
+step:1042/1480 train_time:282131ms step_avg:273.38ms
+step:1043/1480 train_time:282423ms step_avg:273.40ms
+step:1044/1480 train_time:282709ms step_avg:273.41ms
+step:1045/1480 train_time:282991ms step_avg:273.42ms
+step:1046/1480 train_time:283280ms step_avg:273.44ms
+step:1047/1480 train_time:283566ms step_avg:273.45ms
+step:1048/1480 train_time:283849ms step_avg:273.46ms
+step:1049/1480 train_time:284136ms step_avg:273.47ms
+step:1050/1480 train_time:284426ms step_avg:273.49ms
+step:1051/1480 train_time:284711ms step_avg:273.50ms
+step:1052/1480 train_time:284996ms step_avg:273.51ms
+step:1053/1480 train_time:285285ms step_avg:273.52ms
+step:1054/1480 train_time:285567ms step_avg:273.53ms
+step:1055/1480 train_time:285852ms step_avg:273.54ms
+step:1056/1480 train_time:286149ms step_avg:273.56ms
+step:1057/1480 train_time:286435ms step_avg:273.58ms
+step:1058/1480 train_time:286718ms step_avg:273.59ms
+step:1059/1480 train_time:287005ms step_avg:273.60ms
+step:1060/1480 train_time:287286ms step_avg:273.61ms
+step:1061/1480 train_time:287570ms step_avg:273.62ms
+step:1062/1480 train_time:287855ms step_avg:273.63ms
+step:1063/1480 train_time:288137ms step_avg:273.63ms
+step:1064/1480 train_time:288424ms step_avg:273.65ms
+step:1065/1480 train_time:288705ms step_avg:273.65ms
+step:1066/1480 train_time:288989ms step_avg:273.66ms
+step:1067/1480 train_time:289273ms step_avg:273.67ms
+step:1068/1480 train_time:289558ms step_avg:273.68ms
+step:1069/1480 train_time:289843ms step_avg:273.69ms
+step:1070/1480 train_time:290129ms step_avg:273.71ms
+step:1071/1480 train_time:290412ms step_avg:273.71ms
+step:1072/1480 train_time:290692ms step_avg:273.72ms
+step:1073/1480 train_time:290980ms step_avg:273.73ms
+step:1074/1480 train_time:291270ms step_avg:273.75ms
+step:1075/1480 train_time:291561ms step_avg:273.77ms
+step:1076/1480 train_time:291846ms step_avg:273.78ms
+step:1077/1480 train_time:292134ms step_avg:273.79ms
+step:1078/1480 train_time:292420ms step_avg:273.80ms
+step:1079/1480 train_time:292700ms step_avg:273.81ms
+step:1080/1480 train_time:292991ms step_avg:273.82ms
+step:1081/1480 train_time:293272ms step_avg:273.83ms
+step:1082/1480 train_time:293558ms step_avg:273.84ms
+step:1083/1480 train_time:293847ms step_avg:273.86ms
+step:1084/1480 train_time:294130ms step_avg:273.86ms
+step:1085/1480 train_time:294416ms step_avg:273.88ms
+step:1086/1480 train_time:294701ms step_avg:273.89ms
+step:1087/1480 train_time:294992ms step_avg:273.90ms
+step:1088/1480 train_time:295270ms step_avg:273.91ms
+step:1089/1480 train_time:295557ms step_avg:273.92ms
+step:1090/1480 train_time:295843ms step_avg:273.93ms
+step:1091/1480 train_time:296132ms step_avg:273.94ms
+step:1092/1480 train_time:296414ms step_avg:273.95ms
+step:1093/1480 train_time:296699ms step_avg:273.96ms
+step:1094/1480 train_time:296984ms step_avg:273.97ms
+step:1095/1480 train_time:297271ms step_avg:273.98ms
+step:1096/1480 train_time:297569ms step_avg:274.00ms
+step:1097/1480 train_time:297851ms step_avg:274.01ms
+step:1098/1480 train_time:298151ms step_avg:274.04ms
+step:1099/1480 train_time:298443ms step_avg:274.05ms
+step:1100/1480 train_time:298730ms step_avg:274.06ms
+step:1101/1480 train_time:299015ms step_avg:274.07ms
+step:1102/1480 train_time:299315ms step_avg:274.10ms
+step:1103/1480 train_time:299608ms step_avg:274.11ms
+step:1104/1480 train_time:299900ms step_avg:274.13ms
+step:1105/1480 train_time:300186ms step_avg:274.14ms
+step:1106/1480 train_time:300469ms step_avg:274.15ms
+step:1107/1480 train_time:300753ms step_avg:274.16ms
+step:1108/1480 train_time:301035ms step_avg:274.17ms
+step:1109/1480 train_time:301328ms step_avg:274.18ms
+step:1110/1480 train_time:301617ms step_avg:274.20ms
+step:1111/1480 train_time:301910ms step_avg:274.21ms
+step:1112/1480 train_time:302194ms step_avg:274.22ms
+step:1113/1480 train_time:302482ms step_avg:274.24ms
+step:1114/1480 train_time:302771ms step_avg:274.25ms
+step:1115/1480 train_time:303063ms step_avg:274.27ms
+step:1116/1480 train_time:303348ms step_avg:274.28ms
+step:1117/1480 train_time:303642ms step_avg:274.29ms
+step:1118/1480 train_time:303930ms step_avg:274.30ms
+step:1119/1480 train_time:304229ms step_avg:274.33ms
+step:1120/1480 train_time:304510ms step_avg:274.33ms
+step:1121/1480 train_time:304793ms step_avg:274.34ms
+step:1122/1480 train_time:305078ms step_avg:274.35ms
+step:1123/1480 train_time:305365ms step_avg:274.36ms
+step:1124/1480 train_time:305660ms step_avg:274.38ms
+step:1125/1480 train_time:305944ms step_avg:274.39ms
+step:1125/1480 val_loss:3.4110 train_time:306089ms step_avg:274.52ms
+step:1126/1480 train_time:306240ms step_avg:274.41ms
+step:1127/1480 train_time:306528ms step_avg:274.42ms
+step:1128/1480 train_time:306809ms step_avg:274.43ms
+step:1129/1480 train_time:307099ms step_avg:274.44ms
+step:1130/1480 train_time:307388ms step_avg:274.45ms
+step:1131/1480 train_time:307676ms step_avg:274.47ms
+step:1132/1480 train_time:307966ms step_avg:274.48ms
+step:1133/1480 train_time:308248ms step_avg:274.49ms
+step:1134/1480 train_time:308528ms step_avg:274.49ms
+step:1135/1480 train_time:308825ms step_avg:274.51ms
+step:1136/1480 train_time:309107ms step_avg:274.52ms
+step:1137/1480 train_time:309391ms step_avg:274.53ms
+step:1138/1480 train_time:309687ms step_avg:274.55ms
+step:1139/1480 train_time:309978ms step_avg:274.56ms
+step:1140/1480 train_time:310263ms step_avg:274.57ms
+step:1141/1480 train_time:310548ms step_avg:274.58ms
+step:1142/1480 train_time:310831ms step_avg:274.59ms
+step:1143/1480 train_time:311120ms step_avg:274.60ms
+step:1144/1480 train_time:311403ms step_avg:274.61ms
+step:1145/1480 train_time:311688ms step_avg:274.61ms
+step:1146/1480 train_time:311978ms step_avg:274.63ms
+step:1147/1480 train_time:312263ms step_avg:274.64ms
+step:1148/1480 train_time:312549ms step_avg:274.65ms
+step:1149/1480 train_time:312835ms step_avg:274.66ms
+step:1150/1480 train_time:313122ms step_avg:274.67ms
+step:1151/1480 train_time:313410ms step_avg:274.68ms
+step:1152/1480 train_time:313689ms step_avg:274.68ms
+step:1153/1480 train_time:313978ms step_avg:274.70ms
+step:1154/1480 train_time:314263ms step_avg:274.71ms
+step:1155/1480 train_time:314563ms step_avg:274.73ms
+step:1156/1480 train_time:314853ms step_avg:274.74ms
+step:1157/1480 train_time:315143ms step_avg:274.75ms
+step:1158/1480 train_time:315430ms step_avg:274.77ms
+step:1159/1480 train_time:315717ms step_avg:274.78ms
+step:1160/1480 train_time:316002ms step_avg:274.78ms
+step:1161/1480 train_time:316288ms step_avg:274.79ms
+step:1162/1480 train_time:316581ms step_avg:274.81ms
+step:1163/1480 train_time:316871ms step_avg:274.82ms
+step:1164/1480 train_time:317154ms step_avg:274.83ms
+step:1165/1480 train_time:317438ms step_avg:274.84ms
+step:1166/1480 train_time:317728ms step_avg:274.85ms
+step:1167/1480 train_time:318016ms step_avg:274.86ms
+step:1168/1480 train_time:318302ms step_avg:274.87ms
+step:1169/1480 train_time:318591ms step_avg:274.88ms
+step:1170/1480 train_time:318878ms step_avg:274.89ms
+step:1171/1480 train_time:319165ms step_avg:274.90ms
+step:1172/1480 train_time:319447ms step_avg:274.91ms
+step:1173/1480 train_time:319730ms step_avg:274.92ms
+step:1174/1480 train_time:320024ms step_avg:274.93ms
+step:1175/1480 train_time:320306ms step_avg:274.94ms
+step:1176/1480 train_time:320587ms step_avg:274.95ms
+step:1177/1480 train_time:320878ms step_avg:274.96ms
+step:1178/1480 train_time:321163ms step_avg:274.97ms
+step:1179/1480 train_time:321450ms step_avg:274.98ms
+step:1180/1480 train_time:321746ms step_avg:275.00ms
+step:1181/1480 train_time:322032ms step_avg:275.01ms
+step:1182/1480 train_time:322319ms step_avg:275.02ms
+step:1183/1480 train_time:322605ms step_avg:275.03ms
+step:1184/1480 train_time:322891ms step_avg:275.04ms
+step:1185/1480 train_time:323175ms step_avg:275.04ms
+step:1186/1480 train_time:323464ms step_avg:275.05ms
+step:1187/1480 train_time:323753ms step_avg:275.07ms
+step:1188/1480 train_time:324040ms step_avg:275.08ms
+step:1189/1480 train_time:324339ms step_avg:275.10ms
+step:1190/1480 train_time:324627ms step_avg:275.11ms
+step:1191/1480 train_time:324912ms step_avg:275.12ms
+step:1192/1480 train_time:325198ms step_avg:275.13ms
+step:1193/1480 train_time:325485ms step_avg:275.13ms
+step:1194/1480 train_time:325769ms step_avg:275.14ms
+step:1195/1480 train_time:326052ms step_avg:275.15ms
+step:1196/1480 train_time:326340ms step_avg:275.16ms
+step:1197/1480 train_time:326627ms step_avg:275.17ms
+step:1198/1480 train_time:326921ms step_avg:275.19ms
+step:1199/1480 train_time:327207ms step_avg:275.20ms
+step:1200/1480 train_time:327490ms step_avg:275.20ms
+step:1201/1480 train_time:327780ms step_avg:275.21ms
+step:1202/1480 train_time:328071ms step_avg:275.23ms
+step:1203/1480 train_time:328362ms step_avg:275.24ms
+step:1204/1480 train_time:328648ms step_avg:275.25ms
+step:1205/1480 train_time:328930ms step_avg:275.26ms
+step:1206/1480 train_time:329226ms step_avg:275.27ms
+step:1207/1480 train_time:329509ms step_avg:275.28ms
+step:1208/1480 train_time:329797ms step_avg:275.29ms
+step:1209/1480 train_time:330087ms step_avg:275.30ms
+step:1210/1480 train_time:330374ms step_avg:275.31ms
+step:1211/1480 train_time:330660ms step_avg:275.32ms
+step:1212/1480 train_time:330951ms step_avg:275.33ms
+step:1213/1480 train_time:331237ms step_avg:275.34ms
+step:1214/1480 train_time:331528ms step_avg:275.36ms
+step:1215/1480 train_time:331814ms step_avg:275.36ms
+step:1216/1480 train_time:332099ms step_avg:275.37ms
+step:1217/1480 train_time:332388ms step_avg:275.38ms
+step:1218/1480 train_time:332683ms step_avg:275.40ms
+step:1219/1480 train_time:332968ms step_avg:275.41ms
+step:1220/1480 train_time:333265ms step_avg:275.43ms
+step:1221/1480 train_time:333548ms step_avg:275.43ms
+step:1222/1480 train_time:333844ms step_avg:275.45ms
+step:1223/1480 train_time:334128ms step_avg:275.46ms
+step:1224/1480 train_time:334425ms step_avg:275.47ms
+step:1225/1480 train_time:334725ms step_avg:275.49ms
+step:1226/1480 train_time:335010ms step_avg:275.50ms
+step:1227/1480 train_time:335302ms step_avg:275.52ms
+step:1228/1480 train_time:335587ms step_avg:275.52ms
+step:1229/1480 train_time:335895ms step_avg:275.55ms
+step:1230/1480 train_time:336186ms step_avg:275.56ms
+step:1231/1480 train_time:336470ms step_avg:275.57ms
+step:1232/1480 train_time:336760ms step_avg:275.58ms
+step:1233/1480 train_time:337052ms step_avg:275.59ms
+step:1234/1480 train_time:337342ms step_avg:275.61ms
+step:1235/1480 train_time:337627ms step_avg:275.61ms
+step:1236/1480 train_time:337925ms step_avg:275.63ms
+step:1237/1480 train_time:338209ms step_avg:275.64ms
+step:1238/1480 train_time:338497ms step_avg:275.65ms
+step:1239/1480 train_time:338787ms step_avg:275.66ms
+step:1240/1480 train_time:339077ms step_avg:275.67ms
+step:1241/1480 train_time:339366ms step_avg:275.68ms
+step:1242/1480 train_time:339651ms step_avg:275.69ms
+step:1243/1480 train_time:339935ms step_avg:275.70ms
+step:1244/1480 train_time:340225ms step_avg:275.71ms
+step:1245/1480 train_time:340519ms step_avg:275.72ms
+step:1246/1480 train_time:340804ms step_avg:275.73ms
+step:1247/1480 train_time:341090ms step_avg:275.74ms
+step:1248/1480 train_time:341379ms step_avg:275.75ms
+step:1249/1480 train_time:341665ms step_avg:275.76ms
+step:1250/1480 train_time:341952ms step_avg:275.77ms
+step:1250/1480 val_loss:3.3610 train_time:342096ms step_avg:275.88ms
+step:1251/1480 train_time:342247ms step_avg:275.78ms
+step:1252/1480 train_time:342534ms step_avg:275.79ms
+step:1253/1480 train_time:342829ms step_avg:275.81ms
+step:1254/1480 train_time:343118ms step_avg:275.82ms
+step:1255/1480 train_time:343403ms step_avg:275.83ms
+step:1256/1480 train_time:343693ms step_avg:275.84ms
+step:1257/1480 train_time:343987ms step_avg:275.85ms
+step:1258/1480 train_time:344271ms step_avg:275.86ms
+step:1259/1480 train_time:344558ms step_avg:275.87ms
+step:1260/1480 train_time:344851ms step_avg:275.88ms
+step:1261/1480 train_time:345142ms step_avg:275.89ms
+step:1262/1480 train_time:345429ms step_avg:275.90ms
+step:1263/1480 train_time:345724ms step_avg:275.92ms
+step:1264/1480 train_time:346011ms step_avg:275.93ms
+step:1265/1480 train_time:346292ms step_avg:275.93ms
+step:1266/1480 train_time:346583ms step_avg:275.94ms
+step:1267/1480 train_time:346870ms step_avg:275.95ms
+step:1268/1480 train_time:347157ms step_avg:275.96ms
+step:1269/1480 train_time:347454ms step_avg:275.98ms
+step:1270/1480 train_time:347749ms step_avg:275.99ms
+step:1271/1480 train_time:348033ms step_avg:276.00ms
+step:1272/1480 train_time:348327ms step_avg:276.01ms
+step:1273/1480 train_time:348613ms step_avg:276.02ms
+step:1274/1480 train_time:348908ms step_avg:276.03ms
+step:1275/1480 train_time:349194ms step_avg:276.04ms
+step:1276/1480 train_time:349477ms step_avg:276.05ms
+step:1277/1480 train_time:349768ms step_avg:276.06ms
+step:1278/1480 train_time:350052ms step_avg:276.07ms
+step:1279/1480 train_time:350340ms step_avg:276.08ms
+step:1280/1480 train_time:350627ms step_avg:276.08ms
+step:1281/1480 train_time:350926ms step_avg:276.10ms
+step:1282/1480 train_time:351213ms step_avg:276.11ms
+step:1283/1480 train_time:351504ms step_avg:276.12ms
+step:1284/1480 train_time:351793ms step_avg:276.13ms
+step:1285/1480 train_time:352075ms step_avg:276.14ms
+step:1286/1480 train_time:352367ms step_avg:276.15ms
+step:1287/1480 train_time:352652ms step_avg:276.16ms
+step:1288/1480 train_time:352938ms step_avg:276.16ms
+step:1289/1480 train_time:353228ms step_avg:276.17ms
+step:1290/1480 train_time:353512ms step_avg:276.18ms
+step:1291/1480 train_time:353800ms step_avg:276.19ms
+step:1292/1480 train_time:354091ms step_avg:276.20ms
+step:1293/1480 train_time:354377ms step_avg:276.21ms
+step:1294/1480 train_time:354664ms step_avg:276.22ms
+step:1295/1480 train_time:354951ms step_avg:276.23ms
+step:1296/1480 train_time:355234ms step_avg:276.23ms
+step:1297/1480 train_time:355519ms step_avg:276.24ms
+step:1298/1480 train_time:355809ms step_avg:276.25ms
+step:1299/1480 train_time:356092ms step_avg:276.25ms
+step:1300/1480 train_time:356388ms step_avg:276.27ms
+step:1301/1480 train_time:356670ms step_avg:276.27ms
+step:1302/1480 train_time:356954ms step_avg:276.28ms
+step:1303/1480 train_time:357250ms step_avg:276.30ms
+step:1304/1480 train_time:357532ms step_avg:276.30ms
+step:1305/1480 train_time:357823ms step_avg:276.31ms
+step:1306/1480 train_time:358114ms step_avg:276.32ms
+step:1307/1480 train_time:358402ms step_avg:276.33ms
+step:1308/1480 train_time:358687ms step_avg:276.34ms
+step:1309/1480 train_time:358988ms step_avg:276.36ms
+step:1310/1480 train_time:359277ms step_avg:276.37ms
+step:1311/1480 train_time:359568ms step_avg:276.38ms
+step:1312/1480 train_time:359853ms step_avg:276.38ms
+step:1313/1480 train_time:360143ms step_avg:276.39ms
+step:1314/1480 train_time:360432ms step_avg:276.40ms
+step:1315/1480 train_time:360719ms step_avg:276.41ms
+step:1316/1480 train_time:361021ms step_avg:276.43ms
+step:1317/1480 train_time:361313ms step_avg:276.44ms
+step:1318/1480 train_time:361608ms step_avg:276.46ms
+step:1319/1480 train_time:361896ms step_avg:276.47ms
+step:1320/1480 train_time:362189ms step_avg:276.48ms
+step:1321/1480 train_time:362477ms step_avg:276.49ms
+step:1322/1480 train_time:362767ms step_avg:276.50ms
+step:1323/1480 train_time:363052ms step_avg:276.51ms
+step:1324/1480 train_time:363349ms step_avg:276.52ms
+step:1325/1480 train_time:363648ms step_avg:276.54ms
+step:1326/1480 train_time:363933ms step_avg:276.55ms
+step:1327/1480 train_time:364228ms step_avg:276.56ms
+step:1328/1480 train_time:364514ms step_avg:276.57ms
+step:1329/1480 train_time:364801ms step_avg:276.57ms
+step:1330/1480 train_time:365091ms step_avg:276.58ms
+step:1331/1480 train_time:365383ms step_avg:276.60ms
+step:1332/1480 train_time:365674ms step_avg:276.61ms
+step:1333/1480 train_time:365971ms step_avg:276.62ms
+step:1334/1480 train_time:366269ms step_avg:276.64ms
+step:1335/1480 train_time:366554ms step_avg:276.64ms
+step:1336/1480 train_time:366849ms step_avg:276.66ms
+step:1337/1480 train_time:367135ms step_avg:276.67ms
+step:1338/1480 train_time:367421ms step_avg:276.67ms
+step:1339/1480 train_time:367714ms step_avg:276.68ms
+step:1340/1480 train_time:368001ms step_avg:276.69ms
+step:1341/1480 train_time:368289ms step_avg:276.70ms
+step:1342/1480 train_time:368583ms step_avg:276.71ms
+step:1343/1480 train_time:368891ms step_avg:276.74ms
+step:1344/1480 train_time:369175ms step_avg:276.74ms
+step:1345/1480 train_time:369467ms step_avg:276.75ms
+step:1346/1480 train_time:369756ms step_avg:276.76ms
+step:1347/1480 train_time:370052ms step_avg:276.78ms
+step:1348/1480 train_time:370342ms step_avg:276.79ms
+step:1349/1480 train_time:370632ms step_avg:276.80ms
+step:1350/1480 train_time:370926ms step_avg:276.81ms
+step:1351/1480 train_time:371213ms step_avg:276.82ms
+step:1352/1480 train_time:371506ms step_avg:276.83ms
+step:1353/1480 train_time:371790ms step_avg:276.84ms
+step:1354/1480 train_time:372075ms step_avg:276.84ms
+step:1355/1480 train_time:372370ms step_avg:276.86ms
+step:1356/1480 train_time:372662ms step_avg:276.87ms
+step:1357/1480 train_time:372951ms step_avg:276.88ms
+step:1358/1480 train_time:373239ms step_avg:276.88ms
+step:1359/1480 train_time:373531ms step_avg:276.90ms
+step:1360/1480 train_time:373819ms step_avg:276.90ms
+step:1361/1480 train_time:374109ms step_avg:276.91ms
+step:1362/1480 train_time:374391ms step_avg:276.92ms
+step:1363/1480 train_time:374685ms step_avg:276.93ms
+step:1364/1480 train_time:374974ms step_avg:276.94ms
+step:1365/1480 train_time:375269ms step_avg:276.95ms
+step:1366/1480 train_time:375555ms step_avg:276.96ms
+step:1367/1480 train_time:375851ms step_avg:276.97ms
+step:1368/1480 train_time:376136ms step_avg:276.98ms
+step:1369/1480 train_time:376426ms step_avg:276.99ms
+step:1370/1480 train_time:376718ms step_avg:277.00ms
+step:1371/1480 train_time:377025ms step_avg:277.02ms
+step:1372/1480 train_time:377317ms step_avg:277.03ms
+step:1373/1480 train_time:377604ms step_avg:277.04ms
+step:1374/1480 train_time:377900ms step_avg:277.05ms
+step:1375/1480 train_time:378200ms step_avg:277.07ms
+step:1375/1480 val_loss:3.3192 train_time:378340ms step_avg:277.17ms
+step:1376/1480 train_time:378491ms step_avg:277.08ms
+step:1377/1480 train_time:378792ms step_avg:277.10ms
+step:1378/1480 train_time:379091ms step_avg:277.11ms
+step:1379/1480 train_time:379378ms step_avg:277.12ms
+step:1380/1480 train_time:379671ms step_avg:277.13ms
+step:1381/1480 train_time:379962ms step_avg:277.14ms
+step:1382/1480 train_time:380255ms step_avg:277.15ms
+step:1383/1480 train_time:380556ms step_avg:277.17ms
+step:1384/1480 train_time:380854ms step_avg:277.19ms
+step:1385/1480 train_time:381146ms step_avg:277.20ms
+step:1386/1480 train_time:381436ms step_avg:277.21ms
+step:1387/1480 train_time:381729ms step_avg:277.22ms
+step:1388/1480 train_time:382018ms step_avg:277.23ms
+step:1389/1480 train_time:382307ms step_avg:277.23ms
+step:1390/1480 train_time:382593ms step_avg:277.24ms
+step:1391/1480 train_time:382889ms step_avg:277.25ms
+step:1392/1480 train_time:383173ms step_avg:277.26ms
+step:1393/1480 train_time:383461ms step_avg:277.27ms
+step:1394/1480 train_time:383747ms step_avg:277.27ms
+step:1395/1480 train_time:384042ms step_avg:277.29ms
+step:1396/1480 train_time:384332ms step_avg:277.30ms
+step:1397/1480 train_time:384628ms step_avg:277.31ms
+step:1398/1480 train_time:384916ms step_avg:277.32ms
+step:1399/1480 train_time:385214ms step_avg:277.33ms
+step:1400/1480 train_time:385524ms step_avg:277.36ms
+step:1401/1480 train_time:385817ms step_avg:277.37ms
+step:1402/1480 train_time:386133ms step_avg:277.39ms
+step:1403/1480 train_time:386422ms step_avg:277.40ms
+step:1404/1480 train_time:386711ms step_avg:277.41ms
+step:1405/1480 train_time:387002ms step_avg:277.42ms
+step:1406/1480 train_time:387291ms step_avg:277.43ms
+step:1407/1480 train_time:387595ms step_avg:277.45ms
+step:1408/1480 train_time:387889ms step_avg:277.46ms
+step:1409/1480 train_time:388173ms step_avg:277.46ms
+step:1410/1480 train_time:388459ms step_avg:277.47ms
+step:1411/1480 train_time:388753ms step_avg:277.48ms
+step:1412/1480 train_time:389045ms step_avg:277.49ms
+step:1413/1480 train_time:389338ms step_avg:277.50ms
+step:1414/1480 train_time:389633ms step_avg:277.52ms
+step:1415/1480 train_time:389917ms step_avg:277.52ms
+step:1416/1480 train_time:390215ms step_avg:277.54ms
+step:1417/1480 train_time:390505ms step_avg:277.54ms
+step:1418/1480 train_time:390799ms step_avg:277.56ms
+step:1419/1480 train_time:391093ms step_avg:277.57ms
+step:1420/1480 train_time:391389ms step_avg:277.58ms
+step:1421/1480 train_time:391672ms step_avg:277.58ms
+step:1422/1480 train_time:391963ms step_avg:277.59ms
+step:1423/1480 train_time:392250ms step_avg:277.60ms
+step:1424/1480 train_time:392536ms step_avg:277.61ms
+step:1425/1480 train_time:392833ms step_avg:277.62ms
+step:1426/1480 train_time:393134ms step_avg:277.64ms
+step:1427/1480 train_time:393425ms step_avg:277.65ms
+step:1428/1480 train_time:393712ms step_avg:277.65ms
+step:1429/1480 train_time:393996ms step_avg:277.66ms
+step:1430/1480 train_time:394287ms step_avg:277.67ms
+step:1431/1480 train_time:394576ms step_avg:277.67ms
+step:1432/1480 train_time:394872ms step_avg:277.69ms
+step:1433/1480 train_time:395165ms step_avg:277.70ms
+step:1434/1480 train_time:395467ms step_avg:277.72ms
+step:1435/1480 train_time:395755ms step_avg:277.72ms
+step:1436/1480 train_time:396053ms step_avg:277.74ms
+step:1437/1480 train_time:396335ms step_avg:277.74ms
+step:1438/1480 train_time:396637ms step_avg:277.76ms
+step:1439/1480 train_time:396938ms step_avg:277.77ms
+step:1440/1480 train_time:397233ms step_avg:277.79ms
+step:1441/1480 train_time:397527ms step_avg:277.80ms
+step:1442/1480 train_time:397820ms step_avg:277.81ms
+step:1443/1480 train_time:398112ms step_avg:277.82ms
+step:1444/1480 train_time:398401ms step_avg:277.82ms
+step:1445/1480 train_time:398691ms step_avg:277.83ms
+step:1446/1480 train_time:398993ms step_avg:277.85ms
+step:1447/1480 train_time:399293ms step_avg:277.87ms
+step:1448/1480 train_time:399594ms step_avg:277.88ms
+step:1449/1480 train_time:399892ms step_avg:277.90ms
+step:1450/1480 train_time:400174ms step_avg:277.90ms
+step:1451/1480 train_time:400468ms step_avg:277.91ms
+step:1452/1480 train_time:400760ms step_avg:277.92ms
+step:1453/1480 train_time:401049ms step_avg:277.93ms
+step:1454/1480 train_time:401341ms step_avg:277.94ms
+step:1455/1480 train_time:401641ms step_avg:277.95ms
+step:1456/1480 train_time:401929ms step_avg:277.96ms
+step:1457/1480 train_time:402214ms step_avg:277.96ms
+step:1458/1480 train_time:402505ms step_avg:277.97ms
+step:1459/1480 train_time:402801ms step_avg:277.99ms
+step:1460/1480 train_time:403091ms step_avg:277.99ms
+step:1461/1480 train_time:403383ms step_avg:278.00ms
+step:1462/1480 train_time:403672ms step_avg:278.01ms
+step:1463/1480 train_time:403956ms step_avg:278.02ms
+step:1464/1480 train_time:404255ms step_avg:278.03ms
+step:1465/1480 train_time:404553ms step_avg:278.04ms
+step:1466/1480 train_time:404843ms step_avg:278.05ms
+step:1467/1480 train_time:405132ms step_avg:278.06ms
+step:1468/1480 train_time:405424ms step_avg:278.07ms
+step:1469/1480 train_time:405735ms step_avg:278.09ms
+step:1470/1480 train_time:406033ms step_avg:278.10ms
+step:1471/1480 train_time:406331ms step_avg:278.12ms
+step:1472/1480 train_time:406619ms step_avg:278.13ms
+step:1473/1480 train_time:406913ms step_avg:278.14ms
+step:1474/1480 train_time:407198ms step_avg:278.14ms
+step:1475/1480 train_time:407489ms step_avg:278.15ms
+step:1476/1480 train_time:407779ms step_avg:278.16ms
+step:1477/1480 train_time:408076ms step_avg:278.17ms
+step:1478/1480 train_time:408369ms step_avg:278.18ms
+step:1479/1480 train_time:408663ms step_avg:278.19ms
+step:1480/1480 train_time:408953ms step_avg:278.20ms
+step:1480/1480 val_loss:3.3001 train_time:409091ms step_avg:278.29ms
+peak memory consumption: 34262 MiB

--- a/_logs/bias-a82bdcb6-ea9d-4808-9e09-32b9901d21e1.txt
+++ b/_logs/bias-a82bdcb6-ea9d-4808-9e09-32b9901d21e1.txt
@@ -1,0 +1,2201 @@
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+import contextlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import torch.distributed as dist
+import torch._inductor.config as config
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.nn.attention.flex_attention import BlockMask, flex_attention #KoszarskyB
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps):
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert len(G.shape) == 2
+    a, b, c = (3.4445, -4.7750,  2.0315)
+    X = G.bfloat16()
+    if G.size(0) > G.size(1):
+        X = X.T
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm() + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A # adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+    
+    if G.size(0) > G.size(1):
+        X = X.T
+    return X
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Some warnings:
+    - This optimizer assumes that all parameters passed in are 2D.
+    - It should not be used for the embedding layer, the final fully connected layer, or any {0,1}-D
+    parameters; those should all be optimized by a standard method (e.g., AdamW).
+    - To use it with 4D convolutional filters, it works well to just flatten their last 3 dimensions.
+    - We believe it is unlikely to work well for training with small batch size.
+    - We believe it may not work well for finetuning pretrained models, but we haven't tested this.
+    - We have not yet tried this optimizer for training scenarios larger than NanoGPT (124M).
+
+    Arguments:
+        lr: The learning rate used by the internal SGD.
+        momentum: The momentum used by the internal SGD.
+        nesterov: Whether to use Nesterov-style momentum in the internal SGD. (recommended)
+        ns_steps: The number of Newton-Schulz iteration steps to use.
+    """
+    def __init__(self, params, lr=0.02, momentum=0.95, nesterov=True, ns_steps=5):
+        self.world_size = int(os.environ['WORLD_SIZE'])
+        self.rank = int(os.environ['RANK'])
+        defaults = dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps)
+        params = list(params)
+        assert all(isinstance(p, torch.Tensor) for p in params)
+        sizes = {p.numel() for p in params}
+        param_groups = [
+            {
+                'params': [p for p in params if p.numel() == size],
+                'update_buffer': [
+                    torch.empty(size, device='cuda', dtype=torch.bfloat16)
+                    for _ in range(self.world_size)
+                ],
+            }
+            for size in sizes
+        ]
+        super().__init__(param_groups, defaults)
+
+    def step(self):
+
+        for group in self.param_groups:
+
+            lr = group['lr']
+            momentum = group['momentum']
+            nesterov = group['nesterov']
+            ns_steps = group['ns_steps']
+            update_buffers = group['update_buffer']
+            # generate weight updates in distributed fashion
+            params = group['params']
+            assert len(params) % self.world_size == 0
+            handle = None
+            params_world = None
+            def update_prev():
+                if params_world is None:
+                    return
+                assert handle is not None
+                handle.wait()
+                for p_world, g_world in zip(params_world, update_buffers):
+                    p_world.data.add_(
+                        g_world.view_as(p_world),
+                        alpha=-lr * max(1, p_world.size(0) / p_world.size(1)) ** 0.5,
+                    )
+            for base_i in range(len(params))[::self.world_size]:
+                p = params[base_i + self.rank]
+                g = p.grad
+                assert g is not None
+                state = self.state[p]
+                if 'momentum_buffer' not in state:
+                    state['momentum_buffer'] = torch.zeros_like(g)
+                buf = state['momentum_buffer']
+                buf.lerp_(g, 1 - momentum)
+                g = g.lerp_(buf, momentum) if nesterov else buf
+                g = zeropower_via_newtonschulz5(g, steps=ns_steps).flatten()
+                update_prev()
+                handle = dist.all_gather(update_buffers, g, async_op=True)
+                params_world = params[base_i : base_i + self.world_size]
+            update_prev()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the GPT-2 model
+
+def norm(x):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+
+    def __init__(self, in_features, out_features, bias=False):
+        super().__init__(in_features, out_features, bias)
+
+    def forward(self, x):
+        return F.linear(
+            x,
+            self.weight.to(x.dtype),
+            None if self.bias is None else self.bias.to(x.dtype)
+        )
+
+class Rotary(torch.nn.Module):
+
+    def __init__(self, dim, base=10000):
+        super().__init__()
+        self.register_buffer('inv_freq', (1 / base) ** (torch.arange(0, dim, 2) / dim))
+        self.seq_len_cached = None
+        self.cos_cached = None
+        self.sin_cached = None
+
+    def forward(self, x):
+        seq_len = x.shape[1]
+        if seq_len != self.seq_len_cached:
+            t = torch.arange(seq_len, device=x.device)
+            freqs = torch.outer(t, self.inv_freq)
+            self.seq_len_cached = seq_len
+            self.cos_cached = freqs.cos()
+            self.sin_cached = freqs.sin()
+        cos, sin = self.cos_cached[None, :, None, :], self.sin_cached[None, :, None, :]
+        # apply_rotary_emb(x, cos, sin)
+        x1, x2 = x.chunk(2, dim=3)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x)
+
+class CausalSelfAttention(nn.Module):
+
+    def __init__(self, dim, num_heads):
+        super().__init__()
+        assert dim % num_heads == 0
+        self.num_heads = num_heads
+        self.c_q = CastedLinear(dim, dim)
+        self.c_k = CastedLinear(dim, dim)
+        self.c_v = CastedLinear(dim, dim)
+        self.lambdas = nn.Parameter(torch.tensor([0.5, 0.5]))
+        self.rotary = Rotary(dim // num_heads) # dim // num_heads = head_dim
+        self.c_proj = CastedLinear(dim, dim)
+        self.c_proj.weight.data.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x, vi, block_mask):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q = self.c_q(x).view(B, T, self.num_heads, -1)
+        k = self.c_k(x).view(B, T, self.num_heads, -1)
+        v = self.c_v(x).view(B, T, self.num_heads, -1)
+        v = self.lambdas[0] * v + self.lambdas[1] * vi.view_as(v) # @KoszarskyB & @Grad62304977
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, enable_gqa=True)
+        y = y.transpose(1, 2).contiguous().view_as(x) # re-assemble all head outputs side by side
+        y = self.c_proj(y)
+        return y
+
+class MLP(nn.Module):
+
+    def __init__(self, dim):
+        super().__init__()
+        self.c_fc   = CastedLinear(dim, 4 * dim)
+        self.c_proj = CastedLinear(4 * dim, dim)
+        self.c_proj.weight.data.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x):
+        x = self.c_fc(x)
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = self.c_proj(x)
+        return x
+
+class Block(nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+        self.attn = CausalSelfAttention(config.model_dim, config.num_heads)
+        self.mlp = MLP(config.model_dim)
+        self.lambdas = nn.Parameter(torch.tensor([1., 0.]))
+
+    def forward(self, x, vi, x0, block_mask):
+        x = self.lambdas[0] * x + self.lambdas[1] * x0
+        x = x + self.attn(norm(x), vi, block_mask)
+        x = x + self.mlp(norm(x))
+        return x
+
+class ValueEmbedding(nn.Module):
+    def __init__(self, config: "GPTConfig"):
+        super().__init__()
+        self.embed = nn.ModuleList([
+            nn.Embedding(config.vocab_size, config.model_dim)
+            for _ in range(6)
+        ])
+
+    def forward(self, inputs) -> "list[torch.Tensor]":
+        ve = [emb(inputs) for emb in self.embed]
+        ve += reversed(ve)
+        return ve
+
+# -----------------------------------------------------------------------------
+# The main GPT-2 model
+
+@dataclass
+class GPTConfig:
+    vocab_size : int = 50304
+    num_layers : int = 12
+    num_heads : int = 6 # head dim 128 suggested by @Grad62304977
+    model_dim : int = 768
+
+class GPT(nn.Module):
+
+    def __init__(self, config: GPTConfig):
+        super().__init__()
+        self.num_layers = config.num_layers
+
+        # U-net design by @brendanh0gan
+        self.num_encoder_layers = config.num_layers // 2 # Half of the layers for encoder
+        self.num_decoder_layers = config.num_layers - self.num_encoder_layers # Remaining for decoder
+        # Add learnable skip connection weights for decoder layers
+        self.skip_weights = nn.Parameter(torch.ones(self.num_decoder_layers))
+
+        self.embed = nn.Embedding(config.vocab_size, config.model_dim)
+        self.blocks = nn.ModuleList([Block(config) for _ in range(config.num_layers)])
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual learning
+        # U-net structure on token value embeddings by @leloykun
+        self.value_embeds = ValueEmbedding(config)
+        self.lm_head = CastedLinear(config.model_dim, config.vocab_size, bias=True)
+        self.lm_head.weight.data.zero_() # @Grad62304977
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        targets: torch.Tensor,
+        sliding_window_num_blocks: torch.Tensor,
+    ):
+        BLOCK_SIZE = 128
+        seq_len = len(inputs)
+        assert seq_len % BLOCK_SIZE == 0
+        total_num_blocks = seq_len // BLOCK_SIZE
+        assert inputs.ndim == 1
+        docs = (inputs == 50256).cumsum(0)
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_mask: torch.Tensor):
+            num_blocks = dense_mask.sum(dim=-1, dtype=torch.int32)
+            indices = dense_mask.argsort(dim=-1, descending=True, stable=True).to(torch.int32)
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        def create_doc_swc_block_mask(sliding_window_num_blocks: torch.Tensor):
+            kv_idx = block_idx = torch.arange(total_num_blocks, dtype=torch.int32, device="cuda")
+            q_idx = block_idx[:, None]
+            causal_bm = q_idx >= kv_idx
+            causal_full_bm = q_idx > kv_idx
+            window_bm = q_idx - kv_idx < sliding_window_num_blocks
+            window_full_bm = window_bm
+            # document_bm = (docs_low[q_idx] <= docs_high[kv_idx]) & (docs_low[kv_idx] <= docs_high[q_idx])
+            document_bm = (docs_low[:, None] <= docs_high) & (docs_low <= docs_high[:, None])
+            document_full_bm = (docs_low[:, None] == docs_high) & (docs_low == docs_high[:, None])
+            nonzero_bm = causal_bm & window_bm & document_bm
+            full_bm  = causal_full_bm & window_full_bm & document_full_bm
+            kv_num_blocks, kv_indices = dense_to_ordered(nonzero_bm ^ full_bm)
+            full_kv_num_blocks, full_kv_indices = dense_to_ordered(full_bm)
+            return BlockMask.from_kv_blocks(
+                kv_num_blocks,
+                kv_indices,
+                full_kv_num_blocks,
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+
+        block_mask = create_doc_swc_block_mask(sliding_window_num_blocks)
+
+        # forward the GPT model itself
+        x = self.embed(inputs[None]) # token embeddings of shape (b, t, model_dim)
+        x = norm(x) # @Grad62304977
+        x0 = x
+        ve = self.value_embeds(inputs)
+        ve_enc, ve_dec = ve[:self.num_encoder_layers], ve[self.num_encoder_layers:]
+
+        # Store outputs for U-Net skip connections
+        skip_connections = []
+        # Encoder pass - process only the first half of the blocks
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, ve_enc[i], x0, block_mask)
+            skip_connections.append(x)
+        # Decoder pass - process the remaining blocks with weighted skip connections
+        for i in range(self.num_decoder_layers):
+            x = x + self.skip_weights[i] * skip_connections.pop()
+            # U-net structure on token value embeddings by @leloykun
+            x = self.blocks[self.num_encoder_layers + i](x, ve_dec[i], x0, block_mask)
+
+        x = norm(x)
+        logits = self.lm_head(x)
+        logits = 30 * torch.tanh(logits / 30) # @Grad62304977
+        logits = logits.float()
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
+        return loss
+
+# -----------------------------------------------------------------------------
+# Our own simple Distributed Data Loader
+
+def _peek_data_shard(file: Path):
+    # only reads the header, returns header data
+    # header is 256 int32
+    header = torch.from_file(f"{file}", False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    return int(header[2]) # number of tokens (claimed)
+
+def _load_data_shard(path: Path, num_tokens):
+    with path.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header?"
+    return tokens
+
+class DistributedDataLoader:
+    def __init__(self, filename_pattern, seq_len, process_rank, num_processes):
+        self.process_rank = process_rank
+        self.num_processes = num_processes
+        self.seq_len = seq_len
+
+        # glob files that match the pattern
+        self.files = sorted(Path.cwd().glob(filename_pattern))
+        assert len(self.files) > 0, f"did not find any files that match the pattern {filename_pattern}"
+
+        # load and validate all data shards, count number of tokens in total
+        self.files_num_tokens = [_peek_data_shard(file) for file in self.files]
+        assert min(self.files_num_tokens) >= num_processes * seq_len + 1
+        self.total_num_tokens = sum(self.files_num_tokens)
+
+        self.reset()
+
+    def reset(self):
+        self.current_shard = -1
+        self.advance()
+
+    def advance(self): # advance to next data shard
+        self.current_shard = (self.current_shard + 1) % len(self.files)
+        self.current_position = self.process_rank * self.seq_len
+        self.tokens = _load_data_shard(self.files[self.current_shard], self.files_num_tokens[self.current_shard])
+
+    def next_batch(self):
+        batch_size = self.seq_len * self.num_processes
+        buf = self.tokens[self.current_position:self.current_position+self.seq_len+1]
+        # host side async is sufficient;
+        # no performance improvement was observed when introducing a separate stream.
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # inputs
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # targets
+        # advance current position and load next shard if necessary
+        self.current_position += batch_size
+        if self.current_position + batch_size + 1 >= len(self.tokens):
+            self.advance()
+        return inputs, targets
+
+def set_output_layer_bias(model, dataloader, n_batches):
+    # Use token prevalence to initialize output layer bias & avoid initial shock to network of having to find it.
+    t0 = time.perf_counter()
+    num_vocab = model.lm_head.bias.size(0)
+    for i in range(n_batches):
+        _, targets_train = dataloader.next_batch()
+        if i == 0:
+            total_counts = torch.zeros(num_vocab, dtype=torch.int32, device=targets_train.device)
+        ids, counts = torch.unique(targets_train, sorted=True, return_counts=True)
+        total_counts[ids] += counts
+
+    target_probs = total_counts / total_counts.sum()
+    target_probs = (target_probs + 1e-12)
+    target_probs = target_probs / target_probs.sum()
+
+    with torch.no_grad():
+        model.lm_head.bias.copy_(target_probs.log())
+
+    old_init_loss = torch.tensor(1 / num_vocab).log().item()
+    new_init_loss = (target_probs * target_probs.log()).sum().item()
+    total_time = time.perf_counter() - t0
+    print0(f"Centered output layer, initial loss {old_init_loss:.3f} => {new_init_loss:.3f} ({total_time:.1f}s)")
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data hyperparams
+    input_bin : str = 'data/fineweb10B/fineweb_train_*.bin' # input .bin to train on
+    input_val_bin : str = 'data/fineweb10B/fineweb_val_*.bin' # input .bin to eval validation loss on
+    # optimization hyperparams
+    batch_size : int = 8 # batch size, in sequences, across all devices
+    sequence_length : int = 64*1024 # sequence length, in tokens
+    num_iterations : int = 1480 # number of iterations to run
+    warmup_iters : int = 0
+    cooldown_iters : int = 600 # number of iterations of linear warmup/cooldown for triangular or trapezoidal schedule
+    weight_decay : float = 0
+    # evaluation and logging hyperparams
+    val_loss_every : int = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    val_tokens : int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+args = Hyperparameters()
+
+# set up DDP (distributed data parallel). torchrun sets this env variable
+ddp_rank = int(os.environ['RANK'])
+ddp_local_rank = int(os.environ['LOCAL_RANK'])
+ddp_world_size = int(os.environ['WORLD_SIZE'])
+assert torch.cuda.is_available()
+device = torch.device(f'cuda:{ddp_local_rank}')
+torch.cuda.set_device(device)
+print(f'using device: {device}')
+dist.init_process_group(backend='nccl', device_id=device)
+dist.barrier()
+master_process = (ddp_rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = uuid.uuid4()
+    Path('logs').mkdir(exist_ok=True)
+    # logdir = Path('logs') / f'{run_id}'
+    # logdir.mkdir()
+    logfile = Path('logs') / f'{run_id}.txt'
+    print(logfile.stem)
+    # create the log file
+    with logfile.open('w') as f:
+        # begin the log by printing this file (the Python code)
+        print(code, file=f)
+        print('=' * 100, file=f)
+def print0(s, logonly=False):
+    if master_process:
+        with logfile.open('a') as f:
+            if not logonly:
+                print(s)
+            print(s, file=f)
+# log information about the hardware/software environment this is running on
+# and print the full `nvidia-smi` to file
+print0(f'Running python {sys.version}')
+print0(f'Running pytorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}\nnvidia-smi:')
+import subprocess
+result = subprocess.run(['nvidia-smi'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+print0(f'{result.stdout}', logonly=True)
+print0('='*100, logonly=True)
+
+# calculate the number of steps to take in the val loop.
+assert args.val_tokens % (args.sequence_length * ddp_world_size) == 0
+val_steps = args.val_tokens // (args.sequence_length * ddp_world_size)
+# calculate the steps of gradient accumulation required to attain the desired global batch size.
+assert args.batch_size % (ddp_world_size) == 0
+train_accumulation_steps = args.batch_size // ddp_world_size
+
+# load tokens
+train_loader = DistributedDataLoader(args.input_bin, args.sequence_length, ddp_rank, ddp_world_size)
+val_loader = DistributedDataLoader(args.input_val_bin, args.sequence_length, ddp_rank, ddp_world_size)
+print0(f"Training DataLoader: total number of tokens: {train_loader.total_num_tokens} across {len(train_loader.files)} files")
+print0(f"Validation DataLoader: total number of tokens: {val_loader.total_num_tokens} across {len(val_loader.files)} files")
+print0('='*100, logonly=True)
+inputs_train, targets_train = train_loader.next_batch()
+
+# there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency. suggested to me by @Grad62304977.
+# this originates from Karpathy's experiments.
+num_vocab = 50304
+model = GPT(GPTConfig(vocab_size=num_vocab, num_layers=12, num_heads=6, model_dim=768))
+model = model.cuda().bfloat16()
+for m in model.modules():
+    if isinstance(m, CastedLinear):
+        m.float()
+if hasattr(config, "coordinate_descent_tuning"):
+    config.coordinate_descent_tuning = True # suggested by @Chillee
+
+set_output_layer_bias(model, train_loader, n_batches=100)
+
+model = torch.compile(model)
+# here we wrap model into DDP container
+model = DDP(model, device_ids=[ddp_local_rank], broadcast_buffers=False, gradient_as_bucket_view=True)
+raw_model = model.module # always contains the "raw" unwrapped model
+
+# init the optimizer(s)
+embed_params = [*raw_model.embed.parameters(), *raw_model.value_embeds.parameters()]
+optimizer1 = torch.optim.Adam(embed_params, lr=0.6, betas=(0.8, 0.95), fused=True)
+optimizer2 = torch.optim.Adam([raw_model.lm_head.weight, raw_model.lm_head.bias], lr=0.008, betas=(0.8, 0.95), fused=True)
+params = list(raw_model.blocks.parameters())
+matrix_params = [p for p in params if p.ndim == 2]
+scalar_params = [p for p in params if p.ndim < 2] + [raw_model.skip_weights]
+optimizer3 = Muon(matrix_params, lr=0.05, momentum=0.95)
+optimizer4 = torch.optim.Adam(scalar_params, lr=0.04, betas=(0.8, 0.95), fused=True)
+optimizers = [optimizer1, optimizer2, optimizer3, optimizer4]
+# learning rate decay scheduler (linear warmup and cooldown)
+def get_lr(it):
+    assert it <= args.num_iterations
+    # 1) linear warmup for warmup_iters steps
+    if it < args.warmup_iters:
+        return (it+1) / args.warmup_iters
+    # 2) constant lr for a while
+    elif it < args.num_iterations - args.cooldown_iters:
+        return 1.0
+    # 3) linear cooldown
+    else:
+        decay_ratio = (args.num_iterations - it) / args.cooldown_iters
+        return decay_ratio
+schedulers = [torch.optim.lr_scheduler.LambdaLR(opt, get_lr) for opt in optimizers]
+
+sliding_window_num_blocks = torch.tensor(1, dtype=torch.int32, device="cuda")
+sw_num_blocks_prev = 1
+# Start training loop
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+for step in range(args.num_iterations + 1):
+    last_step = (step == args.num_iterations)
+    # This effectively ignores timing first 10 steps, which are slower for weird reasons.
+    # Alternately, and slightly more correctly in terms of benchmarking, we could do 10
+    # steps with dummy data first, and then re-initialize the model and reset the loader.
+    if step == 10:
+        training_time_ms = 0
+        t0 = time.perf_counter()
+    timed_steps = float('nan') if step <= 11 else (step - 10) + 1 # <= 11 to avoid bug in val
+
+    # Linearly increase the sliding window size over training in chunks of 128 from 128 -> 1856. By @fernbear.bsky.social
+    frac_done = step / args.num_iterations # training progress
+    sw_num_blocks = int(((1 - frac_done) * 128 + frac_done * 1856) // 128)
+    if sw_num_blocks != sw_num_blocks_prev:
+        sliding_window_num_blocks.copy_(sw_num_blocks, non_blocking=True)
+        sw_num_blocks_prev = sw_num_blocks
+
+    # once in a while evaluate the validation dataset
+    if (last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)):
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        # run validation batches
+        model.eval()
+        val_loader.reset()
+        val_loss = 0.0
+        for _ in range(val_steps):
+            with torch.no_grad():
+                inputs_val, targets_val = val_loader.next_batch()
+                val_loss += model(inputs_val, targets_val, sliding_window_num_blocks)
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        val_loss /= val_steps
+        # log val loss to console and to logfile
+        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    # uncomment if you want to save any checkpoints
+    #save_every = 1000
+    #if master_process and (last_step or (save_every > 0 and step % save_every == 0)):
+    #    # stop the clock
+    #    torch.cuda.synchronize()
+    #    training_time_ms += 1000 * (time.perf_counter() - t0)
+    #    # save the state of the training process
+    #    log = dict(step=step, code=code, model=raw_model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+    #    torch.save(log, 'logs/%s/state_step%06d.pt' % (run_id, step))
+    #    # start the clock again
+    #    torch.cuda.synchronize()
+    #    t0 = time.perf_counter()
+
+    # bit confusing: we want to make sure to eval on 0th iteration
+    # but also after the very last iteration. so we loop for step <= num_iterations
+    # instead of just < num_iterations (one extra due to <=), only to do
+    # the validation/sampling one last time, and then we break right here as we're done.
+    if last_step:
+        break
+
+    # --------------- TRAINING SECTION BEGIN -----------------
+    model.train()
+    for i in range(1, train_accumulation_steps + 1):
+        with contextlib.ExitStack() as stack:
+            if i < train_accumulation_steps: # there's no need to sync gradients every accumulation step
+                stack.enter_context(model.no_sync())
+            if step >= 5:
+                stack.enter_context(torch.compiler.set_stance(skip_guard_eval_unsafe=True))
+            model(inputs_train, targets_train, sliding_window_num_blocks).backward()
+            inputs_train, targets_train = train_loader.next_batch()
+    if train_accumulation_steps != 1:
+        for p in model.parameters():
+            p.grad /= train_accumulation_steps
+    # momentum warmup for Muon
+    frac = min(step/300, 1)
+    for group in optimizer3.param_groups:
+        group['momentum'] = (1 - frac) * 0.85 + frac * 0.95
+    # step the optimizers and schedulers
+    for opt, sched in zip(optimizers, schedulers):
+        opt.step()
+        sched.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # --------------- TRAINING SECTION END -------------------
+    # everything that follows now is just diagnostics, prints, logging, etc.
+    approx_time = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{args.num_iterations} train_time:{approx_time:.0f}ms step_avg:{approx_time/timed_steps:.2f}ms")
+
+print0(f"peak memory consumption: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB")
+
+# -------------------------------------------------------------------------
+# clean up nice
+dist.destroy_process_group()
+
+====================================================================================================
+Running python 3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
+Running pytorch 2.6.0.dev20241203+cu124 compiled for CUDA 12.4
+nvidia-smi:
+Thu Dec 26 08:22:04 2024       
++---------------------------------------------------------------------------------------+
+| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.4     |
+|-----------------------------------------+----------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
+|                                         |                      |               MIG M. |
+|=========================================+======================+======================|
+|   0  NVIDIA H100 PCIe               On  | 00000000:00:07.0 Off |                    0 |
+| N/A   42C    P0              82W / 350W |   4162MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   1  NVIDIA H100 PCIe               On  | 00000000:00:08.0 Off |                    0 |
+| N/A   46C    P0              87W / 350W |    923MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   2  NVIDIA H100 PCIe               On  | 00000000:00:09.0 Off |                    0 |
+| N/A   39C    P0              82W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   3  NVIDIA H100 PCIe               On  | 00000000:00:0A.0 Off |                    0 |
+| N/A   41C    P0              81W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   4  NVIDIA H100 PCIe               On  | 00000000:00:0B.0 Off |                    0 |
+| N/A   41C    P0              78W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   5  NVIDIA H100 PCIe               On  | 00000000:00:0C.0 Off |                    0 |
+| N/A   39C    P0              78W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   6  NVIDIA H100 PCIe               On  | 00000000:00:0D.0 Off |                    0 |
+| N/A   46C    P0              84W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   7  NVIDIA H100 PCIe               On  | 00000000:00:0E.0 Off |                    0 |
+| N/A   41C    P0              80W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+                                                                                         
++---------------------------------------------------------------------------------------+
+| Processes:                                                                            |
+|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
+|        ID   ID                                                             Usage      |
+|=======================================================================================|
++---------------------------------------------------------------------------------------+
+
+====================================================================================================
+Training DataLoader: total number of tokens: 1000000000 across 10 files
+Validation DataLoader: total number of tokens: 100000000 across 1 files
+====================================================================================================
+Centered output layer, initial loss -10.826 => -7.657 (0.1s)
+step:0/1480 val_loss:7.7109 train_time:0ms step_avg:nanms
+step:1/1480 train_time:23309ms step_avg:nanms
+step:2/1480 train_time:24123ms step_avg:nanms
+step:3/1480 train_time:24373ms step_avg:nanms
+step:4/1480 train_time:24627ms step_avg:nanms
+step:5/1480 train_time:24879ms step_avg:nanms
+step:6/1480 train_time:25136ms step_avg:nanms
+step:7/1480 train_time:25394ms step_avg:nanms
+step:8/1480 train_time:25650ms step_avg:nanms
+step:9/1480 train_time:25901ms step_avg:nanms
+step:10/1480 train_time:26158ms step_avg:nanms
+step:11/1480 train_time:255ms step_avg:nanms
+step:12/1480 train_time:514ms step_avg:nanms
+step:13/1480 train_time:770ms step_avg:256.74ms
+step:14/1480 train_time:1024ms step_avg:256.00ms
+step:15/1480 train_time:1280ms step_avg:256.10ms
+step:16/1480 train_time:1539ms step_avg:256.56ms
+step:17/1480 train_time:1796ms step_avg:256.62ms
+step:18/1480 train_time:2053ms step_avg:256.69ms
+step:19/1480 train_time:2308ms step_avg:256.42ms
+step:20/1480 train_time:2562ms step_avg:256.23ms
+step:21/1480 train_time:2820ms step_avg:256.34ms
+step:22/1480 train_time:3077ms step_avg:256.40ms
+step:23/1480 train_time:3336ms step_avg:256.61ms
+step:24/1480 train_time:3592ms step_avg:256.60ms
+step:25/1480 train_time:3846ms step_avg:256.40ms
+step:26/1480 train_time:4102ms step_avg:256.37ms
+step:27/1480 train_time:4358ms step_avg:256.37ms
+step:28/1480 train_time:4616ms step_avg:256.46ms
+step:29/1480 train_time:4874ms step_avg:256.50ms
+step:30/1480 train_time:5130ms step_avg:256.51ms
+step:31/1480 train_time:5383ms step_avg:256.35ms
+step:32/1480 train_time:5642ms step_avg:256.46ms
+step:33/1480 train_time:5899ms step_avg:256.48ms
+step:34/1480 train_time:6156ms step_avg:256.51ms
+step:35/1480 train_time:6416ms step_avg:256.66ms
+step:36/1480 train_time:6674ms step_avg:256.68ms
+step:37/1480 train_time:6931ms step_avg:256.69ms
+step:38/1480 train_time:7184ms step_avg:256.56ms
+step:39/1480 train_time:7442ms step_avg:256.61ms
+step:40/1480 train_time:7701ms step_avg:256.68ms
+step:41/1480 train_time:7957ms step_avg:256.66ms
+step:42/1480 train_time:8217ms step_avg:256.79ms
+step:43/1480 train_time:8476ms step_avg:256.84ms
+step:44/1480 train_time:8733ms step_avg:256.87ms
+step:45/1480 train_time:8985ms step_avg:256.72ms
+step:46/1480 train_time:9242ms step_avg:256.73ms
+step:47/1480 train_time:9501ms step_avg:256.78ms
+step:48/1480 train_time:9758ms step_avg:256.80ms
+step:49/1480 train_time:10016ms step_avg:256.83ms
+step:50/1480 train_time:10276ms step_avg:256.90ms
+step:51/1480 train_time:10537ms step_avg:257.01ms
+step:52/1480 train_time:10794ms step_avg:256.99ms
+step:53/1480 train_time:11048ms step_avg:256.93ms
+step:54/1480 train_time:11304ms step_avg:256.91ms
+step:55/1480 train_time:11561ms step_avg:256.91ms
+step:56/1480 train_time:11819ms step_avg:256.94ms
+step:57/1480 train_time:12077ms step_avg:256.96ms
+step:58/1480 train_time:12338ms step_avg:257.04ms
+step:59/1480 train_time:12595ms step_avg:257.04ms
+step:60/1480 train_time:12849ms step_avg:256.97ms
+step:61/1480 train_time:13107ms step_avg:257.00ms
+step:62/1480 train_time:13363ms step_avg:256.97ms
+step:63/1480 train_time:13620ms step_avg:256.99ms
+step:64/1480 train_time:13879ms step_avg:257.02ms
+step:65/1480 train_time:14140ms step_avg:257.08ms
+step:66/1480 train_time:14397ms step_avg:257.09ms
+step:67/1480 train_time:14654ms step_avg:257.09ms
+step:68/1480 train_time:14909ms step_avg:257.05ms
+step:69/1480 train_time:15165ms step_avg:257.03ms
+step:70/1480 train_time:15422ms step_avg:257.03ms
+step:71/1480 train_time:15679ms step_avg:257.04ms
+step:72/1480 train_time:15939ms step_avg:257.09ms
+step:73/1480 train_time:16197ms step_avg:257.10ms
+step:74/1480 train_time:16455ms step_avg:257.11ms
+step:75/1480 train_time:16713ms step_avg:257.12ms
+step:76/1480 train_time:16971ms step_avg:257.14ms
+step:77/1480 train_time:17231ms step_avg:257.18ms
+step:78/1480 train_time:17486ms step_avg:257.15ms
+step:79/1480 train_time:17742ms step_avg:257.13ms
+step:80/1480 train_time:18001ms step_avg:257.16ms
+step:81/1480 train_time:18259ms step_avg:257.16ms
+step:82/1480 train_time:18517ms step_avg:257.19ms
+step:83/1480 train_time:18777ms step_avg:257.21ms
+step:84/1480 train_time:19038ms step_avg:257.27ms
+step:85/1480 train_time:19296ms step_avg:257.28ms
+step:86/1480 train_time:19552ms step_avg:257.26ms
+step:87/1480 train_time:19808ms step_avg:257.25ms
+step:88/1480 train_time:20063ms step_avg:257.22ms
+step:89/1480 train_time:20321ms step_avg:257.23ms
+step:90/1480 train_time:20579ms step_avg:257.24ms
+step:91/1480 train_time:20840ms step_avg:257.29ms
+step:92/1480 train_time:21098ms step_avg:257.29ms
+step:93/1480 train_time:21356ms step_avg:257.30ms
+step:94/1480 train_time:21615ms step_avg:257.33ms
+step:95/1480 train_time:21878ms step_avg:257.38ms
+step:96/1480 train_time:22139ms step_avg:257.43ms
+step:97/1480 train_time:22396ms step_avg:257.43ms
+step:98/1480 train_time:22654ms step_avg:257.43ms
+step:99/1480 train_time:22912ms step_avg:257.44ms
+step:100/1480 train_time:23174ms step_avg:257.48ms
+step:101/1480 train_time:23431ms step_avg:257.48ms
+step:102/1480 train_time:23685ms step_avg:257.45ms
+step:103/1480 train_time:23942ms step_avg:257.45ms
+step:104/1480 train_time:24202ms step_avg:257.47ms
+step:105/1480 train_time:24460ms step_avg:257.47ms
+step:106/1480 train_time:24718ms step_avg:257.48ms
+step:107/1480 train_time:24978ms step_avg:257.50ms
+step:108/1480 train_time:25235ms step_avg:257.50ms
+step:109/1480 train_time:25490ms step_avg:257.48ms
+step:110/1480 train_time:25745ms step_avg:257.45ms
+step:111/1480 train_time:26004ms step_avg:257.47ms
+step:112/1480 train_time:26265ms step_avg:257.50ms
+step:113/1480 train_time:26526ms step_avg:257.53ms
+step:114/1480 train_time:26786ms step_avg:257.56ms
+step:115/1480 train_time:27046ms step_avg:257.59ms
+step:116/1480 train_time:27309ms step_avg:257.63ms
+step:117/1480 train_time:27572ms step_avg:257.68ms
+step:118/1480 train_time:27834ms step_avg:257.73ms
+step:119/1480 train_time:28096ms step_avg:257.76ms
+step:120/1480 train_time:28357ms step_avg:257.79ms
+step:121/1480 train_time:28620ms step_avg:257.84ms
+step:122/1480 train_time:28881ms step_avg:257.86ms
+step:123/1480 train_time:29143ms step_avg:257.91ms
+step:124/1480 train_time:29404ms step_avg:257.93ms
+step:125/1480 train_time:29669ms step_avg:257.99ms
+step:125/1480 val_loss:4.3838 train_time:29795ms step_avg:259.08ms
+step:126/1480 train_time:29934ms step_avg:258.05ms
+step:127/1480 train_time:30199ms step_avg:258.11ms
+step:128/1480 train_time:30460ms step_avg:258.14ms
+step:129/1480 train_time:30721ms step_avg:258.16ms
+step:130/1480 train_time:30983ms step_avg:258.19ms
+step:131/1480 train_time:31244ms step_avg:258.22ms
+step:132/1480 train_time:31508ms step_avg:258.26ms
+step:133/1480 train_time:31771ms step_avg:258.30ms
+step:134/1480 train_time:32032ms step_avg:258.33ms
+step:135/1480 train_time:32295ms step_avg:258.36ms
+step:136/1480 train_time:32557ms step_avg:258.39ms
+step:137/1480 train_time:32818ms step_avg:258.41ms
+step:138/1480 train_time:33080ms step_avg:258.43ms
+step:139/1480 train_time:33343ms step_avg:258.47ms
+step:140/1480 train_time:33606ms step_avg:258.51ms
+step:141/1480 train_time:33868ms step_avg:258.54ms
+step:142/1480 train_time:34130ms step_avg:258.56ms
+step:143/1480 train_time:34391ms step_avg:258.58ms
+step:144/1480 train_time:34655ms step_avg:258.62ms
+step:145/1480 train_time:34916ms step_avg:258.64ms
+step:146/1480 train_time:35180ms step_avg:258.67ms
+step:147/1480 train_time:35442ms step_avg:258.70ms
+step:148/1480 train_time:35704ms step_avg:258.73ms
+step:149/1480 train_time:35965ms step_avg:258.74ms
+step:150/1480 train_time:36225ms step_avg:258.75ms
+step:151/1480 train_time:36487ms step_avg:258.77ms
+step:152/1480 train_time:36750ms step_avg:258.80ms
+step:153/1480 train_time:37013ms step_avg:258.83ms
+step:154/1480 train_time:37276ms step_avg:258.86ms
+step:155/1480 train_time:37538ms step_avg:258.88ms
+step:156/1480 train_time:37800ms step_avg:258.90ms
+step:157/1480 train_time:38060ms step_avg:258.91ms
+step:158/1480 train_time:38322ms step_avg:258.93ms
+step:159/1480 train_time:38582ms step_avg:258.94ms
+step:160/1480 train_time:38844ms step_avg:258.96ms
+step:161/1480 train_time:39106ms step_avg:258.98ms
+step:162/1480 train_time:39368ms step_avg:259.00ms
+step:163/1480 train_time:39631ms step_avg:259.03ms
+step:164/1480 train_time:39894ms step_avg:259.05ms
+step:165/1480 train_time:40158ms step_avg:259.08ms
+step:166/1480 train_time:40419ms step_avg:259.10ms
+step:167/1480 train_time:40682ms step_avg:259.12ms
+step:168/1480 train_time:40947ms step_avg:259.16ms
+step:169/1480 train_time:41211ms step_avg:259.19ms
+step:170/1480 train_time:41476ms step_avg:259.22ms
+step:171/1480 train_time:41736ms step_avg:259.23ms
+step:172/1480 train_time:41999ms step_avg:259.25ms
+step:173/1480 train_time:42260ms step_avg:259.26ms
+step:174/1480 train_time:42521ms step_avg:259.27ms
+step:175/1480 train_time:42782ms step_avg:259.29ms
+step:176/1480 train_time:43044ms step_avg:259.30ms
+step:177/1480 train_time:43310ms step_avg:259.34ms
+step:178/1480 train_time:43574ms step_avg:259.37ms
+step:179/1480 train_time:43836ms step_avg:259.39ms
+step:180/1480 train_time:44099ms step_avg:259.40ms
+step:181/1480 train_time:44359ms step_avg:259.41ms
+step:182/1480 train_time:44619ms step_avg:259.41ms
+step:183/1480 train_time:44880ms step_avg:259.42ms
+step:184/1480 train_time:45142ms step_avg:259.44ms
+step:185/1480 train_time:45407ms step_avg:259.47ms
+step:186/1480 train_time:45673ms step_avg:259.51ms
+step:187/1480 train_time:45935ms step_avg:259.52ms
+step:188/1480 train_time:46197ms step_avg:259.53ms
+step:189/1480 train_time:46459ms step_avg:259.55ms
+step:190/1480 train_time:46719ms step_avg:259.55ms
+step:191/1480 train_time:46981ms step_avg:259.56ms
+step:192/1480 train_time:47245ms step_avg:259.59ms
+step:193/1480 train_time:47510ms step_avg:259.61ms
+step:194/1480 train_time:47775ms step_avg:259.65ms
+step:195/1480 train_time:48037ms step_avg:259.66ms
+step:196/1480 train_time:48299ms step_avg:259.67ms
+step:197/1480 train_time:48559ms step_avg:259.67ms
+step:198/1480 train_time:48819ms step_avg:259.67ms
+step:199/1480 train_time:49081ms step_avg:259.69ms
+step:200/1480 train_time:49344ms step_avg:259.70ms
+step:201/1480 train_time:49609ms step_avg:259.73ms
+step:202/1480 train_time:49875ms step_avg:259.77ms
+step:203/1480 train_time:50137ms step_avg:259.78ms
+step:204/1480 train_time:50398ms step_avg:259.78ms
+step:205/1480 train_time:50659ms step_avg:259.79ms
+step:206/1480 train_time:50919ms step_avg:259.79ms
+step:207/1480 train_time:51181ms step_avg:259.80ms
+step:208/1480 train_time:51446ms step_avg:259.83ms
+step:209/1480 train_time:51710ms step_avg:259.85ms
+step:210/1480 train_time:51976ms step_avg:259.88ms
+step:211/1480 train_time:52236ms step_avg:259.88ms
+step:212/1480 train_time:52499ms step_avg:259.89ms
+step:213/1480 train_time:52758ms step_avg:259.89ms
+step:214/1480 train_time:53020ms step_avg:259.90ms
+step:215/1480 train_time:53282ms step_avg:259.91ms
+step:216/1480 train_time:53546ms step_avg:259.93ms
+step:217/1480 train_time:53814ms step_avg:259.97ms
+step:218/1480 train_time:54078ms step_avg:259.99ms
+step:219/1480 train_time:54339ms step_avg:259.99ms
+step:220/1480 train_time:54600ms step_avg:260.00ms
+step:221/1480 train_time:54864ms step_avg:260.02ms
+step:222/1480 train_time:55133ms step_avg:260.06ms
+step:223/1480 train_time:55398ms step_avg:260.08ms
+step:224/1480 train_time:55663ms step_avg:260.11ms
+step:225/1480 train_time:55931ms step_avg:260.15ms
+step:226/1480 train_time:56197ms step_avg:260.17ms
+step:227/1480 train_time:56463ms step_avg:260.20ms
+step:228/1480 train_time:56731ms step_avg:260.23ms
+step:229/1480 train_time:56996ms step_avg:260.25ms
+step:230/1480 train_time:57260ms step_avg:260.27ms
+step:231/1480 train_time:57527ms step_avg:260.30ms
+step:232/1480 train_time:57793ms step_avg:260.33ms
+step:233/1480 train_time:58059ms step_avg:260.35ms
+step:234/1480 train_time:58323ms step_avg:260.37ms
+step:235/1480 train_time:58591ms step_avg:260.40ms
+step:236/1480 train_time:58858ms step_avg:260.44ms
+step:237/1480 train_time:59121ms step_avg:260.45ms
+step:238/1480 train_time:59389ms step_avg:260.48ms
+step:239/1480 train_time:59657ms step_avg:260.51ms
+step:240/1480 train_time:59920ms step_avg:260.52ms
+step:241/1480 train_time:60189ms step_avg:260.56ms
+step:242/1480 train_time:60456ms step_avg:260.59ms
+step:243/1480 train_time:60720ms step_avg:260.60ms
+step:244/1480 train_time:60986ms step_avg:260.62ms
+step:245/1480 train_time:61255ms step_avg:260.66ms
+step:246/1480 train_time:61519ms step_avg:260.68ms
+step:247/1480 train_time:61788ms step_avg:260.71ms
+step:248/1480 train_time:62055ms step_avg:260.73ms
+step:249/1480 train_time:62320ms step_avg:260.75ms
+step:250/1480 train_time:62589ms step_avg:260.79ms
+step:250/1480 val_loss:4.0061 train_time:62718ms step_avg:261.32ms
+step:251/1480 train_time:62856ms step_avg:260.81ms
+step:252/1480 train_time:63128ms step_avg:260.86ms
+step:253/1480 train_time:63395ms step_avg:260.88ms
+step:254/1480 train_time:63665ms step_avg:260.92ms
+step:255/1480 train_time:63929ms step_avg:260.93ms
+step:256/1480 train_time:64199ms step_avg:260.97ms
+step:257/1480 train_time:64468ms step_avg:261.01ms
+step:258/1480 train_time:64732ms step_avg:261.02ms
+step:259/1480 train_time:65004ms step_avg:261.06ms
+step:260/1480 train_time:65270ms step_avg:261.08ms
+step:261/1480 train_time:65538ms step_avg:261.11ms
+step:262/1480 train_time:65806ms step_avg:261.13ms
+step:263/1480 train_time:66070ms step_avg:261.15ms
+step:264/1480 train_time:66341ms step_avg:261.18ms
+step:265/1480 train_time:66609ms step_avg:261.21ms
+step:266/1480 train_time:66874ms step_avg:261.23ms
+step:267/1480 train_time:67143ms step_avg:261.26ms
+step:268/1480 train_time:67410ms step_avg:261.28ms
+step:269/1480 train_time:67677ms step_avg:261.30ms
+step:270/1480 train_time:67946ms step_avg:261.33ms
+step:271/1480 train_time:68210ms step_avg:261.34ms
+step:272/1480 train_time:68477ms step_avg:261.36ms
+step:273/1480 train_time:68745ms step_avg:261.39ms
+step:274/1480 train_time:69009ms step_avg:261.40ms
+step:275/1480 train_time:69277ms step_avg:261.42ms
+step:276/1480 train_time:69544ms step_avg:261.45ms
+step:277/1480 train_time:69810ms step_avg:261.46ms
+step:278/1480 train_time:70075ms step_avg:261.47ms
+step:279/1480 train_time:70344ms step_avg:261.50ms
+step:280/1480 train_time:70608ms step_avg:261.51ms
+step:281/1480 train_time:70875ms step_avg:261.53ms
+step:282/1480 train_time:71143ms step_avg:261.55ms
+step:283/1480 train_time:71409ms step_avg:261.57ms
+step:284/1480 train_time:71674ms step_avg:261.58ms
+step:285/1480 train_time:71944ms step_avg:261.61ms
+step:286/1480 train_time:72210ms step_avg:261.63ms
+step:287/1480 train_time:72477ms step_avg:261.65ms
+step:288/1480 train_time:72745ms step_avg:261.67ms
+step:289/1480 train_time:73010ms step_avg:261.68ms
+step:290/1480 train_time:73276ms step_avg:261.70ms
+step:291/1480 train_time:73545ms step_avg:261.73ms
+step:292/1480 train_time:73810ms step_avg:261.74ms
+step:293/1480 train_time:74077ms step_avg:261.76ms
+step:294/1480 train_time:74344ms step_avg:261.78ms
+step:295/1480 train_time:74609ms step_avg:261.79ms
+step:296/1480 train_time:74873ms step_avg:261.80ms
+step:297/1480 train_time:75145ms step_avg:261.83ms
+step:298/1480 train_time:75409ms step_avg:261.84ms
+step:299/1480 train_time:75677ms step_avg:261.86ms
+step:300/1480 train_time:75946ms step_avg:261.88ms
+step:301/1480 train_time:76209ms step_avg:261.89ms
+step:302/1480 train_time:76478ms step_avg:261.91ms
+step:303/1480 train_time:76746ms step_avg:261.93ms
+step:304/1480 train_time:77012ms step_avg:261.94ms
+step:305/1480 train_time:77281ms step_avg:261.97ms
+step:306/1480 train_time:77547ms step_avg:261.98ms
+step:307/1480 train_time:77810ms step_avg:261.99ms
+step:308/1480 train_time:78079ms step_avg:262.01ms
+step:309/1480 train_time:78347ms step_avg:262.03ms
+step:310/1480 train_time:78610ms step_avg:262.03ms
+step:311/1480 train_time:78876ms step_avg:262.05ms
+step:312/1480 train_time:79144ms step_avg:262.07ms
+step:313/1480 train_time:79409ms step_avg:262.08ms
+step:314/1480 train_time:79677ms step_avg:262.09ms
+step:315/1480 train_time:79945ms step_avg:262.11ms
+step:316/1480 train_time:80209ms step_avg:262.12ms
+step:317/1480 train_time:80477ms step_avg:262.14ms
+step:318/1480 train_time:80747ms step_avg:262.16ms
+step:319/1480 train_time:81011ms step_avg:262.17ms
+step:320/1480 train_time:81279ms step_avg:262.19ms
+step:321/1480 train_time:81547ms step_avg:262.21ms
+step:322/1480 train_time:81812ms step_avg:262.22ms
+step:323/1480 train_time:82080ms step_avg:262.24ms
+step:324/1480 train_time:82347ms step_avg:262.25ms
+step:325/1480 train_time:82611ms step_avg:262.26ms
+step:326/1480 train_time:82880ms step_avg:262.28ms
+step:327/1480 train_time:83147ms step_avg:262.29ms
+step:328/1480 train_time:83411ms step_avg:262.30ms
+step:329/1480 train_time:83680ms step_avg:262.32ms
+step:330/1480 train_time:83948ms step_avg:262.34ms
+step:331/1480 train_time:84220ms step_avg:262.37ms
+step:332/1480 train_time:84488ms step_avg:262.39ms
+step:333/1480 train_time:84763ms step_avg:262.42ms
+step:334/1480 train_time:85030ms step_avg:262.44ms
+step:335/1480 train_time:85301ms step_avg:262.47ms
+step:336/1480 train_time:85571ms step_avg:262.49ms
+step:337/1480 train_time:85845ms step_avg:262.52ms
+step:338/1480 train_time:86112ms step_avg:262.54ms
+step:339/1480 train_time:86385ms step_avg:262.57ms
+step:340/1480 train_time:86654ms step_avg:262.59ms
+step:341/1480 train_time:86927ms step_avg:262.62ms
+step:342/1480 train_time:87197ms step_avg:262.64ms
+step:343/1480 train_time:87469ms step_avg:262.67ms
+step:344/1480 train_time:87739ms step_avg:262.69ms
+step:345/1480 train_time:88009ms step_avg:262.71ms
+step:346/1480 train_time:88280ms step_avg:262.74ms
+step:347/1480 train_time:88549ms step_avg:262.76ms
+step:348/1480 train_time:88819ms step_avg:262.78ms
+step:349/1480 train_time:89089ms step_avg:262.80ms
+step:350/1480 train_time:89362ms step_avg:262.83ms
+step:351/1480 train_time:89631ms step_avg:262.85ms
+step:352/1480 train_time:89907ms step_avg:262.89ms
+step:353/1480 train_time:90178ms step_avg:262.91ms
+step:354/1480 train_time:90450ms step_avg:262.94ms
+step:355/1480 train_time:90722ms step_avg:262.96ms
+step:356/1480 train_time:90989ms step_avg:262.97ms
+step:357/1480 train_time:91263ms step_avg:263.01ms
+step:358/1480 train_time:91531ms step_avg:263.02ms
+step:359/1480 train_time:91803ms step_avg:263.05ms
+step:360/1480 train_time:92075ms step_avg:263.07ms
+step:361/1480 train_time:92348ms step_avg:263.10ms
+step:362/1480 train_time:92616ms step_avg:263.11ms
+step:363/1480 train_time:92886ms step_avg:263.13ms
+step:364/1480 train_time:93158ms step_avg:263.16ms
+step:365/1480 train_time:93428ms step_avg:263.18ms
+step:366/1480 train_time:93701ms step_avg:263.21ms
+step:367/1480 train_time:93971ms step_avg:263.22ms
+step:368/1480 train_time:94246ms step_avg:263.26ms
+step:369/1480 train_time:94513ms step_avg:263.27ms
+step:370/1480 train_time:94787ms step_avg:263.30ms
+step:371/1480 train_time:95056ms step_avg:263.31ms
+step:372/1480 train_time:95327ms step_avg:263.34ms
+step:373/1480 train_time:95601ms step_avg:263.36ms
+step:374/1480 train_time:95871ms step_avg:263.38ms
+step:375/1480 train_time:96145ms step_avg:263.41ms
+step:375/1480 val_loss:3.8346 train_time:96276ms step_avg:263.77ms
+step:376/1480 train_time:96417ms step_avg:263.43ms
+step:377/1480 train_time:96693ms step_avg:263.47ms
+step:378/1480 train_time:96961ms step_avg:263.48ms
+step:379/1480 train_time:97235ms step_avg:263.51ms
+step:380/1480 train_time:97502ms step_avg:263.52ms
+step:381/1480 train_time:97777ms step_avg:263.55ms
+step:382/1480 train_time:98044ms step_avg:263.56ms
+step:383/1480 train_time:98315ms step_avg:263.58ms
+step:384/1480 train_time:98588ms step_avg:263.60ms
+step:385/1480 train_time:98856ms step_avg:263.62ms
+step:386/1480 train_time:99131ms step_avg:263.65ms
+step:387/1480 train_time:99399ms step_avg:263.66ms
+step:388/1480 train_time:99672ms step_avg:263.68ms
+step:389/1480 train_time:99941ms step_avg:263.70ms
+step:390/1480 train_time:100216ms step_avg:263.73ms
+step:391/1480 train_time:100482ms step_avg:263.73ms
+step:392/1480 train_time:100755ms step_avg:263.76ms
+step:393/1480 train_time:101027ms step_avg:263.78ms
+step:394/1480 train_time:101298ms step_avg:263.80ms
+step:395/1480 train_time:101572ms step_avg:263.82ms
+step:396/1480 train_time:101841ms step_avg:263.84ms
+step:397/1480 train_time:102116ms step_avg:263.87ms
+step:398/1480 train_time:102387ms step_avg:263.88ms
+step:399/1480 train_time:102657ms step_avg:263.90ms
+step:400/1480 train_time:102932ms step_avg:263.93ms
+step:401/1480 train_time:103200ms step_avg:263.94ms
+step:402/1480 train_time:103473ms step_avg:263.96ms
+step:403/1480 train_time:103743ms step_avg:263.98ms
+step:404/1480 train_time:104016ms step_avg:264.00ms
+step:405/1480 train_time:104286ms step_avg:264.02ms
+step:406/1480 train_time:104556ms step_avg:264.03ms
+step:407/1480 train_time:104829ms step_avg:264.05ms
+step:408/1480 train_time:105099ms step_avg:264.07ms
+step:409/1480 train_time:105372ms step_avg:264.09ms
+step:410/1480 train_time:105643ms step_avg:264.11ms
+step:411/1480 train_time:105917ms step_avg:264.13ms
+step:412/1480 train_time:106187ms step_avg:264.15ms
+step:413/1480 train_time:106456ms step_avg:264.16ms
+step:414/1480 train_time:106731ms step_avg:264.19ms
+step:415/1480 train_time:106999ms step_avg:264.20ms
+step:416/1480 train_time:107273ms step_avg:264.22ms
+step:417/1480 train_time:107543ms step_avg:264.23ms
+step:418/1480 train_time:107818ms step_avg:264.26ms
+step:419/1480 train_time:108085ms step_avg:264.27ms
+step:420/1480 train_time:108355ms step_avg:264.28ms
+step:421/1480 train_time:108628ms step_avg:264.30ms
+step:422/1480 train_time:108898ms step_avg:264.31ms
+step:423/1480 train_time:109172ms step_avg:264.34ms
+step:424/1480 train_time:109442ms step_avg:264.35ms
+step:425/1480 train_time:109715ms step_avg:264.37ms
+step:426/1480 train_time:109989ms step_avg:264.40ms
+step:427/1480 train_time:110258ms step_avg:264.41ms
+step:428/1480 train_time:110529ms step_avg:264.42ms
+step:429/1480 train_time:110799ms step_avg:264.44ms
+step:430/1480 train_time:111072ms step_avg:264.46ms
+step:431/1480 train_time:111342ms step_avg:264.47ms
+step:432/1480 train_time:111617ms step_avg:264.49ms
+step:433/1480 train_time:111885ms step_avg:264.50ms
+step:434/1480 train_time:112156ms step_avg:264.52ms
+step:435/1480 train_time:112428ms step_avg:264.54ms
+step:436/1480 train_time:112697ms step_avg:264.55ms
+step:437/1480 train_time:112971ms step_avg:264.57ms
+step:438/1480 train_time:113241ms step_avg:264.58ms
+step:439/1480 train_time:113516ms step_avg:264.61ms
+step:440/1480 train_time:113784ms step_avg:264.61ms
+step:441/1480 train_time:114058ms step_avg:264.64ms
+step:442/1480 train_time:114335ms step_avg:264.66ms
+step:443/1480 train_time:114610ms step_avg:264.69ms
+step:444/1480 train_time:114883ms step_avg:264.71ms
+step:445/1480 train_time:115157ms step_avg:264.73ms
+step:446/1480 train_time:115433ms step_avg:264.75ms
+step:447/1480 train_time:115704ms step_avg:264.77ms
+step:448/1480 train_time:115979ms step_avg:264.79ms
+step:449/1480 train_time:116254ms step_avg:264.82ms
+step:450/1480 train_time:116531ms step_avg:264.84ms
+step:451/1480 train_time:116800ms step_avg:264.85ms
+step:452/1480 train_time:117078ms step_avg:264.88ms
+step:453/1480 train_time:117354ms step_avg:264.91ms
+step:454/1480 train_time:117628ms step_avg:264.93ms
+step:455/1480 train_time:117901ms step_avg:264.95ms
+step:456/1480 train_time:118177ms step_avg:264.97ms
+step:457/1480 train_time:118454ms step_avg:265.00ms
+step:458/1480 train_time:118726ms step_avg:265.01ms
+step:459/1480 train_time:118999ms step_avg:265.03ms
+step:460/1480 train_time:119274ms step_avg:265.05ms
+step:461/1480 train_time:119549ms step_avg:265.08ms
+step:462/1480 train_time:119821ms step_avg:265.09ms
+step:463/1480 train_time:120096ms step_avg:265.11ms
+step:464/1480 train_time:120375ms step_avg:265.14ms
+step:465/1480 train_time:120653ms step_avg:265.17ms
+step:466/1480 train_time:120922ms step_avg:265.18ms
+step:467/1480 train_time:121198ms step_avg:265.20ms
+step:468/1480 train_time:121473ms step_avg:265.23ms
+step:469/1480 train_time:121748ms step_avg:265.25ms
+step:470/1480 train_time:122020ms step_avg:265.26ms
+step:471/1480 train_time:122295ms step_avg:265.28ms
+step:472/1480 train_time:122570ms step_avg:265.30ms
+step:473/1480 train_time:122841ms step_avg:265.32ms
+step:474/1480 train_time:123118ms step_avg:265.34ms
+step:475/1480 train_time:123396ms step_avg:265.37ms
+step:476/1480 train_time:123668ms step_avg:265.38ms
+step:477/1480 train_time:123941ms step_avg:265.40ms
+step:478/1480 train_time:124219ms step_avg:265.42ms
+step:479/1480 train_time:124492ms step_avg:265.44ms
+step:480/1480 train_time:124761ms step_avg:265.45ms
+step:481/1480 train_time:125039ms step_avg:265.47ms
+step:482/1480 train_time:125314ms step_avg:265.50ms
+step:483/1480 train_time:125589ms step_avg:265.52ms
+step:484/1480 train_time:125860ms step_avg:265.53ms
+step:485/1480 train_time:126136ms step_avg:265.55ms
+step:486/1480 train_time:126410ms step_avg:265.57ms
+step:487/1480 train_time:126683ms step_avg:265.58ms
+step:488/1480 train_time:126957ms step_avg:265.60ms
+step:489/1480 train_time:127233ms step_avg:265.62ms
+step:490/1480 train_time:127509ms step_avg:265.64ms
+step:491/1480 train_time:127780ms step_avg:265.65ms
+step:492/1480 train_time:128056ms step_avg:265.68ms
+step:493/1480 train_time:128333ms step_avg:265.70ms
+step:494/1480 train_time:128604ms step_avg:265.71ms
+step:495/1480 train_time:128879ms step_avg:265.73ms
+step:496/1480 train_time:129156ms step_avg:265.75ms
+step:497/1480 train_time:129431ms step_avg:265.77ms
+step:498/1480 train_time:129701ms step_avg:265.78ms
+step:499/1480 train_time:129978ms step_avg:265.80ms
+step:500/1480 train_time:130255ms step_avg:265.83ms
+step:500/1480 val_loss:3.7189 train_time:130389ms step_avg:266.10ms
+step:501/1480 train_time:130531ms step_avg:265.85ms
+step:502/1480 train_time:130808ms step_avg:265.87ms
+step:503/1480 train_time:131086ms step_avg:265.89ms
+step:504/1480 train_time:131360ms step_avg:265.91ms
+step:505/1480 train_time:131631ms step_avg:265.92ms
+step:506/1480 train_time:131908ms step_avg:265.94ms
+step:507/1480 train_time:132182ms step_avg:265.96ms
+step:508/1480 train_time:132456ms step_avg:265.98ms
+step:509/1480 train_time:132728ms step_avg:265.99ms
+step:510/1480 train_time:133005ms step_avg:266.01ms
+step:511/1480 train_time:133279ms step_avg:266.03ms
+step:512/1480 train_time:133551ms step_avg:266.04ms
+step:513/1480 train_time:133826ms step_avg:266.06ms
+step:514/1480 train_time:134103ms step_avg:266.08ms
+step:515/1480 train_time:134373ms step_avg:266.09ms
+step:516/1480 train_time:134648ms step_avg:266.10ms
+step:517/1480 train_time:134926ms step_avg:266.13ms
+step:518/1480 train_time:135201ms step_avg:266.14ms
+step:519/1480 train_time:135472ms step_avg:266.15ms
+step:520/1480 train_time:135748ms step_avg:266.17ms
+step:521/1480 train_time:136023ms step_avg:266.19ms
+step:522/1480 train_time:136299ms step_avg:266.21ms
+step:523/1480 train_time:136572ms step_avg:266.22ms
+step:524/1480 train_time:136848ms step_avg:266.24ms
+step:525/1480 train_time:137122ms step_avg:266.26ms
+step:526/1480 train_time:137397ms step_avg:266.27ms
+step:527/1480 train_time:137669ms step_avg:266.29ms
+step:528/1480 train_time:137946ms step_avg:266.31ms
+step:529/1480 train_time:138223ms step_avg:266.33ms
+step:530/1480 train_time:138496ms step_avg:266.34ms
+step:531/1480 train_time:138769ms step_avg:266.35ms
+step:532/1480 train_time:139045ms step_avg:266.37ms
+step:533/1480 train_time:139320ms step_avg:266.39ms
+step:534/1480 train_time:139591ms step_avg:266.40ms
+step:535/1480 train_time:139867ms step_avg:266.41ms
+step:536/1480 train_time:140144ms step_avg:266.43ms
+step:537/1480 train_time:140420ms step_avg:266.45ms
+step:538/1480 train_time:140691ms step_avg:266.46ms
+step:539/1480 train_time:140964ms step_avg:266.47ms
+step:540/1480 train_time:141237ms step_avg:266.48ms
+step:541/1480 train_time:141511ms step_avg:266.50ms
+step:542/1480 train_time:141786ms step_avg:266.52ms
+step:543/1480 train_time:142062ms step_avg:266.53ms
+step:544/1480 train_time:142332ms step_avg:266.54ms
+step:545/1480 train_time:142607ms step_avg:266.56ms
+step:546/1480 train_time:142882ms step_avg:266.57ms
+step:547/1480 train_time:143153ms step_avg:266.58ms
+step:548/1480 train_time:143429ms step_avg:266.60ms
+step:549/1480 train_time:143704ms step_avg:266.61ms
+step:550/1480 train_time:143978ms step_avg:266.63ms
+step:551/1480 train_time:144253ms step_avg:266.64ms
+step:552/1480 train_time:144530ms step_avg:266.66ms
+step:553/1480 train_time:144808ms step_avg:266.68ms
+step:554/1480 train_time:145085ms step_avg:266.70ms
+step:555/1480 train_time:145366ms step_avg:266.73ms
+step:556/1480 train_time:145641ms step_avg:266.74ms
+step:557/1480 train_time:145917ms step_avg:266.76ms
+step:558/1480 train_time:146191ms step_avg:266.77ms
+step:559/1480 train_time:146469ms step_avg:266.79ms
+step:560/1480 train_time:146748ms step_avg:266.81ms
+step:561/1480 train_time:147026ms step_avg:266.83ms
+step:562/1480 train_time:147304ms step_avg:266.86ms
+step:563/1480 train_time:147576ms step_avg:266.86ms
+step:564/1480 train_time:147852ms step_avg:266.88ms
+step:565/1480 train_time:148130ms step_avg:266.90ms
+step:566/1480 train_time:148407ms step_avg:266.92ms
+step:567/1480 train_time:148685ms step_avg:266.94ms
+step:568/1480 train_time:148964ms step_avg:266.96ms
+step:569/1480 train_time:149245ms step_avg:266.99ms
+step:570/1480 train_time:149520ms step_avg:267.00ms
+step:571/1480 train_time:149798ms step_avg:267.02ms
+step:572/1480 train_time:150072ms step_avg:267.03ms
+step:573/1480 train_time:150350ms step_avg:267.05ms
+step:574/1480 train_time:150628ms step_avg:267.07ms
+step:575/1480 train_time:150908ms step_avg:267.09ms
+step:576/1480 train_time:151186ms step_avg:267.11ms
+step:577/1480 train_time:151463ms step_avg:267.13ms
+step:578/1480 train_time:151736ms step_avg:267.14ms
+step:579/1480 train_time:152012ms step_avg:267.16ms
+step:580/1480 train_time:152290ms step_avg:267.17ms
+step:581/1480 train_time:152568ms step_avg:267.19ms
+step:582/1480 train_time:152847ms step_avg:267.21ms
+step:583/1480 train_time:153126ms step_avg:267.24ms
+step:584/1480 train_time:153404ms step_avg:267.25ms
+step:585/1480 train_time:153684ms step_avg:267.28ms
+step:586/1480 train_time:153962ms step_avg:267.30ms
+step:587/1480 train_time:154242ms step_avg:267.32ms
+step:588/1480 train_time:154519ms step_avg:267.33ms
+step:589/1480 train_time:154791ms step_avg:267.34ms
+step:590/1480 train_time:155070ms step_avg:267.36ms
+step:591/1480 train_time:155348ms step_avg:267.38ms
+step:592/1480 train_time:155627ms step_avg:267.40ms
+step:593/1480 train_time:155907ms step_avg:267.42ms
+step:594/1480 train_time:156183ms step_avg:267.44ms
+step:595/1480 train_time:156463ms step_avg:267.46ms
+step:596/1480 train_time:156737ms step_avg:267.47ms
+step:597/1480 train_time:157014ms step_avg:267.49ms
+step:598/1480 train_time:157291ms step_avg:267.50ms
+step:599/1480 train_time:157569ms step_avg:267.52ms
+step:600/1480 train_time:157846ms step_avg:267.53ms
+step:601/1480 train_time:158124ms step_avg:267.55ms
+step:602/1480 train_time:158405ms step_avg:267.58ms
+step:603/1480 train_time:158681ms step_avg:267.59ms
+step:604/1480 train_time:158953ms step_avg:267.60ms
+step:605/1480 train_time:159232ms step_avg:267.62ms
+step:606/1480 train_time:159511ms step_avg:267.64ms
+step:607/1480 train_time:159790ms step_avg:267.66ms
+step:608/1480 train_time:160069ms step_avg:267.67ms
+step:609/1480 train_time:160347ms step_avg:267.69ms
+step:610/1480 train_time:160627ms step_avg:267.71ms
+step:611/1480 train_time:160907ms step_avg:267.73ms
+step:612/1480 train_time:161188ms step_avg:267.75ms
+step:613/1480 train_time:161468ms step_avg:267.77ms
+step:614/1480 train_time:161746ms step_avg:267.79ms
+step:615/1480 train_time:162025ms step_avg:267.81ms
+step:616/1480 train_time:162305ms step_avg:267.83ms
+step:617/1480 train_time:162579ms step_avg:267.84ms
+step:618/1480 train_time:162853ms step_avg:267.85ms
+step:619/1480 train_time:163129ms step_avg:267.86ms
+step:620/1480 train_time:163408ms step_avg:267.88ms
+step:621/1480 train_time:163686ms step_avg:267.90ms
+step:622/1480 train_time:163966ms step_avg:267.92ms
+step:623/1480 train_time:164244ms step_avg:267.93ms
+step:624/1480 train_time:164523ms step_avg:267.95ms
+step:625/1480 train_time:164804ms step_avg:267.97ms
+step:625/1480 val_loss:3.6372 train_time:164940ms step_avg:268.20ms
+step:626/1480 train_time:165081ms step_avg:267.99ms
+step:627/1480 train_time:165362ms step_avg:268.01ms
+step:628/1480 train_time:165641ms step_avg:268.03ms
+step:629/1480 train_time:165918ms step_avg:268.04ms
+step:630/1480 train_time:166198ms step_avg:268.06ms
+step:631/1480 train_time:166474ms step_avg:268.07ms
+step:632/1480 train_time:166749ms step_avg:268.08ms
+step:633/1480 train_time:167022ms step_avg:268.09ms
+step:634/1480 train_time:167301ms step_avg:268.11ms
+step:635/1480 train_time:167578ms step_avg:268.13ms
+step:636/1480 train_time:167859ms step_avg:268.14ms
+step:637/1480 train_time:168133ms step_avg:268.15ms
+step:638/1480 train_time:168412ms step_avg:268.17ms
+step:639/1480 train_time:168684ms step_avg:268.18ms
+step:640/1480 train_time:168963ms step_avg:268.20ms
+step:641/1480 train_time:169240ms step_avg:268.21ms
+step:642/1480 train_time:169518ms step_avg:268.22ms
+step:643/1480 train_time:169797ms step_avg:268.24ms
+step:644/1480 train_time:170078ms step_avg:268.26ms
+step:645/1480 train_time:170358ms step_avg:268.28ms
+step:646/1480 train_time:170634ms step_avg:268.29ms
+step:647/1480 train_time:170908ms step_avg:268.30ms
+step:648/1480 train_time:171185ms step_avg:268.31ms
+step:649/1480 train_time:171463ms step_avg:268.33ms
+step:650/1480 train_time:171741ms step_avg:268.35ms
+step:651/1480 train_time:172020ms step_avg:268.36ms
+step:652/1480 train_time:172298ms step_avg:268.38ms
+step:653/1480 train_time:172579ms step_avg:268.40ms
+step:654/1480 train_time:172860ms step_avg:268.42ms
+step:655/1480 train_time:173137ms step_avg:268.43ms
+step:656/1480 train_time:173415ms step_avg:268.44ms
+step:657/1480 train_time:173692ms step_avg:268.46ms
+step:658/1480 train_time:173969ms step_avg:268.47ms
+step:659/1480 train_time:174245ms step_avg:268.48ms
+step:660/1480 train_time:174523ms step_avg:268.50ms
+step:661/1480 train_time:174803ms step_avg:268.51ms
+step:662/1480 train_time:175082ms step_avg:268.53ms
+step:663/1480 train_time:175362ms step_avg:268.55ms
+step:664/1480 train_time:175641ms step_avg:268.56ms
+step:665/1480 train_time:175921ms step_avg:268.58ms
+step:666/1480 train_time:176200ms step_avg:268.60ms
+step:667/1480 train_time:176481ms step_avg:268.62ms
+step:668/1480 train_time:176762ms step_avg:268.64ms
+step:669/1480 train_time:177041ms step_avg:268.65ms
+step:670/1480 train_time:177320ms step_avg:268.67ms
+step:671/1480 train_time:177599ms step_avg:268.68ms
+step:672/1480 train_time:177880ms step_avg:268.70ms
+step:673/1480 train_time:178160ms step_avg:268.72ms
+step:674/1480 train_time:178439ms step_avg:268.73ms
+step:675/1480 train_time:178719ms step_avg:268.75ms
+step:676/1480 train_time:178999ms step_avg:268.77ms
+step:677/1480 train_time:179280ms step_avg:268.79ms
+step:678/1480 train_time:179559ms step_avg:268.80ms
+step:679/1480 train_time:179839ms step_avg:268.82ms
+step:680/1480 train_time:180121ms step_avg:268.84ms
+step:681/1480 train_time:180400ms step_avg:268.85ms
+step:682/1480 train_time:180682ms step_avg:268.87ms
+step:683/1480 train_time:180962ms step_avg:268.89ms
+step:684/1480 train_time:181239ms step_avg:268.90ms
+step:685/1480 train_time:181518ms step_avg:268.91ms
+step:686/1480 train_time:181800ms step_avg:268.93ms
+step:687/1480 train_time:182080ms step_avg:268.95ms
+step:688/1480 train_time:182363ms step_avg:268.97ms
+step:689/1480 train_time:182642ms step_avg:268.99ms
+step:690/1480 train_time:182921ms step_avg:269.00ms
+step:691/1480 train_time:183203ms step_avg:269.02ms
+step:692/1480 train_time:183483ms step_avg:269.04ms
+step:693/1480 train_time:183762ms step_avg:269.05ms
+step:694/1480 train_time:184040ms step_avg:269.07ms
+step:695/1480 train_time:184320ms step_avg:269.08ms
+step:696/1480 train_time:184603ms step_avg:269.10ms
+step:697/1480 train_time:184881ms step_avg:269.11ms
+step:698/1480 train_time:185161ms step_avg:269.13ms
+step:699/1480 train_time:185441ms step_avg:269.14ms
+step:700/1480 train_time:185719ms step_avg:269.16ms
+step:701/1480 train_time:186000ms step_avg:269.17ms
+step:702/1480 train_time:186283ms step_avg:269.20ms
+step:703/1480 train_time:186562ms step_avg:269.21ms
+step:704/1480 train_time:186841ms step_avg:269.22ms
+step:705/1480 train_time:187122ms step_avg:269.24ms
+step:706/1480 train_time:187399ms step_avg:269.25ms
+step:707/1480 train_time:187680ms step_avg:269.27ms
+step:708/1480 train_time:187962ms step_avg:269.29ms
+step:709/1480 train_time:188241ms step_avg:269.30ms
+step:710/1480 train_time:188520ms step_avg:269.31ms
+step:711/1480 train_time:188801ms step_avg:269.33ms
+step:712/1480 train_time:189082ms step_avg:269.35ms
+step:713/1480 train_time:189360ms step_avg:269.36ms
+step:714/1480 train_time:189640ms step_avg:269.37ms
+step:715/1480 train_time:189920ms step_avg:269.39ms
+step:716/1480 train_time:190201ms step_avg:269.41ms
+step:717/1480 train_time:190481ms step_avg:269.42ms
+step:718/1480 train_time:190760ms step_avg:269.44ms
+step:719/1480 train_time:191039ms step_avg:269.45ms
+step:720/1480 train_time:191319ms step_avg:269.46ms
+step:721/1480 train_time:191598ms step_avg:269.48ms
+step:722/1480 train_time:191879ms step_avg:269.49ms
+step:723/1480 train_time:192161ms step_avg:269.51ms
+step:724/1480 train_time:192438ms step_avg:269.52ms
+step:725/1480 train_time:192720ms step_avg:269.54ms
+step:726/1480 train_time:193001ms step_avg:269.55ms
+step:727/1480 train_time:193282ms step_avg:269.57ms
+step:728/1480 train_time:193561ms step_avg:269.58ms
+step:729/1480 train_time:193840ms step_avg:269.60ms
+step:730/1480 train_time:194121ms step_avg:269.61ms
+step:731/1480 train_time:194402ms step_avg:269.63ms
+step:732/1480 train_time:194682ms step_avg:269.64ms
+step:733/1480 train_time:194963ms step_avg:269.66ms
+step:734/1480 train_time:195240ms step_avg:269.67ms
+step:735/1480 train_time:195520ms step_avg:269.68ms
+step:736/1480 train_time:195801ms step_avg:269.70ms
+step:737/1480 train_time:196080ms step_avg:269.71ms
+step:738/1480 train_time:196362ms step_avg:269.73ms
+step:739/1480 train_time:196640ms step_avg:269.74ms
+step:740/1480 train_time:196918ms step_avg:269.75ms
+step:741/1480 train_time:197197ms step_avg:269.76ms
+step:742/1480 train_time:197477ms step_avg:269.78ms
+step:743/1480 train_time:197756ms step_avg:269.79ms
+step:744/1480 train_time:198030ms step_avg:269.80ms
+step:745/1480 train_time:198312ms step_avg:269.81ms
+step:746/1480 train_time:198587ms step_avg:269.82ms
+step:747/1480 train_time:198865ms step_avg:269.83ms
+step:748/1480 train_time:199143ms step_avg:269.84ms
+step:749/1480 train_time:199422ms step_avg:269.85ms
+step:750/1480 train_time:199700ms step_avg:269.87ms
+step:750/1480 val_loss:3.5790 train_time:199838ms step_avg:270.05ms
+step:751/1480 train_time:199981ms step_avg:269.88ms
+step:752/1480 train_time:200261ms step_avg:269.89ms
+step:753/1480 train_time:200539ms step_avg:269.90ms
+step:754/1480 train_time:200818ms step_avg:269.92ms
+step:755/1480 train_time:201100ms step_avg:269.93ms
+step:756/1480 train_time:201380ms step_avg:269.95ms
+step:757/1480 train_time:201660ms step_avg:269.96ms
+step:758/1480 train_time:201940ms step_avg:269.97ms
+step:759/1480 train_time:202219ms step_avg:269.99ms
+step:760/1480 train_time:202498ms step_avg:270.00ms
+step:761/1480 train_time:202776ms step_avg:270.01ms
+step:762/1480 train_time:203061ms step_avg:270.03ms
+step:763/1480 train_time:203341ms step_avg:270.04ms
+step:764/1480 train_time:203620ms step_avg:270.05ms
+step:765/1480 train_time:203900ms step_avg:270.07ms
+step:766/1480 train_time:204181ms step_avg:270.08ms
+step:767/1480 train_time:204459ms step_avg:270.09ms
+step:768/1480 train_time:204738ms step_avg:270.10ms
+step:769/1480 train_time:205018ms step_avg:270.12ms
+step:770/1480 train_time:205300ms step_avg:270.13ms
+step:771/1480 train_time:205579ms step_avg:270.14ms
+step:772/1480 train_time:205861ms step_avg:270.16ms
+step:773/1480 train_time:206141ms step_avg:270.17ms
+step:774/1480 train_time:206425ms step_avg:270.19ms
+step:775/1480 train_time:206703ms step_avg:270.20ms
+step:776/1480 train_time:206982ms step_avg:270.21ms
+step:777/1480 train_time:207264ms step_avg:270.23ms
+step:778/1480 train_time:207544ms step_avg:270.24ms
+step:779/1480 train_time:207826ms step_avg:270.25ms
+step:780/1480 train_time:208104ms step_avg:270.27ms
+step:781/1480 train_time:208383ms step_avg:270.28ms
+step:782/1480 train_time:208665ms step_avg:270.29ms
+step:783/1480 train_time:208949ms step_avg:270.31ms
+step:784/1480 train_time:209229ms step_avg:270.32ms
+step:785/1480 train_time:209512ms step_avg:270.34ms
+step:786/1480 train_time:209797ms step_avg:270.36ms
+step:787/1480 train_time:210081ms step_avg:270.37ms
+step:788/1480 train_time:210364ms step_avg:270.39ms
+step:789/1480 train_time:210641ms step_avg:270.40ms
+step:790/1480 train_time:210921ms step_avg:270.41ms
+step:791/1480 train_time:211202ms step_avg:270.43ms
+step:792/1480 train_time:211483ms step_avg:270.44ms
+step:793/1480 train_time:211761ms step_avg:270.45ms
+step:794/1480 train_time:212044ms step_avg:270.46ms
+step:795/1480 train_time:212329ms step_avg:270.48ms
+step:796/1480 train_time:212611ms step_avg:270.50ms
+step:797/1480 train_time:212894ms step_avg:270.51ms
+step:798/1480 train_time:213176ms step_avg:270.53ms
+step:799/1480 train_time:213457ms step_avg:270.54ms
+step:800/1480 train_time:213738ms step_avg:270.55ms
+step:801/1480 train_time:214019ms step_avg:270.57ms
+step:802/1480 train_time:214301ms step_avg:270.58ms
+step:803/1480 train_time:214586ms step_avg:270.60ms
+step:804/1480 train_time:214864ms step_avg:270.61ms
+step:805/1480 train_time:215144ms step_avg:270.62ms
+step:806/1480 train_time:215424ms step_avg:270.63ms
+step:807/1480 train_time:215712ms step_avg:270.66ms
+step:808/1480 train_time:215992ms step_avg:270.67ms
+step:809/1480 train_time:216272ms step_avg:270.68ms
+step:810/1480 train_time:216558ms step_avg:270.70ms
+step:811/1480 train_time:216839ms step_avg:270.71ms
+step:812/1480 train_time:217120ms step_avg:270.72ms
+step:813/1480 train_time:217402ms step_avg:270.74ms
+step:814/1480 train_time:217681ms step_avg:270.75ms
+step:815/1480 train_time:217970ms step_avg:270.77ms
+step:816/1480 train_time:218252ms step_avg:270.78ms
+step:817/1480 train_time:218531ms step_avg:270.79ms
+step:818/1480 train_time:218812ms step_avg:270.81ms
+step:819/1480 train_time:219095ms step_avg:270.82ms
+step:820/1480 train_time:219375ms step_avg:270.83ms
+step:821/1480 train_time:219659ms step_avg:270.85ms
+step:822/1480 train_time:219938ms step_avg:270.86ms
+step:823/1480 train_time:220221ms step_avg:270.87ms
+step:824/1480 train_time:220501ms step_avg:270.89ms
+step:825/1480 train_time:220782ms step_avg:270.90ms
+step:826/1480 train_time:221061ms step_avg:270.91ms
+step:827/1480 train_time:221341ms step_avg:270.92ms
+step:828/1480 train_time:221622ms step_avg:270.93ms
+step:829/1480 train_time:221902ms step_avg:270.94ms
+step:830/1480 train_time:222187ms step_avg:270.96ms
+step:831/1480 train_time:222463ms step_avg:270.97ms
+step:832/1480 train_time:222745ms step_avg:270.98ms
+step:833/1480 train_time:223033ms step_avg:271.00ms
+step:834/1480 train_time:223314ms step_avg:271.01ms
+step:835/1480 train_time:223601ms step_avg:271.03ms
+step:836/1480 train_time:223882ms step_avg:271.04ms
+step:837/1480 train_time:224165ms step_avg:271.06ms
+step:838/1480 train_time:224449ms step_avg:271.07ms
+step:839/1480 train_time:224731ms step_avg:271.09ms
+step:840/1480 train_time:225012ms step_avg:271.10ms
+step:841/1480 train_time:225294ms step_avg:271.11ms
+step:842/1480 train_time:225576ms step_avg:271.12ms
+step:843/1480 train_time:225860ms step_avg:271.14ms
+step:844/1480 train_time:226143ms step_avg:271.15ms
+step:845/1480 train_time:226422ms step_avg:271.16ms
+step:846/1480 train_time:226703ms step_avg:271.18ms
+step:847/1480 train_time:226983ms step_avg:271.19ms
+step:848/1480 train_time:227263ms step_avg:271.20ms
+step:849/1480 train_time:227543ms step_avg:271.21ms
+step:850/1480 train_time:227823ms step_avg:271.22ms
+step:851/1480 train_time:228108ms step_avg:271.23ms
+step:852/1480 train_time:228387ms step_avg:271.24ms
+step:853/1480 train_time:228672ms step_avg:271.26ms
+step:854/1480 train_time:228956ms step_avg:271.27ms
+step:855/1480 train_time:229237ms step_avg:271.29ms
+step:856/1480 train_time:229518ms step_avg:271.30ms
+step:857/1480 train_time:229802ms step_avg:271.31ms
+step:858/1480 train_time:230083ms step_avg:271.32ms
+step:859/1480 train_time:230363ms step_avg:271.33ms
+step:860/1480 train_time:230643ms step_avg:271.35ms
+step:861/1480 train_time:230923ms step_avg:271.35ms
+step:862/1480 train_time:231202ms step_avg:271.36ms
+step:863/1480 train_time:231485ms step_avg:271.38ms
+step:864/1480 train_time:231766ms step_avg:271.39ms
+step:865/1480 train_time:232042ms step_avg:271.39ms
+step:866/1480 train_time:232323ms step_avg:271.41ms
+step:867/1480 train_time:232604ms step_avg:271.42ms
+step:868/1480 train_time:232891ms step_avg:271.44ms
+step:869/1480 train_time:233173ms step_avg:271.45ms
+step:870/1480 train_time:233457ms step_avg:271.46ms
+step:871/1480 train_time:233739ms step_avg:271.47ms
+step:872/1480 train_time:234021ms step_avg:271.49ms
+step:873/1480 train_time:234301ms step_avg:271.50ms
+step:874/1480 train_time:234584ms step_avg:271.51ms
+step:875/1480 train_time:234864ms step_avg:271.52ms
+step:875/1480 val_loss:3.5363 train_time:235001ms step_avg:271.68ms
+step:876/1480 train_time:235145ms step_avg:271.53ms
+step:877/1480 train_time:235427ms step_avg:271.54ms
+step:878/1480 train_time:235710ms step_avg:271.56ms
+step:879/1480 train_time:235988ms step_avg:271.56ms
+step:880/1480 train_time:236271ms step_avg:271.58ms
+step:881/1480 train_time:236561ms step_avg:271.60ms
+step:882/1480 train_time:236845ms step_avg:271.61ms
+step:883/1480 train_time:237128ms step_avg:271.62ms
+step:884/1480 train_time:237415ms step_avg:271.64ms
+step:885/1480 train_time:237701ms step_avg:271.66ms
+step:886/1480 train_time:237983ms step_avg:271.67ms
+step:887/1480 train_time:238263ms step_avg:271.68ms
+step:888/1480 train_time:238548ms step_avg:271.69ms
+step:889/1480 train_time:238834ms step_avg:271.71ms
+step:890/1480 train_time:239122ms step_avg:271.73ms
+step:891/1480 train_time:239400ms step_avg:271.74ms
+step:892/1480 train_time:239687ms step_avg:271.75ms
+step:893/1480 train_time:239982ms step_avg:271.78ms
+step:894/1480 train_time:240264ms step_avg:271.79ms
+step:895/1480 train_time:240543ms step_avg:271.80ms
+step:896/1480 train_time:240825ms step_avg:271.81ms
+step:897/1480 train_time:241110ms step_avg:271.83ms
+step:898/1480 train_time:241389ms step_avg:271.83ms
+step:899/1480 train_time:241671ms step_avg:271.85ms
+step:900/1480 train_time:241958ms step_avg:271.86ms
+step:901/1480 train_time:242239ms step_avg:271.87ms
+step:902/1480 train_time:242524ms step_avg:271.89ms
+step:903/1480 train_time:242806ms step_avg:271.90ms
+step:904/1480 train_time:243088ms step_avg:271.91ms
+step:905/1480 train_time:243371ms step_avg:271.92ms
+step:906/1480 train_time:243658ms step_avg:271.94ms
+step:907/1480 train_time:243940ms step_avg:271.95ms
+step:908/1480 train_time:244223ms step_avg:271.96ms
+step:909/1480 train_time:244507ms step_avg:271.98ms
+step:910/1480 train_time:244787ms step_avg:271.99ms
+step:911/1480 train_time:245065ms step_avg:271.99ms
+step:912/1480 train_time:245348ms step_avg:272.00ms
+step:913/1480 train_time:245638ms step_avg:272.02ms
+step:914/1480 train_time:245923ms step_avg:272.04ms
+step:915/1480 train_time:246207ms step_avg:272.05ms
+step:916/1480 train_time:246489ms step_avg:272.06ms
+step:917/1480 train_time:246780ms step_avg:272.08ms
+step:918/1480 train_time:247064ms step_avg:272.10ms
+step:919/1480 train_time:247348ms step_avg:272.11ms
+step:920/1480 train_time:247634ms step_avg:272.13ms
+step:921/1480 train_time:247917ms step_avg:272.14ms
+step:922/1480 train_time:248203ms step_avg:272.15ms
+step:923/1480 train_time:248485ms step_avg:272.16ms
+step:924/1480 train_time:248767ms step_avg:272.17ms
+step:925/1480 train_time:249055ms step_avg:272.19ms
+step:926/1480 train_time:249335ms step_avg:272.20ms
+step:927/1480 train_time:249616ms step_avg:272.21ms
+step:928/1480 train_time:249904ms step_avg:272.23ms
+step:929/1480 train_time:250194ms step_avg:272.25ms
+step:930/1480 train_time:250480ms step_avg:272.26ms
+step:931/1480 train_time:250762ms step_avg:272.27ms
+step:932/1480 train_time:251048ms step_avg:272.29ms
+step:933/1480 train_time:251328ms step_avg:272.29ms
+step:934/1480 train_time:251615ms step_avg:272.31ms
+step:935/1480 train_time:251900ms step_avg:272.32ms
+step:936/1480 train_time:252182ms step_avg:272.33ms
+step:937/1480 train_time:252464ms step_avg:272.35ms
+step:938/1480 train_time:252746ms step_avg:272.36ms
+step:939/1480 train_time:253036ms step_avg:272.37ms
+step:940/1480 train_time:253323ms step_avg:272.39ms
+step:941/1480 train_time:253605ms step_avg:272.40ms
+step:942/1480 train_time:253885ms step_avg:272.41ms
+step:943/1480 train_time:254166ms step_avg:272.42ms
+step:944/1480 train_time:254448ms step_avg:272.43ms
+step:945/1480 train_time:254735ms step_avg:272.44ms
+step:946/1480 train_time:255022ms step_avg:272.46ms
+step:947/1480 train_time:255304ms step_avg:272.47ms
+step:948/1480 train_time:255585ms step_avg:272.48ms
+step:949/1480 train_time:255865ms step_avg:272.49ms
+step:950/1480 train_time:256147ms step_avg:272.50ms
+step:951/1480 train_time:256435ms step_avg:272.51ms
+step:952/1480 train_time:256721ms step_avg:272.53ms
+step:953/1480 train_time:257004ms step_avg:272.54ms
+step:954/1480 train_time:257290ms step_avg:272.55ms
+step:955/1480 train_time:257568ms step_avg:272.56ms
+step:956/1480 train_time:257852ms step_avg:272.57ms
+step:957/1480 train_time:258135ms step_avg:272.58ms
+step:958/1480 train_time:258421ms step_avg:272.60ms
+step:959/1480 train_time:258707ms step_avg:272.61ms
+step:960/1480 train_time:258986ms step_avg:272.62ms
+step:961/1480 train_time:259264ms step_avg:272.62ms
+step:962/1480 train_time:259549ms step_avg:272.64ms
+step:963/1480 train_time:259829ms step_avg:272.64ms
+step:964/1480 train_time:260111ms step_avg:272.65ms
+step:965/1480 train_time:260393ms step_avg:272.66ms
+step:966/1480 train_time:260680ms step_avg:272.68ms
+step:967/1480 train_time:260963ms step_avg:272.69ms
+step:968/1480 train_time:261244ms step_avg:272.70ms
+step:969/1480 train_time:261529ms step_avg:272.71ms
+step:970/1480 train_time:261807ms step_avg:272.72ms
+step:971/1480 train_time:262095ms step_avg:272.73ms
+step:972/1480 train_time:262382ms step_avg:272.75ms
+step:973/1480 train_time:262663ms step_avg:272.75ms
+step:974/1480 train_time:262944ms step_avg:272.76ms
+step:975/1480 train_time:263228ms step_avg:272.78ms
+step:976/1480 train_time:263513ms step_avg:272.79ms
+step:977/1480 train_time:263798ms step_avg:272.80ms
+step:978/1480 train_time:264086ms step_avg:272.82ms
+step:979/1480 train_time:264369ms step_avg:272.83ms
+step:980/1480 train_time:264658ms step_avg:272.84ms
+step:981/1480 train_time:264942ms step_avg:272.85ms
+step:982/1480 train_time:265225ms step_avg:272.87ms
+step:983/1480 train_time:265507ms step_avg:272.87ms
+step:984/1480 train_time:265789ms step_avg:272.88ms
+step:985/1480 train_time:266077ms step_avg:272.90ms
+step:986/1480 train_time:266363ms step_avg:272.91ms
+step:987/1480 train_time:266645ms step_avg:272.92ms
+step:988/1480 train_time:266928ms step_avg:272.93ms
+step:989/1480 train_time:267223ms step_avg:272.96ms
+step:990/1480 train_time:267507ms step_avg:272.97ms
+step:991/1480 train_time:267793ms step_avg:272.98ms
+step:992/1480 train_time:268081ms step_avg:272.99ms
+step:993/1480 train_time:268366ms step_avg:273.01ms
+step:994/1480 train_time:268649ms step_avg:273.02ms
+step:995/1480 train_time:268931ms step_avg:273.03ms
+step:996/1480 train_time:269222ms step_avg:273.04ms
+step:997/1480 train_time:269507ms step_avg:273.06ms
+step:998/1480 train_time:269797ms step_avg:273.07ms
+step:999/1480 train_time:270086ms step_avg:273.09ms
+step:1000/1480 train_time:270380ms step_avg:273.11ms
+step:1000/1480 val_loss:3.4688 train_time:270525ms step_avg:273.26ms
+step:1001/1480 train_time:270673ms step_avg:273.13ms
+step:1002/1480 train_time:270969ms step_avg:273.15ms
+step:1003/1480 train_time:271257ms step_avg:273.17ms
+step:1004/1480 train_time:271538ms step_avg:273.18ms
+step:1005/1480 train_time:271832ms step_avg:273.20ms
+step:1006/1480 train_time:272115ms step_avg:273.21ms
+step:1007/1480 train_time:272400ms step_avg:273.22ms
+step:1008/1480 train_time:272685ms step_avg:273.23ms
+step:1009/1480 train_time:272966ms step_avg:273.24ms
+step:1010/1480 train_time:273248ms step_avg:273.25ms
+step:1011/1480 train_time:273534ms step_avg:273.26ms
+step:1012/1480 train_time:273817ms step_avg:273.27ms
+step:1013/1480 train_time:274113ms step_avg:273.29ms
+step:1014/1480 train_time:274400ms step_avg:273.31ms
+step:1015/1480 train_time:274686ms step_avg:273.32ms
+step:1016/1480 train_time:274972ms step_avg:273.33ms
+step:1017/1480 train_time:275257ms step_avg:273.34ms
+step:1018/1480 train_time:275550ms step_avg:273.36ms
+step:1019/1480 train_time:275834ms step_avg:273.37ms
+step:1020/1480 train_time:276117ms step_avg:273.38ms
+step:1021/1480 train_time:276407ms step_avg:273.40ms
+step:1022/1480 train_time:276694ms step_avg:273.41ms
+step:1023/1480 train_time:276976ms step_avg:273.42ms
+step:1024/1480 train_time:277258ms step_avg:273.43ms
+step:1025/1480 train_time:277540ms step_avg:273.44ms
+step:1026/1480 train_time:277823ms step_avg:273.45ms
+step:1027/1480 train_time:278110ms step_avg:273.46ms
+step:1028/1480 train_time:278397ms step_avg:273.47ms
+step:1029/1480 train_time:278684ms step_avg:273.49ms
+step:1030/1480 train_time:278967ms step_avg:273.50ms
+step:1031/1480 train_time:279258ms step_avg:273.51ms
+step:1032/1480 train_time:279537ms step_avg:273.52ms
+step:1033/1480 train_time:279832ms step_avg:273.54ms
+step:1034/1480 train_time:280117ms step_avg:273.55ms
+step:1035/1480 train_time:280402ms step_avg:273.56ms
+step:1036/1480 train_time:280691ms step_avg:273.58ms
+step:1037/1480 train_time:280976ms step_avg:273.59ms
+step:1038/1480 train_time:281258ms step_avg:273.60ms
+step:1039/1480 train_time:281543ms step_avg:273.61ms
+step:1040/1480 train_time:281828ms step_avg:273.62ms
+step:1041/1480 train_time:282117ms step_avg:273.63ms
+step:1042/1480 train_time:282398ms step_avg:273.64ms
+step:1043/1480 train_time:282692ms step_avg:273.66ms
+step:1044/1480 train_time:282976ms step_avg:273.67ms
+step:1045/1480 train_time:283258ms step_avg:273.68ms
+step:1046/1480 train_time:283548ms step_avg:273.70ms
+step:1047/1480 train_time:283835ms step_avg:273.71ms
+step:1048/1480 train_time:284116ms step_avg:273.72ms
+step:1049/1480 train_time:284408ms step_avg:273.73ms
+step:1050/1480 train_time:284696ms step_avg:273.75ms
+step:1051/1480 train_time:284982ms step_avg:273.76ms
+step:1052/1480 train_time:285269ms step_avg:273.77ms
+step:1053/1480 train_time:285556ms step_avg:273.78ms
+step:1054/1480 train_time:285838ms step_avg:273.79ms
+step:1055/1480 train_time:286130ms step_avg:273.81ms
+step:1056/1480 train_time:286426ms step_avg:273.83ms
+step:1057/1480 train_time:286713ms step_avg:273.84ms
+step:1058/1480 train_time:286995ms step_avg:273.85ms
+step:1059/1480 train_time:287280ms step_avg:273.86ms
+step:1060/1480 train_time:287561ms step_avg:273.87ms
+step:1061/1480 train_time:287849ms step_avg:273.88ms
+step:1062/1480 train_time:288135ms step_avg:273.89ms
+step:1063/1480 train_time:288416ms step_avg:273.90ms
+step:1064/1480 train_time:288698ms step_avg:273.91ms
+step:1065/1480 train_time:288977ms step_avg:273.91ms
+step:1066/1480 train_time:289270ms step_avg:273.93ms
+step:1067/1480 train_time:289556ms step_avg:273.94ms
+step:1068/1480 train_time:289837ms step_avg:273.95ms
+step:1069/1480 train_time:290122ms step_avg:273.96ms
+step:1070/1480 train_time:290409ms step_avg:273.97ms
+step:1071/1480 train_time:290694ms step_avg:273.98ms
+step:1072/1480 train_time:290977ms step_avg:273.99ms
+step:1073/1480 train_time:291259ms step_avg:274.00ms
+step:1074/1480 train_time:291553ms step_avg:274.02ms
+step:1075/1480 train_time:291841ms step_avg:274.03ms
+step:1076/1480 train_time:292133ms step_avg:274.05ms
+step:1077/1480 train_time:292420ms step_avg:274.06ms
+step:1078/1480 train_time:292705ms step_avg:274.07ms
+step:1079/1480 train_time:292989ms step_avg:274.08ms
+step:1080/1480 train_time:293280ms step_avg:274.09ms
+step:1081/1480 train_time:293561ms step_avg:274.10ms
+step:1082/1480 train_time:293850ms step_avg:274.11ms
+step:1083/1480 train_time:294138ms step_avg:274.13ms
+step:1084/1480 train_time:294421ms step_avg:274.14ms
+step:1085/1480 train_time:294713ms step_avg:274.15ms
+step:1086/1480 train_time:294996ms step_avg:274.16ms
+step:1087/1480 train_time:295285ms step_avg:274.17ms
+step:1088/1480 train_time:295567ms step_avg:274.18ms
+step:1089/1480 train_time:295853ms step_avg:274.19ms
+step:1090/1480 train_time:296137ms step_avg:274.20ms
+step:1091/1480 train_time:296421ms step_avg:274.21ms
+step:1092/1480 train_time:296702ms step_avg:274.22ms
+step:1093/1480 train_time:296989ms step_avg:274.23ms
+step:1094/1480 train_time:297273ms step_avg:274.24ms
+step:1095/1480 train_time:297560ms step_avg:274.25ms
+step:1096/1480 train_time:297856ms step_avg:274.27ms
+step:1097/1480 train_time:298139ms step_avg:274.28ms
+step:1098/1480 train_time:298439ms step_avg:274.30ms
+step:1099/1480 train_time:298731ms step_avg:274.32ms
+step:1100/1480 train_time:299015ms step_avg:274.33ms
+step:1101/1480 train_time:299298ms step_avg:274.33ms
+step:1102/1480 train_time:299597ms step_avg:274.36ms
+step:1103/1480 train_time:299888ms step_avg:274.37ms
+step:1104/1480 train_time:300181ms step_avg:274.39ms
+step:1105/1480 train_time:300469ms step_avg:274.40ms
+step:1106/1480 train_time:300755ms step_avg:274.41ms
+step:1107/1480 train_time:301039ms step_avg:274.42ms
+step:1108/1480 train_time:301324ms step_avg:274.43ms
+step:1109/1480 train_time:301614ms step_avg:274.44ms
+step:1110/1480 train_time:301900ms step_avg:274.45ms
+step:1111/1480 train_time:302195ms step_avg:274.47ms
+step:1112/1480 train_time:302480ms step_avg:274.48ms
+step:1113/1480 train_time:302770ms step_avg:274.50ms
+step:1114/1480 train_time:303060ms step_avg:274.51ms
+step:1115/1480 train_time:303352ms step_avg:274.53ms
+step:1116/1480 train_time:303639ms step_avg:274.54ms
+step:1117/1480 train_time:303934ms step_avg:274.56ms
+step:1118/1480 train_time:304217ms step_avg:274.56ms
+step:1119/1480 train_time:304515ms step_avg:274.59ms
+step:1120/1480 train_time:304800ms step_avg:274.59ms
+step:1121/1480 train_time:305084ms step_avg:274.60ms
+step:1122/1480 train_time:305373ms step_avg:274.62ms
+step:1123/1480 train_time:305658ms step_avg:274.63ms
+step:1124/1480 train_time:305952ms step_avg:274.64ms
+step:1125/1480 train_time:306237ms step_avg:274.65ms
+step:1125/1480 val_loss:3.4106 train_time:306384ms step_avg:274.78ms
+step:1126/1480 train_time:306531ms step_avg:274.67ms
+step:1127/1480 train_time:306819ms step_avg:274.68ms
+step:1128/1480 train_time:307104ms step_avg:274.69ms
+step:1129/1480 train_time:307393ms step_avg:274.70ms
+step:1130/1480 train_time:307689ms step_avg:274.72ms
+step:1131/1480 train_time:307974ms step_avg:274.73ms
+step:1132/1480 train_time:308269ms step_avg:274.75ms
+step:1133/1480 train_time:308553ms step_avg:274.76ms
+step:1134/1480 train_time:308835ms step_avg:274.76ms
+step:1135/1480 train_time:309130ms step_avg:274.78ms
+step:1136/1480 train_time:309414ms step_avg:274.79ms
+step:1137/1480 train_time:309699ms step_avg:274.80ms
+step:1138/1480 train_time:309993ms step_avg:274.82ms
+step:1139/1480 train_time:310282ms step_avg:274.83ms
+step:1140/1480 train_time:310568ms step_avg:274.84ms
+step:1141/1480 train_time:310853ms step_avg:274.85ms
+step:1142/1480 train_time:311136ms step_avg:274.85ms
+step:1143/1480 train_time:311426ms step_avg:274.87ms
+step:1144/1480 train_time:311707ms step_avg:274.87ms
+step:1145/1480 train_time:311993ms step_avg:274.88ms
+step:1146/1480 train_time:312285ms step_avg:274.90ms
+step:1147/1480 train_time:312570ms step_avg:274.91ms
+step:1148/1480 train_time:312855ms step_avg:274.92ms
+step:1149/1480 train_time:313140ms step_avg:274.92ms
+step:1150/1480 train_time:313426ms step_avg:274.93ms
+step:1151/1480 train_time:313712ms step_avg:274.94ms
+step:1152/1480 train_time:313994ms step_avg:274.95ms
+step:1153/1480 train_time:314285ms step_avg:274.97ms
+step:1154/1480 train_time:314570ms step_avg:274.97ms
+step:1155/1480 train_time:314868ms step_avg:274.99ms
+step:1156/1480 train_time:315158ms step_avg:275.01ms
+step:1157/1480 train_time:315448ms step_avg:275.02ms
+step:1158/1480 train_time:315737ms step_avg:275.03ms
+step:1159/1480 train_time:316023ms step_avg:275.04ms
+step:1160/1480 train_time:316307ms step_avg:275.05ms
+step:1161/1480 train_time:316594ms step_avg:275.06ms
+step:1162/1480 train_time:316888ms step_avg:275.08ms
+step:1163/1480 train_time:317181ms step_avg:275.09ms
+step:1164/1480 train_time:317462ms step_avg:275.10ms
+step:1165/1480 train_time:317744ms step_avg:275.10ms
+step:1166/1480 train_time:318032ms step_avg:275.11ms
+step:1167/1480 train_time:318323ms step_avg:275.13ms
+step:1168/1480 train_time:318608ms step_avg:275.14ms
+step:1169/1480 train_time:318898ms step_avg:275.15ms
+step:1170/1480 train_time:319185ms step_avg:275.16ms
+step:1171/1480 train_time:319471ms step_avg:275.17ms
+step:1172/1480 train_time:319752ms step_avg:275.17ms
+step:1173/1480 train_time:320037ms step_avg:275.18ms
+step:1174/1480 train_time:320329ms step_avg:275.20ms
+step:1175/1480 train_time:320613ms step_avg:275.20ms
+step:1176/1480 train_time:320892ms step_avg:275.21ms
+step:1177/1480 train_time:321180ms step_avg:275.22ms
+step:1178/1480 train_time:321467ms step_avg:275.23ms
+step:1179/1480 train_time:321755ms step_avg:275.24ms
+step:1180/1480 train_time:322049ms step_avg:275.26ms
+step:1181/1480 train_time:322333ms step_avg:275.26ms
+step:1182/1480 train_time:322617ms step_avg:275.27ms
+step:1183/1480 train_time:322907ms step_avg:275.28ms
+step:1184/1480 train_time:323191ms step_avg:275.29ms
+step:1185/1480 train_time:323474ms step_avg:275.30ms
+step:1186/1480 train_time:323761ms step_avg:275.31ms
+step:1187/1480 train_time:324052ms step_avg:275.32ms
+step:1188/1480 train_time:324337ms step_avg:275.33ms
+step:1189/1480 train_time:324637ms step_avg:275.35ms
+step:1190/1480 train_time:324932ms step_avg:275.37ms
+step:1191/1480 train_time:325215ms step_avg:275.37ms
+step:1192/1480 train_time:325501ms step_avg:275.38ms
+step:1193/1480 train_time:325789ms step_avg:275.39ms
+step:1194/1480 train_time:326073ms step_avg:275.40ms
+step:1195/1480 train_time:326353ms step_avg:275.40ms
+step:1196/1480 train_time:326638ms step_avg:275.41ms
+step:1197/1480 train_time:326930ms step_avg:275.43ms
+step:1198/1480 train_time:327214ms step_avg:275.43ms
+step:1199/1480 train_time:327503ms step_avg:275.44ms
+step:1200/1480 train_time:327788ms step_avg:275.45ms
+step:1201/1480 train_time:328072ms step_avg:275.46ms
+step:1202/1480 train_time:328366ms step_avg:275.47ms
+step:1203/1480 train_time:328652ms step_avg:275.48ms
+step:1204/1480 train_time:328938ms step_avg:275.49ms
+step:1205/1480 train_time:329224ms step_avg:275.50ms
+step:1206/1480 train_time:329512ms step_avg:275.51ms
+step:1207/1480 train_time:329797ms step_avg:275.52ms
+step:1208/1480 train_time:330087ms step_avg:275.53ms
+step:1209/1480 train_time:330379ms step_avg:275.55ms
+step:1210/1480 train_time:330665ms step_avg:275.55ms
+step:1211/1480 train_time:330948ms step_avg:275.56ms
+step:1212/1480 train_time:331242ms step_avg:275.58ms
+step:1213/1480 train_time:331529ms step_avg:275.59ms
+step:1214/1480 train_time:331821ms step_avg:275.60ms
+step:1215/1480 train_time:332110ms step_avg:275.61ms
+step:1216/1480 train_time:332393ms step_avg:275.62ms
+step:1217/1480 train_time:332685ms step_avg:275.63ms
+step:1218/1480 train_time:332978ms step_avg:275.64ms
+step:1219/1480 train_time:333268ms step_avg:275.66ms
+step:1220/1480 train_time:333563ms step_avg:275.67ms
+step:1221/1480 train_time:333847ms step_avg:275.68ms
+step:1222/1480 train_time:334135ms step_avg:275.69ms
+step:1223/1480 train_time:334428ms step_avg:275.70ms
+step:1224/1480 train_time:334717ms step_avg:275.71ms
+step:1225/1480 train_time:335013ms step_avg:275.73ms
+step:1226/1480 train_time:335304ms step_avg:275.74ms
+step:1227/1480 train_time:335592ms step_avg:275.75ms
+step:1228/1480 train_time:335873ms step_avg:275.76ms
+step:1229/1480 train_time:336185ms step_avg:275.79ms
+step:1230/1480 train_time:336475ms step_avg:275.80ms
+step:1231/1480 train_time:336764ms step_avg:275.81ms
+step:1232/1480 train_time:337052ms step_avg:275.82ms
+step:1233/1480 train_time:337346ms step_avg:275.84ms
+step:1234/1480 train_time:337635ms step_avg:275.85ms
+step:1235/1480 train_time:337923ms step_avg:275.86ms
+step:1236/1480 train_time:338220ms step_avg:275.87ms
+step:1237/1480 train_time:338511ms step_avg:275.88ms
+step:1238/1480 train_time:338798ms step_avg:275.89ms
+step:1239/1480 train_time:339090ms step_avg:275.91ms
+step:1240/1480 train_time:339382ms step_avg:275.92ms
+step:1241/1480 train_time:339667ms step_avg:275.93ms
+step:1242/1480 train_time:339953ms step_avg:275.94ms
+step:1243/1480 train_time:340236ms step_avg:275.94ms
+step:1244/1480 train_time:340528ms step_avg:275.95ms
+step:1245/1480 train_time:340825ms step_avg:275.97ms
+step:1246/1480 train_time:341109ms step_avg:275.98ms
+step:1247/1480 train_time:341395ms step_avg:275.99ms
+step:1248/1480 train_time:341683ms step_avg:276.00ms
+step:1249/1480 train_time:341968ms step_avg:276.00ms
+step:1250/1480 train_time:342262ms step_avg:276.02ms
+step:1250/1480 val_loss:3.3593 train_time:342406ms step_avg:276.13ms
+step:1251/1480 train_time:342554ms step_avg:276.03ms
+step:1252/1480 train_time:342847ms step_avg:276.04ms
+step:1253/1480 train_time:343136ms step_avg:276.05ms
+step:1254/1480 train_time:343426ms step_avg:276.07ms
+step:1255/1480 train_time:343711ms step_avg:276.07ms
+step:1256/1480 train_time:344000ms step_avg:276.08ms
+step:1257/1480 train_time:344286ms step_avg:276.09ms
+step:1258/1480 train_time:344569ms step_avg:276.10ms
+step:1259/1480 train_time:344860ms step_avg:276.11ms
+step:1260/1480 train_time:345147ms step_avg:276.12ms
+step:1261/1480 train_time:345440ms step_avg:276.13ms
+step:1262/1480 train_time:345727ms step_avg:276.14ms
+step:1263/1480 train_time:346024ms step_avg:276.16ms
+step:1264/1480 train_time:346306ms step_avg:276.16ms
+step:1265/1480 train_time:346591ms step_avg:276.17ms
+step:1266/1480 train_time:346882ms step_avg:276.18ms
+step:1267/1480 train_time:347166ms step_avg:276.19ms
+step:1268/1480 train_time:347456ms step_avg:276.20ms
+step:1269/1480 train_time:347750ms step_avg:276.21ms
+step:1270/1480 train_time:348045ms step_avg:276.23ms
+step:1271/1480 train_time:348331ms step_avg:276.23ms
+step:1272/1480 train_time:348626ms step_avg:276.25ms
+step:1273/1480 train_time:348918ms step_avg:276.26ms
+step:1274/1480 train_time:349204ms step_avg:276.27ms
+step:1275/1480 train_time:349492ms step_avg:276.28ms
+step:1276/1480 train_time:349778ms step_avg:276.29ms
+step:1277/1480 train_time:350065ms step_avg:276.29ms
+step:1278/1480 train_time:350350ms step_avg:276.30ms
+step:1279/1480 train_time:350641ms step_avg:276.31ms
+step:1280/1480 train_time:350927ms step_avg:276.32ms
+step:1281/1480 train_time:351226ms step_avg:276.34ms
+step:1282/1480 train_time:351509ms step_avg:276.34ms
+step:1283/1480 train_time:351801ms step_avg:276.36ms
+step:1284/1480 train_time:352095ms step_avg:276.37ms
+step:1285/1480 train_time:352379ms step_avg:276.38ms
+step:1286/1480 train_time:352665ms step_avg:276.38ms
+step:1287/1480 train_time:352955ms step_avg:276.39ms
+step:1288/1480 train_time:353242ms step_avg:276.40ms
+step:1289/1480 train_time:353534ms step_avg:276.41ms
+step:1290/1480 train_time:353820ms step_avg:276.42ms
+step:1291/1480 train_time:354104ms step_avg:276.43ms
+step:1292/1480 train_time:354391ms step_avg:276.44ms
+step:1293/1480 train_time:354681ms step_avg:276.45ms
+step:1294/1480 train_time:354964ms step_avg:276.45ms
+step:1295/1480 train_time:355248ms step_avg:276.46ms
+step:1296/1480 train_time:355534ms step_avg:276.46ms
+step:1297/1480 train_time:355821ms step_avg:276.47ms
+step:1298/1480 train_time:356103ms step_avg:276.48ms
+step:1299/1480 train_time:356387ms step_avg:276.48ms
+step:1300/1480 train_time:356685ms step_avg:276.50ms
+step:1301/1480 train_time:356967ms step_avg:276.50ms
+step:1302/1480 train_time:357258ms step_avg:276.52ms
+step:1303/1480 train_time:357550ms step_avg:276.53ms
+step:1304/1480 train_time:357832ms step_avg:276.53ms
+step:1305/1480 train_time:358124ms step_avg:276.54ms
+step:1306/1480 train_time:358418ms step_avg:276.56ms
+step:1307/1480 train_time:358702ms step_avg:276.56ms
+step:1308/1480 train_time:358984ms step_avg:276.57ms
+step:1309/1480 train_time:359285ms step_avg:276.59ms
+step:1310/1480 train_time:359576ms step_avg:276.60ms
+step:1311/1480 train_time:359864ms step_avg:276.61ms
+step:1312/1480 train_time:360153ms step_avg:276.62ms
+step:1313/1480 train_time:360441ms step_avg:276.62ms
+step:1314/1480 train_time:360731ms step_avg:276.63ms
+step:1315/1480 train_time:361023ms step_avg:276.65ms
+step:1316/1480 train_time:361323ms step_avg:276.66ms
+step:1317/1480 train_time:361615ms step_avg:276.68ms
+step:1318/1480 train_time:361905ms step_avg:276.69ms
+step:1319/1480 train_time:362197ms step_avg:276.70ms
+step:1320/1480 train_time:362487ms step_avg:276.71ms
+step:1321/1480 train_time:362778ms step_avg:276.72ms
+step:1322/1480 train_time:363066ms step_avg:276.73ms
+step:1323/1480 train_time:363348ms step_avg:276.73ms
+step:1324/1480 train_time:363645ms step_avg:276.75ms
+step:1325/1480 train_time:363943ms step_avg:276.76ms
+step:1326/1480 train_time:364229ms step_avg:276.77ms
+step:1327/1480 train_time:364526ms step_avg:276.79ms
+step:1328/1480 train_time:364809ms step_avg:276.79ms
+step:1329/1480 train_time:365098ms step_avg:276.80ms
+step:1330/1480 train_time:365388ms step_avg:276.81ms
+step:1331/1480 train_time:365682ms step_avg:276.82ms
+step:1332/1480 train_time:365969ms step_avg:276.83ms
+step:1333/1480 train_time:366266ms step_avg:276.85ms
+step:1334/1480 train_time:366565ms step_avg:276.86ms
+step:1335/1480 train_time:366853ms step_avg:276.87ms
+step:1336/1480 train_time:367145ms step_avg:276.88ms
+step:1337/1480 train_time:367431ms step_avg:276.89ms
+step:1338/1480 train_time:367720ms step_avg:276.90ms
+step:1339/1480 train_time:368013ms step_avg:276.91ms
+step:1340/1480 train_time:368298ms step_avg:276.92ms
+step:1341/1480 train_time:368584ms step_avg:276.92ms
+step:1342/1480 train_time:368882ms step_avg:276.94ms
+step:1343/1480 train_time:369186ms step_avg:276.96ms
+step:1344/1480 train_time:369474ms step_avg:276.97ms
+step:1345/1480 train_time:369764ms step_avg:276.98ms
+step:1346/1480 train_time:370058ms step_avg:276.99ms
+step:1347/1480 train_time:370349ms step_avg:277.00ms
+step:1348/1480 train_time:370641ms step_avg:277.01ms
+step:1349/1480 train_time:370931ms step_avg:277.02ms
+step:1350/1480 train_time:371226ms step_avg:277.03ms
+step:1351/1480 train_time:371519ms step_avg:277.05ms
+step:1352/1480 train_time:371806ms step_avg:277.05ms
+step:1353/1480 train_time:372087ms step_avg:277.06ms
+step:1354/1480 train_time:372377ms step_avg:277.07ms
+step:1355/1480 train_time:372668ms step_avg:277.08ms
+step:1356/1480 train_time:372962ms step_avg:277.09ms
+step:1357/1480 train_time:373250ms step_avg:277.10ms
+step:1358/1480 train_time:373542ms step_avg:277.11ms
+step:1359/1480 train_time:373835ms step_avg:277.12ms
+step:1360/1480 train_time:374126ms step_avg:277.13ms
+step:1361/1480 train_time:374414ms step_avg:277.14ms
+step:1362/1480 train_time:374703ms step_avg:277.15ms
+step:1363/1480 train_time:374991ms step_avg:277.16ms
+step:1364/1480 train_time:375284ms step_avg:277.17ms
+step:1365/1480 train_time:375574ms step_avg:277.18ms
+step:1366/1480 train_time:375863ms step_avg:277.19ms
+step:1367/1480 train_time:376157ms step_avg:277.20ms
+step:1368/1480 train_time:376444ms step_avg:277.20ms
+step:1369/1480 train_time:376733ms step_avg:277.21ms
+step:1370/1480 train_time:377029ms step_avg:277.23ms
+step:1371/1480 train_time:377330ms step_avg:277.24ms
+step:1372/1480 train_time:377629ms step_avg:277.26ms
+step:1373/1480 train_time:377911ms step_avg:277.26ms
+step:1374/1480 train_time:378205ms step_avg:277.28ms
+step:1375/1480 train_time:378502ms step_avg:277.29ms
+step:1375/1480 val_loss:3.3179 train_time:378645ms step_avg:277.40ms
+step:1376/1480 train_time:378790ms step_avg:277.30ms
+step:1377/1480 train_time:379097ms step_avg:277.32ms
+step:1378/1480 train_time:379402ms step_avg:277.34ms
+step:1379/1480 train_time:379691ms step_avg:277.35ms
+step:1380/1480 train_time:379980ms step_avg:277.36ms
+step:1381/1480 train_time:380268ms step_avg:277.37ms
+step:1382/1480 train_time:380563ms step_avg:277.38ms
+step:1383/1480 train_time:380863ms step_avg:277.39ms
+step:1384/1480 train_time:381161ms step_avg:277.41ms
+step:1385/1480 train_time:381449ms step_avg:277.42ms
+step:1386/1480 train_time:381744ms step_avg:277.43ms
+step:1387/1480 train_time:382035ms step_avg:277.44ms
+step:1388/1480 train_time:382331ms step_avg:277.45ms
+step:1389/1480 train_time:382617ms step_avg:277.46ms
+step:1390/1480 train_time:382910ms step_avg:277.47ms
+step:1391/1480 train_time:383205ms step_avg:277.48ms
+step:1392/1480 train_time:383489ms step_avg:277.49ms
+step:1393/1480 train_time:383775ms step_avg:277.49ms
+step:1394/1480 train_time:384066ms step_avg:277.50ms
+step:1395/1480 train_time:384360ms step_avg:277.52ms
+step:1396/1480 train_time:384649ms step_avg:277.52ms
+step:1397/1480 train_time:384946ms step_avg:277.54ms
+step:1398/1480 train_time:385235ms step_avg:277.55ms
+step:1399/1480 train_time:385530ms step_avg:277.56ms
+step:1400/1480 train_time:385836ms step_avg:277.58ms
+step:1401/1480 train_time:386131ms step_avg:277.59ms
+step:1402/1480 train_time:386447ms step_avg:277.62ms
+step:1403/1480 train_time:386732ms step_avg:277.62ms
+step:1404/1480 train_time:387026ms step_avg:277.64ms
+step:1405/1480 train_time:387318ms step_avg:277.65ms
+step:1406/1480 train_time:387608ms step_avg:277.66ms
+step:1407/1480 train_time:387911ms step_avg:277.67ms
+step:1408/1480 train_time:388207ms step_avg:277.69ms
+step:1409/1480 train_time:388491ms step_avg:277.69ms
+step:1410/1480 train_time:388778ms step_avg:277.70ms
+step:1411/1480 train_time:389070ms step_avg:277.71ms
+step:1412/1480 train_time:389356ms step_avg:277.71ms
+step:1413/1480 train_time:389650ms step_avg:277.73ms
+step:1414/1480 train_time:389940ms step_avg:277.73ms
+step:1415/1480 train_time:390226ms step_avg:277.74ms
+step:1416/1480 train_time:390522ms step_avg:277.75ms
+step:1417/1480 train_time:390809ms step_avg:277.76ms
+step:1418/1480 train_time:391101ms step_avg:277.77ms
+step:1419/1480 train_time:391393ms step_avg:277.78ms
+step:1420/1480 train_time:391687ms step_avg:277.79ms
+step:1421/1480 train_time:391973ms step_avg:277.80ms
+step:1422/1480 train_time:392267ms step_avg:277.81ms
+step:1423/1480 train_time:392551ms step_avg:277.81ms
+step:1424/1480 train_time:392841ms step_avg:277.82ms
+step:1425/1480 train_time:393131ms step_avg:277.83ms
+step:1426/1480 train_time:393432ms step_avg:277.85ms
+step:1427/1480 train_time:393723ms step_avg:277.86ms
+step:1428/1480 train_time:394013ms step_avg:277.87ms
+step:1429/1480 train_time:394303ms step_avg:277.87ms
+step:1430/1480 train_time:394589ms step_avg:277.88ms
+step:1431/1480 train_time:394880ms step_avg:277.89ms
+step:1432/1480 train_time:395175ms step_avg:277.90ms
+step:1433/1480 train_time:395470ms step_avg:277.91ms
+step:1434/1480 train_time:395770ms step_avg:277.93ms
+step:1435/1480 train_time:396063ms step_avg:277.94ms
+step:1436/1480 train_time:396354ms step_avg:277.95ms
+step:1437/1480 train_time:396641ms step_avg:277.95ms
+step:1438/1480 train_time:396946ms step_avg:277.97ms
+step:1439/1480 train_time:397243ms step_avg:277.99ms
+step:1440/1480 train_time:397535ms step_avg:278.00ms
+step:1441/1480 train_time:397826ms step_avg:278.01ms
+step:1442/1480 train_time:398121ms step_avg:278.02ms
+step:1443/1480 train_time:398412ms step_avg:278.03ms
+step:1444/1480 train_time:398706ms step_avg:278.04ms
+step:1445/1480 train_time:398990ms step_avg:278.04ms
+step:1446/1480 train_time:399293ms step_avg:278.06ms
+step:1447/1480 train_time:399589ms step_avg:278.07ms
+step:1448/1480 train_time:399891ms step_avg:278.09ms
+step:1449/1480 train_time:400186ms step_avg:278.10ms
+step:1450/1480 train_time:400471ms step_avg:278.10ms
+step:1451/1480 train_time:400765ms step_avg:278.12ms
+step:1452/1480 train_time:401055ms step_avg:278.12ms
+step:1453/1480 train_time:401341ms step_avg:278.13ms
+step:1454/1480 train_time:401629ms step_avg:278.14ms
+step:1455/1480 train_time:401926ms step_avg:278.15ms
+step:1456/1480 train_time:402211ms step_avg:278.15ms
+step:1457/1480 train_time:402501ms step_avg:278.16ms
+step:1458/1480 train_time:402789ms step_avg:278.17ms
+step:1459/1480 train_time:403088ms step_avg:278.18ms
+step:1460/1480 train_time:403373ms step_avg:278.19ms
+step:1461/1480 train_time:403666ms step_avg:278.20ms
+step:1462/1480 train_time:403950ms step_avg:278.20ms
+step:1463/1480 train_time:404240ms step_avg:278.21ms
+step:1464/1480 train_time:404538ms step_avg:278.22ms
+step:1465/1480 train_time:404831ms step_avg:278.23ms
+step:1466/1480 train_time:405122ms step_avg:278.24ms
+step:1467/1480 train_time:405411ms step_avg:278.25ms
+step:1468/1480 train_time:405709ms step_avg:278.26ms
+step:1469/1480 train_time:406021ms step_avg:278.29ms
+step:1470/1480 train_time:406318ms step_avg:278.30ms
+step:1471/1480 train_time:406612ms step_avg:278.31ms
+step:1472/1480 train_time:406906ms step_avg:278.32ms
+step:1473/1480 train_time:407193ms step_avg:278.33ms
+step:1474/1480 train_time:407480ms step_avg:278.33ms
+step:1475/1480 train_time:407769ms step_avg:278.34ms
+step:1476/1480 train_time:408058ms step_avg:278.35ms
+step:1477/1480 train_time:408353ms step_avg:278.36ms
+step:1478/1480 train_time:408647ms step_avg:278.37ms
+step:1479/1480 train_time:408941ms step_avg:278.38ms
+step:1480/1480 train_time:409229ms step_avg:278.39ms
+step:1480/1480 val_loss:3.2988 train_time:409369ms step_avg:278.48ms
+peak memory consumption: 34262 MiB

--- a/_logs/bias-f43dca01-62fd-4f97-9751-2e2ed21a69b8.txt
+++ b/_logs/bias-f43dca01-62fd-4f97-9751-2e2ed21a69b8.txt
@@ -1,0 +1,2201 @@
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+import contextlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import torch.distributed as dist
+import torch._inductor.config as config
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.nn.attention.flex_attention import BlockMask, flex_attention #KoszarskyB
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps):
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert len(G.shape) == 2
+    a, b, c = (3.4445, -4.7750,  2.0315)
+    X = G.bfloat16()
+    if G.size(0) > G.size(1):
+        X = X.T
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm() + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A # adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+    
+    if G.size(0) > G.size(1):
+        X = X.T
+    return X
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Some warnings:
+    - This optimizer assumes that all parameters passed in are 2D.
+    - It should not be used for the embedding layer, the final fully connected layer, or any {0,1}-D
+    parameters; those should all be optimized by a standard method (e.g., AdamW).
+    - To use it with 4D convolutional filters, it works well to just flatten their last 3 dimensions.
+    - We believe it is unlikely to work well for training with small batch size.
+    - We believe it may not work well for finetuning pretrained models, but we haven't tested this.
+    - We have not yet tried this optimizer for training scenarios larger than NanoGPT (124M).
+
+    Arguments:
+        lr: The learning rate used by the internal SGD.
+        momentum: The momentum used by the internal SGD.
+        nesterov: Whether to use Nesterov-style momentum in the internal SGD. (recommended)
+        ns_steps: The number of Newton-Schulz iteration steps to use.
+    """
+    def __init__(self, params, lr=0.02, momentum=0.95, nesterov=True, ns_steps=5):
+        self.world_size = int(os.environ['WORLD_SIZE'])
+        self.rank = int(os.environ['RANK'])
+        defaults = dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps)
+        params = list(params)
+        assert all(isinstance(p, torch.Tensor) for p in params)
+        sizes = {p.numel() for p in params}
+        param_groups = [
+            {
+                'params': [p for p in params if p.numel() == size],
+                'update_buffer': [
+                    torch.empty(size, device='cuda', dtype=torch.bfloat16)
+                    for _ in range(self.world_size)
+                ],
+            }
+            for size in sizes
+        ]
+        super().__init__(param_groups, defaults)
+
+    def step(self):
+
+        for group in self.param_groups:
+
+            lr = group['lr']
+            momentum = group['momentum']
+            nesterov = group['nesterov']
+            ns_steps = group['ns_steps']
+            update_buffers = group['update_buffer']
+            # generate weight updates in distributed fashion
+            params = group['params']
+            assert len(params) % self.world_size == 0
+            handle = None
+            params_world = None
+            def update_prev():
+                if params_world is None:
+                    return
+                assert handle is not None
+                handle.wait()
+                for p_world, g_world in zip(params_world, update_buffers):
+                    p_world.data.add_(
+                        g_world.view_as(p_world),
+                        alpha=-lr * max(1, p_world.size(0) / p_world.size(1)) ** 0.5,
+                    )
+            for base_i in range(len(params))[::self.world_size]:
+                p = params[base_i + self.rank]
+                g = p.grad
+                assert g is not None
+                state = self.state[p]
+                if 'momentum_buffer' not in state:
+                    state['momentum_buffer'] = torch.zeros_like(g)
+                buf = state['momentum_buffer']
+                buf.lerp_(g, 1 - momentum)
+                g = g.lerp_(buf, momentum) if nesterov else buf
+                g = zeropower_via_newtonschulz5(g, steps=ns_steps).flatten()
+                update_prev()
+                handle = dist.all_gather(update_buffers, g, async_op=True)
+                params_world = params[base_i : base_i + self.world_size]
+            update_prev()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the GPT-2 model
+
+def norm(x):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+
+    def __init__(self, in_features, out_features, bias=False):
+        super().__init__(in_features, out_features, bias)
+
+    def forward(self, x):
+        return F.linear(
+            x,
+            self.weight.to(x.dtype),
+            None if self.bias is None else self.bias.to(x.dtype)
+        )
+
+class Rotary(torch.nn.Module):
+
+    def __init__(self, dim, base=10000):
+        super().__init__()
+        self.register_buffer('inv_freq', (1 / base) ** (torch.arange(0, dim, 2) / dim))
+        self.seq_len_cached = None
+        self.cos_cached = None
+        self.sin_cached = None
+
+    def forward(self, x):
+        seq_len = x.shape[1]
+        if seq_len != self.seq_len_cached:
+            t = torch.arange(seq_len, device=x.device)
+            freqs = torch.outer(t, self.inv_freq)
+            self.seq_len_cached = seq_len
+            self.cos_cached = freqs.cos()
+            self.sin_cached = freqs.sin()
+        cos, sin = self.cos_cached[None, :, None, :], self.sin_cached[None, :, None, :]
+        # apply_rotary_emb(x, cos, sin)
+        x1, x2 = x.chunk(2, dim=3)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x)
+
+class CausalSelfAttention(nn.Module):
+
+    def __init__(self, dim, num_heads):
+        super().__init__()
+        assert dim % num_heads == 0
+        self.num_heads = num_heads
+        self.c_q = CastedLinear(dim, dim)
+        self.c_k = CastedLinear(dim, dim)
+        self.c_v = CastedLinear(dim, dim)
+        self.lambdas = nn.Parameter(torch.tensor([0.5, 0.5]))
+        self.rotary = Rotary(dim // num_heads) # dim // num_heads = head_dim
+        self.c_proj = CastedLinear(dim, dim)
+        self.c_proj.weight.data.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x, vi, block_mask):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q = self.c_q(x).view(B, T, self.num_heads, -1)
+        k = self.c_k(x).view(B, T, self.num_heads, -1)
+        v = self.c_v(x).view(B, T, self.num_heads, -1)
+        v = self.lambdas[0] * v + self.lambdas[1] * vi.view_as(v) # @KoszarskyB & @Grad62304977
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, enable_gqa=True)
+        y = y.transpose(1, 2).contiguous().view_as(x) # re-assemble all head outputs side by side
+        y = self.c_proj(y)
+        return y
+
+class MLP(nn.Module):
+
+    def __init__(self, dim):
+        super().__init__()
+        self.c_fc   = CastedLinear(dim, 4 * dim)
+        self.c_proj = CastedLinear(4 * dim, dim)
+        self.c_proj.weight.data.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x):
+        x = self.c_fc(x)
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = self.c_proj(x)
+        return x
+
+class Block(nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+        self.attn = CausalSelfAttention(config.model_dim, config.num_heads)
+        self.mlp = MLP(config.model_dim)
+        self.lambdas = nn.Parameter(torch.tensor([1., 0.]))
+
+    def forward(self, x, vi, x0, block_mask):
+        x = self.lambdas[0] * x + self.lambdas[1] * x0
+        x = x + self.attn(norm(x), vi, block_mask)
+        x = x + self.mlp(norm(x))
+        return x
+
+class ValueEmbedding(nn.Module):
+    def __init__(self, config: "GPTConfig"):
+        super().__init__()
+        self.embed = nn.ModuleList([
+            nn.Embedding(config.vocab_size, config.model_dim)
+            for _ in range(6)
+        ])
+
+    def forward(self, inputs) -> "list[torch.Tensor]":
+        ve = [emb(inputs) for emb in self.embed]
+        ve += reversed(ve)
+        return ve
+
+# -----------------------------------------------------------------------------
+# The main GPT-2 model
+
+@dataclass
+class GPTConfig:
+    vocab_size : int = 50304
+    num_layers : int = 12
+    num_heads : int = 6 # head dim 128 suggested by @Grad62304977
+    model_dim : int = 768
+
+class GPT(nn.Module):
+
+    def __init__(self, config: GPTConfig):
+        super().__init__()
+        self.num_layers = config.num_layers
+
+        # U-net design by @brendanh0gan
+        self.num_encoder_layers = config.num_layers // 2 # Half of the layers for encoder
+        self.num_decoder_layers = config.num_layers - self.num_encoder_layers # Remaining for decoder
+        # Add learnable skip connection weights for decoder layers
+        self.skip_weights = nn.Parameter(torch.ones(self.num_decoder_layers))
+
+        self.embed = nn.Embedding(config.vocab_size, config.model_dim)
+        self.blocks = nn.ModuleList([Block(config) for _ in range(config.num_layers)])
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual learning
+        # U-net structure on token value embeddings by @leloykun
+        self.value_embeds = ValueEmbedding(config)
+        self.lm_head = CastedLinear(config.model_dim, config.vocab_size, bias=True)
+        self.lm_head.weight.data.zero_() # @Grad62304977
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        targets: torch.Tensor,
+        sliding_window_num_blocks: torch.Tensor,
+    ):
+        BLOCK_SIZE = 128
+        seq_len = len(inputs)
+        assert seq_len % BLOCK_SIZE == 0
+        total_num_blocks = seq_len // BLOCK_SIZE
+        assert inputs.ndim == 1
+        docs = (inputs == 50256).cumsum(0)
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_mask: torch.Tensor):
+            num_blocks = dense_mask.sum(dim=-1, dtype=torch.int32)
+            indices = dense_mask.argsort(dim=-1, descending=True, stable=True).to(torch.int32)
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        def create_doc_swc_block_mask(sliding_window_num_blocks: torch.Tensor):
+            kv_idx = block_idx = torch.arange(total_num_blocks, dtype=torch.int32, device="cuda")
+            q_idx = block_idx[:, None]
+            causal_bm = q_idx >= kv_idx
+            causal_full_bm = q_idx > kv_idx
+            window_bm = q_idx - kv_idx < sliding_window_num_blocks
+            window_full_bm = window_bm
+            # document_bm = (docs_low[q_idx] <= docs_high[kv_idx]) & (docs_low[kv_idx] <= docs_high[q_idx])
+            document_bm = (docs_low[:, None] <= docs_high) & (docs_low <= docs_high[:, None])
+            document_full_bm = (docs_low[:, None] == docs_high) & (docs_low == docs_high[:, None])
+            nonzero_bm = causal_bm & window_bm & document_bm
+            full_bm  = causal_full_bm & window_full_bm & document_full_bm
+            kv_num_blocks, kv_indices = dense_to_ordered(nonzero_bm ^ full_bm)
+            full_kv_num_blocks, full_kv_indices = dense_to_ordered(full_bm)
+            return BlockMask.from_kv_blocks(
+                kv_num_blocks,
+                kv_indices,
+                full_kv_num_blocks,
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+
+        block_mask = create_doc_swc_block_mask(sliding_window_num_blocks)
+
+        # forward the GPT model itself
+        x = self.embed(inputs[None]) # token embeddings of shape (b, t, model_dim)
+        x = norm(x) # @Grad62304977
+        x0 = x
+        ve = self.value_embeds(inputs)
+        ve_enc, ve_dec = ve[:self.num_encoder_layers], ve[self.num_encoder_layers:]
+
+        # Store outputs for U-Net skip connections
+        skip_connections = []
+        # Encoder pass - process only the first half of the blocks
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, ve_enc[i], x0, block_mask)
+            skip_connections.append(x)
+        # Decoder pass - process the remaining blocks with weighted skip connections
+        for i in range(self.num_decoder_layers):
+            x = x + self.skip_weights[i] * skip_connections.pop()
+            # U-net structure on token value embeddings by @leloykun
+            x = self.blocks[self.num_encoder_layers + i](x, ve_dec[i], x0, block_mask)
+
+        x = norm(x)
+        logits = self.lm_head(x)
+        logits = 30 * torch.tanh(logits / 30) # @Grad62304977
+        logits = logits.float()
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
+        return loss
+
+# -----------------------------------------------------------------------------
+# Our own simple Distributed Data Loader
+
+def _peek_data_shard(file: Path):
+    # only reads the header, returns header data
+    # header is 256 int32
+    header = torch.from_file(f"{file}", False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    return int(header[2]) # number of tokens (claimed)
+
+def _load_data_shard(path: Path, num_tokens):
+    with path.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header?"
+    return tokens
+
+class DistributedDataLoader:
+    def __init__(self, filename_pattern, seq_len, process_rank, num_processes):
+        self.process_rank = process_rank
+        self.num_processes = num_processes
+        self.seq_len = seq_len
+
+        # glob files that match the pattern
+        self.files = sorted(Path.cwd().glob(filename_pattern))
+        assert len(self.files) > 0, f"did not find any files that match the pattern {filename_pattern}"
+
+        # load and validate all data shards, count number of tokens in total
+        self.files_num_tokens = [_peek_data_shard(file) for file in self.files]
+        assert min(self.files_num_tokens) >= num_processes * seq_len + 1
+        self.total_num_tokens = sum(self.files_num_tokens)
+
+        self.reset()
+
+    def reset(self):
+        self.current_shard = -1
+        self.advance()
+
+    def advance(self): # advance to next data shard
+        self.current_shard = (self.current_shard + 1) % len(self.files)
+        self.current_position = self.process_rank * self.seq_len
+        self.tokens = _load_data_shard(self.files[self.current_shard], self.files_num_tokens[self.current_shard])
+
+    def next_batch(self):
+        batch_size = self.seq_len * self.num_processes
+        buf = self.tokens[self.current_position:self.current_position+self.seq_len+1]
+        # host side async is sufficient;
+        # no performance improvement was observed when introducing a separate stream.
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # inputs
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # targets
+        # advance current position and load next shard if necessary
+        self.current_position += batch_size
+        if self.current_position + batch_size + 1 >= len(self.tokens):
+            self.advance()
+        return inputs, targets
+
+def set_output_layer_bias(model, dataloader, n_batches):
+    # Use token prevalence to initialize output layer bias & avoid initial shock to network of having to find it.
+    t0 = time.perf_counter()
+    num_vocab = model.lm_head.bias.size(0)
+    for i in range(n_batches):
+        _, targets_train = dataloader.next_batch()
+        if i == 0:
+            total_counts = torch.zeros(num_vocab, dtype=torch.int32, device=targets_train.device)
+        ids, counts = torch.unique(targets_train, sorted=True, return_counts=True)
+        total_counts[ids] += counts
+
+    target_probs = total_counts / total_counts.sum()
+    target_probs = (target_probs + 1e-12)
+    target_probs = target_probs / target_probs.sum()
+
+    with torch.no_grad():
+        model.lm_head.bias.copy_(target_probs.log())
+
+    old_init_loss = torch.tensor(1 / num_vocab).log().item()
+    new_init_loss = (target_probs * target_probs.log()).sum().item()
+    total_time = time.perf_counter() - t0
+    print0(f"Centered output layer, initial loss {old_init_loss:.3f} => {new_init_loss:.3f} ({total_time:.1f}s)")
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data hyperparams
+    input_bin : str = 'data/fineweb10B/fineweb_train_*.bin' # input .bin to train on
+    input_val_bin : str = 'data/fineweb10B/fineweb_val_*.bin' # input .bin to eval validation loss on
+    # optimization hyperparams
+    batch_size : int = 8 # batch size, in sequences, across all devices
+    sequence_length : int = 64*1024 # sequence length, in tokens
+    num_iterations : int = 1480 # number of iterations to run
+    warmup_iters : int = 0
+    cooldown_iters : int = 600 # number of iterations of linear warmup/cooldown for triangular or trapezoidal schedule
+    weight_decay : float = 0
+    # evaluation and logging hyperparams
+    val_loss_every : int = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    val_tokens : int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+args = Hyperparameters()
+
+# set up DDP (distributed data parallel). torchrun sets this env variable
+ddp_rank = int(os.environ['RANK'])
+ddp_local_rank = int(os.environ['LOCAL_RANK'])
+ddp_world_size = int(os.environ['WORLD_SIZE'])
+assert torch.cuda.is_available()
+device = torch.device(f'cuda:{ddp_local_rank}')
+torch.cuda.set_device(device)
+print(f'using device: {device}')
+dist.init_process_group(backend='nccl', device_id=device)
+dist.barrier()
+master_process = (ddp_rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = uuid.uuid4()
+    Path('logs').mkdir(exist_ok=True)
+    # logdir = Path('logs') / f'{run_id}'
+    # logdir.mkdir()
+    logfile = Path('logs') / f'{run_id}.txt'
+    print(logfile.stem)
+    # create the log file
+    with logfile.open('w') as f:
+        # begin the log by printing this file (the Python code)
+        print(code, file=f)
+        print('=' * 100, file=f)
+def print0(s, logonly=False):
+    if master_process:
+        with logfile.open('a') as f:
+            if not logonly:
+                print(s)
+            print(s, file=f)
+# log information about the hardware/software environment this is running on
+# and print the full `nvidia-smi` to file
+print0(f'Running python {sys.version}')
+print0(f'Running pytorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}\nnvidia-smi:')
+import subprocess
+result = subprocess.run(['nvidia-smi'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+print0(f'{result.stdout}', logonly=True)
+print0('='*100, logonly=True)
+
+# calculate the number of steps to take in the val loop.
+assert args.val_tokens % (args.sequence_length * ddp_world_size) == 0
+val_steps = args.val_tokens // (args.sequence_length * ddp_world_size)
+# calculate the steps of gradient accumulation required to attain the desired global batch size.
+assert args.batch_size % (ddp_world_size) == 0
+train_accumulation_steps = args.batch_size // ddp_world_size
+
+# load tokens
+train_loader = DistributedDataLoader(args.input_bin, args.sequence_length, ddp_rank, ddp_world_size)
+val_loader = DistributedDataLoader(args.input_val_bin, args.sequence_length, ddp_rank, ddp_world_size)
+print0(f"Training DataLoader: total number of tokens: {train_loader.total_num_tokens} across {len(train_loader.files)} files")
+print0(f"Validation DataLoader: total number of tokens: {val_loader.total_num_tokens} across {len(val_loader.files)} files")
+print0('='*100, logonly=True)
+inputs_train, targets_train = train_loader.next_batch()
+
+# there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency. suggested to me by @Grad62304977.
+# this originates from Karpathy's experiments.
+num_vocab = 50304
+model = GPT(GPTConfig(vocab_size=num_vocab, num_layers=12, num_heads=6, model_dim=768))
+model = model.cuda().bfloat16()
+for m in model.modules():
+    if isinstance(m, CastedLinear):
+        m.float()
+if hasattr(config, "coordinate_descent_tuning"):
+    config.coordinate_descent_tuning = True # suggested by @Chillee
+
+set_output_layer_bias(model, train_loader, n_batches=100)
+
+model = torch.compile(model)
+# here we wrap model into DDP container
+model = DDP(model, device_ids=[ddp_local_rank], broadcast_buffers=False, gradient_as_bucket_view=True)
+raw_model = model.module # always contains the "raw" unwrapped model
+
+# init the optimizer(s)
+embed_params = [*raw_model.embed.parameters(), *raw_model.value_embeds.parameters()]
+optimizer1 = torch.optim.Adam(embed_params, lr=0.6, betas=(0.8, 0.95), fused=True)
+optimizer2 = torch.optim.Adam([raw_model.lm_head.weight, raw_model.lm_head.bias], lr=0.008, betas=(0.8, 0.95), fused=True)
+params = list(raw_model.blocks.parameters())
+matrix_params = [p for p in params if p.ndim == 2]
+scalar_params = [p for p in params if p.ndim < 2] + [raw_model.skip_weights]
+optimizer3 = Muon(matrix_params, lr=0.05, momentum=0.95)
+optimizer4 = torch.optim.Adam(scalar_params, lr=0.04, betas=(0.8, 0.95), fused=True)
+optimizers = [optimizer1, optimizer2, optimizer3, optimizer4]
+# learning rate decay scheduler (linear warmup and cooldown)
+def get_lr(it):
+    assert it <= args.num_iterations
+    # 1) linear warmup for warmup_iters steps
+    if it < args.warmup_iters:
+        return (it+1) / args.warmup_iters
+    # 2) constant lr for a while
+    elif it < args.num_iterations - args.cooldown_iters:
+        return 1.0
+    # 3) linear cooldown
+    else:
+        decay_ratio = (args.num_iterations - it) / args.cooldown_iters
+        return decay_ratio
+schedulers = [torch.optim.lr_scheduler.LambdaLR(opt, get_lr) for opt in optimizers]
+
+sliding_window_num_blocks = torch.tensor(1, dtype=torch.int32, device="cuda")
+sw_num_blocks_prev = 1
+# Start training loop
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+for step in range(args.num_iterations + 1):
+    last_step = (step == args.num_iterations)
+    # This effectively ignores timing first 10 steps, which are slower for weird reasons.
+    # Alternately, and slightly more correctly in terms of benchmarking, we could do 10
+    # steps with dummy data first, and then re-initialize the model and reset the loader.
+    if step == 10:
+        training_time_ms = 0
+        t0 = time.perf_counter()
+    timed_steps = float('nan') if step <= 11 else (step - 10) + 1 # <= 11 to avoid bug in val
+
+    # Linearly increase the sliding window size over training in chunks of 128 from 128 -> 1856. By @fernbear.bsky.social
+    frac_done = step / args.num_iterations # training progress
+    sw_num_blocks = int(((1 - frac_done) * 128 + frac_done * 1856) // 128)
+    if sw_num_blocks != sw_num_blocks_prev:
+        sliding_window_num_blocks.copy_(sw_num_blocks, non_blocking=True)
+        sw_num_blocks_prev = sw_num_blocks
+
+    # once in a while evaluate the validation dataset
+    if (last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)):
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        # run validation batches
+        model.eval()
+        val_loader.reset()
+        val_loss = 0.0
+        for _ in range(val_steps):
+            with torch.no_grad():
+                inputs_val, targets_val = val_loader.next_batch()
+                val_loss += model(inputs_val, targets_val, sliding_window_num_blocks)
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        val_loss /= val_steps
+        # log val loss to console and to logfile
+        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    # uncomment if you want to save any checkpoints
+    #save_every = 1000
+    #if master_process and (last_step or (save_every > 0 and step % save_every == 0)):
+    #    # stop the clock
+    #    torch.cuda.synchronize()
+    #    training_time_ms += 1000 * (time.perf_counter() - t0)
+    #    # save the state of the training process
+    #    log = dict(step=step, code=code, model=raw_model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+    #    torch.save(log, 'logs/%s/state_step%06d.pt' % (run_id, step))
+    #    # start the clock again
+    #    torch.cuda.synchronize()
+    #    t0 = time.perf_counter()
+
+    # bit confusing: we want to make sure to eval on 0th iteration
+    # but also after the very last iteration. so we loop for step <= num_iterations
+    # instead of just < num_iterations (one extra due to <=), only to do
+    # the validation/sampling one last time, and then we break right here as we're done.
+    if last_step:
+        break
+
+    # --------------- TRAINING SECTION BEGIN -----------------
+    model.train()
+    for i in range(1, train_accumulation_steps + 1):
+        with contextlib.ExitStack() as stack:
+            if i < train_accumulation_steps: # there's no need to sync gradients every accumulation step
+                stack.enter_context(model.no_sync())
+            if step >= 5:
+                stack.enter_context(torch.compiler.set_stance(skip_guard_eval_unsafe=True))
+            model(inputs_train, targets_train, sliding_window_num_blocks).backward()
+            inputs_train, targets_train = train_loader.next_batch()
+    if train_accumulation_steps != 1:
+        for p in model.parameters():
+            p.grad /= train_accumulation_steps
+    # momentum warmup for Muon
+    frac = min(step/300, 1)
+    for group in optimizer3.param_groups:
+        group['momentum'] = (1 - frac) * 0.85 + frac * 0.95
+    # step the optimizers and schedulers
+    for opt, sched in zip(optimizers, schedulers):
+        opt.step()
+        sched.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # --------------- TRAINING SECTION END -------------------
+    # everything that follows now is just diagnostics, prints, logging, etc.
+    approx_time = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{args.num_iterations} train_time:{approx_time:.0f}ms step_avg:{approx_time/timed_steps:.2f}ms")
+
+print0(f"peak memory consumption: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB")
+
+# -------------------------------------------------------------------------
+# clean up nice
+dist.destroy_process_group()
+
+====================================================================================================
+Running python 3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
+Running pytorch 2.6.0.dev20241203+cu124 compiled for CUDA 12.4
+nvidia-smi:
+Thu Dec 26 08:12:27 2024       
++---------------------------------------------------------------------------------------+
+| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.4     |
+|-----------------------------------------+----------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
+|                                         |                      |               MIG M. |
+|=========================================+======================+======================|
+|   0  NVIDIA H100 PCIe               On  | 00000000:00:07.0 Off |                    0 |
+| N/A   40C    P0              82W / 350W |   4162MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   1  NVIDIA H100 PCIe               On  | 00000000:00:08.0 Off |                    0 |
+| N/A   45C    P0              87W / 350W |    923MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   2  NVIDIA H100 PCIe               On  | 00000000:00:09.0 Off |                    0 |
+| N/A   38C    P0              81W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   3  NVIDIA H100 PCIe               On  | 00000000:00:0A.0 Off |                    0 |
+| N/A   39C    P0              79W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   4  NVIDIA H100 PCIe               On  | 00000000:00:0B.0 Off |                    0 |
+| N/A   39C    P0              78W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   5  NVIDIA H100 PCIe               On  | 00000000:00:0C.0 Off |                    0 |
+| N/A   37C    P0              77W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   6  NVIDIA H100 PCIe               On  | 00000000:00:0D.0 Off |                    0 |
+| N/A   44C    P0              84W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   7  NVIDIA H100 PCIe               On  | 00000000:00:0E.0 Off |                    0 |
+| N/A   39C    P0              79W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+                                                                                         
++---------------------------------------------------------------------------------------+
+| Processes:                                                                            |
+|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
+|        ID   ID                                                             Usage      |
+|=======================================================================================|
++---------------------------------------------------------------------------------------+
+
+====================================================================================================
+Training DataLoader: total number of tokens: 1000000000 across 10 files
+Validation DataLoader: total number of tokens: 100000000 across 1 files
+====================================================================================================
+Centered output layer, initial loss -10.826 => -7.657 (0.1s)
+step:0/1480 val_loss:7.7109 train_time:0ms step_avg:nanms
+step:1/1480 train_time:26796ms step_avg:nanms
+step:2/1480 train_time:26933ms step_avg:nanms
+step:3/1480 train_time:27181ms step_avg:nanms
+step:4/1480 train_time:27437ms step_avg:nanms
+step:5/1480 train_time:27694ms step_avg:nanms
+step:6/1480 train_time:27948ms step_avg:nanms
+step:7/1480 train_time:28200ms step_avg:nanms
+step:8/1480 train_time:28459ms step_avg:nanms
+step:9/1480 train_time:28713ms step_avg:nanms
+step:10/1480 train_time:28965ms step_avg:nanms
+step:11/1480 train_time:256ms step_avg:nanms
+step:12/1480 train_time:513ms step_avg:nanms
+step:13/1480 train_time:769ms step_avg:256.41ms
+step:14/1480 train_time:1025ms step_avg:256.25ms
+step:15/1480 train_time:1279ms step_avg:255.84ms
+step:16/1480 train_time:1535ms step_avg:255.83ms
+step:17/1480 train_time:1794ms step_avg:256.25ms
+step:18/1480 train_time:2050ms step_avg:256.21ms
+step:19/1480 train_time:2305ms step_avg:256.11ms
+step:20/1480 train_time:2559ms step_avg:255.95ms
+step:21/1480 train_time:2817ms step_avg:256.09ms
+step:22/1480 train_time:3074ms step_avg:256.14ms
+step:23/1480 train_time:3331ms step_avg:256.24ms
+step:24/1480 train_time:3587ms step_avg:256.22ms
+step:25/1480 train_time:3839ms step_avg:255.96ms
+step:26/1480 train_time:4097ms step_avg:256.03ms
+step:27/1480 train_time:4355ms step_avg:256.16ms
+step:28/1480 train_time:4611ms step_avg:256.19ms
+step:29/1480 train_time:4869ms step_avg:256.27ms
+step:30/1480 train_time:5122ms step_avg:256.10ms
+step:31/1480 train_time:5377ms step_avg:256.07ms
+step:32/1480 train_time:5635ms step_avg:256.14ms
+step:33/1480 train_time:5894ms step_avg:256.26ms
+step:34/1480 train_time:6150ms step_avg:256.25ms
+step:35/1480 train_time:6405ms step_avg:256.20ms
+step:36/1480 train_time:6660ms step_avg:256.14ms
+step:37/1480 train_time:6917ms step_avg:256.18ms
+step:38/1480 train_time:7174ms step_avg:256.22ms
+step:39/1480 train_time:7431ms step_avg:256.25ms
+step:40/1480 train_time:7690ms step_avg:256.32ms
+step:41/1480 train_time:7945ms step_avg:256.30ms
+step:42/1480 train_time:8199ms step_avg:256.22ms
+step:43/1480 train_time:8457ms step_avg:256.26ms
+step:44/1480 train_time:8714ms step_avg:256.30ms
+step:45/1480 train_time:8971ms step_avg:256.33ms
+step:46/1480 train_time:9227ms step_avg:256.30ms
+step:47/1480 train_time:9483ms step_avg:256.29ms
+step:48/1480 train_time:9737ms step_avg:256.24ms
+step:49/1480 train_time:9998ms step_avg:256.35ms
+step:50/1480 train_time:10256ms step_avg:256.40ms
+step:51/1480 train_time:10513ms step_avg:256.41ms
+step:52/1480 train_time:10770ms step_avg:256.44ms
+step:53/1480 train_time:11031ms step_avg:256.53ms
+step:54/1480 train_time:11286ms step_avg:256.50ms
+step:55/1480 train_time:11542ms step_avg:256.49ms
+step:56/1480 train_time:11799ms step_avg:256.50ms
+step:57/1480 train_time:12057ms step_avg:256.53ms
+step:58/1480 train_time:12315ms step_avg:256.56ms
+step:59/1480 train_time:12572ms step_avg:256.58ms
+step:60/1480 train_time:12831ms step_avg:256.62ms
+step:61/1480 train_time:13091ms step_avg:256.69ms
+step:62/1480 train_time:13346ms step_avg:256.65ms
+step:63/1480 train_time:13600ms step_avg:256.60ms
+step:64/1480 train_time:13858ms step_avg:256.63ms
+step:65/1480 train_time:14115ms step_avg:256.64ms
+step:66/1480 train_time:14373ms step_avg:256.67ms
+step:67/1480 train_time:14632ms step_avg:256.71ms
+step:68/1480 train_time:14888ms step_avg:256.70ms
+step:69/1480 train_time:15141ms step_avg:256.63ms
+step:70/1480 train_time:15399ms step_avg:256.65ms
+step:71/1480 train_time:15658ms step_avg:256.69ms
+step:72/1480 train_time:15914ms step_avg:256.68ms
+step:73/1480 train_time:16173ms step_avg:256.71ms
+step:74/1480 train_time:16432ms step_avg:256.75ms
+step:75/1480 train_time:16690ms step_avg:256.77ms
+step:76/1480 train_time:16943ms step_avg:256.70ms
+step:77/1480 train_time:17199ms step_avg:256.70ms
+step:78/1480 train_time:17457ms step_avg:256.72ms
+step:79/1480 train_time:17713ms step_avg:256.72ms
+step:80/1480 train_time:17971ms step_avg:256.73ms
+step:81/1480 train_time:18227ms step_avg:256.72ms
+step:82/1480 train_time:18481ms step_avg:256.69ms
+step:83/1480 train_time:18738ms step_avg:256.69ms
+step:84/1480 train_time:18996ms step_avg:256.71ms
+step:85/1480 train_time:19255ms step_avg:256.73ms
+step:86/1480 train_time:19513ms step_avg:256.75ms
+step:87/1480 train_time:19772ms step_avg:256.78ms
+step:88/1480 train_time:20029ms step_avg:256.78ms
+step:89/1480 train_time:20286ms step_avg:256.78ms
+step:90/1480 train_time:20540ms step_avg:256.74ms
+step:91/1480 train_time:20799ms step_avg:256.77ms
+step:92/1480 train_time:21058ms step_avg:256.80ms
+step:93/1480 train_time:21315ms step_avg:256.81ms
+step:94/1480 train_time:21574ms step_avg:256.83ms
+step:95/1480 train_time:21832ms step_avg:256.84ms
+step:96/1480 train_time:22088ms step_avg:256.83ms
+step:97/1480 train_time:22341ms step_avg:256.79ms
+step:98/1480 train_time:22599ms step_avg:256.81ms
+step:99/1480 train_time:22858ms step_avg:256.83ms
+step:100/1480 train_time:23115ms step_avg:256.83ms
+step:101/1480 train_time:23373ms step_avg:256.84ms
+step:102/1480 train_time:23630ms step_avg:256.85ms
+step:103/1480 train_time:23885ms step_avg:256.83ms
+step:104/1480 train_time:24139ms step_avg:256.79ms
+step:105/1480 train_time:24400ms step_avg:256.84ms
+step:106/1480 train_time:24658ms step_avg:256.85ms
+step:107/1480 train_time:24915ms step_avg:256.85ms
+step:108/1480 train_time:25174ms step_avg:256.87ms
+step:109/1480 train_time:25430ms step_avg:256.87ms
+step:110/1480 train_time:25686ms step_avg:256.86ms
+step:111/1480 train_time:25942ms step_avg:256.85ms
+step:112/1480 train_time:26204ms step_avg:256.90ms
+step:113/1480 train_time:26466ms step_avg:256.95ms
+step:114/1480 train_time:26726ms step_avg:256.98ms
+step:115/1480 train_time:26985ms step_avg:257.00ms
+step:116/1480 train_time:27244ms step_avg:257.02ms
+step:117/1480 train_time:27505ms step_avg:257.06ms
+step:118/1480 train_time:27765ms step_avg:257.08ms
+step:119/1480 train_time:28027ms step_avg:257.13ms
+step:120/1480 train_time:28292ms step_avg:257.20ms
+step:121/1480 train_time:28556ms step_avg:257.26ms
+step:122/1480 train_time:28817ms step_avg:257.29ms
+step:123/1480 train_time:29079ms step_avg:257.33ms
+step:124/1480 train_time:29340ms step_avg:257.37ms
+step:125/1480 train_time:29602ms step_avg:257.41ms
+step:125/1480 val_loss:4.3804 train_time:29731ms step_avg:258.53ms
+step:126/1480 train_time:29866ms step_avg:257.46ms
+step:127/1480 train_time:30129ms step_avg:257.51ms
+step:128/1480 train_time:30393ms step_avg:257.57ms
+step:129/1480 train_time:30655ms step_avg:257.61ms
+step:130/1480 train_time:30917ms step_avg:257.64ms
+step:131/1480 train_time:31181ms step_avg:257.69ms
+step:132/1480 train_time:31444ms step_avg:257.74ms
+step:133/1480 train_time:31706ms step_avg:257.78ms
+step:134/1480 train_time:31966ms step_avg:257.79ms
+step:135/1480 train_time:32228ms step_avg:257.82ms
+step:136/1480 train_time:32490ms step_avg:257.86ms
+step:137/1480 train_time:32753ms step_avg:257.90ms
+step:138/1480 train_time:33015ms step_avg:257.93ms
+step:139/1480 train_time:33275ms step_avg:257.94ms
+step:140/1480 train_time:33536ms step_avg:257.97ms
+step:141/1480 train_time:33798ms step_avg:258.00ms
+step:142/1480 train_time:34062ms step_avg:258.04ms
+step:143/1480 train_time:34325ms step_avg:258.08ms
+step:144/1480 train_time:34586ms step_avg:258.10ms
+step:145/1480 train_time:34847ms step_avg:258.13ms
+step:146/1480 train_time:35108ms step_avg:258.15ms
+step:147/1480 train_time:35368ms step_avg:258.16ms
+step:148/1480 train_time:35629ms step_avg:258.18ms
+step:149/1480 train_time:35890ms step_avg:258.20ms
+step:150/1480 train_time:36151ms step_avg:258.22ms
+step:151/1480 train_time:36410ms step_avg:258.23ms
+step:152/1480 train_time:36669ms step_avg:258.24ms
+step:153/1480 train_time:36931ms step_avg:258.26ms
+step:154/1480 train_time:37191ms step_avg:258.27ms
+step:155/1480 train_time:37450ms step_avg:258.28ms
+step:156/1480 train_time:37709ms step_avg:258.28ms
+step:157/1480 train_time:37970ms step_avg:258.30ms
+step:158/1480 train_time:38230ms step_avg:258.31ms
+step:159/1480 train_time:38492ms step_avg:258.33ms
+step:160/1480 train_time:38751ms step_avg:258.34ms
+step:161/1480 train_time:39009ms step_avg:258.34ms
+step:162/1480 train_time:39269ms step_avg:258.35ms
+step:163/1480 train_time:39530ms step_avg:258.36ms
+step:164/1480 train_time:39791ms step_avg:258.38ms
+step:165/1480 train_time:40052ms step_avg:258.40ms
+step:166/1480 train_time:40314ms step_avg:258.43ms
+step:167/1480 train_time:40574ms step_avg:258.43ms
+step:168/1480 train_time:40834ms step_avg:258.45ms
+step:169/1480 train_time:41100ms step_avg:258.49ms
+step:170/1480 train_time:41364ms step_avg:258.52ms
+step:171/1480 train_time:41627ms step_avg:258.55ms
+step:172/1480 train_time:41889ms step_avg:258.58ms
+step:173/1480 train_time:42151ms step_avg:258.59ms
+step:174/1480 train_time:42411ms step_avg:258.60ms
+step:175/1480 train_time:42670ms step_avg:258.61ms
+step:176/1480 train_time:42931ms step_avg:258.62ms
+step:177/1480 train_time:43191ms step_avg:258.63ms
+step:178/1480 train_time:43455ms step_avg:258.66ms
+step:179/1480 train_time:43716ms step_avg:258.67ms
+step:180/1480 train_time:43978ms step_avg:258.69ms
+step:181/1480 train_time:44240ms step_avg:258.71ms
+step:182/1480 train_time:44503ms step_avg:258.74ms
+step:183/1480 train_time:44765ms step_avg:258.76ms
+step:184/1480 train_time:45028ms step_avg:258.78ms
+step:185/1480 train_time:45290ms step_avg:258.80ms
+step:186/1480 train_time:45553ms step_avg:258.83ms
+step:187/1480 train_time:45814ms step_avg:258.84ms
+step:188/1480 train_time:46073ms step_avg:258.84ms
+step:189/1480 train_time:46334ms step_avg:258.85ms
+step:190/1480 train_time:46598ms step_avg:258.88ms
+step:191/1480 train_time:46863ms step_avg:258.91ms
+step:192/1480 train_time:47127ms step_avg:258.94ms
+step:193/1480 train_time:47388ms step_avg:258.95ms
+step:194/1480 train_time:47649ms step_avg:258.96ms
+step:195/1480 train_time:47911ms step_avg:258.98ms
+step:196/1480 train_time:48172ms step_avg:258.99ms
+step:197/1480 train_time:48433ms step_avg:259.00ms
+step:198/1480 train_time:48695ms step_avg:259.01ms
+step:199/1480 train_time:48961ms step_avg:259.05ms
+step:200/1480 train_time:49226ms step_avg:259.08ms
+step:201/1480 train_time:49487ms step_avg:259.09ms
+step:202/1480 train_time:49747ms step_avg:259.10ms
+step:203/1480 train_time:50008ms step_avg:259.11ms
+step:204/1480 train_time:50269ms step_avg:259.12ms
+step:205/1480 train_time:50530ms step_avg:259.13ms
+step:206/1480 train_time:50792ms step_avg:259.14ms
+step:207/1480 train_time:51057ms step_avg:259.17ms
+step:208/1480 train_time:51318ms step_avg:259.18ms
+step:209/1480 train_time:51583ms step_avg:259.21ms
+step:210/1480 train_time:51844ms step_avg:259.22ms
+step:211/1480 train_time:52107ms step_avg:259.24ms
+step:212/1480 train_time:52366ms step_avg:259.24ms
+step:213/1480 train_time:52628ms step_avg:259.25ms
+step:214/1480 train_time:52890ms step_avg:259.26ms
+step:215/1480 train_time:53154ms step_avg:259.29ms
+step:216/1480 train_time:53417ms step_avg:259.31ms
+step:217/1480 train_time:53681ms step_avg:259.33ms
+step:218/1480 train_time:53943ms step_avg:259.34ms
+step:219/1480 train_time:54206ms step_avg:259.36ms
+step:220/1480 train_time:54466ms step_avg:259.36ms
+step:221/1480 train_time:54729ms step_avg:259.38ms
+step:222/1480 train_time:54997ms step_avg:259.42ms
+step:223/1480 train_time:55266ms step_avg:259.46ms
+step:224/1480 train_time:55530ms step_avg:259.49ms
+step:225/1480 train_time:55800ms step_avg:259.54ms
+step:226/1480 train_time:56066ms step_avg:259.57ms
+step:227/1480 train_time:56330ms step_avg:259.59ms
+step:228/1480 train_time:56600ms step_avg:259.63ms
+step:229/1480 train_time:56866ms step_avg:259.66ms
+step:230/1480 train_time:57131ms step_avg:259.69ms
+step:231/1480 train_time:57401ms step_avg:259.73ms
+step:232/1480 train_time:57668ms step_avg:259.77ms
+step:233/1480 train_time:57932ms step_avg:259.78ms
+step:234/1480 train_time:58199ms step_avg:259.82ms
+step:235/1480 train_time:58466ms step_avg:259.85ms
+step:236/1480 train_time:58731ms step_avg:259.87ms
+step:237/1480 train_time:59000ms step_avg:259.91ms
+step:238/1480 train_time:59266ms step_avg:259.94ms
+step:239/1480 train_time:59532ms step_avg:259.97ms
+step:240/1480 train_time:59801ms step_avg:260.01ms
+step:241/1480 train_time:60069ms step_avg:260.04ms
+step:242/1480 train_time:60335ms step_avg:260.07ms
+step:243/1480 train_time:60604ms step_avg:260.10ms
+step:244/1480 train_time:60868ms step_avg:260.12ms
+step:245/1480 train_time:61132ms step_avg:260.14ms
+step:246/1480 train_time:61401ms step_avg:260.17ms
+step:247/1480 train_time:61667ms step_avg:260.20ms
+step:248/1480 train_time:61933ms step_avg:260.22ms
+step:249/1480 train_time:62202ms step_avg:260.26ms
+step:250/1480 train_time:62467ms step_avg:260.28ms
+step:250/1480 val_loss:4.0066 train_time:62597ms step_avg:260.82ms
+step:251/1480 train_time:62736ms step_avg:260.32ms
+step:252/1480 train_time:63004ms step_avg:260.35ms
+step:253/1480 train_time:63269ms step_avg:260.36ms
+step:254/1480 train_time:63537ms step_avg:260.40ms
+step:255/1480 train_time:63803ms step_avg:260.42ms
+step:256/1480 train_time:64069ms step_avg:260.44ms
+step:257/1480 train_time:64337ms step_avg:260.47ms
+step:258/1480 train_time:64602ms step_avg:260.49ms
+step:259/1480 train_time:64869ms step_avg:260.52ms
+step:260/1480 train_time:65136ms step_avg:260.54ms
+step:261/1480 train_time:65403ms step_avg:260.57ms
+step:262/1480 train_time:65667ms step_avg:260.58ms
+step:263/1480 train_time:65935ms step_avg:260.61ms
+step:264/1480 train_time:66202ms step_avg:260.64ms
+step:265/1480 train_time:66467ms step_avg:260.66ms
+step:266/1480 train_time:66736ms step_avg:260.69ms
+step:267/1480 train_time:67003ms step_avg:260.71ms
+step:268/1480 train_time:67268ms step_avg:260.73ms
+step:269/1480 train_time:67534ms step_avg:260.75ms
+step:270/1480 train_time:67802ms step_avg:260.78ms
+step:271/1480 train_time:68069ms step_avg:260.80ms
+step:272/1480 train_time:68335ms step_avg:260.82ms
+step:273/1480 train_time:68602ms step_avg:260.85ms
+step:274/1480 train_time:68866ms step_avg:260.86ms
+step:275/1480 train_time:69135ms step_avg:260.89ms
+step:276/1480 train_time:69401ms step_avg:260.91ms
+step:277/1480 train_time:69664ms step_avg:260.92ms
+step:278/1480 train_time:69932ms step_avg:260.94ms
+step:279/1480 train_time:70201ms step_avg:260.97ms
+step:280/1480 train_time:70464ms step_avg:260.98ms
+step:281/1480 train_time:70731ms step_avg:261.00ms
+step:282/1480 train_time:70999ms step_avg:261.03ms
+step:283/1480 train_time:71264ms step_avg:261.04ms
+step:284/1480 train_time:71531ms step_avg:261.06ms
+step:285/1480 train_time:71800ms step_avg:261.09ms
+step:286/1480 train_time:72063ms step_avg:261.10ms
+step:287/1480 train_time:72329ms step_avg:261.12ms
+step:288/1480 train_time:72597ms step_avg:261.14ms
+step:289/1480 train_time:72862ms step_avg:261.16ms
+step:290/1480 train_time:73126ms step_avg:261.17ms
+step:291/1480 train_time:73395ms step_avg:261.19ms
+step:292/1480 train_time:73663ms step_avg:261.22ms
+step:293/1480 train_time:73927ms step_avg:261.23ms
+step:294/1480 train_time:74193ms step_avg:261.24ms
+step:295/1480 train_time:74461ms step_avg:261.27ms
+step:296/1480 train_time:74727ms step_avg:261.28ms
+step:297/1480 train_time:74996ms step_avg:261.31ms
+step:298/1480 train_time:75263ms step_avg:261.33ms
+step:299/1480 train_time:75526ms step_avg:261.34ms
+step:300/1480 train_time:75795ms step_avg:261.36ms
+step:301/1480 train_time:76062ms step_avg:261.38ms
+step:302/1480 train_time:76328ms step_avg:261.40ms
+step:303/1480 train_time:76596ms step_avg:261.42ms
+step:304/1480 train_time:76862ms step_avg:261.44ms
+step:305/1480 train_time:77127ms step_avg:261.45ms
+step:306/1480 train_time:77396ms step_avg:261.47ms
+step:307/1480 train_time:77662ms step_avg:261.49ms
+step:308/1480 train_time:77928ms step_avg:261.50ms
+step:309/1480 train_time:78196ms step_avg:261.52ms
+step:310/1480 train_time:78462ms step_avg:261.54ms
+step:311/1480 train_time:78728ms step_avg:261.55ms
+step:312/1480 train_time:78997ms step_avg:261.58ms
+step:313/1480 train_time:79263ms step_avg:261.59ms
+step:314/1480 train_time:79528ms step_avg:261.61ms
+step:315/1480 train_time:79797ms step_avg:261.63ms
+step:316/1480 train_time:80064ms step_avg:261.65ms
+step:317/1480 train_time:80332ms step_avg:261.67ms
+step:318/1480 train_time:80600ms step_avg:261.69ms
+step:319/1480 train_time:80865ms step_avg:261.70ms
+step:320/1480 train_time:81135ms step_avg:261.73ms
+step:321/1480 train_time:81403ms step_avg:261.75ms
+step:322/1480 train_time:81667ms step_avg:261.75ms
+step:323/1480 train_time:81934ms step_avg:261.77ms
+step:324/1480 train_time:82201ms step_avg:261.79ms
+step:325/1480 train_time:82464ms step_avg:261.79ms
+step:326/1480 train_time:82734ms step_avg:261.82ms
+step:327/1480 train_time:83002ms step_avg:261.83ms
+step:328/1480 train_time:83267ms step_avg:261.84ms
+step:329/1480 train_time:83532ms step_avg:261.86ms
+step:330/1480 train_time:83802ms step_avg:261.88ms
+step:331/1480 train_time:84071ms step_avg:261.90ms
+step:332/1480 train_time:84342ms step_avg:261.93ms
+step:333/1480 train_time:84613ms step_avg:261.96ms
+step:334/1480 train_time:84885ms step_avg:261.99ms
+step:335/1480 train_time:85157ms step_avg:262.02ms
+step:336/1480 train_time:85426ms step_avg:262.04ms
+step:337/1480 train_time:85698ms step_avg:262.07ms
+step:338/1480 train_time:85965ms step_avg:262.09ms
+step:339/1480 train_time:86238ms step_avg:262.12ms
+step:340/1480 train_time:86507ms step_avg:262.14ms
+step:341/1480 train_time:86779ms step_avg:262.17ms
+step:342/1480 train_time:87051ms step_avg:262.20ms
+step:343/1480 train_time:87325ms step_avg:262.24ms
+step:344/1480 train_time:87598ms step_avg:262.27ms
+step:345/1480 train_time:87866ms step_avg:262.29ms
+step:346/1480 train_time:88140ms step_avg:262.32ms
+step:347/1480 train_time:88410ms step_avg:262.35ms
+step:348/1480 train_time:88682ms step_avg:262.37ms
+step:349/1480 train_time:88955ms step_avg:262.40ms
+step:350/1480 train_time:89225ms step_avg:262.43ms
+step:351/1480 train_time:89497ms step_avg:262.45ms
+step:352/1480 train_time:89766ms step_avg:262.47ms
+step:353/1480 train_time:90039ms step_avg:262.50ms
+step:354/1480 train_time:90308ms step_avg:262.52ms
+step:355/1480 train_time:90581ms step_avg:262.55ms
+step:356/1480 train_time:90851ms step_avg:262.57ms
+step:357/1480 train_time:91123ms step_avg:262.60ms
+step:358/1480 train_time:91393ms step_avg:262.62ms
+step:359/1480 train_time:91663ms step_avg:262.64ms
+step:360/1480 train_time:91934ms step_avg:262.67ms
+step:361/1480 train_time:92203ms step_avg:262.69ms
+step:362/1480 train_time:92475ms step_avg:262.71ms
+step:363/1480 train_time:92745ms step_avg:262.73ms
+step:364/1480 train_time:93017ms step_avg:262.76ms
+step:365/1480 train_time:93285ms step_avg:262.77ms
+step:366/1480 train_time:93559ms step_avg:262.81ms
+step:367/1480 train_time:93828ms step_avg:262.82ms
+step:368/1480 train_time:94099ms step_avg:262.85ms
+step:369/1480 train_time:94368ms step_avg:262.86ms
+step:370/1480 train_time:94640ms step_avg:262.89ms
+step:371/1480 train_time:94911ms step_avg:262.91ms
+step:372/1480 train_time:95182ms step_avg:262.93ms
+step:373/1480 train_time:95453ms step_avg:262.96ms
+step:374/1480 train_time:95725ms step_avg:262.98ms
+step:375/1480 train_time:95996ms step_avg:263.00ms
+step:375/1480 val_loss:3.8302 train_time:96128ms step_avg:263.36ms
+step:376/1480 train_time:96269ms step_avg:263.03ms
+step:377/1480 train_time:96544ms step_avg:263.06ms
+step:378/1480 train_time:96813ms step_avg:263.08ms
+step:379/1480 train_time:97086ms step_avg:263.11ms
+step:380/1480 train_time:97354ms step_avg:263.12ms
+step:381/1480 train_time:97628ms step_avg:263.15ms
+step:382/1480 train_time:97898ms step_avg:263.17ms
+step:383/1480 train_time:98170ms step_avg:263.19ms
+step:384/1480 train_time:98440ms step_avg:263.21ms
+step:385/1480 train_time:98710ms step_avg:263.23ms
+step:386/1480 train_time:98984ms step_avg:263.26ms
+step:387/1480 train_time:99252ms step_avg:263.27ms
+step:388/1480 train_time:99526ms step_avg:263.30ms
+step:389/1480 train_time:99794ms step_avg:263.31ms
+step:390/1480 train_time:100067ms step_avg:263.33ms
+step:391/1480 train_time:100339ms step_avg:263.36ms
+step:392/1480 train_time:100608ms step_avg:263.37ms
+step:393/1480 train_time:100879ms step_avg:263.39ms
+step:394/1480 train_time:101150ms step_avg:263.41ms
+step:395/1480 train_time:101419ms step_avg:263.43ms
+step:396/1480 train_time:101692ms step_avg:263.45ms
+step:397/1480 train_time:101960ms step_avg:263.46ms
+step:398/1480 train_time:102232ms step_avg:263.48ms
+step:399/1480 train_time:102503ms step_avg:263.50ms
+step:400/1480 train_time:102772ms step_avg:263.52ms
+step:401/1480 train_time:103044ms step_avg:263.54ms
+step:402/1480 train_time:103313ms step_avg:263.55ms
+step:403/1480 train_time:103589ms step_avg:263.58ms
+step:404/1480 train_time:103855ms step_avg:263.59ms
+step:405/1480 train_time:104129ms step_avg:263.62ms
+step:406/1480 train_time:104403ms step_avg:263.64ms
+step:407/1480 train_time:104672ms step_avg:263.66ms
+step:408/1480 train_time:104943ms step_avg:263.68ms
+step:409/1480 train_time:105212ms step_avg:263.69ms
+step:410/1480 train_time:105483ms step_avg:263.71ms
+step:411/1480 train_time:105753ms step_avg:263.72ms
+step:412/1480 train_time:106027ms step_avg:263.75ms
+step:413/1480 train_time:106298ms step_avg:263.77ms
+step:414/1480 train_time:106570ms step_avg:263.79ms
+step:415/1480 train_time:106842ms step_avg:263.81ms
+step:416/1480 train_time:107111ms step_avg:263.82ms
+step:417/1480 train_time:107381ms step_avg:263.84ms
+step:418/1480 train_time:107652ms step_avg:263.85ms
+step:419/1480 train_time:107922ms step_avg:263.87ms
+step:420/1480 train_time:108192ms step_avg:263.88ms
+step:421/1480 train_time:108466ms step_avg:263.91ms
+step:422/1480 train_time:108734ms step_avg:263.92ms
+step:423/1480 train_time:109006ms step_avg:263.94ms
+step:424/1480 train_time:109275ms step_avg:263.95ms
+step:425/1480 train_time:109547ms step_avg:263.97ms
+step:426/1480 train_time:109815ms step_avg:263.98ms
+step:427/1480 train_time:110089ms step_avg:264.00ms
+step:428/1480 train_time:110356ms step_avg:264.01ms
+step:429/1480 train_time:110628ms step_avg:264.03ms
+step:430/1480 train_time:110899ms step_avg:264.04ms
+step:431/1480 train_time:111171ms step_avg:264.06ms
+step:432/1480 train_time:111440ms step_avg:264.08ms
+step:433/1480 train_time:111710ms step_avg:264.09ms
+step:434/1480 train_time:111982ms step_avg:264.11ms
+step:435/1480 train_time:112251ms step_avg:264.12ms
+step:436/1480 train_time:112523ms step_avg:264.14ms
+step:437/1480 train_time:112795ms step_avg:264.16ms
+step:438/1480 train_time:113066ms step_avg:264.17ms
+step:439/1480 train_time:113333ms step_avg:264.18ms
+step:440/1480 train_time:113606ms step_avg:264.20ms
+step:441/1480 train_time:113878ms step_avg:264.22ms
+step:442/1480 train_time:114153ms step_avg:264.24ms
+step:443/1480 train_time:114428ms step_avg:264.27ms
+step:444/1480 train_time:114707ms step_avg:264.30ms
+step:445/1480 train_time:114979ms step_avg:264.32ms
+step:446/1480 train_time:115252ms step_avg:264.34ms
+step:447/1480 train_time:115526ms step_avg:264.36ms
+step:448/1480 train_time:115804ms step_avg:264.39ms
+step:449/1480 train_time:116073ms step_avg:264.40ms
+step:450/1480 train_time:116349ms step_avg:264.43ms
+step:451/1480 train_time:116621ms step_avg:264.45ms
+step:452/1480 train_time:116894ms step_avg:264.47ms
+step:453/1480 train_time:117169ms step_avg:264.49ms
+step:454/1480 train_time:117445ms step_avg:264.52ms
+step:455/1480 train_time:117718ms step_avg:264.53ms
+step:456/1480 train_time:117990ms step_avg:264.55ms
+step:457/1480 train_time:118266ms step_avg:264.58ms
+step:458/1480 train_time:118538ms step_avg:264.59ms
+step:459/1480 train_time:118810ms step_avg:264.61ms
+step:460/1480 train_time:119086ms step_avg:264.63ms
+step:461/1480 train_time:119356ms step_avg:264.65ms
+step:462/1480 train_time:119631ms step_avg:264.67ms
+step:463/1480 train_time:119906ms step_avg:264.69ms
+step:464/1480 train_time:120181ms step_avg:264.72ms
+step:465/1480 train_time:120453ms step_avg:264.73ms
+step:466/1480 train_time:120728ms step_avg:264.75ms
+step:467/1480 train_time:121001ms step_avg:264.77ms
+step:468/1480 train_time:121274ms step_avg:264.79ms
+step:469/1480 train_time:121549ms step_avg:264.81ms
+step:470/1480 train_time:121824ms step_avg:264.83ms
+step:471/1480 train_time:122098ms step_avg:264.85ms
+step:472/1480 train_time:122371ms step_avg:264.87ms
+step:473/1480 train_time:122647ms step_avg:264.90ms
+step:474/1480 train_time:122921ms step_avg:264.92ms
+step:475/1480 train_time:123196ms step_avg:264.94ms
+step:476/1480 train_time:123470ms step_avg:264.96ms
+step:477/1480 train_time:123745ms step_avg:264.98ms
+step:478/1480 train_time:124017ms step_avg:264.99ms
+step:479/1480 train_time:124291ms step_avg:265.01ms
+step:480/1480 train_time:124568ms step_avg:265.04ms
+step:481/1480 train_time:124840ms step_avg:265.05ms
+step:482/1480 train_time:125114ms step_avg:265.07ms
+step:483/1480 train_time:125389ms step_avg:265.09ms
+step:484/1480 train_time:125659ms step_avg:265.10ms
+step:485/1480 train_time:125933ms step_avg:265.12ms
+step:486/1480 train_time:126208ms step_avg:265.14ms
+step:487/1480 train_time:126481ms step_avg:265.16ms
+step:488/1480 train_time:126754ms step_avg:265.18ms
+step:489/1480 train_time:127030ms step_avg:265.20ms
+step:490/1480 train_time:127306ms step_avg:265.22ms
+step:491/1480 train_time:127579ms step_avg:265.24ms
+step:492/1480 train_time:127850ms step_avg:265.25ms
+step:493/1480 train_time:128127ms step_avg:265.27ms
+step:494/1480 train_time:128405ms step_avg:265.30ms
+step:495/1480 train_time:128677ms step_avg:265.31ms
+step:496/1480 train_time:128951ms step_avg:265.33ms
+step:497/1480 train_time:129226ms step_avg:265.35ms
+step:498/1480 train_time:129497ms step_avg:265.36ms
+step:499/1480 train_time:129772ms step_avg:265.38ms
+step:500/1480 train_time:130047ms step_avg:265.40ms
+step:500/1480 val_loss:3.7171 train_time:130180ms step_avg:265.67ms
+step:501/1480 train_time:130323ms step_avg:265.42ms
+step:502/1480 train_time:130597ms step_avg:265.44ms
+step:503/1480 train_time:130876ms step_avg:265.47ms
+step:504/1480 train_time:131152ms step_avg:265.49ms
+step:505/1480 train_time:131422ms step_avg:265.50ms
+step:506/1480 train_time:131697ms step_avg:265.52ms
+step:507/1480 train_time:131974ms step_avg:265.54ms
+step:508/1480 train_time:132246ms step_avg:265.55ms
+step:509/1480 train_time:132519ms step_avg:265.57ms
+step:510/1480 train_time:132796ms step_avg:265.59ms
+step:511/1480 train_time:133070ms step_avg:265.61ms
+step:512/1480 train_time:133344ms step_avg:265.63ms
+step:513/1480 train_time:133616ms step_avg:265.64ms
+step:514/1480 train_time:133892ms step_avg:265.66ms
+step:515/1480 train_time:134165ms step_avg:265.67ms
+step:516/1480 train_time:134436ms step_avg:265.68ms
+step:517/1480 train_time:134712ms step_avg:265.70ms
+step:518/1480 train_time:134986ms step_avg:265.72ms
+step:519/1480 train_time:135257ms step_avg:265.73ms
+step:520/1480 train_time:135534ms step_avg:265.75ms
+step:521/1480 train_time:135810ms step_avg:265.77ms
+step:522/1480 train_time:136085ms step_avg:265.79ms
+step:523/1480 train_time:136357ms step_avg:265.80ms
+step:524/1480 train_time:136635ms step_avg:265.83ms
+step:525/1480 train_time:136907ms step_avg:265.84ms
+step:526/1480 train_time:137177ms step_avg:265.85ms
+step:527/1480 train_time:137453ms step_avg:265.87ms
+step:528/1480 train_time:137723ms step_avg:265.88ms
+step:529/1480 train_time:137996ms step_avg:265.89ms
+step:530/1480 train_time:138271ms step_avg:265.91ms
+step:531/1480 train_time:138544ms step_avg:265.92ms
+step:532/1480 train_time:138817ms step_avg:265.93ms
+step:533/1480 train_time:139093ms step_avg:265.95ms
+step:534/1480 train_time:139370ms step_avg:265.97ms
+step:535/1480 train_time:139644ms step_avg:265.99ms
+step:536/1480 train_time:139917ms step_avg:266.00ms
+step:537/1480 train_time:140192ms step_avg:266.02ms
+step:538/1480 train_time:140464ms step_avg:266.03ms
+step:539/1480 train_time:140738ms step_avg:266.04ms
+step:540/1480 train_time:141014ms step_avg:266.06ms
+step:541/1480 train_time:141288ms step_avg:266.08ms
+step:542/1480 train_time:141559ms step_avg:266.09ms
+step:543/1480 train_time:141835ms step_avg:266.11ms
+step:544/1480 train_time:142110ms step_avg:266.12ms
+step:545/1480 train_time:142378ms step_avg:266.13ms
+step:546/1480 train_time:142657ms step_avg:266.15ms
+step:547/1480 train_time:142928ms step_avg:266.16ms
+step:548/1480 train_time:143202ms step_avg:266.17ms
+step:549/1480 train_time:143475ms step_avg:266.19ms
+step:550/1480 train_time:143753ms step_avg:266.21ms
+step:551/1480 train_time:144028ms step_avg:266.23ms
+step:552/1480 train_time:144301ms step_avg:266.24ms
+step:553/1480 train_time:144577ms step_avg:266.26ms
+step:554/1480 train_time:144856ms step_avg:266.28ms
+step:555/1480 train_time:145133ms step_avg:266.30ms
+step:556/1480 train_time:145408ms step_avg:266.32ms
+step:557/1480 train_time:145687ms step_avg:266.34ms
+step:558/1480 train_time:145961ms step_avg:266.35ms
+step:559/1480 train_time:146238ms step_avg:266.37ms
+step:560/1480 train_time:146515ms step_avg:266.39ms
+step:561/1480 train_time:146795ms step_avg:266.42ms
+step:562/1480 train_time:147072ms step_avg:266.44ms
+step:563/1480 train_time:147349ms step_avg:266.45ms
+step:564/1480 train_time:147623ms step_avg:266.47ms
+step:565/1480 train_time:147901ms step_avg:266.49ms
+step:566/1480 train_time:148175ms step_avg:266.50ms
+step:567/1480 train_time:148455ms step_avg:266.53ms
+step:568/1480 train_time:148733ms step_avg:266.55ms
+step:569/1480 train_time:149010ms step_avg:266.57ms
+step:570/1480 train_time:149286ms step_avg:266.58ms
+step:571/1480 train_time:149558ms step_avg:266.59ms
+step:572/1480 train_time:149839ms step_avg:266.62ms
+step:573/1480 train_time:150116ms step_avg:266.64ms
+step:574/1480 train_time:150393ms step_avg:266.65ms
+step:575/1480 train_time:150670ms step_avg:266.67ms
+step:576/1480 train_time:150947ms step_avg:266.69ms
+step:577/1480 train_time:151220ms step_avg:266.70ms
+step:578/1480 train_time:151498ms step_avg:266.72ms
+step:579/1480 train_time:151775ms step_avg:266.74ms
+step:580/1480 train_time:152053ms step_avg:266.76ms
+step:581/1480 train_time:152329ms step_avg:266.78ms
+step:582/1480 train_time:152607ms step_avg:266.79ms
+step:583/1480 train_time:152880ms step_avg:266.81ms
+step:584/1480 train_time:153158ms step_avg:266.83ms
+step:585/1480 train_time:153436ms step_avg:266.84ms
+step:586/1480 train_time:153713ms step_avg:266.86ms
+step:587/1480 train_time:153992ms step_avg:266.88ms
+step:588/1480 train_time:154270ms step_avg:266.90ms
+step:589/1480 train_time:154544ms step_avg:266.92ms
+step:590/1480 train_time:154820ms step_avg:266.93ms
+step:591/1480 train_time:155096ms step_avg:266.95ms
+step:592/1480 train_time:155375ms step_avg:266.97ms
+step:593/1480 train_time:155654ms step_avg:266.99ms
+step:594/1480 train_time:155928ms step_avg:267.00ms
+step:595/1480 train_time:156207ms step_avg:267.02ms
+step:596/1480 train_time:156481ms step_avg:267.03ms
+step:597/1480 train_time:156758ms step_avg:267.05ms
+step:598/1480 train_time:157036ms step_avg:267.07ms
+step:599/1480 train_time:157315ms step_avg:267.09ms
+step:600/1480 train_time:157593ms step_avg:267.11ms
+step:601/1480 train_time:157870ms step_avg:267.12ms
+step:602/1480 train_time:158149ms step_avg:267.14ms
+step:603/1480 train_time:158421ms step_avg:267.15ms
+step:604/1480 train_time:158697ms step_avg:267.17ms
+step:605/1480 train_time:158976ms step_avg:267.19ms
+step:606/1480 train_time:159255ms step_avg:267.21ms
+step:607/1480 train_time:159531ms step_avg:267.22ms
+step:608/1480 train_time:159807ms step_avg:267.24ms
+step:609/1480 train_time:160084ms step_avg:267.25ms
+step:610/1480 train_time:160359ms step_avg:267.26ms
+step:611/1480 train_time:160638ms step_avg:267.28ms
+step:612/1480 train_time:160915ms step_avg:267.30ms
+step:613/1480 train_time:161196ms step_avg:267.32ms
+step:614/1480 train_time:161473ms step_avg:267.34ms
+step:615/1480 train_time:161752ms step_avg:267.36ms
+step:616/1480 train_time:162026ms step_avg:267.37ms
+step:617/1480 train_time:162301ms step_avg:267.38ms
+step:618/1480 train_time:162576ms step_avg:267.39ms
+step:619/1480 train_time:162855ms step_avg:267.41ms
+step:620/1480 train_time:163131ms step_avg:267.43ms
+step:621/1480 train_time:163407ms step_avg:267.44ms
+step:622/1480 train_time:163680ms step_avg:267.45ms
+step:623/1480 train_time:163956ms step_avg:267.47ms
+step:624/1480 train_time:164235ms step_avg:267.48ms
+step:625/1480 train_time:164514ms step_avg:267.50ms
+step:625/1480 val_loss:3.6396 train_time:164649ms step_avg:267.72ms
+step:626/1480 train_time:164793ms step_avg:267.52ms
+step:627/1480 train_time:165073ms step_avg:267.54ms
+step:628/1480 train_time:165351ms step_avg:267.56ms
+step:629/1480 train_time:165628ms step_avg:267.57ms
+step:630/1480 train_time:165907ms step_avg:267.59ms
+step:631/1480 train_time:166180ms step_avg:267.60ms
+step:632/1480 train_time:166455ms step_avg:267.61ms
+step:633/1480 train_time:166730ms step_avg:267.62ms
+step:634/1480 train_time:167010ms step_avg:267.64ms
+step:635/1480 train_time:167285ms step_avg:267.66ms
+step:636/1480 train_time:167565ms step_avg:267.68ms
+step:637/1480 train_time:167838ms step_avg:267.68ms
+step:638/1480 train_time:168114ms step_avg:267.70ms
+step:639/1480 train_time:168390ms step_avg:267.71ms
+step:640/1480 train_time:168669ms step_avg:267.73ms
+step:641/1480 train_time:168947ms step_avg:267.74ms
+step:642/1480 train_time:169226ms step_avg:267.76ms
+step:643/1480 train_time:169503ms step_avg:267.78ms
+step:644/1480 train_time:169781ms step_avg:267.79ms
+step:645/1480 train_time:170062ms step_avg:267.81ms
+step:646/1480 train_time:170334ms step_avg:267.82ms
+step:647/1480 train_time:170613ms step_avg:267.84ms
+step:648/1480 train_time:170893ms step_avg:267.86ms
+step:649/1480 train_time:171172ms step_avg:267.87ms
+step:650/1480 train_time:171449ms step_avg:267.89ms
+step:651/1480 train_time:171729ms step_avg:267.91ms
+step:652/1480 train_time:172006ms step_avg:267.92ms
+step:653/1480 train_time:172281ms step_avg:267.93ms
+step:654/1480 train_time:172554ms step_avg:267.94ms
+step:655/1480 train_time:172833ms step_avg:267.96ms
+step:656/1480 train_time:173111ms step_avg:267.97ms
+step:657/1480 train_time:173389ms step_avg:267.99ms
+step:658/1480 train_time:173666ms step_avg:268.00ms
+step:659/1480 train_time:173947ms step_avg:268.02ms
+step:660/1480 train_time:174227ms step_avg:268.04ms
+step:661/1480 train_time:174511ms step_avg:268.07ms
+step:662/1480 train_time:174791ms step_avg:268.08ms
+step:663/1480 train_time:175070ms step_avg:268.10ms
+step:664/1480 train_time:175351ms step_avg:268.12ms
+step:665/1480 train_time:175629ms step_avg:268.14ms
+step:666/1480 train_time:175911ms step_avg:268.16ms
+step:667/1480 train_time:176192ms step_avg:268.18ms
+step:668/1480 train_time:176472ms step_avg:268.20ms
+step:669/1480 train_time:176753ms step_avg:268.21ms
+step:670/1480 train_time:177032ms step_avg:268.23ms
+step:671/1480 train_time:177313ms step_avg:268.25ms
+step:672/1480 train_time:177591ms step_avg:268.26ms
+step:673/1480 train_time:177871ms step_avg:268.28ms
+step:674/1480 train_time:178149ms step_avg:268.30ms
+step:675/1480 train_time:178426ms step_avg:268.31ms
+step:676/1480 train_time:178709ms step_avg:268.33ms
+step:677/1480 train_time:178989ms step_avg:268.35ms
+step:678/1480 train_time:179265ms step_avg:268.36ms
+step:679/1480 train_time:179543ms step_avg:268.38ms
+step:680/1480 train_time:179825ms step_avg:268.40ms
+step:681/1480 train_time:180103ms step_avg:268.41ms
+step:682/1480 train_time:180385ms step_avg:268.43ms
+step:683/1480 train_time:180660ms step_avg:268.44ms
+step:684/1480 train_time:180937ms step_avg:268.45ms
+step:685/1480 train_time:181215ms step_avg:268.47ms
+step:686/1480 train_time:181494ms step_avg:268.48ms
+step:687/1480 train_time:181772ms step_avg:268.50ms
+step:688/1480 train_time:182052ms step_avg:268.51ms
+step:689/1480 train_time:182331ms step_avg:268.53ms
+step:690/1480 train_time:182614ms step_avg:268.55ms
+step:691/1480 train_time:182895ms step_avg:268.57ms
+step:692/1480 train_time:183175ms step_avg:268.59ms
+step:693/1480 train_time:183453ms step_avg:268.60ms
+step:694/1480 train_time:183733ms step_avg:268.62ms
+step:695/1480 train_time:184014ms step_avg:268.63ms
+step:696/1480 train_time:184291ms step_avg:268.65ms
+step:697/1480 train_time:184571ms step_avg:268.66ms
+step:698/1480 train_time:184851ms step_avg:268.68ms
+step:699/1480 train_time:185131ms step_avg:268.70ms
+step:700/1480 train_time:185411ms step_avg:268.71ms
+step:701/1480 train_time:185691ms step_avg:268.73ms
+step:702/1480 train_time:185975ms step_avg:268.75ms
+step:703/1480 train_time:186251ms step_avg:268.76ms
+step:704/1480 train_time:186529ms step_avg:268.77ms
+step:705/1480 train_time:186811ms step_avg:268.79ms
+step:706/1480 train_time:187089ms step_avg:268.81ms
+step:707/1480 train_time:187370ms step_avg:268.82ms
+step:708/1480 train_time:187651ms step_avg:268.84ms
+step:709/1480 train_time:187932ms step_avg:268.86ms
+step:710/1480 train_time:188211ms step_avg:268.87ms
+step:711/1480 train_time:188491ms step_avg:268.89ms
+step:712/1480 train_time:188771ms step_avg:268.90ms
+step:713/1480 train_time:189048ms step_avg:268.92ms
+step:714/1480 train_time:189330ms step_avg:268.94ms
+step:715/1480 train_time:189611ms step_avg:268.95ms
+step:716/1480 train_time:189890ms step_avg:268.97ms
+step:717/1480 train_time:190171ms step_avg:268.98ms
+step:718/1480 train_time:190450ms step_avg:269.00ms
+step:719/1480 train_time:190728ms step_avg:269.01ms
+step:720/1480 train_time:191010ms step_avg:269.03ms
+step:721/1480 train_time:191287ms step_avg:269.04ms
+step:722/1480 train_time:191568ms step_avg:269.06ms
+step:723/1480 train_time:191849ms step_avg:269.07ms
+step:724/1480 train_time:192128ms step_avg:269.09ms
+step:725/1480 train_time:192411ms step_avg:269.11ms
+step:726/1480 train_time:192690ms step_avg:269.12ms
+step:727/1480 train_time:192972ms step_avg:269.14ms
+step:728/1480 train_time:193251ms step_avg:269.15ms
+step:729/1480 train_time:193531ms step_avg:269.17ms
+step:730/1480 train_time:193811ms step_avg:269.18ms
+step:731/1480 train_time:194092ms step_avg:269.20ms
+step:732/1480 train_time:194372ms step_avg:269.21ms
+step:733/1480 train_time:194652ms step_avg:269.23ms
+step:734/1480 train_time:194930ms step_avg:269.24ms
+step:735/1480 train_time:195211ms step_avg:269.26ms
+step:736/1480 train_time:195490ms step_avg:269.27ms
+step:737/1480 train_time:195769ms step_avg:269.28ms
+step:738/1480 train_time:196049ms step_avg:269.30ms
+step:739/1480 train_time:196327ms step_avg:269.31ms
+step:740/1480 train_time:196610ms step_avg:269.33ms
+step:741/1480 train_time:196888ms step_avg:269.34ms
+step:742/1480 train_time:197169ms step_avg:269.36ms
+step:743/1480 train_time:197448ms step_avg:269.37ms
+step:744/1480 train_time:197722ms step_avg:269.38ms
+step:745/1480 train_time:198003ms step_avg:269.39ms
+step:746/1480 train_time:198280ms step_avg:269.40ms
+step:747/1480 train_time:198559ms step_avg:269.42ms
+step:748/1480 train_time:198835ms step_avg:269.42ms
+step:749/1480 train_time:199114ms step_avg:269.44ms
+step:750/1480 train_time:199394ms step_avg:269.45ms
+step:750/1480 val_loss:3.5809 train_time:199529ms step_avg:269.63ms
+step:751/1480 train_time:199671ms step_avg:269.46ms
+step:752/1480 train_time:199953ms step_avg:269.48ms
+step:753/1480 train_time:200231ms step_avg:269.49ms
+step:754/1480 train_time:200510ms step_avg:269.50ms
+step:755/1480 train_time:200790ms step_avg:269.52ms
+step:756/1480 train_time:201069ms step_avg:269.53ms
+step:757/1480 train_time:201350ms step_avg:269.55ms
+step:758/1480 train_time:201631ms step_avg:269.56ms
+step:759/1480 train_time:201910ms step_avg:269.57ms
+step:760/1480 train_time:202189ms step_avg:269.59ms
+step:761/1480 train_time:202469ms step_avg:269.60ms
+step:762/1480 train_time:202753ms step_avg:269.62ms
+step:763/1480 train_time:203033ms step_avg:269.63ms
+step:764/1480 train_time:203310ms step_avg:269.64ms
+step:765/1480 train_time:203588ms step_avg:269.65ms
+step:766/1480 train_time:203869ms step_avg:269.67ms
+step:767/1480 train_time:204150ms step_avg:269.68ms
+step:768/1480 train_time:204427ms step_avg:269.69ms
+step:769/1480 train_time:204707ms step_avg:269.71ms
+step:770/1480 train_time:204989ms step_avg:269.72ms
+step:771/1480 train_time:205270ms step_avg:269.74ms
+step:772/1480 train_time:205552ms step_avg:269.75ms
+step:773/1480 train_time:205833ms step_avg:269.77ms
+step:774/1480 train_time:206116ms step_avg:269.79ms
+step:775/1480 train_time:206393ms step_avg:269.80ms
+step:776/1480 train_time:206672ms step_avg:269.81ms
+step:777/1480 train_time:206952ms step_avg:269.82ms
+step:778/1480 train_time:207233ms step_avg:269.83ms
+step:779/1480 train_time:207512ms step_avg:269.85ms
+step:780/1480 train_time:207792ms step_avg:269.86ms
+step:781/1480 train_time:208072ms step_avg:269.87ms
+step:782/1480 train_time:208352ms step_avg:269.89ms
+step:783/1480 train_time:208632ms step_avg:269.90ms
+step:784/1480 train_time:208914ms step_avg:269.91ms
+step:785/1480 train_time:209193ms step_avg:269.93ms
+step:786/1480 train_time:209475ms step_avg:269.94ms
+step:787/1480 train_time:209758ms step_avg:269.96ms
+step:788/1480 train_time:210044ms step_avg:269.98ms
+step:789/1480 train_time:210326ms step_avg:269.99ms
+step:790/1480 train_time:210606ms step_avg:270.01ms
+step:791/1480 train_time:210888ms step_avg:270.02ms
+step:792/1480 train_time:211170ms step_avg:270.04ms
+step:793/1480 train_time:211450ms step_avg:270.05ms
+step:794/1480 train_time:211732ms step_avg:270.07ms
+step:795/1480 train_time:212016ms step_avg:270.08ms
+step:796/1480 train_time:212298ms step_avg:270.10ms
+step:797/1480 train_time:212579ms step_avg:270.11ms
+step:798/1480 train_time:212860ms step_avg:270.13ms
+step:799/1480 train_time:213138ms step_avg:270.14ms
+step:800/1480 train_time:213418ms step_avg:270.15ms
+step:801/1480 train_time:213700ms step_avg:270.16ms
+step:802/1480 train_time:213976ms step_avg:270.17ms
+step:803/1480 train_time:214267ms step_avg:270.20ms
+step:804/1480 train_time:214551ms step_avg:270.22ms
+step:805/1480 train_time:214828ms step_avg:270.22ms
+step:806/1480 train_time:215111ms step_avg:270.24ms
+step:807/1480 train_time:215392ms step_avg:270.25ms
+step:808/1480 train_time:215669ms step_avg:270.26ms
+step:809/1480 train_time:215951ms step_avg:270.28ms
+step:810/1480 train_time:216236ms step_avg:270.30ms
+step:811/1480 train_time:216513ms step_avg:270.30ms
+step:812/1480 train_time:216795ms step_avg:270.32ms
+step:813/1480 train_time:217079ms step_avg:270.34ms
+step:814/1480 train_time:217356ms step_avg:270.34ms
+step:815/1480 train_time:217643ms step_avg:270.36ms
+step:816/1480 train_time:217920ms step_avg:270.37ms
+step:817/1480 train_time:218198ms step_avg:270.38ms
+step:818/1480 train_time:218481ms step_avg:270.40ms
+step:819/1480 train_time:218763ms step_avg:270.41ms
+step:820/1480 train_time:219042ms step_avg:270.42ms
+step:821/1480 train_time:219324ms step_avg:270.44ms
+step:822/1480 train_time:219607ms step_avg:270.45ms
+step:823/1480 train_time:219887ms step_avg:270.46ms
+step:824/1480 train_time:220170ms step_avg:270.48ms
+step:825/1480 train_time:220451ms step_avg:270.49ms
+step:826/1480 train_time:220730ms step_avg:270.50ms
+step:827/1480 train_time:221010ms step_avg:270.51ms
+step:828/1480 train_time:221291ms step_avg:270.53ms
+step:829/1480 train_time:221571ms step_avg:270.54ms
+step:830/1480 train_time:221854ms step_avg:270.55ms
+step:831/1480 train_time:222132ms step_avg:270.56ms
+step:832/1480 train_time:222414ms step_avg:270.58ms
+step:833/1480 train_time:222694ms step_avg:270.59ms
+step:834/1480 train_time:222974ms step_avg:270.60ms
+step:835/1480 train_time:223263ms step_avg:270.62ms
+step:836/1480 train_time:223547ms step_avg:270.64ms
+step:837/1480 train_time:223829ms step_avg:270.65ms
+step:838/1480 train_time:224110ms step_avg:270.66ms
+step:839/1480 train_time:224392ms step_avg:270.68ms
+step:840/1480 train_time:224672ms step_avg:270.69ms
+step:841/1480 train_time:224953ms step_avg:270.70ms
+step:842/1480 train_time:225235ms step_avg:270.71ms
+step:843/1480 train_time:225514ms step_avg:270.72ms
+step:844/1480 train_time:225798ms step_avg:270.74ms
+step:845/1480 train_time:226076ms step_avg:270.75ms
+step:846/1480 train_time:226360ms step_avg:270.77ms
+step:847/1480 train_time:226641ms step_avg:270.78ms
+step:848/1480 train_time:226922ms step_avg:270.79ms
+step:849/1480 train_time:227206ms step_avg:270.81ms
+step:850/1480 train_time:227484ms step_avg:270.81ms
+step:851/1480 train_time:227766ms step_avg:270.83ms
+step:852/1480 train_time:228049ms step_avg:270.84ms
+step:853/1480 train_time:228331ms step_avg:270.86ms
+step:854/1480 train_time:228613ms step_avg:270.87ms
+step:855/1480 train_time:228892ms step_avg:270.88ms
+step:856/1480 train_time:229171ms step_avg:270.89ms
+step:857/1480 train_time:229453ms step_avg:270.90ms
+step:858/1480 train_time:229735ms step_avg:270.91ms
+step:859/1480 train_time:230014ms step_avg:270.92ms
+step:860/1480 train_time:230295ms step_avg:270.94ms
+step:861/1480 train_time:230574ms step_avg:270.94ms
+step:862/1480 train_time:230855ms step_avg:270.96ms
+step:863/1480 train_time:231136ms step_avg:270.97ms
+step:864/1480 train_time:231416ms step_avg:270.98ms
+step:865/1480 train_time:231692ms step_avg:270.98ms
+step:866/1480 train_time:231973ms step_avg:271.00ms
+step:867/1480 train_time:232253ms step_avg:271.01ms
+step:868/1480 train_time:232534ms step_avg:271.02ms
+step:869/1480 train_time:232813ms step_avg:271.03ms
+step:870/1480 train_time:233092ms step_avg:271.04ms
+step:871/1480 train_time:233374ms step_avg:271.05ms
+step:872/1480 train_time:233654ms step_avg:271.06ms
+step:873/1480 train_time:233933ms step_avg:271.07ms
+step:874/1480 train_time:234215ms step_avg:271.08ms
+step:875/1480 train_time:234496ms step_avg:271.09ms
+step:875/1480 val_loss:3.5384 train_time:234632ms step_avg:271.25ms
+step:876/1480 train_time:234779ms step_avg:271.11ms
+step:877/1480 train_time:235062ms step_avg:271.12ms
+step:878/1480 train_time:235345ms step_avg:271.13ms
+step:879/1480 train_time:235623ms step_avg:271.14ms
+step:880/1480 train_time:235906ms step_avg:271.16ms
+step:881/1480 train_time:236195ms step_avg:271.18ms
+step:882/1480 train_time:236478ms step_avg:271.19ms
+step:883/1480 train_time:236761ms step_avg:271.20ms
+step:884/1480 train_time:237042ms step_avg:271.22ms
+step:885/1480 train_time:237324ms step_avg:271.23ms
+step:886/1480 train_time:237604ms step_avg:271.24ms
+step:887/1480 train_time:237882ms step_avg:271.24ms
+step:888/1480 train_time:238168ms step_avg:271.26ms
+step:889/1480 train_time:238449ms step_avg:271.27ms
+step:890/1480 train_time:238736ms step_avg:271.29ms
+step:891/1480 train_time:239018ms step_avg:271.30ms
+step:892/1480 train_time:239303ms step_avg:271.32ms
+step:893/1480 train_time:239598ms step_avg:271.35ms
+step:894/1480 train_time:239880ms step_avg:271.36ms
+step:895/1480 train_time:240160ms step_avg:271.37ms
+step:896/1480 train_time:240440ms step_avg:271.38ms
+step:897/1480 train_time:240721ms step_avg:271.39ms
+step:898/1480 train_time:241001ms step_avg:271.40ms
+step:899/1480 train_time:241282ms step_avg:271.41ms
+step:900/1480 train_time:241572ms step_avg:271.43ms
+step:901/1480 train_time:241852ms step_avg:271.44ms
+step:902/1480 train_time:242135ms step_avg:271.45ms
+step:903/1480 train_time:242420ms step_avg:271.47ms
+step:904/1480 train_time:242703ms step_avg:271.48ms
+step:905/1480 train_time:242986ms step_avg:271.49ms
+step:906/1480 train_time:243274ms step_avg:271.51ms
+step:907/1480 train_time:243554ms step_avg:271.52ms
+step:908/1480 train_time:243838ms step_avg:271.53ms
+step:909/1480 train_time:244121ms step_avg:271.55ms
+step:910/1480 train_time:244400ms step_avg:271.56ms
+step:911/1480 train_time:244681ms step_avg:271.57ms
+step:912/1480 train_time:244963ms step_avg:271.58ms
+step:913/1480 train_time:245251ms step_avg:271.60ms
+step:914/1480 train_time:245538ms step_avg:271.61ms
+step:915/1480 train_time:245823ms step_avg:271.63ms
+step:916/1480 train_time:246105ms step_avg:271.64ms
+step:917/1480 train_time:246395ms step_avg:271.66ms
+step:918/1480 train_time:246681ms step_avg:271.68ms
+step:919/1480 train_time:246968ms step_avg:271.69ms
+step:920/1480 train_time:247252ms step_avg:271.71ms
+step:921/1480 train_time:247532ms step_avg:271.71ms
+step:922/1480 train_time:247817ms step_avg:271.73ms
+step:923/1480 train_time:248099ms step_avg:271.74ms
+step:924/1480 train_time:248382ms step_avg:271.75ms
+step:925/1480 train_time:248668ms step_avg:271.77ms
+step:926/1480 train_time:248948ms step_avg:271.78ms
+step:927/1480 train_time:249226ms step_avg:271.78ms
+step:928/1480 train_time:249514ms step_avg:271.80ms
+step:929/1480 train_time:249804ms step_avg:271.82ms
+step:930/1480 train_time:250086ms step_avg:271.83ms
+step:931/1480 train_time:250365ms step_avg:271.84ms
+step:932/1480 train_time:250653ms step_avg:271.86ms
+step:933/1480 train_time:250939ms step_avg:271.87ms
+step:934/1480 train_time:251222ms step_avg:271.88ms
+step:935/1480 train_time:251504ms step_avg:271.90ms
+step:936/1480 train_time:251787ms step_avg:271.91ms
+step:937/1480 train_time:252072ms step_avg:271.92ms
+step:938/1480 train_time:252351ms step_avg:271.93ms
+step:939/1480 train_time:252638ms step_avg:271.95ms
+step:940/1480 train_time:252922ms step_avg:271.96ms
+step:941/1480 train_time:253204ms step_avg:271.97ms
+step:942/1480 train_time:253482ms step_avg:271.98ms
+step:943/1480 train_time:253766ms step_avg:271.99ms
+step:944/1480 train_time:254048ms step_avg:272.00ms
+step:945/1480 train_time:254334ms step_avg:272.01ms
+step:946/1480 train_time:254619ms step_avg:272.03ms
+step:947/1480 train_time:254901ms step_avg:272.04ms
+step:948/1480 train_time:255184ms step_avg:272.05ms
+step:949/1480 train_time:255471ms step_avg:272.07ms
+step:950/1480 train_time:255757ms step_avg:272.08ms
+step:951/1480 train_time:256042ms step_avg:272.10ms
+step:952/1480 train_time:256323ms step_avg:272.11ms
+step:953/1480 train_time:256604ms step_avg:272.11ms
+step:954/1480 train_time:256890ms step_avg:272.13ms
+step:955/1480 train_time:257167ms step_avg:272.13ms
+step:956/1480 train_time:257449ms step_avg:272.14ms
+step:957/1480 train_time:257731ms step_avg:272.16ms
+step:958/1480 train_time:258015ms step_avg:272.17ms
+step:959/1480 train_time:258302ms step_avg:272.18ms
+step:960/1480 train_time:258582ms step_avg:272.19ms
+step:961/1480 train_time:258861ms step_avg:272.20ms
+step:962/1480 train_time:259143ms step_avg:272.21ms
+step:963/1480 train_time:259425ms step_avg:272.22ms
+step:964/1480 train_time:259703ms step_avg:272.23ms
+step:965/1480 train_time:259985ms step_avg:272.24ms
+step:966/1480 train_time:260273ms step_avg:272.25ms
+step:967/1480 train_time:260557ms step_avg:272.26ms
+step:968/1480 train_time:260839ms step_avg:272.27ms
+step:969/1480 train_time:261125ms step_avg:272.29ms
+step:970/1480 train_time:261401ms step_avg:272.29ms
+step:971/1480 train_time:261686ms step_avg:272.31ms
+step:972/1480 train_time:261975ms step_avg:272.32ms
+step:973/1480 train_time:262253ms step_avg:272.33ms
+step:974/1480 train_time:262537ms step_avg:272.34ms
+step:975/1480 train_time:262821ms step_avg:272.35ms
+step:976/1480 train_time:263104ms step_avg:272.36ms
+step:977/1480 train_time:263383ms step_avg:272.37ms
+step:978/1480 train_time:263677ms step_avg:272.39ms
+step:979/1480 train_time:263961ms step_avg:272.41ms
+step:980/1480 train_time:264243ms step_avg:272.42ms
+step:981/1480 train_time:264525ms step_avg:272.43ms
+step:982/1480 train_time:264805ms step_avg:272.43ms
+step:983/1480 train_time:265089ms step_avg:272.45ms
+step:984/1480 train_time:265378ms step_avg:272.46ms
+step:985/1480 train_time:265661ms step_avg:272.47ms
+step:986/1480 train_time:265943ms step_avg:272.48ms
+step:987/1480 train_time:266228ms step_avg:272.50ms
+step:988/1480 train_time:266516ms step_avg:272.51ms
+step:989/1480 train_time:266802ms step_avg:272.52ms
+step:990/1480 train_time:267087ms step_avg:272.54ms
+step:991/1480 train_time:267377ms step_avg:272.56ms
+step:992/1480 train_time:267663ms step_avg:272.57ms
+step:993/1480 train_time:267946ms step_avg:272.58ms
+step:994/1480 train_time:268234ms step_avg:272.60ms
+step:995/1480 train_time:268518ms step_avg:272.61ms
+step:996/1480 train_time:268800ms step_avg:272.62ms
+step:997/1480 train_time:269084ms step_avg:272.63ms
+step:998/1480 train_time:269372ms step_avg:272.64ms
+step:999/1480 train_time:269659ms step_avg:272.66ms
+step:1000/1480 train_time:269949ms step_avg:272.68ms
+step:1000/1480 val_loss:3.4709 train_time:270093ms step_avg:272.82ms
+step:1001/1480 train_time:270242ms step_avg:272.70ms
+step:1002/1480 train_time:270531ms step_avg:272.71ms
+step:1003/1480 train_time:270825ms step_avg:272.73ms
+step:1004/1480 train_time:271107ms step_avg:272.74ms
+step:1005/1480 train_time:271393ms step_avg:272.76ms
+step:1006/1480 train_time:271676ms step_avg:272.77ms
+step:1007/1480 train_time:271963ms step_avg:272.78ms
+step:1008/1480 train_time:272244ms step_avg:272.79ms
+step:1009/1480 train_time:272528ms step_avg:272.80ms
+step:1010/1480 train_time:272811ms step_avg:272.81ms
+step:1011/1480 train_time:273097ms step_avg:272.82ms
+step:1012/1480 train_time:273385ms step_avg:272.84ms
+step:1013/1480 train_time:273679ms step_avg:272.86ms
+step:1014/1480 train_time:273966ms step_avg:272.87ms
+step:1015/1480 train_time:274251ms step_avg:272.89ms
+step:1016/1480 train_time:274538ms step_avg:272.90ms
+step:1017/1480 train_time:274823ms step_avg:272.91ms
+step:1018/1480 train_time:275116ms step_avg:272.93ms
+step:1019/1480 train_time:275399ms step_avg:272.94ms
+step:1020/1480 train_time:275685ms step_avg:272.96ms
+step:1021/1480 train_time:275969ms step_avg:272.97ms
+step:1022/1480 train_time:276251ms step_avg:272.97ms
+step:1023/1480 train_time:276538ms step_avg:272.99ms
+step:1024/1480 train_time:276825ms step_avg:273.00ms
+step:1025/1480 train_time:277107ms step_avg:273.01ms
+step:1026/1480 train_time:277387ms step_avg:273.02ms
+step:1027/1480 train_time:277672ms step_avg:273.03ms
+step:1028/1480 train_time:277963ms step_avg:273.05ms
+step:1029/1480 train_time:278251ms step_avg:273.06ms
+step:1030/1480 train_time:278537ms step_avg:273.08ms
+step:1031/1480 train_time:278828ms step_avg:273.09ms
+step:1032/1480 train_time:279106ms step_avg:273.10ms
+step:1033/1480 train_time:279393ms step_avg:273.11ms
+step:1034/1480 train_time:279679ms step_avg:273.12ms
+step:1035/1480 train_time:279961ms step_avg:273.13ms
+step:1036/1480 train_time:280245ms step_avg:273.14ms
+step:1037/1480 train_time:280527ms step_avg:273.15ms
+step:1038/1480 train_time:280810ms step_avg:273.16ms
+step:1039/1480 train_time:281097ms step_avg:273.17ms
+step:1040/1480 train_time:281384ms step_avg:273.19ms
+step:1041/1480 train_time:281670ms step_avg:273.20ms
+step:1042/1480 train_time:281952ms step_avg:273.21ms
+step:1043/1480 train_time:282243ms step_avg:273.23ms
+step:1044/1480 train_time:282526ms step_avg:273.24ms
+step:1045/1480 train_time:282807ms step_avg:273.24ms
+step:1046/1480 train_time:283098ms step_avg:273.26ms
+step:1047/1480 train_time:283383ms step_avg:273.27ms
+step:1048/1480 train_time:283666ms step_avg:273.28ms
+step:1049/1480 train_time:283952ms step_avg:273.29ms
+step:1050/1480 train_time:284241ms step_avg:273.31ms
+step:1051/1480 train_time:284528ms step_avg:273.32ms
+step:1052/1480 train_time:284815ms step_avg:273.33ms
+step:1053/1480 train_time:285101ms step_avg:273.35ms
+step:1054/1480 train_time:285386ms step_avg:273.36ms
+step:1055/1480 train_time:285671ms step_avg:273.37ms
+step:1056/1480 train_time:285966ms step_avg:273.39ms
+step:1057/1480 train_time:286251ms step_avg:273.40ms
+step:1058/1480 train_time:286539ms step_avg:273.42ms
+step:1059/1480 train_time:286826ms step_avg:273.43ms
+step:1060/1480 train_time:287106ms step_avg:273.43ms
+step:1061/1480 train_time:287390ms step_avg:273.44ms
+step:1062/1480 train_time:287679ms step_avg:273.46ms
+step:1063/1480 train_time:287962ms step_avg:273.47ms
+step:1064/1480 train_time:288245ms step_avg:273.48ms
+step:1065/1480 train_time:288526ms step_avg:273.48ms
+step:1066/1480 train_time:288813ms step_avg:273.50ms
+step:1067/1480 train_time:289101ms step_avg:273.51ms
+step:1068/1480 train_time:289385ms step_avg:273.52ms
+step:1069/1480 train_time:289668ms step_avg:273.53ms
+step:1070/1480 train_time:289951ms step_avg:273.54ms
+step:1071/1480 train_time:290240ms step_avg:273.55ms
+step:1072/1480 train_time:290522ms step_avg:273.56ms
+step:1073/1480 train_time:290806ms step_avg:273.57ms
+step:1074/1480 train_time:291096ms step_avg:273.59ms
+step:1075/1480 train_time:291387ms step_avg:273.60ms
+step:1076/1480 train_time:291674ms step_avg:273.62ms
+step:1077/1480 train_time:291967ms step_avg:273.63ms
+step:1078/1480 train_time:292250ms step_avg:273.64ms
+step:1079/1480 train_time:292536ms step_avg:273.65ms
+step:1080/1480 train_time:292829ms step_avg:273.67ms
+step:1081/1480 train_time:293110ms step_avg:273.68ms
+step:1082/1480 train_time:293394ms step_avg:273.69ms
+step:1083/1480 train_time:293685ms step_avg:273.70ms
+step:1084/1480 train_time:293967ms step_avg:273.71ms
+step:1085/1480 train_time:294250ms step_avg:273.72ms
+step:1086/1480 train_time:294532ms step_avg:273.73ms
+step:1087/1480 train_time:294828ms step_avg:273.75ms
+step:1088/1480 train_time:295106ms step_avg:273.75ms
+step:1089/1480 train_time:295392ms step_avg:273.76ms
+step:1090/1480 train_time:295681ms step_avg:273.78ms
+step:1091/1480 train_time:295969ms step_avg:273.79ms
+step:1092/1480 train_time:296250ms step_avg:273.80ms
+step:1093/1480 train_time:296533ms step_avg:273.81ms
+step:1094/1480 train_time:296821ms step_avg:273.82ms
+step:1095/1480 train_time:297108ms step_avg:273.83ms
+step:1096/1480 train_time:297406ms step_avg:273.85ms
+step:1097/1480 train_time:297688ms step_avg:273.86ms
+step:1098/1480 train_time:297988ms step_avg:273.89ms
+step:1099/1480 train_time:298278ms step_avg:273.90ms
+step:1100/1480 train_time:298564ms step_avg:273.91ms
+step:1101/1480 train_time:298848ms step_avg:273.92ms
+step:1102/1480 train_time:299147ms step_avg:273.94ms
+step:1103/1480 train_time:299440ms step_avg:273.96ms
+step:1104/1480 train_time:299731ms step_avg:273.98ms
+step:1105/1480 train_time:300018ms step_avg:273.99ms
+step:1106/1480 train_time:300304ms step_avg:274.00ms
+step:1107/1480 train_time:300590ms step_avg:274.01ms
+step:1108/1480 train_time:300871ms step_avg:274.02ms
+step:1109/1480 train_time:301163ms step_avg:274.03ms
+step:1110/1480 train_time:301449ms step_avg:274.04ms
+step:1111/1480 train_time:301744ms step_avg:274.06ms
+step:1112/1480 train_time:302030ms step_avg:274.07ms
+step:1113/1480 train_time:302316ms step_avg:274.09ms
+step:1114/1480 train_time:302606ms step_avg:274.10ms
+step:1115/1480 train_time:302897ms step_avg:274.11ms
+step:1116/1480 train_time:303187ms step_avg:274.13ms
+step:1117/1480 train_time:303481ms step_avg:274.15ms
+step:1118/1480 train_time:303766ms step_avg:274.16ms
+step:1119/1480 train_time:304063ms step_avg:274.18ms
+step:1120/1480 train_time:304348ms step_avg:274.19ms
+step:1121/1480 train_time:304632ms step_avg:274.20ms
+step:1122/1480 train_time:304921ms step_avg:274.21ms
+step:1123/1480 train_time:305205ms step_avg:274.22ms
+step:1124/1480 train_time:305497ms step_avg:274.23ms
+step:1125/1480 train_time:305784ms step_avg:274.25ms
+step:1125/1480 val_loss:3.4139 train_time:305928ms step_avg:274.37ms
+step:1126/1480 train_time:306074ms step_avg:274.26ms
+step:1127/1480 train_time:306369ms step_avg:274.28ms
+step:1128/1480 train_time:306651ms step_avg:274.28ms
+step:1129/1480 train_time:306940ms step_avg:274.30ms
+step:1130/1480 train_time:307230ms step_avg:274.31ms
+step:1131/1480 train_time:307518ms step_avg:274.32ms
+step:1132/1480 train_time:307808ms step_avg:274.34ms
+step:1133/1480 train_time:308091ms step_avg:274.35ms
+step:1134/1480 train_time:308375ms step_avg:274.35ms
+step:1135/1480 train_time:308666ms step_avg:274.37ms
+step:1136/1480 train_time:308950ms step_avg:274.38ms
+step:1137/1480 train_time:309232ms step_avg:274.39ms
+step:1138/1480 train_time:309530ms step_avg:274.41ms
+step:1139/1480 train_time:309818ms step_avg:274.42ms
+step:1140/1480 train_time:310104ms step_avg:274.43ms
+step:1141/1480 train_time:310391ms step_avg:274.44ms
+step:1142/1480 train_time:310675ms step_avg:274.45ms
+step:1143/1480 train_time:310961ms step_avg:274.46ms
+step:1144/1480 train_time:311247ms step_avg:274.47ms
+step:1145/1480 train_time:311530ms step_avg:274.48ms
+step:1146/1480 train_time:311822ms step_avg:274.49ms
+step:1147/1480 train_time:312108ms step_avg:274.50ms
+step:1148/1480 train_time:312395ms step_avg:274.51ms
+step:1149/1480 train_time:312681ms step_avg:274.52ms
+step:1150/1480 train_time:312964ms step_avg:274.53ms
+step:1151/1480 train_time:313255ms step_avg:274.54ms
+step:1152/1480 train_time:313537ms step_avg:274.55ms
+step:1153/1480 train_time:313824ms step_avg:274.56ms
+step:1154/1480 train_time:314110ms step_avg:274.57ms
+step:1155/1480 train_time:314406ms step_avg:274.59ms
+step:1156/1480 train_time:314696ms step_avg:274.60ms
+step:1157/1480 train_time:314987ms step_avg:274.62ms
+step:1158/1480 train_time:315273ms step_avg:274.63ms
+step:1159/1480 train_time:315559ms step_avg:274.64ms
+step:1160/1480 train_time:315845ms step_avg:274.65ms
+step:1161/1480 train_time:316130ms step_avg:274.66ms
+step:1162/1480 train_time:316422ms step_avg:274.67ms
+step:1163/1480 train_time:316712ms step_avg:274.69ms
+step:1164/1480 train_time:316993ms step_avg:274.69ms
+step:1165/1480 train_time:317277ms step_avg:274.70ms
+step:1166/1480 train_time:317567ms step_avg:274.71ms
+step:1167/1480 train_time:317852ms step_avg:274.72ms
+step:1168/1480 train_time:318140ms step_avg:274.73ms
+step:1169/1480 train_time:318430ms step_avg:274.75ms
+step:1170/1480 train_time:318711ms step_avg:274.75ms
+step:1171/1480 train_time:318997ms step_avg:274.76ms
+step:1172/1480 train_time:319282ms step_avg:274.77ms
+step:1173/1480 train_time:319569ms step_avg:274.78ms
+step:1174/1480 train_time:319860ms step_avg:274.79ms
+step:1175/1480 train_time:320148ms step_avg:274.80ms
+step:1176/1480 train_time:320427ms step_avg:274.81ms
+step:1177/1480 train_time:320716ms step_avg:274.82ms
+step:1178/1480 train_time:321003ms step_avg:274.83ms
+step:1179/1480 train_time:321291ms step_avg:274.84ms
+step:1180/1480 train_time:321585ms step_avg:274.86ms
+step:1181/1480 train_time:321869ms step_avg:274.87ms
+step:1182/1480 train_time:322151ms step_avg:274.87ms
+step:1183/1480 train_time:322437ms step_avg:274.88ms
+step:1184/1480 train_time:322725ms step_avg:274.89ms
+step:1185/1480 train_time:323009ms step_avg:274.90ms
+step:1186/1480 train_time:323290ms step_avg:274.91ms
+step:1187/1480 train_time:323583ms step_avg:274.92ms
+step:1188/1480 train_time:323866ms step_avg:274.93ms
+step:1189/1480 train_time:324165ms step_avg:274.95ms
+step:1190/1480 train_time:324454ms step_avg:274.96ms
+step:1191/1480 train_time:324746ms step_avg:274.98ms
+step:1192/1480 train_time:325030ms step_avg:274.98ms
+step:1193/1480 train_time:325319ms step_avg:274.99ms
+step:1194/1480 train_time:325603ms step_avg:275.00ms
+step:1195/1480 train_time:325888ms step_avg:275.01ms
+step:1196/1480 train_time:326173ms step_avg:275.02ms
+step:1197/1480 train_time:326464ms step_avg:275.03ms
+step:1198/1480 train_time:326750ms step_avg:275.04ms
+step:1199/1480 train_time:327037ms step_avg:275.05ms
+step:1200/1480 train_time:327323ms step_avg:275.06ms
+step:1201/1480 train_time:327608ms step_avg:275.07ms
+step:1202/1480 train_time:327899ms step_avg:275.08ms
+step:1203/1480 train_time:328189ms step_avg:275.10ms
+step:1204/1480 train_time:328473ms step_avg:275.10ms
+step:1205/1480 train_time:328757ms step_avg:275.11ms
+step:1206/1480 train_time:329049ms step_avg:275.12ms
+step:1207/1480 train_time:329333ms step_avg:275.13ms
+step:1208/1480 train_time:329622ms step_avg:275.14ms
+step:1209/1480 train_time:329912ms step_avg:275.16ms
+step:1210/1480 train_time:330196ms step_avg:275.16ms
+step:1211/1480 train_time:330484ms step_avg:275.17ms
+step:1212/1480 train_time:330777ms step_avg:275.19ms
+step:1213/1480 train_time:331064ms step_avg:275.20ms
+step:1214/1480 train_time:331353ms step_avg:275.21ms
+step:1215/1480 train_time:331641ms step_avg:275.22ms
+step:1216/1480 train_time:331926ms step_avg:275.23ms
+step:1217/1480 train_time:332216ms step_avg:275.24ms
+step:1218/1480 train_time:332509ms step_avg:275.26ms
+step:1219/1480 train_time:332796ms step_avg:275.27ms
+step:1220/1480 train_time:333091ms step_avg:275.28ms
+step:1221/1480 train_time:333381ms step_avg:275.29ms
+step:1222/1480 train_time:333670ms step_avg:275.31ms
+step:1223/1480 train_time:333959ms step_avg:275.32ms
+step:1224/1480 train_time:334250ms step_avg:275.33ms
+step:1225/1480 train_time:334549ms step_avg:275.35ms
+step:1226/1480 train_time:334838ms step_avg:275.36ms
+step:1227/1480 train_time:335126ms step_avg:275.37ms
+step:1228/1480 train_time:335408ms step_avg:275.38ms
+step:1229/1480 train_time:335720ms step_avg:275.41ms
+step:1230/1480 train_time:336011ms step_avg:275.42ms
+step:1231/1480 train_time:336295ms step_avg:275.43ms
+step:1232/1480 train_time:336587ms step_avg:275.44ms
+step:1233/1480 train_time:336877ms step_avg:275.45ms
+step:1234/1480 train_time:337167ms step_avg:275.46ms
+step:1235/1480 train_time:337450ms step_avg:275.47ms
+step:1236/1480 train_time:337746ms step_avg:275.49ms
+step:1237/1480 train_time:338031ms step_avg:275.49ms
+step:1238/1480 train_time:338318ms step_avg:275.50ms
+step:1239/1480 train_time:338608ms step_avg:275.52ms
+step:1240/1480 train_time:338901ms step_avg:275.53ms
+step:1241/1480 train_time:339190ms step_avg:275.54ms
+step:1242/1480 train_time:339476ms step_avg:275.55ms
+step:1243/1480 train_time:339760ms step_avg:275.56ms
+step:1244/1480 train_time:340048ms step_avg:275.57ms
+step:1245/1480 train_time:340345ms step_avg:275.58ms
+step:1246/1480 train_time:340631ms step_avg:275.59ms
+step:1247/1480 train_time:340918ms step_avg:275.60ms
+step:1248/1480 train_time:341207ms step_avg:275.61ms
+step:1249/1480 train_time:341492ms step_avg:275.62ms
+step:1250/1480 train_time:341786ms step_avg:275.63ms
+step:1250/1480 val_loss:3.3625 train_time:341927ms step_avg:275.75ms
+step:1251/1480 train_time:342078ms step_avg:275.65ms
+step:1252/1480 train_time:342368ms step_avg:275.66ms
+step:1253/1480 train_time:342661ms step_avg:275.67ms
+step:1254/1480 train_time:342949ms step_avg:275.68ms
+step:1255/1480 train_time:343237ms step_avg:275.69ms
+step:1256/1480 train_time:343527ms step_avg:275.70ms
+step:1257/1480 train_time:343817ms step_avg:275.72ms
+step:1258/1480 train_time:344100ms step_avg:275.72ms
+step:1259/1480 train_time:344388ms step_avg:275.73ms
+step:1260/1480 train_time:344681ms step_avg:275.74ms
+step:1261/1480 train_time:344975ms step_avg:275.76ms
+step:1262/1480 train_time:345261ms step_avg:275.77ms
+step:1263/1480 train_time:345557ms step_avg:275.78ms
+step:1264/1480 train_time:345842ms step_avg:275.79ms
+step:1265/1480 train_time:346126ms step_avg:275.80ms
+step:1266/1480 train_time:346416ms step_avg:275.81ms
+step:1267/1480 train_time:346701ms step_avg:275.82ms
+step:1268/1480 train_time:346989ms step_avg:275.83ms
+step:1269/1480 train_time:347286ms step_avg:275.84ms
+step:1270/1480 train_time:347580ms step_avg:275.86ms
+step:1271/1480 train_time:347868ms step_avg:275.87ms
+step:1272/1480 train_time:348161ms step_avg:275.88ms
+step:1273/1480 train_time:348448ms step_avg:275.89ms
+step:1274/1480 train_time:348738ms step_avg:275.90ms
+step:1275/1480 train_time:349024ms step_avg:275.91ms
+step:1276/1480 train_time:349308ms step_avg:275.91ms
+step:1277/1480 train_time:349598ms step_avg:275.93ms
+step:1278/1480 train_time:349883ms step_avg:275.93ms
+step:1279/1480 train_time:350177ms step_avg:275.95ms
+step:1280/1480 train_time:350462ms step_avg:275.95ms
+step:1281/1480 train_time:350759ms step_avg:275.97ms
+step:1282/1480 train_time:351044ms step_avg:275.98ms
+step:1283/1480 train_time:351337ms step_avg:275.99ms
+step:1284/1480 train_time:351627ms step_avg:276.00ms
+step:1285/1480 train_time:351909ms step_avg:276.01ms
+step:1286/1480 train_time:352199ms step_avg:276.02ms
+step:1287/1480 train_time:352489ms step_avg:276.03ms
+step:1288/1480 train_time:352778ms step_avg:276.04ms
+step:1289/1480 train_time:353075ms step_avg:276.06ms
+step:1290/1480 train_time:353359ms step_avg:276.06ms
+step:1291/1480 train_time:353642ms step_avg:276.07ms
+step:1292/1480 train_time:353936ms step_avg:276.08ms
+step:1293/1480 train_time:354222ms step_avg:276.09ms
+step:1294/1480 train_time:354505ms step_avg:276.09ms
+step:1295/1480 train_time:354793ms step_avg:276.10ms
+step:1296/1480 train_time:355080ms step_avg:276.11ms
+step:1297/1480 train_time:355362ms step_avg:276.12ms
+step:1298/1480 train_time:355644ms step_avg:276.12ms
+step:1299/1480 train_time:355930ms step_avg:276.13ms
+step:1300/1480 train_time:356222ms step_avg:276.14ms
+step:1301/1480 train_time:356506ms step_avg:276.15ms
+step:1302/1480 train_time:356792ms step_avg:276.16ms
+step:1303/1480 train_time:357083ms step_avg:276.17ms
+step:1304/1480 train_time:357366ms step_avg:276.17ms
+step:1305/1480 train_time:357656ms step_avg:276.18ms
+step:1306/1480 train_time:357949ms step_avg:276.20ms
+step:1307/1480 train_time:358237ms step_avg:276.20ms
+step:1308/1480 train_time:358521ms step_avg:276.21ms
+step:1309/1480 train_time:358821ms step_avg:276.23ms
+step:1310/1480 train_time:359112ms step_avg:276.24ms
+step:1311/1480 train_time:359400ms step_avg:276.25ms
+step:1312/1480 train_time:359686ms step_avg:276.26ms
+step:1313/1480 train_time:359978ms step_avg:276.27ms
+step:1314/1480 train_time:360263ms step_avg:276.28ms
+step:1315/1480 train_time:360554ms step_avg:276.29ms
+step:1316/1480 train_time:360854ms step_avg:276.30ms
+step:1317/1480 train_time:361146ms step_avg:276.32ms
+step:1318/1480 train_time:361438ms step_avg:276.33ms
+step:1319/1480 train_time:361728ms step_avg:276.34ms
+step:1320/1480 train_time:362019ms step_avg:276.35ms
+step:1321/1480 train_time:362309ms step_avg:276.36ms
+step:1322/1480 train_time:362599ms step_avg:276.37ms
+step:1323/1480 train_time:362882ms step_avg:276.38ms
+step:1324/1480 train_time:363180ms step_avg:276.39ms
+step:1325/1480 train_time:363482ms step_avg:276.41ms
+step:1326/1480 train_time:363771ms step_avg:276.42ms
+step:1327/1480 train_time:364064ms step_avg:276.43ms
+step:1328/1480 train_time:364352ms step_avg:276.44ms
+step:1329/1480 train_time:364638ms step_avg:276.45ms
+step:1330/1480 train_time:364928ms step_avg:276.46ms
+step:1331/1480 train_time:365219ms step_avg:276.47ms
+step:1332/1480 train_time:365511ms step_avg:276.48ms
+step:1333/1480 train_time:365803ms step_avg:276.49ms
+step:1334/1480 train_time:366098ms step_avg:276.51ms
+step:1335/1480 train_time:366384ms step_avg:276.52ms
+step:1336/1480 train_time:366680ms step_avg:276.53ms
+step:1337/1480 train_time:366966ms step_avg:276.54ms
+step:1338/1480 train_time:367253ms step_avg:276.55ms
+step:1339/1480 train_time:367544ms step_avg:276.56ms
+step:1340/1480 train_time:367834ms step_avg:276.57ms
+step:1341/1480 train_time:368118ms step_avg:276.57ms
+step:1342/1480 train_time:368415ms step_avg:276.59ms
+step:1343/1480 train_time:368721ms step_avg:276.61ms
+step:1344/1480 train_time:369010ms step_avg:276.62ms
+step:1345/1480 train_time:369299ms step_avg:276.63ms
+step:1346/1480 train_time:369593ms step_avg:276.64ms
+step:1347/1480 train_time:369886ms step_avg:276.65ms
+step:1348/1480 train_time:370176ms step_avg:276.66ms
+step:1349/1480 train_time:370464ms step_avg:276.67ms
+step:1350/1480 train_time:370758ms step_avg:276.68ms
+step:1351/1480 train_time:371043ms step_avg:276.69ms
+step:1352/1480 train_time:371337ms step_avg:276.70ms
+step:1353/1480 train_time:371620ms step_avg:276.71ms
+step:1354/1480 train_time:371905ms step_avg:276.72ms
+step:1355/1480 train_time:372199ms step_avg:276.73ms
+step:1356/1480 train_time:372492ms step_avg:276.74ms
+step:1357/1480 train_time:372781ms step_avg:276.75ms
+step:1358/1480 train_time:373072ms step_avg:276.76ms
+step:1359/1480 train_time:373363ms step_avg:276.77ms
+step:1360/1480 train_time:373650ms step_avg:276.78ms
+step:1361/1480 train_time:373940ms step_avg:276.79ms
+step:1362/1480 train_time:374221ms step_avg:276.79ms
+step:1363/1480 train_time:374517ms step_avg:276.80ms
+step:1364/1480 train_time:374804ms step_avg:276.81ms
+step:1365/1480 train_time:375095ms step_avg:276.82ms
+step:1366/1480 train_time:375381ms step_avg:276.83ms
+step:1367/1480 train_time:375674ms step_avg:276.84ms
+step:1368/1480 train_time:375960ms step_avg:276.85ms
+step:1369/1480 train_time:376247ms step_avg:276.86ms
+step:1370/1480 train_time:376543ms step_avg:276.87ms
+step:1371/1480 train_time:376850ms step_avg:276.89ms
+step:1372/1480 train_time:377144ms step_avg:276.90ms
+step:1373/1480 train_time:377428ms step_avg:276.91ms
+step:1374/1480 train_time:377720ms step_avg:276.92ms
+step:1375/1480 train_time:378018ms step_avg:276.94ms
+step:1375/1480 val_loss:3.3208 train_time:378162ms step_avg:277.04ms
+step:1376/1480 train_time:378310ms step_avg:276.95ms
+step:1377/1480 train_time:378617ms step_avg:276.97ms
+step:1378/1480 train_time:378918ms step_avg:276.99ms
+step:1379/1480 train_time:379212ms step_avg:277.00ms
+step:1380/1480 train_time:379501ms step_avg:277.01ms
+step:1381/1480 train_time:379795ms step_avg:277.02ms
+step:1382/1480 train_time:380084ms step_avg:277.03ms
+step:1383/1480 train_time:380387ms step_avg:277.05ms
+step:1384/1480 train_time:380682ms step_avg:277.06ms
+step:1385/1480 train_time:380972ms step_avg:277.07ms
+step:1386/1480 train_time:381264ms step_avg:277.08ms
+step:1387/1480 train_time:381558ms step_avg:277.09ms
+step:1388/1480 train_time:381844ms step_avg:277.10ms
+step:1389/1480 train_time:382134ms step_avg:277.11ms
+step:1390/1480 train_time:382422ms step_avg:277.12ms
+step:1391/1480 train_time:382714ms step_avg:277.13ms
+step:1392/1480 train_time:383001ms step_avg:277.14ms
+step:1393/1480 train_time:383288ms step_avg:277.14ms
+step:1394/1480 train_time:383575ms step_avg:277.15ms
+step:1395/1480 train_time:383868ms step_avg:277.16ms
+step:1396/1480 train_time:384162ms step_avg:277.17ms
+step:1397/1480 train_time:384459ms step_avg:277.19ms
+step:1398/1480 train_time:384744ms step_avg:277.19ms
+step:1399/1480 train_time:385040ms step_avg:277.21ms
+step:1400/1480 train_time:385344ms step_avg:277.23ms
+step:1401/1480 train_time:385639ms step_avg:277.24ms
+step:1402/1480 train_time:385946ms step_avg:277.26ms
+step:1403/1480 train_time:386235ms step_avg:277.27ms
+step:1404/1480 train_time:386522ms step_avg:277.28ms
+step:1405/1480 train_time:386813ms step_avg:277.29ms
+step:1406/1480 train_time:387099ms step_avg:277.29ms
+step:1407/1480 train_time:387404ms step_avg:277.31ms
+step:1408/1480 train_time:387698ms step_avg:277.32ms
+step:1409/1480 train_time:387982ms step_avg:277.33ms
+step:1410/1480 train_time:388268ms step_avg:277.33ms
+step:1411/1480 train_time:388561ms step_avg:277.35ms
+step:1412/1480 train_time:388849ms step_avg:277.35ms
+step:1413/1480 train_time:389140ms step_avg:277.36ms
+step:1414/1480 train_time:389427ms step_avg:277.37ms
+step:1415/1480 train_time:389717ms step_avg:277.38ms
+step:1416/1480 train_time:390013ms step_avg:277.39ms
+step:1417/1480 train_time:390300ms step_avg:277.40ms
+step:1418/1480 train_time:390596ms step_avg:277.41ms
+step:1419/1480 train_time:390888ms step_avg:277.42ms
+step:1420/1480 train_time:391181ms step_avg:277.43ms
+step:1421/1480 train_time:391467ms step_avg:277.44ms
+step:1422/1480 train_time:391763ms step_avg:277.45ms
+step:1423/1480 train_time:392046ms step_avg:277.46ms
+step:1424/1480 train_time:392337ms step_avg:277.47ms
+step:1425/1480 train_time:392629ms step_avg:277.48ms
+step:1426/1480 train_time:392934ms step_avg:277.50ms
+step:1427/1480 train_time:393224ms step_avg:277.50ms
+step:1428/1480 train_time:393519ms step_avg:277.52ms
+step:1429/1480 train_time:393807ms step_avg:277.52ms
+step:1430/1480 train_time:394096ms step_avg:277.53ms
+step:1431/1480 train_time:394384ms step_avg:277.54ms
+step:1432/1480 train_time:394681ms step_avg:277.55ms
+step:1433/1480 train_time:394974ms step_avg:277.56ms
+step:1434/1480 train_time:395276ms step_avg:277.58ms
+step:1435/1480 train_time:395564ms step_avg:277.59ms
+step:1436/1480 train_time:395863ms step_avg:277.60ms
+step:1437/1480 train_time:396149ms step_avg:277.61ms
+step:1438/1480 train_time:396452ms step_avg:277.63ms
+step:1439/1480 train_time:396751ms step_avg:277.64ms
+step:1440/1480 train_time:397042ms step_avg:277.65ms
+step:1441/1480 train_time:397333ms step_avg:277.66ms
+step:1442/1480 train_time:397626ms step_avg:277.67ms
+step:1443/1480 train_time:397920ms step_avg:277.68ms
+step:1444/1480 train_time:398210ms step_avg:277.69ms
+step:1445/1480 train_time:398498ms step_avg:277.70ms
+step:1446/1480 train_time:398800ms step_avg:277.72ms
+step:1447/1480 train_time:399097ms step_avg:277.73ms
+step:1448/1480 train_time:399400ms step_avg:277.75ms
+step:1449/1480 train_time:399696ms step_avg:277.76ms
+step:1450/1480 train_time:399981ms step_avg:277.76ms
+step:1451/1480 train_time:400275ms step_avg:277.78ms
+step:1452/1480 train_time:400566ms step_avg:277.79ms
+step:1453/1480 train_time:400854ms step_avg:277.79ms
+step:1454/1480 train_time:401142ms step_avg:277.80ms
+step:1455/1480 train_time:401438ms step_avg:277.81ms
+step:1456/1480 train_time:401725ms step_avg:277.82ms
+step:1457/1480 train_time:402017ms step_avg:277.83ms
+step:1458/1480 train_time:402303ms step_avg:277.83ms
+step:1459/1480 train_time:402602ms step_avg:277.85ms
+step:1460/1480 train_time:402886ms step_avg:277.85ms
+step:1461/1480 train_time:403177ms step_avg:277.86ms
+step:1462/1480 train_time:403463ms step_avg:277.87ms
+step:1463/1480 train_time:403752ms step_avg:277.87ms
+step:1464/1480 train_time:404050ms step_avg:277.89ms
+step:1465/1480 train_time:404342ms step_avg:277.90ms
+step:1466/1480 train_time:404633ms step_avg:277.91ms
+step:1467/1480 train_time:404922ms step_avg:277.91ms
+step:1468/1480 train_time:405217ms step_avg:277.93ms
+step:1469/1480 train_time:405524ms step_avg:277.95ms
+step:1470/1480 train_time:405822ms step_avg:277.96ms
+step:1471/1480 train_time:406119ms step_avg:277.97ms
+step:1472/1480 train_time:406404ms step_avg:277.98ms
+step:1473/1480 train_time:406701ms step_avg:277.99ms
+step:1474/1480 train_time:406986ms step_avg:278.00ms
+step:1475/1480 train_time:407278ms step_avg:278.01ms
+step:1476/1480 train_time:407567ms step_avg:278.01ms
+step:1477/1480 train_time:407864ms step_avg:278.03ms
+step:1478/1480 train_time:408159ms step_avg:278.04ms
+step:1479/1480 train_time:408453ms step_avg:278.05ms
+step:1480/1480 train_time:408740ms step_avg:278.05ms
+step:1480/1480 val_loss:3.3015 train_time:408880ms step_avg:278.15ms
+peak memory consumption: 34262 MiB

--- a/_logs/master-82de927d-20a6-422a-b45a-81de62bbfecc.txt
+++ b/_logs/master-82de927d-20a6-422a-b45a-81de62bbfecc.txt
@@ -1,0 +1,2169 @@
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+import contextlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import torch.distributed as dist
+import torch._inductor.config as config
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.nn.attention.flex_attention import BlockMask, flex_attention #KoszarskyB
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps):
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert len(G.shape) == 2
+    a, b, c = (3.4445, -4.7750,  2.0315)
+    X = G.bfloat16()
+    if G.size(0) > G.size(1):
+        X = X.T
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm() + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A # adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+    
+    if G.size(0) > G.size(1):
+        X = X.T
+    return X
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Some warnings:
+    - This optimizer assumes that all parameters passed in are 2D.
+    - It should not be used for the embedding layer, the final fully connected layer, or any {0,1}-D
+    parameters; those should all be optimized by a standard method (e.g., AdamW).
+    - To use it with 4D convolutional filters, it works well to just flatten their last 3 dimensions.
+    - We believe it is unlikely to work well for training with small batch size.
+    - We believe it may not work well for finetuning pretrained models, but we haven't tested this.
+    - We have not yet tried this optimizer for training scenarios larger than NanoGPT (124M).
+
+    Arguments:
+        lr: The learning rate used by the internal SGD.
+        momentum: The momentum used by the internal SGD.
+        nesterov: Whether to use Nesterov-style momentum in the internal SGD. (recommended)
+        ns_steps: The number of Newton-Schulz iteration steps to use.
+    """
+    def __init__(self, params, lr=0.02, momentum=0.95, nesterov=True, ns_steps=5):
+        self.world_size = int(os.environ['WORLD_SIZE'])
+        self.rank = int(os.environ['RANK'])
+        defaults = dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps)
+        params = list(params)
+        assert all(isinstance(p, torch.Tensor) for p in params)
+        sizes = {p.numel() for p in params}
+        param_groups = [
+            {
+                'params': [p for p in params if p.numel() == size],
+                'update_buffer': [
+                    torch.empty(size, device='cuda', dtype=torch.bfloat16)
+                    for _ in range(self.world_size)
+                ],
+            }
+            for size in sizes
+        ]
+        super().__init__(param_groups, defaults)
+
+    def step(self):
+
+        for group in self.param_groups:
+
+            lr = group['lr']
+            momentum = group['momentum']
+            nesterov = group['nesterov']
+            ns_steps = group['ns_steps']
+            update_buffers = group['update_buffer']
+            # generate weight updates in distributed fashion
+            params = group['params']
+            assert len(params) % self.world_size == 0
+            handle = None
+            params_world = None
+            def update_prev():
+                if params_world is None:
+                    return
+                assert handle is not None
+                handle.wait()
+                for p_world, g_world in zip(params_world, update_buffers):
+                    p_world.data.add_(
+                        g_world.view_as(p_world),
+                        alpha=-lr * max(1, p_world.size(0) / p_world.size(1)) ** 0.5,
+                    )
+            for base_i in range(len(params))[::self.world_size]:
+                p = params[base_i + self.rank]
+                g = p.grad
+                assert g is not None
+                state = self.state[p]
+                if 'momentum_buffer' not in state:
+                    state['momentum_buffer'] = torch.zeros_like(g)
+                buf = state['momentum_buffer']
+                buf.lerp_(g, 1 - momentum)
+                g = g.lerp_(buf, momentum) if nesterov else buf
+                g = zeropower_via_newtonschulz5(g, steps=ns_steps).flatten()
+                update_prev()
+                handle = dist.all_gather(update_buffers, g, async_op=True)
+                params_world = params[base_i : base_i + self.world_size]
+            update_prev()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the GPT-2 model
+
+def norm(x):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=False)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.to(x.dtype))
+
+class Rotary(torch.nn.Module):
+
+    def __init__(self, dim, base=10000):
+        super().__init__()
+        self.register_buffer('inv_freq', (1 / base) ** (torch.arange(0, dim, 2) / dim))
+        self.seq_len_cached = None
+        self.cos_cached = None
+        self.sin_cached = None
+
+    def forward(self, x):
+        seq_len = x.shape[1]
+        if seq_len != self.seq_len_cached:
+            t = torch.arange(seq_len, device=x.device)
+            freqs = torch.outer(t, self.inv_freq)
+            self.seq_len_cached = seq_len
+            self.cos_cached = freqs.cos()
+            self.sin_cached = freqs.sin()
+        cos, sin = self.cos_cached[None, :, None, :], self.sin_cached[None, :, None, :]
+        # apply_rotary_emb(x, cos, sin)
+        x1, x2 = x.chunk(2, dim=3)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x)
+
+class CausalSelfAttention(nn.Module):
+
+    def __init__(self, dim, num_heads):
+        super().__init__()
+        assert dim % num_heads == 0
+        self.num_heads = num_heads
+        self.c_q = CastedLinear(dim, dim)
+        self.c_k = CastedLinear(dim, dim)
+        self.c_v = CastedLinear(dim, dim)
+        self.lambdas = nn.Parameter(torch.tensor([0.5, 0.5]))
+        self.rotary = Rotary(dim // num_heads) # dim // num_heads = head_dim
+        self.c_proj = CastedLinear(dim, dim)
+        self.c_proj.weight.data.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x, vi, block_mask):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q = self.c_q(x).view(B, T, self.num_heads, -1)
+        k = self.c_k(x).view(B, T, self.num_heads, -1)
+        v = self.c_v(x).view(B, T, self.num_heads, -1)
+        v = self.lambdas[0] * v + self.lambdas[1] * vi.view_as(v) # @KoszarskyB & @Grad62304977
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, enable_gqa=True)
+        y = y.transpose(1, 2).contiguous().view_as(x) # re-assemble all head outputs side by side
+        y = self.c_proj(y)
+        return y
+
+class MLP(nn.Module):
+
+    def __init__(self, dim):
+        super().__init__()
+        self.c_fc   = CastedLinear(dim, 4 * dim)
+        self.c_proj = CastedLinear(4 * dim, dim)
+        self.c_proj.weight.data.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x):
+        x = self.c_fc(x)
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = self.c_proj(x)
+        return x
+
+class Block(nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+        self.attn = CausalSelfAttention(config.model_dim, config.num_heads)
+        self.mlp = MLP(config.model_dim)
+        self.lambdas = nn.Parameter(torch.tensor([1., 0.]))
+
+    def forward(self, x, vi, x0, block_mask):
+        x = self.lambdas[0] * x + self.lambdas[1] * x0
+        x = x + self.attn(norm(x), vi, block_mask)
+        x = x + self.mlp(norm(x))
+        return x
+
+class ValueEmbedding(nn.Module):
+    def __init__(self, config: "GPTConfig"):
+        super().__init__()
+        self.embed = nn.ModuleList([
+            nn.Embedding(config.vocab_size, config.model_dim)
+            for _ in range(6)
+        ])
+
+    def forward(self, inputs) -> "list[torch.Tensor]":
+        ve = [emb(inputs) for emb in self.embed]
+        ve += reversed(ve)
+        return ve
+
+# -----------------------------------------------------------------------------
+# The main GPT-2 model
+
+@dataclass
+class GPTConfig:
+    vocab_size : int = 50304
+    num_layers : int = 12
+    num_heads : int = 6 # head dim 128 suggested by @Grad62304977
+    model_dim : int = 768
+
+class GPT(nn.Module):
+
+    def __init__(self, config: GPTConfig):
+        super().__init__()
+        self.num_layers = config.num_layers
+
+        # U-net design by @brendanh0gan
+        self.num_encoder_layers = config.num_layers // 2 # Half of the layers for encoder
+        self.num_decoder_layers = config.num_layers - self.num_encoder_layers # Remaining for decoder
+        # Add learnable skip connection weights for decoder layers
+        self.skip_weights = nn.Parameter(torch.ones(self.num_decoder_layers))
+
+        self.embed = nn.Embedding(config.vocab_size, config.model_dim)
+        self.blocks = nn.ModuleList([Block(config) for _ in range(config.num_layers)])
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual learning
+        # U-net structure on token value embeddings by @leloykun
+        self.value_embeds = ValueEmbedding(config)
+        self.lm_head = CastedLinear(config.model_dim, config.vocab_size)
+        self.lm_head.weight.data.zero_() # @Grad62304977
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        targets: torch.Tensor,
+        sliding_window_num_blocks: torch.Tensor,
+    ):
+        BLOCK_SIZE = 128
+        seq_len = len(inputs)
+        assert seq_len % BLOCK_SIZE == 0
+        total_num_blocks = seq_len // BLOCK_SIZE
+        assert inputs.ndim == 1
+        docs = (inputs == 50256).cumsum(0)
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_mask: torch.Tensor):
+            num_blocks = dense_mask.sum(dim=-1, dtype=torch.int32)
+            indices = dense_mask.argsort(dim=-1, descending=True, stable=True).to(torch.int32)
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        def create_doc_swc_block_mask(sliding_window_num_blocks: torch.Tensor):
+            kv_idx = block_idx = torch.arange(total_num_blocks, dtype=torch.int32, device="cuda")
+            q_idx = block_idx[:, None]
+            causal_bm = q_idx >= kv_idx
+            causal_full_bm = q_idx > kv_idx
+            window_bm = q_idx - kv_idx < sliding_window_num_blocks
+            window_full_bm = window_bm
+            # document_bm = (docs_low[q_idx] <= docs_high[kv_idx]) & (docs_low[kv_idx] <= docs_high[q_idx])
+            document_bm = (docs_low[:, None] <= docs_high) & (docs_low <= docs_high[:, None])
+            document_full_bm = (docs_low[:, None] == docs_high) & (docs_low == docs_high[:, None])
+            nonzero_bm = causal_bm & window_bm & document_bm
+            full_bm  = causal_full_bm & window_full_bm & document_full_bm
+            kv_num_blocks, kv_indices = dense_to_ordered(nonzero_bm ^ full_bm)
+            full_kv_num_blocks, full_kv_indices = dense_to_ordered(full_bm)
+            return BlockMask.from_kv_blocks(
+                kv_num_blocks,
+                kv_indices,
+                full_kv_num_blocks,
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+
+        block_mask = create_doc_swc_block_mask(sliding_window_num_blocks)
+
+        # forward the GPT model itself
+        x = self.embed(inputs[None]) # token embeddings of shape (b, t, model_dim)
+        x = norm(x) # @Grad62304977
+        x0 = x
+        ve = self.value_embeds(inputs)
+        ve_enc, ve_dec = ve[:self.num_encoder_layers], ve[self.num_encoder_layers:]
+
+        # Store outputs for U-Net skip connections
+        skip_connections = []
+        # Encoder pass - process only the first half of the blocks
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, ve_enc[i], x0, block_mask)
+            skip_connections.append(x)
+        # Decoder pass - process the remaining blocks with weighted skip connections
+        for i in range(self.num_decoder_layers):
+            x = x + self.skip_weights[i] * skip_connections.pop()
+            # U-net structure on token value embeddings by @leloykun
+            x = self.blocks[self.num_encoder_layers + i](x, ve_dec[i], x0, block_mask)
+
+        x = norm(x)
+        logits = self.lm_head(x)
+        logits = 30 * torch.tanh(logits / 30) # @Grad62304977
+        logits = logits.float()
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
+        return loss
+
+# -----------------------------------------------------------------------------
+# Our own simple Distributed Data Loader
+
+def _peek_data_shard(file: Path):
+    # only reads the header, returns header data
+    # header is 256 int32
+    header = torch.from_file(f"{file}", False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    return int(header[2]) # number of tokens (claimed)
+
+def _load_data_shard(path: Path, num_tokens):
+    with path.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header?"
+    return tokens
+
+class DistributedDataLoader:
+    def __init__(self, filename_pattern, seq_len, process_rank, num_processes):
+        self.process_rank = process_rank
+        self.num_processes = num_processes
+        self.seq_len = seq_len
+
+        # glob files that match the pattern
+        self.files = sorted(Path.cwd().glob(filename_pattern))
+        assert len(self.files) > 0, f"did not find any files that match the pattern {filename_pattern}"
+
+        # load and validate all data shards, count number of tokens in total
+        self.files_num_tokens = [_peek_data_shard(file) for file in self.files]
+        assert min(self.files_num_tokens) >= num_processes * seq_len + 1
+        self.total_num_tokens = sum(self.files_num_tokens)
+
+        self.reset()
+
+    def reset(self):
+        self.current_shard = -1
+        self.advance()
+
+    def advance(self): # advance to next data shard
+        self.current_shard = (self.current_shard + 1) % len(self.files)
+        self.current_position = self.process_rank * self.seq_len
+        self.tokens = _load_data_shard(self.files[self.current_shard], self.files_num_tokens[self.current_shard])
+
+    def next_batch(self):
+        batch_size = self.seq_len * self.num_processes
+        buf = self.tokens[self.current_position:self.current_position+self.seq_len+1]
+        # host side async is sufficient;
+        # no performance improvement was observed when introducing a separate stream.
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # inputs
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # targets
+        # advance current position and load next shard if necessary
+        self.current_position += batch_size
+        if self.current_position + batch_size + 1 >= len(self.tokens):
+            self.advance()
+        return inputs, targets
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data hyperparams
+    input_bin : str = 'data/fineweb10B/fineweb_train_*.bin' # input .bin to train on
+    input_val_bin : str = 'data/fineweb10B/fineweb_val_*.bin' # input .bin to eval validation loss on
+    # optimization hyperparams
+    batch_size : int = 8 # batch size, in sequences, across all devices
+    sequence_length : int = 64*1024 # sequence length, in tokens
+    num_iterations : int = 1480 # number of iterations to run
+    warmup_iters : int = 0
+    cooldown_iters : int = 600 # number of iterations of linear warmup/cooldown for triangular or trapezoidal schedule
+    weight_decay : float = 0
+    # evaluation and logging hyperparams
+    val_loss_every : int = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    val_tokens : int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+args = Hyperparameters()
+
+# set up DDP (distributed data parallel). torchrun sets this env variable
+ddp_rank = int(os.environ['RANK'])
+ddp_local_rank = int(os.environ['LOCAL_RANK'])
+ddp_world_size = int(os.environ['WORLD_SIZE'])
+assert torch.cuda.is_available()
+device = torch.device(f'cuda:{ddp_local_rank}')
+torch.cuda.set_device(device)
+print(f'using device: {device}')
+dist.init_process_group(backend='nccl', device_id=device)
+dist.barrier()
+master_process = (ddp_rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = uuid.uuid4()
+    Path('logs').mkdir(exist_ok=True)
+    # logdir = Path('logs') / f'{run_id}'
+    # logdir.mkdir()
+    logfile = Path('logs') / f'{run_id}.txt'
+    print(logfile.stem)
+    # create the log file
+    with logfile.open('w') as f:
+        # begin the log by printing this file (the Python code)
+        print(code, file=f)
+        print('=' * 100, file=f)
+def print0(s, logonly=False):
+    if master_process:
+        with logfile.open('a') as f:
+            if not logonly:
+                print(s)
+            print(s, file=f)
+# log information about the hardware/software environment this is running on
+# and print the full `nvidia-smi` to file
+print0(f'Running python {sys.version}')
+print0(f'Running pytorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}\nnvidia-smi:')
+import subprocess
+result = subprocess.run(['nvidia-smi'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+print0(f'{result.stdout}', logonly=True)
+print0('='*100, logonly=True)
+
+# calculate the number of steps to take in the val loop.
+assert args.val_tokens % (args.sequence_length * ddp_world_size) == 0
+val_steps = args.val_tokens // (args.sequence_length * ddp_world_size)
+# calculate the steps of gradient accumulation required to attain the desired global batch size.
+assert args.batch_size % (ddp_world_size) == 0
+train_accumulation_steps = args.batch_size // ddp_world_size
+
+# load tokens
+train_loader = DistributedDataLoader(args.input_bin, args.sequence_length, ddp_rank, ddp_world_size)
+val_loader = DistributedDataLoader(args.input_val_bin, args.sequence_length, ddp_rank, ddp_world_size)
+print0(f"Training DataLoader: total number of tokens: {train_loader.total_num_tokens} across {len(train_loader.files)} files")
+print0(f"Validation DataLoader: total number of tokens: {val_loader.total_num_tokens} across {len(val_loader.files)} files")
+print0('='*100, logonly=True)
+inputs_train, targets_train = train_loader.next_batch()
+
+# there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency. suggested to me by @Grad62304977.
+# this originates from Karpathy's experiments.
+num_vocab = 50304
+model = GPT(GPTConfig(vocab_size=num_vocab, num_layers=12, num_heads=6, model_dim=768))
+model = model.cuda().bfloat16()
+for m in model.modules():
+    if isinstance(m, CastedLinear):
+        m.float()
+config.coordinate_descent_tuning = True # suggested by @Chillee
+model = torch.compile(model)
+# here we wrap model into DDP container
+model = DDP(model, device_ids=[ddp_local_rank], broadcast_buffers=False, gradient_as_bucket_view=True)
+raw_model = model.module # always contains the "raw" unwrapped model
+
+# init the optimizer(s)
+embed_params = [*raw_model.embed.parameters(), *raw_model.value_embeds.parameters()]
+optimizer1 = torch.optim.Adam(embed_params, lr=0.6, betas=(0.8, 0.95), fused=True)
+optimizer2 = torch.optim.Adam([raw_model.lm_head.weight], lr=0.008, betas=(0.8, 0.95), fused=True)
+params = list(raw_model.blocks.parameters())
+matrix_params = [p for p in params if p.ndim == 2]
+scalar_params = [p for p in params if p.ndim < 2] + [raw_model.skip_weights]
+optimizer3 = Muon(matrix_params, lr=0.05, momentum=0.95)
+optimizer4 = torch.optim.Adam(scalar_params, lr=0.04, betas=(0.8, 0.95), fused=True)
+optimizers = [optimizer1, optimizer2, optimizer3, optimizer4]
+# learning rate decay scheduler (linear warmup and cooldown)
+def get_lr(it):
+    assert it <= args.num_iterations
+    # 1) linear warmup for warmup_iters steps
+    if it < args.warmup_iters:
+        return (it+1) / args.warmup_iters
+    # 2) constant lr for a while
+    elif it < args.num_iterations - args.cooldown_iters:
+        return 1.0
+    # 3) linear cooldown
+    else:
+        decay_ratio = (args.num_iterations - it) / args.cooldown_iters
+        return decay_ratio
+schedulers = [torch.optim.lr_scheduler.LambdaLR(opt, get_lr) for opt in optimizers]
+
+sliding_window_num_blocks = torch.tensor(1, dtype=torch.int32, device="cuda")
+sw_num_blocks_prev = 1
+# Start training loop
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+for step in range(args.num_iterations + 1):
+    last_step = (step == args.num_iterations)
+    # This effectively ignores timing first 10 steps, which are slower for weird reasons.
+    # Alternately, and slightly more correctly in terms of benchmarking, we could do 10
+    # steps with dummy data first, and then re-initialize the model and reset the loader.
+    if step == 10:
+        training_time_ms = 0
+        t0 = time.perf_counter()
+    timed_steps = float('nan') if step <= 11 else (step - 10) + 1 # <= 11 to avoid bug in val
+
+    # Linearly increase the sliding window size over training in chunks of 128 from 128 -> 1856. By @fernbear.bsky.social
+    frac_done = step / args.num_iterations # training progress
+    sw_num_blocks = int(((1 - frac_done) * 128 + frac_done * 1856) // 128)
+    if sw_num_blocks != sw_num_blocks_prev:
+        sliding_window_num_blocks.copy_(sw_num_blocks, non_blocking=True)
+        sw_num_blocks_prev = sw_num_blocks
+
+    # once in a while evaluate the validation dataset
+    if (last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)):
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        # run validation batches
+        model.eval()
+        val_loader.reset()
+        val_loss = 0.0
+        for _ in range(val_steps):
+            with torch.no_grad():
+                inputs_val, targets_val = val_loader.next_batch()
+                val_loss += model(inputs_val, targets_val, sliding_window_num_blocks)
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        val_loss /= val_steps
+        # log val loss to console and to logfile
+        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    # uncomment if you want to save any checkpoints
+    #save_every = 1000
+    #if master_process and (last_step or (save_every > 0 and step % save_every == 0)):
+    #    # stop the clock
+    #    torch.cuda.synchronize()
+    #    training_time_ms += 1000 * (time.perf_counter() - t0)
+    #    # save the state of the training process
+    #    log = dict(step=step, code=code, model=raw_model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+    #    torch.save(log, 'logs/%s/state_step%06d.pt' % (run_id, step))
+    #    # start the clock again
+    #    torch.cuda.synchronize()
+    #    t0 = time.perf_counter()
+
+    # bit confusing: we want to make sure to eval on 0th iteration
+    # but also after the very last iteration. so we loop for step <= num_iterations
+    # instead of just < num_iterations (one extra due to <=), only to do
+    # the validation/sampling one last time, and then we break right here as we're done.
+    if last_step:
+        break
+
+    # --------------- TRAINING SECTION BEGIN -----------------
+    model.train()
+    for i in range(1, train_accumulation_steps + 1):
+        with contextlib.ExitStack() as stack:
+            if i < train_accumulation_steps: # there's no need to sync gradients every accumulation step
+                stack.enter_context(model.no_sync())
+            if step >= 5:
+                stack.enter_context(torch.compiler.set_stance(skip_guard_eval_unsafe=True))
+            model(inputs_train, targets_train, sliding_window_num_blocks).backward()
+            inputs_train, targets_train = train_loader.next_batch()
+    if train_accumulation_steps != 1:
+        for p in model.parameters():
+            p.grad /= train_accumulation_steps
+    # momentum warmup for Muon
+    frac = min(step/300, 1)
+    for group in optimizer3.param_groups:
+        group['momentum'] = (1 - frac) * 0.85 + frac * 0.95
+    # step the optimizers and schedulers
+    for opt, sched in zip(optimizers, schedulers):
+        opt.step()
+        sched.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # --------------- TRAINING SECTION END -------------------
+    # everything that follows now is just diagnostics, prints, logging, etc.
+    approx_time = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{args.num_iterations} train_time:{approx_time:.0f}ms step_avg:{approx_time/timed_steps:.2f}ms")
+
+print0(f"peak memory consumption: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB")
+
+# -------------------------------------------------------------------------
+# clean up nice
+dist.destroy_process_group()
+
+====================================================================================================
+Running python 3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0]
+Running pytorch 2.6.0.dev20241203+cu124 compiled for CUDA 12.4
+nvidia-smi:
+Thu Dec 26 07:38:48 2024       
++---------------------------------------------------------------------------------------+
+| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.4     |
+|-----------------------------------------+----------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
+|                                         |                      |               MIG M. |
+|=========================================+======================+======================|
+|   0  NVIDIA H100 PCIe               On  | 00000000:00:07.0 Off |                    0 |
+| N/A   35C    P0              79W / 350W |   4162MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   1  NVIDIA H100 PCIe               On  | 00000000:00:08.0 Off |                    0 |
+| N/A   40C    P0              84W / 350W |    923MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   2  NVIDIA H100 PCIe               On  | 00000000:00:09.0 Off |                    0 |
+| N/A   33C    P0              78W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   3  NVIDIA H100 PCIe               On  | 00000000:00:0A.0 Off |                    0 |
+| N/A   34C    P0              77W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   4  NVIDIA H100 PCIe               On  | 00000000:00:0B.0 Off |                    0 |
+| N/A   33C    P0              75W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   5  NVIDIA H100 PCIe               On  | 00000000:00:0C.0 Off |                    0 |
+| N/A   32C    P0              76W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   6  NVIDIA H100 PCIe               On  | 00000000:00:0D.0 Off |                    0 |
+| N/A   40C    P0              81W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   7  NVIDIA H100 PCIe               On  | 00000000:00:0E.0 Off |                    0 |
+| N/A   34C    P0              76W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+                                                                                         
++---------------------------------------------------------------------------------------+
+| Processes:                                                                            |
+|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
+|        ID   ID                                                             Usage      |
+|=======================================================================================|
++---------------------------------------------------------------------------------------+
+
+====================================================================================================
+Training DataLoader: total number of tokens: 1000000000 across 10 files
+Validation DataLoader: total number of tokens: 100000000 across 1 files
+====================================================================================================
+step:0/1480 val_loss:10.8258 train_time:0ms step_avg:nanms
+step:1/1480 train_time:454531ms step_avg:nanms
+step:2/1480 train_time:458892ms step_avg:nanms
+step:3/1480 train_time:459134ms step_avg:nanms
+step:4/1480 train_time:459381ms step_avg:nanms
+step:5/1480 train_time:460440ms step_avg:nanms
+step:6/1480 train_time:460691ms step_avg:nanms
+step:7/1480 train_time:460938ms step_avg:nanms
+step:8/1480 train_time:461190ms step_avg:nanms
+step:9/1480 train_time:461435ms step_avg:nanms
+step:10/1480 train_time:461686ms step_avg:nanms
+step:11/1480 train_time:248ms step_avg:nanms
+step:12/1480 train_time:499ms step_avg:nanms
+step:13/1480 train_time:749ms step_avg:249.78ms
+step:14/1480 train_time:1000ms step_avg:250.05ms
+step:15/1480 train_time:1249ms step_avg:249.71ms
+step:16/1480 train_time:1499ms step_avg:249.80ms
+step:17/1480 train_time:1749ms step_avg:249.81ms
+step:18/1480 train_time:2000ms step_avg:249.94ms
+step:19/1480 train_time:2250ms step_avg:249.95ms
+step:20/1480 train_time:2502ms step_avg:250.20ms
+step:21/1480 train_time:2748ms step_avg:249.85ms
+step:22/1480 train_time:2999ms step_avg:249.94ms
+step:23/1480 train_time:3249ms step_avg:249.89ms
+step:24/1480 train_time:3497ms step_avg:249.78ms
+step:25/1480 train_time:3751ms step_avg:250.04ms
+step:26/1480 train_time:3999ms step_avg:249.92ms
+step:27/1480 train_time:4248ms step_avg:249.90ms
+step:28/1480 train_time:4502ms step_avg:250.09ms
+step:29/1480 train_time:4750ms step_avg:249.98ms
+step:30/1480 train_time:4999ms step_avg:249.96ms
+step:31/1480 train_time:5248ms step_avg:249.92ms
+step:32/1480 train_time:5501ms step_avg:250.03ms
+step:33/1480 train_time:5749ms step_avg:249.96ms
+step:34/1480 train_time:5998ms step_avg:249.90ms
+step:35/1480 train_time:6249ms step_avg:249.96ms
+step:36/1480 train_time:6503ms step_avg:250.10ms
+step:37/1480 train_time:6749ms step_avg:249.96ms
+step:38/1480 train_time:6999ms step_avg:249.97ms
+step:39/1480 train_time:7250ms step_avg:250.00ms
+step:40/1480 train_time:7502ms step_avg:250.08ms
+step:41/1480 train_time:7749ms step_avg:249.95ms
+step:42/1480 train_time:7999ms step_avg:249.96ms
+step:43/1480 train_time:8249ms step_avg:249.98ms
+step:44/1480 train_time:8500ms step_avg:249.99ms
+step:45/1480 train_time:8750ms step_avg:250.01ms
+step:46/1480 train_time:9001ms step_avg:250.04ms
+step:47/1480 train_time:9250ms step_avg:250.00ms
+step:48/1480 train_time:9501ms step_avg:250.04ms
+step:49/1480 train_time:9749ms step_avg:249.97ms
+step:50/1480 train_time:9999ms step_avg:249.97ms
+step:51/1480 train_time:10249ms step_avg:249.99ms
+step:52/1480 train_time:10501ms step_avg:250.02ms
+step:53/1480 train_time:10748ms step_avg:249.97ms
+step:54/1480 train_time:10998ms step_avg:249.95ms
+step:55/1480 train_time:11250ms step_avg:250.00ms
+step:56/1480 train_time:11501ms step_avg:250.03ms
+step:57/1480 train_time:11749ms step_avg:249.98ms
+step:58/1480 train_time:12000ms step_avg:250.00ms
+step:59/1480 train_time:12250ms step_avg:250.00ms
+step:60/1480 train_time:12502ms step_avg:250.04ms
+step:61/1480 train_time:12750ms step_avg:249.99ms
+step:62/1480 train_time:13000ms step_avg:250.01ms
+step:63/1480 train_time:13250ms step_avg:250.01ms
+step:64/1480 train_time:13503ms step_avg:250.05ms
+step:65/1480 train_time:13750ms step_avg:250.01ms
+step:66/1480 train_time:14002ms step_avg:250.03ms
+step:67/1480 train_time:14249ms step_avg:249.99ms
+step:68/1480 train_time:14501ms step_avg:250.02ms
+step:69/1480 train_time:14752ms step_avg:250.03ms
+step:70/1480 train_time:15004ms step_avg:250.06ms
+step:71/1480 train_time:15252ms step_avg:250.03ms
+step:72/1480 train_time:15503ms step_avg:250.04ms
+step:73/1480 train_time:15750ms step_avg:250.00ms
+step:74/1480 train_time:16000ms step_avg:249.99ms
+step:75/1480 train_time:16252ms step_avg:250.03ms
+step:76/1480 train_time:16503ms step_avg:250.04ms
+step:77/1480 train_time:16750ms step_avg:250.00ms
+step:78/1480 train_time:17001ms step_avg:250.01ms
+step:79/1480 train_time:17250ms step_avg:250.00ms
+step:80/1480 train_time:17500ms step_avg:250.00ms
+step:81/1480 train_time:17750ms step_avg:250.01ms
+step:82/1480 train_time:18001ms step_avg:250.01ms
+step:83/1480 train_time:18250ms step_avg:250.00ms
+step:84/1480 train_time:18499ms step_avg:249.99ms
+step:85/1480 train_time:18751ms step_avg:250.01ms
+step:86/1480 train_time:19004ms step_avg:250.05ms
+step:87/1480 train_time:19250ms step_avg:250.00ms
+step:88/1480 train_time:19502ms step_avg:250.03ms
+step:89/1480 train_time:19750ms step_avg:250.00ms
+step:90/1480 train_time:20001ms step_avg:250.01ms
+step:91/1480 train_time:20252ms step_avg:250.02ms
+step:92/1480 train_time:20502ms step_avg:250.03ms
+step:93/1480 train_time:20749ms step_avg:249.98ms
+step:94/1480 train_time:20999ms step_avg:249.99ms
+step:95/1480 train_time:21250ms step_avg:249.99ms
+step:96/1480 train_time:21502ms step_avg:250.03ms
+step:97/1480 train_time:21750ms step_avg:250.00ms
+step:98/1480 train_time:22000ms step_avg:250.00ms
+step:99/1480 train_time:22250ms step_avg:250.00ms
+step:100/1480 train_time:22502ms step_avg:250.03ms
+step:101/1480 train_time:22750ms step_avg:250.00ms
+step:102/1480 train_time:23000ms step_avg:250.00ms
+step:103/1480 train_time:23249ms step_avg:249.99ms
+step:104/1480 train_time:23503ms step_avg:250.03ms
+step:105/1480 train_time:23750ms step_avg:250.00ms
+step:106/1480 train_time:24000ms step_avg:250.00ms
+step:107/1480 train_time:24251ms step_avg:250.01ms
+step:108/1480 train_time:24502ms step_avg:250.02ms
+step:109/1480 train_time:24749ms step_avg:249.99ms
+step:110/1480 train_time:25001ms step_avg:250.01ms
+step:111/1480 train_time:25252ms step_avg:250.02ms
+step:112/1480 train_time:25507ms step_avg:250.07ms
+step:113/1480 train_time:25760ms step_avg:250.10ms
+step:114/1480 train_time:26018ms step_avg:250.17ms
+step:115/1480 train_time:26270ms step_avg:250.19ms
+step:116/1480 train_time:26526ms step_avg:250.24ms
+step:117/1480 train_time:26783ms step_avg:250.30ms
+step:118/1480 train_time:27038ms step_avg:250.35ms
+step:119/1480 train_time:27295ms step_avg:250.41ms
+step:120/1480 train_time:27549ms step_avg:250.45ms
+step:121/1480 train_time:27805ms step_avg:250.50ms
+step:122/1480 train_time:28059ms step_avg:250.52ms
+step:123/1480 train_time:28315ms step_avg:250.57ms
+step:124/1480 train_time:28567ms step_avg:250.59ms
+step:125/1480 train_time:28822ms step_avg:250.63ms
+step:125/1480 val_loss:4.4223 train_time:28947ms step_avg:251.71ms
+step:126/1480 train_time:29076ms step_avg:250.65ms
+step:127/1480 train_time:29335ms step_avg:250.73ms
+step:128/1480 train_time:29588ms step_avg:250.75ms
+step:129/1480 train_time:29843ms step_avg:250.78ms
+step:130/1480 train_time:30094ms step_avg:250.79ms
+step:131/1480 train_time:30348ms step_avg:250.81ms
+step:132/1480 train_time:30603ms step_avg:250.85ms
+step:133/1480 train_time:30862ms step_avg:250.91ms
+step:134/1480 train_time:31115ms step_avg:250.92ms
+step:135/1480 train_time:31370ms step_avg:250.96ms
+step:136/1480 train_time:31626ms step_avg:251.00ms
+step:137/1480 train_time:31879ms step_avg:251.02ms
+step:138/1480 train_time:32135ms step_avg:251.05ms
+step:139/1480 train_time:32387ms step_avg:251.06ms
+step:140/1480 train_time:32642ms step_avg:251.09ms
+step:141/1480 train_time:32894ms step_avg:251.10ms
+step:142/1480 train_time:33148ms step_avg:251.12ms
+step:143/1480 train_time:33404ms step_avg:251.16ms
+step:144/1480 train_time:33660ms step_avg:251.19ms
+step:145/1480 train_time:33912ms step_avg:251.20ms
+step:146/1480 train_time:34168ms step_avg:251.23ms
+step:147/1480 train_time:34423ms step_avg:251.26ms
+step:148/1480 train_time:34675ms step_avg:251.27ms
+step:149/1480 train_time:34931ms step_avg:251.30ms
+step:150/1480 train_time:35186ms step_avg:251.33ms
+step:151/1480 train_time:35442ms step_avg:251.36ms
+step:152/1480 train_time:35698ms step_avg:251.39ms
+step:153/1480 train_time:35949ms step_avg:251.39ms
+step:154/1480 train_time:36206ms step_avg:251.43ms
+step:155/1480 train_time:36461ms step_avg:251.45ms
+step:156/1480 train_time:36713ms step_avg:251.46ms
+step:157/1480 train_time:36968ms step_avg:251.48ms
+step:158/1480 train_time:37225ms step_avg:251.52ms
+step:159/1480 train_time:37478ms step_avg:251.53ms
+step:160/1480 train_time:37733ms step_avg:251.56ms
+step:161/1480 train_time:37988ms step_avg:251.57ms
+step:162/1480 train_time:38243ms step_avg:251.60ms
+step:163/1480 train_time:38496ms step_avg:251.61ms
+step:164/1480 train_time:38748ms step_avg:251.61ms
+step:165/1480 train_time:39006ms step_avg:251.65ms
+step:166/1480 train_time:39262ms step_avg:251.68ms
+step:167/1480 train_time:39514ms step_avg:251.68ms
+step:168/1480 train_time:39768ms step_avg:251.70ms
+step:169/1480 train_time:40026ms step_avg:251.74ms
+step:170/1480 train_time:40278ms step_avg:251.73ms
+step:171/1480 train_time:40534ms step_avg:251.77ms
+step:172/1480 train_time:40788ms step_avg:251.77ms
+step:173/1480 train_time:41043ms step_avg:251.80ms
+step:174/1480 train_time:41296ms step_avg:251.81ms
+step:175/1480 train_time:41549ms step_avg:251.81ms
+step:176/1480 train_time:41805ms step_avg:251.84ms
+step:177/1480 train_time:42063ms step_avg:251.88ms
+step:178/1480 train_time:42315ms step_avg:251.88ms
+step:179/1480 train_time:42569ms step_avg:251.89ms
+step:180/1480 train_time:42824ms step_avg:251.91ms
+step:181/1480 train_time:43077ms step_avg:251.91ms
+step:182/1480 train_time:43333ms step_avg:251.93ms
+step:183/1480 train_time:43586ms step_avg:251.94ms
+step:184/1480 train_time:43843ms step_avg:251.97ms
+step:185/1480 train_time:44099ms step_avg:251.99ms
+step:186/1480 train_time:44353ms step_avg:252.01ms
+step:187/1480 train_time:44608ms step_avg:252.02ms
+step:188/1480 train_time:44865ms step_avg:252.05ms
+step:189/1480 train_time:45118ms step_avg:252.05ms
+step:190/1480 train_time:45373ms step_avg:252.07ms
+step:191/1480 train_time:45629ms step_avg:252.09ms
+step:192/1480 train_time:45884ms step_avg:252.11ms
+step:193/1480 train_time:46142ms step_avg:252.14ms
+step:194/1480 train_time:46396ms step_avg:252.15ms
+step:195/1480 train_time:46648ms step_avg:252.15ms
+step:196/1480 train_time:46905ms step_avg:252.18ms
+step:197/1480 train_time:47161ms step_avg:252.20ms
+step:198/1480 train_time:47415ms step_avg:252.21ms
+step:199/1480 train_time:47671ms step_avg:252.23ms
+step:200/1480 train_time:47926ms step_avg:252.24ms
+step:201/1480 train_time:48179ms step_avg:252.25ms
+step:202/1480 train_time:48436ms step_avg:252.27ms
+step:203/1480 train_time:48687ms step_avg:252.27ms
+step:204/1480 train_time:48944ms step_avg:252.29ms
+step:205/1480 train_time:49202ms step_avg:252.32ms
+step:206/1480 train_time:49457ms step_avg:252.33ms
+step:207/1480 train_time:49710ms step_avg:252.34ms
+step:208/1480 train_time:49966ms step_avg:252.36ms
+step:209/1480 train_time:50222ms step_avg:252.37ms
+step:210/1480 train_time:50478ms step_avg:252.39ms
+step:211/1480 train_time:50733ms step_avg:252.41ms
+step:212/1480 train_time:50987ms step_avg:252.41ms
+step:213/1480 train_time:51242ms step_avg:252.42ms
+step:214/1480 train_time:51496ms step_avg:252.43ms
+step:215/1480 train_time:51750ms step_avg:252.44ms
+step:216/1480 train_time:52006ms step_avg:252.46ms
+step:217/1480 train_time:52263ms step_avg:252.48ms
+step:218/1480 train_time:52517ms step_avg:252.49ms
+step:219/1480 train_time:52774ms step_avg:252.51ms
+step:220/1480 train_time:53030ms step_avg:252.52ms
+step:221/1480 train_time:53288ms step_avg:252.55ms
+step:222/1480 train_time:53548ms step_avg:252.58ms
+step:223/1480 train_time:53807ms step_avg:252.62ms
+step:224/1480 train_time:54069ms step_avg:252.66ms
+step:225/1480 train_time:54328ms step_avg:252.69ms
+step:226/1480 train_time:54585ms step_avg:252.71ms
+step:227/1480 train_time:54846ms step_avg:252.75ms
+step:228/1480 train_time:55107ms step_avg:252.79ms
+step:229/1480 train_time:55369ms step_avg:252.83ms
+step:230/1480 train_time:55629ms step_avg:252.86ms
+step:231/1480 train_time:55885ms step_avg:252.88ms
+step:232/1480 train_time:56147ms step_avg:252.91ms
+step:233/1480 train_time:56407ms step_avg:252.95ms
+step:234/1480 train_time:56670ms step_avg:252.99ms
+step:235/1480 train_time:56930ms step_avg:253.02ms
+step:236/1480 train_time:57188ms step_avg:253.04ms
+step:237/1480 train_time:57447ms step_avg:253.07ms
+step:238/1480 train_time:57707ms step_avg:253.10ms
+step:239/1480 train_time:57969ms step_avg:253.14ms
+step:240/1480 train_time:58231ms step_avg:253.18ms
+step:241/1480 train_time:58488ms step_avg:253.20ms
+step:242/1480 train_time:58748ms step_avg:253.23ms
+step:243/1480 train_time:59008ms step_avg:253.26ms
+step:244/1480 train_time:59269ms step_avg:253.29ms
+step:245/1480 train_time:59528ms step_avg:253.31ms
+step:246/1480 train_time:59788ms step_avg:253.34ms
+step:247/1480 train_time:60049ms step_avg:253.37ms
+step:248/1480 train_time:60307ms step_avg:253.39ms
+step:249/1480 train_time:60569ms step_avg:253.43ms
+step:250/1480 train_time:60828ms step_avg:253.45ms
+step:250/1480 val_loss:3.9975 train_time:60957ms step_avg:253.99ms
+step:251/1480 train_time:61088ms step_avg:253.48ms
+step:252/1480 train_time:61351ms step_avg:253.52ms
+step:253/1480 train_time:61613ms step_avg:253.55ms
+step:254/1480 train_time:61874ms step_avg:253.58ms
+step:255/1480 train_time:62132ms step_avg:253.60ms
+step:256/1480 train_time:62391ms step_avg:253.62ms
+step:257/1480 train_time:62652ms step_avg:253.65ms
+step:258/1480 train_time:62913ms step_avg:253.68ms
+step:259/1480 train_time:63173ms step_avg:253.71ms
+step:260/1480 train_time:63433ms step_avg:253.73ms
+step:261/1480 train_time:63691ms step_avg:253.75ms
+step:262/1480 train_time:63952ms step_avg:253.78ms
+step:263/1480 train_time:64211ms step_avg:253.80ms
+step:264/1480 train_time:64472ms step_avg:253.83ms
+step:265/1480 train_time:64732ms step_avg:253.85ms
+step:266/1480 train_time:64991ms step_avg:253.87ms
+step:267/1480 train_time:65251ms step_avg:253.89ms
+step:268/1480 train_time:65512ms step_avg:253.92ms
+step:269/1480 train_time:65773ms step_avg:253.95ms
+step:270/1480 train_time:66035ms step_avg:253.98ms
+step:271/1480 train_time:66294ms step_avg:254.00ms
+step:272/1480 train_time:66553ms step_avg:254.02ms
+step:273/1480 train_time:66813ms step_avg:254.04ms
+step:274/1480 train_time:67074ms step_avg:254.07ms
+step:275/1480 train_time:67334ms step_avg:254.09ms
+step:276/1480 train_time:67592ms step_avg:254.11ms
+step:277/1480 train_time:67852ms step_avg:254.13ms
+step:278/1480 train_time:68112ms step_avg:254.15ms
+step:279/1480 train_time:68374ms step_avg:254.18ms
+step:280/1480 train_time:68634ms step_avg:254.20ms
+step:281/1480 train_time:68891ms step_avg:254.21ms
+step:282/1480 train_time:69152ms step_avg:254.24ms
+step:283/1480 train_time:69412ms step_avg:254.26ms
+step:284/1480 train_time:69674ms step_avg:254.28ms
+step:285/1480 train_time:69933ms step_avg:254.30ms
+step:286/1480 train_time:70191ms step_avg:254.32ms
+step:287/1480 train_time:70452ms step_avg:254.34ms
+step:288/1480 train_time:70712ms step_avg:254.36ms
+step:289/1480 train_time:70972ms step_avg:254.38ms
+step:290/1480 train_time:71233ms step_avg:254.40ms
+step:291/1480 train_time:71491ms step_avg:254.42ms
+step:292/1480 train_time:71751ms step_avg:254.44ms
+step:293/1480 train_time:72012ms step_avg:254.46ms
+step:294/1480 train_time:72274ms step_avg:254.49ms
+step:295/1480 train_time:72534ms step_avg:254.50ms
+step:296/1480 train_time:72791ms step_avg:254.51ms
+step:297/1480 train_time:73051ms step_avg:254.53ms
+step:298/1480 train_time:73312ms step_avg:254.56ms
+step:299/1480 train_time:73574ms step_avg:254.58ms
+step:300/1480 train_time:73834ms step_avg:254.60ms
+step:301/1480 train_time:74093ms step_avg:254.62ms
+step:302/1480 train_time:74353ms step_avg:254.63ms
+step:303/1480 train_time:74614ms step_avg:254.65ms
+step:304/1480 train_time:74874ms step_avg:254.67ms
+step:305/1480 train_time:75133ms step_avg:254.69ms
+step:306/1480 train_time:75392ms step_avg:254.70ms
+step:307/1480 train_time:75652ms step_avg:254.72ms
+step:308/1480 train_time:75912ms step_avg:254.74ms
+step:309/1480 train_time:76174ms step_avg:254.76ms
+step:310/1480 train_time:76433ms step_avg:254.78ms
+step:311/1480 train_time:76691ms step_avg:254.79ms
+step:312/1480 train_time:76951ms step_avg:254.80ms
+step:313/1480 train_time:77212ms step_avg:254.83ms
+step:314/1480 train_time:77474ms step_avg:254.85ms
+step:315/1480 train_time:77734ms step_avg:254.87ms
+step:316/1480 train_time:77993ms step_avg:254.88ms
+step:317/1480 train_time:78252ms step_avg:254.89ms
+step:318/1480 train_time:78513ms step_avg:254.91ms
+step:319/1480 train_time:78774ms step_avg:254.93ms
+step:320/1480 train_time:79034ms step_avg:254.95ms
+step:321/1480 train_time:79292ms step_avg:254.96ms
+step:322/1480 train_time:79552ms step_avg:254.97ms
+step:323/1480 train_time:79812ms step_avg:254.99ms
+step:324/1480 train_time:80073ms step_avg:255.01ms
+step:325/1480 train_time:80333ms step_avg:255.03ms
+step:326/1480 train_time:80591ms step_avg:255.04ms
+step:327/1480 train_time:80853ms step_avg:255.06ms
+step:328/1480 train_time:81113ms step_avg:255.07ms
+step:329/1480 train_time:81375ms step_avg:255.09ms
+step:330/1480 train_time:81636ms step_avg:255.11ms
+step:331/1480 train_time:81898ms step_avg:255.14ms
+step:332/1480 train_time:82162ms step_avg:255.16ms
+step:333/1480 train_time:82425ms step_avg:255.18ms
+step:334/1480 train_time:82693ms step_avg:255.23ms
+step:335/1480 train_time:82955ms step_avg:255.25ms
+step:336/1480 train_time:83216ms step_avg:255.27ms
+step:337/1480 train_time:83479ms step_avg:255.29ms
+step:338/1480 train_time:83740ms step_avg:255.31ms
+step:339/1480 train_time:84003ms step_avg:255.33ms
+step:340/1480 train_time:84265ms step_avg:255.35ms
+step:341/1480 train_time:84534ms step_avg:255.39ms
+step:342/1480 train_time:84794ms step_avg:255.40ms
+step:343/1480 train_time:85056ms step_avg:255.42ms
+step:344/1480 train_time:85317ms step_avg:255.44ms
+step:345/1480 train_time:85580ms step_avg:255.46ms
+step:346/1480 train_time:85840ms step_avg:255.48ms
+step:347/1480 train_time:86100ms step_avg:255.49ms
+step:348/1480 train_time:86361ms step_avg:255.51ms
+step:349/1480 train_time:86625ms step_avg:255.53ms
+step:350/1480 train_time:86893ms step_avg:255.57ms
+step:351/1480 train_time:87155ms step_avg:255.59ms
+step:352/1480 train_time:87415ms step_avg:255.60ms
+step:353/1480 train_time:87678ms step_avg:255.62ms
+step:354/1480 train_time:87940ms step_avg:255.64ms
+step:355/1480 train_time:88202ms step_avg:255.66ms
+step:356/1480 train_time:88464ms step_avg:255.68ms
+step:357/1480 train_time:88731ms step_avg:255.71ms
+step:358/1480 train_time:88993ms step_avg:255.73ms
+step:359/1480 train_time:89255ms step_avg:255.75ms
+step:360/1480 train_time:89516ms step_avg:255.76ms
+step:361/1480 train_time:89778ms step_avg:255.78ms
+step:362/1480 train_time:90039ms step_avg:255.79ms
+step:363/1480 train_time:90300ms step_avg:255.81ms
+step:364/1480 train_time:90562ms step_avg:255.83ms
+step:365/1480 train_time:90828ms step_avg:255.85ms
+step:366/1480 train_time:91093ms step_avg:255.88ms
+step:367/1480 train_time:91355ms step_avg:255.90ms
+step:368/1480 train_time:91616ms step_avg:255.91ms
+step:369/1480 train_time:91878ms step_avg:255.93ms
+step:370/1480 train_time:92139ms step_avg:255.94ms
+step:371/1480 train_time:92399ms step_avg:255.95ms
+step:372/1480 train_time:92661ms step_avg:255.97ms
+step:373/1480 train_time:92923ms step_avg:255.99ms
+step:374/1480 train_time:93192ms step_avg:256.02ms
+step:375/1480 train_time:93455ms step_avg:256.04ms
+step:375/1480 val_loss:3.8093 train_time:93586ms step_avg:256.40ms
+step:376/1480 train_time:93718ms step_avg:256.06ms
+step:377/1480 train_time:93988ms step_avg:256.10ms
+step:378/1480 train_time:94251ms step_avg:256.12ms
+step:379/1480 train_time:94514ms step_avg:256.14ms
+step:380/1480 train_time:94776ms step_avg:256.15ms
+step:381/1480 train_time:95038ms step_avg:256.17ms
+step:382/1480 train_time:95305ms step_avg:256.20ms
+step:383/1480 train_time:95568ms step_avg:256.21ms
+step:384/1480 train_time:95830ms step_avg:256.23ms
+step:385/1480 train_time:96091ms step_avg:256.24ms
+step:386/1480 train_time:96355ms step_avg:256.26ms
+step:387/1480 train_time:96618ms step_avg:256.28ms
+step:388/1480 train_time:96879ms step_avg:256.29ms
+step:389/1480 train_time:97148ms step_avg:256.33ms
+step:390/1480 train_time:97410ms step_avg:256.34ms
+step:391/1480 train_time:97674ms step_avg:256.36ms
+step:392/1480 train_time:97935ms step_avg:256.37ms
+step:393/1480 train_time:98197ms step_avg:256.39ms
+step:394/1480 train_time:98463ms step_avg:256.41ms
+step:395/1480 train_time:98729ms step_avg:256.44ms
+step:396/1480 train_time:98991ms step_avg:256.45ms
+step:397/1480 train_time:99252ms step_avg:256.46ms
+step:398/1480 train_time:99514ms step_avg:256.48ms
+step:399/1480 train_time:99775ms step_avg:256.49ms
+step:400/1480 train_time:100038ms step_avg:256.51ms
+step:401/1480 train_time:100304ms step_avg:256.53ms
+step:402/1480 train_time:100570ms step_avg:256.56ms
+step:403/1480 train_time:100830ms step_avg:256.56ms
+step:404/1480 train_time:101091ms step_avg:256.58ms
+step:405/1480 train_time:101355ms step_avg:256.59ms
+step:406/1480 train_time:101618ms step_avg:256.61ms
+step:407/1480 train_time:101880ms step_avg:256.62ms
+step:408/1480 train_time:102149ms step_avg:256.65ms
+step:409/1480 train_time:102411ms step_avg:256.67ms
+step:410/1480 train_time:102673ms step_avg:256.68ms
+step:411/1480 train_time:102936ms step_avg:256.70ms
+step:412/1480 train_time:103199ms step_avg:256.71ms
+step:413/1480 train_time:103468ms step_avg:256.74ms
+step:414/1480 train_time:103730ms step_avg:256.76ms
+step:415/1480 train_time:103992ms step_avg:256.77ms
+step:416/1480 train_time:104253ms step_avg:256.78ms
+step:417/1480 train_time:104517ms step_avg:256.80ms
+step:418/1480 train_time:104777ms step_avg:256.81ms
+step:419/1480 train_time:105038ms step_avg:256.82ms
+step:420/1480 train_time:105306ms step_avg:256.84ms
+step:421/1480 train_time:105569ms step_avg:256.86ms
+step:422/1480 train_time:105830ms step_avg:256.87ms
+step:423/1480 train_time:106092ms step_avg:256.88ms
+step:424/1480 train_time:106354ms step_avg:256.89ms
+step:425/1480 train_time:106615ms step_avg:256.90ms
+step:426/1480 train_time:106878ms step_avg:256.92ms
+step:427/1480 train_time:107143ms step_avg:256.94ms
+step:428/1480 train_time:107411ms step_avg:256.96ms
+step:429/1480 train_time:107672ms step_avg:256.97ms
+step:430/1480 train_time:107935ms step_avg:256.99ms
+step:431/1480 train_time:108197ms step_avg:257.00ms
+step:432/1480 train_time:108458ms step_avg:257.01ms
+step:433/1480 train_time:108725ms step_avg:257.03ms
+step:434/1480 train_time:108989ms step_avg:257.05ms
+step:435/1480 train_time:109252ms step_avg:257.06ms
+step:436/1480 train_time:109513ms step_avg:257.07ms
+step:437/1480 train_time:109775ms step_avg:257.08ms
+step:438/1480 train_time:110035ms step_avg:257.09ms
+step:439/1480 train_time:110297ms step_avg:257.10ms
+step:440/1480 train_time:110564ms step_avg:257.13ms
+step:441/1480 train_time:110832ms step_avg:257.15ms
+step:442/1480 train_time:111096ms step_avg:257.17ms
+step:443/1480 train_time:111359ms step_avg:257.18ms
+step:444/1480 train_time:111631ms step_avg:257.21ms
+step:445/1480 train_time:111893ms step_avg:257.22ms
+step:446/1480 train_time:112160ms step_avg:257.25ms
+step:447/1480 train_time:112431ms step_avg:257.28ms
+step:448/1480 train_time:112694ms step_avg:257.29ms
+step:449/1480 train_time:112961ms step_avg:257.31ms
+step:450/1480 train_time:113230ms step_avg:257.34ms
+step:451/1480 train_time:113496ms step_avg:257.36ms
+step:452/1480 train_time:113760ms step_avg:257.37ms
+step:453/1480 train_time:114029ms step_avg:257.40ms
+step:454/1480 train_time:114292ms step_avg:257.41ms
+step:455/1480 train_time:114559ms step_avg:257.44ms
+step:456/1480 train_time:114827ms step_avg:257.46ms
+step:457/1480 train_time:115091ms step_avg:257.47ms
+step:458/1480 train_time:115355ms step_avg:257.49ms
+step:459/1480 train_time:115622ms step_avg:257.51ms
+step:460/1480 train_time:115890ms step_avg:257.53ms
+step:461/1480 train_time:116157ms step_avg:257.55ms
+step:462/1480 train_time:116423ms step_avg:257.57ms
+step:463/1480 train_time:116689ms step_avg:257.59ms
+step:464/1480 train_time:116953ms step_avg:257.61ms
+step:465/1480 train_time:117221ms step_avg:257.63ms
+step:466/1480 train_time:117488ms step_avg:257.65ms
+step:467/1480 train_time:117753ms step_avg:257.67ms
+step:468/1480 train_time:118018ms step_avg:257.68ms
+step:469/1480 train_time:118283ms step_avg:257.70ms
+step:470/1480 train_time:118552ms step_avg:257.72ms
+step:471/1480 train_time:118815ms step_avg:257.73ms
+step:472/1480 train_time:119082ms step_avg:257.75ms
+step:473/1480 train_time:119348ms step_avg:257.77ms
+step:474/1480 train_time:119613ms step_avg:257.79ms
+step:475/1480 train_time:119878ms step_avg:257.80ms
+step:476/1480 train_time:120144ms step_avg:257.82ms
+step:477/1480 train_time:120413ms step_avg:257.84ms
+step:478/1480 train_time:120681ms step_avg:257.86ms
+step:479/1480 train_time:120951ms step_avg:257.89ms
+step:480/1480 train_time:121218ms step_avg:257.91ms
+step:481/1480 train_time:121484ms step_avg:257.93ms
+step:482/1480 train_time:121751ms step_avg:257.95ms
+step:483/1480 train_time:122017ms step_avg:257.96ms
+step:484/1480 train_time:122282ms step_avg:257.98ms
+step:485/1480 train_time:122552ms step_avg:258.00ms
+step:486/1480 train_time:122819ms step_avg:258.02ms
+step:487/1480 train_time:123084ms step_avg:258.04ms
+step:488/1480 train_time:123354ms step_avg:258.06ms
+step:489/1480 train_time:123619ms step_avg:258.08ms
+step:490/1480 train_time:123885ms step_avg:258.09ms
+step:491/1480 train_time:124151ms step_avg:258.11ms
+step:492/1480 train_time:124419ms step_avg:258.13ms
+step:493/1480 train_time:124686ms step_avg:258.15ms
+step:494/1480 train_time:124954ms step_avg:258.17ms
+step:495/1480 train_time:125222ms step_avg:258.19ms
+step:496/1480 train_time:125488ms step_avg:258.21ms
+step:497/1480 train_time:125752ms step_avg:258.22ms
+step:498/1480 train_time:126020ms step_avg:258.24ms
+step:499/1480 train_time:126288ms step_avg:258.26ms
+step:500/1480 train_time:126554ms step_avg:258.27ms
+step:500/1480 val_loss:3.6880 train_time:126688ms step_avg:258.55ms
+step:501/1480 train_time:126821ms step_avg:258.29ms
+step:502/1480 train_time:127090ms step_avg:258.31ms
+step:503/1480 train_time:127359ms step_avg:258.34ms
+step:504/1480 train_time:127626ms step_avg:258.35ms
+step:505/1480 train_time:127891ms step_avg:258.37ms
+step:506/1480 train_time:128158ms step_avg:258.38ms
+step:507/1480 train_time:128425ms step_avg:258.40ms
+step:508/1480 train_time:128690ms step_avg:258.41ms
+step:509/1480 train_time:128954ms step_avg:258.43ms
+step:510/1480 train_time:129219ms step_avg:258.44ms
+step:511/1480 train_time:129487ms step_avg:258.46ms
+step:512/1480 train_time:129756ms step_avg:258.48ms
+step:513/1480 train_time:130024ms step_avg:258.50ms
+step:514/1480 train_time:130291ms step_avg:258.51ms
+step:515/1480 train_time:130558ms step_avg:258.53ms
+step:516/1480 train_time:130824ms step_avg:258.55ms
+step:517/1480 train_time:131088ms step_avg:258.56ms
+step:518/1480 train_time:131357ms step_avg:258.58ms
+step:519/1480 train_time:131625ms step_avg:258.60ms
+step:520/1480 train_time:131890ms step_avg:258.61ms
+step:521/1480 train_time:132156ms step_avg:258.62ms
+step:522/1480 train_time:132427ms step_avg:258.65ms
+step:523/1480 train_time:132691ms step_avg:258.66ms
+step:524/1480 train_time:132956ms step_avg:258.67ms
+step:525/1480 train_time:133225ms step_avg:258.69ms
+step:526/1480 train_time:133490ms step_avg:258.70ms
+step:527/1480 train_time:133757ms step_avg:258.72ms
+step:528/1480 train_time:134023ms step_avg:258.73ms
+step:529/1480 train_time:134289ms step_avg:258.75ms
+step:530/1480 train_time:134556ms step_avg:258.76ms
+step:531/1480 train_time:134822ms step_avg:258.78ms
+step:532/1480 train_time:135090ms step_avg:258.79ms
+step:533/1480 train_time:135356ms step_avg:258.81ms
+step:534/1480 train_time:135622ms step_avg:258.82ms
+step:535/1480 train_time:135888ms step_avg:258.83ms
+step:536/1480 train_time:136157ms step_avg:258.85ms
+step:537/1480 train_time:136425ms step_avg:258.87ms
+step:538/1480 train_time:136689ms step_avg:258.88ms
+step:539/1480 train_time:136957ms step_avg:258.90ms
+step:540/1480 train_time:137223ms step_avg:258.91ms
+step:541/1480 train_time:137489ms step_avg:258.92ms
+step:542/1480 train_time:137756ms step_avg:258.94ms
+step:543/1480 train_time:138025ms step_avg:258.96ms
+step:544/1480 train_time:138289ms step_avg:258.97ms
+step:545/1480 train_time:138556ms step_avg:258.98ms
+step:546/1480 train_time:138823ms step_avg:259.00ms
+step:547/1480 train_time:139089ms step_avg:259.01ms
+step:548/1480 train_time:139358ms step_avg:259.03ms
+step:549/1480 train_time:139624ms step_avg:259.04ms
+step:550/1480 train_time:139890ms step_avg:259.06ms
+step:551/1480 train_time:140159ms step_avg:259.07ms
+step:552/1480 train_time:140426ms step_avg:259.09ms
+step:553/1480 train_time:140691ms step_avg:259.10ms
+step:554/1480 train_time:140962ms step_avg:259.12ms
+step:555/1480 train_time:141232ms step_avg:259.14ms
+step:556/1480 train_time:141500ms step_avg:259.16ms
+step:557/1480 train_time:141770ms step_avg:259.18ms
+step:558/1480 train_time:142040ms step_avg:259.20ms
+step:559/1480 train_time:142309ms step_avg:259.22ms
+step:560/1480 train_time:142580ms step_avg:259.24ms
+step:561/1480 train_time:142850ms step_avg:259.26ms
+step:562/1480 train_time:143119ms step_avg:259.27ms
+step:563/1480 train_time:143388ms step_avg:259.29ms
+step:564/1480 train_time:143657ms step_avg:259.31ms
+step:565/1480 train_time:143927ms step_avg:259.33ms
+step:566/1480 train_time:144195ms step_avg:259.34ms
+step:567/1480 train_time:144464ms step_avg:259.36ms
+step:568/1480 train_time:144730ms step_avg:259.37ms
+step:569/1480 train_time:145001ms step_avg:259.39ms
+step:570/1480 train_time:145273ms step_avg:259.42ms
+step:571/1480 train_time:145543ms step_avg:259.44ms
+step:572/1480 train_time:145809ms step_avg:259.45ms
+step:573/1480 train_time:146083ms step_avg:259.47ms
+step:574/1480 train_time:146353ms step_avg:259.49ms
+step:575/1480 train_time:146624ms step_avg:259.51ms
+step:576/1480 train_time:146892ms step_avg:259.53ms
+step:577/1480 train_time:147162ms step_avg:259.54ms
+step:578/1480 train_time:147430ms step_avg:259.56ms
+step:579/1480 train_time:147699ms step_avg:259.58ms
+step:580/1480 train_time:147969ms step_avg:259.60ms
+step:581/1480 train_time:148238ms step_avg:259.61ms
+step:582/1480 train_time:148509ms step_avg:259.63ms
+step:583/1480 train_time:148780ms step_avg:259.65ms
+step:584/1480 train_time:149049ms step_avg:259.67ms
+step:585/1480 train_time:149321ms step_avg:259.69ms
+step:586/1480 train_time:149590ms step_avg:259.70ms
+step:587/1480 train_time:149862ms step_avg:259.73ms
+step:588/1480 train_time:150128ms step_avg:259.74ms
+step:589/1480 train_time:150398ms step_avg:259.75ms
+step:590/1480 train_time:150667ms step_avg:259.77ms
+step:591/1480 train_time:150934ms step_avg:259.78ms
+step:592/1480 train_time:151208ms step_avg:259.81ms
+step:593/1480 train_time:151479ms step_avg:259.83ms
+step:594/1480 train_time:151749ms step_avg:259.84ms
+step:595/1480 train_time:152018ms step_avg:259.86ms
+step:596/1480 train_time:152289ms step_avg:259.88ms
+step:597/1480 train_time:152556ms step_avg:259.89ms
+step:598/1480 train_time:152825ms step_avg:259.91ms
+step:599/1480 train_time:153091ms step_avg:259.92ms
+step:600/1480 train_time:153360ms step_avg:259.93ms
+step:601/1480 train_time:153631ms step_avg:259.95ms
+step:602/1480 train_time:153901ms step_avg:259.97ms
+step:603/1480 train_time:154170ms step_avg:259.98ms
+step:604/1480 train_time:154440ms step_avg:260.00ms
+step:605/1480 train_time:154710ms step_avg:260.02ms
+step:606/1480 train_time:154982ms step_avg:260.04ms
+step:607/1480 train_time:155256ms step_avg:260.06ms
+step:608/1480 train_time:155526ms step_avg:260.08ms
+step:609/1480 train_time:155792ms step_avg:260.09ms
+step:610/1480 train_time:156060ms step_avg:260.10ms
+step:611/1480 train_time:156330ms step_avg:260.12ms
+step:612/1480 train_time:156599ms step_avg:260.13ms
+step:613/1480 train_time:156868ms step_avg:260.15ms
+step:614/1480 train_time:157136ms step_avg:260.16ms
+step:615/1480 train_time:157408ms step_avg:260.18ms
+step:616/1480 train_time:157680ms step_avg:260.20ms
+step:617/1480 train_time:157948ms step_avg:260.21ms
+step:618/1480 train_time:158218ms step_avg:260.23ms
+step:619/1480 train_time:158489ms step_avg:260.25ms
+step:620/1480 train_time:158759ms step_avg:260.26ms
+step:621/1480 train_time:159028ms step_avg:260.27ms
+step:622/1480 train_time:159297ms step_avg:260.29ms
+step:623/1480 train_time:159572ms step_avg:260.31ms
+step:624/1480 train_time:159841ms step_avg:260.33ms
+step:625/1480 train_time:160109ms step_avg:260.34ms
+step:625/1480 val_loss:3.6085 train_time:160247ms step_avg:260.56ms
+step:626/1480 train_time:160382ms step_avg:260.36ms
+step:627/1480 train_time:160653ms step_avg:260.38ms
+step:628/1480 train_time:160921ms step_avg:260.39ms
+step:629/1480 train_time:161192ms step_avg:260.41ms
+step:630/1480 train_time:161460ms step_avg:260.42ms
+step:631/1480 train_time:161730ms step_avg:260.44ms
+step:632/1480 train_time:161999ms step_avg:260.45ms
+step:633/1480 train_time:162273ms step_avg:260.47ms
+step:634/1480 train_time:162542ms step_avg:260.48ms
+step:635/1480 train_time:162811ms step_avg:260.50ms
+step:636/1480 train_time:163078ms step_avg:260.51ms
+step:637/1480 train_time:163350ms step_avg:260.53ms
+step:638/1480 train_time:163615ms step_avg:260.53ms
+step:639/1480 train_time:163886ms step_avg:260.55ms
+step:640/1480 train_time:164153ms step_avg:260.56ms
+step:641/1480 train_time:164423ms step_avg:260.58ms
+step:642/1480 train_time:164692ms step_avg:260.59ms
+step:643/1480 train_time:164962ms step_avg:260.60ms
+step:644/1480 train_time:165231ms step_avg:260.62ms
+step:645/1480 train_time:165503ms step_avg:260.64ms
+step:646/1480 train_time:165773ms step_avg:260.65ms
+step:647/1480 train_time:166041ms step_avg:260.66ms
+step:648/1480 train_time:166312ms step_avg:260.68ms
+step:649/1480 train_time:166577ms step_avg:260.68ms
+step:650/1480 train_time:166846ms step_avg:260.70ms
+step:651/1480 train_time:167116ms step_avg:260.71ms
+step:652/1480 train_time:167386ms step_avg:260.73ms
+step:653/1480 train_time:167653ms step_avg:260.74ms
+step:654/1480 train_time:167922ms step_avg:260.75ms
+step:655/1480 train_time:168192ms step_avg:260.76ms
+step:656/1480 train_time:168462ms step_avg:260.78ms
+step:657/1480 train_time:168732ms step_avg:260.79ms
+step:658/1480 train_time:169006ms step_avg:260.81ms
+step:659/1480 train_time:169276ms step_avg:260.83ms
+step:660/1480 train_time:169549ms step_avg:260.85ms
+step:661/1480 train_time:169819ms step_avg:260.86ms
+step:662/1480 train_time:170091ms step_avg:260.88ms
+step:663/1480 train_time:170362ms step_avg:260.89ms
+step:664/1480 train_time:170634ms step_avg:260.91ms
+step:665/1480 train_time:170908ms step_avg:260.93ms
+step:666/1480 train_time:171176ms step_avg:260.94ms
+step:667/1480 train_time:171448ms step_avg:260.96ms
+step:668/1480 train_time:171721ms step_avg:260.97ms
+step:669/1480 train_time:172000ms step_avg:261.00ms
+step:670/1480 train_time:172273ms step_avg:261.02ms
+step:671/1480 train_time:172545ms step_avg:261.04ms
+step:672/1480 train_time:172816ms step_avg:261.05ms
+step:673/1480 train_time:173089ms step_avg:261.07ms
+step:674/1480 train_time:173362ms step_avg:261.09ms
+step:675/1480 train_time:173635ms step_avg:261.11ms
+step:676/1480 train_time:173910ms step_avg:261.13ms
+step:677/1480 train_time:174179ms step_avg:261.14ms
+step:678/1480 train_time:174449ms step_avg:261.15ms
+step:679/1480 train_time:174721ms step_avg:261.17ms
+step:680/1480 train_time:174993ms step_avg:261.18ms
+step:681/1480 train_time:175264ms step_avg:261.20ms
+step:682/1480 train_time:175541ms step_avg:261.22ms
+step:683/1480 train_time:175811ms step_avg:261.23ms
+step:684/1480 train_time:176081ms step_avg:261.25ms
+step:685/1480 train_time:176352ms step_avg:261.26ms
+step:686/1480 train_time:176622ms step_avg:261.28ms
+step:687/1480 train_time:176892ms step_avg:261.29ms
+step:688/1480 train_time:177169ms step_avg:261.31ms
+step:689/1480 train_time:177439ms step_avg:261.32ms
+step:690/1480 train_time:177711ms step_avg:261.34ms
+step:691/1480 train_time:177981ms step_avg:261.35ms
+step:692/1480 train_time:178251ms step_avg:261.36ms
+step:693/1480 train_time:178523ms step_avg:261.38ms
+step:694/1480 train_time:178795ms step_avg:261.40ms
+step:695/1480 train_time:179068ms step_avg:261.41ms
+step:696/1480 train_time:179337ms step_avg:261.42ms
+step:697/1480 train_time:179611ms step_avg:261.44ms
+step:698/1480 train_time:179881ms step_avg:261.45ms
+step:699/1480 train_time:180152ms step_avg:261.47ms
+step:700/1480 train_time:180423ms step_avg:261.48ms
+step:701/1480 train_time:180694ms step_avg:261.50ms
+step:702/1480 train_time:180967ms step_avg:261.51ms
+step:703/1480 train_time:181235ms step_avg:261.52ms
+step:704/1480 train_time:181507ms step_avg:261.54ms
+step:705/1480 train_time:181780ms step_avg:261.55ms
+step:706/1480 train_time:182054ms step_avg:261.57ms
+step:707/1480 train_time:182326ms step_avg:261.59ms
+step:708/1480 train_time:182595ms step_avg:261.60ms
+step:709/1480 train_time:182868ms step_avg:261.61ms
+step:710/1480 train_time:183136ms step_avg:261.62ms
+step:711/1480 train_time:183410ms step_avg:261.64ms
+step:712/1480 train_time:183686ms step_avg:261.66ms
+step:713/1480 train_time:183958ms step_avg:261.68ms
+step:714/1480 train_time:184227ms step_avg:261.69ms
+step:715/1480 train_time:184497ms step_avg:261.70ms
+step:716/1480 train_time:184769ms step_avg:261.71ms
+step:717/1480 train_time:185041ms step_avg:261.73ms
+step:718/1480 train_time:185314ms step_avg:261.74ms
+step:719/1480 train_time:185585ms step_avg:261.76ms
+step:720/1480 train_time:185857ms step_avg:261.77ms
+step:721/1480 train_time:186126ms step_avg:261.78ms
+step:722/1480 train_time:186399ms step_avg:261.80ms
+step:723/1480 train_time:186670ms step_avg:261.81ms
+step:724/1480 train_time:186940ms step_avg:261.82ms
+step:725/1480 train_time:187212ms step_avg:261.84ms
+step:726/1480 train_time:187488ms step_avg:261.85ms
+step:727/1480 train_time:187759ms step_avg:261.87ms
+step:728/1480 train_time:188030ms step_avg:261.88ms
+step:729/1480 train_time:188300ms step_avg:261.89ms
+step:730/1480 train_time:188573ms step_avg:261.91ms
+step:731/1480 train_time:188845ms step_avg:261.92ms
+step:732/1480 train_time:189113ms step_avg:261.93ms
+step:733/1480 train_time:189385ms step_avg:261.94ms
+step:734/1480 train_time:189656ms step_avg:261.96ms
+step:735/1480 train_time:189926ms step_avg:261.97ms
+step:736/1480 train_time:190198ms step_avg:261.98ms
+step:737/1480 train_time:190470ms step_avg:261.99ms
+step:738/1480 train_time:190738ms step_avg:262.00ms
+step:739/1480 train_time:191011ms step_avg:262.02ms
+step:740/1480 train_time:191285ms step_avg:262.03ms
+step:741/1480 train_time:191552ms step_avg:262.04ms
+step:742/1480 train_time:191824ms step_avg:262.05ms
+step:743/1480 train_time:192096ms step_avg:262.07ms
+step:744/1480 train_time:192370ms step_avg:262.08ms
+step:745/1480 train_time:192643ms step_avg:262.10ms
+step:746/1480 train_time:192914ms step_avg:262.11ms
+step:747/1480 train_time:193187ms step_avg:262.13ms
+step:748/1480 train_time:193461ms step_avg:262.14ms
+step:749/1480 train_time:193734ms step_avg:262.16ms
+step:750/1480 train_time:194007ms step_avg:262.17ms
+step:750/1480 val_loss:3.5517 train_time:194143ms step_avg:262.36ms
+step:751/1480 train_time:194279ms step_avg:262.19ms
+step:752/1480 train_time:194553ms step_avg:262.20ms
+step:753/1480 train_time:194825ms step_avg:262.21ms
+step:754/1480 train_time:195097ms step_avg:262.23ms
+step:755/1480 train_time:195371ms step_avg:262.24ms
+step:756/1480 train_time:195646ms step_avg:262.26ms
+step:757/1480 train_time:195920ms step_avg:262.28ms
+step:758/1480 train_time:196191ms step_avg:262.29ms
+step:759/1480 train_time:196462ms step_avg:262.30ms
+step:760/1480 train_time:196734ms step_avg:262.31ms
+step:761/1480 train_time:197006ms step_avg:262.33ms
+step:762/1480 train_time:197279ms step_avg:262.34ms
+step:763/1480 train_time:197549ms step_avg:262.35ms
+step:764/1480 train_time:197821ms step_avg:262.36ms
+step:765/1480 train_time:198090ms step_avg:262.37ms
+step:766/1480 train_time:198360ms step_avg:262.38ms
+step:767/1480 train_time:198630ms step_avg:262.39ms
+step:768/1480 train_time:198902ms step_avg:262.40ms
+step:769/1480 train_time:199178ms step_avg:262.42ms
+step:770/1480 train_time:199449ms step_avg:262.43ms
+step:771/1480 train_time:199721ms step_avg:262.45ms
+step:772/1480 train_time:199993ms step_avg:262.46ms
+step:773/1480 train_time:200262ms step_avg:262.47ms
+step:774/1480 train_time:200535ms step_avg:262.48ms
+step:775/1480 train_time:200805ms step_avg:262.49ms
+step:776/1480 train_time:201080ms step_avg:262.51ms
+step:777/1480 train_time:201353ms step_avg:262.52ms
+step:778/1480 train_time:201622ms step_avg:262.53ms
+step:779/1480 train_time:201896ms step_avg:262.54ms
+step:780/1480 train_time:202169ms step_avg:262.56ms
+step:781/1480 train_time:202446ms step_avg:262.58ms
+step:782/1480 train_time:202720ms step_avg:262.59ms
+step:783/1480 train_time:202992ms step_avg:262.60ms
+step:784/1480 train_time:203264ms step_avg:262.61ms
+step:785/1480 train_time:203536ms step_avg:262.63ms
+step:786/1480 train_time:203810ms step_avg:262.64ms
+step:787/1480 train_time:204083ms step_avg:262.65ms
+step:788/1480 train_time:204358ms step_avg:262.67ms
+step:789/1480 train_time:204630ms step_avg:262.68ms
+step:790/1480 train_time:204908ms step_avg:262.70ms
+step:791/1480 train_time:205188ms step_avg:262.73ms
+step:792/1480 train_time:205461ms step_avg:262.74ms
+step:793/1480 train_time:205734ms step_avg:262.75ms
+step:794/1480 train_time:206008ms step_avg:262.76ms
+step:795/1480 train_time:206282ms step_avg:262.78ms
+step:796/1480 train_time:206557ms step_avg:262.79ms
+step:797/1480 train_time:206827ms step_avg:262.80ms
+step:798/1480 train_time:207100ms step_avg:262.82ms
+step:799/1480 train_time:207381ms step_avg:262.84ms
+step:800/1480 train_time:207651ms step_avg:262.85ms
+step:801/1480 train_time:207925ms step_avg:262.86ms
+step:802/1480 train_time:208202ms step_avg:262.88ms
+step:803/1480 train_time:208476ms step_avg:262.89ms
+step:804/1480 train_time:208745ms step_avg:262.90ms
+step:805/1480 train_time:209021ms step_avg:262.92ms
+step:806/1480 train_time:209295ms step_avg:262.93ms
+step:807/1480 train_time:209567ms step_avg:262.94ms
+step:808/1480 train_time:209844ms step_avg:262.96ms
+step:809/1480 train_time:210118ms step_avg:262.98ms
+step:810/1480 train_time:210388ms step_avg:262.98ms
+step:811/1480 train_time:210659ms step_avg:263.00ms
+step:812/1480 train_time:210932ms step_avg:263.01ms
+step:813/1480 train_time:211202ms step_avg:263.02ms
+step:814/1480 train_time:211476ms step_avg:263.03ms
+step:815/1480 train_time:211748ms step_avg:263.04ms
+step:816/1480 train_time:212021ms step_avg:263.05ms
+step:817/1480 train_time:212297ms step_avg:263.07ms
+step:818/1480 train_time:212565ms step_avg:263.08ms
+step:819/1480 train_time:212838ms step_avg:263.09ms
+step:820/1480 train_time:213117ms step_avg:263.11ms
+step:821/1480 train_time:213386ms step_avg:263.11ms
+step:822/1480 train_time:213660ms step_avg:263.13ms
+step:823/1480 train_time:213930ms step_avg:263.14ms
+step:824/1480 train_time:214207ms step_avg:263.15ms
+step:825/1480 train_time:214484ms step_avg:263.17ms
+step:826/1480 train_time:214759ms step_avg:263.19ms
+step:827/1480 train_time:215033ms step_avg:263.20ms
+step:828/1480 train_time:215307ms step_avg:263.21ms
+step:829/1480 train_time:215582ms step_avg:263.23ms
+step:830/1480 train_time:215857ms step_avg:263.24ms
+step:831/1480 train_time:216134ms step_avg:263.26ms
+step:832/1480 train_time:216409ms step_avg:263.27ms
+step:833/1480 train_time:216684ms step_avg:263.29ms
+step:834/1480 train_time:216958ms step_avg:263.30ms
+step:835/1480 train_time:217231ms step_avg:263.31ms
+step:836/1480 train_time:217507ms step_avg:263.33ms
+step:837/1480 train_time:217784ms step_avg:263.34ms
+step:838/1480 train_time:218058ms step_avg:263.36ms
+step:839/1480 train_time:218333ms step_avg:263.37ms
+step:840/1480 train_time:218609ms step_avg:263.38ms
+step:841/1480 train_time:218884ms step_avg:263.40ms
+step:842/1480 train_time:219159ms step_avg:263.41ms
+step:843/1480 train_time:219429ms step_avg:263.42ms
+step:844/1480 train_time:219701ms step_avg:263.43ms
+step:845/1480 train_time:219977ms step_avg:263.44ms
+step:846/1480 train_time:220247ms step_avg:263.45ms
+step:847/1480 train_time:220521ms step_avg:263.47ms
+step:848/1480 train_time:220794ms step_avg:263.48ms
+step:849/1480 train_time:221065ms step_avg:263.49ms
+step:850/1480 train_time:221335ms step_avg:263.49ms
+step:851/1480 train_time:221611ms step_avg:263.51ms
+step:852/1480 train_time:221884ms step_avg:263.52ms
+step:853/1480 train_time:222157ms step_avg:263.53ms
+step:854/1480 train_time:222430ms step_avg:263.54ms
+step:855/1480 train_time:222702ms step_avg:263.55ms
+step:856/1480 train_time:222976ms step_avg:263.57ms
+step:857/1480 train_time:223251ms step_avg:263.58ms
+step:858/1480 train_time:223526ms step_avg:263.59ms
+step:859/1480 train_time:223799ms step_avg:263.60ms
+step:860/1480 train_time:224069ms step_avg:263.61ms
+step:861/1480 train_time:224349ms step_avg:263.63ms
+step:862/1480 train_time:224631ms step_avg:263.65ms
+step:863/1480 train_time:224914ms step_avg:263.67ms
+step:864/1480 train_time:225189ms step_avg:263.69ms
+step:865/1480 train_time:225460ms step_avg:263.70ms
+step:866/1480 train_time:225736ms step_avg:263.71ms
+step:867/1480 train_time:226007ms step_avg:263.72ms
+step:868/1480 train_time:226279ms step_avg:263.73ms
+step:869/1480 train_time:226552ms step_avg:263.74ms
+step:870/1480 train_time:226825ms step_avg:263.75ms
+step:871/1480 train_time:227099ms step_avg:263.76ms
+step:872/1480 train_time:227375ms step_avg:263.78ms
+step:873/1480 train_time:227646ms step_avg:263.78ms
+step:874/1480 train_time:227923ms step_avg:263.80ms
+step:875/1480 train_time:228197ms step_avg:263.81ms
+step:875/1480 val_loss:3.5069 train_time:228336ms step_avg:263.97ms
+step:876/1480 train_time:228471ms step_avg:263.82ms
+step:877/1480 train_time:228754ms step_avg:263.84ms
+step:878/1480 train_time:229029ms step_avg:263.86ms
+step:879/1480 train_time:229301ms step_avg:263.87ms
+step:880/1480 train_time:229573ms step_avg:263.88ms
+step:881/1480 train_time:229846ms step_avg:263.89ms
+step:882/1480 train_time:230121ms step_avg:263.90ms
+step:883/1480 train_time:230398ms step_avg:263.92ms
+step:884/1480 train_time:230675ms step_avg:263.93ms
+step:885/1480 train_time:230949ms step_avg:263.94ms
+step:886/1480 train_time:231230ms step_avg:263.96ms
+step:887/1480 train_time:231508ms step_avg:263.98ms
+step:888/1480 train_time:231791ms step_avg:264.00ms
+step:889/1480 train_time:232068ms step_avg:264.01ms
+step:890/1480 train_time:232338ms step_avg:264.02ms
+step:891/1480 train_time:232612ms step_avg:264.03ms
+step:892/1480 train_time:232888ms step_avg:264.05ms
+step:893/1480 train_time:233159ms step_avg:264.05ms
+step:894/1480 train_time:233434ms step_avg:264.07ms
+step:895/1480 train_time:233710ms step_avg:264.08ms
+step:896/1480 train_time:233985ms step_avg:264.09ms
+step:897/1480 train_time:234263ms step_avg:264.11ms
+step:898/1480 train_time:234541ms step_avg:264.12ms
+step:899/1480 train_time:234819ms step_avg:264.14ms
+step:900/1480 train_time:235094ms step_avg:264.15ms
+step:901/1480 train_time:235369ms step_avg:264.16ms
+step:902/1480 train_time:235645ms step_avg:264.18ms
+step:903/1480 train_time:235930ms step_avg:264.20ms
+step:904/1480 train_time:236202ms step_avg:264.21ms
+step:905/1480 train_time:236470ms step_avg:264.21ms
+step:906/1480 train_time:236746ms step_avg:264.23ms
+step:907/1480 train_time:237022ms step_avg:264.24ms
+step:908/1480 train_time:237297ms step_avg:264.25ms
+step:909/1480 train_time:237569ms step_avg:264.26ms
+step:910/1480 train_time:237852ms step_avg:264.28ms
+step:911/1480 train_time:238128ms step_avg:264.29ms
+step:912/1480 train_time:238408ms step_avg:264.31ms
+step:913/1480 train_time:238687ms step_avg:264.33ms
+step:914/1480 train_time:238959ms step_avg:264.34ms
+step:915/1480 train_time:239240ms step_avg:264.35ms
+step:916/1480 train_time:239516ms step_avg:264.37ms
+step:917/1480 train_time:239792ms step_avg:264.38ms
+step:918/1480 train_time:240070ms step_avg:264.39ms
+step:919/1480 train_time:240347ms step_avg:264.41ms
+step:920/1480 train_time:240625ms step_avg:264.42ms
+step:921/1480 train_time:240899ms step_avg:264.43ms
+step:922/1480 train_time:241178ms step_avg:264.45ms
+step:923/1480 train_time:241451ms step_avg:264.46ms
+step:924/1480 train_time:241728ms step_avg:264.47ms
+step:925/1480 train_time:242002ms step_avg:264.48ms
+step:926/1480 train_time:242274ms step_avg:264.49ms
+step:927/1480 train_time:242547ms step_avg:264.50ms
+step:928/1480 train_time:242822ms step_avg:264.51ms
+step:929/1480 train_time:243095ms step_avg:264.52ms
+step:930/1480 train_time:243369ms step_avg:264.53ms
+step:931/1480 train_time:243642ms step_avg:264.54ms
+step:932/1480 train_time:243922ms step_avg:264.56ms
+step:933/1480 train_time:244202ms step_avg:264.57ms
+step:934/1480 train_time:244476ms step_avg:264.58ms
+step:935/1480 train_time:244759ms step_avg:264.60ms
+step:936/1480 train_time:245034ms step_avg:264.62ms
+step:937/1480 train_time:245311ms step_avg:264.63ms
+step:938/1480 train_time:245587ms step_avg:264.64ms
+step:939/1480 train_time:245865ms step_avg:264.66ms
+step:940/1480 train_time:246140ms step_avg:264.67ms
+step:941/1480 train_time:246418ms step_avg:264.68ms
+step:942/1480 train_time:246691ms step_avg:264.69ms
+step:943/1480 train_time:246968ms step_avg:264.70ms
+step:944/1480 train_time:247251ms step_avg:264.72ms
+step:945/1480 train_time:247530ms step_avg:264.74ms
+step:946/1480 train_time:247809ms step_avg:264.75ms
+step:947/1480 train_time:248085ms step_avg:264.77ms
+step:948/1480 train_time:248363ms step_avg:264.78ms
+step:949/1480 train_time:248638ms step_avg:264.79ms
+step:950/1480 train_time:248909ms step_avg:264.80ms
+step:951/1480 train_time:249189ms step_avg:264.81ms
+step:952/1480 train_time:249464ms step_avg:264.82ms
+step:953/1480 train_time:249745ms step_avg:264.84ms
+step:954/1480 train_time:250027ms step_avg:264.86ms
+step:955/1480 train_time:250304ms step_avg:264.87ms
+step:956/1480 train_time:250579ms step_avg:264.88ms
+step:957/1480 train_time:250864ms step_avg:264.90ms
+step:958/1480 train_time:251145ms step_avg:264.92ms
+step:959/1480 train_time:251416ms step_avg:264.93ms
+step:960/1480 train_time:251691ms step_avg:264.94ms
+step:961/1480 train_time:251968ms step_avg:264.95ms
+step:962/1480 train_time:252244ms step_avg:264.96ms
+step:963/1480 train_time:252525ms step_avg:264.98ms
+step:964/1480 train_time:252799ms step_avg:264.99ms
+step:965/1480 train_time:253070ms step_avg:264.99ms
+step:966/1480 train_time:253346ms step_avg:265.01ms
+step:967/1480 train_time:253618ms step_avg:265.01ms
+step:968/1480 train_time:253898ms step_avg:265.03ms
+step:969/1480 train_time:254171ms step_avg:265.04ms
+step:970/1480 train_time:254444ms step_avg:265.05ms
+step:971/1480 train_time:254721ms step_avg:265.06ms
+step:972/1480 train_time:254994ms step_avg:265.07ms
+step:973/1480 train_time:255267ms step_avg:265.07ms
+step:974/1480 train_time:255547ms step_avg:265.09ms
+step:975/1480 train_time:255820ms step_avg:265.10ms
+step:976/1480 train_time:256092ms step_avg:265.11ms
+step:977/1480 train_time:256368ms step_avg:265.12ms
+step:978/1480 train_time:256644ms step_avg:265.13ms
+step:979/1480 train_time:256922ms step_avg:265.14ms
+step:980/1480 train_time:257199ms step_avg:265.15ms
+step:981/1480 train_time:257479ms step_avg:265.17ms
+step:982/1480 train_time:257757ms step_avg:265.18ms
+step:983/1480 train_time:258034ms step_avg:265.19ms
+step:984/1480 train_time:258309ms step_avg:265.20ms
+step:985/1480 train_time:258588ms step_avg:265.22ms
+step:986/1480 train_time:258863ms step_avg:265.23ms
+step:987/1480 train_time:259136ms step_avg:265.24ms
+step:988/1480 train_time:259414ms step_avg:265.25ms
+step:989/1480 train_time:259691ms step_avg:265.26ms
+step:990/1480 train_time:259969ms step_avg:265.27ms
+step:991/1480 train_time:260245ms step_avg:265.29ms
+step:992/1480 train_time:260528ms step_avg:265.30ms
+step:993/1480 train_time:260815ms step_avg:265.33ms
+step:994/1480 train_time:261089ms step_avg:265.33ms
+step:995/1480 train_time:261363ms step_avg:265.34ms
+step:996/1480 train_time:261640ms step_avg:265.35ms
+step:997/1480 train_time:261922ms step_avg:265.37ms
+step:998/1480 train_time:262194ms step_avg:265.38ms
+step:999/1480 train_time:262469ms step_avg:265.39ms
+step:1000/1480 train_time:262748ms step_avg:265.40ms
+step:1000/1480 val_loss:3.4433 train_time:262890ms step_avg:265.55ms
+step:1001/1480 train_time:263027ms step_avg:265.42ms
+step:1002/1480 train_time:263309ms step_avg:265.43ms
+step:1003/1480 train_time:263594ms step_avg:265.45ms
+step:1004/1480 train_time:263869ms step_avg:265.46ms
+step:1005/1480 train_time:264147ms step_avg:265.47ms
+step:1006/1480 train_time:264423ms step_avg:265.49ms
+step:1007/1480 train_time:264701ms step_avg:265.50ms
+step:1008/1480 train_time:264979ms step_avg:265.51ms
+step:1009/1480 train_time:265263ms step_avg:265.53ms
+step:1010/1480 train_time:265540ms step_avg:265.54ms
+step:1011/1480 train_time:265812ms step_avg:265.55ms
+step:1012/1480 train_time:266088ms step_avg:265.56ms
+step:1013/1480 train_time:266371ms step_avg:265.57ms
+step:1014/1480 train_time:266651ms step_avg:265.59ms
+step:1015/1480 train_time:266938ms step_avg:265.61ms
+step:1016/1480 train_time:267218ms step_avg:265.62ms
+step:1017/1480 train_time:267499ms step_avg:265.64ms
+step:1018/1480 train_time:267779ms step_avg:265.65ms
+step:1019/1480 train_time:268059ms step_avg:265.67ms
+step:1020/1480 train_time:268339ms step_avg:265.68ms
+step:1021/1480 train_time:268614ms step_avg:265.69ms
+step:1022/1480 train_time:268896ms step_avg:265.71ms
+step:1023/1480 train_time:269172ms step_avg:265.72ms
+step:1024/1480 train_time:269452ms step_avg:265.73ms
+step:1025/1480 train_time:269733ms step_avg:265.75ms
+step:1026/1480 train_time:270005ms step_avg:265.75ms
+step:1027/1480 train_time:270279ms step_avg:265.76ms
+step:1028/1480 train_time:270560ms step_avg:265.78ms
+step:1029/1480 train_time:270842ms step_avg:265.79ms
+step:1030/1480 train_time:271119ms step_avg:265.80ms
+step:1031/1480 train_time:271393ms step_avg:265.81ms
+step:1032/1480 train_time:271679ms step_avg:265.83ms
+step:1033/1480 train_time:271955ms step_avg:265.84ms
+step:1034/1480 train_time:272234ms step_avg:265.85ms
+step:1035/1480 train_time:272514ms step_avg:265.87ms
+step:1036/1480 train_time:272791ms step_avg:265.88ms
+step:1037/1480 train_time:273067ms step_avg:265.89ms
+step:1038/1480 train_time:273340ms step_avg:265.89ms
+step:1039/1480 train_time:273624ms step_avg:265.91ms
+step:1040/1480 train_time:273900ms step_avg:265.92ms
+step:1041/1480 train_time:274180ms step_avg:265.94ms
+step:1042/1480 train_time:274456ms step_avg:265.95ms
+step:1043/1480 train_time:274732ms step_avg:265.96ms
+step:1044/1480 train_time:275006ms step_avg:265.96ms
+step:1045/1480 train_time:275284ms step_avg:265.97ms
+step:1046/1480 train_time:275560ms step_avg:265.98ms
+step:1047/1480 train_time:275839ms step_avg:266.00ms
+step:1048/1480 train_time:276115ms step_avg:266.01ms
+step:1049/1480 train_time:276392ms step_avg:266.02ms
+step:1050/1480 train_time:276677ms step_avg:266.04ms
+step:1051/1480 train_time:276958ms step_avg:266.05ms
+step:1052/1480 train_time:277237ms step_avg:266.06ms
+step:1053/1480 train_time:277512ms step_avg:266.07ms
+step:1054/1480 train_time:277787ms step_avg:266.08ms
+step:1055/1480 train_time:278061ms step_avg:266.09ms
+step:1056/1480 train_time:278340ms step_avg:266.10ms
+step:1057/1480 train_time:278620ms step_avg:266.11ms
+step:1058/1480 train_time:278900ms step_avg:266.13ms
+step:1059/1480 train_time:279182ms step_avg:266.14ms
+step:1060/1480 train_time:279459ms step_avg:266.15ms
+step:1061/1480 train_time:279733ms step_avg:266.16ms
+step:1062/1480 train_time:280010ms step_avg:266.17ms
+step:1063/1480 train_time:280287ms step_avg:266.18ms
+step:1064/1480 train_time:280560ms step_avg:266.19ms
+step:1065/1480 train_time:280839ms step_avg:266.20ms
+step:1066/1480 train_time:281115ms step_avg:266.21ms
+step:1067/1480 train_time:281392ms step_avg:266.22ms
+step:1068/1480 train_time:281664ms step_avg:266.22ms
+step:1069/1480 train_time:281948ms step_avg:266.24ms
+step:1070/1480 train_time:282219ms step_avg:266.24ms
+step:1071/1480 train_time:282501ms step_avg:266.26ms
+step:1072/1480 train_time:282778ms step_avg:266.27ms
+step:1073/1480 train_time:283054ms step_avg:266.28ms
+step:1074/1480 train_time:283331ms step_avg:266.29ms
+step:1075/1480 train_time:283615ms step_avg:266.31ms
+step:1076/1480 train_time:283897ms step_avg:266.32ms
+step:1077/1480 train_time:284177ms step_avg:266.33ms
+step:1078/1480 train_time:284461ms step_avg:266.35ms
+step:1079/1480 train_time:284739ms step_avg:266.36ms
+step:1080/1480 train_time:285020ms step_avg:266.37ms
+step:1081/1480 train_time:285298ms step_avg:266.39ms
+step:1082/1480 train_time:285578ms step_avg:266.40ms
+step:1083/1480 train_time:285857ms step_avg:266.41ms
+step:1084/1480 train_time:286129ms step_avg:266.41ms
+step:1085/1480 train_time:286410ms step_avg:266.43ms
+step:1086/1480 train_time:286689ms step_avg:266.44ms
+step:1087/1480 train_time:286967ms step_avg:266.45ms
+step:1088/1480 train_time:287243ms step_avg:266.46ms
+step:1089/1480 train_time:287524ms step_avg:266.47ms
+step:1090/1480 train_time:287805ms step_avg:266.49ms
+step:1091/1480 train_time:288083ms step_avg:266.50ms
+step:1092/1480 train_time:288365ms step_avg:266.51ms
+step:1093/1480 train_time:288641ms step_avg:266.52ms
+step:1094/1480 train_time:288918ms step_avg:266.53ms
+step:1095/1480 train_time:289195ms step_avg:266.54ms
+step:1096/1480 train_time:289472ms step_avg:266.55ms
+step:1097/1480 train_time:289753ms step_avg:266.56ms
+step:1098/1480 train_time:290033ms step_avg:266.57ms
+step:1099/1480 train_time:290316ms step_avg:266.59ms
+step:1100/1480 train_time:290600ms step_avg:266.61ms
+step:1101/1480 train_time:290881ms step_avg:266.62ms
+step:1102/1480 train_time:291162ms step_avg:266.63ms
+step:1103/1480 train_time:291450ms step_avg:266.65ms
+step:1104/1480 train_time:291724ms step_avg:266.66ms
+step:1105/1480 train_time:292003ms step_avg:266.67ms
+step:1106/1480 train_time:292279ms step_avg:266.68ms
+step:1107/1480 train_time:292562ms step_avg:266.69ms
+step:1108/1480 train_time:292838ms step_avg:266.70ms
+step:1109/1480 train_time:293114ms step_avg:266.71ms
+step:1110/1480 train_time:293392ms step_avg:266.72ms
+step:1111/1480 train_time:293668ms step_avg:266.73ms
+step:1112/1480 train_time:293948ms step_avg:266.74ms
+step:1113/1480 train_time:294242ms step_avg:266.77ms
+step:1114/1480 train_time:294523ms step_avg:266.78ms
+step:1115/1480 train_time:294804ms step_avg:266.79ms
+step:1116/1480 train_time:295080ms step_avg:266.80ms
+step:1117/1480 train_time:295365ms step_avg:266.82ms
+step:1118/1480 train_time:295652ms step_avg:266.83ms
+step:1119/1480 train_time:295930ms step_avg:266.84ms
+step:1120/1480 train_time:296208ms step_avg:266.85ms
+step:1121/1480 train_time:296489ms step_avg:266.87ms
+step:1122/1480 train_time:296771ms step_avg:266.88ms
+step:1123/1480 train_time:297046ms step_avg:266.89ms
+step:1124/1480 train_time:297328ms step_avg:266.90ms
+step:1125/1480 train_time:297605ms step_avg:266.91ms
+step:1125/1480 val_loss:3.3872 train_time:297743ms step_avg:267.03ms
+step:1126/1480 train_time:297881ms step_avg:266.92ms
+step:1127/1480 train_time:298167ms step_avg:266.94ms
+step:1128/1480 train_time:298449ms step_avg:266.95ms
+step:1129/1480 train_time:298735ms step_avg:266.97ms
+step:1130/1480 train_time:299011ms step_avg:266.97ms
+step:1131/1480 train_time:299302ms step_avg:267.00ms
+step:1132/1480 train_time:299575ms step_avg:267.00ms
+step:1133/1480 train_time:299854ms step_avg:267.01ms
+step:1134/1480 train_time:300132ms step_avg:267.02ms
+step:1135/1480 train_time:300412ms step_avg:267.03ms
+step:1136/1480 train_time:300690ms step_avg:267.04ms
+step:1137/1480 train_time:300970ms step_avg:267.05ms
+step:1138/1480 train_time:301248ms step_avg:267.06ms
+step:1139/1480 train_time:301528ms step_avg:267.08ms
+step:1140/1480 train_time:301806ms step_avg:267.08ms
+step:1141/1480 train_time:302090ms step_avg:267.10ms
+step:1142/1480 train_time:302367ms step_avg:267.11ms
+step:1143/1480 train_time:302647ms step_avg:267.12ms
+step:1144/1480 train_time:302928ms step_avg:267.13ms
+step:1145/1480 train_time:303203ms step_avg:267.14ms
+step:1146/1480 train_time:303483ms step_avg:267.15ms
+step:1147/1480 train_time:303763ms step_avg:267.16ms
+step:1148/1480 train_time:304043ms step_avg:267.17ms
+step:1149/1480 train_time:304327ms step_avg:267.19ms
+step:1150/1480 train_time:304608ms step_avg:267.20ms
+step:1151/1480 train_time:304891ms step_avg:267.21ms
+step:1152/1480 train_time:305174ms step_avg:267.23ms
+step:1153/1480 train_time:305452ms step_avg:267.24ms
+step:1154/1480 train_time:305729ms step_avg:267.25ms
+step:1155/1480 train_time:306011ms step_avg:267.26ms
+step:1156/1480 train_time:306299ms step_avg:267.28ms
+step:1157/1480 train_time:306576ms step_avg:267.29ms
+step:1158/1480 train_time:306851ms step_avg:267.29ms
+step:1159/1480 train_time:307129ms step_avg:267.30ms
+step:1160/1480 train_time:307404ms step_avg:267.31ms
+step:1161/1480 train_time:307687ms step_avg:267.32ms
+step:1162/1480 train_time:307968ms step_avg:267.33ms
+step:1163/1480 train_time:308246ms step_avg:267.34ms
+step:1164/1480 train_time:308523ms step_avg:267.35ms
+step:1165/1480 train_time:308797ms step_avg:267.36ms
+step:1166/1480 train_time:309079ms step_avg:267.37ms
+step:1167/1480 train_time:309361ms step_avg:267.38ms
+step:1168/1480 train_time:309639ms step_avg:267.39ms
+step:1169/1480 train_time:309918ms step_avg:267.40ms
+step:1170/1480 train_time:310195ms step_avg:267.41ms
+step:1171/1480 train_time:310473ms step_avg:267.42ms
+step:1172/1480 train_time:310749ms step_avg:267.43ms
+step:1173/1480 train_time:311028ms step_avg:267.44ms
+step:1174/1480 train_time:311311ms step_avg:267.45ms
+step:1175/1480 train_time:311593ms step_avg:267.46ms
+step:1176/1480 train_time:311875ms step_avg:267.47ms
+step:1177/1480 train_time:312167ms step_avg:267.50ms
+step:1178/1480 train_time:312447ms step_avg:267.51ms
+step:1179/1480 train_time:312720ms step_avg:267.51ms
+step:1180/1480 train_time:313011ms step_avg:267.53ms
+step:1181/1480 train_time:313288ms step_avg:267.54ms
+step:1182/1480 train_time:313570ms step_avg:267.55ms
+step:1183/1480 train_time:313850ms step_avg:267.56ms
+step:1184/1480 train_time:314129ms step_avg:267.57ms
+step:1185/1480 train_time:314411ms step_avg:267.58ms
+step:1186/1480 train_time:314688ms step_avg:267.59ms
+step:1187/1480 train_time:314974ms step_avg:267.61ms
+step:1188/1480 train_time:315250ms step_avg:267.61ms
+step:1189/1480 train_time:315533ms step_avg:267.63ms
+step:1190/1480 train_time:315813ms step_avg:267.64ms
+step:1191/1480 train_time:316094ms step_avg:267.65ms
+step:1192/1480 train_time:316370ms step_avg:267.66ms
+step:1193/1480 train_time:316648ms step_avg:267.66ms
+step:1194/1480 train_time:316924ms step_avg:267.67ms
+step:1195/1480 train_time:317207ms step_avg:267.69ms
+step:1196/1480 train_time:317498ms step_avg:267.71ms
+step:1197/1480 train_time:317777ms step_avg:267.71ms
+step:1198/1480 train_time:318072ms step_avg:267.74ms
+step:1199/1480 train_time:318354ms step_avg:267.75ms
+step:1200/1480 train_time:318635ms step_avg:267.76ms
+step:1201/1480 train_time:318911ms step_avg:267.77ms
+step:1202/1480 train_time:319200ms step_avg:267.79ms
+step:1203/1480 train_time:319483ms step_avg:267.80ms
+step:1204/1480 train_time:319771ms step_avg:267.82ms
+step:1205/1480 train_time:320049ms step_avg:267.82ms
+step:1206/1480 train_time:320329ms step_avg:267.83ms
+step:1207/1480 train_time:320609ms step_avg:267.84ms
+step:1208/1480 train_time:320890ms step_avg:267.85ms
+step:1209/1480 train_time:321172ms step_avg:267.87ms
+step:1210/1480 train_time:321462ms step_avg:267.89ms
+step:1211/1480 train_time:321748ms step_avg:267.90ms
+step:1212/1480 train_time:322031ms step_avg:267.91ms
+step:1213/1480 train_time:322311ms step_avg:267.92ms
+step:1214/1480 train_time:322594ms step_avg:267.94ms
+step:1215/1480 train_time:322877ms step_avg:267.95ms
+step:1216/1480 train_time:323161ms step_avg:267.96ms
+step:1217/1480 train_time:323448ms step_avg:267.98ms
+step:1218/1480 train_time:323729ms step_avg:267.99ms
+step:1219/1480 train_time:324021ms step_avg:268.01ms
+step:1220/1480 train_time:324307ms step_avg:268.02ms
+step:1221/1480 train_time:324589ms step_avg:268.03ms
+step:1222/1480 train_time:324868ms step_avg:268.04ms
+step:1223/1480 train_time:325149ms step_avg:268.05ms
+step:1224/1480 train_time:325437ms step_avg:268.07ms
+step:1225/1480 train_time:325713ms step_avg:268.08ms
+step:1226/1480 train_time:325999ms step_avg:268.09ms
+step:1227/1480 train_time:326279ms step_avg:268.10ms
+step:1228/1480 train_time:326554ms step_avg:268.11ms
+step:1229/1480 train_time:326838ms step_avg:268.12ms
+step:1230/1480 train_time:327125ms step_avg:268.14ms
+step:1231/1480 train_time:327409ms step_avg:268.15ms
+step:1232/1480 train_time:327694ms step_avg:268.16ms
+step:1233/1480 train_time:327972ms step_avg:268.17ms
+step:1234/1480 train_time:328249ms step_avg:268.18ms
+step:1235/1480 train_time:328537ms step_avg:268.19ms
+step:1236/1480 train_time:328815ms step_avg:268.20ms
+step:1237/1480 train_time:329093ms step_avg:268.21ms
+step:1238/1480 train_time:329388ms step_avg:268.23ms
+step:1239/1480 train_time:329671ms step_avg:268.24ms
+step:1240/1480 train_time:329951ms step_avg:268.25ms
+step:1241/1480 train_time:330236ms step_avg:268.27ms
+step:1242/1480 train_time:330513ms step_avg:268.27ms
+step:1243/1480 train_time:330795ms step_avg:268.28ms
+step:1244/1480 train_time:331071ms step_avg:268.29ms
+step:1245/1480 train_time:331350ms step_avg:268.30ms
+step:1246/1480 train_time:331633ms step_avg:268.31ms
+step:1247/1480 train_time:331914ms step_avg:268.32ms
+step:1248/1480 train_time:332193ms step_avg:268.33ms
+step:1249/1480 train_time:332473ms step_avg:268.34ms
+step:1250/1480 train_time:332751ms step_avg:268.35ms
+step:1250/1480 val_loss:3.3373 train_time:332898ms step_avg:268.47ms
+step:1251/1480 train_time:333043ms step_avg:268.37ms
+step:1252/1480 train_time:333324ms step_avg:268.38ms
+step:1253/1480 train_time:333604ms step_avg:268.39ms
+step:1254/1480 train_time:333883ms step_avg:268.39ms
+step:1255/1480 train_time:334177ms step_avg:268.42ms
+step:1256/1480 train_time:334463ms step_avg:268.43ms
+step:1257/1480 train_time:334744ms step_avg:268.44ms
+step:1258/1480 train_time:335025ms step_avg:268.45ms
+step:1259/1480 train_time:335306ms step_avg:268.46ms
+step:1260/1480 train_time:335585ms step_avg:268.47ms
+step:1261/1480 train_time:335865ms step_avg:268.48ms
+step:1262/1480 train_time:336148ms step_avg:268.49ms
+step:1263/1480 train_time:336435ms step_avg:268.50ms
+step:1264/1480 train_time:336711ms step_avg:268.51ms
+step:1265/1480 train_time:336986ms step_avg:268.51ms
+step:1266/1480 train_time:337268ms step_avg:268.53ms
+step:1267/1480 train_time:337545ms step_avg:268.53ms
+step:1268/1480 train_time:337824ms step_avg:268.54ms
+step:1269/1480 train_time:338112ms step_avg:268.56ms
+step:1270/1480 train_time:338387ms step_avg:268.56ms
+step:1271/1480 train_time:338667ms step_avg:268.57ms
+step:1272/1480 train_time:338945ms step_avg:268.58ms
+step:1273/1480 train_time:339224ms step_avg:268.59ms
+step:1274/1480 train_time:339507ms step_avg:268.60ms
+step:1275/1480 train_time:339784ms step_avg:268.60ms
+step:1276/1480 train_time:340060ms step_avg:268.61ms
+step:1277/1480 train_time:340344ms step_avg:268.62ms
+step:1278/1480 train_time:340622ms step_avg:268.63ms
+step:1279/1480 train_time:340905ms step_avg:268.64ms
+step:1280/1480 train_time:341191ms step_avg:268.65ms
+step:1281/1480 train_time:341467ms step_avg:268.66ms
+step:1282/1480 train_time:341745ms step_avg:268.67ms
+step:1283/1480 train_time:342024ms step_avg:268.68ms
+step:1284/1480 train_time:342304ms step_avg:268.68ms
+step:1285/1480 train_time:342582ms step_avg:268.69ms
+step:1286/1480 train_time:342859ms step_avg:268.70ms
+step:1287/1480 train_time:343144ms step_avg:268.71ms
+step:1288/1480 train_time:343424ms step_avg:268.72ms
+step:1289/1480 train_time:343715ms step_avg:268.74ms
+step:1290/1480 train_time:344003ms step_avg:268.75ms
+step:1291/1480 train_time:344285ms step_avg:268.76ms
+step:1292/1480 train_time:344567ms step_avg:268.77ms
+step:1293/1480 train_time:344850ms step_avg:268.78ms
+step:1294/1480 train_time:345128ms step_avg:268.79ms
+step:1295/1480 train_time:345406ms step_avg:268.80ms
+step:1296/1480 train_time:345686ms step_avg:268.81ms
+step:1297/1480 train_time:345969ms step_avg:268.82ms
+step:1298/1480 train_time:346249ms step_avg:268.83ms
+step:1299/1480 train_time:346529ms step_avg:268.84ms
+step:1300/1480 train_time:346807ms step_avg:268.84ms
+step:1301/1480 train_time:347083ms step_avg:268.85ms
+step:1302/1480 train_time:347366ms step_avg:268.86ms
+step:1303/1480 train_time:347649ms step_avg:268.87ms
+step:1304/1480 train_time:347933ms step_avg:268.88ms
+step:1305/1480 train_time:348207ms step_avg:268.89ms
+step:1306/1480 train_time:348491ms step_avg:268.90ms
+step:1307/1480 train_time:348767ms step_avg:268.90ms
+step:1308/1480 train_time:349045ms step_avg:268.91ms
+step:1309/1480 train_time:349325ms step_avg:268.92ms
+step:1310/1480 train_time:349607ms step_avg:268.93ms
+step:1311/1480 train_time:349885ms step_avg:268.94ms
+step:1312/1480 train_time:350168ms step_avg:268.95ms
+step:1313/1480 train_time:350445ms step_avg:268.95ms
+step:1314/1480 train_time:350726ms step_avg:268.96ms
+step:1315/1480 train_time:351004ms step_avg:268.97ms
+step:1316/1480 train_time:351281ms step_avg:268.97ms
+step:1317/1480 train_time:351563ms step_avg:268.98ms
+step:1318/1480 train_time:351851ms step_avg:269.00ms
+step:1319/1480 train_time:352132ms step_avg:269.01ms
+step:1320/1480 train_time:352425ms step_avg:269.03ms
+step:1321/1480 train_time:352707ms step_avg:269.04ms
+step:1322/1480 train_time:352994ms step_avg:269.05ms
+step:1323/1480 train_time:353283ms step_avg:269.07ms
+step:1324/1480 train_time:353568ms step_avg:269.08ms
+step:1325/1480 train_time:353861ms step_avg:269.10ms
+step:1326/1480 train_time:354145ms step_avg:269.11ms
+step:1327/1480 train_time:354425ms step_avg:269.12ms
+step:1328/1480 train_time:354703ms step_avg:269.12ms
+step:1329/1480 train_time:355010ms step_avg:269.15ms
+step:1330/1480 train_time:355295ms step_avg:269.16ms
+step:1331/1480 train_time:355574ms step_avg:269.17ms
+step:1332/1480 train_time:355854ms step_avg:269.18ms
+step:1333/1480 train_time:356143ms step_avg:269.19ms
+step:1334/1480 train_time:356424ms step_avg:269.20ms
+step:1335/1480 train_time:356704ms step_avg:269.21ms
+step:1336/1480 train_time:356993ms step_avg:269.23ms
+step:1337/1480 train_time:357280ms step_avg:269.24ms
+step:1338/1480 train_time:357563ms step_avg:269.25ms
+step:1339/1480 train_time:357846ms step_avg:269.26ms
+step:1340/1480 train_time:358127ms step_avg:269.27ms
+step:1341/1480 train_time:358406ms step_avg:269.28ms
+step:1342/1480 train_time:358688ms step_avg:269.29ms
+step:1343/1480 train_time:358967ms step_avg:269.29ms
+step:1344/1480 train_time:359246ms step_avg:269.30ms
+step:1345/1480 train_time:359541ms step_avg:269.32ms
+step:1346/1480 train_time:359819ms step_avg:269.33ms
+step:1347/1480 train_time:360102ms step_avg:269.34ms
+step:1348/1480 train_time:360383ms step_avg:269.34ms
+step:1349/1480 train_time:360662ms step_avg:269.35ms
+step:1350/1480 train_time:360947ms step_avg:269.36ms
+step:1351/1480 train_time:361228ms step_avg:269.37ms
+step:1352/1480 train_time:361507ms step_avg:269.38ms
+step:1353/1480 train_time:361790ms step_avg:269.39ms
+step:1354/1480 train_time:362077ms step_avg:269.40ms
+step:1355/1480 train_time:362357ms step_avg:269.41ms
+step:1356/1480 train_time:362646ms step_avg:269.42ms
+step:1357/1480 train_time:362932ms step_avg:269.44ms
+step:1358/1480 train_time:363217ms step_avg:269.45ms
+step:1359/1480 train_time:363503ms step_avg:269.46ms
+step:1360/1480 train_time:363785ms step_avg:269.47ms
+step:1361/1480 train_time:364068ms step_avg:269.48ms
+step:1362/1480 train_time:364349ms step_avg:269.49ms
+step:1363/1480 train_time:364643ms step_avg:269.51ms
+step:1364/1480 train_time:364923ms step_avg:269.51ms
+step:1365/1480 train_time:365203ms step_avg:269.52ms
+step:1366/1480 train_time:365484ms step_avg:269.53ms
+step:1367/1480 train_time:365765ms step_avg:269.54ms
+step:1368/1480 train_time:366047ms step_avg:269.55ms
+step:1369/1480 train_time:366334ms step_avg:269.56ms
+step:1370/1480 train_time:366623ms step_avg:269.58ms
+step:1371/1480 train_time:366906ms step_avg:269.59ms
+step:1372/1480 train_time:367191ms step_avg:269.60ms
+step:1373/1480 train_time:367468ms step_avg:269.60ms
+step:1374/1480 train_time:367753ms step_avg:269.61ms
+step:1375/1480 train_time:368043ms step_avg:269.63ms
+step:1375/1480 val_loss:3.2983 train_time:368181ms step_avg:269.73ms
+step:1376/1480 train_time:368322ms step_avg:269.64ms
+step:1377/1480 train_time:368606ms step_avg:269.65ms
+step:1378/1480 train_time:368889ms step_avg:269.66ms
+step:1379/1480 train_time:369173ms step_avg:269.67ms
+step:1380/1480 train_time:369454ms step_avg:269.67ms
+step:1381/1480 train_time:369745ms step_avg:269.69ms
+step:1382/1480 train_time:370022ms step_avg:269.70ms
+step:1383/1480 train_time:370304ms step_avg:269.70ms
+step:1384/1480 train_time:370595ms step_avg:269.72ms
+step:1385/1480 train_time:370872ms step_avg:269.73ms
+step:1386/1480 train_time:371158ms step_avg:269.74ms
+step:1387/1480 train_time:371439ms step_avg:269.75ms
+step:1388/1480 train_time:371717ms step_avg:269.75ms
+step:1389/1480 train_time:372003ms step_avg:269.76ms
+step:1390/1480 train_time:372280ms step_avg:269.77ms
+step:1391/1480 train_time:372559ms step_avg:269.78ms
+step:1392/1480 train_time:372839ms step_avg:269.78ms
+step:1393/1480 train_time:373121ms step_avg:269.79ms
+step:1394/1480 train_time:373400ms step_avg:269.80ms
+step:1395/1480 train_time:373678ms step_avg:269.80ms
+step:1396/1480 train_time:373959ms step_avg:269.81ms
+step:1397/1480 train_time:374236ms step_avg:269.82ms
+step:1398/1480 train_time:374515ms step_avg:269.82ms
+step:1399/1480 train_time:374799ms step_avg:269.83ms
+step:1400/1480 train_time:375087ms step_avg:269.85ms
+step:1401/1480 train_time:375364ms step_avg:269.85ms
+step:1402/1480 train_time:375639ms step_avg:269.86ms
+step:1403/1480 train_time:375924ms step_avg:269.87ms
+step:1404/1480 train_time:376201ms step_avg:269.87ms
+step:1405/1480 train_time:376481ms step_avg:269.88ms
+step:1406/1480 train_time:376768ms step_avg:269.89ms
+step:1407/1480 train_time:377044ms step_avg:269.90ms
+step:1408/1480 train_time:377319ms step_avg:269.90ms
+step:1409/1480 train_time:377617ms step_avg:269.92ms
+step:1410/1480 train_time:377899ms step_avg:269.93ms
+step:1411/1480 train_time:378178ms step_avg:269.93ms
+step:1412/1480 train_time:378461ms step_avg:269.94ms
+step:1413/1480 train_time:378744ms step_avg:269.95ms
+step:1414/1480 train_time:379029ms step_avg:269.96ms
+step:1415/1480 train_time:379309ms step_avg:269.97ms
+step:1416/1480 train_time:379603ms step_avg:269.99ms
+step:1417/1480 train_time:379891ms step_avg:270.00ms
+step:1418/1480 train_time:380177ms step_avg:270.01ms
+step:1419/1480 train_time:380461ms step_avg:270.02ms
+step:1420/1480 train_time:380741ms step_avg:270.03ms
+step:1421/1480 train_time:381024ms step_avg:270.04ms
+step:1422/1480 train_time:381303ms step_avg:270.04ms
+step:1423/1480 train_time:381580ms step_avg:270.05ms
+step:1424/1480 train_time:381868ms step_avg:270.06ms
+step:1425/1480 train_time:382159ms step_avg:270.08ms
+step:1426/1480 train_time:382439ms step_avg:270.08ms
+step:1427/1480 train_time:382724ms step_avg:270.09ms
+step:1428/1480 train_time:383004ms step_avg:270.10ms
+step:1429/1480 train_time:383282ms step_avg:270.11ms
+step:1430/1480 train_time:383567ms step_avg:270.12ms
+step:1431/1480 train_time:383856ms step_avg:270.13ms
+step:1432/1480 train_time:384145ms step_avg:270.14ms
+step:1433/1480 train_time:384437ms step_avg:270.16ms
+step:1434/1480 train_time:384729ms step_avg:270.17ms
+step:1435/1480 train_time:385011ms step_avg:270.18ms
+step:1436/1480 train_time:385299ms step_avg:270.20ms
+step:1437/1480 train_time:385579ms step_avg:270.20ms
+step:1438/1480 train_time:385860ms step_avg:270.21ms
+step:1439/1480 train_time:386143ms step_avg:270.22ms
+step:1440/1480 train_time:386420ms step_avg:270.22ms
+step:1441/1480 train_time:386702ms step_avg:270.23ms
+step:1442/1480 train_time:386988ms step_avg:270.24ms
+step:1443/1480 train_time:387297ms step_avg:270.27ms
+step:1444/1480 train_time:387577ms step_avg:270.28ms
+step:1445/1480 train_time:387861ms step_avg:270.29ms
+step:1446/1480 train_time:388148ms step_avg:270.30ms
+step:1447/1480 train_time:388438ms step_avg:270.31ms
+step:1448/1480 train_time:388720ms step_avg:270.32ms
+step:1449/1480 train_time:389003ms step_avg:270.33ms
+step:1450/1480 train_time:389287ms step_avg:270.34ms
+step:1451/1480 train_time:389570ms step_avg:270.35ms
+step:1452/1480 train_time:389857ms step_avg:270.36ms
+step:1453/1480 train_time:390137ms step_avg:270.36ms
+step:1454/1480 train_time:390419ms step_avg:270.37ms
+step:1455/1480 train_time:390706ms step_avg:270.39ms
+step:1456/1480 train_time:390996ms step_avg:270.40ms
+step:1457/1480 train_time:391279ms step_avg:270.41ms
+step:1458/1480 train_time:391560ms step_avg:270.41ms
+step:1459/1480 train_time:391846ms step_avg:270.43ms
+step:1460/1480 train_time:392130ms step_avg:270.43ms
+step:1461/1480 train_time:392413ms step_avg:270.44ms
+step:1462/1480 train_time:392696ms step_avg:270.45ms
+step:1463/1480 train_time:392981ms step_avg:270.46ms
+step:1464/1480 train_time:393262ms step_avg:270.47ms
+step:1465/1480 train_time:393543ms step_avg:270.48ms
+step:1466/1480 train_time:393824ms step_avg:270.48ms
+step:1467/1480 train_time:394107ms step_avg:270.49ms
+step:1468/1480 train_time:394391ms step_avg:270.50ms
+step:1469/1480 train_time:394673ms step_avg:270.51ms
+step:1470/1480 train_time:394962ms step_avg:270.52ms
+step:1471/1480 train_time:395261ms step_avg:270.54ms
+step:1472/1480 train_time:395558ms step_avg:270.56ms
+step:1473/1480 train_time:395837ms step_avg:270.57ms
+step:1474/1480 train_time:396128ms step_avg:270.58ms
+step:1475/1480 train_time:396422ms step_avg:270.60ms
+step:1476/1480 train_time:396701ms step_avg:270.60ms
+step:1477/1480 train_time:396995ms step_avg:270.62ms
+step:1478/1480 train_time:397289ms step_avg:270.63ms
+step:1479/1480 train_time:397579ms step_avg:270.65ms
+step:1480/1480 train_time:397861ms step_avg:270.65ms
+step:1480/1480 val_loss:3.2792 train_time:398007ms step_avg:270.75ms
+peak memory consumption: 34238 MiB

--- a/_logs/master-8ba61738-7464-4dc1-a9a9-ca222d2d62bb.txt
+++ b/_logs/master-8ba61738-7464-4dc1-a9a9-ca222d2d62bb.txt
@@ -1,0 +1,2184 @@
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+import contextlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import torch.distributed as dist
+import torch._inductor.config as config
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.nn.attention.flex_attention import BlockMask, flex_attention #KoszarskyB
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps):
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert len(G.shape) == 2
+    a, b, c = (3.4445, -4.7750,  2.0315)
+    X = G.bfloat16()
+    if G.size(0) > G.size(1):
+        X = X.T
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm() + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A # adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+    
+    if G.size(0) > G.size(1):
+        X = X.T
+    return X
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Some warnings:
+    - This optimizer assumes that all parameters passed in are 2D.
+    - It should not be used for the embedding layer, the final fully connected layer, or any {0,1}-D
+    parameters; those should all be optimized by a standard method (e.g., AdamW).
+    - To use it with 4D convolutional filters, it works well to just flatten their last 3 dimensions.
+    - We believe it is unlikely to work well for training with small batch size.
+    - We believe it may not work well for finetuning pretrained models, but we haven't tested this.
+    - We have not yet tried this optimizer for training scenarios larger than NanoGPT (124M).
+
+    Arguments:
+        lr: The learning rate used by the internal SGD.
+        momentum: The momentum used by the internal SGD.
+        nesterov: Whether to use Nesterov-style momentum in the internal SGD. (recommended)
+        ns_steps: The number of Newton-Schulz iteration steps to use.
+    """
+    def __init__(self, params, lr=0.02, momentum=0.95, nesterov=True, ns_steps=5):
+        self.world_size = int(os.environ['WORLD_SIZE'])
+        self.rank = int(os.environ['RANK'])
+        defaults = dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps)
+        params = list(params)
+        assert all(isinstance(p, torch.Tensor) for p in params)
+        sizes = {p.numel() for p in params}
+        param_groups = [
+            {
+                'params': [p for p in params if p.numel() == size],
+                'update_buffer': [
+                    torch.empty(size, device='cuda', dtype=torch.bfloat16)
+                    for _ in range(self.world_size)
+                ],
+            }
+            for size in sizes
+        ]
+        super().__init__(param_groups, defaults)
+
+    def step(self):
+
+        for group in self.param_groups:
+
+            lr = group['lr']
+            momentum = group['momentum']
+            nesterov = group['nesterov']
+            ns_steps = group['ns_steps']
+            update_buffers = group['update_buffer']
+            # generate weight updates in distributed fashion
+            params = group['params']
+            assert len(params) % self.world_size == 0
+            handle = None
+            params_world = None
+            def update_prev():
+                if params_world is None:
+                    return
+                assert handle is not None
+                handle.wait()
+                for p_world, g_world in zip(params_world, update_buffers):
+                    p_world.data.add_(
+                        g_world.view_as(p_world),
+                        alpha=-lr * max(1, p_world.size(0) / p_world.size(1)) ** 0.5,
+                    )
+            for base_i in range(len(params))[::self.world_size]:
+                p = params[base_i + self.rank]
+                g = p.grad
+                assert g is not None
+                state = self.state[p]
+                if 'momentum_buffer' not in state:
+                    state['momentum_buffer'] = torch.zeros_like(g)
+                buf = state['momentum_buffer']
+                buf.lerp_(g, 1 - momentum)
+                g = g.lerp_(buf, momentum) if nesterov else buf
+                g = zeropower_via_newtonschulz5(g, steps=ns_steps).flatten()
+                update_prev()
+                handle = dist.all_gather(update_buffers, g, async_op=True)
+                params_world = params[base_i : base_i + self.world_size]
+            update_prev()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the GPT-2 model
+
+def norm(x):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features, out_features, bias=False)
+
+    def forward(self, x):
+        return F.linear(x, self.weight.to(x.dtype))
+
+class Rotary(torch.nn.Module):
+
+    def __init__(self, dim, base=10000):
+        super().__init__()
+        self.register_buffer('inv_freq', (1 / base) ** (torch.arange(0, dim, 2) / dim))
+        self.seq_len_cached = None
+        self.cos_cached = None
+        self.sin_cached = None
+
+    def forward(self, x):
+        seq_len = x.shape[1]
+        if seq_len != self.seq_len_cached:
+            t = torch.arange(seq_len, device=x.device)
+            freqs = torch.outer(t, self.inv_freq)
+            self.seq_len_cached = seq_len
+            self.cos_cached = freqs.cos()
+            self.sin_cached = freqs.sin()
+        cos, sin = self.cos_cached[None, :, None, :], self.sin_cached[None, :, None, :]
+        # apply_rotary_emb(x, cos, sin)
+        x1, x2 = x.chunk(2, dim=3)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x)
+
+class CausalSelfAttention(nn.Module):
+
+    def __init__(self, dim, num_heads):
+        super().__init__()
+        assert dim % num_heads == 0
+        self.num_heads = num_heads
+        self.c_q = CastedLinear(dim, dim)
+        self.c_k = CastedLinear(dim, dim)
+        self.c_v = CastedLinear(dim, dim)
+        self.lambdas = nn.Parameter(torch.tensor([0.5, 0.5]))
+        self.rotary = Rotary(dim // num_heads) # dim // num_heads = head_dim
+        self.c_proj = CastedLinear(dim, dim)
+        self.c_proj.weight.data.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x, vi, block_mask):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q = self.c_q(x).view(B, T, self.num_heads, -1)
+        k = self.c_k(x).view(B, T, self.num_heads, -1)
+        v = self.c_v(x).view(B, T, self.num_heads, -1)
+        v = self.lambdas[0] * v + self.lambdas[1] * vi.view_as(v) # @KoszarskyB & @Grad62304977
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, enable_gqa=True)
+        y = y.transpose(1, 2).contiguous().view_as(x) # re-assemble all head outputs side by side
+        y = self.c_proj(y)
+        return y
+
+class MLP(nn.Module):
+
+    def __init__(self, dim):
+        super().__init__()
+        self.c_fc   = CastedLinear(dim, 4 * dim)
+        self.c_proj = CastedLinear(4 * dim, dim)
+        self.c_proj.weight.data.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x):
+        x = self.c_fc(x)
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = self.c_proj(x)
+        return x
+
+class Block(nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+        self.attn = CausalSelfAttention(config.model_dim, config.num_heads)
+        self.mlp = MLP(config.model_dim)
+        self.lambdas = nn.Parameter(torch.tensor([1., 0.]))
+
+    def forward(self, x, vi, x0, block_mask):
+        x = self.lambdas[0] * x + self.lambdas[1] * x0
+        x = x + self.attn(norm(x), vi, block_mask)
+        x = x + self.mlp(norm(x))
+        return x
+
+class ValueEmbedding(nn.Module):
+    def __init__(self, config: "GPTConfig"):
+        super().__init__()
+        self.embed = nn.ModuleList([
+            nn.Embedding(config.vocab_size, config.model_dim)
+            for _ in range(6)
+        ])
+
+    def forward(self, inputs) -> "list[torch.Tensor]":
+        ve = [emb(inputs) for emb in self.embed]
+        ve += reversed(ve)
+        return ve
+
+# -----------------------------------------------------------------------------
+# The main GPT-2 model
+
+@dataclass
+class GPTConfig:
+    vocab_size : int = 50304
+    num_layers : int = 12
+    num_heads : int = 6 # head dim 128 suggested by @Grad62304977
+    model_dim : int = 768
+
+class GPT(nn.Module):
+
+    def __init__(self, config: GPTConfig):
+        super().__init__()
+        self.num_layers = config.num_layers
+
+        # U-net design by @brendanh0gan
+        self.num_encoder_layers = config.num_layers // 2 # Half of the layers for encoder
+        self.num_decoder_layers = config.num_layers - self.num_encoder_layers # Remaining for decoder
+        # Add learnable skip connection weights for decoder layers
+        self.skip_weights = nn.Parameter(torch.ones(self.num_decoder_layers))
+
+        self.embed = nn.Embedding(config.vocab_size, config.model_dim)
+        self.blocks = nn.ModuleList([Block(config) for _ in range(config.num_layers)])
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual learning
+        # U-net structure on token value embeddings by @leloykun
+        self.value_embeds = ValueEmbedding(config)
+        self.lm_head = CastedLinear(config.model_dim, config.vocab_size)
+        self.lm_head.weight.data.zero_() # @Grad62304977
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        targets: torch.Tensor,
+        sliding_window_num_blocks: torch.Tensor,
+    ):
+        BLOCK_SIZE = 128
+        seq_len = len(inputs)
+        assert seq_len % BLOCK_SIZE == 0
+        total_num_blocks = seq_len // BLOCK_SIZE
+        assert inputs.ndim == 1
+        docs = (inputs == 50256).cumsum(0)
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_mask: torch.Tensor):
+            num_blocks = dense_mask.sum(dim=-1, dtype=torch.int32)
+            indices = dense_mask.argsort(dim=-1, descending=True, stable=True).to(torch.int32)
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        def create_doc_swc_block_mask(sliding_window_num_blocks: torch.Tensor):
+            kv_idx = block_idx = torch.arange(total_num_blocks, dtype=torch.int32, device="cuda")
+            q_idx = block_idx[:, None]
+            causal_bm = q_idx >= kv_idx
+            causal_full_bm = q_idx > kv_idx
+            window_bm = q_idx - kv_idx < sliding_window_num_blocks
+            window_full_bm = window_bm
+            # document_bm = (docs_low[q_idx] <= docs_high[kv_idx]) & (docs_low[kv_idx] <= docs_high[q_idx])
+            document_bm = (docs_low[:, None] <= docs_high) & (docs_low <= docs_high[:, None])
+            document_full_bm = (docs_low[:, None] == docs_high) & (docs_low == docs_high[:, None])
+            nonzero_bm = causal_bm & window_bm & document_bm
+            full_bm  = causal_full_bm & window_full_bm & document_full_bm
+            kv_num_blocks, kv_indices = dense_to_ordered(nonzero_bm ^ full_bm)
+            full_kv_num_blocks, full_kv_indices = dense_to_ordered(full_bm)
+            return BlockMask.from_kv_blocks(
+                kv_num_blocks,
+                kv_indices,
+                full_kv_num_blocks,
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+
+        block_mask = create_doc_swc_block_mask(sliding_window_num_blocks)
+
+        # forward the GPT model itself
+        x = self.embed(inputs[None]) # token embeddings of shape (b, t, model_dim)
+        x = norm(x) # @Grad62304977
+        x0 = x
+        ve = self.value_embeds(inputs)
+        ve_enc, ve_dec = ve[:self.num_encoder_layers], ve[self.num_encoder_layers:]
+
+        # Store outputs for U-Net skip connections
+        skip_connections = []
+        # Encoder pass - process only the first half of the blocks
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, ve_enc[i], x0, block_mask)
+            skip_connections.append(x)
+        # Decoder pass - process the remaining blocks with weighted skip connections
+        for i in range(self.num_decoder_layers):
+            x = x + self.skip_weights[i] * skip_connections.pop()
+            # U-net structure on token value embeddings by @leloykun
+            x = self.blocks[self.num_encoder_layers + i](x, ve_dec[i], x0, block_mask)
+
+        x = norm(x)
+        logits = self.lm_head(x)
+        logits = 30 * torch.tanh(logits / 30) # @Grad62304977
+        logits = logits.float()
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
+        return loss
+
+# -----------------------------------------------------------------------------
+# Our own simple Distributed Data Loader
+
+def _peek_data_shard(file: Path):
+    # only reads the header, returns header data
+    # header is 256 int32
+    header = torch.from_file(f"{file}", False, 256, dtype=torch.int32)
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    return int(header[2]) # number of tokens (claimed)
+
+def _load_data_shard(path: Path, num_tokens):
+    with path.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True)
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header?"
+    return tokens
+
+class DistributedDataLoader:
+    def __init__(self, filename_pattern, seq_len, process_rank, num_processes):
+        self.process_rank = process_rank
+        self.num_processes = num_processes
+        self.seq_len = seq_len
+
+        # glob files that match the pattern
+        self.files = sorted(Path.cwd().glob(filename_pattern))
+        assert len(self.files) > 0, f"did not find any files that match the pattern {filename_pattern}"
+
+        # load and validate all data shards, count number of tokens in total
+        self.files_num_tokens = [_peek_data_shard(file) for file in self.files]
+        assert min(self.files_num_tokens) >= num_processes * seq_len + 1
+        self.total_num_tokens = sum(self.files_num_tokens)
+
+        self.reset()
+
+    def reset(self):
+        self.current_shard = -1
+        self.advance()
+
+    def advance(self): # advance to next data shard
+        self.current_shard = (self.current_shard + 1) % len(self.files)
+        self.current_position = self.process_rank * self.seq_len
+        self.tokens = _load_data_shard(self.files[self.current_shard], self.files_num_tokens[self.current_shard])
+
+    def next_batch(self):
+        batch_size = self.seq_len * self.num_processes
+        buf = self.tokens[self.current_position:self.current_position+self.seq_len+1]
+        # host side async is sufficient;
+        # no performance improvement was observed when introducing a separate stream.
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # inputs
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # targets
+        # advance current position and load next shard if necessary
+        self.current_position += batch_size
+        if self.current_position + batch_size + 1 >= len(self.tokens):
+            self.advance()
+        return inputs, targets
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data hyperparams
+    input_bin : str = 'data/fineweb10B/fineweb_train_*.bin' # input .bin to train on
+    input_val_bin : str = 'data/fineweb10B/fineweb_val_*.bin' # input .bin to eval validation loss on
+    # optimization hyperparams
+    batch_size : int = 8 # batch size, in sequences, across all devices
+    sequence_length : int = 64*1024 # sequence length, in tokens
+    num_iterations : int = 1480 # number of iterations to run
+    warmup_iters : int = 0
+    cooldown_iters : int = 600 # number of iterations of linear warmup/cooldown for triangular or trapezoidal schedule
+    weight_decay : float = 0
+    # evaluation and logging hyperparams
+    val_loss_every : int = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    val_tokens : int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+args = Hyperparameters()
+
+# set up DDP (distributed data parallel). torchrun sets this env variable
+ddp_rank = int(os.environ['RANK'])
+ddp_local_rank = int(os.environ['LOCAL_RANK'])
+ddp_world_size = int(os.environ['WORLD_SIZE'])
+assert torch.cuda.is_available()
+device = torch.device(f'cuda:{ddp_local_rank}')
+torch.cuda.set_device(device)
+print(f'using device: {device}')
+dist.init_process_group(backend='nccl', device_id=device)
+dist.barrier()
+master_process = (ddp_rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = uuid.uuid4()
+    Path('logs').mkdir(exist_ok=True)
+    # logdir = Path('logs') / f'{run_id}'
+    # logdir.mkdir()
+    logfile = Path('logs') / f'{run_id}.txt'
+    print(logfile.stem)
+    # create the log file
+    with logfile.open('w') as f:
+        # begin the log by printing this file (the Python code)
+        print(code, file=f)
+        print('=' * 100, file=f)
+def print0(s, logonly=False):
+    if master_process:
+        with logfile.open('a') as f:
+            if not logonly:
+                print(s)
+            print(s, file=f)
+# log information about the hardware/software environment this is running on
+# and print the full `nvidia-smi` to file
+print0(f'Running python {sys.version}')
+print0(f'Running pytorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}\nnvidia-smi:')
+import subprocess
+result = subprocess.run(['nvidia-smi'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+print0(f'{result.stdout}', logonly=True)
+print0('='*100, logonly=True)
+
+# calculate the number of steps to take in the val loop.
+assert args.val_tokens % (args.sequence_length * ddp_world_size) == 0
+val_steps = args.val_tokens // (args.sequence_length * ddp_world_size)
+# calculate the steps of gradient accumulation required to attain the desired global batch size.
+assert args.batch_size % (ddp_world_size) == 0
+train_accumulation_steps = args.batch_size // ddp_world_size
+
+# load tokens
+train_loader = DistributedDataLoader(args.input_bin, args.sequence_length, ddp_rank, ddp_world_size)
+val_loader = DistributedDataLoader(args.input_val_bin, args.sequence_length, ddp_rank, ddp_world_size)
+print0(f"Training DataLoader: total number of tokens: {train_loader.total_num_tokens} across {len(train_loader.files)} files")
+print0(f"Validation DataLoader: total number of tokens: {val_loader.total_num_tokens} across {len(val_loader.files)} files")
+print0('='*100, logonly=True)
+inputs_train, targets_train = train_loader.next_batch()
+
+# there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency. suggested to me by @Grad62304977.
+# this originates from Karpathy's experiments.
+num_vocab = 50304
+model = GPT(GPTConfig(vocab_size=num_vocab, num_layers=12, num_heads=6, model_dim=768))
+model = model.cuda().bfloat16()
+for m in model.modules():
+    if isinstance(m, CastedLinear):
+        m.float()
+config.coordinate_descent_tuning = True # suggested by @Chillee
+model = torch.compile(model)
+# here we wrap model into DDP container
+model = DDP(model, device_ids=[ddp_local_rank], broadcast_buffers=False, gradient_as_bucket_view=True)
+raw_model = model.module # always contains the "raw" unwrapped model
+
+# init the optimizer(s)
+embed_params = [*raw_model.embed.parameters(), *raw_model.value_embeds.parameters()]
+optimizer1 = torch.optim.Adam(embed_params, lr=0.6, betas=(0.8, 0.95), fused=True)
+optimizer2 = torch.optim.Adam([raw_model.lm_head.weight], lr=0.008, betas=(0.8, 0.95), fused=True)
+params = list(raw_model.blocks.parameters())
+matrix_params = [p for p in params if p.ndim == 2]
+scalar_params = [p for p in params if p.ndim < 2] + [raw_model.skip_weights]
+optimizer3 = Muon(matrix_params, lr=0.05, momentum=0.95)
+optimizer4 = torch.optim.Adam(scalar_params, lr=0.04, betas=(0.8, 0.95), fused=True)
+optimizers = [optimizer1, optimizer2, optimizer3, optimizer4]
+# learning rate decay scheduler (linear warmup and cooldown)
+def get_lr(it):
+    assert it <= args.num_iterations
+    # 1) linear warmup for warmup_iters steps
+    if it < args.warmup_iters:
+        return (it+1) / args.warmup_iters
+    # 2) constant lr for a while
+    elif it < args.num_iterations - args.cooldown_iters:
+        return 1.0
+    # 3) linear cooldown
+    else:
+        decay_ratio = (args.num_iterations - it) / args.cooldown_iters
+        return decay_ratio
+schedulers = [torch.optim.lr_scheduler.LambdaLR(opt, get_lr) for opt in optimizers]
+
+sliding_window_num_blocks = torch.tensor(1, dtype=torch.int32, device="cuda")
+sw_num_blocks_prev = 1
+# Start training loop
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+for step in range(args.num_iterations + 1):
+    last_step = (step == args.num_iterations)
+    # This effectively ignores timing first 10 steps, which are slower for weird reasons.
+    # Alternately, and slightly more correctly in terms of benchmarking, we could do 10
+    # steps with dummy data first, and then re-initialize the model and reset the loader.
+    if step == 10:
+        training_time_ms = 0
+        t0 = time.perf_counter()
+    timed_steps = float('nan') if step <= 11 else (step - 10) + 1 # <= 11 to avoid bug in val
+
+    # Linearly increase the sliding window size over training in chunks of 128 from 128 -> 1856. By @fernbear.bsky.social
+    frac_done = step / args.num_iterations # training progress
+    sw_num_blocks = int(((1 - frac_done) * 128 + frac_done * 1856) // 128)
+    if sw_num_blocks != sw_num_blocks_prev:
+        sliding_window_num_blocks.copy_(sw_num_blocks, non_blocking=True)
+        sw_num_blocks_prev = sw_num_blocks
+
+    # once in a while evaluate the validation dataset
+    if (last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)):
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        # run validation batches
+        model.eval()
+        val_loader.reset()
+        val_loss = 0.0
+        for _ in range(val_steps):
+            with torch.no_grad():
+                inputs_val, targets_val = val_loader.next_batch()
+                val_loss += model(inputs_val, targets_val, sliding_window_num_blocks)
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        val_loss /= val_steps
+        # log val loss to console and to logfile
+        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    # uncomment if you want to save any checkpoints
+    #save_every = 1000
+    #if master_process and (last_step or (save_every > 0 and step % save_every == 0)):
+    #    # stop the clock
+    #    torch.cuda.synchronize()
+    #    training_time_ms += 1000 * (time.perf_counter() - t0)
+    #    # save the state of the training process
+    #    log = dict(step=step, code=code, model=raw_model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+    #    torch.save(log, 'logs/%s/state_step%06d.pt' % (run_id, step))
+    #    # start the clock again
+    #    torch.cuda.synchronize()
+    #    t0 = time.perf_counter()
+
+    # bit confusing: we want to make sure to eval on 0th iteration
+    # but also after the very last iteration. so we loop for step <= num_iterations
+    # instead of just < num_iterations (one extra due to <=), only to do
+    # the validation/sampling one last time, and then we break right here as we're done.
+    if last_step:
+        break
+
+    # --------------- TRAINING SECTION BEGIN -----------------
+    model.train()
+    for i in range(1, train_accumulation_steps + 1):
+        with contextlib.ExitStack() as stack:
+            if i < train_accumulation_steps: # there's no need to sync gradients every accumulation step
+                stack.enter_context(model.no_sync())
+            if step >= 5:
+                stack.enter_context(torch.compiler.set_stance(skip_guard_eval_unsafe=True))
+            model(inputs_train, targets_train, sliding_window_num_blocks).backward()
+            inputs_train, targets_train = train_loader.next_batch()
+    if train_accumulation_steps != 1:
+        for p in model.parameters():
+            p.grad /= train_accumulation_steps
+    # momentum warmup for Muon
+    frac = min(step/300, 1)
+    for group in optimizer3.param_groups:
+        group['momentum'] = (1 - frac) * 0.85 + frac * 0.95
+    # step the optimizers and schedulers
+    for opt, sched in zip(optimizers, schedulers):
+        opt.step()
+        sched.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # --------------- TRAINING SECTION END -------------------
+    # everything that follows now is just diagnostics, prints, logging, etc.
+    approx_time = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{args.num_iterations} train_time:{approx_time:.0f}ms step_avg:{approx_time/timed_steps:.2f}ms")
+
+print0(f"peak memory consumption: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB")
+
+# -------------------------------------------------------------------------
+# clean up nice
+dist.destroy_process_group()
+
+====================================================================================================
+Running python 3.10.12 (main, Nov  6 2024, 20:22:13) [GCC 11.4.0]
+Running pytorch 2.6.0.dev20241203+cu124 compiled for CUDA 12.4
+nvidia-smi:
+Tue Dec 24 08:44:51 2024       
++---------------------------------------------------------------------------------------+
+| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
+|-----------------------------------------+----------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
+|                                         |                      |               MIG M. |
+|=========================================+======================+======================|
+|   0  NVIDIA H100 PCIe               On  | 00000000:00:07.0 Off |                    0 |
+| N/A   31C    P0              76W / 350W |   4162MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   1  NVIDIA H100 PCIe               On  | 00000000:00:08.0 Off |                    0 |
+| N/A   37C    P0              79W / 350W |    923MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   2  NVIDIA H100 PCIe               On  | 00000000:00:09.0 Off |                    0 |
+| N/A   28C    P0              73W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   3  NVIDIA H100 PCIe               On  | 00000000:00:0A.0 Off |                    0 |
+| N/A   29C    P0              74W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   4  NVIDIA H100 PCIe               On  | 00000000:00:0B.0 Off |                    0 |
+| N/A   30C    P0              75W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   5  NVIDIA H100 PCIe               On  | 00000000:00:0C.0 Off |                    0 |
+| N/A   29C    P0              73W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   6  NVIDIA H100 PCIe               On  | 00000000:00:0D.0 Off |                    0 |
+| N/A   35C    P0              80W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+|   7  NVIDIA H100 PCIe               On  | 00000000:00:0E.0 Off |                    0 |
+| N/A   30C    P0              76W / 350W |    963MiB / 81559MiB |      0%      Default |
+|                                         |                      |             Disabled |
++-----------------------------------------+----------------------+----------------------+
+                                                                                         
++---------------------------------------------------------------------------------------+
+| Processes:                                                                            |
+|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
+|        ID   ID                                                             Usage      |
+|=======================================================================================|
+|    0   N/A  N/A     94853      C   /usr/bin/python3                            946MiB |
+|    0   N/A  N/A     94854      C   /usr/bin/python3                            452MiB |
+|    0   N/A  N/A     94855      C   /usr/bin/python3                            452MiB |
+|    0   N/A  N/A     94856      C   /usr/bin/python3                            452MiB |
+|    0   N/A  N/A     94857      C   /usr/bin/python3                            452MiB |
+|    0   N/A  N/A     94858      C   /usr/bin/python3                            452MiB |
+|    0   N/A  N/A     94859      C   /usr/bin/python3                            452MiB |
+|    0   N/A  N/A     94860      C   /usr/bin/python3                            452MiB |
+|    1   N/A  N/A     94854      C   /usr/bin/python3                            914MiB |
+|    2   N/A  N/A     94855      C   /usr/bin/python3                            954MiB |
+|    3   N/A  N/A     94856      C   /usr/bin/python3                            954MiB |
+|    4   N/A  N/A     94857      C   /usr/bin/python3                            954MiB |
+|    5   N/A  N/A     94858      C   /usr/bin/python3                            954MiB |
+|    6   N/A  N/A     94859      C   /usr/bin/python3                            954MiB |
+|    7   N/A  N/A     94860      C   /usr/bin/python3                            954MiB |
++---------------------------------------------------------------------------------------+
+
+====================================================================================================
+Training DataLoader: total number of tokens: 1000000000 across 10 files
+Validation DataLoader: total number of tokens: 100000000 across 1 files
+====================================================================================================
+step:0/1480 val_loss:10.8258 train_time:0ms step_avg:nanms
+step:1/1480 train_time:24755ms step_avg:nanms
+step:2/1480 train_time:25331ms step_avg:nanms
+step:3/1480 train_time:25572ms step_avg:nanms
+step:4/1480 train_time:25819ms step_avg:nanms
+step:5/1480 train_time:26069ms step_avg:nanms
+step:6/1480 train_time:26317ms step_avg:nanms
+step:7/1480 train_time:26567ms step_avg:nanms
+step:8/1480 train_time:26816ms step_avg:nanms
+step:9/1480 train_time:27063ms step_avg:nanms
+step:10/1480 train_time:27313ms step_avg:nanms
+step:11/1480 train_time:249ms step_avg:nanms
+step:12/1480 train_time:498ms step_avg:nanms
+step:13/1480 train_time:746ms step_avg:248.58ms
+step:14/1480 train_time:993ms step_avg:248.26ms
+step:15/1480 train_time:1245ms step_avg:248.93ms
+step:16/1480 train_time:1493ms step_avg:248.76ms
+step:17/1480 train_time:1745ms step_avg:249.30ms
+step:18/1480 train_time:1992ms step_avg:249.04ms
+step:19/1480 train_time:2243ms step_avg:249.23ms
+step:20/1480 train_time:2490ms step_avg:249.00ms
+step:21/1480 train_time:2741ms step_avg:249.22ms
+step:22/1480 train_time:2990ms step_avg:249.20ms
+step:23/1480 train_time:3242ms step_avg:249.41ms
+step:24/1480 train_time:3490ms step_avg:249.31ms
+step:25/1480 train_time:3743ms step_avg:249.53ms
+step:26/1480 train_time:3991ms step_avg:249.44ms
+step:27/1480 train_time:4243ms step_avg:249.61ms
+step:28/1480 train_time:4491ms step_avg:249.51ms
+step:29/1480 train_time:4746ms step_avg:249.79ms
+step:30/1480 train_time:4994ms step_avg:249.72ms
+step:31/1480 train_time:5244ms step_avg:249.73ms
+step:32/1480 train_time:5492ms step_avg:249.62ms
+step:33/1480 train_time:5745ms step_avg:249.80ms
+step:34/1480 train_time:5994ms step_avg:249.75ms
+step:35/1480 train_time:6245ms step_avg:249.79ms
+step:36/1480 train_time:6492ms step_avg:249.71ms
+step:37/1480 train_time:6745ms step_avg:249.82ms
+step:38/1480 train_time:6994ms step_avg:249.78ms
+step:39/1480 train_time:7245ms step_avg:249.83ms
+step:40/1480 train_time:7492ms step_avg:249.74ms
+step:41/1480 train_time:7745ms step_avg:249.85ms
+step:42/1480 train_time:7994ms step_avg:249.81ms
+step:43/1480 train_time:8244ms step_avg:249.83ms
+step:44/1480 train_time:8493ms step_avg:249.78ms
+step:45/1480 train_time:8746ms step_avg:249.89ms
+step:46/1480 train_time:8994ms step_avg:249.83ms
+step:47/1480 train_time:9245ms step_avg:249.87ms
+step:48/1480 train_time:9494ms step_avg:249.83ms
+step:49/1480 train_time:9746ms step_avg:249.89ms
+step:50/1480 train_time:9994ms step_avg:249.85ms
+step:51/1480 train_time:10244ms step_avg:249.85ms
+step:52/1480 train_time:10493ms step_avg:249.83ms
+step:53/1480 train_time:10744ms step_avg:249.86ms
+step:54/1480 train_time:10992ms step_avg:249.81ms
+step:55/1480 train_time:11244ms step_avg:249.86ms
+step:56/1480 train_time:11491ms step_avg:249.80ms
+step:57/1480 train_time:11745ms step_avg:249.89ms
+step:58/1480 train_time:11993ms step_avg:249.86ms
+step:59/1480 train_time:12245ms step_avg:249.91ms
+step:60/1480 train_time:12494ms step_avg:249.88ms
+step:61/1480 train_time:12746ms step_avg:249.91ms
+step:62/1480 train_time:12994ms step_avg:249.88ms
+step:63/1480 train_time:13246ms step_avg:249.92ms
+step:64/1480 train_time:13493ms step_avg:249.88ms
+step:65/1480 train_time:13746ms step_avg:249.92ms
+step:66/1480 train_time:13993ms step_avg:249.88ms
+step:67/1480 train_time:14245ms step_avg:249.91ms
+step:68/1480 train_time:14494ms step_avg:249.89ms
+step:69/1480 train_time:14746ms step_avg:249.93ms
+step:70/1480 train_time:14994ms step_avg:249.90ms
+step:71/1480 train_time:15245ms step_avg:249.92ms
+step:72/1480 train_time:15495ms step_avg:249.91ms
+step:73/1480 train_time:15745ms step_avg:249.93ms
+step:74/1480 train_time:15994ms step_avg:249.90ms
+step:75/1480 train_time:16246ms step_avg:249.94ms
+step:76/1480 train_time:16495ms step_avg:249.93ms
+step:77/1480 train_time:16748ms step_avg:249.97ms
+step:78/1480 train_time:16998ms step_avg:249.97ms
+step:79/1480 train_time:17247ms step_avg:249.95ms
+step:80/1480 train_time:17496ms step_avg:249.95ms
+step:81/1480 train_time:18305ms step_avg:257.82ms
+step:82/1480 train_time:18540ms step_avg:257.50ms
+step:83/1480 train_time:18791ms step_avg:257.40ms
+step:84/1480 train_time:19043ms step_avg:257.34ms
+step:85/1480 train_time:19292ms step_avg:257.22ms
+step:86/1480 train_time:19545ms step_avg:257.17ms
+step:87/1480 train_time:19793ms step_avg:257.05ms
+step:88/1480 train_time:20045ms step_avg:256.99ms
+step:89/1480 train_time:20294ms step_avg:256.88ms
+step:90/1480 train_time:20546ms step_avg:256.82ms
+step:91/1480 train_time:20794ms step_avg:256.72ms
+step:92/1480 train_time:21045ms step_avg:256.65ms
+step:93/1480 train_time:21294ms step_avg:256.55ms
+step:94/1480 train_time:21545ms step_avg:256.49ms
+step:95/1480 train_time:21795ms step_avg:256.41ms
+step:96/1480 train_time:22046ms step_avg:256.34ms
+step:97/1480 train_time:22294ms step_avg:256.26ms
+step:98/1480 train_time:22546ms step_avg:256.21ms
+step:99/1480 train_time:22795ms step_avg:256.12ms
+step:100/1480 train_time:23046ms step_avg:256.07ms
+step:101/1480 train_time:23295ms step_avg:255.99ms
+step:102/1480 train_time:23546ms step_avg:255.94ms
+step:103/1480 train_time:23795ms step_avg:255.86ms
+step:104/1480 train_time:24046ms step_avg:255.81ms
+step:105/1480 train_time:24296ms step_avg:255.74ms
+step:106/1480 train_time:24546ms step_avg:255.69ms
+step:107/1480 train_time:24795ms step_avg:255.62ms
+step:108/1480 train_time:25046ms step_avg:255.57ms
+step:109/1480 train_time:25296ms step_avg:255.52ms
+step:110/1480 train_time:25545ms step_avg:255.45ms
+step:111/1480 train_time:25797ms step_avg:255.42ms
+step:112/1480 train_time:26052ms step_avg:255.41ms
+step:113/1480 train_time:26306ms step_avg:255.40ms
+step:114/1480 train_time:26561ms step_avg:255.40ms
+step:115/1480 train_time:26814ms step_avg:255.37ms
+step:116/1480 train_time:27070ms step_avg:255.38ms
+step:117/1480 train_time:27328ms step_avg:255.40ms
+step:118/1480 train_time:27582ms step_avg:255.39ms
+step:119/1480 train_time:27836ms step_avg:255.37ms
+step:120/1480 train_time:28095ms step_avg:255.41ms
+step:121/1480 train_time:28351ms step_avg:255.41ms
+step:122/1480 train_time:28606ms step_avg:255.41ms
+step:123/1480 train_time:28862ms step_avg:255.41ms
+step:124/1480 train_time:29117ms step_avg:255.41ms
+step:125/1480 train_time:29372ms step_avg:255.41ms
+step:125/1480 val_loss:4.4388 train_time:29503ms step_avg:256.55ms
+step:126/1480 train_time:29632ms step_avg:255.45ms
+step:127/1480 train_time:29892ms step_avg:255.49ms
+step:128/1480 train_time:30144ms step_avg:255.46ms
+step:129/1480 train_time:30400ms step_avg:255.47ms
+step:130/1480 train_time:30655ms step_avg:255.46ms
+step:131/1480 train_time:30911ms step_avg:255.46ms
+step:132/1480 train_time:31165ms step_avg:255.45ms
+step:133/1480 train_time:31418ms step_avg:255.43ms
+step:134/1480 train_time:31675ms step_avg:255.45ms
+step:135/1480 train_time:31933ms step_avg:255.47ms
+step:136/1480 train_time:32187ms step_avg:255.46ms
+step:137/1480 train_time:32442ms step_avg:255.45ms
+step:138/1480 train_time:32699ms step_avg:255.46ms
+step:139/1480 train_time:32958ms step_avg:255.49ms
+step:140/1480 train_time:33212ms step_avg:255.48ms
+step:141/1480 train_time:33467ms step_avg:255.47ms
+step:142/1480 train_time:33724ms step_avg:255.48ms
+step:143/1480 train_time:33979ms step_avg:255.48ms
+step:144/1480 train_time:34237ms step_avg:255.50ms
+step:145/1480 train_time:34499ms step_avg:255.55ms
+step:146/1480 train_time:34756ms step_avg:255.56ms
+step:147/1480 train_time:35012ms step_avg:255.56ms
+step:148/1480 train_time:35267ms step_avg:255.56ms
+step:149/1480 train_time:35523ms step_avg:255.56ms
+step:150/1480 train_time:35780ms step_avg:255.57ms
+step:151/1480 train_time:36034ms step_avg:255.56ms
+step:152/1480 train_time:36289ms step_avg:255.55ms
+step:153/1480 train_time:36543ms step_avg:255.55ms
+step:154/1480 train_time:36797ms step_avg:255.54ms
+step:155/1480 train_time:37053ms step_avg:255.53ms
+step:156/1480 train_time:37308ms step_avg:255.53ms
+step:157/1480 train_time:37563ms step_avg:255.53ms
+step:158/1480 train_time:37818ms step_avg:255.52ms
+step:159/1480 train_time:38073ms step_avg:255.52ms
+step:160/1480 train_time:38329ms step_avg:255.53ms
+step:161/1480 train_time:38583ms step_avg:255.52ms
+step:162/1480 train_time:38838ms step_avg:255.51ms
+step:163/1480 train_time:39093ms step_avg:255.51ms
+step:164/1480 train_time:39347ms step_avg:255.50ms
+step:165/1480 train_time:39603ms step_avg:255.50ms
+step:166/1480 train_time:39857ms step_avg:255.49ms
+step:167/1480 train_time:40111ms step_avg:255.48ms
+step:168/1480 train_time:40365ms step_avg:255.48ms
+step:169/1480 train_time:40619ms step_avg:255.46ms
+step:170/1480 train_time:40874ms step_avg:255.46ms
+step:171/1480 train_time:41130ms step_avg:255.46ms
+step:172/1480 train_time:41385ms step_avg:255.46ms
+step:173/1480 train_time:41639ms step_avg:255.45ms
+step:174/1480 train_time:41899ms step_avg:255.48ms
+step:175/1480 train_time:42156ms step_avg:255.49ms
+step:176/1480 train_time:42410ms step_avg:255.48ms
+step:177/1480 train_time:42665ms step_avg:255.48ms
+step:178/1480 train_time:42918ms step_avg:255.47ms
+step:179/1480 train_time:43174ms step_avg:255.47ms
+step:180/1480 train_time:43429ms step_avg:255.46ms
+step:181/1480 train_time:43683ms step_avg:255.45ms
+step:182/1480 train_time:43938ms step_avg:255.45ms
+step:183/1480 train_time:44196ms step_avg:255.47ms
+step:184/1480 train_time:44449ms step_avg:255.45ms
+step:185/1480 train_time:44705ms step_avg:255.45ms
+step:186/1480 train_time:44958ms step_avg:255.44ms
+step:187/1480 train_time:45212ms step_avg:255.44ms
+step:188/1480 train_time:45467ms step_avg:255.43ms
+step:189/1480 train_time:45720ms step_avg:255.42ms
+step:190/1480 train_time:45975ms step_avg:255.42ms
+step:191/1480 train_time:46231ms step_avg:255.42ms
+step:192/1480 train_time:46486ms step_avg:255.42ms
+step:193/1480 train_time:46739ms step_avg:255.41ms
+step:194/1480 train_time:46999ms step_avg:255.43ms
+step:195/1480 train_time:47254ms step_avg:255.43ms
+step:196/1480 train_time:47510ms step_avg:255.43ms
+step:197/1480 train_time:47765ms step_avg:255.43ms
+step:198/1480 train_time:48020ms step_avg:255.43ms
+step:199/1480 train_time:48275ms step_avg:255.42ms
+step:200/1480 train_time:48533ms step_avg:255.44ms
+step:201/1480 train_time:48788ms step_avg:255.43ms
+step:202/1480 train_time:49041ms step_avg:255.42ms
+step:203/1480 train_time:49302ms step_avg:255.45ms
+step:204/1480 train_time:49556ms step_avg:255.45ms
+step:205/1480 train_time:49811ms step_avg:255.44ms
+step:206/1480 train_time:50065ms step_avg:255.43ms
+step:207/1480 train_time:50318ms step_avg:255.42ms
+step:208/1480 train_time:50574ms step_avg:255.42ms
+step:209/1480 train_time:50831ms step_avg:255.43ms
+step:210/1480 train_time:51086ms step_avg:255.43ms
+step:211/1480 train_time:51340ms step_avg:255.42ms
+step:212/1480 train_time:51598ms step_avg:255.44ms
+step:213/1480 train_time:51855ms step_avg:255.44ms
+step:214/1480 train_time:52109ms step_avg:255.44ms
+step:215/1480 train_time:52363ms step_avg:255.43ms
+step:216/1480 train_time:52616ms step_avg:255.42ms
+step:217/1480 train_time:52872ms step_avg:255.42ms
+step:218/1480 train_time:53129ms step_avg:255.43ms
+step:219/1480 train_time:53384ms step_avg:255.42ms
+step:220/1480 train_time:53638ms step_avg:255.42ms
+step:221/1480 train_time:53899ms step_avg:255.44ms
+step:222/1480 train_time:54158ms step_avg:255.46ms
+step:223/1480 train_time:54416ms step_avg:255.47ms
+step:224/1480 train_time:54674ms step_avg:255.48ms
+step:225/1480 train_time:54932ms step_avg:255.50ms
+step:226/1480 train_time:55192ms step_avg:255.52ms
+step:227/1480 train_time:55449ms step_avg:255.53ms
+step:228/1480 train_time:55711ms step_avg:255.56ms
+step:229/1480 train_time:55970ms step_avg:255.57ms
+step:230/1480 train_time:56230ms step_avg:255.59ms
+step:231/1480 train_time:56490ms step_avg:255.61ms
+step:232/1480 train_time:56749ms step_avg:255.62ms
+step:233/1480 train_time:57009ms step_avg:255.65ms
+step:234/1480 train_time:57268ms step_avg:255.66ms
+step:235/1480 train_time:57528ms step_avg:255.68ms
+step:236/1480 train_time:57789ms step_avg:255.70ms
+step:237/1480 train_time:58047ms step_avg:255.71ms
+step:238/1480 train_time:58309ms step_avg:255.74ms
+step:239/1480 train_time:58569ms step_avg:255.76ms
+step:240/1480 train_time:58831ms step_avg:255.79ms
+step:241/1480 train_time:59090ms step_avg:255.80ms
+step:242/1480 train_time:59349ms step_avg:255.81ms
+step:243/1480 train_time:59609ms step_avg:255.83ms
+step:244/1480 train_time:59869ms step_avg:255.85ms
+step:245/1480 train_time:60131ms step_avg:255.88ms
+step:246/1480 train_time:60391ms step_avg:255.89ms
+step:247/1480 train_time:60649ms step_avg:255.90ms
+step:248/1480 train_time:60910ms step_avg:255.93ms
+step:249/1480 train_time:61169ms step_avg:255.94ms
+step:250/1480 train_time:61430ms step_avg:255.96ms
+step:250/1480 val_loss:3.9939 train_time:61559ms step_avg:256.49ms
+step:251/1480 train_time:61689ms step_avg:255.97ms
+step:252/1480 train_time:61958ms step_avg:256.03ms
+step:253/1480 train_time:62220ms step_avg:256.05ms
+step:254/1480 train_time:62482ms step_avg:256.07ms
+step:255/1480 train_time:62739ms step_avg:256.08ms
+step:256/1480 train_time:63001ms step_avg:256.10ms
+step:257/1480 train_time:63260ms step_avg:256.11ms
+step:258/1480 train_time:63522ms step_avg:256.14ms
+step:259/1480 train_time:63781ms step_avg:256.15ms
+step:260/1480 train_time:64038ms step_avg:256.15ms
+step:261/1480 train_time:64298ms step_avg:256.17ms
+step:262/1480 train_time:64557ms step_avg:256.18ms
+step:263/1480 train_time:64818ms step_avg:256.20ms
+step:264/1480 train_time:65081ms step_avg:256.23ms
+step:265/1480 train_time:65339ms step_avg:256.23ms
+step:266/1480 train_time:65600ms step_avg:256.25ms
+step:267/1480 train_time:65858ms step_avg:256.26ms
+step:268/1480 train_time:66119ms step_avg:256.27ms
+step:269/1480 train_time:66381ms step_avg:256.30ms
+step:270/1480 train_time:66639ms step_avg:256.30ms
+step:271/1480 train_time:66897ms step_avg:256.31ms
+step:272/1480 train_time:67156ms step_avg:256.32ms
+step:273/1480 train_time:67415ms step_avg:256.33ms
+step:274/1480 train_time:67675ms step_avg:256.34ms
+step:275/1480 train_time:67933ms step_avg:256.35ms
+step:276/1480 train_time:68196ms step_avg:256.38ms
+step:277/1480 train_time:68455ms step_avg:256.38ms
+step:278/1480 train_time:68714ms step_avg:256.39ms
+step:279/1480 train_time:68973ms step_avg:256.40ms
+step:280/1480 train_time:69234ms step_avg:256.42ms
+step:281/1480 train_time:69496ms step_avg:256.44ms
+step:282/1480 train_time:69756ms step_avg:256.46ms
+step:283/1480 train_time:70016ms step_avg:256.47ms
+step:284/1480 train_time:70277ms step_avg:256.49ms
+step:285/1480 train_time:70536ms step_avg:256.50ms
+step:286/1480 train_time:70795ms step_avg:256.50ms
+step:287/1480 train_time:71057ms step_avg:256.52ms
+step:288/1480 train_time:71317ms step_avg:256.53ms
+step:289/1480 train_time:71578ms step_avg:256.55ms
+step:290/1480 train_time:71836ms step_avg:256.56ms
+step:291/1480 train_time:72096ms step_avg:256.57ms
+step:292/1480 train_time:72357ms step_avg:256.58ms
+step:293/1480 train_time:72618ms step_avg:256.60ms
+step:294/1480 train_time:72880ms step_avg:256.62ms
+step:295/1480 train_time:73140ms step_avg:256.63ms
+step:296/1480 train_time:73400ms step_avg:256.64ms
+step:297/1480 train_time:73659ms step_avg:256.65ms
+step:298/1480 train_time:73920ms step_avg:256.67ms
+step:299/1480 train_time:74181ms step_avg:256.68ms
+step:300/1480 train_time:74440ms step_avg:256.69ms
+step:301/1480 train_time:74700ms step_avg:256.70ms
+step:302/1480 train_time:74960ms step_avg:256.71ms
+step:303/1480 train_time:75222ms step_avg:256.73ms
+step:304/1480 train_time:75481ms step_avg:256.74ms
+step:305/1480 train_time:75739ms step_avg:256.74ms
+step:306/1480 train_time:76000ms step_avg:256.76ms
+step:307/1480 train_time:76259ms step_avg:256.76ms
+step:308/1480 train_time:76520ms step_avg:256.78ms
+step:309/1480 train_time:76782ms step_avg:256.80ms
+step:310/1480 train_time:77041ms step_avg:256.80ms
+step:311/1480 train_time:77301ms step_avg:256.81ms
+step:312/1480 train_time:77560ms step_avg:256.82ms
+step:313/1480 train_time:77822ms step_avg:256.84ms
+step:314/1480 train_time:78081ms step_avg:256.85ms
+step:315/1480 train_time:78340ms step_avg:256.85ms
+step:316/1480 train_time:78600ms step_avg:256.86ms
+step:317/1480 train_time:78858ms step_avg:256.87ms
+step:318/1480 train_time:79118ms step_avg:256.88ms
+step:319/1480 train_time:79378ms step_avg:256.89ms
+step:320/1480 train_time:79637ms step_avg:256.89ms
+step:321/1480 train_time:79896ms step_avg:256.90ms
+step:322/1480 train_time:80157ms step_avg:256.91ms
+step:323/1480 train_time:80418ms step_avg:256.93ms
+step:324/1480 train_time:80682ms step_avg:256.95ms
+step:325/1480 train_time:80939ms step_avg:256.95ms
+step:326/1480 train_time:81201ms step_avg:256.97ms
+step:327/1480 train_time:81459ms step_avg:256.97ms
+step:328/1480 train_time:81720ms step_avg:256.98ms
+step:329/1480 train_time:81982ms step_avg:257.00ms
+step:330/1480 train_time:82242ms step_avg:257.01ms
+step:331/1480 train_time:82504ms step_avg:257.02ms
+step:332/1480 train_time:82764ms step_avg:257.03ms
+step:333/1480 train_time:83025ms step_avg:257.04ms
+step:334/1480 train_time:83286ms step_avg:257.06ms
+step:335/1480 train_time:83546ms step_avg:257.07ms
+step:336/1480 train_time:83806ms step_avg:257.07ms
+step:337/1480 train_time:84069ms step_avg:257.09ms
+step:338/1480 train_time:84334ms step_avg:257.12ms
+step:339/1480 train_time:84602ms step_avg:257.15ms
+step:340/1480 train_time:84864ms step_avg:257.16ms
+step:341/1480 train_time:85125ms step_avg:257.17ms
+step:342/1480 train_time:85385ms step_avg:257.18ms
+step:343/1480 train_time:85646ms step_avg:257.19ms
+step:344/1480 train_time:85906ms step_avg:257.20ms
+step:345/1480 train_time:86167ms step_avg:257.21ms
+step:346/1480 train_time:86428ms step_avg:257.23ms
+step:347/1480 train_time:86690ms step_avg:257.24ms
+step:348/1480 train_time:86951ms step_avg:257.25ms
+step:349/1480 train_time:87216ms step_avg:257.27ms
+step:350/1480 train_time:87479ms step_avg:257.29ms
+step:351/1480 train_time:87742ms step_avg:257.31ms
+step:352/1480 train_time:88004ms step_avg:257.32ms
+step:353/1480 train_time:88265ms step_avg:257.33ms
+step:354/1480 train_time:88526ms step_avg:257.34ms
+step:355/1480 train_time:88787ms step_avg:257.35ms
+step:356/1480 train_time:89047ms step_avg:257.36ms
+step:357/1480 train_time:89309ms step_avg:257.37ms
+step:358/1480 train_time:89569ms step_avg:257.38ms
+step:359/1480 train_time:89834ms step_avg:257.40ms
+step:360/1480 train_time:90102ms step_avg:257.44ms
+step:361/1480 train_time:90364ms step_avg:257.45ms
+step:362/1480 train_time:90625ms step_avg:257.46ms
+step:363/1480 train_time:90887ms step_avg:257.47ms
+step:364/1480 train_time:91148ms step_avg:257.48ms
+step:365/1480 train_time:91409ms step_avg:257.49ms
+step:366/1480 train_time:91672ms step_avg:257.51ms
+step:367/1480 train_time:91936ms step_avg:257.52ms
+step:368/1480 train_time:92202ms step_avg:257.55ms
+step:369/1480 train_time:92464ms step_avg:257.56ms
+step:370/1480 train_time:92726ms step_avg:257.57ms
+step:371/1480 train_time:92987ms step_avg:257.58ms
+step:372/1480 train_time:93247ms step_avg:257.59ms
+step:373/1480 train_time:93507ms step_avg:257.60ms
+step:374/1480 train_time:93768ms step_avg:257.60ms
+step:375/1480 train_time:94031ms step_avg:257.62ms
+step:375/1480 val_loss:3.8118 train_time:94170ms step_avg:258.00ms
+step:376/1480 train_time:94302ms step_avg:257.66ms
+step:377/1480 train_time:94570ms step_avg:257.68ms
+step:378/1480 train_time:94836ms step_avg:257.71ms
+step:379/1480 train_time:95099ms step_avg:257.72ms
+step:380/1480 train_time:95363ms step_avg:257.74ms
+step:381/1480 train_time:95627ms step_avg:257.75ms
+step:382/1480 train_time:95887ms step_avg:257.76ms
+step:383/1480 train_time:96148ms step_avg:257.77ms
+step:384/1480 train_time:96410ms step_avg:257.78ms
+step:385/1480 train_time:96673ms step_avg:257.79ms
+step:386/1480 train_time:96937ms step_avg:257.81ms
+step:387/1480 train_time:97201ms step_avg:257.83ms
+step:388/1480 train_time:97464ms step_avg:257.84ms
+step:389/1480 train_time:97725ms step_avg:257.85ms
+step:390/1480 train_time:97986ms step_avg:257.86ms
+step:391/1480 train_time:98248ms step_avg:257.87ms
+step:392/1480 train_time:98508ms step_avg:257.87ms
+step:393/1480 train_time:98768ms step_avg:257.88ms
+step:394/1480 train_time:99030ms step_avg:257.89ms
+step:395/1480 train_time:99291ms step_avg:257.90ms
+step:396/1480 train_time:99560ms step_avg:257.93ms
+step:397/1480 train_time:99823ms step_avg:257.94ms
+step:398/1480 train_time:100086ms step_avg:257.95ms
+step:399/1480 train_time:100347ms step_avg:257.96ms
+step:400/1480 train_time:100606ms step_avg:257.96ms
+step:401/1480 train_time:100866ms step_avg:257.97ms
+step:402/1480 train_time:101129ms step_avg:257.98ms
+step:403/1480 train_time:101395ms step_avg:258.00ms
+step:404/1480 train_time:101662ms step_avg:258.02ms
+step:405/1480 train_time:101924ms step_avg:258.04ms
+step:406/1480 train_time:102186ms step_avg:258.04ms
+step:407/1480 train_time:102447ms step_avg:258.05ms
+step:408/1480 train_time:102706ms step_avg:258.06ms
+step:409/1480 train_time:102966ms step_avg:258.06ms
+step:410/1480 train_time:103229ms step_avg:258.07ms
+step:411/1480 train_time:103492ms step_avg:258.08ms
+step:412/1480 train_time:103761ms step_avg:258.11ms
+step:413/1480 train_time:104024ms step_avg:258.13ms
+step:414/1480 train_time:104287ms step_avg:258.14ms
+step:415/1480 train_time:104547ms step_avg:258.14ms
+step:416/1480 train_time:104808ms step_avg:258.15ms
+step:417/1480 train_time:105069ms step_avg:258.15ms
+step:418/1480 train_time:105330ms step_avg:258.16ms
+step:419/1480 train_time:105594ms step_avg:258.18ms
+step:420/1480 train_time:105862ms step_avg:258.20ms
+step:421/1480 train_time:106125ms step_avg:258.21ms
+step:422/1480 train_time:106386ms step_avg:258.22ms
+step:423/1480 train_time:106648ms step_avg:258.23ms
+step:424/1480 train_time:106908ms step_avg:258.23ms
+step:425/1480 train_time:107168ms step_avg:258.24ms
+step:426/1480 train_time:107430ms step_avg:258.24ms
+step:427/1480 train_time:107695ms step_avg:258.26ms
+step:428/1480 train_time:107962ms step_avg:258.28ms
+step:429/1480 train_time:108225ms step_avg:258.29ms
+step:430/1480 train_time:108488ms step_avg:258.30ms
+step:431/1480 train_time:108750ms step_avg:258.31ms
+step:432/1480 train_time:109011ms step_avg:258.32ms
+step:433/1480 train_time:109275ms step_avg:258.33ms
+step:434/1480 train_time:109541ms step_avg:258.35ms
+step:435/1480 train_time:109803ms step_avg:258.36ms
+step:436/1480 train_time:110067ms step_avg:258.37ms
+step:437/1480 train_time:110327ms step_avg:258.38ms
+step:438/1480 train_time:110588ms step_avg:258.38ms
+step:439/1480 train_time:110849ms step_avg:258.39ms
+step:440/1480 train_time:111113ms step_avg:258.40ms
+step:441/1480 train_time:111385ms step_avg:258.43ms
+step:442/1480 train_time:111652ms step_avg:258.45ms
+step:443/1480 train_time:111918ms step_avg:258.47ms
+step:444/1480 train_time:112185ms step_avg:258.49ms
+step:445/1480 train_time:112449ms step_avg:258.50ms
+step:446/1480 train_time:112713ms step_avg:258.52ms
+step:447/1480 train_time:112980ms step_avg:258.53ms
+step:448/1480 train_time:113247ms step_avg:258.55ms
+step:449/1480 train_time:113510ms step_avg:258.57ms
+step:450/1480 train_time:113775ms step_avg:258.58ms
+step:451/1480 train_time:114044ms step_avg:258.60ms
+step:452/1480 train_time:114309ms step_avg:258.62ms
+step:453/1480 train_time:114573ms step_avg:258.63ms
+step:454/1480 train_time:114842ms step_avg:258.65ms
+step:455/1480 train_time:115107ms step_avg:258.67ms
+step:456/1480 train_time:115369ms step_avg:258.68ms
+step:457/1480 train_time:115637ms step_avg:258.70ms
+step:458/1480 train_time:115904ms step_avg:258.71ms
+step:459/1480 train_time:116169ms step_avg:258.73ms
+step:460/1480 train_time:116432ms step_avg:258.74ms
+step:461/1480 train_time:116704ms step_avg:258.77ms
+step:462/1480 train_time:116968ms step_avg:258.78ms
+step:463/1480 train_time:117230ms step_avg:258.79ms
+step:464/1480 train_time:117498ms step_avg:258.81ms
+step:465/1480 train_time:117765ms step_avg:258.82ms
+step:466/1480 train_time:118030ms step_avg:258.84ms
+step:467/1480 train_time:118297ms step_avg:258.86ms
+step:468/1480 train_time:118565ms step_avg:258.88ms
+step:469/1480 train_time:118828ms step_avg:258.88ms
+step:470/1480 train_time:119095ms step_avg:258.90ms
+step:471/1480 train_time:119365ms step_avg:258.93ms
+step:472/1480 train_time:119628ms step_avg:258.94ms
+step:473/1480 train_time:119894ms step_avg:258.95ms
+step:474/1480 train_time:120164ms step_avg:258.97ms
+step:475/1480 train_time:120428ms step_avg:258.99ms
+step:476/1480 train_time:120693ms step_avg:259.00ms
+step:477/1480 train_time:120961ms step_avg:259.02ms
+step:478/1480 train_time:121226ms step_avg:259.03ms
+step:479/1480 train_time:121489ms step_avg:259.04ms
+step:480/1480 train_time:121756ms step_avg:259.05ms
+step:481/1480 train_time:122026ms step_avg:259.08ms
+step:482/1480 train_time:122290ms step_avg:259.09ms
+step:483/1480 train_time:122553ms step_avg:259.10ms
+step:484/1480 train_time:122824ms step_avg:259.12ms
+step:485/1480 train_time:123089ms step_avg:259.13ms
+step:486/1480 train_time:123354ms step_avg:259.15ms
+step:487/1480 train_time:123622ms step_avg:259.16ms
+step:488/1480 train_time:123888ms step_avg:259.18ms
+step:489/1480 train_time:124154ms step_avg:259.19ms
+step:490/1480 train_time:124422ms step_avg:259.21ms
+step:491/1480 train_time:124689ms step_avg:259.23ms
+step:492/1480 train_time:124951ms step_avg:259.23ms
+step:493/1480 train_time:125218ms step_avg:259.25ms
+step:494/1480 train_time:125486ms step_avg:259.27ms
+step:495/1480 train_time:125752ms step_avg:259.28ms
+step:496/1480 train_time:126020ms step_avg:259.30ms
+step:497/1480 train_time:126286ms step_avg:259.31ms
+step:498/1480 train_time:126553ms step_avg:259.33ms
+step:499/1480 train_time:126819ms step_avg:259.34ms
+step:500/1480 train_time:127086ms step_avg:259.36ms
+step:500/1480 val_loss:3.6871 train_time:127220ms step_avg:259.63ms
+step:501/1480 train_time:127352ms step_avg:259.37ms
+step:502/1480 train_time:127626ms step_avg:259.40ms
+step:503/1480 train_time:127890ms step_avg:259.41ms
+step:504/1480 train_time:128153ms step_avg:259.42ms
+step:505/1480 train_time:128421ms step_avg:259.44ms
+step:506/1480 train_time:128691ms step_avg:259.46ms
+step:507/1480 train_time:128954ms step_avg:259.46ms
+step:508/1480 train_time:129223ms step_avg:259.48ms
+step:509/1480 train_time:129490ms step_avg:259.50ms
+step:510/1480 train_time:129751ms step_avg:259.50ms
+step:511/1480 train_time:130015ms step_avg:259.51ms
+step:512/1480 train_time:130287ms step_avg:259.54ms
+step:513/1480 train_time:130550ms step_avg:259.54ms
+step:514/1480 train_time:130817ms step_avg:259.56ms
+step:515/1480 train_time:131084ms step_avg:259.57ms
+step:516/1480 train_time:131349ms step_avg:259.58ms
+step:517/1480 train_time:131612ms step_avg:259.59ms
+step:518/1480 train_time:131877ms step_avg:259.60ms
+step:519/1480 train_time:132143ms step_avg:259.61ms
+step:520/1480 train_time:132409ms step_avg:259.63ms
+step:521/1480 train_time:132675ms step_avg:259.64ms
+step:522/1480 train_time:132944ms step_avg:259.66ms
+step:523/1480 train_time:133209ms step_avg:259.67ms
+step:524/1480 train_time:133472ms step_avg:259.67ms
+step:525/1480 train_time:133739ms step_avg:259.69ms
+step:526/1480 train_time:134006ms step_avg:259.70ms
+step:527/1480 train_time:134270ms step_avg:259.71ms
+step:528/1480 train_time:134536ms step_avg:259.72ms
+step:529/1480 train_time:134805ms step_avg:259.74ms
+step:530/1480 train_time:135071ms step_avg:259.75ms
+step:531/1480 train_time:135339ms step_avg:259.77ms
+step:532/1480 train_time:135608ms step_avg:259.79ms
+step:533/1480 train_time:135870ms step_avg:259.79ms
+step:534/1480 train_time:136137ms step_avg:259.80ms
+step:535/1480 train_time:136405ms step_avg:259.82ms
+step:536/1480 train_time:136670ms step_avg:259.83ms
+step:537/1480 train_time:136937ms step_avg:259.84ms
+step:538/1480 train_time:137205ms step_avg:259.86ms
+step:539/1480 train_time:137471ms step_avg:259.87ms
+step:540/1480 train_time:137738ms step_avg:259.88ms
+step:541/1480 train_time:138005ms step_avg:259.90ms
+step:542/1480 train_time:138270ms step_avg:259.91ms
+step:543/1480 train_time:138535ms step_avg:259.92ms
+step:544/1480 train_time:138806ms step_avg:259.94ms
+step:545/1480 train_time:139070ms step_avg:259.94ms
+step:546/1480 train_time:139337ms step_avg:259.96ms
+step:547/1480 train_time:139606ms step_avg:259.97ms
+step:548/1480 train_time:139872ms step_avg:259.99ms
+step:549/1480 train_time:140137ms step_avg:260.00ms
+step:550/1480 train_time:140408ms step_avg:260.02ms
+step:551/1480 train_time:140674ms step_avg:260.03ms
+step:552/1480 train_time:140946ms step_avg:260.05ms
+step:553/1480 train_time:141213ms step_avg:260.06ms
+step:554/1480 train_time:141486ms step_avg:260.08ms
+step:555/1480 train_time:141755ms step_avg:260.10ms
+step:556/1480 train_time:142027ms step_avg:260.12ms
+step:557/1480 train_time:142294ms step_avg:260.14ms
+step:558/1480 train_time:142562ms step_avg:260.15ms
+step:559/1480 train_time:142829ms step_avg:260.16ms
+step:560/1480 train_time:143096ms step_avg:260.17ms
+step:561/1480 train_time:143367ms step_avg:260.19ms
+step:562/1480 train_time:143636ms step_avg:260.21ms
+step:563/1480 train_time:143909ms step_avg:260.23ms
+step:564/1480 train_time:144173ms step_avg:260.24ms
+step:565/1480 train_time:144441ms step_avg:260.25ms
+step:566/1480 train_time:144710ms step_avg:260.27ms
+step:567/1480 train_time:144975ms step_avg:260.28ms
+step:568/1480 train_time:145247ms step_avg:260.30ms
+step:569/1480 train_time:145512ms step_avg:260.31ms
+step:570/1480 train_time:145780ms step_avg:260.32ms
+step:571/1480 train_time:146049ms step_avg:260.34ms
+step:572/1480 train_time:146315ms step_avg:260.35ms
+step:573/1480 train_time:146585ms step_avg:260.36ms
+step:574/1480 train_time:146855ms step_avg:260.38ms
+step:575/1480 train_time:147127ms step_avg:260.40ms
+step:576/1480 train_time:147393ms step_avg:260.41ms
+step:577/1480 train_time:147663ms step_avg:260.43ms
+step:578/1480 train_time:147932ms step_avg:260.44ms
+step:579/1480 train_time:148204ms step_avg:260.46ms
+step:580/1480 train_time:148472ms step_avg:260.48ms
+step:581/1480 train_time:148741ms step_avg:260.49ms
+step:582/1480 train_time:149010ms step_avg:260.51ms
+step:583/1480 train_time:149276ms step_avg:260.52ms
+step:584/1480 train_time:149549ms step_avg:260.54ms
+step:585/1480 train_time:149814ms step_avg:260.55ms
+step:586/1480 train_time:150088ms step_avg:260.57ms
+step:587/1480 train_time:150353ms step_avg:260.58ms
+step:588/1480 train_time:150623ms step_avg:260.59ms
+step:589/1480 train_time:150892ms step_avg:260.61ms
+step:590/1480 train_time:151160ms step_avg:260.62ms
+step:591/1480 train_time:151430ms step_avg:260.64ms
+step:592/1480 train_time:151697ms step_avg:260.65ms
+step:593/1480 train_time:151969ms step_avg:260.67ms
+step:594/1480 train_time:152237ms step_avg:260.68ms
+step:595/1480 train_time:152510ms step_avg:260.70ms
+step:596/1480 train_time:152777ms step_avg:260.71ms
+step:597/1480 train_time:153047ms step_avg:260.73ms
+step:598/1480 train_time:153312ms step_avg:260.73ms
+step:599/1480 train_time:153585ms step_avg:260.75ms
+step:600/1480 train_time:153850ms step_avg:260.76ms
+step:601/1480 train_time:154120ms step_avg:260.78ms
+step:602/1480 train_time:154391ms step_avg:260.80ms
+step:603/1480 train_time:154658ms step_avg:260.81ms
+step:604/1480 train_time:154928ms step_avg:260.82ms
+step:605/1480 train_time:155195ms step_avg:260.83ms
+step:606/1480 train_time:155467ms step_avg:260.85ms
+step:607/1480 train_time:155739ms step_avg:260.87ms
+step:608/1480 train_time:156009ms step_avg:260.89ms
+step:609/1480 train_time:156275ms step_avg:260.89ms
+step:610/1480 train_time:156545ms step_avg:260.91ms
+step:611/1480 train_time:156813ms step_avg:260.92ms
+step:612/1480 train_time:157085ms step_avg:260.94ms
+step:613/1480 train_time:157355ms step_avg:260.95ms
+step:614/1480 train_time:157626ms step_avg:260.97ms
+step:615/1480 train_time:157892ms step_avg:260.98ms
+step:616/1480 train_time:158159ms step_avg:260.99ms
+step:617/1480 train_time:158431ms step_avg:261.01ms
+step:618/1480 train_time:158696ms step_avg:261.01ms
+step:619/1480 train_time:158967ms step_avg:261.03ms
+step:620/1480 train_time:159236ms step_avg:261.04ms
+step:621/1480 train_time:159510ms step_avg:261.06ms
+step:622/1480 train_time:159777ms step_avg:261.07ms
+step:623/1480 train_time:160048ms step_avg:261.09ms
+step:624/1480 train_time:160315ms step_avg:261.10ms
+step:625/1480 train_time:160588ms step_avg:261.12ms
+step:625/1480 val_loss:3.6052 train_time:160723ms step_avg:261.34ms
+step:626/1480 train_time:160859ms step_avg:261.13ms
+step:627/1480 train_time:161135ms step_avg:261.16ms
+step:628/1480 train_time:161402ms step_avg:261.17ms
+step:629/1480 train_time:161672ms step_avg:261.18ms
+step:630/1480 train_time:161939ms step_avg:261.19ms
+step:631/1480 train_time:162203ms step_avg:261.20ms
+step:632/1480 train_time:162473ms step_avg:261.21ms
+step:633/1480 train_time:162739ms step_avg:261.22ms
+step:634/1480 train_time:163005ms step_avg:261.23ms
+step:635/1480 train_time:163275ms step_avg:261.24ms
+step:636/1480 train_time:163542ms step_avg:261.25ms
+step:637/1480 train_time:163812ms step_avg:261.26ms
+step:638/1480 train_time:164078ms step_avg:261.27ms
+step:639/1480 train_time:164344ms step_avg:261.28ms
+step:640/1480 train_time:164619ms step_avg:261.30ms
+step:641/1480 train_time:164885ms step_avg:261.31ms
+step:642/1480 train_time:165158ms step_avg:261.33ms
+step:643/1480 train_time:165425ms step_avg:261.34ms
+step:644/1480 train_time:165694ms step_avg:261.35ms
+step:645/1480 train_time:165961ms step_avg:261.36ms
+step:646/1480 train_time:166231ms step_avg:261.37ms
+step:647/1480 train_time:166498ms step_avg:261.38ms
+step:648/1480 train_time:166767ms step_avg:261.39ms
+step:649/1480 train_time:167038ms step_avg:261.41ms
+step:650/1480 train_time:167304ms step_avg:261.41ms
+step:651/1480 train_time:167575ms step_avg:261.43ms
+step:652/1480 train_time:167844ms step_avg:261.44ms
+step:653/1480 train_time:168116ms step_avg:261.46ms
+step:654/1480 train_time:168383ms step_avg:261.46ms
+step:655/1480 train_time:168652ms step_avg:261.48ms
+step:656/1480 train_time:168924ms step_avg:261.49ms
+step:657/1480 train_time:169194ms step_avg:261.50ms
+step:658/1480 train_time:169462ms step_avg:261.51ms
+step:659/1480 train_time:169730ms step_avg:261.53ms
+step:660/1480 train_time:170002ms step_avg:261.54ms
+step:661/1480 train_time:170275ms step_avg:261.56ms
+step:662/1480 train_time:170542ms step_avg:261.57ms
+step:663/1480 train_time:170815ms step_avg:261.59ms
+step:664/1480 train_time:171086ms step_avg:261.60ms
+step:665/1480 train_time:171359ms step_avg:261.62ms
+step:666/1480 train_time:171628ms step_avg:261.63ms
+step:667/1480 train_time:171901ms step_avg:261.65ms
+step:668/1480 train_time:172170ms step_avg:261.66ms
+step:669/1480 train_time:172441ms step_avg:261.67ms
+step:670/1480 train_time:172710ms step_avg:261.68ms
+step:671/1480 train_time:172979ms step_avg:261.69ms
+step:672/1480 train_time:173252ms step_avg:261.71ms
+step:673/1480 train_time:173524ms step_avg:261.73ms
+step:674/1480 train_time:173796ms step_avg:261.74ms
+step:675/1480 train_time:174067ms step_avg:261.76ms
+step:676/1480 train_time:174339ms step_avg:261.77ms
+step:677/1480 train_time:174609ms step_avg:261.78ms
+step:678/1480 train_time:174882ms step_avg:261.80ms
+step:679/1480 train_time:175153ms step_avg:261.81ms
+step:680/1480 train_time:175424ms step_avg:261.83ms
+step:681/1480 train_time:175695ms step_avg:261.84ms
+step:682/1480 train_time:175967ms step_avg:261.86ms
+step:683/1480 train_time:176240ms step_avg:261.87ms
+step:684/1480 train_time:176509ms step_avg:261.88ms
+step:685/1480 train_time:176780ms step_avg:261.90ms
+step:686/1480 train_time:177051ms step_avg:261.91ms
+step:687/1480 train_time:177321ms step_avg:261.92ms
+step:688/1480 train_time:177591ms step_avg:261.93ms
+step:689/1480 train_time:177860ms step_avg:261.94ms
+step:690/1480 train_time:178131ms step_avg:261.96ms
+step:691/1480 train_time:178402ms step_avg:261.97ms
+step:692/1480 train_time:178671ms step_avg:261.98ms
+step:693/1480 train_time:178940ms step_avg:261.99ms
+step:694/1480 train_time:179208ms step_avg:262.00ms
+step:695/1480 train_time:179478ms step_avg:262.01ms
+step:696/1480 train_time:179747ms step_avg:262.02ms
+step:697/1480 train_time:180021ms step_avg:262.04ms
+step:698/1480 train_time:180290ms step_avg:262.05ms
+step:699/1480 train_time:180562ms step_avg:262.06ms
+step:700/1480 train_time:180832ms step_avg:262.08ms
+step:701/1480 train_time:181103ms step_avg:262.09ms
+step:702/1480 train_time:181375ms step_avg:262.10ms
+step:703/1480 train_time:181646ms step_avg:262.12ms
+step:704/1480 train_time:181920ms step_avg:262.13ms
+step:705/1480 train_time:182193ms step_avg:262.15ms
+step:706/1480 train_time:182468ms step_avg:262.17ms
+step:707/1480 train_time:182743ms step_avg:262.18ms
+step:708/1480 train_time:183018ms step_avg:262.20ms
+step:709/1480 train_time:183287ms step_avg:262.21ms
+step:710/1480 train_time:183558ms step_avg:262.23ms
+step:711/1480 train_time:183828ms step_avg:262.24ms
+step:712/1480 train_time:184102ms step_avg:262.25ms
+step:713/1480 train_time:184380ms step_avg:262.28ms
+step:714/1480 train_time:184649ms step_avg:262.29ms
+step:715/1480 train_time:184921ms step_avg:262.30ms
+step:716/1480 train_time:185189ms step_avg:262.31ms
+step:717/1480 train_time:185461ms step_avg:262.32ms
+step:718/1480 train_time:185729ms step_avg:262.33ms
+step:719/1480 train_time:186001ms step_avg:262.34ms
+step:720/1480 train_time:186272ms step_avg:262.35ms
+step:721/1480 train_time:186540ms step_avg:262.36ms
+step:722/1480 train_time:186810ms step_avg:262.37ms
+step:723/1480 train_time:187079ms step_avg:262.38ms
+step:724/1480 train_time:187349ms step_avg:262.39ms
+step:725/1480 train_time:187622ms step_avg:262.41ms
+step:726/1480 train_time:187895ms step_avg:262.42ms
+step:727/1480 train_time:188169ms step_avg:262.44ms
+step:728/1480 train_time:188442ms step_avg:262.45ms
+step:729/1480 train_time:188714ms step_avg:262.47ms
+step:730/1480 train_time:188988ms step_avg:262.48ms
+step:731/1480 train_time:189259ms step_avg:262.50ms
+step:732/1480 train_time:189527ms step_avg:262.50ms
+step:733/1480 train_time:189799ms step_avg:262.52ms
+step:734/1480 train_time:190070ms step_avg:262.53ms
+step:735/1480 train_time:190340ms step_avg:262.54ms
+step:736/1480 train_time:190610ms step_avg:262.55ms
+step:737/1480 train_time:190880ms step_avg:262.56ms
+step:738/1480 train_time:191149ms step_avg:262.57ms
+step:739/1480 train_time:191420ms step_avg:262.58ms
+step:740/1480 train_time:191691ms step_avg:262.59ms
+step:741/1480 train_time:191962ms step_avg:262.60ms
+step:742/1480 train_time:192234ms step_avg:262.61ms
+step:743/1480 train_time:192504ms step_avg:262.62ms
+step:744/1480 train_time:192777ms step_avg:262.64ms
+step:745/1480 train_time:193050ms step_avg:262.65ms
+step:746/1480 train_time:193320ms step_avg:262.66ms
+step:747/1480 train_time:193592ms step_avg:262.68ms
+step:748/1480 train_time:193866ms step_avg:262.69ms
+step:749/1480 train_time:194138ms step_avg:262.70ms
+step:750/1480 train_time:194406ms step_avg:262.71ms
+step:750/1480 val_loss:3.5514 train_time:194546ms step_avg:262.90ms
+step:751/1480 train_time:194680ms step_avg:262.73ms
+step:752/1480 train_time:194953ms step_avg:262.74ms
+step:753/1480 train_time:195225ms step_avg:262.75ms
+step:754/1480 train_time:195493ms step_avg:262.76ms
+step:755/1480 train_time:195768ms step_avg:262.78ms
+step:756/1480 train_time:196038ms step_avg:262.78ms
+step:757/1480 train_time:196309ms step_avg:262.80ms
+step:758/1480 train_time:196577ms step_avg:262.80ms
+step:759/1480 train_time:196851ms step_avg:262.82ms
+step:760/1480 train_time:197121ms step_avg:262.83ms
+step:761/1480 train_time:197395ms step_avg:262.84ms
+step:762/1480 train_time:197668ms step_avg:262.86ms
+step:763/1480 train_time:197937ms step_avg:262.86ms
+step:764/1480 train_time:198211ms step_avg:262.88ms
+step:765/1480 train_time:198480ms step_avg:262.89ms
+step:766/1480 train_time:198752ms step_avg:262.90ms
+step:767/1480 train_time:199021ms step_avg:262.91ms
+step:768/1480 train_time:199292ms step_avg:262.92ms
+step:769/1480 train_time:199569ms step_avg:262.94ms
+step:770/1480 train_time:199841ms step_avg:262.95ms
+step:771/1480 train_time:200114ms step_avg:262.96ms
+step:772/1480 train_time:200388ms step_avg:262.98ms
+step:773/1480 train_time:200659ms step_avg:262.99ms
+step:774/1480 train_time:200932ms step_avg:263.00ms
+step:775/1480 train_time:201202ms step_avg:263.01ms
+step:776/1480 train_time:201475ms step_avg:263.02ms
+step:777/1480 train_time:201749ms step_avg:263.04ms
+step:778/1480 train_time:202020ms step_avg:263.05ms
+step:779/1480 train_time:202293ms step_avg:263.06ms
+step:780/1480 train_time:202569ms step_avg:263.08ms
+step:781/1480 train_time:202841ms step_avg:263.09ms
+step:782/1480 train_time:203113ms step_avg:263.10ms
+step:783/1480 train_time:203386ms step_avg:263.11ms
+step:784/1480 train_time:203659ms step_avg:263.13ms
+step:785/1480 train_time:203931ms step_avg:263.14ms
+step:786/1480 train_time:204205ms step_avg:263.15ms
+step:787/1480 train_time:204478ms step_avg:263.16ms
+step:788/1480 train_time:204753ms step_avg:263.18ms
+step:789/1480 train_time:205031ms step_avg:263.20ms
+step:790/1480 train_time:205302ms step_avg:263.21ms
+step:791/1480 train_time:205580ms step_avg:263.23ms
+step:792/1480 train_time:205856ms step_avg:263.24ms
+step:793/1480 train_time:206130ms step_avg:263.26ms
+step:794/1480 train_time:206403ms step_avg:263.27ms
+step:795/1480 train_time:206677ms step_avg:263.28ms
+step:796/1480 train_time:206953ms step_avg:263.30ms
+step:797/1480 train_time:207226ms step_avg:263.31ms
+step:798/1480 train_time:207501ms step_avg:263.33ms
+step:799/1480 train_time:207777ms step_avg:263.34ms
+step:800/1480 train_time:208051ms step_avg:263.36ms
+step:801/1480 train_time:208324ms step_avg:263.37ms
+step:802/1480 train_time:208604ms step_avg:263.39ms
+step:803/1480 train_time:208876ms step_avg:263.40ms
+step:804/1480 train_time:209153ms step_avg:263.42ms
+step:805/1480 train_time:209428ms step_avg:263.43ms
+step:806/1480 train_time:209698ms step_avg:263.44ms
+step:807/1480 train_time:209971ms step_avg:263.45ms
+step:808/1480 train_time:210244ms step_avg:263.46ms
+step:809/1480 train_time:210517ms step_avg:263.48ms
+step:810/1480 train_time:210789ms step_avg:263.49ms
+step:811/1480 train_time:211061ms step_avg:263.50ms
+step:812/1480 train_time:211334ms step_avg:263.51ms
+step:813/1480 train_time:211607ms step_avg:263.52ms
+step:814/1480 train_time:211878ms step_avg:263.53ms
+step:815/1480 train_time:212152ms step_avg:263.54ms
+step:816/1480 train_time:212429ms step_avg:263.56ms
+step:817/1480 train_time:212700ms step_avg:263.57ms
+step:818/1480 train_time:212971ms step_avg:263.58ms
+step:819/1480 train_time:213242ms step_avg:263.59ms
+step:820/1480 train_time:213515ms step_avg:263.60ms
+step:821/1480 train_time:213787ms step_avg:263.61ms
+step:822/1480 train_time:214060ms step_avg:263.62ms
+step:823/1480 train_time:214334ms step_avg:263.63ms
+step:824/1480 train_time:214605ms step_avg:263.64ms
+step:825/1480 train_time:214880ms step_avg:263.66ms
+step:826/1480 train_time:215153ms step_avg:263.67ms
+step:827/1480 train_time:215426ms step_avg:263.68ms
+step:828/1480 train_time:215701ms step_avg:263.69ms
+step:829/1480 train_time:215975ms step_avg:263.71ms
+step:830/1480 train_time:216252ms step_avg:263.72ms
+step:831/1480 train_time:216526ms step_avg:263.73ms
+step:832/1480 train_time:216800ms step_avg:263.75ms
+step:833/1480 train_time:217077ms step_avg:263.76ms
+step:834/1480 train_time:217351ms step_avg:263.78ms
+step:835/1480 train_time:217624ms step_avg:263.79ms
+step:836/1480 train_time:217901ms step_avg:263.80ms
+step:837/1480 train_time:218174ms step_avg:263.81ms
+step:838/1480 train_time:218446ms step_avg:263.82ms
+step:839/1480 train_time:218717ms step_avg:263.83ms
+step:840/1480 train_time:218991ms step_avg:263.84ms
+step:841/1480 train_time:219263ms step_avg:263.85ms
+step:842/1480 train_time:219538ms step_avg:263.87ms
+step:843/1480 train_time:219814ms step_avg:263.88ms
+step:844/1480 train_time:220089ms step_avg:263.90ms
+step:845/1480 train_time:220364ms step_avg:263.91ms
+step:846/1480 train_time:220637ms step_avg:263.92ms
+step:847/1480 train_time:220912ms step_avg:263.93ms
+step:848/1480 train_time:221183ms step_avg:263.94ms
+step:849/1480 train_time:221456ms step_avg:263.95ms
+step:850/1480 train_time:221730ms step_avg:263.96ms
+step:851/1480 train_time:222002ms step_avg:263.97ms
+step:852/1480 train_time:222274ms step_avg:263.98ms
+step:853/1480 train_time:222545ms step_avg:263.99ms
+step:854/1480 train_time:222816ms step_avg:264.00ms
+step:855/1480 train_time:223093ms step_avg:264.02ms
+step:856/1480 train_time:223368ms step_avg:264.03ms
+step:857/1480 train_time:223645ms step_avg:264.04ms
+step:858/1480 train_time:223922ms step_avg:264.06ms
+step:859/1480 train_time:224193ms step_avg:264.07ms
+step:860/1480 train_time:224466ms step_avg:264.08ms
+step:861/1480 train_time:224742ms step_avg:264.09ms
+step:862/1480 train_time:225020ms step_avg:264.11ms
+step:863/1480 train_time:225298ms step_avg:264.12ms
+step:864/1480 train_time:225573ms step_avg:264.14ms
+step:865/1480 train_time:225842ms step_avg:264.14ms
+step:866/1480 train_time:226119ms step_avg:264.16ms
+step:867/1480 train_time:226391ms step_avg:264.17ms
+step:868/1480 train_time:226661ms step_avg:264.17ms
+step:869/1480 train_time:226933ms step_avg:264.18ms
+step:870/1480 train_time:227206ms step_avg:264.19ms
+step:871/1480 train_time:227477ms step_avg:264.20ms
+step:872/1480 train_time:227756ms step_avg:264.22ms
+step:873/1480 train_time:228033ms step_avg:264.23ms
+step:874/1480 train_time:228307ms step_avg:264.24ms
+step:875/1480 train_time:228578ms step_avg:264.25ms
+step:875/1480 val_loss:3.5026 train_time:228722ms step_avg:264.42ms
+step:876/1480 train_time:228858ms step_avg:264.27ms
+step:877/1480 train_time:229141ms step_avg:264.29ms
+step:878/1480 train_time:229413ms step_avg:264.30ms
+step:879/1480 train_time:229685ms step_avg:264.31ms
+step:880/1480 train_time:229958ms step_avg:264.32ms
+step:881/1480 train_time:230228ms step_avg:264.33ms
+step:882/1480 train_time:230503ms step_avg:264.34ms
+step:883/1480 train_time:230780ms step_avg:264.35ms
+step:884/1480 train_time:231056ms step_avg:264.37ms
+step:885/1480 train_time:231330ms step_avg:264.38ms
+step:886/1480 train_time:231605ms step_avg:264.39ms
+step:887/1480 train_time:231884ms step_avg:264.41ms
+step:888/1480 train_time:232163ms step_avg:264.42ms
+step:889/1480 train_time:232440ms step_avg:264.44ms
+step:890/1480 train_time:232710ms step_avg:264.44ms
+step:891/1480 train_time:232983ms step_avg:264.45ms
+step:892/1480 train_time:233257ms step_avg:264.46ms
+step:893/1480 train_time:233530ms step_avg:264.47ms
+step:894/1480 train_time:233811ms step_avg:264.49ms
+step:895/1480 train_time:234091ms step_avg:264.51ms
+step:896/1480 train_time:234367ms step_avg:264.52ms
+step:897/1480 train_time:234644ms step_avg:264.54ms
+step:898/1480 train_time:234919ms step_avg:264.55ms
+step:899/1480 train_time:235192ms step_avg:264.56ms
+step:900/1480 train_time:235464ms step_avg:264.57ms
+step:901/1480 train_time:235739ms step_avg:264.58ms
+step:902/1480 train_time:236010ms step_avg:264.59ms
+step:903/1480 train_time:236294ms step_avg:264.61ms
+step:904/1480 train_time:236570ms step_avg:264.62ms
+step:905/1480 train_time:236843ms step_avg:264.63ms
+step:906/1480 train_time:237120ms step_avg:264.64ms
+step:907/1480 train_time:237398ms step_avg:264.66ms
+step:908/1480 train_time:237671ms step_avg:264.67ms
+step:909/1480 train_time:237943ms step_avg:264.68ms
+step:910/1480 train_time:238221ms step_avg:264.69ms
+step:911/1480 train_time:238494ms step_avg:264.70ms
+step:912/1480 train_time:238771ms step_avg:264.71ms
+step:913/1480 train_time:239051ms step_avg:264.73ms
+step:914/1480 train_time:239325ms step_avg:264.74ms
+step:915/1480 train_time:239612ms step_avg:264.76ms
+step:916/1480 train_time:239889ms step_avg:264.78ms
+step:917/1480 train_time:240162ms step_avg:264.79ms
+step:918/1480 train_time:240441ms step_avg:264.80ms
+step:919/1480 train_time:240718ms step_avg:264.82ms
+step:920/1480 train_time:240990ms step_avg:264.82ms
+step:921/1480 train_time:241264ms step_avg:264.83ms
+step:922/1480 train_time:241544ms step_avg:264.85ms
+step:923/1480 train_time:241822ms step_avg:264.87ms
+step:924/1480 train_time:242097ms step_avg:264.88ms
+step:925/1480 train_time:242374ms step_avg:264.89ms
+step:926/1480 train_time:242650ms step_avg:264.90ms
+step:927/1480 train_time:242924ms step_avg:264.91ms
+step:928/1480 train_time:243202ms step_avg:264.93ms
+step:929/1480 train_time:243477ms step_avg:264.94ms
+step:930/1480 train_time:243754ms step_avg:264.95ms
+step:931/1480 train_time:244027ms step_avg:264.96ms
+step:932/1480 train_time:244308ms step_avg:264.98ms
+step:933/1480 train_time:244586ms step_avg:264.99ms
+step:934/1480 train_time:244868ms step_avg:265.01ms
+step:935/1480 train_time:245151ms step_avg:265.03ms
+step:936/1480 train_time:245427ms step_avg:265.04ms
+step:937/1480 train_time:245707ms step_avg:265.06ms
+step:938/1480 train_time:245981ms step_avg:265.07ms
+step:939/1480 train_time:246260ms step_avg:265.08ms
+step:940/1480 train_time:246536ms step_avg:265.09ms
+step:941/1480 train_time:246811ms step_avg:265.10ms
+step:942/1480 train_time:247088ms step_avg:265.12ms
+step:943/1480 train_time:247368ms step_avg:265.13ms
+step:944/1480 train_time:247652ms step_avg:265.15ms
+step:945/1480 train_time:247926ms step_avg:265.16ms
+step:946/1480 train_time:248207ms step_avg:265.18ms
+step:947/1480 train_time:248483ms step_avg:265.19ms
+step:948/1480 train_time:248758ms step_avg:265.20ms
+step:949/1480 train_time:249035ms step_avg:265.21ms
+step:950/1480 train_time:249305ms step_avg:265.22ms
+step:951/1480 train_time:249589ms step_avg:265.24ms
+step:952/1480 train_time:249865ms step_avg:265.25ms
+step:953/1480 train_time:250145ms step_avg:265.27ms
+step:954/1480 train_time:250425ms step_avg:265.28ms
+step:955/1480 train_time:250698ms step_avg:265.29ms
+step:956/1480 train_time:250971ms step_avg:265.30ms
+step:957/1480 train_time:251248ms step_avg:265.31ms
+step:958/1480 train_time:251531ms step_avg:265.33ms
+step:959/1480 train_time:251805ms step_avg:265.34ms
+step:960/1480 train_time:252081ms step_avg:265.35ms
+step:961/1480 train_time:252354ms step_avg:265.36ms
+step:962/1480 train_time:252628ms step_avg:265.37ms
+step:963/1480 train_time:252905ms step_avg:265.38ms
+step:964/1480 train_time:253181ms step_avg:265.39ms
+step:965/1480 train_time:253455ms step_avg:265.40ms
+step:966/1480 train_time:253730ms step_avg:265.41ms
+step:967/1480 train_time:254008ms step_avg:265.42ms
+step:968/1480 train_time:254285ms step_avg:265.43ms
+step:969/1480 train_time:254560ms step_avg:265.44ms
+step:970/1480 train_time:254832ms step_avg:265.45ms
+step:971/1480 train_time:255107ms step_avg:265.46ms
+step:972/1480 train_time:255381ms step_avg:265.47ms
+step:973/1480 train_time:255653ms step_avg:265.48ms
+step:974/1480 train_time:255935ms step_avg:265.49ms
+step:975/1480 train_time:256208ms step_avg:265.50ms
+step:976/1480 train_time:256482ms step_avg:265.51ms
+step:977/1480 train_time:256755ms step_avg:265.52ms
+step:978/1480 train_time:257032ms step_avg:265.53ms
+step:979/1480 train_time:257305ms step_avg:265.54ms
+step:980/1480 train_time:257582ms step_avg:265.55ms
+step:981/1480 train_time:257862ms step_avg:265.56ms
+step:982/1480 train_time:258132ms step_avg:265.57ms
+step:983/1480 train_time:258409ms step_avg:265.58ms
+step:984/1480 train_time:258686ms step_avg:265.59ms
+step:985/1480 train_time:258964ms step_avg:265.60ms
+step:986/1480 train_time:259237ms step_avg:265.61ms
+step:987/1480 train_time:259508ms step_avg:265.62ms
+step:988/1480 train_time:259786ms step_avg:265.63ms
+step:989/1480 train_time:260061ms step_avg:265.64ms
+step:990/1480 train_time:260341ms step_avg:265.65ms
+step:991/1480 train_time:260617ms step_avg:265.66ms
+step:992/1480 train_time:260901ms step_avg:265.68ms
+step:993/1480 train_time:261189ms step_avg:265.71ms
+step:994/1480 train_time:261465ms step_avg:265.72ms
+step:995/1480 train_time:261739ms step_avg:265.72ms
+step:996/1480 train_time:262013ms step_avg:265.73ms
+step:997/1480 train_time:262291ms step_avg:265.75ms
+step:998/1480 train_time:262565ms step_avg:265.75ms
+step:999/1480 train_time:262845ms step_avg:265.77ms
+step:1000/1480 train_time:263126ms step_avg:265.78ms
+step:1000/1480 val_loss:3.4401 train_time:263268ms step_avg:265.93ms
+step:1001/1480 train_time:263408ms step_avg:265.80ms
+step:1002/1480 train_time:263685ms step_avg:265.81ms
+step:1003/1480 train_time:263963ms step_avg:265.82ms
+step:1004/1480 train_time:264246ms step_avg:265.84ms
+step:1005/1480 train_time:264525ms step_avg:265.85ms
+step:1006/1480 train_time:264805ms step_avg:265.87ms
+step:1007/1480 train_time:265082ms step_avg:265.88ms
+step:1008/1480 train_time:265359ms step_avg:265.89ms
+step:1009/1480 train_time:265649ms step_avg:265.91ms
+step:1010/1480 train_time:265923ms step_avg:265.92ms
+step:1011/1480 train_time:266197ms step_avg:265.93ms
+step:1012/1480 train_time:266473ms step_avg:265.94ms
+step:1013/1480 train_time:266753ms step_avg:265.96ms
+step:1014/1480 train_time:267037ms step_avg:265.97ms
+step:1015/1480 train_time:267319ms step_avg:265.99ms
+step:1016/1480 train_time:267598ms step_avg:266.00ms
+step:1017/1480 train_time:267880ms step_avg:266.02ms
+step:1018/1480 train_time:268159ms step_avg:266.03ms
+step:1019/1480 train_time:268442ms step_avg:266.05ms
+step:1020/1480 train_time:268724ms step_avg:266.06ms
+step:1021/1480 train_time:268998ms step_avg:266.07ms
+step:1022/1480 train_time:269276ms step_avg:266.08ms
+step:1023/1480 train_time:269554ms step_avg:266.09ms
+step:1024/1480 train_time:269832ms step_avg:266.11ms
+step:1025/1480 train_time:270116ms step_avg:266.12ms
+step:1026/1480 train_time:270390ms step_avg:266.13ms
+step:1027/1480 train_time:270663ms step_avg:266.14ms
+step:1028/1480 train_time:270947ms step_avg:266.16ms
+step:1029/1480 train_time:271230ms step_avg:266.17ms
+step:1030/1480 train_time:271509ms step_avg:266.19ms
+step:1031/1480 train_time:271781ms step_avg:266.19ms
+step:1032/1480 train_time:272062ms step_avg:266.21ms
+step:1033/1480 train_time:272340ms step_avg:266.22ms
+step:1034/1480 train_time:272622ms step_avg:266.23ms
+step:1035/1480 train_time:272901ms step_avg:266.24ms
+step:1036/1480 train_time:273178ms step_avg:266.26ms
+step:1037/1480 train_time:273455ms step_avg:266.27ms
+step:1038/1480 train_time:273735ms step_avg:266.28ms
+step:1039/1480 train_time:274021ms step_avg:266.30ms
+step:1040/1480 train_time:274299ms step_avg:266.31ms
+step:1041/1480 train_time:274576ms step_avg:266.32ms
+step:1042/1480 train_time:274851ms step_avg:266.33ms
+step:1043/1480 train_time:275127ms step_avg:266.34ms
+step:1044/1480 train_time:275402ms step_avg:266.35ms
+step:1045/1480 train_time:275683ms step_avg:266.36ms
+step:1046/1480 train_time:275963ms step_avg:266.37ms
+step:1047/1480 train_time:276240ms step_avg:266.38ms
+step:1048/1480 train_time:276514ms step_avg:266.39ms
+step:1049/1480 train_time:276790ms step_avg:266.40ms
+step:1050/1480 train_time:277069ms step_avg:266.41ms
+step:1051/1480 train_time:277348ms step_avg:266.42ms
+step:1052/1480 train_time:277623ms step_avg:266.43ms
+step:1053/1480 train_time:277899ms step_avg:266.44ms
+step:1054/1480 train_time:278180ms step_avg:266.46ms
+step:1055/1480 train_time:278454ms step_avg:266.46ms
+step:1056/1480 train_time:278732ms step_avg:266.47ms
+step:1057/1480 train_time:279013ms step_avg:266.49ms
+step:1058/1480 train_time:279289ms step_avg:266.50ms
+step:1059/1480 train_time:279569ms step_avg:266.51ms
+step:1060/1480 train_time:279848ms step_avg:266.52ms
+step:1061/1480 train_time:280120ms step_avg:266.53ms
+step:1062/1480 train_time:280398ms step_avg:266.54ms
+step:1063/1480 train_time:280672ms step_avg:266.54ms
+step:1064/1480 train_time:280946ms step_avg:266.55ms
+step:1065/1480 train_time:281224ms step_avg:266.56ms
+step:1066/1480 train_time:281506ms step_avg:266.58ms
+step:1067/1480 train_time:281782ms step_avg:266.59ms
+step:1068/1480 train_time:282056ms step_avg:266.59ms
+step:1069/1480 train_time:282340ms step_avg:266.61ms
+step:1070/1480 train_time:282615ms step_avg:266.62ms
+step:1071/1480 train_time:282896ms step_avg:266.63ms
+step:1072/1480 train_time:283173ms step_avg:266.64ms
+step:1073/1480 train_time:283448ms step_avg:266.65ms
+step:1074/1480 train_time:283723ms step_avg:266.66ms
+step:1075/1480 train_time:284006ms step_avg:266.67ms
+step:1076/1480 train_time:284284ms step_avg:266.68ms
+step:1077/1480 train_time:284562ms step_avg:266.69ms
+step:1078/1480 train_time:284848ms step_avg:266.71ms
+step:1079/1480 train_time:285129ms step_avg:266.72ms
+step:1080/1480 train_time:285409ms step_avg:266.74ms
+step:1081/1480 train_time:285685ms step_avg:266.75ms
+step:1082/1480 train_time:285959ms step_avg:266.75ms
+step:1083/1480 train_time:286238ms step_avg:266.76ms
+step:1084/1480 train_time:286515ms step_avg:266.77ms
+step:1085/1480 train_time:286792ms step_avg:266.78ms
+step:1086/1480 train_time:287072ms step_avg:266.80ms
+step:1087/1480 train_time:287348ms step_avg:266.80ms
+step:1088/1480 train_time:287627ms step_avg:266.82ms
+step:1089/1480 train_time:287908ms step_avg:266.83ms
+step:1090/1480 train_time:288188ms step_avg:266.84ms
+step:1091/1480 train_time:288464ms step_avg:266.85ms
+step:1092/1480 train_time:288743ms step_avg:266.86ms
+step:1093/1480 train_time:289020ms step_avg:266.87ms
+step:1094/1480 train_time:289295ms step_avg:266.88ms
+step:1095/1480 train_time:289573ms step_avg:266.89ms
+step:1096/1480 train_time:289851ms step_avg:266.90ms
+step:1097/1480 train_time:290131ms step_avg:266.91ms
+step:1098/1480 train_time:290415ms step_avg:266.93ms
+step:1099/1480 train_time:290699ms step_avg:266.94ms
+step:1100/1480 train_time:290985ms step_avg:266.96ms
+step:1101/1480 train_time:291265ms step_avg:266.97ms
+step:1102/1480 train_time:291548ms step_avg:266.99ms
+step:1103/1480 train_time:291835ms step_avg:267.00ms
+step:1104/1480 train_time:292115ms step_avg:267.02ms
+step:1105/1480 train_time:292401ms step_avg:267.03ms
+step:1106/1480 train_time:292677ms step_avg:267.04ms
+step:1107/1480 train_time:292955ms step_avg:267.05ms
+step:1108/1480 train_time:293230ms step_avg:267.06ms
+step:1109/1480 train_time:293509ms step_avg:267.07ms
+step:1110/1480 train_time:293785ms step_avg:267.08ms
+step:1111/1480 train_time:294064ms step_avg:267.09ms
+step:1112/1480 train_time:294342ms step_avg:267.10ms
+step:1113/1480 train_time:294631ms step_avg:267.12ms
+step:1114/1480 train_time:294915ms step_avg:267.13ms
+step:1115/1480 train_time:295195ms step_avg:267.14ms
+step:1116/1480 train_time:295472ms step_avg:267.15ms
+step:1117/1480 train_time:295754ms step_avg:267.17ms
+step:1118/1480 train_time:296040ms step_avg:267.18ms
+step:1119/1480 train_time:296315ms step_avg:267.19ms
+step:1120/1480 train_time:296593ms step_avg:267.20ms
+step:1121/1480 train_time:296879ms step_avg:267.22ms
+step:1122/1480 train_time:297157ms step_avg:267.23ms
+step:1123/1480 train_time:297438ms step_avg:267.24ms
+step:1124/1480 train_time:297719ms step_avg:267.25ms
+step:1125/1480 train_time:297994ms step_avg:267.26ms
+step:1125/1480 val_loss:3.3848 train_time:298135ms step_avg:267.39ms
+step:1126/1480 train_time:298275ms step_avg:267.27ms
+step:1127/1480 train_time:298561ms step_avg:267.29ms
+step:1128/1480 train_time:298841ms step_avg:267.30ms
+step:1129/1480 train_time:299126ms step_avg:267.32ms
+step:1130/1480 train_time:299403ms step_avg:267.32ms
+step:1131/1480 train_time:299694ms step_avg:267.35ms
+step:1132/1480 train_time:299969ms step_avg:267.35ms
+step:1133/1480 train_time:300251ms step_avg:267.37ms
+step:1134/1480 train_time:300531ms step_avg:267.38ms
+step:1135/1480 train_time:300810ms step_avg:267.39ms
+step:1136/1480 train_time:301089ms step_avg:267.40ms
+step:1137/1480 train_time:301369ms step_avg:267.41ms
+step:1138/1480 train_time:301649ms step_avg:267.42ms
+step:1139/1480 train_time:301926ms step_avg:267.43ms
+step:1140/1480 train_time:302206ms step_avg:267.44ms
+step:1141/1480 train_time:302489ms step_avg:267.45ms
+step:1142/1480 train_time:302764ms step_avg:267.46ms
+step:1143/1480 train_time:303049ms step_avg:267.48ms
+step:1144/1480 train_time:303330ms step_avg:267.49ms
+step:1145/1480 train_time:303605ms step_avg:267.49ms
+step:1146/1480 train_time:303886ms step_avg:267.51ms
+step:1147/1480 train_time:304169ms step_avg:267.52ms
+step:1148/1480 train_time:304446ms step_avg:267.53ms
+step:1149/1480 train_time:304727ms step_avg:267.54ms
+step:1150/1480 train_time:305008ms step_avg:267.55ms
+step:1151/1480 train_time:305291ms step_avg:267.56ms
+step:1152/1480 train_time:305573ms step_avg:267.58ms
+step:1153/1480 train_time:305854ms step_avg:267.59ms
+step:1154/1480 train_time:306128ms step_avg:267.59ms
+step:1155/1480 train_time:306410ms step_avg:267.61ms
+step:1156/1480 train_time:306698ms step_avg:267.62ms
+step:1157/1480 train_time:306976ms step_avg:267.63ms
+step:1158/1480 train_time:307252ms step_avg:267.64ms
+step:1159/1480 train_time:307528ms step_avg:267.65ms
+step:1160/1480 train_time:307803ms step_avg:267.65ms
+step:1161/1480 train_time:308089ms step_avg:267.67ms
+step:1162/1480 train_time:308367ms step_avg:267.68ms
+step:1163/1480 train_time:308644ms step_avg:267.69ms
+step:1164/1480 train_time:308919ms step_avg:267.69ms
+step:1165/1480 train_time:309195ms step_avg:267.70ms
+step:1166/1480 train_time:309484ms step_avg:267.72ms
+step:1167/1480 train_time:309765ms step_avg:267.73ms
+step:1168/1480 train_time:310045ms step_avg:267.74ms
+step:1169/1480 train_time:310322ms step_avg:267.75ms
+step:1170/1480 train_time:310601ms step_avg:267.76ms
+step:1171/1480 train_time:310878ms step_avg:267.77ms
+step:1172/1480 train_time:311152ms step_avg:267.77ms
+step:1173/1480 train_time:311426ms step_avg:267.78ms
+step:1174/1480 train_time:311716ms step_avg:267.80ms
+step:1175/1480 train_time:312002ms step_avg:267.81ms
+step:1176/1480 train_time:312282ms step_avg:267.82ms
+step:1177/1480 train_time:312571ms step_avg:267.84ms
+step:1178/1480 train_time:312849ms step_avg:267.85ms
+step:1179/1480 train_time:313124ms step_avg:267.86ms
+step:1180/1480 train_time:313416ms step_avg:267.88ms
+step:1181/1480 train_time:313695ms step_avg:267.89ms
+step:1182/1480 train_time:313975ms step_avg:267.90ms
+step:1183/1480 train_time:314255ms step_avg:267.91ms
+step:1184/1480 train_time:314533ms step_avg:267.92ms
+step:1185/1480 train_time:314816ms step_avg:267.93ms
+step:1186/1480 train_time:315092ms step_avg:267.94ms
+step:1187/1480 train_time:315381ms step_avg:267.95ms
+step:1188/1480 train_time:315654ms step_avg:267.96ms
+step:1189/1480 train_time:315936ms step_avg:267.97ms
+step:1190/1480 train_time:316215ms step_avg:267.98ms
+step:1191/1480 train_time:316499ms step_avg:267.99ms
+step:1192/1480 train_time:316776ms step_avg:268.00ms
+step:1193/1480 train_time:317056ms step_avg:268.01ms
+step:1194/1480 train_time:317333ms step_avg:268.02ms
+step:1195/1480 train_time:317615ms step_avg:268.03ms
+step:1196/1480 train_time:317911ms step_avg:268.05ms
+step:1197/1480 train_time:318191ms step_avg:268.06ms
+step:1198/1480 train_time:318481ms step_avg:268.08ms
+step:1199/1480 train_time:318768ms step_avg:268.10ms
+step:1200/1480 train_time:319048ms step_avg:268.11ms
+step:1201/1480 train_time:319324ms step_avg:268.11ms
+step:1202/1480 train_time:319615ms step_avg:268.13ms
+step:1203/1480 train_time:319898ms step_avg:268.15ms
+step:1204/1480 train_time:320183ms step_avg:268.16ms
+step:1205/1480 train_time:320463ms step_avg:268.17ms
+step:1206/1480 train_time:320743ms step_avg:268.18ms
+step:1207/1480 train_time:321021ms step_avg:268.19ms
+step:1208/1480 train_time:321297ms step_avg:268.19ms
+step:1209/1480 train_time:321579ms step_avg:268.21ms
+step:1210/1480 train_time:321866ms step_avg:268.22ms
+step:1211/1480 train_time:322152ms step_avg:268.24ms
+step:1212/1480 train_time:322433ms step_avg:268.25ms
+step:1213/1480 train_time:322713ms step_avg:268.26ms
+step:1214/1480 train_time:322995ms step_avg:268.27ms
+step:1215/1480 train_time:323279ms step_avg:268.28ms
+step:1216/1480 train_time:323559ms step_avg:268.29ms
+step:1217/1480 train_time:323848ms step_avg:268.31ms
+step:1218/1480 train_time:324128ms step_avg:268.32ms
+step:1219/1480 train_time:324419ms step_avg:268.34ms
+step:1220/1480 train_time:324700ms step_avg:268.35ms
+step:1221/1480 train_time:324983ms step_avg:268.36ms
+step:1222/1480 train_time:325257ms step_avg:268.36ms
+step:1223/1480 train_time:325540ms step_avg:268.38ms
+step:1224/1480 train_time:325829ms step_avg:268.39ms
+step:1225/1480 train_time:326110ms step_avg:268.40ms
+step:1226/1480 train_time:326391ms step_avg:268.41ms
+step:1227/1480 train_time:326675ms step_avg:268.43ms
+step:1228/1480 train_time:326953ms step_avg:268.43ms
+step:1229/1480 train_time:327235ms step_avg:268.45ms
+step:1230/1480 train_time:327521ms step_avg:268.46ms
+step:1231/1480 train_time:327805ms step_avg:268.47ms
+step:1232/1480 train_time:328092ms step_avg:268.49ms
+step:1233/1480 train_time:328367ms step_avg:268.49ms
+step:1234/1480 train_time:328645ms step_avg:268.50ms
+step:1235/1480 train_time:328931ms step_avg:268.52ms
+step:1236/1480 train_time:329211ms step_avg:268.52ms
+step:1237/1480 train_time:329488ms step_avg:268.53ms
+step:1238/1480 train_time:329780ms step_avg:268.55ms
+step:1239/1480 train_time:330066ms step_avg:268.56ms
+step:1240/1480 train_time:330348ms step_avg:268.58ms
+step:1241/1480 train_time:330632ms step_avg:268.59ms
+step:1242/1480 train_time:330911ms step_avg:268.60ms
+step:1243/1480 train_time:331188ms step_avg:268.60ms
+step:1244/1480 train_time:331466ms step_avg:268.61ms
+step:1245/1480 train_time:331746ms step_avg:268.62ms
+step:1246/1480 train_time:332026ms step_avg:268.63ms
+step:1247/1480 train_time:332310ms step_avg:268.64ms
+step:1248/1480 train_time:332589ms step_avg:268.65ms
+step:1249/1480 train_time:332869ms step_avg:268.66ms
+step:1250/1480 train_time:333147ms step_avg:268.67ms
+step:1250/1480 val_loss:3.3342 train_time:333289ms step_avg:268.78ms
+step:1251/1480 train_time:333431ms step_avg:268.68ms
+step:1252/1480 train_time:333709ms step_avg:268.69ms
+step:1253/1480 train_time:333987ms step_avg:268.69ms
+step:1254/1480 train_time:334269ms step_avg:268.70ms
+step:1255/1480 train_time:334563ms step_avg:268.73ms
+step:1256/1480 train_time:334851ms step_avg:268.74ms
+step:1257/1480 train_time:335132ms step_avg:268.75ms
+step:1258/1480 train_time:335416ms step_avg:268.76ms
+step:1259/1480 train_time:335695ms step_avg:268.77ms
+step:1260/1480 train_time:335974ms step_avg:268.78ms
+step:1261/1480 train_time:336259ms step_avg:268.79ms
+step:1262/1480 train_time:336544ms step_avg:268.81ms
+step:1263/1480 train_time:336829ms step_avg:268.82ms
+step:1264/1480 train_time:337108ms step_avg:268.83ms
+step:1265/1480 train_time:337386ms step_avg:268.83ms
+step:1266/1480 train_time:337667ms step_avg:268.84ms
+step:1267/1480 train_time:337950ms step_avg:268.85ms
+step:1268/1480 train_time:338228ms step_avg:268.86ms
+step:1269/1480 train_time:338518ms step_avg:268.88ms
+step:1270/1480 train_time:338796ms step_avg:268.89ms
+step:1271/1480 train_time:339081ms step_avg:268.90ms
+step:1272/1480 train_time:339357ms step_avg:268.90ms
+step:1273/1480 train_time:339637ms step_avg:268.91ms
+step:1274/1480 train_time:339919ms step_avg:268.92ms
+step:1275/1480 train_time:340196ms step_avg:268.93ms
+step:1276/1480 train_time:340473ms step_avg:268.94ms
+step:1277/1480 train_time:340759ms step_avg:268.95ms
+step:1278/1480 train_time:341040ms step_avg:268.96ms
+step:1279/1480 train_time:341320ms step_avg:268.97ms
+step:1280/1480 train_time:341606ms step_avg:268.98ms
+step:1281/1480 train_time:341886ms step_avg:268.99ms
+step:1282/1480 train_time:342164ms step_avg:269.00ms
+step:1283/1480 train_time:342447ms step_avg:269.01ms
+step:1284/1480 train_time:342728ms step_avg:269.02ms
+step:1285/1480 train_time:343006ms step_avg:269.02ms
+step:1286/1480 train_time:343283ms step_avg:269.03ms
+step:1287/1480 train_time:343564ms step_avg:269.04ms
+step:1288/1480 train_time:343847ms step_avg:269.05ms
+step:1289/1480 train_time:344142ms step_avg:269.07ms
+step:1290/1480 train_time:344426ms step_avg:269.08ms
+step:1291/1480 train_time:344706ms step_avg:269.09ms
+step:1292/1480 train_time:344986ms step_avg:269.10ms
+step:1293/1480 train_time:345270ms step_avg:269.11ms
+step:1294/1480 train_time:345552ms step_avg:269.12ms
+step:1295/1480 train_time:345829ms step_avg:269.13ms
+step:1296/1480 train_time:346115ms step_avg:269.14ms
+step:1297/1480 train_time:346397ms step_avg:269.15ms
+step:1298/1480 train_time:346681ms step_avg:269.16ms
+step:1299/1480 train_time:346961ms step_avg:269.17ms
+step:1300/1480 train_time:347238ms step_avg:269.18ms
+step:1301/1480 train_time:347519ms step_avg:269.19ms
+step:1302/1480 train_time:347802ms step_avg:269.20ms
+step:1303/1480 train_time:348084ms step_avg:269.21ms
+step:1304/1480 train_time:348365ms step_avg:269.22ms
+step:1305/1480 train_time:348641ms step_avg:269.22ms
+step:1306/1480 train_time:348923ms step_avg:269.23ms
+step:1307/1480 train_time:349200ms step_avg:269.24ms
+step:1308/1480 train_time:349478ms step_avg:269.24ms
+step:1309/1480 train_time:349760ms step_avg:269.25ms
+step:1310/1480 train_time:350036ms step_avg:269.26ms
+step:1311/1480 train_time:350313ms step_avg:269.26ms
+step:1312/1480 train_time:350597ms step_avg:269.28ms
+step:1313/1480 train_time:350876ms step_avg:269.28ms
+step:1314/1480 train_time:351158ms step_avg:269.29ms
+step:1315/1480 train_time:351439ms step_avg:269.30ms
+step:1316/1480 train_time:351716ms step_avg:269.31ms
+step:1317/1480 train_time:351997ms step_avg:269.32ms
+step:1318/1480 train_time:352283ms step_avg:269.33ms
+step:1319/1480 train_time:352565ms step_avg:269.34ms
+step:1320/1480 train_time:352857ms step_avg:269.36ms
+step:1321/1480 train_time:353140ms step_avg:269.37ms
+step:1322/1480 train_time:353427ms step_avg:269.38ms
+step:1323/1480 train_time:353713ms step_avg:269.39ms
+step:1324/1480 train_time:354000ms step_avg:269.41ms
+step:1325/1480 train_time:354295ms step_avg:269.43ms
+step:1326/1480 train_time:354581ms step_avg:269.44ms
+step:1327/1480 train_time:354860ms step_avg:269.45ms
+step:1328/1480 train_time:355138ms step_avg:269.45ms
+step:1329/1480 train_time:355443ms step_avg:269.48ms
+step:1330/1480 train_time:355730ms step_avg:269.49ms
+step:1331/1480 train_time:356011ms step_avg:269.50ms
+step:1332/1480 train_time:356294ms step_avg:269.51ms
+step:1333/1480 train_time:356582ms step_avg:269.53ms
+step:1334/1480 train_time:356864ms step_avg:269.53ms
+step:1335/1480 train_time:357146ms step_avg:269.54ms
+step:1336/1480 train_time:357440ms step_avg:269.56ms
+step:1337/1480 train_time:357723ms step_avg:269.57ms
+step:1338/1480 train_time:358006ms step_avg:269.58ms
+step:1339/1480 train_time:358289ms step_avg:269.59ms
+step:1340/1480 train_time:358577ms step_avg:269.61ms
+step:1341/1480 train_time:358853ms step_avg:269.61ms
+step:1342/1480 train_time:359136ms step_avg:269.62ms
+step:1343/1480 train_time:359414ms step_avg:269.63ms
+step:1344/1480 train_time:359696ms step_avg:269.64ms
+step:1345/1480 train_time:359987ms step_avg:269.65ms
+step:1346/1480 train_time:360266ms step_avg:269.66ms
+step:1347/1480 train_time:360547ms step_avg:269.67ms
+step:1348/1480 train_time:360830ms step_avg:269.68ms
+step:1349/1480 train_time:361111ms step_avg:269.69ms
+step:1350/1480 train_time:361396ms step_avg:269.70ms
+step:1351/1480 train_time:361679ms step_avg:269.71ms
+step:1352/1480 train_time:361958ms step_avg:269.72ms
+step:1353/1480 train_time:362244ms step_avg:269.73ms
+step:1354/1480 train_time:362529ms step_avg:269.74ms
+step:1355/1480 train_time:362809ms step_avg:269.75ms
+step:1356/1480 train_time:363095ms step_avg:269.76ms
+step:1357/1480 train_time:363380ms step_avg:269.77ms
+step:1358/1480 train_time:363661ms step_avg:269.78ms
+step:1359/1480 train_time:363944ms step_avg:269.79ms
+step:1360/1480 train_time:364233ms step_avg:269.80ms
+step:1361/1480 train_time:364521ms step_avg:269.82ms
+step:1362/1480 train_time:364803ms step_avg:269.82ms
+step:1363/1480 train_time:365093ms step_avg:269.84ms
+step:1364/1480 train_time:365378ms step_avg:269.85ms
+step:1365/1480 train_time:365653ms step_avg:269.85ms
+step:1366/1480 train_time:365936ms step_avg:269.86ms
+step:1367/1480 train_time:366219ms step_avg:269.87ms
+step:1368/1480 train_time:366498ms step_avg:269.88ms
+step:1369/1480 train_time:366788ms step_avg:269.90ms
+step:1370/1480 train_time:367078ms step_avg:269.91ms
+step:1371/1480 train_time:367358ms step_avg:269.92ms
+step:1372/1480 train_time:367645ms step_avg:269.93ms
+step:1373/1480 train_time:367930ms step_avg:269.94ms
+step:1374/1480 train_time:368217ms step_avg:269.95ms
+step:1375/1480 train_time:368494ms step_avg:269.96ms
+step:1375/1480 val_loss:3.2957 train_time:368634ms step_avg:270.06ms
+step:1376/1480 train_time:368775ms step_avg:269.97ms
+step:1377/1480 train_time:369063ms step_avg:269.98ms
+step:1378/1480 train_time:369341ms step_avg:269.99ms
+step:1379/1480 train_time:369623ms step_avg:270.00ms
+step:1380/1480 train_time:369903ms step_avg:270.00ms
+step:1381/1480 train_time:370195ms step_avg:270.02ms
+step:1382/1480 train_time:370476ms step_avg:270.03ms
+step:1383/1480 train_time:370761ms step_avg:270.04ms
+step:1384/1480 train_time:371048ms step_avg:270.05ms
+step:1385/1480 train_time:371327ms step_avg:270.06ms
+step:1386/1480 train_time:371610ms step_avg:270.07ms
+step:1387/1480 train_time:371894ms step_avg:270.08ms
+step:1388/1480 train_time:372173ms step_avg:270.08ms
+step:1389/1480 train_time:372458ms step_avg:270.09ms
+step:1390/1480 train_time:372739ms step_avg:270.10ms
+step:1391/1480 train_time:373023ms step_avg:270.11ms
+step:1392/1480 train_time:373309ms step_avg:270.12ms
+step:1393/1480 train_time:373591ms step_avg:270.13ms
+step:1394/1480 train_time:373871ms step_avg:270.14ms
+step:1395/1480 train_time:374147ms step_avg:270.14ms
+step:1396/1480 train_time:374427ms step_avg:270.15ms
+step:1397/1480 train_time:374704ms step_avg:270.15ms
+step:1398/1480 train_time:374983ms step_avg:270.16ms
+step:1399/1480 train_time:375261ms step_avg:270.17ms
+step:1400/1480 train_time:375553ms step_avg:270.18ms
+step:1401/1480 train_time:375830ms step_avg:270.19ms
+step:1402/1480 train_time:376107ms step_avg:270.19ms
+step:1403/1480 train_time:376395ms step_avg:270.20ms
+step:1404/1480 train_time:376675ms step_avg:270.21ms
+step:1405/1480 train_time:376962ms step_avg:270.22ms
+step:1406/1480 train_time:377249ms step_avg:270.24ms
+step:1407/1480 train_time:377532ms step_avg:270.24ms
+step:1408/1480 train_time:377808ms step_avg:270.25ms
+step:1409/1480 train_time:378103ms step_avg:270.27ms
+step:1410/1480 train_time:378384ms step_avg:270.27ms
+step:1411/1480 train_time:378666ms step_avg:270.28ms
+step:1412/1480 train_time:378948ms step_avg:270.29ms
+step:1413/1480 train_time:379231ms step_avg:270.30ms
+step:1414/1480 train_time:379513ms step_avg:270.31ms
+step:1415/1480 train_time:379794ms step_avg:270.32ms
+step:1416/1480 train_time:380090ms step_avg:270.33ms
+step:1417/1480 train_time:380373ms step_avg:270.34ms
+step:1418/1480 train_time:380661ms step_avg:270.36ms
+step:1419/1480 train_time:380943ms step_avg:270.36ms
+step:1420/1480 train_time:381227ms step_avg:270.37ms
+step:1421/1480 train_time:381511ms step_avg:270.38ms
+step:1422/1480 train_time:381793ms step_avg:270.39ms
+step:1423/1480 train_time:382069ms step_avg:270.40ms
+step:1424/1480 train_time:382357ms step_avg:270.41ms
+step:1425/1480 train_time:382648ms step_avg:270.42ms
+step:1426/1480 train_time:382930ms step_avg:270.43ms
+step:1427/1480 train_time:383214ms step_avg:270.44ms
+step:1428/1480 train_time:383494ms step_avg:270.45ms
+step:1429/1480 train_time:383773ms step_avg:270.45ms
+step:1430/1480 train_time:384066ms step_avg:270.47ms
+step:1431/1480 train_time:384353ms step_avg:270.48ms
+step:1432/1480 train_time:384636ms step_avg:270.49ms
+step:1433/1480 train_time:384924ms step_avg:270.50ms
+step:1434/1480 train_time:385215ms step_avg:270.52ms
+step:1435/1480 train_time:385498ms step_avg:270.52ms
+step:1436/1480 train_time:385791ms step_avg:270.54ms
+step:1437/1480 train_time:386070ms step_avg:270.55ms
+step:1438/1480 train_time:386347ms step_avg:270.55ms
+step:1439/1480 train_time:386632ms step_avg:270.56ms
+step:1440/1480 train_time:386909ms step_avg:270.57ms
+step:1441/1480 train_time:387192ms step_avg:270.57ms
+step:1442/1480 train_time:387480ms step_avg:270.59ms
+step:1443/1480 train_time:387780ms step_avg:270.61ms
+step:1444/1480 train_time:388062ms step_avg:270.62ms
+step:1445/1480 train_time:388344ms step_avg:270.62ms
+step:1446/1480 train_time:388632ms step_avg:270.63ms
+step:1447/1480 train_time:388917ms step_avg:270.64ms
+step:1448/1480 train_time:389201ms step_avg:270.65ms
+step:1449/1480 train_time:389487ms step_avg:270.67ms
+step:1450/1480 train_time:389770ms step_avg:270.67ms
+step:1451/1480 train_time:390051ms step_avg:270.68ms
+step:1452/1480 train_time:390333ms step_avg:270.69ms
+step:1453/1480 train_time:390611ms step_avg:270.69ms
+step:1454/1480 train_time:390892ms step_avg:270.70ms
+step:1455/1480 train_time:391176ms step_avg:270.71ms
+step:1456/1480 train_time:391461ms step_avg:270.72ms
+step:1457/1480 train_time:391742ms step_avg:270.73ms
+step:1458/1480 train_time:392027ms step_avg:270.74ms
+step:1459/1480 train_time:392312ms step_avg:270.75ms
+step:1460/1480 train_time:392593ms step_avg:270.75ms
+step:1461/1480 train_time:392875ms step_avg:270.76ms
+step:1462/1480 train_time:393154ms step_avg:270.77ms
+step:1463/1480 train_time:393443ms step_avg:270.78ms
+step:1464/1480 train_time:393730ms step_avg:270.79ms
+step:1465/1480 train_time:394010ms step_avg:270.80ms
+step:1466/1480 train_time:394291ms step_avg:270.80ms
+step:1467/1480 train_time:394575ms step_avg:270.81ms
+step:1468/1480 train_time:394857ms step_avg:270.82ms
+step:1469/1480 train_time:395138ms step_avg:270.83ms
+step:1470/1480 train_time:395427ms step_avg:270.84ms
+step:1471/1480 train_time:395723ms step_avg:270.86ms
+step:1472/1480 train_time:396014ms step_avg:270.87ms
+step:1473/1480 train_time:396293ms step_avg:270.88ms
+step:1474/1480 train_time:396589ms step_avg:270.89ms
+step:1475/1480 train_time:396876ms step_avg:270.91ms
+step:1476/1480 train_time:397160ms step_avg:270.91ms
+step:1477/1480 train_time:397455ms step_avg:270.93ms
+step:1478/1480 train_time:397749ms step_avg:270.95ms
+step:1479/1480 train_time:398034ms step_avg:270.96ms
+step:1480/1480 train_time:398313ms step_avg:270.96ms
+step:1480/1480 val_loss:3.2769 train_time:398464ms step_avg:271.06ms
+peak memory consumption: 34237 MiB

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,2 @@
-torchrun --standalone --nproc_per_node=8 train_gpt2.py
+# torchrun --standalone --nproc_per_node=8 train_gpt2.py
+torchrun --standalone --nproc_per_node=1 train_gpt2.py --train.batch_size 8 --train.sequence_length 32768

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
-# torchrun --standalone --nproc_per_node=8 train_gpt2.py
-torchrun --standalone --nproc_per_node=1 train_gpt2.py --train.batch_size 8 --train.sequence_length 32768
+torchrun --standalone --nproc_per_node=8 train_gpt2.py
+# torchrun --standalone --nproc_per_node=1 train_gpt2.py --train.batch_size 8 --train.sequence_length 32768

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,1 @@
 torchrun --standalone --nproc_per_node=8 train_gpt2.py
-# torchrun --standalone --nproc_per_node=1 train_gpt2.py --train.batch_size 8 --train.sequence_length 32768

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -369,23 +369,22 @@ def set_output_layer_bias(model, dataloader, n_batches):
     num_vocab = model.lm_head.bias.size(0)
     for i in range(n_batches):
         _, targets_train = dataloader.next_batch()
-        if i==0:
+        if i == 0:
             total_counts = torch.zeros(num_vocab, dtype=torch.int32, device=targets_train.device)
         ids, counts = torch.unique(targets_train, sorted=True, return_counts=True)
         total_counts[ids] += counts
 
     target_probs = total_counts / total_counts.sum()
-    target_probs = (target_probs+1e-12) # Avoid zero's
-    target_probs = target_probs/target_probs.sum()
+    target_probs = (target_probs + 1e-12)
+    target_probs = target_probs / target_probs.sum()
 
     with torch.no_grad():
         model.lm_head.bias.copy_(target_probs.log())
 
-    old_init_loss = torch.tensor(1/num_vocab).log().item()
-    new_init_loss = (target_probs*target_probs.log()).sum().item()
-    total_time = time.perf_counter()-t0
+    old_init_loss = torch.tensor(1 / num_vocab).log().item()
+    new_init_loss = (target_probs * target_probs.log()).sum().item()
+    total_time = time.perf_counter() - t0
     print0(f"Centered output layer, initial loss {old_init_loss:.3f} => {new_init_loss:.3f} ({total_time:.1f}s)")
-
 
 # -----------------------------------------------------------------------------
 # int main

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -143,7 +143,11 @@ class CastedLinear(nn.Linear):
         super().__init__(in_features, out_features, bias)
 
     def forward(self, x):
-        return F.linear(x, self.weight.to(x.dtype))
+        return F.linear(
+            x,
+            self.weight.to(x.dtype),
+            None if self.bias is None else self.bias.to(x.dtype)
+        )
 
 class Rotary(torch.nn.Module):
 

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -300,7 +300,7 @@ class GPT(nn.Module):
 
         x = norm(x)
         logits = self.lm_head(x)
-        logits = 30 * torch.tanh(logits / 30) # @Grad62304977 # Not needed anymore?
+        logits = 30 * torch.tanh(logits / 30) # @Grad62304977
         logits = logits.float()
         loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
         return loss

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -365,10 +365,8 @@ class DistributedDataLoader:
 
 def set_output_layer_bias(model, dataloader, n_batches):
     # Use token prevalence to initialize output layer bias & avoid initial shock to network of having to find it.
-    print0("Centering output layer  bias..")
     num_vocab = model.lm_head.bias.size(0)
     for i in range(n_batches):
-        # n_batches*batch_size "stratified" samples of 1024 tokens. n=100 => ~+- 0.1 @ 0.95 CI
         _, targets_train = dataloader.next_batch()
         if i==0:
             total_counts = torch.zeros(num_vocab, dtype=torch.int32, device=targets_train.device)

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -365,7 +365,7 @@ class DistributedDataLoader:
 
 def set_output_layer_bias(model, dataloader, num_vocab, n_batches):
     # Use token prevalence to initialize output layer bias & avoid initial shock to network of having to find it.
-    for i in enumerate(range(n_batches)):
+    for i in range(n_batches):
         # n_batches*batch_size "stratified" samples of 1024 tokens. n=100 => ~+- 0.1 @ 0.95 CI
         _, targets_train = dataloader.next_batch()
         if i==0:

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -189,7 +189,6 @@ class CausalSelfAttention(nn.Module):
         v = self.lambdas[0] * v + self.lambdas[1] * vi.view_as(v) # @KoszarskyB & @Grad62304977
         q, k = norm(q), norm(k) # QK norm @Grad62304977
         q, k = self.rotary(q), self.rotary(k)
-        # y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, kernel_options={"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_M1": 32, "BLOCK_N1": 64, "BLOCK_M2": 64, "BLOCK_N2": 32})
         y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask)
         y = y.transpose(1, 2).contiguous().view_as(x) # re-assemble all head outputs side by side
         y = self.c_proj(y)

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -365,6 +365,7 @@ class DistributedDataLoader:
 
 def set_output_layer_bias(model, dataloader, n_batches):
     # Use token prevalence to initialize output layer bias & avoid initial shock to network of having to find it.
+    t0 = time.perf_counter()
     num_vocab = model.lm_head.bias.size(0)
     for i in range(n_batches):
         _, targets_train = dataloader.next_batch()
@@ -382,7 +383,8 @@ def set_output_layer_bias(model, dataloader, n_batches):
 
     old_init_loss = torch.tensor(1/num_vocab).log().item()
     new_init_loss = (target_probs*target_probs.log()).sum().item()
-    print0(f"Centered output layer, initial loss {old_init_loss:3f} => {new_init_loss:3f}")
+    total_time = time.perf_counter()-t0
+    print0(f"Centered output layer, initial loss {old_init_loss:.3f} => {new_init_loss:.3f} ({total_time:.1f}s)")
 
 
 # -----------------------------------------------------------------------------

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -189,7 +189,8 @@ class CausalSelfAttention(nn.Module):
         v = self.lambdas[0] * v + self.lambdas[1] * vi.view_as(v) # @KoszarskyB & @Grad62304977
         q, k = norm(q), norm(k) # QK norm @Grad62304977
         q, k = self.rotary(q), self.rotary(k)
-        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, kernel_options={"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_M1": 32, "BLOCK_N1": 64, "BLOCK_M2": 64, "BLOCK_N2": 32})
+        # y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, kernel_options={"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_M1": 32, "BLOCK_N1": 64, "BLOCK_M2": 64, "BLOCK_N2": 32})
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask)
         y = y.transpose(1, 2).contiguous().view_as(x) # re-assemble all head outputs side by side
         y = self.c_proj(y)
         return y

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -522,7 +522,7 @@ raw_model = model.module # always contains the "raw" unwrapped model
 # init the optimizer(s)
 embed_params = [*raw_model.embed.parameters(), *raw_model.value_embeds.parameters()]
 optimizer1 = torch.optim.Adam(embed_params, lr=0.6, betas=(0.8, 0.95), fused=True)
-optimizer2 = torch.optim.Adam([raw_model.lm_head.weight], lr=0.008, betas=(0.8, 0.95), fused=True)
+optimizer2 = torch.optim.Adam([raw_model.lm_head.weight, raw_model.lm_head.bias], lr=0.008, betas=(0.8, 0.95), fused=True)
 params = list(raw_model.blocks.parameters())
 matrix_params = [p for p in params if p.ndim == 2]
 scalar_params = [p for p in params if p.ndim < 2] + [raw_model.skip_weights]

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -189,7 +189,7 @@ class CausalSelfAttention(nn.Module):
         v = self.lambdas[0] * v + self.lambdas[1] * vi.view_as(v) # @KoszarskyB & @Grad62304977
         q, k = norm(q), norm(k) # QK norm @Grad62304977
         q, k = self.rotary(q), self.rotary(k)
-        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask)
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, kernel_options={"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_M1": 32, "BLOCK_N1": 64, "BLOCK_M2": 64, "BLOCK_N2": 32})
         y = y.transpose(1, 2).contiguous().view_as(x) # re-assemble all head outputs side by side
         y = self.c_proj(y)
         return y

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -378,7 +378,12 @@ def set_output_layer_bias(model, dataloader, num_vocab, n_batches):
     target_probs = target_probs/target_probs.sum()
 
     with torch.no_grad():
-        model.linear_out.bias.copy_(target_probs.log())
+        model.lm_head.bias.copy_(target_probs.log())
+
+    old_init_loss = torch.log(1/num_vocab).item()
+    new_init_loss = (target_probs*target_probs.log()).sum().item()
+    print0(f"Centered output layer, init loss {old_init_loss:3f}=>{new_init_loss:3f}")
+
 
 # -----------------------------------------------------------------------------
 # int main


### PR DESCRIPTION
My theory was that there seems to be a few tweaks here and there that are there to counter high loss in the initial steps (warmup etc), and that is typically a counter to starting at a prediction `1/vocab` when the optimal initialization is `p[k] = prob of token k = %token k`. However, it ended up being marginally slower and worse overall:

* With bias: `258ms~278ms/step` to reach `~3.30` loss
* Without  : ` 256ms~271ms/step` to reach `~3.27` loss

<details> 
  <summary> (Spoiler) Loss/logs </summary>
 
**This branch**
```
 cat _logs/bias-3e010137-10fc-46f7-a68b-7649ff13cc7d.txt _logs/bias-a82bdcb6-ea9d-4808-9e09-32b9901d21e1.txt _logs/bias-f43dca01-62fd-4f97-9751-2e2ed21a69b8.txt  | grep
val_loss:
        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
step:0/1480 val_loss:7.7109 train_time:0ms step_avg:nanms
step:125/1480 val_loss:4.3719 train_time:29736ms step_avg:258.57ms
step:250/1480 val_loss:3.9992 train_time:62563ms step_avg:260.68ms
step:375/1480 val_loss:3.8241 train_time:96107ms step_avg:263.31ms
step:500/1480 val_loss:3.7067 train_time:130164ms step_avg:265.64ms
step:625/1480 val_loss:3.6328 train_time:164680ms step_avg:267.77ms
step:750/1480 val_loss:3.5784 train_time:199620ms step_avg:269.76ms
step:875/1480 val_loss:3.5303 train_time:234743ms step_avg:271.38ms
step:1000/1480 val_loss:3.4681 train_time:270262ms step_avg:272.99ms
step:1125/1480 val_loss:3.4110 train_time:306089ms step_avg:274.52ms
step:1250/1480 val_loss:3.3610 train_time:342096ms step_avg:275.88ms
step:1375/1480 val_loss:3.3192 train_time:378340ms step_avg:277.17ms
step:1480/1480 val_loss:3.3001 train_time:409091ms step_avg:278.29ms
        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
step:0/1480 val_loss:7.7109 train_time:0ms step_avg:nanms
step:125/1480 val_loss:4.3838 train_time:29795ms step_avg:259.08ms
step:250/1480 val_loss:4.0061 train_time:62718ms step_avg:261.32ms
step:375/1480 val_loss:3.8346 train_time:96276ms step_avg:263.77ms
step:500/1480 val_loss:3.7189 train_time:130389ms step_avg:266.10ms
step:625/1480 val_loss:3.6372 train_time:164940ms step_avg:268.20ms
step:750/1480 val_loss:3.5790 train_time:199838ms step_avg:270.05ms
step:875/1480 val_loss:3.5363 train_time:235001ms step_avg:271.68ms
step:1000/1480 val_loss:3.4688 train_time:270525ms step_avg:273.26ms
step:1125/1480 val_loss:3.4106 train_time:306384ms step_avg:274.78ms
step:1250/1480 val_loss:3.3593 train_time:342406ms step_avg:276.13ms
step:1375/1480 val_loss:3.3179 train_time:378645ms step_avg:277.40ms
step:1480/1480 val_loss:3.2988 train_time:409369ms step_avg:278.48ms
        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
step:0/1480 val_loss:7.7109 train_time:0ms step_avg:nanms
step:125/1480 val_loss:4.3804 train_time:29731ms step_avg:258.53ms
step:250/1480 val_loss:4.0066 train_time:62597ms step_avg:260.82ms
step:375/1480 val_loss:3.8302 train_time:96128ms step_avg:263.36ms
step:500/1480 val_loss:3.7171 train_time:130180ms step_avg:265.67ms
step:625/1480 val_loss:3.6396 train_time:164649ms step_avg:267.72ms
step:750/1480 val_loss:3.5809 train_time:199529ms step_avg:269.63ms
step:875/1480 val_loss:3.5384 train_time:234632ms step_avg:271.25ms
step:1000/1480 val_loss:3.4709 train_time:270093ms step_avg:272.82ms
step:1125/1480 val_loss:3.4139 train_time:305928ms step_avg:274.37ms
step:1250/1480 val_loss:3.3625 train_time:341927ms step_avg:275.75ms
step:1375/1480 val_loss:3.3208 train_time:378162ms step_avg:277.04ms
step:1480/1480 val_loss:3.3015 train_time:408880ms step_avg:278.15ms
```
**master branch**
```
(base) [egil/lm_head_bias][~/Projects/github/ragulpr/modded-nanogpt]$ cat _logs/master-82de927d-20a6-422a-b45a-81de62bbfecc.txt
_logs/master-8ba61738-7464-4dc1-a9a9-ca222d2d62bb.txt   | grep val_loss:
        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
step:0/1480 val_loss:10.8258 train_time:0ms step_avg:nanms
step:125/1480 val_loss:4.4223 train_time:28947ms step_avg:251.71ms
step:250/1480 val_loss:3.9975 train_time:60957ms step_avg:253.99ms
step:375/1480 val_loss:3.8093 train_time:93586ms step_avg:256.40ms
step:500/1480 val_loss:3.6880 train_time:126688ms step_avg:258.55ms
step:625/1480 val_loss:3.6085 train_time:160247ms step_avg:260.56ms
step:750/1480 val_loss:3.5517 train_time:194143ms step_avg:262.36ms
step:875/1480 val_loss:3.5069 train_time:228336ms step_avg:263.97ms
step:1000/1480 val_loss:3.4433 train_time:262890ms step_avg:265.55ms
step:1125/1480 val_loss:3.3872 train_time:297743ms step_avg:267.03ms
step:1250/1480 val_loss:3.3373 train_time:332898ms step_avg:268.47ms
step:1375/1480 val_loss:3.2983 train_time:368181ms step_avg:269.73ms
step:1480/1480 val_loss:3.2792 train_time:398007ms step_avg:270.75ms
        print0(f'step:{step}/{args.num_iterations} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/(timed_steps-1):.2f}ms')
step:0/1480 val_loss:10.8258 train_time:0ms step_avg:nanms
step:125/1480 val_loss:4.4388 train_time:29503ms step_avg:256.55ms
step:250/1480 val_loss:3.9939 train_time:61559ms step_avg:256.49ms
step:375/1480 val_loss:3.8118 train_time:94170ms step_avg:258.00ms
step:500/1480 val_loss:3.6871 train_time:127220ms step_avg:259.63ms
step:625/1480 val_loss:3.6052 train_time:160723ms step_avg:261.34ms
step:750/1480 val_loss:3.5514 train_time:194546ms step_avg:262.90ms
step:875/1480 val_loss:3.5026 train_time:228722ms step_avg:264.42ms
step:1000/1480 val_loss:3.4401 train_time:263268ms step_avg:265.93ms
step:1125/1480 val_loss:3.3848 train_time:298135ms step_avg:267.39ms
step:1250/1480 val_loss:3.3342 train_time:333289ms step_avg:268.78ms
step:1375/1480 val_loss:3.2957 train_time:368634ms step_avg:270.06ms
step:1480/1480 val_loss:3.2769 train_time:398464ms step_avg:271.06ms
```
</details>

PS: Some observations:
* Every step takes increasing amount of time throughout training, could not immediately figure out why.
* Was not able to achieve `~140ms/step` on [my machine](https://app.primeintellect.ai/dashboard/create-cluster/search?gpu_type=H100_80GB&image=cuda_12_4_pytorch_2_5&location=Cheapest&quantity=8&security=Cheapest&show_spot=false) using instances from https://www.primeintellect.ai/. Would be interesting to hear what provider / exact hardware people are using apart from GPU setup.
* During compile step my machine uses exactly 1 CPU core.