### PR TITLE
2.941 max-autotune record

### DIFF
--- a/records/021225_MaxAutotune/11e9d28c-fde3-40f6-adaf-398a49a14b93.txt
+++ b/records/021225_MaxAutotune/11e9d28c-fde3-40f6-adaf-398a49a14b93.txt
@@ -1,0 +1,2479 @@
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+import copy
+import glob
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+torch.empty(1, device="cuda", requires_grad=True).backward() # prevents a bug on some systems
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+# use of FlexAttention contributed by @KoszarskyB
+from torch.nn.attention.flex_attention import BlockMask, flex_attention
+#torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+@torch.compile
+def zeropower_via_newtonschulz5(G: Tensor, steps: int) -> Tensor:
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert G.ndim >= 2 # batched Muon implementation by @scottjmaddox, and put into practice in the record by @YouJiacheng
+    a, b, c = (3.4445, -4.7750,  2.0315)
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * A @ A # quintic computation strategy adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+    
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Some warnings:
+    - This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+    - To use it with 4D convolutional filters, it works well to just flatten their last 3 dimensions.
+
+    Arguments:
+        lr: The learning rate used by the internal SGD.
+        momentum: The momentum used by the internal SGD.
+        nesterov: Whether to use Nesterov-style momentum in the internal SGD. (recommended)
+        ns_steps: The number of Newton-Schulz iteration steps to use.
+    """
+    def __init__(self, params, lr=0.02, momentum=0.95, nesterov=True, ns_steps=5, rank=0, world_size=1):
+        self.rank = rank
+        self.world_size = world_size
+        defaults = dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps)
+        params: list[Tensor] = [*params]
+        param_groups = []
+        for size in {p.numel() for p in params}:
+            b = torch.empty(world_size, size, dtype=torch.bfloat16, device="cuda")
+            group = dict(params=[p for p in params if p.numel() == size],
+                         update_buffer=b, update_buffer_views=[b[i] for i in range(world_size)])
+            param_groups.append(group)
+        super().__init__(param_groups, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        for group in self.param_groups:
+            update_buffer: Tensor = group["update_buffer"]
+            update_buffer_views: list[Tensor] = group["update_buffer_views"]
+            # generate weight updates in distributed fashion
+            params: list[Tensor] = group["params"]
+            handle = None
+            params_world = None
+            def update_prev(): # optimized Muon implementation contributed by @YouJiacheng
+                handle.wait()
+                for p_world, g_world in zip(params_world, update_buffer_views):
+                    p_world.add_(g_world.view_as(p_world),
+                                 alpha=-group["lr"] * max(1, p_world.size(-2) / p_world.size(-1))**0.5)
+            for base_i in range(len(params))[::self.world_size]:
+                if base_i + self.rank < len(params):
+                    p = params[base_i + self.rank]
+                    g = p.grad
+                    assert g is not None
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf: Tensor = state["momentum_buffer"]
+                    buf.lerp_(g, 1 - group["momentum"])
+                    g = g.lerp_(buf, group["momentum"]) if group["nesterov"] else buf
+                    g = zeropower_via_newtonschulz5(g, steps=group["ns_steps"]).flatten()
+                else:
+                    g = update_buffer_views[self.rank]
+                if base_i > 0:
+                    update_prev() # async all_gather instead of sync all_reduce by @YouJiacheng
+                handle = dist.all_gather_into_tensor(update_buffer, g, async_op=True)
+                params_world = params[base_i : base_i + self.world_size]
+            update_prev()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        std = 0.5 * (self.in_features ** -0.5) # 0.5 is a bit better than the default 1/sqrt(3)
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.weight.uniform_(-bound, bound)
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, max_seq_len: int):
+        super().__init__()
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(dim//4)])
+        t = torch.arange(max_seq_len, dtype=torch.float32)
+        theta = torch.einsum("i,j -> ij", t, angular_freq)
+        self.cos = nn.Buffer(theta.cos(), persistent=False)
+        self.sin = nn.Buffer(theta.sin(), persistent=False)
+
+    def forward(self, x_BTHD: Tensor):
+        assert self.cos.size(0) >= x_BTHD.size(-3)
+        cos, sin = self.cos[None, :x_BTHD.size(-3), None, :], self.sin[None, :x_BTHD.size(-3), None, :]
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, head_dim=128):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        hdim = num_heads * head_dim
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKV weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        self.qkv_w = nn.Parameter(torch.empty(3, hdim, dim).uniform_(-bound, bound))
+        self.lambdas = nn.Parameter(torch.tensor([0.5, 0.5]))
+        self.rotary = Rotary(head_dim, max_seq_len)
+        self.c_proj = CastedLinear(hdim, dim)
+        self.c_proj.weight.detach().zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor, ve: Tensor | None, block_mask: BlockMask):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q, k, v = F.linear(x, self.qkv_w.flatten(end_dim=1).type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        if ve is not None:
+            v = self.lambdas[0] * v + self.lambdas[1] * ve.view_as(v) # @KoszarskyB & @Grad62304977
+        else: # skip mid-layers token value embeddings by @YouJiacheng
+            v = self.lambdas[0] * v
+        # scale the attention logits by given constant, instead of the default head_dim**-0.5, by @leloykun
+        # inspired by learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, scale=15/self.head_dim).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = self.c_proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.c_fc = CastedLinear(dim, hdim)
+        self.c_proj = CastedLinear(hdim, dim)
+        self.c_proj.weight.detach().zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = self.c_fc(x)
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = self.c_proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.7 (the 8th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, num_heads, max_seq_len) if layer_idx != 7 else None
+        self.mlp = MLP(dim)
+        self.lambdas = nn.Parameter(torch.tensor([1., 0.]))
+
+    def forward(self, x: Tensor, ve: Tensor | None, x0: Tensor, block_mask: BlockMask):
+        x = self.lambdas[0] * x + self.lambdas[1] * x0
+        if self.attn is not None:
+            x = x + self.attn(norm(x), ve, block_mask)
+        x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        self.blocks = nn.ModuleList([Block(model_dim, num_heads, max_seq_len, i) for i in range(num_layers)])
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        self.lm_head = CastedLinear(model_dim, next_multiple_of_n(vocab_size, n=128),
+                                    use_fp8=True, x_s=(model_dim**0.5)/448, w_s=24/448, grad_s=1/448)
+        self.lm_head.weight.detach().zero_() # @Grad62304977
+        # Add learnable skip connection weights for decoder layers
+        assert num_layers % 2 == 0
+        self.skip_weights = nn.Parameter(torch.ones(num_layers//2))
+
+    def create_blockmasks(self, input_seq: Tensor, sliding_window_num_blocks: Tensor):
+        BLOCK_SIZE = 128
+        docs = (input_seq == 50256).cumsum(0)
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_blockmask: Tensor):
+            num_blocks = dense_blockmask.sum(dim=-1, dtype=torch.int32)
+            indices = dense_blockmask.argsort(dim=-1, descending=False, stable=True).flip(-1).to(torch.int32)
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        # manual block mask creation by @YouJiacheng
+        assert len(input_seq) % BLOCK_SIZE == 0
+        NUM_BLOCKS = len(input_seq) // BLOCK_SIZE
+        block_idx = torch.arange(NUM_BLOCKS, dtype=torch.int32, device="cuda")
+        causal_blockmask_any = block_idx[:, None] >= block_idx
+        causal_blockmask_all = block_idx[:, None] > block_idx
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+        document_blockmask_any = (docs_low[:, None] <= docs_high) & (docs_high[:, None] >= docs_low)
+        document_blockmask_all = (docs_low[:, None] == docs_high) & (docs_high[:, None] == docs_low)
+        blockmask_any = causal_blockmask_any & document_blockmask_any
+        blockmask_all = causal_blockmask_all & document_blockmask_all
+        partial_kv_num_blocks, partial_kv_indices = dense_to_ordered(blockmask_any & ~blockmask_all)
+        full_kv_num_blocks, full_kv_indices = dense_to_ordered(blockmask_all)
+        def build_bm(window_size_blocks: Tensor) -> BlockMask:
+            return BlockMask.from_kv_blocks(
+                torch.clamp_max(partial_kv_num_blocks, torch.clamp_min(window_size_blocks - full_kv_num_blocks, 1)),
+                partial_kv_indices,
+                torch.clamp_max(full_kv_num_blocks, window_size_blocks - 1),
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+        # Long-short SWA block masks by @leloykun & @YouJiacheng, adapated from suggestion by @Grad62304977, following Gemma 2 paper
+        return build_bm(sliding_window_num_blocks), build_bm(sliding_window_num_blocks // 2)
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, sliding_window_num_blocks: Tensor):
+        assert input_seq.ndim == 1
+
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        ve = [ve[0], ve[1], ve[2]] + [None] * (len(self.blocks) - 6) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == len(self.blocks)
+
+        long_bm, short_bm = self.create_blockmasks(input_seq, sliding_window_num_blocks)
+        block_masks = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(block_masks) == len(self.blocks)
+
+        x = x0 = norm(self.embed(input_seq)[None]) # use of norm here by @Grad62304977
+
+        # U-net design by @brendanh0gan
+        skip_connections = []
+        n = len(self.skip_weights)
+        for i in range(len(self.blocks)):
+            if i >= n:
+                x = x + self.skip_weights[i - n] * skip_connections.pop()
+            x = self.blocks[i](x, ve[i], x0, block_masks[i])
+            if i < n:
+                skip_connections.append(x)
+
+        x = norm(x)
+        logits = self.lm_head(x).float()
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15, @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1)
+        logits = 30 * torch.sigmoid(logits / (7.5 * x.size(-1)**0.5))
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq, reduction='sum' if self.training else 'mean')
+        return loss
+
+# -----------------------------------------------------------------------------
+# Our own simple Distributed Data Loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, rank : int, world_size : int):
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files) # use itertools.cycle(files) instead if you want to do multi-epoch training
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # no sync on host side;
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # H2D in another stream isn't helpful.
+        pos += batch_size
+        yield inputs, targets
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    train_seq_len = 48*1024 # FlexAttention sequence length
+    val_seq_len = 4*64*1024 # FlexAttention sequence length for validation
+    # optimization
+    num_iterations = 1770 # number of iterations to run
+    cooldown_frac = 0.4 # fraction of training spent cooling down the learning rate
+    # architecture
+    vocab_size = 50257
+    # evaluation and logging
+    val_loss_every = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint = False
+args = Hyperparameters()
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert world_size == 8 # this code is designed for 8xH100
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = uuid.uuid4()
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+########################################
+#    Construct model and optimizer     #
+########################################
+
+model: nn.Module = GPT(vocab_size=args.vocab_size, num_layers=12, num_heads=6, model_dim=768,
+                       max_seq_len=max(args.train_seq_len, args.val_seq_len)).cuda()
+for m in model.modules():
+    if isinstance(m, nn.Embedding):
+        m.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+# collect the parameters to optimize
+hidden_matrix_params = [p for n, p in model.blocks.named_parameters() if p.ndim >= 2 and "embed" not in n]
+embed_params = [p for n, p in model.named_parameters() if "embed" in n]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+head_params = [model.lm_head.weight]
+
+# init the optimizer(s)
+adam_params = [dict(params=head_params, lr=0.22), dict(params=embed_params, lr=0.6), dict(params=scalar_params, lr=0.04)]
+# small adam epsilon by @YouJiacheng. this is an alternate method of fixing the world_size dependence
+# discovered by @fernbear.bsky.social https://x.com/hi_tysam/status/1879692937589875094
+optimizer1 = torch.optim.Adam(adam_params, betas=(0.8, 0.95), eps=1e-10, fused=True)
+optimizer2 = Muon(hidden_matrix_params, lr=0.05, momentum=0.95, rank=rank, world_size=world_size)
+optimizers = [optimizer1, optimizer2]
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+
+# learning rate schedule: stable then decay
+def get_lr(step: int):
+    x = step / args.num_iterations # progress in training
+    assert 0 <= x < 1
+    if x < 1 - args.cooldown_frac:
+        return 1.0
+    else:
+        w = (1 - x) / args.cooldown_frac
+        return w * 1.0 + (1 - w) * 0.1
+
+# attention window size schedule: linearly increase
+@lru_cache(1)
+def get_window_size_blocks_helper(window_size: int):
+    return torch.tensor(window_size // 128, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
+def get_window_size_blocks(step: int):
+    x = step / args.num_iterations # progress in training
+    assert 0 <= x <= 1
+    # Linearly increase the block-wise sliding window size over training 128 -> 1792
+    # increase by @fernbear.bsky.social; block-wise by @YouJiacheng
+    window_size = next_multiple_of_n(1728 * x, n=128)
+    return get_window_size_blocks_helper(window_size)
+
+model: nn.Module = torch.compile(model, dynamic=False, mode="max-autotune-no-cudagraphs",)
+
+########################################
+#            Warmup kernels            #
+########################################
+
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+warmup_steps = 10
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=[copy.deepcopy(opt.state_dict()) for opt in optimizers]) # save the initial state
+for _ in range(warmup_steps):
+    inputs = targets = torch.randint(0, args.vocab_size, size=(args.train_seq_len,), device="cuda")
+    model(inputs.to(torch.int32), targets, get_window_size_blocks(0)).backward()
+    for param in model.parameters():
+        dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+for opt, opt_state in zip(optimizers, initial_state["optimizers"]):
+    opt.load_state_dict(opt_state)
+del initial_state
+
+########################################
+#        Training and validation       #
+########################################
+
+train_loader = distributed_data_generator(args.train_files, world_size * args.train_seq_len, rank, world_size)
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        val_batch_size = world_size * args.val_seq_len
+        assert args.val_tokens % val_batch_size == 0
+        val_steps = args.val_tokens // val_batch_size
+        val_loader = distributed_data_generator(args.val_files, val_batch_size, rank, world_size)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets = next(val_loader)
+                val_loss += model(inputs, targets, get_window_size_blocks(step))
+        val_loss /= val_steps
+        del val_loader
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    model(inputs, targets, get_window_size_blocks(step)).backward()
+    for param in model.parameters():
+        dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
+    # set optimization hyperparameters
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["lr"] = group["initial_lr"] * get_lr(step)
+    for group in optimizer2.param_groups:
+        frac = min(step / 300, 1) # momentum warmup for muon
+        group["momentum"] = (1 - frac) * 0.85 + frac * 0.95
+    # step the optimizers
+    for opt in optimizers:
+        opt.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.11.10 (main, Sep  7 2024, 18:35:41) [GCC 11.4.0]
+Running PyTorch 2.7.0.dev20250110+cu126 compiled for CUDA 12.6
+Wed Feb 12 11:41:42 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.4     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:00:05.0 Off |                    0 |
+| N/A   36C    P0            116W /  700W |    7714MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:00:06.0 Off |                    0 |
+| N/A   30C    P0            114W /  700W |    3452MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:00:07.0 Off |                    0 |
+| N/A   31C    P0            113W /  700W |    3452MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:00:08.0 Off |                    0 |
+| N/A   36C    P0            115W /  700W |    3452MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:00:09.0 Off |                    0 |
+| N/A   36C    P0            117W /  700W |    3452MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:00:0A.0 Off |                    0 |
+| N/A   30C    P0            112W /  700W |    3452MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:00:0B.0 Off |                    0 |
+| N/A   30C    P0            112W /  700W |    3452MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:00:0C.0 Off |                    0 |
+| N/A   37C    P0            118W /  700W |    3212MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+step:0/1770 val_loss:10.8258 train_time:0ms step_avg:0.02ms
+step:1/1770 train_time:96ms step_avg:95.77ms
+step:2/1770 train_time:165ms step_avg:82.46ms
+step:3/1770 train_time:248ms step_avg:82.67ms
+step:4/1770 train_time:341ms step_avg:85.28ms
+step:5/1770 train_time:435ms step_avg:87.09ms
+step:6/1770 train_time:530ms step_avg:88.26ms
+step:7/1770 train_time:623ms step_avg:89.01ms
+step:8/1770 train_time:717ms step_avg:89.69ms
+step:9/1770 train_time:812ms step_avg:90.18ms
+step:10/1770 train_time:905ms step_avg:90.50ms
+step:11/1770 train_time:999ms step_avg:90.81ms
+step:12/1770 train_time:1096ms step_avg:91.33ms
+step:13/1770 train_time:1193ms step_avg:91.75ms
+step:14/1770 train_time:1287ms step_avg:91.95ms
+step:15/1770 train_time:1381ms step_avg:92.09ms
+step:16/1770 train_time:1477ms step_avg:92.34ms
+step:17/1770 train_time:1571ms step_avg:92.39ms
+step:18/1770 train_time:1664ms step_avg:92.46ms
+step:19/1770 train_time:1757ms step_avg:92.49ms
+step:20/1770 train_time:1852ms step_avg:92.58ms
+step:21/1770 train_time:1945ms step_avg:92.64ms
+step:22/1770 train_time:2040ms step_avg:92.72ms
+step:23/1770 train_time:2135ms step_avg:92.83ms
+step:24/1770 train_time:2231ms step_avg:92.96ms
+step:25/1770 train_time:2325ms step_avg:93.02ms
+step:26/1770 train_time:2420ms step_avg:93.06ms
+step:27/1770 train_time:2514ms step_avg:93.12ms
+step:28/1770 train_time:2609ms step_avg:93.17ms
+step:29/1770 train_time:2702ms step_avg:93.17ms
+step:30/1770 train_time:2796ms step_avg:93.21ms
+step:31/1770 train_time:2892ms step_avg:93.29ms
+step:32/1770 train_time:2984ms step_avg:93.26ms
+step:33/1770 train_time:3079ms step_avg:93.29ms
+step:34/1770 train_time:3174ms step_avg:93.35ms
+step:35/1770 train_time:3269ms step_avg:93.41ms
+step:36/1770 train_time:3365ms step_avg:93.46ms
+step:37/1770 train_time:3459ms step_avg:93.50ms
+step:38/1770 train_time:3554ms step_avg:93.54ms
+step:39/1770 train_time:3649ms step_avg:93.56ms
+step:40/1770 train_time:3743ms step_avg:93.57ms
+step:41/1770 train_time:3836ms step_avg:93.57ms
+step:42/1770 train_time:3930ms step_avg:93.58ms
+step:43/1770 train_time:4024ms step_avg:93.57ms
+step:44/1770 train_time:4118ms step_avg:93.59ms
+step:45/1770 train_time:4212ms step_avg:93.61ms
+step:46/1770 train_time:4309ms step_avg:93.66ms
+step:47/1770 train_time:4401ms step_avg:93.64ms
+step:48/1770 train_time:4496ms step_avg:93.67ms
+step:49/1770 train_time:4591ms step_avg:93.70ms
+step:50/1770 train_time:4685ms step_avg:93.70ms
+step:51/1770 train_time:4779ms step_avg:93.71ms
+step:52/1770 train_time:4873ms step_avg:93.72ms
+step:53/1770 train_time:4967ms step_avg:93.72ms
+step:54/1770 train_time:5061ms step_avg:93.72ms
+step:55/1770 train_time:5155ms step_avg:93.73ms
+step:56/1770 train_time:5249ms step_avg:93.74ms
+step:57/1770 train_time:5343ms step_avg:93.73ms
+step:58/1770 train_time:5437ms step_avg:93.74ms
+step:59/1770 train_time:5531ms step_avg:93.75ms
+step:60/1770 train_time:5627ms step_avg:93.78ms
+step:61/1770 train_time:5719ms step_avg:93.76ms
+step:62/1770 train_time:5813ms step_avg:93.76ms
+step:63/1770 train_time:5907ms step_avg:93.76ms
+step:64/1770 train_time:6002ms step_avg:93.78ms
+step:65/1770 train_time:6096ms step_avg:93.79ms
+step:66/1770 train_time:6191ms step_avg:93.81ms
+step:67/1770 train_time:6285ms step_avg:93.81ms
+step:68/1770 train_time:6380ms step_avg:93.83ms
+step:69/1770 train_time:6473ms step_avg:93.82ms
+step:70/1770 train_time:6567ms step_avg:93.82ms
+step:71/1770 train_time:6661ms step_avg:93.82ms
+step:72/1770 train_time:6756ms step_avg:93.84ms
+step:73/1770 train_time:6850ms step_avg:93.84ms
+step:74/1770 train_time:6944ms step_avg:93.84ms
+step:75/1770 train_time:7038ms step_avg:93.84ms
+step:76/1770 train_time:7133ms step_avg:93.85ms
+step:77/1770 train_time:7227ms step_avg:93.86ms
+step:78/1770 train_time:7321ms step_avg:93.86ms
+step:79/1770 train_time:7416ms step_avg:93.87ms
+step:80/1770 train_time:7510ms step_avg:93.87ms
+step:81/1770 train_time:7603ms step_avg:93.86ms
+step:82/1770 train_time:7697ms step_avg:93.87ms
+step:83/1770 train_time:7791ms step_avg:93.87ms
+step:84/1770 train_time:7885ms step_avg:93.87ms
+step:85/1770 train_time:7979ms step_avg:93.88ms
+step:86/1770 train_time:8074ms step_avg:93.88ms
+step:87/1770 train_time:8168ms step_avg:93.89ms
+step:88/1770 train_time:8262ms step_avg:93.89ms
+step:89/1770 train_time:8358ms step_avg:93.91ms
+step:90/1770 train_time:8452ms step_avg:93.91ms
+step:91/1770 train_time:8544ms step_avg:93.89ms
+step:92/1770 train_time:8639ms step_avg:93.90ms
+step:93/1770 train_time:8734ms step_avg:93.91ms
+step:94/1770 train_time:8827ms step_avg:93.91ms
+step:95/1770 train_time:8921ms step_avg:93.91ms
+step:96/1770 train_time:9016ms step_avg:93.92ms
+step:97/1770 train_time:9111ms step_avg:93.92ms
+step:98/1770 train_time:9204ms step_avg:93.91ms
+step:99/1770 train_time:9298ms step_avg:93.92ms
+step:100/1770 train_time:9393ms step_avg:93.93ms
+step:101/1770 train_time:9487ms step_avg:93.93ms
+step:102/1770 train_time:9581ms step_avg:93.93ms
+step:103/1770 train_time:9675ms step_avg:93.94ms
+step:104/1770 train_time:9769ms step_avg:93.93ms
+step:105/1770 train_time:9862ms step_avg:93.92ms
+step:106/1770 train_time:9956ms step_avg:93.93ms
+step:107/1770 train_time:10051ms step_avg:93.93ms
+step:108/1770 train_time:10145ms step_avg:93.93ms
+step:109/1770 train_time:10240ms step_avg:93.95ms
+step:110/1770 train_time:10335ms step_avg:93.95ms
+step:111/1770 train_time:10429ms step_avg:93.96ms
+step:112/1770 train_time:10522ms step_avg:93.95ms
+step:113/1770 train_time:10616ms step_avg:93.95ms
+step:114/1770 train_time:10710ms step_avg:93.95ms
+step:115/1770 train_time:10803ms step_avg:93.94ms
+step:116/1770 train_time:10897ms step_avg:93.94ms
+step:117/1770 train_time:10991ms step_avg:93.94ms
+step:118/1770 train_time:11085ms step_avg:93.94ms
+step:119/1770 train_time:11179ms step_avg:93.94ms
+step:120/1770 train_time:11273ms step_avg:93.94ms
+step:121/1770 train_time:11367ms step_avg:93.95ms
+step:122/1770 train_time:11461ms step_avg:93.95ms
+step:123/1770 train_time:11556ms step_avg:93.95ms
+step:124/1770 train_time:11651ms step_avg:93.96ms
+step:125/1770 train_time:11744ms step_avg:93.96ms
+step:125/1770 val_loss:4.6472 train_time:11837ms step_avg:94.70ms
+step:126/1770 train_time:11865ms step_avg:94.17ms
+step:127/1770 train_time:11943ms step_avg:94.04ms
+step:128/1770 train_time:12047ms step_avg:94.12ms
+step:129/1770 train_time:12148ms step_avg:94.17ms
+step:130/1770 train_time:12242ms step_avg:94.17ms
+step:131/1770 train_time:12336ms step_avg:94.17ms
+step:132/1770 train_time:12429ms step_avg:94.16ms
+step:133/1770 train_time:12523ms step_avg:94.16ms
+step:134/1770 train_time:12617ms step_avg:94.16ms
+step:135/1770 train_time:12712ms step_avg:94.16ms
+step:136/1770 train_time:12805ms step_avg:94.16ms
+step:137/1770 train_time:12900ms step_avg:94.16ms
+step:138/1770 train_time:12996ms step_avg:94.18ms
+step:139/1770 train_time:13094ms step_avg:94.20ms
+step:140/1770 train_time:13189ms step_avg:94.21ms
+step:141/1770 train_time:13283ms step_avg:94.21ms
+step:142/1770 train_time:13378ms step_avg:94.21ms
+step:143/1770 train_time:13472ms step_avg:94.21ms
+step:144/1770 train_time:13567ms step_avg:94.21ms
+step:145/1770 train_time:13660ms step_avg:94.21ms
+step:146/1770 train_time:13755ms step_avg:94.21ms
+step:147/1770 train_time:13849ms step_avg:94.21ms
+step:148/1770 train_time:13944ms step_avg:94.21ms
+step:149/1770 train_time:14040ms step_avg:94.23ms
+step:150/1770 train_time:14136ms step_avg:94.24ms
+step:151/1770 train_time:14231ms step_avg:94.24ms
+step:152/1770 train_time:14325ms step_avg:94.25ms
+step:153/1770 train_time:14421ms step_avg:94.25ms
+step:154/1770 train_time:14515ms step_avg:94.25ms
+step:155/1770 train_time:14609ms step_avg:94.25ms
+step:156/1770 train_time:14703ms step_avg:94.25ms
+step:157/1770 train_time:14799ms step_avg:94.26ms
+step:158/1770 train_time:14893ms step_avg:94.26ms
+step:159/1770 train_time:14988ms step_avg:94.26ms
+step:160/1770 train_time:15084ms step_avg:94.27ms
+step:161/1770 train_time:15178ms step_avg:94.27ms
+step:162/1770 train_time:15274ms step_avg:94.28ms
+step:163/1770 train_time:15369ms step_avg:94.29ms
+step:164/1770 train_time:15463ms step_avg:94.28ms
+step:165/1770 train_time:15558ms step_avg:94.29ms
+step:166/1770 train_time:15652ms step_avg:94.29ms
+step:167/1770 train_time:15746ms step_avg:94.29ms
+step:168/1770 train_time:15841ms step_avg:94.29ms
+step:169/1770 train_time:15936ms step_avg:94.29ms
+step:170/1770 train_time:16030ms step_avg:94.30ms
+step:171/1770 train_time:16124ms step_avg:94.29ms
+step:172/1770 train_time:16219ms step_avg:94.30ms
+step:173/1770 train_time:16315ms step_avg:94.31ms
+step:174/1770 train_time:16410ms step_avg:94.31ms
+step:175/1770 train_time:16504ms step_avg:94.31ms
+step:176/1770 train_time:16600ms step_avg:94.32ms
+step:177/1770 train_time:16693ms step_avg:94.31ms
+step:178/1770 train_time:16787ms step_avg:94.31ms
+step:179/1770 train_time:16882ms step_avg:94.31ms
+step:180/1770 train_time:16977ms step_avg:94.32ms
+step:181/1770 train_time:17072ms step_avg:94.32ms
+step:182/1770 train_time:17166ms step_avg:94.32ms
+step:183/1770 train_time:17262ms step_avg:94.33ms
+step:184/1770 train_time:17356ms step_avg:94.33ms
+step:185/1770 train_time:17451ms step_avg:94.33ms
+step:186/1770 train_time:17546ms step_avg:94.33ms
+step:187/1770 train_time:17640ms step_avg:94.33ms
+step:188/1770 train_time:17735ms step_avg:94.33ms
+step:189/1770 train_time:17830ms step_avg:94.34ms
+step:190/1770 train_time:17924ms step_avg:94.34ms
+step:191/1770 train_time:18019ms step_avg:94.34ms
+step:192/1770 train_time:18115ms step_avg:94.35ms
+step:193/1770 train_time:18210ms step_avg:94.35ms
+step:194/1770 train_time:18305ms step_avg:94.35ms
+step:195/1770 train_time:18399ms step_avg:94.35ms
+step:196/1770 train_time:18494ms step_avg:94.36ms
+step:197/1770 train_time:18589ms step_avg:94.36ms
+step:198/1770 train_time:18682ms step_avg:94.36ms
+step:199/1770 train_time:18777ms step_avg:94.36ms
+step:200/1770 train_time:18872ms step_avg:94.36ms
+step:201/1770 train_time:18966ms step_avg:94.36ms
+step:202/1770 train_time:19060ms step_avg:94.36ms
+step:203/1770 train_time:19155ms step_avg:94.36ms
+step:204/1770 train_time:19251ms step_avg:94.37ms
+step:205/1770 train_time:19345ms step_avg:94.36ms
+step:206/1770 train_time:19440ms step_avg:94.37ms
+step:207/1770 train_time:19536ms step_avg:94.38ms
+step:208/1770 train_time:19630ms step_avg:94.37ms
+step:209/1770 train_time:19724ms step_avg:94.37ms
+step:210/1770 train_time:19819ms step_avg:94.37ms
+step:211/1770 train_time:19914ms step_avg:94.38ms
+step:212/1770 train_time:20008ms step_avg:94.38ms
+step:213/1770 train_time:20102ms step_avg:94.38ms
+step:214/1770 train_time:20197ms step_avg:94.38ms
+step:215/1770 train_time:20293ms step_avg:94.39ms
+step:216/1770 train_time:20388ms step_avg:94.39ms
+step:217/1770 train_time:20482ms step_avg:94.39ms
+step:218/1770 train_time:20577ms step_avg:94.39ms
+step:219/1770 train_time:20673ms step_avg:94.40ms
+step:220/1770 train_time:20767ms step_avg:94.40ms
+step:221/1770 train_time:20862ms step_avg:94.40ms
+step:222/1770 train_time:20957ms step_avg:94.40ms
+step:223/1770 train_time:21053ms step_avg:94.41ms
+step:224/1770 train_time:21146ms step_avg:94.40ms
+step:225/1770 train_time:21242ms step_avg:94.41ms
+step:226/1770 train_time:21337ms step_avg:94.41ms
+step:227/1770 train_time:21432ms step_avg:94.41ms
+step:228/1770 train_time:21526ms step_avg:94.41ms
+step:229/1770 train_time:21620ms step_avg:94.41ms
+step:230/1770 train_time:21715ms step_avg:94.41ms
+step:231/1770 train_time:21811ms step_avg:94.42ms
+step:232/1770 train_time:21905ms step_avg:94.42ms
+step:233/1770 train_time:21999ms step_avg:94.42ms
+step:234/1770 train_time:22094ms step_avg:94.42ms
+step:235/1770 train_time:22188ms step_avg:94.42ms
+step:236/1770 train_time:22283ms step_avg:94.42ms
+step:237/1770 train_time:22378ms step_avg:94.42ms
+step:238/1770 train_time:22474ms step_avg:94.43ms
+step:239/1770 train_time:22567ms step_avg:94.42ms
+step:240/1770 train_time:22662ms step_avg:94.42ms
+step:241/1770 train_time:22758ms step_avg:94.43ms
+step:242/1770 train_time:22853ms step_avg:94.43ms
+step:243/1770 train_time:22947ms step_avg:94.43ms
+step:244/1770 train_time:23042ms step_avg:94.43ms
+step:245/1770 train_time:23137ms step_avg:94.44ms
+step:246/1770 train_time:23232ms step_avg:94.44ms
+step:247/1770 train_time:23327ms step_avg:94.44ms
+step:248/1770 train_time:23422ms step_avg:94.44ms
+step:249/1770 train_time:23517ms step_avg:94.45ms
+step:250/1770 train_time:23612ms step_avg:94.45ms
+step:250/1770 val_loss:4.1043 train_time:23704ms step_avg:94.82ms
+step:251/1770 train_time:23729ms step_avg:94.54ms
+step:252/1770 train_time:23810ms step_avg:94.48ms
+step:253/1770 train_time:23915ms step_avg:94.53ms
+step:254/1770 train_time:24012ms step_avg:94.54ms
+step:255/1770 train_time:24107ms step_avg:94.54ms
+step:256/1770 train_time:24201ms step_avg:94.54ms
+step:257/1770 train_time:24295ms step_avg:94.53ms
+step:258/1770 train_time:24389ms step_avg:94.53ms
+step:259/1770 train_time:24483ms step_avg:94.53ms
+step:260/1770 train_time:24577ms step_avg:94.53ms
+step:261/1770 train_time:24671ms step_avg:94.53ms
+step:262/1770 train_time:24766ms step_avg:94.53ms
+step:263/1770 train_time:24862ms step_avg:94.53ms
+step:264/1770 train_time:24959ms step_avg:94.54ms
+step:265/1770 train_time:25056ms step_avg:94.55ms
+step:266/1770 train_time:25150ms step_avg:94.55ms
+step:267/1770 train_time:25245ms step_avg:94.55ms
+step:268/1770 train_time:25340ms step_avg:94.55ms
+step:269/1770 train_time:25434ms step_avg:94.55ms
+step:270/1770 train_time:25529ms step_avg:94.55ms
+step:271/1770 train_time:25624ms step_avg:94.55ms
+step:272/1770 train_time:25720ms step_avg:94.56ms
+step:273/1770 train_time:25815ms step_avg:94.56ms
+step:274/1770 train_time:25912ms step_avg:94.57ms
+step:275/1770 train_time:26009ms step_avg:94.58ms
+step:276/1770 train_time:26105ms step_avg:94.58ms
+step:277/1770 train_time:26201ms step_avg:94.59ms
+step:278/1770 train_time:26295ms step_avg:94.59ms
+step:279/1770 train_time:26390ms step_avg:94.59ms
+step:280/1770 train_time:26486ms step_avg:94.59ms
+step:281/1770 train_time:26581ms step_avg:94.59ms
+step:282/1770 train_time:26678ms step_avg:94.60ms
+step:283/1770 train_time:26772ms step_avg:94.60ms
+step:284/1770 train_time:26867ms step_avg:94.60ms
+step:285/1770 train_time:26963ms step_avg:94.61ms
+step:286/1770 train_time:27058ms step_avg:94.61ms
+step:287/1770 train_time:27153ms step_avg:94.61ms
+step:288/1770 train_time:27249ms step_avg:94.62ms
+step:289/1770 train_time:27345ms step_avg:94.62ms
+step:290/1770 train_time:27441ms step_avg:94.62ms
+step:291/1770 train_time:27536ms step_avg:94.63ms
+step:292/1770 train_time:27630ms step_avg:94.62ms
+step:293/1770 train_time:27726ms step_avg:94.63ms
+step:294/1770 train_time:27821ms step_avg:94.63ms
+step:295/1770 train_time:27916ms step_avg:94.63ms
+step:296/1770 train_time:28012ms step_avg:94.64ms
+step:297/1770 train_time:28108ms step_avg:94.64ms
+step:298/1770 train_time:28203ms step_avg:94.64ms
+step:299/1770 train_time:28301ms step_avg:94.65ms
+step:300/1770 train_time:28394ms step_avg:94.65ms
+step:301/1770 train_time:28490ms step_avg:94.65ms
+step:302/1770 train_time:28585ms step_avg:94.65ms
+step:303/1770 train_time:28680ms step_avg:94.65ms
+step:304/1770 train_time:28775ms step_avg:94.66ms
+step:305/1770 train_time:28871ms step_avg:94.66ms
+step:306/1770 train_time:28968ms step_avg:94.67ms
+step:307/1770 train_time:29064ms step_avg:94.67ms
+step:308/1770 train_time:29160ms step_avg:94.67ms
+step:309/1770 train_time:29255ms step_avg:94.67ms
+step:310/1770 train_time:29351ms step_avg:94.68ms
+step:311/1770 train_time:29446ms step_avg:94.68ms
+step:312/1770 train_time:29541ms step_avg:94.68ms
+step:313/1770 train_time:29635ms step_avg:94.68ms
+step:314/1770 train_time:29731ms step_avg:94.68ms
+step:315/1770 train_time:29826ms step_avg:94.69ms
+step:316/1770 train_time:29924ms step_avg:94.70ms
+step:317/1770 train_time:30017ms step_avg:94.69ms
+step:318/1770 train_time:30112ms step_avg:94.69ms
+step:319/1770 train_time:30207ms step_avg:94.69ms
+step:320/1770 train_time:30304ms step_avg:94.70ms
+step:321/1770 train_time:30399ms step_avg:94.70ms
+step:322/1770 train_time:30494ms step_avg:94.70ms
+step:323/1770 train_time:30590ms step_avg:94.71ms
+step:324/1770 train_time:30686ms step_avg:94.71ms
+step:325/1770 train_time:30781ms step_avg:94.71ms
+step:326/1770 train_time:30876ms step_avg:94.71ms
+step:327/1770 train_time:30972ms step_avg:94.72ms
+step:328/1770 train_time:31068ms step_avg:94.72ms
+step:329/1770 train_time:31164ms step_avg:94.72ms
+step:330/1770 train_time:31259ms step_avg:94.73ms
+step:331/1770 train_time:31355ms step_avg:94.73ms
+step:332/1770 train_time:31450ms step_avg:94.73ms
+step:333/1770 train_time:31548ms step_avg:94.74ms
+step:334/1770 train_time:31641ms step_avg:94.73ms
+step:335/1770 train_time:31736ms step_avg:94.73ms
+step:336/1770 train_time:31831ms step_avg:94.74ms
+step:337/1770 train_time:31927ms step_avg:94.74ms
+step:338/1770 train_time:32022ms step_avg:94.74ms
+step:339/1770 train_time:32117ms step_avg:94.74ms
+step:340/1770 train_time:32213ms step_avg:94.74ms
+step:341/1770 train_time:32308ms step_avg:94.74ms
+step:342/1770 train_time:32404ms step_avg:94.75ms
+step:343/1770 train_time:32499ms step_avg:94.75ms
+step:344/1770 train_time:32594ms step_avg:94.75ms
+step:345/1770 train_time:32690ms step_avg:94.75ms
+step:346/1770 train_time:32786ms step_avg:94.76ms
+step:347/1770 train_time:32881ms step_avg:94.76ms
+step:348/1770 train_time:32976ms step_avg:94.76ms
+step:349/1770 train_time:33071ms step_avg:94.76ms
+step:350/1770 train_time:33169ms step_avg:94.77ms
+step:351/1770 train_time:33263ms step_avg:94.77ms
+step:352/1770 train_time:33359ms step_avg:94.77ms
+step:353/1770 train_time:33454ms step_avg:94.77ms
+step:354/1770 train_time:33550ms step_avg:94.77ms
+step:355/1770 train_time:33645ms step_avg:94.77ms
+step:356/1770 train_time:33741ms step_avg:94.78ms
+step:357/1770 train_time:33835ms step_avg:94.78ms
+step:358/1770 train_time:33930ms step_avg:94.78ms
+step:359/1770 train_time:34026ms step_avg:94.78ms
+step:360/1770 train_time:34122ms step_avg:94.78ms
+step:361/1770 train_time:34217ms step_avg:94.79ms
+step:362/1770 train_time:34313ms step_avg:94.79ms
+step:363/1770 train_time:34409ms step_avg:94.79ms
+step:364/1770 train_time:34505ms step_avg:94.79ms
+step:365/1770 train_time:34599ms step_avg:94.79ms
+step:366/1770 train_time:34695ms step_avg:94.79ms
+step:367/1770 train_time:34790ms step_avg:94.80ms
+step:368/1770 train_time:34886ms step_avg:94.80ms
+step:369/1770 train_time:34981ms step_avg:94.80ms
+step:370/1770 train_time:35076ms step_avg:94.80ms
+step:371/1770 train_time:35172ms step_avg:94.80ms
+step:372/1770 train_time:35268ms step_avg:94.81ms
+step:373/1770 train_time:35363ms step_avg:94.81ms
+step:374/1770 train_time:35459ms step_avg:94.81ms
+step:375/1770 train_time:35554ms step_avg:94.81ms
+step:375/1770 val_loss:3.8966 train_time:35647ms step_avg:95.06ms
+step:376/1770 train_time:35675ms step_avg:94.88ms
+step:377/1770 train_time:35749ms step_avg:94.83ms
+step:378/1770 train_time:35858ms step_avg:94.86ms
+step:379/1770 train_time:35956ms step_avg:94.87ms
+step:380/1770 train_time:36050ms step_avg:94.87ms
+step:381/1770 train_time:36145ms step_avg:94.87ms
+step:382/1770 train_time:36239ms step_avg:94.87ms
+step:383/1770 train_time:36334ms step_avg:94.87ms
+step:384/1770 train_time:36429ms step_avg:94.87ms
+step:385/1770 train_time:36523ms step_avg:94.86ms
+step:386/1770 train_time:36617ms step_avg:94.86ms
+step:387/1770 train_time:36713ms step_avg:94.87ms
+step:388/1770 train_time:36811ms step_avg:94.87ms
+step:389/1770 train_time:36909ms step_avg:94.88ms
+step:390/1770 train_time:37005ms step_avg:94.88ms
+step:391/1770 train_time:37100ms step_avg:94.88ms
+step:392/1770 train_time:37195ms step_avg:94.89ms
+step:393/1770 train_time:37291ms step_avg:94.89ms
+step:394/1770 train_time:37386ms step_avg:94.89ms
+step:395/1770 train_time:37480ms step_avg:94.89ms
+step:396/1770 train_time:37578ms step_avg:94.89ms
+step:397/1770 train_time:37674ms step_avg:94.90ms
+step:398/1770 train_time:37772ms step_avg:94.90ms
+step:399/1770 train_time:37870ms step_avg:94.91ms
+step:400/1770 train_time:37969ms step_avg:94.92ms
+step:401/1770 train_time:38067ms step_avg:94.93ms
+step:402/1770 train_time:38165ms step_avg:94.94ms
+step:403/1770 train_time:38261ms step_avg:94.94ms
+step:404/1770 train_time:38358ms step_avg:94.95ms
+step:405/1770 train_time:38456ms step_avg:94.95ms
+step:406/1770 train_time:38552ms step_avg:94.96ms
+step:407/1770 train_time:38649ms step_avg:94.96ms
+step:408/1770 train_time:38745ms step_avg:94.96ms
+step:409/1770 train_time:38842ms step_avg:94.97ms
+step:410/1770 train_time:38940ms step_avg:94.98ms
+step:411/1770 train_time:39038ms step_avg:94.98ms
+step:412/1770 train_time:39137ms step_avg:94.99ms
+step:413/1770 train_time:39234ms step_avg:95.00ms
+step:414/1770 train_time:39332ms step_avg:95.00ms
+step:415/1770 train_time:39430ms step_avg:95.01ms
+step:416/1770 train_time:39526ms step_avg:95.01ms
+step:417/1770 train_time:39622ms step_avg:95.02ms
+step:418/1770 train_time:39719ms step_avg:95.02ms
+step:419/1770 train_time:39817ms step_avg:95.03ms
+step:420/1770 train_time:39914ms step_avg:95.03ms
+step:421/1770 train_time:40014ms step_avg:95.04ms
+step:422/1770 train_time:40109ms step_avg:95.05ms
+step:423/1770 train_time:40206ms step_avg:95.05ms
+step:424/1770 train_time:40302ms step_avg:95.05ms
+step:425/1770 train_time:40399ms step_avg:95.06ms
+step:426/1770 train_time:40496ms step_avg:95.06ms
+step:427/1770 train_time:40594ms step_avg:95.07ms
+step:428/1770 train_time:40691ms step_avg:95.07ms
+step:429/1770 train_time:40788ms step_avg:95.08ms
+step:430/1770 train_time:40885ms step_avg:95.08ms
+step:431/1770 train_time:40982ms step_avg:95.08ms
+step:432/1770 train_time:41079ms step_avg:95.09ms
+step:433/1770 train_time:41178ms step_avg:95.10ms
+step:434/1770 train_time:41275ms step_avg:95.10ms
+step:435/1770 train_time:41373ms step_avg:95.11ms
+step:436/1770 train_time:41471ms step_avg:95.12ms
+step:437/1770 train_time:41567ms step_avg:95.12ms
+step:438/1770 train_time:41664ms step_avg:95.12ms
+step:439/1770 train_time:41761ms step_avg:95.13ms
+step:440/1770 train_time:41858ms step_avg:95.13ms
+step:441/1770 train_time:41955ms step_avg:95.14ms
+step:442/1770 train_time:42053ms step_avg:95.14ms
+step:443/1770 train_time:42152ms step_avg:95.15ms
+step:444/1770 train_time:42249ms step_avg:95.16ms
+step:445/1770 train_time:42348ms step_avg:95.16ms
+step:446/1770 train_time:42442ms step_avg:95.16ms
+step:447/1770 train_time:42539ms step_avg:95.17ms
+step:448/1770 train_time:42637ms step_avg:95.17ms
+step:449/1770 train_time:42735ms step_avg:95.18ms
+step:450/1770 train_time:42834ms step_avg:95.19ms
+step:451/1770 train_time:42932ms step_avg:95.19ms
+step:452/1770 train_time:43029ms step_avg:95.20ms
+step:453/1770 train_time:43125ms step_avg:95.20ms
+step:454/1770 train_time:43222ms step_avg:95.20ms
+step:455/1770 train_time:43319ms step_avg:95.21ms
+step:456/1770 train_time:43416ms step_avg:95.21ms
+step:457/1770 train_time:43514ms step_avg:95.22ms
+step:458/1770 train_time:43611ms step_avg:95.22ms
+step:459/1770 train_time:43709ms step_avg:95.23ms
+step:460/1770 train_time:43806ms step_avg:95.23ms
+step:461/1770 train_time:43902ms step_avg:95.23ms
+step:462/1770 train_time:44000ms step_avg:95.24ms
+step:463/1770 train_time:44098ms step_avg:95.24ms
+step:464/1770 train_time:44195ms step_avg:95.25ms
+step:465/1770 train_time:44292ms step_avg:95.25ms
+step:466/1770 train_time:44389ms step_avg:95.26ms
+step:467/1770 train_time:44486ms step_avg:95.26ms
+step:468/1770 train_time:44583ms step_avg:95.26ms
+step:469/1770 train_time:44681ms step_avg:95.27ms
+step:470/1770 train_time:44777ms step_avg:95.27ms
+step:471/1770 train_time:44874ms step_avg:95.27ms
+step:472/1770 train_time:44972ms step_avg:95.28ms
+step:473/1770 train_time:45070ms step_avg:95.29ms
+step:474/1770 train_time:45169ms step_avg:95.29ms
+step:475/1770 train_time:45265ms step_avg:95.30ms
+step:476/1770 train_time:45362ms step_avg:95.30ms
+step:477/1770 train_time:45458ms step_avg:95.30ms
+step:478/1770 train_time:45556ms step_avg:95.30ms
+step:479/1770 train_time:45655ms step_avg:95.31ms
+step:480/1770 train_time:45752ms step_avg:95.32ms
+step:481/1770 train_time:45849ms step_avg:95.32ms
+step:482/1770 train_time:45945ms step_avg:95.32ms
+step:483/1770 train_time:46042ms step_avg:95.32ms
+step:484/1770 train_time:46140ms step_avg:95.33ms
+step:485/1770 train_time:46237ms step_avg:95.33ms
+step:486/1770 train_time:46335ms step_avg:95.34ms
+step:487/1770 train_time:46433ms step_avg:95.34ms
+step:488/1770 train_time:46530ms step_avg:95.35ms
+step:489/1770 train_time:46627ms step_avg:95.35ms
+step:490/1770 train_time:46724ms step_avg:95.35ms
+step:491/1770 train_time:46820ms step_avg:95.36ms
+step:492/1770 train_time:46918ms step_avg:95.36ms
+step:493/1770 train_time:47017ms step_avg:95.37ms
+step:494/1770 train_time:47113ms step_avg:95.37ms
+step:495/1770 train_time:47210ms step_avg:95.37ms
+step:496/1770 train_time:47308ms step_avg:95.38ms
+step:497/1770 train_time:47403ms step_avg:95.38ms
+step:498/1770 train_time:47500ms step_avg:95.38ms
+step:499/1770 train_time:47597ms step_avg:95.39ms
+step:500/1770 train_time:47695ms step_avg:95.39ms
+step:500/1770 val_loss:3.7462 train_time:47791ms step_avg:95.58ms
+step:501/1770 train_time:47819ms step_avg:95.45ms
+step:502/1770 train_time:47903ms step_avg:95.42ms
+step:503/1770 train_time:48004ms step_avg:95.44ms
+step:504/1770 train_time:48103ms step_avg:95.44ms
+step:505/1770 train_time:48200ms step_avg:95.45ms
+step:506/1770 train_time:48297ms step_avg:95.45ms
+step:507/1770 train_time:48393ms step_avg:95.45ms
+step:508/1770 train_time:48489ms step_avg:95.45ms
+step:509/1770 train_time:48585ms step_avg:95.45ms
+step:510/1770 train_time:48681ms step_avg:95.45ms
+step:511/1770 train_time:48778ms step_avg:95.46ms
+step:512/1770 train_time:48877ms step_avg:95.46ms
+step:513/1770 train_time:48976ms step_avg:95.47ms
+step:514/1770 train_time:49074ms step_avg:95.48ms
+step:515/1770 train_time:49173ms step_avg:95.48ms
+step:516/1770 train_time:49268ms step_avg:95.48ms
+step:517/1770 train_time:49364ms step_avg:95.48ms
+step:518/1770 train_time:49461ms step_avg:95.48ms
+step:519/1770 train_time:49558ms step_avg:95.49ms
+step:520/1770 train_time:49654ms step_avg:95.49ms
+step:521/1770 train_time:49751ms step_avg:95.49ms
+step:522/1770 train_time:49848ms step_avg:95.49ms
+step:523/1770 train_time:49945ms step_avg:95.50ms
+step:524/1770 train_time:50043ms step_avg:95.50ms
+step:525/1770 train_time:50141ms step_avg:95.51ms
+step:526/1770 train_time:50239ms step_avg:95.51ms
+step:527/1770 train_time:50337ms step_avg:95.52ms
+step:528/1770 train_time:50435ms step_avg:95.52ms
+step:529/1770 train_time:50532ms step_avg:95.52ms
+step:530/1770 train_time:50629ms step_avg:95.53ms
+step:531/1770 train_time:50725ms step_avg:95.53ms
+step:532/1770 train_time:50823ms step_avg:95.53ms
+step:533/1770 train_time:50921ms step_avg:95.54ms
+step:534/1770 train_time:51019ms step_avg:95.54ms
+step:535/1770 train_time:51117ms step_avg:95.54ms
+step:536/1770 train_time:51214ms step_avg:95.55ms
+step:537/1770 train_time:51311ms step_avg:95.55ms
+step:538/1770 train_time:51408ms step_avg:95.55ms
+step:539/1770 train_time:51506ms step_avg:95.56ms
+step:540/1770 train_time:51606ms step_avg:95.57ms
+step:541/1770 train_time:51701ms step_avg:95.57ms
+step:542/1770 train_time:51799ms step_avg:95.57ms
+step:543/1770 train_time:51897ms step_avg:95.57ms
+step:544/1770 train_time:51996ms step_avg:95.58ms
+step:545/1770 train_time:52094ms step_avg:95.59ms
+step:546/1770 train_time:52191ms step_avg:95.59ms
+step:547/1770 train_time:52289ms step_avg:95.59ms
+step:548/1770 train_time:52385ms step_avg:95.59ms
+step:549/1770 train_time:52482ms step_avg:95.60ms
+step:550/1770 train_time:52580ms step_avg:95.60ms
+step:551/1770 train_time:52677ms step_avg:95.60ms
+step:552/1770 train_time:52774ms step_avg:95.60ms
+step:553/1770 train_time:52871ms step_avg:95.61ms
+step:554/1770 train_time:52968ms step_avg:95.61ms
+step:555/1770 train_time:53065ms step_avg:95.61ms
+step:556/1770 train_time:53163ms step_avg:95.62ms
+step:557/1770 train_time:53261ms step_avg:95.62ms
+step:558/1770 train_time:53359ms step_avg:95.63ms
+step:559/1770 train_time:53457ms step_avg:95.63ms
+step:560/1770 train_time:53554ms step_avg:95.63ms
+step:561/1770 train_time:53651ms step_avg:95.64ms
+step:562/1770 train_time:53748ms step_avg:95.64ms
+step:563/1770 train_time:53845ms step_avg:95.64ms
+step:564/1770 train_time:53944ms step_avg:95.64ms
+step:565/1770 train_time:54042ms step_avg:95.65ms
+step:566/1770 train_time:54140ms step_avg:95.65ms
+step:567/1770 train_time:54239ms step_avg:95.66ms
+step:568/1770 train_time:54338ms step_avg:95.67ms
+step:569/1770 train_time:54435ms step_avg:95.67ms
+step:570/1770 train_time:54532ms step_avg:95.67ms
+step:571/1770 train_time:54629ms step_avg:95.67ms
+step:572/1770 train_time:54726ms step_avg:95.68ms
+step:573/1770 train_time:54824ms step_avg:95.68ms
+step:574/1770 train_time:54921ms step_avg:95.68ms
+step:575/1770 train_time:55019ms step_avg:95.69ms
+step:576/1770 train_time:55117ms step_avg:95.69ms
+step:577/1770 train_time:55214ms step_avg:95.69ms
+step:578/1770 train_time:55312ms step_avg:95.70ms
+step:579/1770 train_time:55409ms step_avg:95.70ms
+step:580/1770 train_time:55506ms step_avg:95.70ms
+step:581/1770 train_time:55604ms step_avg:95.70ms
+step:582/1770 train_time:55702ms step_avg:95.71ms
+step:583/1770 train_time:55800ms step_avg:95.71ms
+step:584/1770 train_time:55898ms step_avg:95.72ms
+step:585/1770 train_time:55996ms step_avg:95.72ms
+step:586/1770 train_time:56094ms step_avg:95.72ms
+step:587/1770 train_time:56192ms step_avg:95.73ms
+step:588/1770 train_time:56289ms step_avg:95.73ms
+step:589/1770 train_time:56386ms step_avg:95.73ms
+step:590/1770 train_time:56484ms step_avg:95.74ms
+step:591/1770 train_time:56581ms step_avg:95.74ms
+step:592/1770 train_time:56680ms step_avg:95.74ms
+step:593/1770 train_time:56777ms step_avg:95.75ms
+step:594/1770 train_time:56874ms step_avg:95.75ms
+step:595/1770 train_time:56971ms step_avg:95.75ms
+step:596/1770 train_time:57069ms step_avg:95.75ms
+step:597/1770 train_time:57165ms step_avg:95.75ms
+step:598/1770 train_time:57263ms step_avg:95.76ms
+step:599/1770 train_time:57361ms step_avg:95.76ms
+step:600/1770 train_time:57459ms step_avg:95.77ms
+step:601/1770 train_time:57557ms step_avg:95.77ms
+step:602/1770 train_time:57655ms step_avg:95.77ms
+step:603/1770 train_time:57752ms step_avg:95.77ms
+step:604/1770 train_time:57849ms step_avg:95.78ms
+step:605/1770 train_time:57946ms step_avg:95.78ms
+step:606/1770 train_time:58044ms step_avg:95.78ms
+step:607/1770 train_time:58142ms step_avg:95.79ms
+step:608/1770 train_time:58240ms step_avg:95.79ms
+step:609/1770 train_time:58338ms step_avg:95.79ms
+step:610/1770 train_time:58436ms step_avg:95.80ms
+step:611/1770 train_time:58534ms step_avg:95.80ms
+step:612/1770 train_time:58632ms step_avg:95.80ms
+step:613/1770 train_time:58728ms step_avg:95.80ms
+step:614/1770 train_time:58825ms step_avg:95.81ms
+step:615/1770 train_time:58924ms step_avg:95.81ms
+step:616/1770 train_time:59021ms step_avg:95.81ms
+step:617/1770 train_time:59119ms step_avg:95.82ms
+step:618/1770 train_time:59217ms step_avg:95.82ms
+step:619/1770 train_time:59315ms step_avg:95.82ms
+step:620/1770 train_time:59412ms step_avg:95.83ms
+step:621/1770 train_time:59509ms step_avg:95.83ms
+step:622/1770 train_time:59606ms step_avg:95.83ms
+step:623/1770 train_time:59704ms step_avg:95.83ms
+step:624/1770 train_time:59803ms step_avg:95.84ms
+step:625/1770 train_time:59900ms step_avg:95.84ms
+step:625/1770 val_loss:3.6617 train_time:59996ms step_avg:95.99ms
+step:626/1770 train_time:60022ms step_avg:95.88ms
+step:627/1770 train_time:60103ms step_avg:95.86ms
+step:628/1770 train_time:60205ms step_avg:95.87ms
+step:629/1770 train_time:60303ms step_avg:95.87ms
+step:630/1770 train_time:60401ms step_avg:95.87ms
+step:631/1770 train_time:60497ms step_avg:95.88ms
+step:632/1770 train_time:60594ms step_avg:95.88ms
+step:633/1770 train_time:60692ms step_avg:95.88ms
+step:634/1770 train_time:60788ms step_avg:95.88ms
+step:635/1770 train_time:60885ms step_avg:95.88ms
+step:636/1770 train_time:60981ms step_avg:95.88ms
+step:637/1770 train_time:61079ms step_avg:95.89ms
+step:638/1770 train_time:61178ms step_avg:95.89ms
+step:639/1770 train_time:61278ms step_avg:95.90ms
+step:640/1770 train_time:61377ms step_avg:95.90ms
+step:641/1770 train_time:61475ms step_avg:95.90ms
+step:642/1770 train_time:61572ms step_avg:95.91ms
+step:643/1770 train_time:61669ms step_avg:95.91ms
+step:644/1770 train_time:61765ms step_avg:95.91ms
+step:645/1770 train_time:61863ms step_avg:95.91ms
+step:646/1770 train_time:61959ms step_avg:95.91ms
+step:647/1770 train_time:62056ms step_avg:95.91ms
+step:648/1770 train_time:62155ms step_avg:95.92ms
+step:649/1770 train_time:62253ms step_avg:95.92ms
+step:650/1770 train_time:62352ms step_avg:95.93ms
+step:651/1770 train_time:62450ms step_avg:95.93ms
+step:652/1770 train_time:62547ms step_avg:95.93ms
+step:653/1770 train_time:62644ms step_avg:95.93ms
+step:654/1770 train_time:62740ms step_avg:95.93ms
+step:655/1770 train_time:62837ms step_avg:95.94ms
+step:656/1770 train_time:62935ms step_avg:95.94ms
+step:657/1770 train_time:63033ms step_avg:95.94ms
+step:658/1770 train_time:63133ms step_avg:95.95ms
+step:659/1770 train_time:63234ms step_avg:95.95ms
+step:660/1770 train_time:63333ms step_avg:95.96ms
+step:661/1770 train_time:63433ms step_avg:95.96ms
+step:662/1770 train_time:63533ms step_avg:95.97ms
+step:663/1770 train_time:63632ms step_avg:95.98ms
+step:664/1770 train_time:63733ms step_avg:95.98ms
+step:665/1770 train_time:63832ms step_avg:95.99ms
+step:666/1770 train_time:63931ms step_avg:95.99ms
+step:667/1770 train_time:64030ms step_avg:96.00ms
+step:668/1770 train_time:64130ms step_avg:96.00ms
+step:669/1770 train_time:64231ms step_avg:96.01ms
+step:670/1770 train_time:64330ms step_avg:96.02ms
+step:671/1770 train_time:64431ms step_avg:96.02ms
+step:672/1770 train_time:64530ms step_avg:96.03ms
+step:673/1770 train_time:64629ms step_avg:96.03ms
+step:674/1770 train_time:64728ms step_avg:96.04ms
+step:675/1770 train_time:64826ms step_avg:96.04ms
+step:676/1770 train_time:64924ms step_avg:96.04ms
+step:677/1770 train_time:65023ms step_avg:96.05ms
+step:678/1770 train_time:65121ms step_avg:96.05ms
+step:679/1770 train_time:65220ms step_avg:96.05ms
+step:680/1770 train_time:65319ms step_avg:96.06ms
+step:681/1770 train_time:65418ms step_avg:96.06ms
+step:682/1770 train_time:65517ms step_avg:96.07ms
+step:683/1770 train_time:65617ms step_avg:96.07ms
+step:684/1770 train_time:65716ms step_avg:96.08ms
+step:685/1770 train_time:65816ms step_avg:96.08ms
+step:686/1770 train_time:65916ms step_avg:96.09ms
+step:687/1770 train_time:66016ms step_avg:96.09ms
+step:688/1770 train_time:66116ms step_avg:96.10ms
+step:689/1770 train_time:66216ms step_avg:96.10ms
+step:690/1770 train_time:66316ms step_avg:96.11ms
+step:691/1770 train_time:66415ms step_avg:96.11ms
+step:692/1770 train_time:66513ms step_avg:96.12ms
+step:693/1770 train_time:66613ms step_avg:96.12ms
+step:694/1770 train_time:66712ms step_avg:96.13ms
+step:695/1770 train_time:66812ms step_avg:96.13ms
+step:696/1770 train_time:66911ms step_avg:96.14ms
+step:697/1770 train_time:67011ms step_avg:96.14ms
+step:698/1770 train_time:67110ms step_avg:96.15ms
+step:699/1770 train_time:67208ms step_avg:96.15ms
+step:700/1770 train_time:67308ms step_avg:96.15ms
+step:701/1770 train_time:67407ms step_avg:96.16ms
+step:702/1770 train_time:67506ms step_avg:96.16ms
+step:703/1770 train_time:67604ms step_avg:96.16ms
+step:704/1770 train_time:67702ms step_avg:96.17ms
+step:705/1770 train_time:67801ms step_avg:96.17ms
+step:706/1770 train_time:67900ms step_avg:96.18ms
+step:707/1770 train_time:67999ms step_avg:96.18ms
+step:708/1770 train_time:68097ms step_avg:96.18ms
+step:709/1770 train_time:68196ms step_avg:96.19ms
+step:710/1770 train_time:68296ms step_avg:96.19ms
+step:711/1770 train_time:68395ms step_avg:96.20ms
+step:712/1770 train_time:68496ms step_avg:96.20ms
+step:713/1770 train_time:68595ms step_avg:96.21ms
+step:714/1770 train_time:68695ms step_avg:96.21ms
+step:715/1770 train_time:68795ms step_avg:96.22ms
+step:716/1770 train_time:68894ms step_avg:96.22ms
+step:717/1770 train_time:68994ms step_avg:96.23ms
+step:718/1770 train_time:69094ms step_avg:96.23ms
+step:719/1770 train_time:69193ms step_avg:96.24ms
+step:720/1770 train_time:69292ms step_avg:96.24ms
+step:721/1770 train_time:69393ms step_avg:96.24ms
+step:722/1770 train_time:69492ms step_avg:96.25ms
+step:723/1770 train_time:69591ms step_avg:96.25ms
+step:724/1770 train_time:69691ms step_avg:96.26ms
+step:725/1770 train_time:69790ms step_avg:96.26ms
+step:726/1770 train_time:69889ms step_avg:96.27ms
+step:727/1770 train_time:69989ms step_avg:96.27ms
+step:728/1770 train_time:70088ms step_avg:96.27ms
+step:729/1770 train_time:70187ms step_avg:96.28ms
+step:730/1770 train_time:70285ms step_avg:96.28ms
+step:731/1770 train_time:70383ms step_avg:96.28ms
+step:732/1770 train_time:70482ms step_avg:96.29ms
+step:733/1770 train_time:70581ms step_avg:96.29ms
+step:734/1770 train_time:70679ms step_avg:96.29ms
+step:735/1770 train_time:70779ms step_avg:96.30ms
+step:736/1770 train_time:70878ms step_avg:96.30ms
+step:737/1770 train_time:70978ms step_avg:96.31ms
+step:738/1770 train_time:71078ms step_avg:96.31ms
+step:739/1770 train_time:71178ms step_avg:96.32ms
+step:740/1770 train_time:71277ms step_avg:96.32ms
+step:741/1770 train_time:71377ms step_avg:96.33ms
+step:742/1770 train_time:71478ms step_avg:96.33ms
+step:743/1770 train_time:71578ms step_avg:96.34ms
+step:744/1770 train_time:71676ms step_avg:96.34ms
+step:745/1770 train_time:71776ms step_avg:96.34ms
+step:746/1770 train_time:71875ms step_avg:96.35ms
+step:747/1770 train_time:71975ms step_avg:96.35ms
+step:748/1770 train_time:72074ms step_avg:96.36ms
+step:749/1770 train_time:72174ms step_avg:96.36ms
+step:750/1770 train_time:72273ms step_avg:96.36ms
+step:750/1770 val_loss:3.5965 train_time:72371ms step_avg:96.49ms
+step:751/1770 train_time:72399ms step_avg:96.40ms
+step:752/1770 train_time:72483ms step_avg:96.39ms
+step:753/1770 train_time:72591ms step_avg:96.40ms
+step:754/1770 train_time:72690ms step_avg:96.41ms
+step:755/1770 train_time:72789ms step_avg:96.41ms
+step:756/1770 train_time:72888ms step_avg:96.41ms
+step:757/1770 train_time:72987ms step_avg:96.42ms
+step:758/1770 train_time:73086ms step_avg:96.42ms
+step:759/1770 train_time:73185ms step_avg:96.42ms
+step:760/1770 train_time:73284ms step_avg:96.43ms
+step:761/1770 train_time:73382ms step_avg:96.43ms
+step:762/1770 train_time:73483ms step_avg:96.43ms
+step:763/1770 train_time:73583ms step_avg:96.44ms
+step:764/1770 train_time:73683ms step_avg:96.44ms
+step:765/1770 train_time:73784ms step_avg:96.45ms
+step:766/1770 train_time:73883ms step_avg:96.45ms
+step:767/1770 train_time:73982ms step_avg:96.46ms
+step:768/1770 train_time:74082ms step_avg:96.46ms
+step:769/1770 train_time:74180ms step_avg:96.46ms
+step:770/1770 train_time:74279ms step_avg:96.47ms
+step:771/1770 train_time:74378ms step_avg:96.47ms
+step:772/1770 train_time:74476ms step_avg:96.47ms
+step:773/1770 train_time:74575ms step_avg:96.48ms
+step:774/1770 train_time:74675ms step_avg:96.48ms
+step:775/1770 train_time:74774ms step_avg:96.48ms
+step:776/1770 train_time:74873ms step_avg:96.49ms
+step:777/1770 train_time:74971ms step_avg:96.49ms
+step:778/1770 train_time:75070ms step_avg:96.49ms
+step:779/1770 train_time:75168ms step_avg:96.49ms
+step:780/1770 train_time:75266ms step_avg:96.50ms
+step:781/1770 train_time:75365ms step_avg:96.50ms
+step:782/1770 train_time:75465ms step_avg:96.50ms
+step:783/1770 train_time:75564ms step_avg:96.51ms
+step:784/1770 train_time:75664ms step_avg:96.51ms
+step:785/1770 train_time:75764ms step_avg:96.51ms
+step:786/1770 train_time:75864ms step_avg:96.52ms
+step:787/1770 train_time:75965ms step_avg:96.52ms
+step:788/1770 train_time:76065ms step_avg:96.53ms
+step:789/1770 train_time:76165ms step_avg:96.53ms
+step:790/1770 train_time:76265ms step_avg:96.54ms
+step:791/1770 train_time:76364ms step_avg:96.54ms
+step:792/1770 train_time:76463ms step_avg:96.54ms
+step:793/1770 train_time:76564ms step_avg:96.55ms
+step:794/1770 train_time:76664ms step_avg:96.55ms
+step:795/1770 train_time:76764ms step_avg:96.56ms
+step:796/1770 train_time:76865ms step_avg:96.56ms
+step:797/1770 train_time:76965ms step_avg:96.57ms
+step:798/1770 train_time:77065ms step_avg:96.57ms
+step:799/1770 train_time:77165ms step_avg:96.58ms
+step:800/1770 train_time:77266ms step_avg:96.58ms
+step:801/1770 train_time:77365ms step_avg:96.59ms
+step:802/1770 train_time:77465ms step_avg:96.59ms
+step:803/1770 train_time:77565ms step_avg:96.59ms
+step:804/1770 train_time:77665ms step_avg:96.60ms
+step:805/1770 train_time:77765ms step_avg:96.60ms
+step:806/1770 train_time:77865ms step_avg:96.61ms
+step:807/1770 train_time:77965ms step_avg:96.61ms
+step:808/1770 train_time:78065ms step_avg:96.61ms
+step:809/1770 train_time:78165ms step_avg:96.62ms
+step:810/1770 train_time:78266ms step_avg:96.62ms
+step:811/1770 train_time:78365ms step_avg:96.63ms
+step:812/1770 train_time:78465ms step_avg:96.63ms
+step:813/1770 train_time:78566ms step_avg:96.64ms
+step:814/1770 train_time:78666ms step_avg:96.64ms
+step:815/1770 train_time:78766ms step_avg:96.65ms
+step:816/1770 train_time:78867ms step_avg:96.65ms
+step:817/1770 train_time:78967ms step_avg:96.65ms
+step:818/1770 train_time:79066ms step_avg:96.66ms
+step:819/1770 train_time:79167ms step_avg:96.66ms
+step:820/1770 train_time:79267ms step_avg:96.67ms
+step:821/1770 train_time:79367ms step_avg:96.67ms
+step:822/1770 train_time:79466ms step_avg:96.67ms
+step:823/1770 train_time:79566ms step_avg:96.68ms
+step:824/1770 train_time:79666ms step_avg:96.68ms
+step:825/1770 train_time:79767ms step_avg:96.69ms
+step:826/1770 train_time:79866ms step_avg:96.69ms
+step:827/1770 train_time:79966ms step_avg:96.69ms
+step:828/1770 train_time:80066ms step_avg:96.70ms
+step:829/1770 train_time:80165ms step_avg:96.70ms
+step:830/1770 train_time:80265ms step_avg:96.70ms
+step:831/1770 train_time:80365ms step_avg:96.71ms
+step:832/1770 train_time:80464ms step_avg:96.71ms
+step:833/1770 train_time:80564ms step_avg:96.72ms
+step:834/1770 train_time:80664ms step_avg:96.72ms
+step:835/1770 train_time:80764ms step_avg:96.72ms
+step:836/1770 train_time:80865ms step_avg:96.73ms
+step:837/1770 train_time:80964ms step_avg:96.73ms
+step:838/1770 train_time:81064ms step_avg:96.73ms
+step:839/1770 train_time:81164ms step_avg:96.74ms
+step:840/1770 train_time:81264ms step_avg:96.74ms
+step:841/1770 train_time:81364ms step_avg:96.75ms
+step:842/1770 train_time:81464ms step_avg:96.75ms
+step:843/1770 train_time:81564ms step_avg:96.75ms
+step:844/1770 train_time:81663ms step_avg:96.76ms
+step:845/1770 train_time:81763ms step_avg:96.76ms
+step:846/1770 train_time:81863ms step_avg:96.77ms
+step:847/1770 train_time:81963ms step_avg:96.77ms
+step:848/1770 train_time:82063ms step_avg:96.77ms
+step:849/1770 train_time:82163ms step_avg:96.78ms
+step:850/1770 train_time:82264ms step_avg:96.78ms
+step:851/1770 train_time:82364ms step_avg:96.79ms
+step:852/1770 train_time:82464ms step_avg:96.79ms
+step:853/1770 train_time:82564ms step_avg:96.79ms
+step:854/1770 train_time:82664ms step_avg:96.80ms
+step:855/1770 train_time:82764ms step_avg:96.80ms
+step:856/1770 train_time:82864ms step_avg:96.80ms
+step:857/1770 train_time:82965ms step_avg:96.81ms
+step:858/1770 train_time:83066ms step_avg:96.81ms
+step:859/1770 train_time:83166ms step_avg:96.82ms
+step:860/1770 train_time:83265ms step_avg:96.82ms
+step:861/1770 train_time:83365ms step_avg:96.82ms
+step:862/1770 train_time:83466ms step_avg:96.83ms
+step:863/1770 train_time:83565ms step_avg:96.83ms
+step:864/1770 train_time:83665ms step_avg:96.83ms
+step:865/1770 train_time:83766ms step_avg:96.84ms
+step:866/1770 train_time:83866ms step_avg:96.84ms
+step:867/1770 train_time:83966ms step_avg:96.85ms
+step:868/1770 train_time:84067ms step_avg:96.85ms
+step:869/1770 train_time:84167ms step_avg:96.86ms
+step:870/1770 train_time:84266ms step_avg:96.86ms
+step:871/1770 train_time:84366ms step_avg:96.86ms
+step:872/1770 train_time:84466ms step_avg:96.86ms
+step:873/1770 train_time:84566ms step_avg:96.87ms
+step:874/1770 train_time:84665ms step_avg:96.87ms
+step:875/1770 train_time:84765ms step_avg:96.87ms
+step:875/1770 val_loss:3.5466 train_time:84864ms step_avg:96.99ms
+step:876/1770 train_time:84895ms step_avg:96.91ms
+step:877/1770 train_time:84974ms step_avg:96.89ms
+step:878/1770 train_time:85081ms step_avg:96.90ms
+step:879/1770 train_time:85180ms step_avg:96.91ms
+step:880/1770 train_time:85278ms step_avg:96.91ms
+step:881/1770 train_time:85376ms step_avg:96.91ms
+step:882/1770 train_time:85474ms step_avg:96.91ms
+step:883/1770 train_time:85572ms step_avg:96.91ms
+step:884/1770 train_time:85670ms step_avg:96.91ms
+step:885/1770 train_time:85769ms step_avg:96.91ms
+step:886/1770 train_time:85869ms step_avg:96.92ms
+step:887/1770 train_time:85970ms step_avg:96.92ms
+step:888/1770 train_time:86071ms step_avg:96.93ms
+step:889/1770 train_time:86170ms step_avg:96.93ms
+step:890/1770 train_time:86270ms step_avg:96.93ms
+step:891/1770 train_time:86369ms step_avg:96.94ms
+step:892/1770 train_time:86468ms step_avg:96.94ms
+step:893/1770 train_time:86567ms step_avg:96.94ms
+step:894/1770 train_time:86666ms step_avg:96.94ms
+step:895/1770 train_time:86766ms step_avg:96.94ms
+step:896/1770 train_time:86867ms step_avg:96.95ms
+step:897/1770 train_time:86967ms step_avg:96.95ms
+step:898/1770 train_time:87068ms step_avg:96.96ms
+step:899/1770 train_time:87168ms step_avg:96.96ms
+step:900/1770 train_time:87269ms step_avg:96.97ms
+step:901/1770 train_time:87367ms step_avg:96.97ms
+step:902/1770 train_time:87467ms step_avg:96.97ms
+step:903/1770 train_time:87567ms step_avg:96.97ms
+step:904/1770 train_time:87666ms step_avg:96.98ms
+step:905/1770 train_time:87765ms step_avg:96.98ms
+step:906/1770 train_time:87865ms step_avg:96.98ms
+step:907/1770 train_time:87966ms step_avg:96.99ms
+step:908/1770 train_time:88066ms step_avg:96.99ms
+step:909/1770 train_time:88167ms step_avg:96.99ms
+step:910/1770 train_time:88268ms step_avg:97.00ms
+step:911/1770 train_time:88368ms step_avg:97.00ms
+step:912/1770 train_time:88467ms step_avg:97.00ms
+step:913/1770 train_time:88567ms step_avg:97.01ms
+step:914/1770 train_time:88667ms step_avg:97.01ms
+step:915/1770 train_time:88767ms step_avg:97.01ms
+step:916/1770 train_time:88866ms step_avg:97.02ms
+step:917/1770 train_time:88966ms step_avg:97.02ms
+step:918/1770 train_time:89066ms step_avg:97.02ms
+step:919/1770 train_time:89167ms step_avg:97.03ms
+step:920/1770 train_time:89268ms step_avg:97.03ms
+step:921/1770 train_time:89370ms step_avg:97.04ms
+step:922/1770 train_time:89472ms step_avg:97.04ms
+step:923/1770 train_time:89572ms step_avg:97.04ms
+step:924/1770 train_time:89672ms step_avg:97.05ms
+step:925/1770 train_time:89773ms step_avg:97.05ms
+step:926/1770 train_time:89872ms step_avg:97.05ms
+step:927/1770 train_time:89972ms step_avg:97.06ms
+step:928/1770 train_time:90072ms step_avg:97.06ms
+step:929/1770 train_time:90172ms step_avg:97.06ms
+step:930/1770 train_time:90272ms step_avg:97.07ms
+step:931/1770 train_time:90372ms step_avg:97.07ms
+step:932/1770 train_time:90472ms step_avg:97.07ms
+step:933/1770 train_time:90572ms step_avg:97.08ms
+step:934/1770 train_time:90672ms step_avg:97.08ms
+step:935/1770 train_time:90772ms step_avg:97.08ms
+step:936/1770 train_time:90873ms step_avg:97.09ms
+step:937/1770 train_time:90973ms step_avg:97.09ms
+step:938/1770 train_time:91074ms step_avg:97.09ms
+step:939/1770 train_time:91173ms step_avg:97.10ms
+step:940/1770 train_time:91273ms step_avg:97.10ms
+step:941/1770 train_time:91372ms step_avg:97.10ms
+step:942/1770 train_time:91473ms step_avg:97.10ms
+step:943/1770 train_time:91573ms step_avg:97.11ms
+step:944/1770 train_time:91672ms step_avg:97.11ms
+step:945/1770 train_time:91772ms step_avg:97.11ms
+step:946/1770 train_time:91874ms step_avg:97.12ms
+step:947/1770 train_time:91974ms step_avg:97.12ms
+step:948/1770 train_time:92075ms step_avg:97.13ms
+step:949/1770 train_time:92176ms step_avg:97.13ms
+step:950/1770 train_time:92276ms step_avg:97.13ms
+step:951/1770 train_time:92377ms step_avg:97.14ms
+step:952/1770 train_time:92477ms step_avg:97.14ms
+step:953/1770 train_time:92577ms step_avg:97.14ms
+step:954/1770 train_time:92678ms step_avg:97.15ms
+step:955/1770 train_time:92779ms step_avg:97.15ms
+step:956/1770 train_time:92880ms step_avg:97.15ms
+step:957/1770 train_time:92981ms step_avg:97.16ms
+step:958/1770 train_time:93082ms step_avg:97.16ms
+step:959/1770 train_time:93184ms step_avg:97.17ms
+step:960/1770 train_time:93285ms step_avg:97.17ms
+step:961/1770 train_time:93386ms step_avg:97.18ms
+step:962/1770 train_time:93488ms step_avg:97.18ms
+step:963/1770 train_time:93589ms step_avg:97.19ms
+step:964/1770 train_time:93692ms step_avg:97.19ms
+step:965/1770 train_time:93792ms step_avg:97.19ms
+step:966/1770 train_time:93892ms step_avg:97.20ms
+step:967/1770 train_time:93992ms step_avg:97.20ms
+step:968/1770 train_time:94092ms step_avg:97.20ms
+step:969/1770 train_time:94193ms step_avg:97.21ms
+step:970/1770 train_time:94293ms step_avg:97.21ms
+step:971/1770 train_time:94394ms step_avg:97.21ms
+step:972/1770 train_time:94494ms step_avg:97.22ms
+step:973/1770 train_time:94595ms step_avg:97.22ms
+step:974/1770 train_time:94694ms step_avg:97.22ms
+step:975/1770 train_time:94795ms step_avg:97.23ms
+step:976/1770 train_time:94895ms step_avg:97.23ms
+step:977/1770 train_time:94995ms step_avg:97.23ms
+step:978/1770 train_time:95096ms step_avg:97.24ms
+step:979/1770 train_time:95196ms step_avg:97.24ms
+step:980/1770 train_time:95297ms step_avg:97.24ms
+step:981/1770 train_time:95398ms step_avg:97.25ms
+step:982/1770 train_time:95500ms step_avg:97.25ms
+step:983/1770 train_time:95601ms step_avg:97.25ms
+step:984/1770 train_time:95702ms step_avg:97.26ms
+step:985/1770 train_time:95803ms step_avg:97.26ms
+step:986/1770 train_time:95904ms step_avg:97.27ms
+step:987/1770 train_time:96005ms step_avg:97.27ms
+step:988/1770 train_time:96107ms step_avg:97.27ms
+step:989/1770 train_time:96210ms step_avg:97.28ms
+step:990/1770 train_time:96311ms step_avg:97.28ms
+step:991/1770 train_time:96412ms step_avg:97.29ms
+step:992/1770 train_time:96513ms step_avg:97.29ms
+step:993/1770 train_time:96613ms step_avg:97.29ms
+step:994/1770 train_time:96713ms step_avg:97.30ms
+step:995/1770 train_time:96813ms step_avg:97.30ms
+step:996/1770 train_time:96913ms step_avg:97.30ms
+step:997/1770 train_time:97013ms step_avg:97.30ms
+step:998/1770 train_time:97112ms step_avg:97.31ms
+step:999/1770 train_time:97212ms step_avg:97.31ms
+step:1000/1770 train_time:97312ms step_avg:97.31ms
+step:1000/1770 val_loss:3.5086 train_time:97411ms step_avg:97.41ms
+step:1001/1770 train_time:97439ms step_avg:97.34ms
+step:1002/1770 train_time:97527ms step_avg:97.33ms
+step:1003/1770 train_time:97633ms step_avg:97.34ms
+step:1004/1770 train_time:97734ms step_avg:97.34ms
+step:1005/1770 train_time:97834ms step_avg:97.35ms
+step:1006/1770 train_time:97933ms step_avg:97.35ms
+step:1007/1770 train_time:98033ms step_avg:97.35ms
+step:1008/1770 train_time:98132ms step_avg:97.35ms
+step:1009/1770 train_time:98232ms step_avg:97.36ms
+step:1010/1770 train_time:98331ms step_avg:97.36ms
+step:1011/1770 train_time:98432ms step_avg:97.36ms
+step:1012/1770 train_time:98534ms step_avg:97.37ms
+step:1013/1770 train_time:98636ms step_avg:97.37ms
+step:1014/1770 train_time:98737ms step_avg:97.37ms
+step:1015/1770 train_time:98836ms step_avg:97.38ms
+step:1016/1770 train_time:98938ms step_avg:97.38ms
+step:1017/1770 train_time:99038ms step_avg:97.38ms
+step:1018/1770 train_time:99138ms step_avg:97.39ms
+step:1019/1770 train_time:99239ms step_avg:97.39ms
+step:1020/1770 train_time:99340ms step_avg:97.39ms
+step:1021/1770 train_time:99442ms step_avg:97.40ms
+step:1022/1770 train_time:99544ms step_avg:97.40ms
+step:1023/1770 train_time:99646ms step_avg:97.41ms
+step:1024/1770 train_time:99747ms step_avg:97.41ms
+step:1025/1770 train_time:99848ms step_avg:97.41ms
+step:1026/1770 train_time:99950ms step_avg:97.42ms
+step:1027/1770 train_time:100051ms step_avg:97.42ms
+step:1028/1770 train_time:100151ms step_avg:97.42ms
+step:1029/1770 train_time:100252ms step_avg:97.43ms
+step:1030/1770 train_time:100352ms step_avg:97.43ms
+step:1031/1770 train_time:100452ms step_avg:97.43ms
+step:1032/1770 train_time:100552ms step_avg:97.43ms
+step:1033/1770 train_time:100653ms step_avg:97.44ms
+step:1034/1770 train_time:100753ms step_avg:97.44ms
+step:1035/1770 train_time:100854ms step_avg:97.44ms
+step:1036/1770 train_time:100953ms step_avg:97.45ms
+step:1037/1770 train_time:101053ms step_avg:97.45ms
+step:1038/1770 train_time:101153ms step_avg:97.45ms
+step:1039/1770 train_time:101253ms step_avg:97.45ms
+step:1040/1770 train_time:101353ms step_avg:97.46ms
+step:1041/1770 train_time:101453ms step_avg:97.46ms
+step:1042/1770 train_time:101554ms step_avg:97.46ms
+step:1043/1770 train_time:101654ms step_avg:97.46ms
+step:1044/1770 train_time:101754ms step_avg:97.47ms
+step:1045/1770 train_time:101854ms step_avg:97.47ms
+step:1046/1770 train_time:101955ms step_avg:97.47ms
+step:1047/1770 train_time:102056ms step_avg:97.47ms
+step:1048/1770 train_time:102156ms step_avg:97.48ms
+step:1049/1770 train_time:102255ms step_avg:97.48ms
+step:1050/1770 train_time:102355ms step_avg:97.48ms
+step:1051/1770 train_time:102456ms step_avg:97.48ms
+step:1052/1770 train_time:102557ms step_avg:97.49ms
+step:1053/1770 train_time:102659ms step_avg:97.49ms
+step:1054/1770 train_time:102759ms step_avg:97.49ms
+step:1055/1770 train_time:102861ms step_avg:97.50ms
+step:1056/1770 train_time:102963ms step_avg:97.50ms
+step:1057/1770 train_time:103065ms step_avg:97.51ms
+step:1058/1770 train_time:103168ms step_avg:97.51ms
+step:1059/1770 train_time:103268ms step_avg:97.51ms
+step:1060/1770 train_time:103369ms step_avg:97.52ms
+step:1061/1770 train_time:103469ms step_avg:97.52ms
+step:1062/1770 train_time:103570ms step_avg:97.52ms
+step:1063/1770 train_time:103672ms step_avg:97.53ms
+step:1064/1770 train_time:103772ms step_avg:97.53ms
+step:1065/1770 train_time:103873ms step_avg:97.53ms
+step:1066/1770 train_time:103973ms step_avg:97.54ms
+step:1067/1770 train_time:104073ms step_avg:97.54ms
+step:1068/1770 train_time:104174ms step_avg:97.54ms
+step:1069/1770 train_time:104275ms step_avg:97.54ms
+step:1070/1770 train_time:104375ms step_avg:97.55ms
+step:1071/1770 train_time:104476ms step_avg:97.55ms
+step:1072/1770 train_time:104577ms step_avg:97.55ms
+step:1073/1770 train_time:104678ms step_avg:97.56ms
+step:1074/1770 train_time:104779ms step_avg:97.56ms
+step:1075/1770 train_time:104880ms step_avg:97.56ms
+step:1076/1770 train_time:104982ms step_avg:97.57ms
+step:1077/1770 train_time:105084ms step_avg:97.57ms
+step:1078/1770 train_time:105187ms step_avg:97.58ms
+step:1079/1770 train_time:105288ms step_avg:97.58ms
+step:1080/1770 train_time:105388ms step_avg:97.58ms
+step:1081/1770 train_time:105488ms step_avg:97.58ms
+step:1082/1770 train_time:105590ms step_avg:97.59ms
+step:1083/1770 train_time:105691ms step_avg:97.59ms
+step:1084/1770 train_time:105792ms step_avg:97.59ms
+step:1085/1770 train_time:105893ms step_avg:97.60ms
+step:1086/1770 train_time:105993ms step_avg:97.60ms
+step:1087/1770 train_time:106093ms step_avg:97.60ms
+step:1088/1770 train_time:106194ms step_avg:97.60ms
+step:1089/1770 train_time:106294ms step_avg:97.61ms
+step:1090/1770 train_time:106397ms step_avg:97.61ms
+step:1091/1770 train_time:106497ms step_avg:97.61ms
+step:1092/1770 train_time:106599ms step_avg:97.62ms
+step:1093/1770 train_time:106701ms step_avg:97.62ms
+step:1094/1770 train_time:106803ms step_avg:97.63ms
+step:1095/1770 train_time:106905ms step_avg:97.63ms
+step:1096/1770 train_time:107006ms step_avg:97.63ms
+step:1097/1770 train_time:107108ms step_avg:97.64ms
+step:1098/1770 train_time:107209ms step_avg:97.64ms
+step:1099/1770 train_time:107311ms step_avg:97.64ms
+step:1100/1770 train_time:107412ms step_avg:97.65ms
+step:1101/1770 train_time:107512ms step_avg:97.65ms
+step:1102/1770 train_time:107613ms step_avg:97.65ms
+step:1103/1770 train_time:107713ms step_avg:97.66ms
+step:1104/1770 train_time:107814ms step_avg:97.66ms
+step:1105/1770 train_time:107915ms step_avg:97.66ms
+step:1106/1770 train_time:108016ms step_avg:97.66ms
+step:1107/1770 train_time:108116ms step_avg:97.67ms
+step:1108/1770 train_time:108218ms step_avg:97.67ms
+step:1109/1770 train_time:108319ms step_avg:97.67ms
+step:1110/1770 train_time:108422ms step_avg:97.68ms
+step:1111/1770 train_time:108524ms step_avg:97.68ms
+step:1112/1770 train_time:108626ms step_avg:97.69ms
+step:1113/1770 train_time:108727ms step_avg:97.69ms
+step:1114/1770 train_time:108829ms step_avg:97.69ms
+step:1115/1770 train_time:108930ms step_avg:97.69ms
+step:1116/1770 train_time:109030ms step_avg:97.70ms
+step:1117/1770 train_time:109131ms step_avg:97.70ms
+step:1118/1770 train_time:109230ms step_avg:97.70ms
+step:1119/1770 train_time:109331ms step_avg:97.70ms
+step:1120/1770 train_time:109431ms step_avg:97.71ms
+step:1121/1770 train_time:109532ms step_avg:97.71ms
+step:1122/1770 train_time:109632ms step_avg:97.71ms
+step:1123/1770 train_time:109732ms step_avg:97.71ms
+step:1124/1770 train_time:109833ms step_avg:97.72ms
+step:1125/1770 train_time:109933ms step_avg:97.72ms
+step:1125/1770 val_loss:3.4685 train_time:110032ms step_avg:97.81ms
+step:1126/1770 train_time:110058ms step_avg:97.74ms
+step:1127/1770 train_time:110147ms step_avg:97.73ms
+step:1128/1770 train_time:110250ms step_avg:97.74ms
+step:1129/1770 train_time:110351ms step_avg:97.74ms
+step:1130/1770 train_time:110451ms step_avg:97.74ms
+step:1131/1770 train_time:110550ms step_avg:97.75ms
+step:1132/1770 train_time:110650ms step_avg:97.75ms
+step:1133/1770 train_time:110749ms step_avg:97.75ms
+step:1134/1770 train_time:110850ms step_avg:97.75ms
+step:1135/1770 train_time:110950ms step_avg:97.75ms
+step:1136/1770 train_time:111051ms step_avg:97.76ms
+step:1137/1770 train_time:111156ms step_avg:97.76ms
+step:1138/1770 train_time:111258ms step_avg:97.77ms
+step:1139/1770 train_time:111359ms step_avg:97.77ms
+step:1140/1770 train_time:111462ms step_avg:97.77ms
+step:1141/1770 train_time:111562ms step_avg:97.78ms
+step:1142/1770 train_time:111663ms step_avg:97.78ms
+step:1143/1770 train_time:111764ms step_avg:97.78ms
+step:1144/1770 train_time:111865ms step_avg:97.78ms
+step:1145/1770 train_time:111965ms step_avg:97.79ms
+step:1146/1770 train_time:112066ms step_avg:97.79ms
+step:1147/1770 train_time:112167ms step_avg:97.79ms
+step:1148/1770 train_time:112268ms step_avg:97.79ms
+step:1149/1770 train_time:112369ms step_avg:97.80ms
+step:1150/1770 train_time:112469ms step_avg:97.80ms
+step:1151/1770 train_time:112569ms step_avg:97.80ms
+step:1152/1770 train_time:112670ms step_avg:97.80ms
+step:1153/1770 train_time:112771ms step_avg:97.81ms
+step:1154/1770 train_time:112873ms step_avg:97.81ms
+step:1155/1770 train_time:112973ms step_avg:97.81ms
+step:1156/1770 train_time:113074ms step_avg:97.82ms
+step:1157/1770 train_time:113177ms step_avg:97.82ms
+step:1158/1770 train_time:113280ms step_avg:97.82ms
+step:1159/1770 train_time:113382ms step_avg:97.83ms
+step:1160/1770 train_time:113482ms step_avg:97.83ms
+step:1161/1770 train_time:113583ms step_avg:97.83ms
+step:1162/1770 train_time:113685ms step_avg:97.84ms
+step:1163/1770 train_time:113785ms step_avg:97.84ms
+step:1164/1770 train_time:113886ms step_avg:97.84ms
+step:1165/1770 train_time:113985ms step_avg:97.84ms
+step:1166/1770 train_time:114086ms step_avg:97.84ms
+step:1167/1770 train_time:114188ms step_avg:97.85ms
+step:1168/1770 train_time:114289ms step_avg:97.85ms
+step:1169/1770 train_time:114389ms step_avg:97.85ms
+step:1170/1770 train_time:114490ms step_avg:97.85ms
+step:1171/1770 train_time:114591ms step_avg:97.86ms
+step:1172/1770 train_time:114691ms step_avg:97.86ms
+step:1173/1770 train_time:114792ms step_avg:97.86ms
+step:1174/1770 train_time:114894ms step_avg:97.87ms
+step:1175/1770 train_time:114995ms step_avg:97.87ms
+step:1176/1770 train_time:115097ms step_avg:97.87ms
+step:1177/1770 train_time:115199ms step_avg:97.88ms
+step:1178/1770 train_time:115301ms step_avg:97.88ms
+step:1179/1770 train_time:115402ms step_avg:97.88ms
+step:1180/1770 train_time:115503ms step_avg:97.88ms
+step:1181/1770 train_time:115605ms step_avg:97.89ms
+step:1182/1770 train_time:115705ms step_avg:97.89ms
+step:1183/1770 train_time:115807ms step_avg:97.89ms
+step:1184/1770 train_time:115910ms step_avg:97.90ms
+step:1185/1770 train_time:116011ms step_avg:97.90ms
+step:1186/1770 train_time:116113ms step_avg:97.90ms
+step:1187/1770 train_time:116216ms step_avg:97.91ms
+step:1188/1770 train_time:116318ms step_avg:97.91ms
+step:1189/1770 train_time:116420ms step_avg:97.91ms
+step:1190/1770 train_time:116522ms step_avg:97.92ms
+step:1191/1770 train_time:116627ms step_avg:97.92ms
+step:1192/1770 train_time:116728ms step_avg:97.93ms
+step:1193/1770 train_time:116829ms step_avg:97.93ms
+step:1194/1770 train_time:116930ms step_avg:97.93ms
+step:1195/1770 train_time:117033ms step_avg:97.94ms
+step:1196/1770 train_time:117135ms step_avg:97.94ms
+step:1197/1770 train_time:117236ms step_avg:97.94ms
+step:1198/1770 train_time:117339ms step_avg:97.95ms
+step:1199/1770 train_time:117442ms step_avg:97.95ms
+step:1200/1770 train_time:117544ms step_avg:97.95ms
+step:1201/1770 train_time:117646ms step_avg:97.96ms
+step:1202/1770 train_time:117747ms step_avg:97.96ms
+step:1203/1770 train_time:117849ms step_avg:97.96ms
+step:1204/1770 train_time:117951ms step_avg:97.97ms
+step:1205/1770 train_time:118052ms step_avg:97.97ms
+step:1206/1770 train_time:118154ms step_avg:97.97ms
+step:1207/1770 train_time:118255ms step_avg:97.97ms
+step:1208/1770 train_time:118359ms step_avg:97.98ms
+step:1209/1770 train_time:118463ms step_avg:97.98ms
+step:1210/1770 train_time:118565ms step_avg:97.99ms
+step:1211/1770 train_time:118667ms step_avg:97.99ms
+step:1212/1770 train_time:118770ms step_avg:98.00ms
+step:1213/1770 train_time:118871ms step_avg:98.00ms
+step:1214/1770 train_time:118973ms step_avg:98.00ms
+step:1215/1770 train_time:119075ms step_avg:98.00ms
+step:1216/1770 train_time:119179ms step_avg:98.01ms
+step:1217/1770 train_time:119281ms step_avg:98.01ms
+step:1218/1770 train_time:119383ms step_avg:98.02ms
+step:1219/1770 train_time:119486ms step_avg:98.02ms
+step:1220/1770 train_time:119587ms step_avg:98.02ms
+step:1221/1770 train_time:119688ms step_avg:98.02ms
+step:1222/1770 train_time:119790ms step_avg:98.03ms
+step:1223/1770 train_time:119890ms step_avg:98.03ms
+step:1224/1770 train_time:119993ms step_avg:98.03ms
+step:1225/1770 train_time:120094ms step_avg:98.04ms
+step:1226/1770 train_time:120195ms step_avg:98.04ms
+step:1227/1770 train_time:120299ms step_avg:98.04ms
+step:1228/1770 train_time:120403ms step_avg:98.05ms
+step:1229/1770 train_time:120504ms step_avg:98.05ms
+step:1230/1770 train_time:120607ms step_avg:98.05ms
+step:1231/1770 train_time:120709ms step_avg:98.06ms
+step:1232/1770 train_time:120811ms step_avg:98.06ms
+step:1233/1770 train_time:120912ms step_avg:98.06ms
+step:1234/1770 train_time:121013ms step_avg:98.07ms
+step:1235/1770 train_time:121115ms step_avg:98.07ms
+step:1236/1770 train_time:121217ms step_avg:98.07ms
+step:1237/1770 train_time:121320ms step_avg:98.08ms
+step:1238/1770 train_time:121424ms step_avg:98.08ms
+step:1239/1770 train_time:121526ms step_avg:98.08ms
+step:1240/1770 train_time:121627ms step_avg:98.09ms
+step:1241/1770 train_time:121729ms step_avg:98.09ms
+step:1242/1770 train_time:121831ms step_avg:98.09ms
+step:1243/1770 train_time:121932ms step_avg:98.09ms
+step:1244/1770 train_time:122033ms step_avg:98.10ms
+step:1245/1770 train_time:122134ms step_avg:98.10ms
+step:1246/1770 train_time:122236ms step_avg:98.10ms
+step:1247/1770 train_time:122340ms step_avg:98.11ms
+step:1248/1770 train_time:122443ms step_avg:98.11ms
+step:1249/1770 train_time:122546ms step_avg:98.12ms
+step:1250/1770 train_time:122648ms step_avg:98.12ms
+step:1250/1770 val_loss:3.4219 train_time:122748ms step_avg:98.20ms
+step:1251/1770 train_time:122775ms step_avg:98.14ms
+step:1252/1770 train_time:122863ms step_avg:98.13ms
+step:1253/1770 train_time:122971ms step_avg:98.14ms
+step:1254/1770 train_time:123074ms step_avg:98.15ms
+step:1255/1770 train_time:123177ms step_avg:98.15ms
+step:1256/1770 train_time:123278ms step_avg:98.15ms
+step:1257/1770 train_time:123378ms step_avg:98.15ms
+step:1258/1770 train_time:123480ms step_avg:98.16ms
+step:1259/1770 train_time:123580ms step_avg:98.16ms
+step:1260/1770 train_time:123681ms step_avg:98.16ms
+step:1261/1770 train_time:123784ms step_avg:98.16ms
+step:1262/1770 train_time:123891ms step_avg:98.17ms
+step:1263/1770 train_time:123993ms step_avg:98.17ms
+step:1264/1770 train_time:124096ms step_avg:98.18ms
+step:1265/1770 train_time:124198ms step_avg:98.18ms
+step:1266/1770 train_time:124300ms step_avg:98.18ms
+step:1267/1770 train_time:124402ms step_avg:98.19ms
+step:1268/1770 train_time:124504ms step_avg:98.19ms
+step:1269/1770 train_time:124605ms step_avg:98.19ms
+step:1270/1770 train_time:124707ms step_avg:98.19ms
+step:1271/1770 train_time:124809ms step_avg:98.20ms
+step:1272/1770 train_time:124912ms step_avg:98.20ms
+step:1273/1770 train_time:125016ms step_avg:98.21ms
+step:1274/1770 train_time:125118ms step_avg:98.21ms
+step:1275/1770 train_time:125219ms step_avg:98.21ms
+step:1276/1770 train_time:125320ms step_avg:98.21ms
+step:1277/1770 train_time:125422ms step_avg:98.22ms
+step:1278/1770 train_time:125524ms step_avg:98.22ms
+step:1279/1770 train_time:125624ms step_avg:98.22ms
+step:1280/1770 train_time:125727ms step_avg:98.22ms
+step:1281/1770 train_time:125829ms step_avg:98.23ms
+step:1282/1770 train_time:125934ms step_avg:98.23ms
+step:1283/1770 train_time:126037ms step_avg:98.24ms
+step:1284/1770 train_time:126139ms step_avg:98.24ms
+step:1285/1770 train_time:126241ms step_avg:98.24ms
+step:1286/1770 train_time:126345ms step_avg:98.25ms
+step:1287/1770 train_time:126448ms step_avg:98.25ms
+step:1288/1770 train_time:126550ms step_avg:98.25ms
+step:1289/1770 train_time:126653ms step_avg:98.26ms
+step:1290/1770 train_time:126754ms step_avg:98.26ms
+step:1291/1770 train_time:126856ms step_avg:98.26ms
+step:1292/1770 train_time:126957ms step_avg:98.26ms
+step:1293/1770 train_time:127059ms step_avg:98.27ms
+step:1294/1770 train_time:127161ms step_avg:98.27ms
+step:1295/1770 train_time:127263ms step_avg:98.27ms
+step:1296/1770 train_time:127366ms step_avg:98.28ms
+step:1297/1770 train_time:127468ms step_avg:98.28ms
+step:1298/1770 train_time:127570ms step_avg:98.28ms
+step:1299/1770 train_time:127672ms step_avg:98.28ms
+step:1300/1770 train_time:127774ms step_avg:98.29ms
+step:1301/1770 train_time:127876ms step_avg:98.29ms
+step:1302/1770 train_time:127978ms step_avg:98.29ms
+step:1303/1770 train_time:128079ms step_avg:98.30ms
+step:1304/1770 train_time:128180ms step_avg:98.30ms
+step:1305/1770 train_time:128282ms step_avg:98.30ms
+step:1306/1770 train_time:128385ms step_avg:98.30ms
+step:1307/1770 train_time:128489ms step_avg:98.31ms
+step:1308/1770 train_time:128592ms step_avg:98.31ms
+step:1309/1770 train_time:128693ms step_avg:98.31ms
+step:1310/1770 train_time:128795ms step_avg:98.32ms
+step:1311/1770 train_time:128897ms step_avg:98.32ms
+step:1312/1770 train_time:128998ms step_avg:98.32ms
+step:1313/1770 train_time:129099ms step_avg:98.32ms
+step:1314/1770 train_time:129200ms step_avg:98.33ms
+step:1315/1770 train_time:129301ms step_avg:98.33ms
+step:1316/1770 train_time:129403ms step_avg:98.33ms
+step:1317/1770 train_time:129506ms step_avg:98.33ms
+step:1318/1770 train_time:129611ms step_avg:98.34ms
+step:1319/1770 train_time:129713ms step_avg:98.34ms
+step:1320/1770 train_time:129815ms step_avg:98.34ms
+step:1321/1770 train_time:129916ms step_avg:98.35ms
+step:1322/1770 train_time:130018ms step_avg:98.35ms
+step:1323/1770 train_time:130120ms step_avg:98.35ms
+step:1324/1770 train_time:130221ms step_avg:98.35ms
+step:1325/1770 train_time:130324ms step_avg:98.36ms
+step:1326/1770 train_time:130427ms step_avg:98.36ms
+step:1327/1770 train_time:130531ms step_avg:98.37ms
+step:1328/1770 train_time:130633ms step_avg:98.37ms
+step:1329/1770 train_time:130735ms step_avg:98.37ms
+step:1330/1770 train_time:130836ms step_avg:98.37ms
+step:1331/1770 train_time:130938ms step_avg:98.38ms
+step:1332/1770 train_time:131039ms step_avg:98.38ms
+step:1333/1770 train_time:131140ms step_avg:98.38ms
+step:1334/1770 train_time:131240ms step_avg:98.38ms
+step:1335/1770 train_time:131342ms step_avg:98.38ms
+step:1336/1770 train_time:131445ms step_avg:98.39ms
+step:1337/1770 train_time:131549ms step_avg:98.39ms
+step:1338/1770 train_time:131651ms step_avg:98.39ms
+step:1339/1770 train_time:131755ms step_avg:98.40ms
+step:1340/1770 train_time:131858ms step_avg:98.40ms
+step:1341/1770 train_time:131959ms step_avg:98.40ms
+step:1342/1770 train_time:132061ms step_avg:98.41ms
+step:1343/1770 train_time:132162ms step_avg:98.41ms
+step:1344/1770 train_time:132264ms step_avg:98.41ms
+step:1345/1770 train_time:132366ms step_avg:98.41ms
+step:1346/1770 train_time:132470ms step_avg:98.42ms
+step:1347/1770 train_time:132572ms step_avg:98.42ms
+step:1348/1770 train_time:132676ms step_avg:98.42ms
+step:1349/1770 train_time:132777ms step_avg:98.43ms
+step:1350/1770 train_time:132879ms step_avg:98.43ms
+step:1351/1770 train_time:132980ms step_avg:98.43ms
+step:1352/1770 train_time:133081ms step_avg:98.43ms
+step:1353/1770 train_time:133185ms step_avg:98.44ms
+step:1354/1770 train_time:133287ms step_avg:98.44ms
+step:1355/1770 train_time:133390ms step_avg:98.44ms
+step:1356/1770 train_time:133492ms step_avg:98.45ms
+step:1357/1770 train_time:133595ms step_avg:98.45ms
+step:1358/1770 train_time:133697ms step_avg:98.45ms
+step:1359/1770 train_time:133798ms step_avg:98.45ms
+step:1360/1770 train_time:133899ms step_avg:98.46ms
+step:1361/1770 train_time:134003ms step_avg:98.46ms
+step:1362/1770 train_time:134106ms step_avg:98.46ms
+step:1363/1770 train_time:134209ms step_avg:98.47ms
+step:1364/1770 train_time:134311ms step_avg:98.47ms
+step:1365/1770 train_time:134413ms step_avg:98.47ms
+step:1366/1770 train_time:134515ms step_avg:98.47ms
+step:1367/1770 train_time:134618ms step_avg:98.48ms
+step:1368/1770 train_time:134719ms step_avg:98.48ms
+step:1369/1770 train_time:134822ms step_avg:98.48ms
+step:1370/1770 train_time:134925ms step_avg:98.49ms
+step:1371/1770 train_time:135027ms step_avg:98.49ms
+step:1372/1770 train_time:135129ms step_avg:98.49ms
+step:1373/1770 train_time:135232ms step_avg:98.49ms
+step:1374/1770 train_time:135335ms step_avg:98.50ms
+step:1375/1770 train_time:135436ms step_avg:98.50ms
+step:1375/1770 val_loss:3.3780 train_time:135539ms step_avg:98.57ms
+step:1376/1770 train_time:135565ms step_avg:98.52ms
+step:1377/1770 train_time:135656ms step_avg:98.52ms
+step:1378/1770 train_time:135759ms step_avg:98.52ms
+step:1379/1770 train_time:135860ms step_avg:98.52ms
+step:1380/1770 train_time:135961ms step_avg:98.52ms
+step:1381/1770 train_time:136063ms step_avg:98.53ms
+step:1382/1770 train_time:136165ms step_avg:98.53ms
+step:1383/1770 train_time:136266ms step_avg:98.53ms
+step:1384/1770 train_time:136367ms step_avg:98.53ms
+step:1385/1770 train_time:136468ms step_avg:98.53ms
+step:1386/1770 train_time:136574ms step_avg:98.54ms
+step:1387/1770 train_time:136678ms step_avg:98.54ms
+step:1388/1770 train_time:136781ms step_avg:98.55ms
+step:1389/1770 train_time:136884ms step_avg:98.55ms
+step:1390/1770 train_time:136986ms step_avg:98.55ms
+step:1391/1770 train_time:137088ms step_avg:98.55ms
+step:1392/1770 train_time:137190ms step_avg:98.56ms
+step:1393/1770 train_time:137293ms step_avg:98.56ms
+step:1394/1770 train_time:137395ms step_avg:98.56ms
+step:1395/1770 train_time:137496ms step_avg:98.56ms
+step:1396/1770 train_time:137601ms step_avg:98.57ms
+step:1397/1770 train_time:137704ms step_avg:98.57ms
+step:1398/1770 train_time:137806ms step_avg:98.57ms
+step:1399/1770 train_time:137907ms step_avg:98.58ms
+step:1400/1770 train_time:138010ms step_avg:98.58ms
+step:1401/1770 train_time:138112ms step_avg:98.58ms
+step:1402/1770 train_time:138214ms step_avg:98.58ms
+step:1403/1770 train_time:138316ms step_avg:98.59ms
+step:1404/1770 train_time:138418ms step_avg:98.59ms
+step:1405/1770 train_time:138520ms step_avg:98.59ms
+step:1406/1770 train_time:138621ms step_avg:98.59ms
+step:1407/1770 train_time:138723ms step_avg:98.59ms
+step:1408/1770 train_time:138824ms step_avg:98.60ms
+step:1409/1770 train_time:138926ms step_avg:98.60ms
+step:1410/1770 train_time:139029ms step_avg:98.60ms
+step:1411/1770 train_time:139134ms step_avg:98.61ms
+step:1412/1770 train_time:139236ms step_avg:98.61ms
+step:1413/1770 train_time:139338ms step_avg:98.61ms
+step:1414/1770 train_time:139440ms step_avg:98.61ms
+step:1415/1770 train_time:139541ms step_avg:98.62ms
+step:1416/1770 train_time:139643ms step_avg:98.62ms
+step:1417/1770 train_time:139744ms step_avg:98.62ms
+step:1418/1770 train_time:139847ms step_avg:98.62ms
+step:1419/1770 train_time:139948ms step_avg:98.62ms
+step:1420/1770 train_time:140050ms step_avg:98.63ms
+step:1421/1770 train_time:140154ms step_avg:98.63ms
+step:1422/1770 train_time:140257ms step_avg:98.63ms
+step:1423/1770 train_time:140358ms step_avg:98.64ms
+step:1424/1770 train_time:140460ms step_avg:98.64ms
+step:1425/1770 train_time:140563ms step_avg:98.64ms
+step:1426/1770 train_time:140663ms step_avg:98.64ms
+step:1427/1770 train_time:140764ms step_avg:98.64ms
+step:1428/1770 train_time:140866ms step_avg:98.65ms
+step:1429/1770 train_time:140970ms step_avg:98.65ms
+step:1430/1770 train_time:141074ms step_avg:98.65ms
+step:1431/1770 train_time:141178ms step_avg:98.66ms
+step:1432/1770 train_time:141279ms step_avg:98.66ms
+step:1433/1770 train_time:141380ms step_avg:98.66ms
+step:1434/1770 train_time:141482ms step_avg:98.66ms
+step:1435/1770 train_time:141585ms step_avg:98.67ms
+step:1436/1770 train_time:141688ms step_avg:98.67ms
+step:1437/1770 train_time:141791ms step_avg:98.67ms
+step:1438/1770 train_time:141892ms step_avg:98.67ms
+step:1439/1770 train_time:141996ms step_avg:98.68ms
+step:1440/1770 train_time:142097ms step_avg:98.68ms
+step:1441/1770 train_time:142202ms step_avg:98.68ms
+step:1442/1770 train_time:142303ms step_avg:98.68ms
+step:1443/1770 train_time:142405ms step_avg:98.69ms
+step:1444/1770 train_time:142507ms step_avg:98.69ms
+step:1445/1770 train_time:142609ms step_avg:98.69ms
+step:1446/1770 train_time:142713ms step_avg:98.69ms
+step:1447/1770 train_time:142816ms step_avg:98.70ms
+step:1448/1770 train_time:142920ms step_avg:98.70ms
+step:1449/1770 train_time:143024ms step_avg:98.71ms
+step:1450/1770 train_time:143127ms step_avg:98.71ms
+step:1451/1770 train_time:143230ms step_avg:98.71ms
+step:1452/1770 train_time:143333ms step_avg:98.71ms
+step:1453/1770 train_time:143436ms step_avg:98.72ms
+step:1454/1770 train_time:143539ms step_avg:98.72ms
+step:1455/1770 train_time:143643ms step_avg:98.72ms
+step:1456/1770 train_time:143747ms step_avg:98.73ms
+step:1457/1770 train_time:143853ms step_avg:98.73ms
+step:1458/1770 train_time:143957ms step_avg:98.74ms
+step:1459/1770 train_time:144059ms step_avg:98.74ms
+step:1460/1770 train_time:144162ms step_avg:98.74ms
+step:1461/1770 train_time:144266ms step_avg:98.74ms
+step:1462/1770 train_time:144369ms step_avg:98.75ms
+step:1463/1770 train_time:144473ms step_avg:98.75ms
+step:1464/1770 train_time:144576ms step_avg:98.75ms
+step:1465/1770 train_time:144678ms step_avg:98.76ms
+step:1466/1770 train_time:144782ms step_avg:98.76ms
+step:1467/1770 train_time:144887ms step_avg:98.76ms
+step:1468/1770 train_time:144990ms step_avg:98.77ms
+step:1469/1770 train_time:145094ms step_avg:98.77ms
+step:1470/1770 train_time:145196ms step_avg:98.77ms
+step:1471/1770 train_time:145299ms step_avg:98.78ms
+step:1472/1770 train_time:145402ms step_avg:98.78ms
+step:1473/1770 train_time:145505ms step_avg:98.78ms
+step:1474/1770 train_time:145609ms step_avg:98.78ms
+step:1475/1770 train_time:145712ms step_avg:98.79ms
+step:1476/1770 train_time:145816ms step_avg:98.79ms
+step:1477/1770 train_time:145921ms step_avg:98.80ms
+step:1478/1770 train_time:146024ms step_avg:98.80ms
+step:1479/1770 train_time:146126ms step_avg:98.80ms
+step:1480/1770 train_time:146230ms step_avg:98.80ms
+step:1481/1770 train_time:146336ms step_avg:98.81ms
+step:1482/1770 train_time:146438ms step_avg:98.81ms
+step:1483/1770 train_time:146541ms step_avg:98.81ms
+step:1484/1770 train_time:146644ms step_avg:98.82ms
+step:1485/1770 train_time:146748ms step_avg:98.82ms
+step:1486/1770 train_time:146851ms step_avg:98.82ms
+step:1487/1770 train_time:146954ms step_avg:98.83ms
+step:1488/1770 train_time:147057ms step_avg:98.83ms
+step:1489/1770 train_time:147161ms step_avg:98.83ms
+step:1490/1770 train_time:147264ms step_avg:98.83ms
+step:1491/1770 train_time:147366ms step_avg:98.84ms
+step:1492/1770 train_time:147469ms step_avg:98.84ms
+step:1493/1770 train_time:147575ms step_avg:98.84ms
+step:1494/1770 train_time:147681ms step_avg:98.85ms
+step:1495/1770 train_time:147784ms step_avg:98.85ms
+step:1496/1770 train_time:147887ms step_avg:98.85ms
+step:1497/1770 train_time:147991ms step_avg:98.86ms
+step:1498/1770 train_time:148094ms step_avg:98.86ms
+step:1499/1770 train_time:148197ms step_avg:98.86ms
+step:1500/1770 train_time:148300ms step_avg:98.87ms
+step:1500/1770 val_loss:3.3406 train_time:148401ms step_avg:98.93ms
+step:1501/1770 train_time:148427ms step_avg:98.89ms
+step:1502/1770 train_time:148521ms step_avg:98.88ms
+step:1503/1770 train_time:148626ms step_avg:98.89ms
+step:1504/1770 train_time:148730ms step_avg:98.89ms
+step:1505/1770 train_time:148833ms step_avg:98.89ms
+step:1506/1770 train_time:148936ms step_avg:98.90ms
+step:1507/1770 train_time:149038ms step_avg:98.90ms
+step:1508/1770 train_time:149143ms step_avg:98.90ms
+step:1509/1770 train_time:149245ms step_avg:98.90ms
+step:1510/1770 train_time:149346ms step_avg:98.90ms
+step:1511/1770 train_time:149451ms step_avg:98.91ms
+step:1512/1770 train_time:149555ms step_avg:98.91ms
+step:1513/1770 train_time:149660ms step_avg:98.92ms
+step:1514/1770 train_time:149762ms step_avg:98.92ms
+step:1515/1770 train_time:149865ms step_avg:98.92ms
+step:1516/1770 train_time:149969ms step_avg:98.92ms
+step:1517/1770 train_time:150072ms step_avg:98.93ms
+step:1518/1770 train_time:150176ms step_avg:98.93ms
+step:1519/1770 train_time:150279ms step_avg:98.93ms
+step:1520/1770 train_time:150382ms step_avg:98.94ms
+step:1521/1770 train_time:150484ms step_avg:98.94ms
+step:1522/1770 train_time:150588ms step_avg:98.94ms
+step:1523/1770 train_time:150692ms step_avg:98.94ms
+step:1524/1770 train_time:150796ms step_avg:98.95ms
+step:1525/1770 train_time:150898ms step_avg:98.95ms
+step:1526/1770 train_time:151001ms step_avg:98.95ms
+step:1527/1770 train_time:151104ms step_avg:98.95ms
+step:1528/1770 train_time:151208ms step_avg:98.96ms
+step:1529/1770 train_time:151311ms step_avg:98.96ms
+step:1530/1770 train_time:151414ms step_avg:98.96ms
+step:1531/1770 train_time:151516ms step_avg:98.97ms
+step:1532/1770 train_time:151620ms step_avg:98.97ms
+step:1533/1770 train_time:151723ms step_avg:98.97ms
+step:1534/1770 train_time:151827ms step_avg:98.97ms
+step:1535/1770 train_time:151929ms step_avg:98.98ms
+step:1536/1770 train_time:152032ms step_avg:98.98ms
+step:1537/1770 train_time:152135ms step_avg:98.98ms
+step:1538/1770 train_time:152239ms step_avg:98.99ms
+step:1539/1770 train_time:152342ms step_avg:98.99ms
+step:1540/1770 train_time:152447ms step_avg:98.99ms
+step:1541/1770 train_time:152550ms step_avg:98.99ms
+step:1542/1770 train_time:152654ms step_avg:99.00ms
+step:1543/1770 train_time:152757ms step_avg:99.00ms
+step:1544/1770 train_time:152862ms step_avg:99.00ms
+step:1545/1770 train_time:152964ms step_avg:99.01ms
+step:1546/1770 train_time:153067ms step_avg:99.01ms
+step:1547/1770 train_time:153170ms step_avg:99.01ms
+step:1548/1770 train_time:153273ms step_avg:99.01ms
+step:1549/1770 train_time:153378ms step_avg:99.02ms
+step:1550/1770 train_time:153481ms step_avg:99.02ms
+step:1551/1770 train_time:153583ms step_avg:99.02ms
+step:1552/1770 train_time:153688ms step_avg:99.03ms
+step:1553/1770 train_time:153790ms step_avg:99.03ms
+step:1554/1770 train_time:153893ms step_avg:99.03ms
+step:1555/1770 train_time:153998ms step_avg:99.03ms
+step:1556/1770 train_time:154101ms step_avg:99.04ms
+step:1557/1770 train_time:154202ms step_avg:99.04ms
+step:1558/1770 train_time:154306ms step_avg:99.04ms
+step:1559/1770 train_time:154409ms step_avg:99.04ms
+step:1560/1770 train_time:154512ms step_avg:99.05ms
+step:1561/1770 train_time:154616ms step_avg:99.05ms
+step:1562/1770 train_time:154721ms step_avg:99.05ms
+step:1563/1770 train_time:154824ms step_avg:99.06ms
+step:1564/1770 train_time:154926ms step_avg:99.06ms
+step:1565/1770 train_time:155029ms step_avg:99.06ms
+step:1566/1770 train_time:155133ms step_avg:99.06ms
+step:1567/1770 train_time:155236ms step_avg:99.07ms
+step:1568/1770 train_time:155339ms step_avg:99.07ms
+step:1569/1770 train_time:155445ms step_avg:99.07ms
+step:1570/1770 train_time:155547ms step_avg:99.07ms
+step:1571/1770 train_time:155652ms step_avg:99.08ms
+step:1572/1770 train_time:155755ms step_avg:99.08ms
+step:1573/1770 train_time:155859ms step_avg:99.08ms
+step:1574/1770 train_time:155962ms step_avg:99.09ms
+step:1575/1770 train_time:156063ms step_avg:99.09ms
+step:1576/1770 train_time:156167ms step_avg:99.09ms
+step:1577/1770 train_time:156274ms step_avg:99.10ms
+step:1578/1770 train_time:156377ms step_avg:99.10ms
+step:1579/1770 train_time:156479ms step_avg:99.10ms
+step:1580/1770 train_time:156582ms step_avg:99.10ms
+step:1581/1770 train_time:156687ms step_avg:99.11ms
+step:1582/1770 train_time:156791ms step_avg:99.11ms
+step:1583/1770 train_time:156895ms step_avg:99.11ms
+step:1584/1770 train_time:156999ms step_avg:99.12ms
+step:1585/1770 train_time:157102ms step_avg:99.12ms
+step:1586/1770 train_time:157208ms step_avg:99.12ms
+step:1587/1770 train_time:157311ms step_avg:99.12ms
+step:1588/1770 train_time:157415ms step_avg:99.13ms
+step:1589/1770 train_time:157520ms step_avg:99.13ms
+step:1590/1770 train_time:157623ms step_avg:99.13ms
+step:1591/1770 train_time:157725ms step_avg:99.14ms
+step:1592/1770 train_time:157830ms step_avg:99.14ms
+step:1593/1770 train_time:157934ms step_avg:99.14ms
+step:1594/1770 train_time:158039ms step_avg:99.15ms
+step:1595/1770 train_time:158141ms step_avg:99.15ms
+step:1596/1770 train_time:158245ms step_avg:99.15ms
+step:1597/1770 train_time:158346ms step_avg:99.15ms
+step:1598/1770 train_time:158450ms step_avg:99.16ms
+step:1599/1770 train_time:158553ms step_avg:99.16ms
+step:1600/1770 train_time:158658ms step_avg:99.16ms
+step:1601/1770 train_time:158761ms step_avg:99.16ms
+step:1602/1770 train_time:158864ms step_avg:99.17ms
+step:1603/1770 train_time:158968ms step_avg:99.17ms
+step:1604/1770 train_time:159071ms step_avg:99.17ms
+step:1605/1770 train_time:159174ms step_avg:99.17ms
+step:1606/1770 train_time:159278ms step_avg:99.18ms
+step:1607/1770 train_time:159385ms step_avg:99.18ms
+step:1608/1770 train_time:159488ms step_avg:99.18ms
+step:1609/1770 train_time:159590ms step_avg:99.19ms
+step:1610/1770 train_time:159696ms step_avg:99.19ms
+step:1611/1770 train_time:159799ms step_avg:99.19ms
+step:1612/1770 train_time:159904ms step_avg:99.20ms
+step:1613/1770 train_time:160006ms step_avg:99.20ms
+step:1614/1770 train_time:160108ms step_avg:99.20ms
+step:1615/1770 train_time:160211ms step_avg:99.20ms
+step:1616/1770 train_time:160315ms step_avg:99.20ms
+step:1617/1770 train_time:160420ms step_avg:99.21ms
+step:1618/1770 train_time:160524ms step_avg:99.21ms
+step:1619/1770 train_time:160627ms step_avg:99.21ms
+step:1620/1770 train_time:160732ms step_avg:99.22ms
+step:1621/1770 train_time:160838ms step_avg:99.22ms
+step:1622/1770 train_time:160942ms step_avg:99.22ms
+step:1623/1770 train_time:161047ms step_avg:99.23ms
+step:1624/1770 train_time:161151ms step_avg:99.23ms
+step:1625/1770 train_time:161254ms step_avg:99.23ms
+step:1625/1770 val_loss:3.3067 train_time:161357ms step_avg:99.30ms
+step:1626/1770 train_time:161384ms step_avg:99.25ms
+step:1627/1770 train_time:161473ms step_avg:99.25ms
+step:1628/1770 train_time:161582ms step_avg:99.25ms
+step:1629/1770 train_time:161686ms step_avg:99.25ms
+step:1630/1770 train_time:161789ms step_avg:99.26ms
+step:1631/1770 train_time:161892ms step_avg:99.26ms
+step:1632/1770 train_time:161995ms step_avg:99.26ms
+step:1633/1770 train_time:162097ms step_avg:99.26ms
+step:1634/1770 train_time:162200ms step_avg:99.27ms
+step:1635/1770 train_time:162304ms step_avg:99.27ms
+step:1636/1770 train_time:162407ms step_avg:99.27ms
+step:1637/1770 train_time:162512ms step_avg:99.27ms
+step:1638/1770 train_time:162619ms step_avg:99.28ms
+step:1639/1770 train_time:162723ms step_avg:99.28ms
+step:1640/1770 train_time:162827ms step_avg:99.28ms
+step:1641/1770 train_time:162929ms step_avg:99.29ms
+step:1642/1770 train_time:163031ms step_avg:99.29ms
+step:1643/1770 train_time:163134ms step_avg:99.29ms
+step:1644/1770 train_time:163239ms step_avg:99.29ms
+step:1645/1770 train_time:163341ms step_avg:99.30ms
+step:1646/1770 train_time:163447ms step_avg:99.30ms
+step:1647/1770 train_time:163552ms step_avg:99.30ms
+step:1648/1770 train_time:163657ms step_avg:99.31ms
+step:1649/1770 train_time:163761ms step_avg:99.31ms
+step:1650/1770 train_time:163864ms step_avg:99.31ms
+step:1651/1770 train_time:163967ms step_avg:99.31ms
+step:1652/1770 train_time:164069ms step_avg:99.32ms
+step:1653/1770 train_time:164171ms step_avg:99.32ms
+step:1654/1770 train_time:164278ms step_avg:99.32ms
+step:1655/1770 train_time:164383ms step_avg:99.33ms
+step:1656/1770 train_time:164485ms step_avg:99.33ms
+step:1657/1770 train_time:164589ms step_avg:99.33ms
+step:1658/1770 train_time:164692ms step_avg:99.33ms
+step:1659/1770 train_time:164796ms step_avg:99.33ms
+step:1660/1770 train_time:164900ms step_avg:99.34ms
+step:1661/1770 train_time:165004ms step_avg:99.34ms
+step:1662/1770 train_time:165107ms step_avg:99.34ms
+step:1663/1770 train_time:165209ms step_avg:99.34ms
+step:1664/1770 train_time:165312ms step_avg:99.35ms
+step:1665/1770 train_time:165414ms step_avg:99.35ms
+step:1666/1770 train_time:165519ms step_avg:99.35ms
+step:1667/1770 train_time:165623ms step_avg:99.35ms
+step:1668/1770 train_time:165725ms step_avg:99.36ms
+step:1669/1770 train_time:165828ms step_avg:99.36ms
+step:1670/1770 train_time:165931ms step_avg:99.36ms
+step:1671/1770 train_time:166035ms step_avg:99.36ms
+step:1672/1770 train_time:166139ms step_avg:99.37ms
+step:1673/1770 train_time:166243ms step_avg:99.37ms
+step:1674/1770 train_time:166345ms step_avg:99.37ms
+step:1675/1770 train_time:166447ms step_avg:99.37ms
+step:1676/1770 train_time:166550ms step_avg:99.37ms
+step:1677/1770 train_time:166656ms step_avg:99.38ms
+step:1678/1770 train_time:166760ms step_avg:99.38ms
+step:1679/1770 train_time:166863ms step_avg:99.38ms
+step:1680/1770 train_time:166965ms step_avg:99.38ms
+step:1681/1770 train_time:167069ms step_avg:99.39ms
+step:1682/1770 train_time:167173ms step_avg:99.39ms
+step:1683/1770 train_time:167276ms step_avg:99.39ms
+step:1684/1770 train_time:167380ms step_avg:99.39ms
+step:1685/1770 train_time:167485ms step_avg:99.40ms
+step:1686/1770 train_time:167589ms step_avg:99.40ms
+step:1687/1770 train_time:167694ms step_avg:99.40ms
+step:1688/1770 train_time:167800ms step_avg:99.41ms
+step:1689/1770 train_time:167902ms step_avg:99.41ms
+step:1690/1770 train_time:168005ms step_avg:99.41ms
+step:1691/1770 train_time:168108ms step_avg:99.41ms
+step:1692/1770 train_time:168210ms step_avg:99.42ms
+step:1693/1770 train_time:168313ms step_avg:99.42ms
+step:1694/1770 train_time:168418ms step_avg:99.42ms
+step:1695/1770 train_time:168522ms step_avg:99.42ms
+step:1696/1770 train_time:168627ms step_avg:99.43ms
+step:1697/1770 train_time:168731ms step_avg:99.43ms
+step:1698/1770 train_time:168836ms step_avg:99.43ms
+step:1699/1770 train_time:168940ms step_avg:99.44ms
+step:1700/1770 train_time:169043ms step_avg:99.44ms
+step:1701/1770 train_time:169146ms step_avg:99.44ms
+step:1702/1770 train_time:169248ms step_avg:99.44ms
+step:1703/1770 train_time:169351ms step_avg:99.44ms
+step:1704/1770 train_time:169454ms step_avg:99.44ms
+step:1705/1770 train_time:169558ms step_avg:99.45ms
+step:1706/1770 train_time:169660ms step_avg:99.45ms
+step:1707/1770 train_time:169765ms step_avg:99.45ms
+step:1708/1770 train_time:169868ms step_avg:99.45ms
+step:1709/1770 train_time:169973ms step_avg:99.46ms
+step:1710/1770 train_time:170079ms step_avg:99.46ms
+step:1711/1770 train_time:170187ms step_avg:99.47ms
+step:1712/1770 train_time:170290ms step_avg:99.47ms
+step:1713/1770 train_time:170391ms step_avg:99.47ms
+step:1714/1770 train_time:170496ms step_avg:99.47ms
+step:1715/1770 train_time:170601ms step_avg:99.48ms
+step:1716/1770 train_time:170705ms step_avg:99.48ms
+step:1717/1770 train_time:170808ms step_avg:99.48ms
+step:1718/1770 train_time:170912ms step_avg:99.48ms
+step:1719/1770 train_time:171017ms step_avg:99.49ms
+step:1720/1770 train_time:171122ms step_avg:99.49ms
+step:1721/1770 train_time:171225ms step_avg:99.49ms
+step:1722/1770 train_time:171331ms step_avg:99.50ms
+step:1723/1770 train_time:171435ms step_avg:99.50ms
+step:1724/1770 train_time:171541ms step_avg:99.50ms
+step:1725/1770 train_time:171646ms step_avg:99.51ms
+step:1726/1770 train_time:171752ms step_avg:99.51ms
+step:1727/1770 train_time:171855ms step_avg:99.51ms
+step:1728/1770 train_time:171962ms step_avg:99.51ms
+step:1729/1770 train_time:172066ms step_avg:99.52ms
+step:1730/1770 train_time:172170ms step_avg:99.52ms
+step:1731/1770 train_time:172274ms step_avg:99.52ms
+step:1732/1770 train_time:172378ms step_avg:99.53ms
+step:1733/1770 train_time:172484ms step_avg:99.53ms
+step:1734/1770 train_time:172587ms step_avg:99.53ms
+step:1735/1770 train_time:172693ms step_avg:99.53ms
+step:1736/1770 train_time:172796ms step_avg:99.54ms
+step:1737/1770 train_time:172901ms step_avg:99.54ms
+step:1738/1770 train_time:173006ms step_avg:99.54ms
+step:1739/1770 train_time:173110ms step_avg:99.55ms
+step:1740/1770 train_time:173215ms step_avg:99.55ms
+step:1741/1770 train_time:173323ms step_avg:99.55ms
+step:1742/1770 train_time:173427ms step_avg:99.56ms
+step:1743/1770 train_time:173532ms step_avg:99.56ms
+step:1744/1770 train_time:173636ms step_avg:99.56ms
+step:1745/1770 train_time:173739ms step_avg:99.56ms
+step:1746/1770 train_time:173846ms step_avg:99.57ms
+step:1747/1770 train_time:173950ms step_avg:99.57ms
+step:1748/1770 train_time:174056ms step_avg:99.57ms
+step:1749/1770 train_time:174162ms step_avg:99.58ms
+step:1750/1770 train_time:174264ms step_avg:99.58ms
+step:1750/1770 val_loss:3.2799 train_time:174367ms step_avg:99.64ms
+step:1751/1770 train_time:174394ms step_avg:99.60ms
+step:1752/1770 train_time:174484ms step_avg:99.59ms
+step:1753/1770 train_time:174591ms step_avg:99.60ms
+step:1754/1770 train_time:174696ms step_avg:99.60ms
+step:1755/1770 train_time:174798ms step_avg:99.60ms
+step:1756/1770 train_time:174901ms step_avg:99.60ms
+step:1757/1770 train_time:175004ms step_avg:99.60ms
+step:1758/1770 train_time:175108ms step_avg:99.61ms
+step:1759/1770 train_time:175213ms step_avg:99.61ms
+step:1760/1770 train_time:175317ms step_avg:99.61ms
+step:1761/1770 train_time:175424ms step_avg:99.62ms
+step:1762/1770 train_time:175530ms step_avg:99.62ms
+step:1763/1770 train_time:175634ms step_avg:99.62ms
+step:1764/1770 train_time:175739ms step_avg:99.63ms
+step:1765/1770 train_time:175843ms step_avg:99.63ms
+step:1766/1770 train_time:175951ms step_avg:99.63ms
+step:1767/1770 train_time:176053ms step_avg:99.63ms
+step:1768/1770 train_time:176156ms step_avg:99.64ms
+step:1769/1770 train_time:176259ms step_avg:99.64ms
+step:1770/1770 train_time:176363ms step_avg:99.64ms
+step:1770/1770 val_loss:3.2769 train_time:176467ms step_avg:99.70ms
+peak memory allocated: 30724 MiB reserved: 50494 MiB

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -544,7 +544,7 @@ def get_window_size_blocks(step: int):
     window_size = next_multiple_of_n(1728 * x, n=128)
     return get_window_size_blocks_helper(window_size)
 
-model: nn.Module = torch.compile(model, dynamic=False)
+model: nn.Module = torch.compile(model, dynamic=False, mode="max-autotune-no-cudagraphs")
 
 ########################################
 #            Warmup kernels            #


### PR DESCRIPTION
Hi, just learned about this benchmark and wanted to contribute a pr from my experiences, so i just added mode="max-autotune-no-cudagraphs" to torch.compile.

3.5 seconds faster than [020125_RuleTweak](https://github.com/KellerJordan/modded-nanogpt/tree/master/records/020125_RuleTweak)

train_time:176467ms vs train_time:179828ms and step_avgs are faster now

also tried "max-autotune" too but error occurs, compilation time did not change much so i think its valid.

trying to make "max-autotune" and some other args like "epilogue_fusion" of torch.compile can help, it was all i could test with 20 usd spent on runpod