### PR TITLE
[WIP] BFloat16 weights; 2 sec improvement

### DIFF
--- a/train_gpt.py
+++ b/train_gpt.py
@@ -470,7 +470,7 @@ class Hyperparameters:
     # optimization
     batch_size = 8*64*1024 # batch size in tokens
     num_iterations = 1400 # number of iterations to run
-    cooldown_frac = 0.4 # fraction of training spent cooling down the learning rate
+    cooldown_frac = 0.35 # fraction of training spent cooling down the learning rate
     # evaluation and logging
     val_loss_every = 125 # every how many steps to evaluate val loss? 0 for only at the end
     # implementation

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -460,7 +460,7 @@ class Hyperparameters:
     val_tokens = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
     # optimization
     batch_size = 8*64*1024 # batch size in tokens
-    num_iterations = 1393 # number of iterations to run
+    num_iterations = 1395 # number of iterations to run
     cooldown_frac = 0.4 # fraction of training spent cooling down the learning rate
     # evaluation and logging
     val_loss_every = 125 # every how many steps to evaluate val loss? 0 for only at the end

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -253,7 +253,7 @@ class Rotary(nn.Module):
     def forward(self, x_BTHD: Tensor):
         assert self.cos.size(0) >= x_BTHD.size(-3)
         cos, sin = self.cos[None, :x_BTHD.size(-3), None, :], self.sin[None, :x_BTHD.size(-3), None, :]
-        x1, x2 = x_BTHD.to(dtype=torch.bfloat16).chunk(2, dim=-1)
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
         y1 = x1 * cos + x2 * sin
         y2 = x1 * (-sin) + x2 * cos
         return torch.cat((y1, y2), 3).type_as(x_BTHD)

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -622,7 +622,8 @@ def train(args: Hyperparameters):
 
     print0(
         f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
-        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB",
+        console=True,
     )
     dist.destroy_process_group()
 

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -32,8 +32,8 @@ def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[
             x_f8,
             w_f8.t(),
             out_dtype=torch.bfloat16,
-            scale_a=x.new_tensor(1 / x_s, dtype=torch.bfloat16),
-            scale_b=x.new_tensor(1 / w_s, dtype=torch.bfloat16),
+            scale_a=x.new_tensor(1 / x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(1 / w_s, dtype=torch.float32),
             use_fast_accum=True,
         )
         return out, x_f8, w_f8
@@ -53,9 +53,9 @@ def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float
     @torch.compile
     def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
         assert grad.is_contiguous()
-        x_inv_s = grad.new_tensor(1 / x_s, dtype=torch.bfloat16)
-        w_inv_s = grad.new_tensor(1 / w_s, dtype=torch.bfloat16)
-        grad_inv_s = grad.new_tensor(1 / grad_s, dtype=torch.bfloat16)
+        x_inv_s = grad.new_tensor(1 / x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(1 / w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(1 / grad_s, dtype=torch.float32)
         grad_f8 = grad.mul(grad_s).to(torch.float8_e5m2)
         grad_x = torch._scaled_mm(
             grad_f8,

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -352,7 +352,7 @@ class GPT(nn.Module):
         self.skip_weights = nn.Parameter(torch.ones(self.num_decoder_layers))
         # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
         # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
-        self.lm_head = CastedLinear(model_dim, next_multiple_of_n(vocab_size, n=128), use_fp8=True, x_scale=2.0, w_scale=2.0**5, grad_scale=2.0**29)
+        self.lm_head = CastedLinear(model_dim, next_multiple_of_n(vocab_size, n=128), use_fp8=True, x_scale=2.0, w_scale=2.0, grad_scale=2.0**9)
         self.lm_head.weight.detach().zero_() # @Grad62304977
 
     def forward(self, input_seq: Tensor, target_seq: Tensor, sliding_window_num_blocks: Tensor):


### PR DESCRIPTION
From the pytorch trace below, see that the current record is bottlenecked by the backwards pass. Thus, it makes sense to shift our focus on optimizing this part of the run.

Converting the weights to bfloat16 is the lowest hanging fruit we can do & it seems to reduce wallclock time by 2 secs.

![image](https://github.com/user-attachments/assets/183fc4e9-de99-43f3-a6eb-b733e263f828)
