### PR TITLE
New Medium WR: -27 seconds via Layer Reuse; includes #137

### DIFF
--- a/records/100124_GPT2MediumLayerReuse/000_9dbc0505-5fc3-4a3c-b520-88834bbf40b3.txt
+++ b/records/100124_GPT2MediumLayerReuse/000_9dbc0505-5fc3-4a3c-b520-88834bbf40b3.txt
@@ -1,0 +1,6612 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import time
+import uuid
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device="cuda", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import nn, Tensor
+
+# use of FlexAttention contributed by @KoszarskyB
+from torch.nn.attention.flex_attention import BlockMask, flex_attention
+
+
+torch._inductor.config.coordinate_descent_tuning = (
+    True  # we allow this flag for medium track
+)
+# torch._dynamo.config.compiled_autograd = True
+
+
+class Snoo:
+    """
+    @DominikKallusky, @vishal9-team, @vinaysrao
+
+    Sparse Nesterov Outer Optimizer (Snoo) is a momentum-based wrapper to any optimizer that can
+    improve the stability and smoothness of the optimization process and thus the quality
+    of large language models (LLM) and other models. Snoo implicitly adds temporal regularization
+    to the parameters, thus smoothing the training trajectory and instilling a bias towards flatter
+    minima and lower parameter norms. Snoo is computationally efficient, incurring minimal overhead
+    in compute and moderate memory usage.
+    """
+
+    @torch.no_grad()
+    def __init__(self, model: nn.Module, lr: float, momentum: float, k: int) -> None:
+        self.model = model
+        self.lr = lr
+        self.momentum = momentum
+        self.k = k
+        self.current_step = 0
+        self.outer_buf = [p.clone() for p in model.parameters()]
+        self.model_params = list(self.model.parameters())
+        self.optimizer = torch.optim.SGD(
+            self.model.parameters(),
+            lr=lr,
+            momentum=momentum,
+            nesterov=True,
+            fused=True,
+        )
+
+    @torch.no_grad()
+    def step(
+        self,
+    ) -> None:
+        if self.current_step % self.k == 0:
+            for p_new, p_old in zip(self.model_params, self.outer_buf):
+                p_new.grad = p_old.data - p_new.data
+                p_new.copy_(p_old, non_blocking=True)
+
+            self.optimizer.step()
+
+            for p_new, p_old in zip(self.model_params, self.outer_buf):
+                p_old.copy_(p_new, non_blocking=True)
+        self.current_step += 1
+
+    def state_dict(self):
+        state_dict = {
+            "current_step": self.current_step,
+            "lr": self.lr,
+            "momentum": self.momentum,
+            "k": self.k,
+            "outer_buf": [p.clone() for p in self.outer_buf],
+            "optimizer_state_dict": self.optimizer.state_dict(),
+        }
+        return state_dict
+
+    def load_state_dict(self, state_dict):
+        self.current_step = state_dict["current_step"]
+        self.lr = state_dict["lr"]
+        self.momentum = state_dict["momentum"]
+        self.k = state_dict["k"]
+        for p_src, p_dst in zip(state_dict["outer_buf"], self.outer_buf):
+            p_dst.copy_(p_src)
+        self.optimizer.load_state_dict(state_dict["optimizer_state_dict"])
+
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+
+def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ∈ [1 - l, 1 + r], which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert (
+        G.ndim >= 2
+    )  # batched Muon implementation by @scottjmaddox, and put into practice in the record by @YouJiacheng
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations
+    for a, b, c in [
+        (4.0848, -6.8946, 2.9270),
+        (3.9505, -6.3029, 2.6377),
+        (3.7418, -5.5913, 2.3037),
+        (2.8769, -3.1427, 1.2046),
+        (2.8366, -3.0525, 1.2012),
+    ]:
+        A = X @ X.mT
+        B = (
+            b * A + c * A @ A
+        )  # quintic computation strategy adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+@torch.compile
+def update(
+    acc_bf16_view_u16: Tensor,
+    mantissa: Tensor,
+    momentum_buffer: Tensor,
+    update_smoothing_buffer: Tensor,
+    grad: Tensor,
+    momentum: Tensor,
+    update_smoothing: Tensor,
+    eff_lr: Tensor,
+    eff_weight_decay: Tensor,
+):
+    assert acc_bf16_view_u16.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    momentum_buffer.copy_(momentum * momentum_buffer + (1 - momentum) * grad)
+    v = zeropower_via_newtonschulz5(momentum * momentum_buffer + (1 - momentum) * grad)
+
+    update_smoothing_buffer.copy_(update_smoothing * update_smoothing_buffer + (1 - update_smoothing) * v)
+    v = update_smoothing_buffer
+
+    acc_m_u32 = (acc_bf16_view_u16.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    acc_m_u32.view(torch.float32).mul_(1 - eff_weight_decay)
+    acc_m_u32.view(torch.float32).add_(other=v, alpha=-eff_lr)
+    acc_bf16_view_u16.copy_((acc_m_u32 >> 16).to(torch.uint16))
+    mantissa.copy_(acc_m_u32.to(torch.uint16))
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+    """
+
+    def __init__(
+        self, params, lr=0.02, weight_decay=0.01, momentum=0.95, update_smoothing=0.0, rank=0, world_size=1
+    ):
+        self.rank = rank
+        self.world_size = world_size
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, update_smoothing=update_smoothing)
+        super().__init__(params, defaults)
+        assert all(
+            p.dtype == torch.bfloat16
+            for group in self.param_groups
+            for p in group["params"]
+        )
+
+    @torch.no_grad()
+    def step(self):
+        futures: list[torch.Future] = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * self.world_size
+            momentum = torch._as_tensor_fullprec(group["momentum"])
+            update_smoothing = torch._as_tensor_fullprec(group["update_smoothing"])
+            for base_i in range(len(params))[:: self.world_size]:
+                if base_i + self.rank < len(params):
+                    p = params[base_i + self.rank]
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["mantissa"] = torch.zeros_like(p, dtype=torch.uint16)
+                        state["momentum_buffer"] = torch.zeros_like(
+                            p, dtype=torch.float32
+                        )
+                        state["update_smoothing_buffer"] = torch.zeros_like(
+                            p, dtype=torch.bfloat16
+                        )
+                    update(
+                        p.view(torch.uint16),
+                        state["mantissa"],
+                        state["momentum_buffer"],
+                        state["update_smoothing_buffer"],
+                        p.grad,
+                        momentum,
+                        update_smoothing,
+                        eff_lr=torch._as_tensor_fullprec(
+                            group["lr"] * max(1, p.size(-2) / p.size(-1)) ** 0.5
+                        ),
+                        eff_weight_decay=torch._as_tensor_fullprec(
+                            group["lr"]
+                            * group["weight_decay"]
+                            * getattr(p, "wd_mul", 1.0)
+                        ),
+                    )
+                futures.append(
+                    dist.all_gather(
+                        params_pad[base_i : base_i + self.world_size],
+                        params_pad[base_i + self.rank],
+                        async_op=True,
+                    ).get_future()
+                )
+        torch.futures.collect_all(futures).wait()
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+@torch.no_grad()
+def init_linear(w: Tensor):
+    std = 0.5 * (w.size(-1) ** -0.5)  # 0.5 is a bit better than the default 1/sqrt(3)
+    bound = (3**0.5) * std
+    return w.uniform_(-bound, bound)
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, max_seq_len: int):
+        super().__init__()
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(
+            0, 1, steps=dim // 4, dtype=torch.float32
+        )
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(dim // 4)])
+        t = torch.arange(max_seq_len, dtype=torch.float32)
+        theta = torch.einsum("i,j -> ij", t, angular_freq)
+        self.cos = nn.Buffer(theta.cos(), persistent=False)
+        self.sin = nn.Buffer(theta.sin(), persistent=False)
+
+    def forward(self, x_BTHD: Tensor):
+        assert self.cos.size(0) >= x_BTHD.size(-3)
+        cos, sin = (
+            self.cos[None, : x_BTHD.size(-3), None, :],
+            self.sin[None, : x_BTHD.size(-3), None, :],
+        )
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, head_dim=128):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        hdim = num_heads * head_dim
+        # merged QKV weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        self.qkvo_w = nn.Parameter(init_linear(torch.empty(4, hdim, dim)).bfloat16())
+        self.qkvo_w.detach()[3].zero_()  # out zero init suggested by @Grad62304977
+        self.rotary = Rotary(head_dim, max_seq_len)
+        # scale the attention logits by given constant, instead of the default head_dim**-0.5, by @leloykun
+        # inspired by learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.12
+
+    def forward(
+        self, x: Tensor, ve: Tensor | None, block_mask: BlockMask, lambdas: Tensor
+    ):
+        B, T = x.size(0), x.size(1)  # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q, k, v = (
+            F.linear(x, self.qkvo_w[:3].flatten(end_dim=1))
+            .view(B, T, 3 * self.num_heads, self.head_dim)
+            .chunk(3, dim=-2)
+        )
+        q, k = norm(q), norm(k)  # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        v = norm(v)
+        if ve is not None:
+            v = lambdas[0] * v + lambdas[1] * ve.view_as(
+                v
+            )  # @KoszarskyB & @Grad62304977
+        else:  # skip mid-layers token value embeddings by @YouJiacheng
+            v = lambdas[0] * v
+        y = flex_attention(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            block_mask=block_mask,
+            scale=self.attn_scale,
+        ).transpose(1, 2)
+        y = y.contiguous().view(
+            B, T, self.num_heads * self.head_dim
+        )  # re-assemble all head outputs side by side
+        y = F.linear(y, self.qkvo_w[3])
+        return y
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.fc_w = nn.Parameter(init_linear(torch.empty(hdim, dim)).bfloat16())
+        self.proj_w = nn.Parameter(torch.zeros(dim, hdim).bfloat16())
+        self.fc_w.wd_mul = 2.0
+        self.proj_w.wd_mul = 2.0
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.fc_w)
+        x = F.relu(
+            x
+        ).square()  # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.proj_w)
+        return x
+
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.7 (the 8th layer) by @YouJiacheng
+        self.attn = (
+            CausalSelfAttention(dim, num_heads, max_seq_len) if layer_idx != 7 else None
+        )
+        self.mlp = MLP(dim)
+
+    def forward(
+        self,
+        x: Tensor,
+        ve: Tensor | None,
+        x00: Tensor,
+        x01: Tensor,
+        block_mask: BlockMask,
+        lambdas: Tensor,
+        sa_lambdas: Tensor,
+    ):
+        x = lambdas[0] * x + lambdas[1] * x00 + lambdas[2] * x01
+        if self.attn is not None:
+            x = x + self.attn(x, ve, block_mask, sa_lambdas)
+        x = x + self.mlp(norm(x))
+        return x
+
+
+# -----------------------------------------------------------------------------
+# The main model
+
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        num_heads: int,
+        model_dim: int,
+        max_seq_len: int,
+    ):
+        super().__init__()
+        self.embed1 = nn.Embedding(vocab_size, model_dim)
+        self.embed2 = nn.Embedding(vocab_size, model_dim)
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList(
+            [nn.Embedding(vocab_size, model_dim) for _ in range(5)]
+        )
+        self.blocks = nn.ModuleList(
+            [Block(model_dim, num_heads, max_seq_len, i) for i in range(num_layers)]
+        )
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        self.lm_head_w = nn.Parameter(
+            torch.zeros(next_multiple_of_n(vocab_size, n=128), model_dim)
+        )
+        # Add learnable skip connection weights for decoder layers
+        assert num_layers % 2 == 0
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    torch.ones(num_layers),  # skip_weights
+                    *[
+                        torch.tensor([1.0, 0.0, 0.0]) for _ in range(num_layers)
+                    ],  # block lambdas
+                    *[
+                        torch.tensor([0.5, 0.5]) for _ in range(num_layers)
+                    ],  # SA lambdas
+                    torch.tensor([1.0, 0.0]),  # skip-to-head lambdas
+                ]
+            )
+        )
+        for m in self.modules():
+            if isinstance(m, nn.Embedding):
+                m.bfloat16()
+
+    def create_blockmasks(self, input_seq: Tensor, sliding_window_num_blocks: Tensor):
+        BLOCK_SIZE = 128
+        docs = (input_seq == 50256).cumsum(0)
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_blockmask: Tensor):
+            num_blocks = dense_blockmask.sum(dim=-1, dtype=torch.int32)
+            indices = (
+                dense_blockmask.argsort(dim=-1, descending=False, stable=True)
+                .flip(-1)
+                .to(torch.int32)
+            )
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        # manual block mask creation by @YouJiacheng
+        assert len(input_seq) % BLOCK_SIZE == 0
+        NUM_BLOCKS = len(input_seq) // BLOCK_SIZE
+        block_idx = torch.arange(NUM_BLOCKS, dtype=torch.int32, device="cuda")
+        causal_blockmask_any = block_idx[:, None] >= block_idx
+        causal_blockmask_all = block_idx[:, None] > block_idx
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+        document_blockmask_any = (docs_low[:, None] <= docs_high) & (
+            docs_high[:, None] >= docs_low
+        )
+        document_blockmask_all = (docs_low[:, None] == docs_high) & (
+            docs_high[:, None] == docs_low
+        )
+        blockmask_any = causal_blockmask_any & document_blockmask_any
+        blockmask_all = causal_blockmask_all & document_blockmask_all
+        partial_kv_num_blocks, partial_kv_indices = dense_to_ordered(
+            blockmask_any & ~blockmask_all
+        )
+        full_kv_num_blocks, full_kv_indices = dense_to_ordered(blockmask_all)
+
+        def build_bm(window_size_blocks: Tensor) -> BlockMask:
+            return BlockMask.from_kv_blocks(
+                torch.clamp_max(
+                    partial_kv_num_blocks,
+                    torch.clamp_min(window_size_blocks - full_kv_num_blocks, 1),
+                ),
+                partial_kv_indices,
+                torch.clamp_max(full_kv_num_blocks, window_size_blocks - 1),
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+
+        # Long-short SWA block masks by @leloykun & @YouJiacheng, adapated from suggestion by @Grad62304977, following Gemma 2 paper
+        return build_bm(sliding_window_num_blocks), build_bm(
+            sliding_window_num_blocks // 2
+        )
+
+    def forward(
+        self, input_seq: Tensor, target_seq: Tensor, sliding_window_num_blocks: Tensor
+    ):
+        assert input_seq.ndim == 1
+
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        ve = (
+            [ve[0], ve[1], ve[2], ve[3], ve[4]]
+            + [None] * (len(self.blocks) - 10)
+            + [ve[0], ve[1], ve[2], ve[3], ve[4]]
+        )
+        assert len(ve) == len(self.blocks)
+
+        long_bm, short_bm = self.create_blockmasks(input_seq, sliding_window_num_blocks)
+        block_masks = [
+            long_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            long_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            long_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            long_bm,
+        ]
+        assert len(block_masks) == len(self.blocks)
+
+        x = x00 = norm(
+            self.embed1(input_seq)[None]
+        )  # use of norm here by @Grad62304977
+        x01 = norm(self.embed2(input_seq)[None])
+
+        skip_connections = []
+        skip_map = {
+            9: 6,
+            10: 4,
+            11: 2,
+        }
+        skip_weights = self.scalars[: len(self.blocks)]
+        lambdas = self.scalars[1 * len(self.blocks) : 4 * len(self.blocks)].view(-1, 3)
+        sa_lambdas = self.scalars[4 * len(self.blocks) : 6 * len(self.blocks)].view(
+            -1, 2
+        )
+        for i in range(len(self.blocks)):
+            if i in skip_map:
+                x = x + skip_weights[skip_map[i]] * skip_connections[skip_map[i]]
+            x = self.blocks[i](
+                x, ve[i], x00, x01, block_masks[i], lambdas[i], sa_lambdas[i]
+            )
+            skip_connections.append(x)
+
+        skip_lambdas = self.scalars[-2:]
+        x = norm(x) * skip_lambdas[0] + norm(skip_connections[11]) * skip_lambdas[1]
+        if self.training:
+            logits: Tensor = F.linear(
+                x.flatten(end_dim=1), self.lm_head_w.bfloat16()
+            ).float()
+            loss = F.cross_entropy(
+                15 * logits * torch.rsqrt(logits.square() + 225), target_seq
+            )
+            return loss
+
+        loss = 0
+        for i in range(4):
+            logits: Tensor = F.linear(
+                x.flatten(end_dim=1).chunk(4)[i], self.lm_head_w.bfloat16()
+            ).float()
+            loss += (
+                F.cross_entropy(
+                    15 * logits * torch.rsqrt(logits.square() + 225),
+                    target_seq.chunk(4)[i],
+                )
+                / 4
+            )
+        return loss
+
+
+# -----------------------------------------------------------------------------
+# Our own simple Distributed Data Loader
+
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(
+        str(file), False, 256, dtype=torch.int32
+    )  # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2])  # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(
+            num_tokens, dtype=torch.uint16, pin_memory=True
+        )  # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy())  # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+
+def distributed_data_generator(
+    filename_pattern: str, batch_size: int, rank: int, world_size: int
+):
+    files = sorted(Path.cwd().glob(filename_pattern))
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(
+        files
+    )  # use itertools.cycle(files) instead if you want to do multi-epoch training
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    while True:
+        if pos + batch_size + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        buf = tokens[pos + rank * local_batch_size :][: local_batch_size + 1]
+        inputs = buf[:-1].to(
+            device="cuda", dtype=torch.int32, non_blocking=True
+        )  # no sync on host side;
+        targets = buf[1:].to(
+            device="cuda", dtype=torch.int64, non_blocking=True
+        )  # H2D in another stream isn't helpful.
+        pos += batch_size
+        yield inputs, targets
+
+
+# -----------------------------------------------------------------------------
+# int main
+
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files = "data/fineweb10B/fineweb_train_*.bin"  # input .bin to train on
+    val_files = (
+        "data/fineweb10B/fineweb_val_*.bin"  # input .bin to eval validation loss on
+    )
+    val_tokens = 10485760  # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    train_seq_len = 64 * 1024  # FlexAttention sequence length
+    val_seq_len = 4 * 64 * 1024  # FlexAttention sequence length for validation
+    # optimization
+    num_iterations = 5560  # number of iterations to run
+    cooldown_frac = 0.7  # fraction of training spent cooling down the learning rate
+    final_lr_scale = 0.01
+    # architecture
+    vocab_size = 50257
+    # evaluation and logging
+    val_loss_every = (
+        125  # every how many steps to evaluate val loss? 0 for only at the end
+    )
+    save_checkpoint = False
+
+
+args = Hyperparameters()
+
+run_id = int(os.environ.get("RUN_ID", 0))
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert world_size == 8  # this code is designed for 8xH100
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = rank == 0  # this process will do logging, checkpointing etc.
+
+# begin logging
+if master_process:
+    run_id_full = f"{run_id:03d}_{uuid.uuid4()}"
+    path = "logs"
+    os.makedirs(path, exist_ok=True)
+    logfile = f"{path}/{run_id_full}.txt"
+    print(logfile)
+
+
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("=" * 100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(
+    f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+)
+
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+
+    try:
+        return subprocess.run(
+            ["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        ).stdout
+    except FileNotFoundError:
+        print0("nvidia-smi not found. Using library functions instead.", console=True)
+    import pynvml
+
+    pynvml.nvmlInit()
+    device_count = pynvml.nvmlDeviceGetCount()
+    print0(
+        f"{'GPU':<3} {'Name':<25} {'Temp':<5} {'Power':<10} {'Mem Used':<15} {'Mem Total':<15} {'Util':<6}",
+        console=True,
+    )
+    for i in range(device_count):
+        handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+        name = pynvml.nvmlDeviceGetName(handle)
+        temp = pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
+        power = pynvml.nvmlDeviceGetPowerUsage(handle) // 1000  # mW to W
+        mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+        mem_used = mem_info.used // (1024 * 1024)
+        mem_total = mem_info.total // (1024 * 1024)
+        util = pynvml.nvmlDeviceGetUtilizationRates(handle).gpu
+        print0(
+            f"{i:<3} {name:<25} {temp:<5} {power:<10} {mem_used:<15} {mem_total:<15} {util:<6}%",
+            console=True,
+        )
+    pynvml.nvmlShutdown()
+
+
+print0(nvidia_smi())
+print0("=" * 100)
+
+########################################
+#    Construct model and optimizer     #
+########################################
+
+model: nn.Module = GPT(
+    vocab_size=args.vocab_size,
+    num_layers=16,
+    num_heads=8,
+    model_dim=1024,
+    max_seq_len=max(args.train_seq_len, args.val_seq_len),
+).cuda()
+for m in model.modules():
+    if isinstance(m, nn.Embedding):
+        m.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+# collect the parameters to optimize
+hidden_matrix_params = sorted(
+    (p for p in model.blocks.parameters() if p.ndim >= 2),
+    key=lambda x: x.size(),
+    reverse=True,
+)
+embed_params = [
+    *model.embed1.parameters(),
+    *model.embed2.parameters(),
+    *model.value_embeds.parameters(),
+]
+scalar_params = [model.scalars]
+head_params: list[nn.Parameter] = [model.lm_head_w]
+# sanity check
+params_collections = [hidden_matrix_params, embed_params, scalar_params, head_params]
+optimized_parameters_set = {p for params in params_collections for p in params}
+assert optimized_parameters_set == {*model.parameters()}
+assert len(optimized_parameters_set) == sum(len(lst) for lst in params_collections)
+
+# init the optimizer(s)
+adam_param_groups = [
+    dict(params=head_params, lr=1 / 320),
+    dict(params=embed_params, lr=0.3),
+    dict(params=scalar_params, lr=0.015),
+]
+# small adam epsilon by @YouJiacheng. this is an alternate method of fixing the world_size dependence
+# discovered by @fernbear.bsky.social https://x.com/hi_tysam/status/1879692937589875094
+inner_optimizers = [
+    torch.optim.AdamW(
+        adam_param_groups, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.0, fused=True
+    )
+]
+inner_hidden_optim = Muon(
+    hidden_matrix_params, lr=0.03, momentum=0.95, update_smoothing=0.2, rank=rank, world_size=world_size
+)
+inner_optimizers += [inner_hidden_optim]
+outer_optim = Snoo(model, lr=0.68, momentum=0.37, k=28)
+all_optimizers: list[torch.optim.Optimizer] = [outer_optim] + inner_optimizers
+
+
+def opt_params(opt: torch.optim.Optimizer) -> list[nn.Parameter]:
+    return [p for group in opt.param_groups for p in group["params"]]
+
+
+opt2params = {opt: opt_params(opt) for opt in inner_optimizers}
+for opt in inner_optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+
+
+# learning rate schedule: stable then decay
+def get_lr(step: int):
+    x = step / args.num_iterations  # progress in training
+    assert 0 <= x < 1
+    if x < 1 - args.cooldown_frac:
+        return 1.0
+    else:
+        return (1 - x) / args.cooldown_frac * (1 - args.final_lr_scale) + args.final_lr_scale
+
+# attention window size schedule: linearly increase
+@lru_cache(1)
+def get_window_size_blocks_helper(window_size: int):
+    return torch.tensor(window_size // 128, dtype=torch.int32, pin_memory=True).cuda(
+        non_blocking=True
+    )
+
+
+def get_window_size_blocks(step: int):
+    x = step / args.num_iterations  # progress in training
+    assert 0 <= x <= 1
+    # Linearly increase the block-wise sliding window size over training 128 -> 1792
+    # increase by @fernbear.bsky.social; block-wise by @YouJiacheng
+    factor = 4 * x**3 - 6 * x**2 + 3 * x  # cubic schedule by @jadenj3o
+    window_size = next_multiple_of_n(3456 * factor, n=128)
+    return get_window_size_blocks_helper(window_size)
+
+
+model: nn.Module = torch.compile(model, dynamic=False)
+
+########################################
+#            Warmup kernels            #
+########################################
+
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+warmup_steps = 10
+initial_state = copy.deepcopy(
+    dict(
+        model=model.state_dict(),
+        optimizers=[opt.state_dict() for opt in all_optimizers],
+    )
+)
+for _ in range(warmup_steps):
+    inputs = targets = torch.randint(
+        0, args.vocab_size, size=(args.train_seq_len,), device="cuda"
+    )
+    model(inputs.to(torch.int32), targets, get_window_size_blocks(0)).backward()
+    for param in model.parameters():
+        dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
+    for opt in inner_optimizers:
+        opt.step()
+    outer_optim.step()
+    model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+for opt, opt_state in zip(all_optimizers, initial_state["optimizers"]):
+    opt.load_state_dict(opt_state)
+del initial_state
+
+########################################
+#        Training and validation       #
+########################################
+
+torch.cuda.reset_peak_memory_stats()
+train_loader = distributed_data_generator(
+    args.train_files, world_size * args.train_seq_len, rank, world_size
+)
+training_time_ms = 0
+# start the clock
+dist.barrier()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = step == train_steps
+
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        # stop the clock
+        dist.barrier()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        val_batch_size = world_size * args.val_seq_len
+        assert args.val_tokens % val_batch_size == 0
+        val_steps = args.val_tokens // val_batch_size
+        val_loader = distributed_data_generator(
+            args.val_files, val_batch_size, rank, world_size
+        )
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets = next(val_loader)
+                val_loss += model(inputs, targets, get_window_size_blocks(step))
+        val_loss /= val_steps
+        del val_loader
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(
+            f"step:{step}/{train_steps} val_loss:{val_loss:.6f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms",
+            console=True,
+        )
+        model.train()
+        # start the clock again
+        dist.barrier()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(
+                step=step,
+                code=code,
+                model=model.state_dict(),
+                optimizers=[opt.state_dict() for opt in all_optimizers],
+            )
+            os.makedirs(f"logs/{run_id_full}", exist_ok=True)
+            torch.save(log, f"logs/{run_id_full}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    model(inputs, targets, get_window_size_blocks(step)).backward()
+    opt2futures = {
+        opt: [
+            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            for p in params
+        ]
+        for opt, params in opt2params.items()
+    }
+    # set optimization hyperparameters
+    for opt in inner_optimizers:
+        for group in opt.param_groups:
+            group["lr"] = group["initial_lr"] * get_lr(step)
+    for group in inner_hidden_optim.param_groups:
+        frac = min(step / 300, 1)  # momentum warmup for muon
+        group["momentum"] = (1 - frac) * 0.85 + frac * 0.95
+
+    # step the optimizers
+    for opt in inner_optimizers:
+        torch.futures.collect_all(opt2futures[opt]).wait()
+        opt.step()
+    outer_optim.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(
+        f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms",
+        console=True,
+    )
+
+print0(
+    f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+    f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB",
+    console=True,
+)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251001+cu126 compiled for CUDA 12.6
+Wed Oct  1 20:36:31 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   26C    P0            119W /  700W |    5840MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   25C    P0            119W /  700W |    1502MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   22C    P0            115W /  700W |    1502MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   24C    P0            119W /  700W |    1502MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   25C    P0            118W /  700W |    1502MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   25C    P0            113W /  700W |    1502MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   25C    P0            118W /  700W |    1502MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   23C    P0            119W /  700W |    1502MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A       717      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    0   N/A  N/A       718      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    0   N/A  N/A       719      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    0   N/A  N/A       720      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    0   N/A  N/A       721      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    0   N/A  N/A       722      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    0   N/A  N/A       723      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    0   N/A  N/A       724      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    1   N/A  N/A       718      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    2   N/A  N/A       719      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    3   N/A  N/A       720      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    4   N/A  N/A       721      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    5   N/A  N/A       722      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    6   N/A  N/A       723      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
+|    7   N/A  N/A       724      C   /root/modded-nanogpt/.venv/bin/python3          0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+step:0/5560 val_loss:10.825840 train_time:0ms step_avg:0.11ms
+step:1/5560 train_time:129ms step_avg:129.40ms
+step:2/5560 train_time:304ms step_avg:151.95ms
+step:3/5560 train_time:514ms step_avg:171.50ms
+step:4/5560 train_time:737ms step_avg:184.21ms
+step:5/5560 train_time:958ms step_avg:191.62ms
+step:6/5560 train_time:1182ms step_avg:196.99ms
+step:7/5560 train_time:1416ms step_avg:202.23ms
+step:8/5560 train_time:1646ms step_avg:205.76ms
+step:9/5560 train_time:1872ms step_avg:207.95ms
+step:10/5560 train_time:2094ms step_avg:209.40ms
+step:11/5560 train_time:2325ms step_avg:211.36ms
+step:12/5560 train_time:2556ms step_avg:212.96ms
+step:13/5560 train_time:2783ms step_avg:214.08ms
+step:14/5560 train_time:3009ms step_avg:214.92ms
+step:15/5560 train_time:3234ms step_avg:215.58ms
+step:16/5560 train_time:3463ms step_avg:216.41ms
+step:17/5560 train_time:3690ms step_avg:217.08ms
+step:18/5560 train_time:3917ms step_avg:217.61ms
+step:19/5560 train_time:4144ms step_avg:218.08ms
+step:20/5560 train_time:4370ms step_avg:218.52ms
+step:21/5560 train_time:4599ms step_avg:219.00ms
+step:22/5560 train_time:4827ms step_avg:219.42ms
+step:23/5560 train_time:5054ms step_avg:219.76ms
+step:24/5560 train_time:5284ms step_avg:220.17ms
+step:25/5560 train_time:5513ms step_avg:220.52ms
+step:26/5560 train_time:5741ms step_avg:220.82ms
+step:27/5560 train_time:5968ms step_avg:221.03ms
+step:28/5560 train_time:6195ms step_avg:221.23ms
+step:29/5560 train_time:6450ms step_avg:222.41ms
+step:30/5560 train_time:6656ms step_avg:221.88ms
+step:31/5560 train_time:6883ms step_avg:222.04ms
+step:32/5560 train_time:7110ms step_avg:222.19ms
+step:33/5560 train_time:7337ms step_avg:222.35ms
+step:34/5560 train_time:7565ms step_avg:222.51ms
+step:35/5560 train_time:7792ms step_avg:222.64ms
+step:36/5560 train_time:8019ms step_avg:222.76ms
+step:37/5560 train_time:8246ms step_avg:222.85ms
+step:38/5560 train_time:8471ms step_avg:222.91ms
+step:39/5560 train_time:8698ms step_avg:223.02ms
+step:40/5560 train_time:8926ms step_avg:223.15ms
+step:41/5560 train_time:9154ms step_avg:223.27ms
+step:42/5560 train_time:9381ms step_avg:223.35ms
+step:43/5560 train_time:9608ms step_avg:223.44ms
+step:44/5560 train_time:9835ms step_avg:223.53ms
+step:45/5560 train_time:10064ms step_avg:223.63ms
+step:46/5560 train_time:10289ms step_avg:223.68ms
+step:47/5560 train_time:10516ms step_avg:223.73ms
+step:48/5560 train_time:10744ms step_avg:223.84ms
+step:49/5560 train_time:10971ms step_avg:223.89ms
+step:50/5560 train_time:11197ms step_avg:223.95ms
+step:51/5560 train_time:11425ms step_avg:224.02ms
+step:52/5560 train_time:11652ms step_avg:224.08ms
+step:53/5560 train_time:11879ms step_avg:224.13ms
+step:54/5560 train_time:12106ms step_avg:224.18ms
+step:55/5560 train_time:12333ms step_avg:224.24ms
+step:56/5560 train_time:12560ms step_avg:224.28ms
+step:57/5560 train_time:12813ms step_avg:224.79ms
+step:58/5560 train_time:13019ms step_avg:224.46ms
+step:59/5560 train_time:13246ms step_avg:224.50ms
+step:60/5560 train_time:13472ms step_avg:224.53ms
+step:61/5560 train_time:13698ms step_avg:224.56ms
+step:62/5560 train_time:13926ms step_avg:224.61ms
+step:63/5560 train_time:14153ms step_avg:224.65ms
+step:64/5560 train_time:14380ms step_avg:224.69ms
+step:65/5560 train_time:14608ms step_avg:224.74ms
+step:66/5560 train_time:14836ms step_avg:224.79ms
+step:67/5560 train_time:15064ms step_avg:224.84ms
+step:68/5560 train_time:15290ms step_avg:224.86ms
+step:69/5560 train_time:15517ms step_avg:224.89ms
+step:70/5560 train_time:15746ms step_avg:224.95ms
+step:71/5560 train_time:15971ms step_avg:224.95ms
+step:72/5560 train_time:16199ms step_avg:224.99ms
+step:73/5560 train_time:16429ms step_avg:225.06ms
+step:74/5560 train_time:16658ms step_avg:225.11ms
+step:75/5560 train_time:16887ms step_avg:225.15ms
+step:76/5560 train_time:17116ms step_avg:225.21ms
+step:77/5560 train_time:17344ms step_avg:225.24ms
+step:78/5560 train_time:17571ms step_avg:225.27ms
+step:79/5560 train_time:17800ms step_avg:225.32ms
+step:80/5560 train_time:18028ms step_avg:225.35ms
+step:81/5560 train_time:18256ms step_avg:225.38ms
+step:82/5560 train_time:18483ms step_avg:225.41ms
+step:83/5560 train_time:18711ms step_avg:225.44ms
+step:84/5560 train_time:18940ms step_avg:225.47ms
+step:85/5560 train_time:19195ms step_avg:225.82ms
+step:86/5560 train_time:19399ms step_avg:225.57ms
+step:87/5560 train_time:19629ms step_avg:225.62ms
+step:88/5560 train_time:19858ms step_avg:225.66ms
+step:89/5560 train_time:20087ms step_avg:225.70ms
+step:90/5560 train_time:20314ms step_avg:225.71ms
+step:91/5560 train_time:20541ms step_avg:225.73ms
+step:92/5560 train_time:20770ms step_avg:225.76ms
+step:93/5560 train_time:20997ms step_avg:225.78ms
+step:94/5560 train_time:21225ms step_avg:225.80ms
+step:95/5560 train_time:21453ms step_avg:225.82ms
+step:96/5560 train_time:21682ms step_avg:225.85ms
+step:97/5560 train_time:21910ms step_avg:225.88ms
+step:98/5560 train_time:22138ms step_avg:225.90ms
+step:99/5560 train_time:22366ms step_avg:225.92ms
+step:100/5560 train_time:22591ms step_avg:225.91ms
+step:101/5560 train_time:22818ms step_avg:225.92ms
+step:102/5560 train_time:23047ms step_avg:225.95ms
+step:103/5560 train_time:23275ms step_avg:225.97ms
+step:104/5560 train_time:23503ms step_avg:225.99ms
+step:105/5560 train_time:23733ms step_avg:226.03ms
+step:106/5560 train_time:23960ms step_avg:226.04ms
+step:107/5560 train_time:24188ms step_avg:226.05ms
+step:108/5560 train_time:24416ms step_avg:226.07ms
+step:109/5560 train_time:24644ms step_avg:226.10ms
+step:110/5560 train_time:24871ms step_avg:226.10ms
+step:111/5560 train_time:25100ms step_avg:226.12ms
+step:112/5560 train_time:25328ms step_avg:226.14ms
+step:113/5560 train_time:25582ms step_avg:226.39ms
+step:114/5560 train_time:25790ms step_avg:226.23ms
+step:115/5560 train_time:26019ms step_avg:226.26ms
+step:116/5560 train_time:26247ms step_avg:226.27ms
+step:117/5560 train_time:26474ms step_avg:226.27ms
+step:118/5560 train_time:26702ms step_avg:226.29ms
+step:119/5560 train_time:26932ms step_avg:226.32ms
+step:120/5560 train_time:27160ms step_avg:226.33ms
+step:121/5560 train_time:27387ms step_avg:226.34ms
+step:122/5560 train_time:27615ms step_avg:226.35ms
+step:123/5560 train_time:27844ms step_avg:226.38ms
+step:124/5560 train_time:28072ms step_avg:226.38ms
+step:125/5560 train_time:28299ms step_avg:226.39ms
+step:125/5560 val_loss:4.264910 train_time:28528ms step_avg:228.22ms
+step:126/5560 train_time:28545ms step_avg:226.55ms
+step:127/5560 train_time:28752ms step_avg:226.39ms
+step:128/5560 train_time:28979ms step_avg:226.40ms
+step:129/5560 train_time:29215ms step_avg:226.47ms
+step:130/5560 train_time:29442ms step_avg:226.48ms
+step:131/5560 train_time:29668ms step_avg:226.48ms
+step:132/5560 train_time:29894ms step_avg:226.47ms
+step:133/5560 train_time:30126ms step_avg:226.51ms
+step:134/5560 train_time:30355ms step_avg:226.53ms
+step:135/5560 train_time:30582ms step_avg:226.54ms
+step:136/5560 train_time:30808ms step_avg:226.53ms
+step:137/5560 train_time:31034ms step_avg:226.52ms
+step:138/5560 train_time:31265ms step_avg:226.56ms
+step:139/5560 train_time:31494ms step_avg:226.57ms
+step:140/5560 train_time:31722ms step_avg:226.58ms
+step:141/5560 train_time:31973ms step_avg:226.76ms
+step:142/5560 train_time:32180ms step_avg:226.62ms
+step:143/5560 train_time:32409ms step_avg:226.64ms
+step:144/5560 train_time:32637ms step_avg:226.65ms
+step:145/5560 train_time:32864ms step_avg:226.65ms
+step:146/5560 train_time:33091ms step_avg:226.65ms
+step:147/5560 train_time:33320ms step_avg:226.67ms
+step:148/5560 train_time:33550ms step_avg:226.69ms
+step:149/5560 train_time:33779ms step_avg:226.71ms
+step:150/5560 train_time:34007ms step_avg:226.71ms
+step:151/5560 train_time:34235ms step_avg:226.72ms
+step:152/5560 train_time:34464ms step_avg:226.74ms
+step:153/5560 train_time:34692ms step_avg:226.74ms
+step:154/5560 train_time:34921ms step_avg:226.76ms
+step:155/5560 train_time:35149ms step_avg:226.77ms
+step:156/5560 train_time:35378ms step_avg:226.78ms
+step:157/5560 train_time:35608ms step_avg:226.80ms
+step:158/5560 train_time:35837ms step_avg:226.82ms
+step:159/5560 train_time:36065ms step_avg:226.83ms
+step:160/5560 train_time:36293ms step_avg:226.83ms
+step:161/5560 train_time:36524ms step_avg:226.85ms
+step:162/5560 train_time:36752ms step_avg:226.86ms
+step:163/5560 train_time:36980ms step_avg:226.87ms
+step:164/5560 train_time:37210ms step_avg:226.89ms
+step:165/5560 train_time:37439ms step_avg:226.91ms
+step:166/5560 train_time:37668ms step_avg:226.91ms
+step:167/5560 train_time:37895ms step_avg:226.91ms
+step:168/5560 train_time:38123ms step_avg:226.93ms
+step:169/5560 train_time:38380ms step_avg:227.10ms
+step:170/5560 train_time:38587ms step_avg:226.98ms
+step:171/5560 train_time:38816ms step_avg:226.99ms
+step:172/5560 train_time:39044ms step_avg:227.00ms
+step:173/5560 train_time:39275ms step_avg:227.02ms
+step:174/5560 train_time:39504ms step_avg:227.03ms
+step:175/5560 train_time:39732ms step_avg:227.04ms
+step:176/5560 train_time:39960ms step_avg:227.05ms
+step:177/5560 train_time:40190ms step_avg:227.06ms
+step:178/5560 train_time:40419ms step_avg:227.07ms
+step:179/5560 train_time:40649ms step_avg:227.09ms
+step:180/5560 train_time:40876ms step_avg:227.09ms
+step:181/5560 train_time:41106ms step_avg:227.10ms
+step:182/5560 train_time:41337ms step_avg:227.13ms
+step:183/5560 train_time:41565ms step_avg:227.13ms
+step:184/5560 train_time:41796ms step_avg:227.15ms
+step:185/5560 train_time:42024ms step_avg:227.16ms
+step:186/5560 train_time:42253ms step_avg:227.16ms
+step:187/5560 train_time:42480ms step_avg:227.17ms
+step:188/5560 train_time:42709ms step_avg:227.18ms
+step:189/5560 train_time:42937ms step_avg:227.18ms
+step:190/5560 train_time:43170ms step_avg:227.21ms
+step:191/5560 train_time:43398ms step_avg:227.21ms
+step:192/5560 train_time:43626ms step_avg:227.22ms
+step:193/5560 train_time:43855ms step_avg:227.23ms
+step:194/5560 train_time:44084ms step_avg:227.24ms
+step:195/5560 train_time:44313ms step_avg:227.25ms
+step:196/5560 train_time:44543ms step_avg:227.26ms
+step:197/5560 train_time:44799ms step_avg:227.41ms
+step:198/5560 train_time:45005ms step_avg:227.30ms
+step:199/5560 train_time:45236ms step_avg:227.32ms
+step:200/5560 train_time:45465ms step_avg:227.33ms
+step:201/5560 train_time:45693ms step_avg:227.33ms
+step:202/5560 train_time:45923ms step_avg:227.34ms
+step:203/5560 train_time:46151ms step_avg:227.34ms
+step:204/5560 train_time:46378ms step_avg:227.34ms
+step:205/5560 train_time:46606ms step_avg:227.34ms
+step:206/5560 train_time:46835ms step_avg:227.36ms
+step:207/5560 train_time:47064ms step_avg:227.36ms
+step:208/5560 train_time:47292ms step_avg:227.36ms
+step:209/5560 train_time:47521ms step_avg:227.37ms
+step:210/5560 train_time:47748ms step_avg:227.37ms
+step:211/5560 train_time:47976ms step_avg:227.37ms
+step:212/5560 train_time:48205ms step_avg:227.38ms
+step:213/5560 train_time:48435ms step_avg:227.40ms
+step:214/5560 train_time:48664ms step_avg:227.40ms
+step:215/5560 train_time:48891ms step_avg:227.40ms
+step:216/5560 train_time:49121ms step_avg:227.41ms
+step:217/5560 train_time:49350ms step_avg:227.42ms
+step:218/5560 train_time:49579ms step_avg:227.43ms
+step:219/5560 train_time:49805ms step_avg:227.42ms
+step:220/5560 train_time:50034ms step_avg:227.43ms
+step:221/5560 train_time:50263ms step_avg:227.43ms
+step:222/5560 train_time:50490ms step_avg:227.43ms
+step:223/5560 train_time:50721ms step_avg:227.45ms
+step:224/5560 train_time:50949ms step_avg:227.45ms
+step:225/5560 train_time:51205ms step_avg:227.58ms
+step:226/5560 train_time:51415ms step_avg:227.50ms
+step:227/5560 train_time:51650ms step_avg:227.53ms
+step:228/5560 train_time:51884ms step_avg:227.56ms
+step:229/5560 train_time:52118ms step_avg:227.59ms
+step:230/5560 train_time:52351ms step_avg:227.61ms
+step:231/5560 train_time:52583ms step_avg:227.63ms
+step:232/5560 train_time:52814ms step_avg:227.65ms
+step:233/5560 train_time:53050ms step_avg:227.68ms
+step:234/5560 train_time:53282ms step_avg:227.70ms
+step:235/5560 train_time:53514ms step_avg:227.72ms
+step:236/5560 train_time:53747ms step_avg:227.74ms
+step:237/5560 train_time:53981ms step_avg:227.77ms
+step:238/5560 train_time:54213ms step_avg:227.79ms
+step:239/5560 train_time:54447ms step_avg:227.81ms
+step:240/5560 train_time:54679ms step_avg:227.83ms
+step:241/5560 train_time:54911ms step_avg:227.84ms
+step:242/5560 train_time:55145ms step_avg:227.87ms
+step:243/5560 train_time:55378ms step_avg:227.89ms
+step:244/5560 train_time:55611ms step_avg:227.91ms
+step:245/5560 train_time:55843ms step_avg:227.93ms
+step:246/5560 train_time:56074ms step_avg:227.94ms
+step:247/5560 train_time:56307ms step_avg:227.96ms
+step:248/5560 train_time:56539ms step_avg:227.98ms
+step:249/5560 train_time:56770ms step_avg:227.99ms
+step:250/5560 train_time:57003ms step_avg:228.01ms
+step:250/5560 val_loss:3.849046 train_time:57237ms step_avg:228.95ms
+step:251/5560 train_time:57257ms step_avg:228.12ms
+step:252/5560 train_time:57471ms step_avg:228.06ms
+step:253/5560 train_time:57740ms step_avg:228.22ms
+step:254/5560 train_time:57952ms step_avg:228.16ms
+step:255/5560 train_time:58183ms step_avg:228.17ms
+step:256/5560 train_time:58412ms step_avg:228.17ms
+step:257/5560 train_time:58644ms step_avg:228.19ms
+step:258/5560 train_time:58881ms step_avg:228.22ms
+step:259/5560 train_time:59114ms step_avg:228.24ms
+step:260/5560 train_time:59343ms step_avg:228.24ms
+step:261/5560 train_time:59575ms step_avg:228.26ms
+step:262/5560 train_time:59810ms step_avg:228.28ms
+step:263/5560 train_time:60043ms step_avg:228.30ms
+step:264/5560 train_time:60274ms step_avg:228.31ms
+step:265/5560 train_time:60506ms step_avg:228.33ms
+step:266/5560 train_time:60739ms step_avg:228.34ms
+step:267/5560 train_time:60972ms step_avg:228.36ms
+step:268/5560 train_time:61205ms step_avg:228.38ms
+step:269/5560 train_time:61438ms step_avg:228.39ms
+step:270/5560 train_time:61672ms step_avg:228.42ms
+step:271/5560 train_time:61905ms step_avg:228.43ms
+step:272/5560 train_time:62137ms step_avg:228.44ms
+step:273/5560 train_time:62370ms step_avg:228.46ms
+step:274/5560 train_time:62600ms step_avg:228.47ms
+step:275/5560 train_time:62834ms step_avg:228.49ms
+step:276/5560 train_time:63068ms step_avg:228.51ms
+step:277/5560 train_time:63299ms step_avg:228.52ms
+step:278/5560 train_time:63532ms step_avg:228.53ms
+step:279/5560 train_time:63765ms step_avg:228.55ms
+step:280/5560 train_time:63997ms step_avg:228.56ms
+step:281/5560 train_time:64258ms step_avg:228.68ms
+step:282/5560 train_time:64467ms step_avg:228.61ms
+step:283/5560 train_time:64701ms step_avg:228.63ms
+step:284/5560 train_time:64934ms step_avg:228.64ms
+step:285/5560 train_time:65167ms step_avg:228.66ms
+step:286/5560 train_time:65402ms step_avg:228.68ms
+step:287/5560 train_time:65634ms step_avg:228.69ms
+step:288/5560 train_time:65864ms step_avg:228.70ms
+step:289/5560 train_time:66097ms step_avg:228.71ms
+step:290/5560 train_time:66332ms step_avg:228.73ms
+step:291/5560 train_time:66564ms step_avg:228.74ms
+step:292/5560 train_time:66797ms step_avg:228.76ms
+step:293/5560 train_time:67030ms step_avg:228.77ms
+step:294/5560 train_time:67262ms step_avg:228.78ms
+step:295/5560 train_time:67495ms step_avg:228.80ms
+step:296/5560 train_time:67730ms step_avg:228.82ms
+step:297/5560 train_time:67961ms step_avg:228.83ms
+step:298/5560 train_time:68194ms step_avg:228.84ms
+step:299/5560 train_time:68428ms step_avg:228.86ms
+step:300/5560 train_time:68658ms step_avg:228.86ms
+step:301/5560 train_time:68892ms step_avg:228.88ms
+step:302/5560 train_time:69124ms step_avg:228.89ms
+step:303/5560 train_time:69356ms step_avg:228.90ms
+step:304/5560 train_time:69588ms step_avg:228.91ms
+step:305/5560 train_time:69820ms step_avg:228.92ms
+step:306/5560 train_time:70053ms step_avg:228.93ms
+step:307/5560 train_time:70286ms step_avg:228.95ms
+step:308/5560 train_time:70519ms step_avg:228.96ms
+step:309/5560 train_time:70780ms step_avg:229.06ms
+step:310/5560 train_time:70992ms step_avg:229.01ms
+step:311/5560 train_time:71227ms step_avg:229.03ms
+step:312/5560 train_time:71459ms step_avg:229.03ms
+step:313/5560 train_time:71694ms step_avg:229.05ms
+step:314/5560 train_time:71928ms step_avg:229.07ms
+step:315/5560 train_time:72162ms step_avg:229.08ms
+step:316/5560 train_time:72395ms step_avg:229.10ms
+step:317/5560 train_time:72629ms step_avg:229.11ms
+step:318/5560 train_time:72861ms step_avg:229.12ms
+step:319/5560 train_time:73094ms step_avg:229.14ms
+step:320/5560 train_time:73328ms step_avg:229.15ms
+step:321/5560 train_time:73561ms step_avg:229.16ms
+step:322/5560 train_time:73796ms step_avg:229.18ms
+step:323/5560 train_time:74031ms step_avg:229.20ms
+step:324/5560 train_time:74263ms step_avg:229.21ms
+step:325/5560 train_time:74498ms step_avg:229.22ms
+step:326/5560 train_time:74732ms step_avg:229.24ms
+step:327/5560 train_time:74964ms step_avg:229.25ms
+step:328/5560 train_time:75200ms step_avg:229.27ms
+step:329/5560 train_time:75434ms step_avg:229.28ms
+step:330/5560 train_time:75667ms step_avg:229.30ms
+step:331/5560 train_time:75900ms step_avg:229.30ms
+step:332/5560 train_time:76135ms step_avg:229.32ms
+step:333/5560 train_time:76371ms step_avg:229.34ms
+step:334/5560 train_time:76605ms step_avg:229.35ms
+step:335/5560 train_time:76837ms step_avg:229.36ms
+step:336/5560 train_time:77069ms step_avg:229.37ms
+step:337/5560 train_time:77330ms step_avg:229.47ms
+step:338/5560 train_time:77544ms step_avg:229.42ms
+step:339/5560 train_time:77778ms step_avg:229.43ms
+step:340/5560 train_time:78012ms step_avg:229.45ms
+step:341/5560 train_time:78244ms step_avg:229.45ms
+step:342/5560 train_time:78479ms step_avg:229.47ms
+step:343/5560 train_time:78714ms step_avg:229.49ms
+step:344/5560 train_time:78947ms step_avg:229.50ms
+step:345/5560 train_time:79180ms step_avg:229.51ms
+step:346/5560 train_time:79415ms step_avg:229.52ms
+step:347/5560 train_time:79650ms step_avg:229.54ms
+step:348/5560 train_time:79884ms step_avg:229.55ms
+step:349/5560 train_time:80116ms step_avg:229.56ms
+step:350/5560 train_time:80350ms step_avg:229.57ms
+step:351/5560 train_time:80582ms step_avg:229.58ms
+step:352/5560 train_time:80816ms step_avg:229.59ms
+step:353/5560 train_time:81051ms step_avg:229.60ms
+step:354/5560 train_time:81284ms step_avg:229.62ms
+step:355/5560 train_time:81518ms step_avg:229.63ms
+step:356/5560 train_time:81752ms step_avg:229.64ms
+step:357/5560 train_time:81985ms step_avg:229.65ms
+step:358/5560 train_time:82219ms step_avg:229.66ms
+step:359/5560 train_time:82453ms step_avg:229.67ms
+step:360/5560 train_time:82688ms step_avg:229.69ms
+step:361/5560 train_time:82922ms step_avg:229.70ms
+step:362/5560 train_time:83155ms step_avg:229.71ms
+step:363/5560 train_time:83388ms step_avg:229.72ms
+step:364/5560 train_time:83622ms step_avg:229.73ms
+step:365/5560 train_time:83883ms step_avg:229.82ms
+step:366/5560 train_time:84095ms step_avg:229.77ms
+step:367/5560 train_time:84330ms step_avg:229.78ms
+step:368/5560 train_time:84562ms step_avg:229.79ms
+step:369/5560 train_time:84796ms step_avg:229.80ms
+step:370/5560 train_time:85030ms step_avg:229.81ms
+step:371/5560 train_time:85263ms step_avg:229.82ms
+step:372/5560 train_time:85496ms step_avg:229.83ms
+step:373/5560 train_time:85730ms step_avg:229.84ms
+step:374/5560 train_time:85963ms step_avg:229.85ms
+step:375/5560 train_time:86196ms step_avg:229.86ms
+step:375/5560 val_loss:3.671920 train_time:86432ms step_avg:230.49ms
+step:376/5560 train_time:86485ms step_avg:230.01ms
+step:377/5560 train_time:86673ms step_avg:229.90ms
+step:378/5560 train_time:86912ms step_avg:229.93ms
+step:379/5560 train_time:87181ms step_avg:230.03ms
+step:380/5560 train_time:87408ms step_avg:230.02ms
+step:381/5560 train_time:87786ms step_avg:230.41ms
+step:382/5560 train_time:87907ms step_avg:230.12ms
+step:383/5560 train_time:88136ms step_avg:230.12ms
+step:384/5560 train_time:88364ms step_avg:230.12ms
+step:385/5560 train_time:88599ms step_avg:230.13ms
+step:386/5560 train_time:88841ms step_avg:230.16ms
+step:387/5560 train_time:89076ms step_avg:230.17ms
+step:388/5560 train_time:89307ms step_avg:230.17ms
+step:389/5560 train_time:89538ms step_avg:230.17ms
+step:390/5560 train_time:89774ms step_avg:230.19ms
+step:391/5560 train_time:90009ms step_avg:230.20ms
+step:392/5560 train_time:90241ms step_avg:230.21ms
+step:393/5560 train_time:90500ms step_avg:230.28ms
+step:394/5560 train_time:90713ms step_avg:230.24ms
+step:395/5560 train_time:90948ms step_avg:230.25ms
+step:396/5560 train_time:91183ms step_avg:230.26ms
+step:397/5560 train_time:91415ms step_avg:230.26ms
+step:398/5560 train_time:91648ms step_avg:230.27ms
+step:399/5560 train_time:91885ms step_avg:230.29ms
+step:400/5560 train_time:92122ms step_avg:230.31ms
+step:401/5560 train_time:92360ms step_avg:230.32ms
+step:402/5560 train_time:92597ms step_avg:230.34ms
+step:403/5560 train_time:92834ms step_avg:230.36ms
+step:404/5560 train_time:93072ms step_avg:230.38ms
+step:405/5560 train_time:93309ms step_avg:230.39ms
+step:406/5560 train_time:93545ms step_avg:230.41ms
+step:407/5560 train_time:93784ms step_avg:230.43ms
+step:408/5560 train_time:94022ms step_avg:230.45ms
+step:409/5560 train_time:94259ms step_avg:230.46ms
+step:410/5560 train_time:94497ms step_avg:230.48ms
+step:411/5560 train_time:94733ms step_avg:230.49ms
+step:412/5560 train_time:94970ms step_avg:230.51ms
+step:413/5560 train_time:95205ms step_avg:230.52ms
+step:414/5560 train_time:95443ms step_avg:230.54ms
+step:415/5560 train_time:95683ms step_avg:230.56ms
+step:416/5560 train_time:95920ms step_avg:230.58ms
+step:417/5560 train_time:96156ms step_avg:230.59ms
+step:418/5560 train_time:96394ms step_avg:230.61ms
+step:419/5560 train_time:96631ms step_avg:230.62ms
+step:420/5560 train_time:96868ms step_avg:230.64ms
+step:421/5560 train_time:97131ms step_avg:230.71ms
+step:422/5560 train_time:97346ms step_avg:230.68ms
+step:423/5560 train_time:97584ms step_avg:230.69ms
+step:424/5560 train_time:97822ms step_avg:230.71ms
+step:425/5560 train_time:98060ms step_avg:230.73ms
+step:426/5560 train_time:98299ms step_avg:230.75ms
+step:427/5560 train_time:98535ms step_avg:230.76ms
+step:428/5560 train_time:98772ms step_avg:230.78ms
+step:429/5560 train_time:99009ms step_avg:230.79ms
+step:430/5560 train_time:99245ms step_avg:230.80ms
+step:431/5560 train_time:99484ms step_avg:230.82ms
+step:432/5560 train_time:99722ms step_avg:230.84ms
+step:433/5560 train_time:99961ms step_avg:230.86ms
+step:434/5560 train_time:100198ms step_avg:230.87ms
+step:435/5560 train_time:100438ms step_avg:230.89ms
+step:436/5560 train_time:100672ms step_avg:230.90ms
+step:437/5560 train_time:100908ms step_avg:230.91ms
+step:438/5560 train_time:101144ms step_avg:230.92ms
+step:439/5560 train_time:101382ms step_avg:230.94ms
+step:440/5560 train_time:101622ms step_avg:230.96ms
+step:441/5560 train_time:101860ms step_avg:230.97ms
+step:442/5560 train_time:102099ms step_avg:230.99ms
+step:443/5560 train_time:102336ms step_avg:231.01ms
+step:444/5560 train_time:102573ms step_avg:231.02ms
+step:445/5560 train_time:102810ms step_avg:231.03ms
+step:446/5560 train_time:103044ms step_avg:231.04ms
+step:447/5560 train_time:103282ms step_avg:231.06ms
+step:448/5560 train_time:103518ms step_avg:231.07ms
+step:449/5560 train_time:103782ms step_avg:231.14ms
+step:450/5560 train_time:103998ms step_avg:231.11ms
+step:451/5560 train_time:104235ms step_avg:231.12ms
+step:452/5560 train_time:104471ms step_avg:231.13ms
+step:453/5560 train_time:104708ms step_avg:231.14ms
+step:454/5560 train_time:104944ms step_avg:231.15ms
+step:455/5560 train_time:105181ms step_avg:231.17ms
+step:456/5560 train_time:105419ms step_avg:231.18ms
+step:457/5560 train_time:105657ms step_avg:231.20ms
+step:458/5560 train_time:105896ms step_avg:231.21ms
+step:459/5560 train_time:106132ms step_avg:231.22ms
+step:460/5560 train_time:106369ms step_avg:231.24ms
+step:461/5560 train_time:106607ms step_avg:231.25ms
+step:462/5560 train_time:106844ms step_avg:231.26ms
+step:463/5560 train_time:107081ms step_avg:231.28ms
+step:464/5560 train_time:107320ms step_avg:231.29ms
+step:465/5560 train_time:107557ms step_avg:231.30ms
+step:466/5560 train_time:107794ms step_avg:231.32ms
+step:467/5560 train_time:108030ms step_avg:231.33ms
+step:468/5560 train_time:108267ms step_avg:231.34ms
+step:469/5560 train_time:108504ms step_avg:231.35ms
+step:470/5560 train_time:108742ms step_avg:231.37ms
+step:471/5560 train_time:108980ms step_avg:231.38ms
+step:472/5560 train_time:109220ms step_avg:231.40ms
+step:473/5560 train_time:109456ms step_avg:231.41ms
+step:474/5560 train_time:109693ms step_avg:231.42ms
+step:475/5560 train_time:109929ms step_avg:231.43ms
+step:476/5560 train_time:110166ms step_avg:231.44ms
+step:477/5560 train_time:110429ms step_avg:231.51ms
+step:478/5560 train_time:110645ms step_avg:231.47ms
+step:479/5560 train_time:110885ms step_avg:231.49ms
+step:480/5560 train_time:111121ms step_avg:231.50ms
+step:481/5560 train_time:111357ms step_avg:231.51ms
+step:482/5560 train_time:111595ms step_avg:231.52ms
+step:483/5560 train_time:111832ms step_avg:231.54ms
+step:484/5560 train_time:112070ms step_avg:231.55ms
+step:485/5560 train_time:112309ms step_avg:231.57ms
+step:486/5560 train_time:112544ms step_avg:231.57ms
+step:487/5560 train_time:112782ms step_avg:231.59ms
+step:488/5560 train_time:113019ms step_avg:231.60ms
+step:489/5560 train_time:113259ms step_avg:231.61ms
+step:490/5560 train_time:113497ms step_avg:231.63ms
+step:491/5560 train_time:113735ms step_avg:231.64ms
+step:492/5560 train_time:113970ms step_avg:231.65ms
+step:493/5560 train_time:114208ms step_avg:231.66ms
+step:494/5560 train_time:114443ms step_avg:231.67ms
+step:495/5560 train_time:114683ms step_avg:231.68ms
+step:496/5560 train_time:114919ms step_avg:231.69ms
+step:497/5560 train_time:115158ms step_avg:231.71ms
+step:498/5560 train_time:115398ms step_avg:231.72ms
+step:499/5560 train_time:115635ms step_avg:231.73ms
+step:500/5560 train_time:115872ms step_avg:231.74ms
+step:500/5560 val_loss:3.557146 train_time:116111ms step_avg:232.22ms
+step:501/5560 train_time:116128ms step_avg:231.79ms
+step:502/5560 train_time:116349ms step_avg:231.77ms
+step:503/5560 train_time:116590ms step_avg:231.79ms
+step:504/5560 train_time:116827ms step_avg:231.80ms
+step:505/5560 train_time:117090ms step_avg:231.86ms
+step:506/5560 train_time:117304ms step_avg:231.83ms
+step:507/5560 train_time:117546ms step_avg:231.85ms
+step:508/5560 train_time:117783ms step_avg:231.86ms
+step:509/5560 train_time:118017ms step_avg:231.86ms
+step:510/5560 train_time:118257ms step_avg:231.88ms
+step:511/5560 train_time:118495ms step_avg:231.89ms
+step:512/5560 train_time:118734ms step_avg:231.90ms
+step:513/5560 train_time:118972ms step_avg:231.91ms
+step:514/5560 train_time:119209ms step_avg:231.92ms
+step:515/5560 train_time:119446ms step_avg:231.93ms
+step:516/5560 train_time:119684ms step_avg:231.95ms
+step:517/5560 train_time:119922ms step_avg:231.96ms
+step:518/5560 train_time:120160ms step_avg:231.97ms
+step:519/5560 train_time:120396ms step_avg:231.98ms
+step:520/5560 train_time:120637ms step_avg:231.99ms
+step:521/5560 train_time:120875ms step_avg:232.00ms
+step:522/5560 train_time:121112ms step_avg:232.02ms
+step:523/5560 train_time:121350ms step_avg:232.03ms
+step:524/5560 train_time:121588ms step_avg:232.04ms
+step:525/5560 train_time:121825ms step_avg:232.05ms
+step:526/5560 train_time:122063ms step_avg:232.06ms
+step:527/5560 train_time:122300ms step_avg:232.07ms
+step:528/5560 train_time:122537ms step_avg:232.08ms
+step:529/5560 train_time:122778ms step_avg:232.09ms
+step:530/5560 train_time:123016ms step_avg:232.11ms
+step:531/5560 train_time:123254ms step_avg:232.12ms
+step:532/5560 train_time:123490ms step_avg:232.12ms
+step:533/5560 train_time:123759ms step_avg:232.19ms
+step:534/5560 train_time:123975ms step_avg:232.16ms
+step:535/5560 train_time:124211ms step_avg:232.17ms
+step:536/5560 train_time:124449ms step_avg:232.18ms
+step:537/5560 train_time:124686ms step_avg:232.19ms
+step:538/5560 train_time:124926ms step_avg:232.20ms
+step:539/5560 train_time:125162ms step_avg:232.21ms
+step:540/5560 train_time:125399ms step_avg:232.22ms
+step:541/5560 train_time:125637ms step_avg:232.23ms
+step:542/5560 train_time:125876ms step_avg:232.24ms
+step:543/5560 train_time:126114ms step_avg:232.25ms
+step:544/5560 train_time:126353ms step_avg:232.27ms
+step:545/5560 train_time:126591ms step_avg:232.28ms
+step:546/5560 train_time:126829ms step_avg:232.29ms
+step:547/5560 train_time:127066ms step_avg:232.30ms
+step:548/5560 train_time:127303ms step_avg:232.31ms
+step:549/5560 train_time:127543ms step_avg:232.32ms
+step:550/5560 train_time:127779ms step_avg:232.33ms
+step:551/5560 train_time:128017ms step_avg:232.34ms
+step:552/5560 train_time:128255ms step_avg:232.35ms
+step:553/5560 train_time:128493ms step_avg:232.36ms
+step:554/5560 train_time:128731ms step_avg:232.37ms
+step:555/5560 train_time:128969ms step_avg:232.38ms
+step:556/5560 train_time:129205ms step_avg:232.38ms
+step:557/5560 train_time:129441ms step_avg:232.39ms
+step:558/5560 train_time:129679ms step_avg:232.40ms
+step:559/5560 train_time:129916ms step_avg:232.41ms
+step:560/5560 train_time:130155ms step_avg:232.42ms
+step:561/5560 train_time:130420ms step_avg:232.48ms
+step:562/5560 train_time:130635ms step_avg:232.45ms
+step:563/5560 train_time:130874ms step_avg:232.46ms
+step:564/5560 train_time:131113ms step_avg:232.47ms
+step:565/5560 train_time:131351ms step_avg:232.48ms
+step:566/5560 train_time:131590ms step_avg:232.49ms
+step:567/5560 train_time:131827ms step_avg:232.50ms
+step:568/5560 train_time:132066ms step_avg:232.51ms
+step:569/5560 train_time:132301ms step_avg:232.51ms
+step:570/5560 train_time:132539ms step_avg:232.52ms
+step:571/5560 train_time:132776ms step_avg:232.53ms
+step:572/5560 train_time:133012ms step_avg:232.54ms
+step:573/5560 train_time:133249ms step_avg:232.55ms
+step:574/5560 train_time:133488ms step_avg:232.56ms
+step:575/5560 train_time:133725ms step_avg:232.57ms
+step:576/5560 train_time:133961ms step_avg:232.57ms
+step:577/5560 train_time:134198ms step_avg:232.58ms
+step:578/5560 train_time:134440ms step_avg:232.60ms
+step:579/5560 train_time:134678ms step_avg:232.60ms
+step:580/5560 train_time:134914ms step_avg:232.61ms
+step:581/5560 train_time:135152ms step_avg:232.62ms
+step:582/5560 train_time:135391ms step_avg:232.63ms
+step:583/5560 train_time:135629ms step_avg:232.64ms
+step:584/5560 train_time:135867ms step_avg:232.65ms
+step:585/5560 train_time:136102ms step_avg:232.65ms
+step:586/5560 train_time:136341ms step_avg:232.66ms
+step:587/5560 train_time:136580ms step_avg:232.67ms
+step:588/5560 train_time:136818ms step_avg:232.68ms
+step:589/5560 train_time:137084ms step_avg:232.74ms
+step:590/5560 train_time:137298ms step_avg:232.71ms
+step:591/5560 train_time:137538ms step_avg:232.72ms
+step:592/5560 train_time:137774ms step_avg:232.73ms
+step:593/5560 train_time:138013ms step_avg:232.74ms
+step:594/5560 train_time:138252ms step_avg:232.75ms
+step:595/5560 train_time:138489ms step_avg:232.76ms
+step:596/5560 train_time:138726ms step_avg:232.76ms
+step:597/5560 train_time:138962ms step_avg:232.77ms
+step:598/5560 train_time:139201ms step_avg:232.78ms
+step:599/5560 train_time:139440ms step_avg:232.79ms
+step:600/5560 train_time:139677ms step_avg:232.80ms
+step:601/5560 train_time:139913ms step_avg:232.80ms
+step:602/5560 train_time:140151ms step_avg:232.81ms
+step:603/5560 train_time:140389ms step_avg:232.82ms
+step:604/5560 train_time:140629ms step_avg:232.83ms
+step:605/5560 train_time:140872ms step_avg:232.85ms
+step:606/5560 train_time:141111ms step_avg:232.86ms
+step:607/5560 train_time:141354ms step_avg:232.87ms
+step:608/5560 train_time:141594ms step_avg:232.89ms
+step:609/5560 train_time:141836ms step_avg:232.90ms
+step:610/5560 train_time:142077ms step_avg:232.91ms
+step:611/5560 train_time:142315ms step_avg:232.92ms
+step:612/5560 train_time:142556ms step_avg:232.93ms
+step:613/5560 train_time:142797ms step_avg:232.95ms
+step:614/5560 train_time:143039ms step_avg:232.96ms
+step:615/5560 train_time:143281ms step_avg:232.98ms
+step:616/5560 train_time:143521ms step_avg:232.99ms
+step:617/5560 train_time:143790ms step_avg:233.05ms
+step:618/5560 train_time:144006ms step_avg:233.02ms
+step:619/5560 train_time:144249ms step_avg:233.04ms
+step:620/5560 train_time:144488ms step_avg:233.04ms
+step:621/5560 train_time:144729ms step_avg:233.06ms
+step:622/5560 train_time:144971ms step_avg:233.07ms
+step:623/5560 train_time:145211ms step_avg:233.08ms
+step:624/5560 train_time:145452ms step_avg:233.10ms
+step:625/5560 train_time:145692ms step_avg:233.11ms
+step:625/5560 val_loss:3.479997 train_time:145933ms step_avg:233.49ms
+step:626/5560 train_time:145950ms step_avg:233.15ms
+step:627/5560 train_time:146176ms step_avg:233.14ms
+step:628/5560 train_time:146425ms step_avg:233.16ms
+step:629/5560 train_time:146665ms step_avg:233.17ms
+step:630/5560 train_time:146903ms step_avg:233.18ms
+step:631/5560 train_time:147142ms step_avg:233.19ms
+step:632/5560 train_time:147386ms step_avg:233.21ms
+step:633/5560 train_time:147626ms step_avg:233.22ms
+step:634/5560 train_time:147864ms step_avg:233.22ms
+step:635/5560 train_time:148106ms step_avg:233.24ms
+step:636/5560 train_time:148347ms step_avg:233.25ms
+step:637/5560 train_time:148588ms step_avg:233.26ms
+step:638/5560 train_time:148828ms step_avg:233.27ms
+step:639/5560 train_time:149065ms step_avg:233.28ms
+step:640/5560 train_time:149308ms step_avg:233.29ms
+step:641/5560 train_time:149550ms step_avg:233.31ms
+step:642/5560 train_time:149790ms step_avg:233.32ms
+step:643/5560 train_time:150029ms step_avg:233.33ms
+step:644/5560 train_time:150270ms step_avg:233.34ms
+step:645/5560 train_time:150539ms step_avg:233.39ms
+step:646/5560 train_time:150756ms step_avg:233.37ms
+step:647/5560 train_time:150995ms step_avg:233.38ms
+step:648/5560 train_time:151238ms step_avg:233.39ms
+step:649/5560 train_time:151478ms step_avg:233.40ms
+step:650/5560 train_time:151719ms step_avg:233.41ms
+step:651/5560 train_time:151959ms step_avg:233.42ms
+step:652/5560 train_time:152200ms step_avg:233.44ms
+step:653/5560 train_time:152440ms step_avg:233.45ms
+step:654/5560 train_time:152681ms step_avg:233.46ms
+step:655/5560 train_time:152923ms step_avg:233.47ms
+step:656/5560 train_time:153162ms step_avg:233.48ms
+step:657/5560 train_time:153405ms step_avg:233.49ms
+step:658/5560 train_time:153646ms step_avg:233.50ms
+step:659/5560 train_time:153887ms step_avg:233.52ms
+step:660/5560 train_time:154126ms step_avg:233.52ms
+step:661/5560 train_time:154368ms step_avg:233.54ms
+step:662/5560 train_time:154609ms step_avg:233.55ms
+step:663/5560 train_time:154848ms step_avg:233.56ms
+step:664/5560 train_time:155088ms step_avg:233.57ms
+step:665/5560 train_time:155327ms step_avg:233.58ms
+step:666/5560 train_time:155570ms step_avg:233.59ms
+step:667/5560 train_time:155809ms step_avg:233.60ms
+step:668/5560 train_time:156049ms step_avg:233.61ms
+step:669/5560 train_time:156288ms step_avg:233.61ms
+step:670/5560 train_time:156527ms step_avg:233.62ms
+step:671/5560 train_time:156767ms step_avg:233.63ms
+step:672/5560 train_time:157009ms step_avg:233.64ms
+step:673/5560 train_time:157279ms step_avg:233.70ms
+step:674/5560 train_time:157497ms step_avg:233.67ms
+step:675/5560 train_time:157741ms step_avg:233.69ms
+step:676/5560 train_time:157981ms step_avg:233.70ms
+step:677/5560 train_time:158224ms step_avg:233.71ms
+step:678/5560 train_time:158465ms step_avg:233.72ms
+step:679/5560 train_time:158706ms step_avg:233.73ms
+step:680/5560 train_time:158945ms step_avg:233.74ms
+step:681/5560 train_time:159186ms step_avg:233.75ms
+step:682/5560 train_time:159425ms step_avg:233.76ms
+step:683/5560 train_time:159666ms step_avg:233.77ms
+step:684/5560 train_time:159909ms step_avg:233.79ms
+step:685/5560 train_time:160148ms step_avg:233.79ms
+step:686/5560 train_time:160389ms step_avg:233.80ms
+step:687/5560 train_time:160628ms step_avg:233.81ms
+step:688/5560 train_time:160868ms step_avg:233.82ms
+step:689/5560 train_time:161111ms step_avg:233.83ms
+step:690/5560 train_time:161350ms step_avg:233.84ms
+step:691/5560 train_time:161594ms step_avg:233.86ms
+step:692/5560 train_time:161832ms step_avg:233.86ms
+step:693/5560 train_time:162073ms step_avg:233.87ms
+step:694/5560 train_time:162313ms step_avg:233.88ms
+step:695/5560 train_time:162554ms step_avg:233.89ms
+step:696/5560 train_time:162795ms step_avg:233.90ms
+step:697/5560 train_time:163034ms step_avg:233.91ms
+step:698/5560 train_time:163274ms step_avg:233.92ms
+step:699/5560 train_time:163515ms step_avg:233.93ms
+step:700/5560 train_time:163758ms step_avg:233.94ms
+step:701/5560 train_time:164025ms step_avg:233.99ms
+step:702/5560 train_time:164245ms step_avg:233.97ms
+step:703/5560 train_time:164485ms step_avg:233.98ms
+step:704/5560 train_time:164726ms step_avg:233.99ms
+step:705/5560 train_time:164967ms step_avg:234.00ms
+step:706/5560 train_time:165209ms step_avg:234.01ms
+step:707/5560 train_time:165448ms step_avg:234.01ms
+step:708/5560 train_time:165688ms step_avg:234.02ms
+step:709/5560 train_time:165928ms step_avg:234.03ms
+step:710/5560 train_time:166169ms step_avg:234.04ms
+step:711/5560 train_time:166409ms step_avg:234.05ms
+step:712/5560 train_time:166651ms step_avg:234.06ms
+step:713/5560 train_time:166894ms step_avg:234.07ms
+step:714/5560 train_time:167134ms step_avg:234.08ms
+step:715/5560 train_time:167374ms step_avg:234.09ms
+step:716/5560 train_time:167616ms step_avg:234.10ms
+step:717/5560 train_time:167855ms step_avg:234.11ms
+step:718/5560 train_time:168096ms step_avg:234.12ms
+step:719/5560 train_time:168335ms step_avg:234.12ms
+step:720/5560 train_time:168579ms step_avg:234.14ms
+step:721/5560 train_time:168821ms step_avg:234.15ms
+step:722/5560 train_time:169061ms step_avg:234.16ms
+step:723/5560 train_time:169304ms step_avg:234.17ms
+step:724/5560 train_time:169543ms step_avg:234.18ms
+step:725/5560 train_time:169787ms step_avg:234.19ms
+step:726/5560 train_time:170028ms step_avg:234.20ms
+step:727/5560 train_time:170269ms step_avg:234.21ms
+step:728/5560 train_time:170508ms step_avg:234.21ms
+step:729/5560 train_time:170779ms step_avg:234.26ms
+step:730/5560 train_time:170996ms step_avg:234.24ms
+step:731/5560 train_time:171238ms step_avg:234.25ms
+step:732/5560 train_time:171478ms step_avg:234.26ms
+step:733/5560 train_time:171721ms step_avg:234.27ms
+step:734/5560 train_time:171964ms step_avg:234.28ms
+step:735/5560 train_time:172206ms step_avg:234.29ms
+step:736/5560 train_time:172445ms step_avg:234.30ms
+step:737/5560 train_time:172687ms step_avg:234.31ms
+step:738/5560 train_time:172930ms step_avg:234.32ms
+step:739/5560 train_time:173171ms step_avg:234.33ms
+step:740/5560 train_time:173409ms step_avg:234.34ms
+step:741/5560 train_time:173652ms step_avg:234.35ms
+step:742/5560 train_time:173893ms step_avg:234.36ms
+step:743/5560 train_time:174133ms step_avg:234.36ms
+step:744/5560 train_time:174375ms step_avg:234.38ms
+step:745/5560 train_time:174617ms step_avg:234.39ms
+step:746/5560 train_time:174858ms step_avg:234.39ms
+step:747/5560 train_time:175100ms step_avg:234.40ms
+step:748/5560 train_time:175340ms step_avg:234.41ms
+step:749/5560 train_time:175582ms step_avg:234.42ms
+step:750/5560 train_time:175826ms step_avg:234.43ms
+step:750/5560 val_loss:3.427546 train_time:176070ms step_avg:234.76ms
+step:751/5560 train_time:176087ms step_avg:234.47ms
+step:752/5560 train_time:176310ms step_avg:234.45ms
+step:753/5560 train_time:176558ms step_avg:234.47ms
+step:754/5560 train_time:176799ms step_avg:234.48ms
+step:755/5560 train_time:177036ms step_avg:234.48ms
+step:756/5560 train_time:177274ms step_avg:234.49ms
+step:757/5560 train_time:177545ms step_avg:234.54ms
+step:758/5560 train_time:177769ms step_avg:234.52ms
+step:759/5560 train_time:178007ms step_avg:234.53ms
+step:760/5560 train_time:178245ms step_avg:234.53ms
+step:761/5560 train_time:178485ms step_avg:234.54ms
+step:762/5560 train_time:178729ms step_avg:234.55ms
+step:763/5560 train_time:178971ms step_avg:234.56ms
+step:764/5560 train_time:179211ms step_avg:234.57ms
+step:765/5560 train_time:179452ms step_avg:234.58ms
+step:766/5560 train_time:179694ms step_avg:234.59ms
+step:767/5560 train_time:179937ms step_avg:234.60ms
+step:768/5560 train_time:180179ms step_avg:234.61ms
+step:769/5560 train_time:180417ms step_avg:234.61ms
+step:770/5560 train_time:180658ms step_avg:234.62ms
+step:771/5560 train_time:180897ms step_avg:234.63ms
+step:772/5560 train_time:181138ms step_avg:234.63ms
+step:773/5560 train_time:181379ms step_avg:234.64ms
+step:774/5560 train_time:181618ms step_avg:234.65ms
+step:775/5560 train_time:181859ms step_avg:234.66ms
+step:776/5560 train_time:182100ms step_avg:234.66ms
+step:777/5560 train_time:182342ms step_avg:234.67ms
+step:778/5560 train_time:182582ms step_avg:234.68ms
+step:779/5560 train_time:182823ms step_avg:234.69ms
+step:780/5560 train_time:183066ms step_avg:234.70ms
+step:781/5560 train_time:183307ms step_avg:234.71ms
+step:782/5560 train_time:183550ms step_avg:234.72ms
+step:783/5560 train_time:183791ms step_avg:234.73ms
+step:784/5560 train_time:184033ms step_avg:234.74ms
+step:785/5560 train_time:184302ms step_avg:234.78ms
+step:786/5560 train_time:184519ms step_avg:234.76ms
+step:787/5560 train_time:184762ms step_avg:234.77ms
+step:788/5560 train_time:185001ms step_avg:234.77ms
+step:789/5560 train_time:185242ms step_avg:234.78ms
+step:790/5560 train_time:185485ms step_avg:234.79ms
+step:791/5560 train_time:185725ms step_avg:234.80ms
+step:792/5560 train_time:185967ms step_avg:234.81ms
+step:793/5560 train_time:186209ms step_avg:234.82ms
+step:794/5560 train_time:186451ms step_avg:234.82ms
+step:795/5560 train_time:186693ms step_avg:234.83ms
+step:796/5560 train_time:186936ms step_avg:234.84ms
+step:797/5560 train_time:187176ms step_avg:234.85ms
+step:798/5560 train_time:187418ms step_avg:234.86ms
+step:799/5560 train_time:187659ms step_avg:234.87ms
+step:800/5560 train_time:187903ms step_avg:234.88ms
+step:801/5560 train_time:188142ms step_avg:234.88ms
+step:802/5560 train_time:188384ms step_avg:234.89ms
+step:803/5560 train_time:188623ms step_avg:234.90ms
+step:804/5560 train_time:188866ms step_avg:234.91ms
+step:805/5560 train_time:189108ms step_avg:234.92ms
+step:806/5560 train_time:189351ms step_avg:234.93ms
+step:807/5560 train_time:189589ms step_avg:234.93ms
+step:808/5560 train_time:189832ms step_avg:234.94ms
+step:809/5560 train_time:190073ms step_avg:234.95ms
+step:810/5560 train_time:190315ms step_avg:234.96ms
+step:811/5560 train_time:190557ms step_avg:234.97ms
+step:812/5560 train_time:190797ms step_avg:234.97ms
+step:813/5560 train_time:191064ms step_avg:235.01ms
+step:814/5560 train_time:191281ms step_avg:234.99ms
+step:815/5560 train_time:191522ms step_avg:235.00ms
+step:816/5560 train_time:191763ms step_avg:235.00ms
+step:817/5560 train_time:192004ms step_avg:235.01ms
+step:818/5560 train_time:192246ms step_avg:235.02ms
+step:819/5560 train_time:192486ms step_avg:235.03ms
+step:820/5560 train_time:192727ms step_avg:235.03ms
+step:821/5560 train_time:192970ms step_avg:235.04ms
+step:822/5560 train_time:193210ms step_avg:235.05ms
+step:823/5560 train_time:193454ms step_avg:235.06ms
+step:824/5560 train_time:193696ms step_avg:235.07ms
+step:825/5560 train_time:193935ms step_avg:235.07ms
+step:826/5560 train_time:194176ms step_avg:235.08ms
+step:827/5560 train_time:194417ms step_avg:235.09ms
+step:828/5560 train_time:194658ms step_avg:235.09ms
+step:829/5560 train_time:194901ms step_avg:235.10ms
+step:830/5560 train_time:195139ms step_avg:235.11ms
+step:831/5560 train_time:195381ms step_avg:235.12ms
+step:832/5560 train_time:195621ms step_avg:235.12ms
+step:833/5560 train_time:195863ms step_avg:235.13ms
+step:834/5560 train_time:196105ms step_avg:235.14ms
+step:835/5560 train_time:196347ms step_avg:235.15ms
+step:836/5560 train_time:196586ms step_avg:235.15ms
+step:837/5560 train_time:196830ms step_avg:235.16ms
+step:838/5560 train_time:197069ms step_avg:235.17ms
+step:839/5560 train_time:197309ms step_avg:235.17ms
+step:840/5560 train_time:197552ms step_avg:235.18ms
+step:841/5560 train_time:197821ms step_avg:235.22ms
+step:842/5560 train_time:198039ms step_avg:235.20ms
+step:843/5560 train_time:198283ms step_avg:235.21ms
+step:844/5560 train_time:198522ms step_avg:235.22ms
+step:845/5560 train_time:198762ms step_avg:235.22ms
+step:846/5560 train_time:199003ms step_avg:235.23ms
+step:847/5560 train_time:199246ms step_avg:235.24ms
+step:848/5560 train_time:199486ms step_avg:235.24ms
+step:849/5560 train_time:199726ms step_avg:235.25ms
+step:850/5560 train_time:199968ms step_avg:235.26ms
+step:851/5560 train_time:200209ms step_avg:235.26ms
+step:852/5560 train_time:200450ms step_avg:235.27ms
+step:853/5560 train_time:200690ms step_avg:235.28ms
+step:854/5560 train_time:200931ms step_avg:235.28ms
+step:855/5560 train_time:201175ms step_avg:235.29ms
+step:856/5560 train_time:201418ms step_avg:235.30ms
+step:857/5560 train_time:201661ms step_avg:235.31ms
+step:858/5560 train_time:201904ms step_avg:235.32ms
+step:859/5560 train_time:202151ms step_avg:235.33ms
+step:860/5560 train_time:202395ms step_avg:235.34ms
+step:861/5560 train_time:202637ms step_avg:235.35ms
+step:862/5560 train_time:202885ms step_avg:235.36ms
+step:863/5560 train_time:203128ms step_avg:235.37ms
+step:864/5560 train_time:203371ms step_avg:235.38ms
+step:865/5560 train_time:203615ms step_avg:235.39ms
+step:866/5560 train_time:203864ms step_avg:235.41ms
+step:867/5560 train_time:204108ms step_avg:235.42ms
+step:868/5560 train_time:204351ms step_avg:235.43ms
+step:869/5560 train_time:204622ms step_avg:235.47ms
+step:870/5560 train_time:204843ms step_avg:235.45ms
+step:871/5560 train_time:205089ms step_avg:235.46ms
+step:872/5560 train_time:205330ms step_avg:235.47ms
+step:873/5560 train_time:205574ms step_avg:235.48ms
+step:874/5560 train_time:205817ms step_avg:235.49ms
+step:875/5560 train_time:206063ms step_avg:235.50ms
+step:875/5560 val_loss:3.381777 train_time:206307ms step_avg:235.78ms
+step:876/5560 train_time:206326ms step_avg:235.53ms
+step:877/5560 train_time:206550ms step_avg:235.52ms
+step:878/5560 train_time:206804ms step_avg:235.54ms
+step:879/5560 train_time:207050ms step_avg:235.55ms
+step:880/5560 train_time:207289ms step_avg:235.56ms
+step:881/5560 train_time:207531ms step_avg:235.56ms
+step:882/5560 train_time:207778ms step_avg:235.58ms
+step:883/5560 train_time:208027ms step_avg:235.59ms
+step:884/5560 train_time:208268ms step_avg:235.60ms
+step:885/5560 train_time:208512ms step_avg:235.61ms
+step:886/5560 train_time:208757ms step_avg:235.62ms
+step:887/5560 train_time:209002ms step_avg:235.63ms
+step:888/5560 train_time:209248ms step_avg:235.64ms
+step:889/5560 train_time:209496ms step_avg:235.65ms
+step:890/5560 train_time:209737ms step_avg:235.66ms
+step:891/5560 train_time:209979ms step_avg:235.67ms
+step:892/5560 train_time:210225ms step_avg:235.68ms
+step:893/5560 train_time:210470ms step_avg:235.69ms
+step:894/5560 train_time:210711ms step_avg:235.69ms
+step:895/5560 train_time:210955ms step_avg:235.70ms
+step:896/5560 train_time:211198ms step_avg:235.71ms
+step:897/5560 train_time:211471ms step_avg:235.75ms
+step:898/5560 train_time:211693ms step_avg:235.74ms
+step:899/5560 train_time:211938ms step_avg:235.75ms
+step:900/5560 train_time:212181ms step_avg:235.76ms
+step:901/5560 train_time:212425ms step_avg:235.77ms
+step:902/5560 train_time:212668ms step_avg:235.77ms
+step:903/5560 train_time:212912ms step_avg:235.78ms
+step:904/5560 train_time:213152ms step_avg:235.79ms
+step:905/5560 train_time:213398ms step_avg:235.80ms
+step:906/5560 train_time:213643ms step_avg:235.81ms
+step:907/5560 train_time:213890ms step_avg:235.82ms
+step:908/5560 train_time:214133ms step_avg:235.83ms
+step:909/5560 train_time:214378ms step_avg:235.84ms
+step:910/5560 train_time:214624ms step_avg:235.85ms
+step:911/5560 train_time:214868ms step_avg:235.86ms
+step:912/5560 train_time:215110ms step_avg:235.87ms
+step:913/5560 train_time:215352ms step_avg:235.87ms
+step:914/5560 train_time:215596ms step_avg:235.88ms
+step:915/5560 train_time:215840ms step_avg:235.89ms
+step:916/5560 train_time:216086ms step_avg:235.90ms
+step:917/5560 train_time:216330ms step_avg:235.91ms
+step:918/5560 train_time:216574ms step_avg:235.92ms
+step:919/5560 train_time:216821ms step_avg:235.93ms
+step:920/5560 train_time:217070ms step_avg:235.95ms
+step:921/5560 train_time:217312ms step_avg:235.95ms
+step:922/5560 train_time:217557ms step_avg:235.96ms
+step:923/5560 train_time:217800ms step_avg:235.97ms
+step:924/5560 train_time:218042ms step_avg:235.98ms
+step:925/5560 train_time:218316ms step_avg:236.02ms
+step:926/5560 train_time:218536ms step_avg:236.00ms
+step:927/5560 train_time:218778ms step_avg:236.01ms
+step:928/5560 train_time:219022ms step_avg:236.01ms
+step:929/5560 train_time:219266ms step_avg:236.02ms
+step:930/5560 train_time:219509ms step_avg:236.03ms
+step:931/5560 train_time:219751ms step_avg:236.04ms
+step:932/5560 train_time:219996ms step_avg:236.05ms
+step:933/5560 train_time:220240ms step_avg:236.06ms
+step:934/5560 train_time:220484ms step_avg:236.06ms
+step:935/5560 train_time:220727ms step_avg:236.07ms
+step:936/5560 train_time:220971ms step_avg:236.08ms
+step:937/5560 train_time:221218ms step_avg:236.09ms
+step:938/5560 train_time:221464ms step_avg:236.10ms
+step:939/5560 train_time:221707ms step_avg:236.11ms
+step:940/5560 train_time:221953ms step_avg:236.12ms
+step:941/5560 train_time:222196ms step_avg:236.13ms
+step:942/5560 train_time:222439ms step_avg:236.14ms
+step:943/5560 train_time:222685ms step_avg:236.15ms
+step:944/5560 train_time:222927ms step_avg:236.15ms
+step:945/5560 train_time:223171ms step_avg:236.16ms
+step:946/5560 train_time:223416ms step_avg:236.17ms
+step:947/5560 train_time:223664ms step_avg:236.18ms
+step:948/5560 train_time:223909ms step_avg:236.19ms
+step:949/5560 train_time:224152ms step_avg:236.20ms
+step:950/5560 train_time:224395ms step_avg:236.21ms
+step:951/5560 train_time:224639ms step_avg:236.21ms
+step:952/5560 train_time:224882ms step_avg:236.22ms
+step:953/5560 train_time:225154ms step_avg:236.26ms
+step:954/5560 train_time:225377ms step_avg:236.24ms
+step:955/5560 train_time:225618ms step_avg:236.25ms
+step:956/5560 train_time:225865ms step_avg:236.26ms
+step:957/5560 train_time:226107ms step_avg:236.27ms
+step:958/5560 train_time:226354ms step_avg:236.28ms
+step:959/5560 train_time:226597ms step_avg:236.28ms
+step:960/5560 train_time:226841ms step_avg:236.29ms
+step:961/5560 train_time:227085ms step_avg:236.30ms
+step:962/5560 train_time:227330ms step_avg:236.31ms
+step:963/5560 train_time:227575ms step_avg:236.32ms
+step:964/5560 train_time:227817ms step_avg:236.32ms
+step:965/5560 train_time:228062ms step_avg:236.33ms
+step:966/5560 train_time:228305ms step_avg:236.34ms
+step:967/5560 train_time:228551ms step_avg:236.35ms
+step:968/5560 train_time:228792ms step_avg:236.36ms
+step:969/5560 train_time:229036ms step_avg:236.36ms
+step:970/5560 train_time:229282ms step_avg:236.37ms
+step:971/5560 train_time:229524ms step_avg:236.38ms
+step:972/5560 train_time:229767ms step_avg:236.39ms
+step:973/5560 train_time:230010ms step_avg:236.39ms
+step:974/5560 train_time:230253ms step_avg:236.40ms
+step:975/5560 train_time:230498ms step_avg:236.41ms
+step:976/5560 train_time:230742ms step_avg:236.42ms
+step:977/5560 train_time:230988ms step_avg:236.43ms
+step:978/5560 train_time:231230ms step_avg:236.43ms
+step:979/5560 train_time:231475ms step_avg:236.44ms
+step:980/5560 train_time:231719ms step_avg:236.45ms
+step:981/5560 train_time:231991ms step_avg:236.48ms
+step:982/5560 train_time:232211ms step_avg:236.47ms
+step:983/5560 train_time:232457ms step_avg:236.48ms
+step:984/5560 train_time:232699ms step_avg:236.48ms
+step:985/5560 train_time:232942ms step_avg:236.49ms
+step:986/5560 train_time:233188ms step_avg:236.50ms
+step:987/5560 train_time:233433ms step_avg:236.51ms
+step:988/5560 train_time:233676ms step_avg:236.51ms
+step:989/5560 train_time:233921ms step_avg:236.52ms
+step:990/5560 train_time:234165ms step_avg:236.53ms
+step:991/5560 train_time:234410ms step_avg:236.54ms
+step:992/5560 train_time:234651ms step_avg:236.54ms
+step:993/5560 train_time:234899ms step_avg:236.55ms
+step:994/5560 train_time:235143ms step_avg:236.56ms
+step:995/5560 train_time:235386ms step_avg:236.57ms
+step:996/5560 train_time:235628ms step_avg:236.57ms
+step:997/5560 train_time:235870ms step_avg:236.58ms
+step:998/5560 train_time:236113ms step_avg:236.59ms
+step:999/5560 train_time:236358ms step_avg:236.59ms
+step:1000/5560 train_time:236601ms step_avg:236.60ms
+step:1000/5560 val_loss:3.346987 train_time:236844ms step_avg:236.84ms
+step:1001/5560 train_time:236862ms step_avg:236.62ms
+step:1002/5560 train_time:237087ms step_avg:236.61ms
+step:1003/5560 train_time:237337ms step_avg:236.63ms
+step:1004/5560 train_time:237580ms step_avg:236.63ms
+step:1005/5560 train_time:237822ms step_avg:236.64ms
+step:1006/5560 train_time:238063ms step_avg:236.64ms
+step:1007/5560 train_time:238311ms step_avg:236.65ms
+step:1008/5560 train_time:238554ms step_avg:236.66ms
+step:1009/5560 train_time:238828ms step_avg:236.70ms
+step:1010/5560 train_time:239048ms step_avg:236.68ms
+step:1011/5560 train_time:239297ms step_avg:236.69ms
+step:1012/5560 train_time:239544ms step_avg:236.70ms
+step:1013/5560 train_time:239784ms step_avg:236.71ms
+step:1014/5560 train_time:240026ms step_avg:236.71ms
+step:1015/5560 train_time:240273ms step_avg:236.72ms
+step:1016/5560 train_time:240517ms step_avg:236.73ms
+step:1017/5560 train_time:240762ms step_avg:236.74ms
+step:1018/5560 train_time:241006ms step_avg:236.74ms
+step:1019/5560 train_time:241250ms step_avg:236.75ms
+step:1020/5560 train_time:241494ms step_avg:236.76ms
+step:1021/5560 train_time:241738ms step_avg:236.77ms
+step:1022/5560 train_time:241979ms step_avg:236.77ms
+step:1023/5560 train_time:242225ms step_avg:236.78ms
+step:1024/5560 train_time:242468ms step_avg:236.79ms
+step:1025/5560 train_time:242713ms step_avg:236.79ms
+step:1026/5560 train_time:242957ms step_avg:236.80ms
+step:1027/5560 train_time:243203ms step_avg:236.81ms
+step:1028/5560 train_time:243446ms step_avg:236.82ms
+step:1029/5560 train_time:243692ms step_avg:236.82ms
+step:1030/5560 train_time:243936ms step_avg:236.83ms
+step:1031/5560 train_time:244178ms step_avg:236.84ms
+step:1032/5560 train_time:244422ms step_avg:236.84ms
+step:1033/5560 train_time:244667ms step_avg:236.85ms
+step:1034/5560 train_time:244912ms step_avg:236.86ms
+step:1035/5560 train_time:245156ms step_avg:236.87ms
+step:1036/5560 train_time:245399ms step_avg:236.87ms
+step:1037/5560 train_time:245672ms step_avg:236.91ms
+step:1038/5560 train_time:245895ms step_avg:236.89ms
+step:1039/5560 train_time:246140ms step_avg:236.90ms
+step:1040/5560 train_time:246381ms step_avg:236.90ms
+step:1041/5560 train_time:246625ms step_avg:236.91ms
+step:1042/5560 train_time:246871ms step_avg:236.92ms
+step:1043/5560 train_time:247117ms step_avg:236.93ms
+step:1044/5560 train_time:247361ms step_avg:236.94ms
+step:1045/5560 train_time:247605ms step_avg:236.94ms
+step:1046/5560 train_time:247848ms step_avg:236.95ms
+step:1047/5560 train_time:248093ms step_avg:236.96ms
+step:1048/5560 train_time:248340ms step_avg:236.97ms
+step:1049/5560 train_time:248583ms step_avg:236.97ms
+step:1050/5560 train_time:248827ms step_avg:236.98ms
+step:1051/5560 train_time:249074ms step_avg:236.99ms
+step:1052/5560 train_time:249319ms step_avg:237.00ms
+step:1053/5560 train_time:249560ms step_avg:237.00ms
+step:1054/5560 train_time:249806ms step_avg:237.01ms
+step:1055/5560 train_time:250052ms step_avg:237.02ms
+step:1056/5560 train_time:250298ms step_avg:237.02ms
+step:1057/5560 train_time:250541ms step_avg:237.03ms
+step:1058/5560 train_time:250784ms step_avg:237.04ms
+step:1059/5560 train_time:251028ms step_avg:237.04ms
+step:1060/5560 train_time:251276ms step_avg:237.05ms
+step:1061/5560 train_time:251519ms step_avg:237.06ms
+step:1062/5560 train_time:251761ms step_avg:237.06ms
+step:1063/5560 train_time:252004ms step_avg:237.07ms
+step:1064/5560 train_time:252249ms step_avg:237.08ms
+step:1065/5560 train_time:252522ms step_avg:237.11ms
+step:1066/5560 train_time:252746ms step_avg:237.10ms
+step:1067/5560 train_time:252990ms step_avg:237.10ms
+step:1068/5560 train_time:253234ms step_avg:237.11ms
+step:1069/5560 train_time:253482ms step_avg:237.12ms
+step:1070/5560 train_time:253725ms step_avg:237.13ms
+step:1071/5560 train_time:253969ms step_avg:237.13ms
+step:1072/5560 train_time:254218ms step_avg:237.14ms
+step:1073/5560 train_time:254458ms step_avg:237.15ms
+step:1074/5560 train_time:254703ms step_avg:237.15ms
+step:1075/5560 train_time:254948ms step_avg:237.16ms
+step:1076/5560 train_time:255191ms step_avg:237.17ms
+step:1077/5560 train_time:255433ms step_avg:237.17ms
+step:1078/5560 train_time:255676ms step_avg:237.18ms
+step:1079/5560 train_time:255928ms step_avg:237.19ms
+step:1080/5560 train_time:256171ms step_avg:237.20ms
+step:1081/5560 train_time:256416ms step_avg:237.20ms
+step:1082/5560 train_time:256657ms step_avg:237.21ms
+step:1083/5560 train_time:256902ms step_avg:237.21ms
+step:1084/5560 train_time:257146ms step_avg:237.22ms
+step:1085/5560 train_time:257393ms step_avg:237.23ms
+step:1086/5560 train_time:257635ms step_avg:237.23ms
+step:1087/5560 train_time:257879ms step_avg:237.24ms
+step:1088/5560 train_time:258126ms step_avg:237.25ms
+step:1089/5560 train_time:258368ms step_avg:237.25ms
+step:1090/5560 train_time:258612ms step_avg:237.26ms
+step:1091/5560 train_time:258855ms step_avg:237.26ms
+step:1092/5560 train_time:259100ms step_avg:237.27ms
+step:1093/5560 train_time:259371ms step_avg:237.30ms
+step:1094/5560 train_time:259596ms step_avg:237.29ms
+step:1095/5560 train_time:259841ms step_avg:237.30ms
+step:1096/5560 train_time:260085ms step_avg:237.30ms
+step:1097/5560 train_time:260330ms step_avg:237.31ms
+step:1098/5560 train_time:260573ms step_avg:237.32ms
+step:1099/5560 train_time:260818ms step_avg:237.32ms
+step:1100/5560 train_time:261060ms step_avg:237.33ms
+step:1101/5560 train_time:261305ms step_avg:237.33ms
+step:1102/5560 train_time:261547ms step_avg:237.34ms
+step:1103/5560 train_time:261791ms step_avg:237.34ms
+step:1104/5560 train_time:262037ms step_avg:237.35ms
+step:1105/5560 train_time:262285ms step_avg:237.36ms
+step:1106/5560 train_time:262529ms step_avg:237.37ms
+step:1107/5560 train_time:262772ms step_avg:237.37ms
+step:1108/5560 train_time:263022ms step_avg:237.38ms
+step:1109/5560 train_time:263266ms step_avg:237.39ms
+step:1110/5560 train_time:263512ms step_avg:237.40ms
+step:1111/5560 train_time:263754ms step_avg:237.40ms
+step:1112/5560 train_time:263998ms step_avg:237.41ms
+step:1113/5560 train_time:264239ms step_avg:237.41ms
+step:1114/5560 train_time:264485ms step_avg:237.42ms
+step:1115/5560 train_time:264728ms step_avg:237.42ms
+step:1116/5560 train_time:264973ms step_avg:237.43ms
+step:1117/5560 train_time:265218ms step_avg:237.44ms
+step:1118/5560 train_time:265464ms step_avg:237.45ms
+step:1119/5560 train_time:265708ms step_avg:237.45ms
+step:1120/5560 train_time:265952ms step_avg:237.46ms
+step:1121/5560 train_time:266227ms step_avg:237.49ms
+step:1122/5560 train_time:266447ms step_avg:237.48ms
+step:1123/5560 train_time:266689ms step_avg:237.48ms
+step:1124/5560 train_time:266932ms step_avg:237.48ms
+step:1125/5560 train_time:267173ms step_avg:237.49ms
+step:1125/5560 val_loss:3.317942 train_time:267422ms step_avg:237.71ms
+step:1126/5560 train_time:267439ms step_avg:237.51ms
+step:1127/5560 train_time:267666ms step_avg:237.50ms
+step:1128/5560 train_time:267919ms step_avg:237.52ms
+step:1129/5560 train_time:268164ms step_avg:237.52ms
+step:1130/5560 train_time:268404ms step_avg:237.53ms
+step:1131/5560 train_time:268646ms step_avg:237.53ms
+step:1132/5560 train_time:268892ms step_avg:237.54ms
+step:1133/5560 train_time:269138ms step_avg:237.54ms
+step:1134/5560 train_time:269383ms step_avg:237.55ms
+step:1135/5560 train_time:269624ms step_avg:237.55ms
+step:1136/5560 train_time:269870ms step_avg:237.56ms
+step:1137/5560 train_time:270113ms step_avg:237.57ms
+step:1138/5560 train_time:270359ms step_avg:237.57ms
+step:1139/5560 train_time:270602ms step_avg:237.58ms
+step:1140/5560 train_time:270846ms step_avg:237.58ms
+step:1141/5560 train_time:271092ms step_avg:237.59ms
+step:1142/5560 train_time:271340ms step_avg:237.60ms
+step:1143/5560 train_time:271582ms step_avg:237.60ms
+step:1144/5560 train_time:271824ms step_avg:237.61ms
+step:1145/5560 train_time:272068ms step_avg:237.61ms
+step:1146/5560 train_time:272312ms step_avg:237.62ms
+step:1147/5560 train_time:272557ms step_avg:237.63ms
+step:1148/5560 train_time:272799ms step_avg:237.63ms
+step:1149/5560 train_time:273070ms step_avg:237.66ms
+step:1150/5560 train_time:273291ms step_avg:237.64ms
+step:1151/5560 train_time:273534ms step_avg:237.65ms
+step:1152/5560 train_time:273779ms step_avg:237.66ms
+step:1153/5560 train_time:274026ms step_avg:237.66ms
+step:1154/5560 train_time:274271ms step_avg:237.67ms
+step:1155/5560 train_time:274513ms step_avg:237.67ms
+step:1156/5560 train_time:274760ms step_avg:237.68ms
+step:1157/5560 train_time:275004ms step_avg:237.69ms
+step:1158/5560 train_time:275247ms step_avg:237.69ms
+step:1159/5560 train_time:275490ms step_avg:237.70ms
+step:1160/5560 train_time:275737ms step_avg:237.70ms
+step:1161/5560 train_time:275980ms step_avg:237.71ms
+step:1162/5560 train_time:276226ms step_avg:237.72ms
+step:1163/5560 train_time:276467ms step_avg:237.72ms
+step:1164/5560 train_time:276712ms step_avg:237.73ms
+step:1165/5560 train_time:276957ms step_avg:237.73ms
+step:1166/5560 train_time:277199ms step_avg:237.74ms
+step:1167/5560 train_time:277441ms step_avg:237.74ms
+step:1168/5560 train_time:277687ms step_avg:237.75ms
+step:1169/5560 train_time:277932ms step_avg:237.75ms
+step:1170/5560 train_time:278176ms step_avg:237.76ms
+step:1171/5560 train_time:278417ms step_avg:237.76ms
+step:1172/5560 train_time:278664ms step_avg:237.77ms
+step:1173/5560 train_time:278905ms step_avg:237.77ms
+step:1174/5560 train_time:279152ms step_avg:237.78ms
+step:1175/5560 train_time:279395ms step_avg:237.78ms
+step:1176/5560 train_time:279639ms step_avg:237.79ms
+step:1177/5560 train_time:279915ms step_avg:237.82ms
+step:1178/5560 train_time:280135ms step_avg:237.81ms
+step:1179/5560 train_time:280376ms step_avg:237.81ms
+step:1180/5560 train_time:280620ms step_avg:237.81ms
+step:1181/5560 train_time:280867ms step_avg:237.82ms
+step:1182/5560 train_time:281112ms step_avg:237.83ms
+step:1183/5560 train_time:281356ms step_avg:237.83ms
+step:1184/5560 train_time:281602ms step_avg:237.84ms
+step:1185/5560 train_time:281847ms step_avg:237.85ms
+step:1186/5560 train_time:282092ms step_avg:237.85ms
+step:1187/5560 train_time:282337ms step_avg:237.86ms
+step:1188/5560 train_time:282582ms step_avg:237.86ms
+step:1189/5560 train_time:282827ms step_avg:237.87ms
+step:1190/5560 train_time:283071ms step_avg:237.87ms
+step:1191/5560 train_time:283315ms step_avg:237.88ms
+step:1192/5560 train_time:283559ms step_avg:237.88ms
+step:1193/5560 train_time:283804ms step_avg:237.89ms
+step:1194/5560 train_time:284047ms step_avg:237.90ms
+step:1195/5560 train_time:284290ms step_avg:237.90ms
+step:1196/5560 train_time:284535ms step_avg:237.91ms
+step:1197/5560 train_time:284777ms step_avg:237.91ms
+step:1198/5560 train_time:285026ms step_avg:237.92ms
+step:1199/5560 train_time:285274ms step_avg:237.93ms
+step:1200/5560 train_time:285518ms step_avg:237.93ms
+step:1201/5560 train_time:285763ms step_avg:237.94ms
+step:1202/5560 train_time:286018ms step_avg:237.95ms
+step:1203/5560 train_time:286269ms step_avg:237.96ms
+step:1204/5560 train_time:286512ms step_avg:237.97ms
+step:1205/5560 train_time:286788ms step_avg:238.00ms
+step:1206/5560 train_time:287015ms step_avg:237.99ms
+step:1207/5560 train_time:287260ms step_avg:238.00ms
+step:1208/5560 train_time:287506ms step_avg:238.00ms
+step:1209/5560 train_time:287752ms step_avg:238.01ms
+step:1210/5560 train_time:288001ms step_avg:238.02ms
+step:1211/5560 train_time:288249ms step_avg:238.03ms
+step:1212/5560 train_time:288493ms step_avg:238.03ms
+step:1213/5560 train_time:288739ms step_avg:238.04ms
+step:1214/5560 train_time:288989ms step_avg:238.05ms
+step:1215/5560 train_time:289242ms step_avg:238.06ms
+step:1216/5560 train_time:289482ms step_avg:238.06ms
+step:1217/5560 train_time:289728ms step_avg:238.07ms
+step:1218/5560 train_time:289973ms step_avg:238.07ms
+step:1219/5560 train_time:290220ms step_avg:238.08ms
+step:1220/5560 train_time:290463ms step_avg:238.08ms
+step:1221/5560 train_time:290708ms step_avg:238.09ms
+step:1222/5560 train_time:290953ms step_avg:238.10ms
+step:1223/5560 train_time:291198ms step_avg:238.10ms
+step:1224/5560 train_time:291445ms step_avg:238.11ms
+step:1225/5560 train_time:291695ms step_avg:238.12ms
+step:1226/5560 train_time:291941ms step_avg:238.12ms
+step:1227/5560 train_time:292188ms step_avg:238.13ms
+step:1228/5560 train_time:292436ms step_avg:238.14ms
+step:1229/5560 train_time:292680ms step_avg:238.14ms
+step:1230/5560 train_time:292928ms step_avg:238.15ms
+step:1231/5560 train_time:293178ms step_avg:238.16ms
+step:1232/5560 train_time:293425ms step_avg:238.17ms
+step:1233/5560 train_time:293699ms step_avg:238.20ms
+step:1234/5560 train_time:293922ms step_avg:238.19ms
+step:1235/5560 train_time:294170ms step_avg:238.19ms
+step:1236/5560 train_time:294415ms step_avg:238.20ms
+step:1237/5560 train_time:294661ms step_avg:238.21ms
+step:1238/5560 train_time:294911ms step_avg:238.22ms
+step:1239/5560 train_time:295156ms step_avg:238.22ms
+step:1240/5560 train_time:295403ms step_avg:238.23ms
+step:1241/5560 train_time:295654ms step_avg:238.24ms
+step:1242/5560 train_time:295900ms step_avg:238.24ms
+step:1243/5560 train_time:296146ms step_avg:238.25ms
+step:1244/5560 train_time:296391ms step_avg:238.26ms
+step:1245/5560 train_time:296638ms step_avg:238.26ms
+step:1246/5560 train_time:296883ms step_avg:238.27ms
+step:1247/5560 train_time:297130ms step_avg:238.28ms
+step:1248/5560 train_time:297373ms step_avg:238.28ms
+step:1249/5560 train_time:297617ms step_avg:238.28ms
+step:1250/5560 train_time:297866ms step_avg:238.29ms
+step:1250/5560 val_loss:3.292978 train_time:298117ms step_avg:238.49ms
+step:1251/5560 train_time:298173ms step_avg:238.35ms
+step:1252/5560 train_time:298374ms step_avg:238.32ms
+step:1253/5560 train_time:298628ms step_avg:238.33ms
+step:1254/5560 train_time:298904ms step_avg:238.36ms
+step:1255/5560 train_time:299141ms step_avg:238.36ms
+step:1256/5560 train_time:299391ms step_avg:238.37ms
+step:1257/5560 train_time:299606ms step_avg:238.35ms
+step:1258/5560 train_time:299851ms step_avg:238.36ms
+step:1259/5560 train_time:300100ms step_avg:238.36ms
+step:1260/5560 train_time:300343ms step_avg:238.37ms
+step:1261/5560 train_time:300619ms step_avg:238.40ms
+step:1262/5560 train_time:300844ms step_avg:238.39ms
+step:1263/5560 train_time:301090ms step_avg:238.39ms
+step:1264/5560 train_time:301336ms step_avg:238.40ms
+step:1265/5560 train_time:301580ms step_avg:238.40ms
+step:1266/5560 train_time:301826ms step_avg:238.41ms
+step:1267/5560 train_time:302073ms step_avg:238.42ms
+step:1268/5560 train_time:302316ms step_avg:238.42ms
+step:1269/5560 train_time:302561ms step_avg:238.42ms
+step:1270/5560 train_time:302809ms step_avg:238.43ms
+step:1271/5560 train_time:303056ms step_avg:238.44ms
+step:1272/5560 train_time:303302ms step_avg:238.45ms
+step:1273/5560 train_time:303546ms step_avg:238.45ms
+step:1274/5560 train_time:303790ms step_avg:238.45ms
+step:1275/5560 train_time:304039ms step_avg:238.46ms
+step:1276/5560 train_time:304284ms step_avg:238.47ms
+step:1277/5560 train_time:304529ms step_avg:238.47ms
+step:1278/5560 train_time:304775ms step_avg:238.48ms
+step:1279/5560 train_time:305020ms step_avg:238.48ms
+step:1280/5560 train_time:305272ms step_avg:238.49ms
+step:1281/5560 train_time:305515ms step_avg:238.50ms
+step:1282/5560 train_time:305760ms step_avg:238.50ms
+step:1283/5560 train_time:306003ms step_avg:238.51ms
+step:1284/5560 train_time:306252ms step_avg:238.51ms
+step:1285/5560 train_time:306497ms step_avg:238.52ms
+step:1286/5560 train_time:306744ms step_avg:238.53ms
+step:1287/5560 train_time:306989ms step_avg:238.53ms
+step:1288/5560 train_time:307233ms step_avg:238.54ms
+step:1289/5560 train_time:307512ms step_avg:238.57ms
+step:1290/5560 train_time:307734ms step_avg:238.55ms
+step:1291/5560 train_time:307984ms step_avg:238.56ms
+step:1292/5560 train_time:308230ms step_avg:238.57ms
+step:1293/5560 train_time:308476ms step_avg:238.57ms
+step:1294/5560 train_time:308721ms step_avg:238.58ms
+step:1295/5560 train_time:308970ms step_avg:238.59ms
+step:1296/5560 train_time:309213ms step_avg:238.59ms
+step:1297/5560 train_time:309460ms step_avg:238.60ms
+step:1298/5560 train_time:309705ms step_avg:238.60ms
+step:1299/5560 train_time:309952ms step_avg:238.61ms
+step:1300/5560 train_time:310199ms step_avg:238.61ms
+step:1301/5560 train_time:310443ms step_avg:238.62ms
+step:1302/5560 train_time:310687ms step_avg:238.62ms
+step:1303/5560 train_time:310933ms step_avg:238.63ms
+step:1304/5560 train_time:311182ms step_avg:238.64ms
+step:1305/5560 train_time:311430ms step_avg:238.64ms
+step:1306/5560 train_time:311673ms step_avg:238.65ms
+step:1307/5560 train_time:311920ms step_avg:238.65ms
+step:1308/5560 train_time:312169ms step_avg:238.66ms
+step:1309/5560 train_time:312416ms step_avg:238.67ms
+step:1310/5560 train_time:312663ms step_avg:238.67ms
+step:1311/5560 train_time:312908ms step_avg:238.68ms
+step:1312/5560 train_time:313153ms step_avg:238.68ms
+step:1313/5560 train_time:313401ms step_avg:238.69ms
+step:1314/5560 train_time:313646ms step_avg:238.70ms
+step:1315/5560 train_time:313894ms step_avg:238.70ms
+step:1316/5560 train_time:314139ms step_avg:238.71ms
+step:1317/5560 train_time:314413ms step_avg:238.73ms
+step:1318/5560 train_time:314636ms step_avg:238.72ms
+step:1319/5560 train_time:314887ms step_avg:238.73ms
+step:1320/5560 train_time:315133ms step_avg:238.74ms
+step:1321/5560 train_time:315380ms step_avg:238.74ms
+step:1322/5560 train_time:315629ms step_avg:238.75ms
+step:1323/5560 train_time:315874ms step_avg:238.76ms
+step:1324/5560 train_time:316116ms step_avg:238.76ms
+step:1325/5560 train_time:316366ms step_avg:238.77ms
+step:1326/5560 train_time:316612ms step_avg:238.77ms
+step:1327/5560 train_time:316860ms step_avg:238.78ms
+step:1328/5560 train_time:317111ms step_avg:238.79ms
+step:1329/5560 train_time:317363ms step_avg:238.80ms
+step:1330/5560 train_time:317641ms step_avg:238.83ms
+step:1331/5560 train_time:318059ms step_avg:238.96ms
+step:1332/5560 train_time:318191ms step_avg:238.88ms
+step:1333/5560 train_time:318395ms step_avg:238.86ms
+step:1334/5560 train_time:318637ms step_avg:238.86ms
+step:1335/5560 train_time:318887ms step_avg:238.87ms
+step:1336/5560 train_time:319138ms step_avg:238.88ms
+step:1337/5560 train_time:319380ms step_avg:238.88ms
+step:1338/5560 train_time:319623ms step_avg:238.88ms
+step:1339/5560 train_time:319870ms step_avg:238.89ms
+step:1340/5560 train_time:320123ms step_avg:238.90ms
+step:1341/5560 train_time:320368ms step_avg:238.90ms
+step:1342/5560 train_time:320610ms step_avg:238.90ms
+step:1343/5560 train_time:320854ms step_avg:238.91ms
+step:1344/5560 train_time:321099ms step_avg:238.91ms
+step:1345/5560 train_time:321374ms step_avg:238.94ms
+step:1346/5560 train_time:321597ms step_avg:238.93ms
+step:1347/5560 train_time:321845ms step_avg:238.93ms
+step:1348/5560 train_time:322089ms step_avg:238.94ms
+step:1349/5560 train_time:322335ms step_avg:238.94ms
+step:1350/5560 train_time:322579ms step_avg:238.95ms
+step:1351/5560 train_time:322823ms step_avg:238.95ms
+step:1352/5560 train_time:323072ms step_avg:238.96ms
+step:1353/5560 train_time:323318ms step_avg:238.96ms
+step:1354/5560 train_time:323564ms step_avg:238.97ms
+step:1355/5560 train_time:323810ms step_avg:238.97ms
+step:1356/5560 train_time:324054ms step_avg:238.98ms
+step:1357/5560 train_time:324300ms step_avg:238.98ms
+step:1358/5560 train_time:324547ms step_avg:238.99ms
+step:1359/5560 train_time:324791ms step_avg:238.99ms
+step:1360/5560 train_time:325037ms step_avg:239.00ms
+step:1361/5560 train_time:325283ms step_avg:239.00ms
+step:1362/5560 train_time:325534ms step_avg:239.01ms
+step:1363/5560 train_time:325778ms step_avg:239.02ms
+step:1364/5560 train_time:326025ms step_avg:239.02ms
+step:1365/5560 train_time:326270ms step_avg:239.03ms
+step:1366/5560 train_time:326514ms step_avg:239.03ms
+step:1367/5560 train_time:326762ms step_avg:239.04ms
+step:1368/5560 train_time:327007ms step_avg:239.04ms
+step:1369/5560 train_time:327257ms step_avg:239.05ms
+step:1370/5560 train_time:327505ms step_avg:239.05ms
+step:1371/5560 train_time:327751ms step_avg:239.06ms
+step:1372/5560 train_time:327996ms step_avg:239.06ms
+step:1373/5560 train_time:328270ms step_avg:239.09ms
+step:1374/5560 train_time:328492ms step_avg:239.08ms
+step:1375/5560 train_time:328738ms step_avg:239.08ms
+step:1375/5560 val_loss:3.272458 train_time:328986ms step_avg:239.26ms
+step:1376/5560 train_time:329003ms step_avg:239.10ms
+step:1377/5560 train_time:329233ms step_avg:239.09ms
+step:1378/5560 train_time:329488ms step_avg:239.11ms
+step:1379/5560 train_time:329732ms step_avg:239.11ms
+step:1380/5560 train_time:329978ms step_avg:239.11ms
+step:1381/5560 train_time:330224ms step_avg:239.12ms
+step:1382/5560 train_time:330477ms step_avg:239.13ms
+step:1383/5560 train_time:330721ms step_avg:239.13ms
+step:1384/5560 train_time:330967ms step_avg:239.14ms
+step:1385/5560 train_time:331211ms step_avg:239.14ms
+step:1386/5560 train_time:331458ms step_avg:239.15ms
+step:1387/5560 train_time:331704ms step_avg:239.15ms
+step:1388/5560 train_time:331949ms step_avg:239.16ms
+step:1389/5560 train_time:332195ms step_avg:239.16ms
+step:1390/5560 train_time:332442ms step_avg:239.17ms
+step:1391/5560 train_time:332687ms step_avg:239.17ms
+step:1392/5560 train_time:332932ms step_avg:239.18ms
+step:1393/5560 train_time:333178ms step_avg:239.18ms
+step:1394/5560 train_time:333422ms step_avg:239.18ms
+step:1395/5560 train_time:333669ms step_avg:239.19ms
+step:1396/5560 train_time:333916ms step_avg:239.19ms
+step:1397/5560 train_time:334160ms step_avg:239.20ms
+step:1398/5560 train_time:334407ms step_avg:239.20ms
+step:1399/5560 train_time:334652ms step_avg:239.21ms
+step:1400/5560 train_time:334901ms step_avg:239.21ms
+step:1401/5560 train_time:335174ms step_avg:239.24ms
+step:1402/5560 train_time:335395ms step_avg:239.23ms
+step:1403/5560 train_time:335640ms step_avg:239.23ms
+step:1404/5560 train_time:335891ms step_avg:239.24ms
+step:1405/5560 train_time:336135ms step_avg:239.24ms
+step:1406/5560 train_time:336383ms step_avg:239.25ms
+step:1407/5560 train_time:336628ms step_avg:239.25ms
+step:1408/5560 train_time:336876ms step_avg:239.26ms
+step:1409/5560 train_time:337126ms step_avg:239.27ms
+step:1410/5560 train_time:337373ms step_avg:239.27ms
+step:1411/5560 train_time:337617ms step_avg:239.28ms
+step:1412/5560 train_time:337864ms step_avg:239.28ms
+step:1413/5560 train_time:338111ms step_avg:239.29ms
+step:1414/5560 train_time:338358ms step_avg:239.29ms
+step:1415/5560 train_time:338601ms step_avg:239.29ms
+step:1416/5560 train_time:338854ms step_avg:239.30ms
+step:1417/5560 train_time:339098ms step_avg:239.31ms
+step:1418/5560 train_time:339344ms step_avg:239.31ms
+step:1419/5560 train_time:339588ms step_avg:239.31ms
+step:1420/5560 train_time:339838ms step_avg:239.32ms
+step:1421/5560 train_time:340084ms step_avg:239.33ms
+step:1422/5560 train_time:340328ms step_avg:239.33ms
+step:1423/5560 train_time:340577ms step_avg:239.34ms
+step:1424/5560 train_time:340823ms step_avg:239.34ms
+step:1425/5560 train_time:341074ms step_avg:239.35ms
+step:1426/5560 train_time:341320ms step_avg:239.35ms
+step:1427/5560 train_time:341566ms step_avg:239.36ms
+step:1428/5560 train_time:341811ms step_avg:239.36ms
+step:1429/5560 train_time:342085ms step_avg:239.39ms
+step:1430/5560 train_time:342308ms step_avg:239.38ms
+step:1431/5560 train_time:342560ms step_avg:239.39ms
+step:1432/5560 train_time:342809ms step_avg:239.39ms
+step:1433/5560 train_time:343057ms step_avg:239.40ms
+step:1434/5560 train_time:343304ms step_avg:239.40ms
+step:1435/5560 train_time:343555ms step_avg:239.41ms
+step:1436/5560 train_time:343800ms step_avg:239.42ms
+step:1437/5560 train_time:344047ms step_avg:239.42ms
+step:1438/5560 train_time:344291ms step_avg:239.42ms
+step:1439/5560 train_time:344538ms step_avg:239.43ms
+step:1440/5560 train_time:344786ms step_avg:239.43ms
+step:1441/5560 train_time:345034ms step_avg:239.44ms
+step:1442/5560 train_time:345280ms step_avg:239.45ms
+step:1443/5560 train_time:345528ms step_avg:239.45ms
+step:1444/5560 train_time:345775ms step_avg:239.46ms
+step:1445/5560 train_time:346020ms step_avg:239.46ms
+step:1446/5560 train_time:346266ms step_avg:239.47ms
+step:1447/5560 train_time:346514ms step_avg:239.47ms
+step:1448/5560 train_time:346758ms step_avg:239.47ms
+step:1449/5560 train_time:347006ms step_avg:239.48ms
+step:1450/5560 train_time:347254ms step_avg:239.49ms
+step:1451/5560 train_time:347501ms step_avg:239.49ms
+step:1452/5560 train_time:347746ms step_avg:239.49ms
+step:1453/5560 train_time:347992ms step_avg:239.50ms
+step:1454/5560 train_time:348236ms step_avg:239.50ms
+step:1455/5560 train_time:348482ms step_avg:239.51ms
+step:1456/5560 train_time:348728ms step_avg:239.51ms
+step:1457/5560 train_time:349007ms step_avg:239.54ms
+step:1458/5560 train_time:349229ms step_avg:239.53ms
+step:1459/5560 train_time:349477ms step_avg:239.53ms
+step:1460/5560 train_time:349722ms step_avg:239.54ms
+step:1461/5560 train_time:349967ms step_avg:239.54ms
+step:1462/5560 train_time:350211ms step_avg:239.54ms
+step:1463/5560 train_time:350459ms step_avg:239.55ms
+step:1464/5560 train_time:350705ms step_avg:239.55ms
+step:1465/5560 train_time:350952ms step_avg:239.56ms
+step:1466/5560 train_time:351198ms step_avg:239.56ms
+step:1467/5560 train_time:351444ms step_avg:239.57ms
+step:1468/5560 train_time:351689ms step_avg:239.57ms
+step:1469/5560 train_time:351934ms step_avg:239.57ms
+step:1470/5560 train_time:352183ms step_avg:239.58ms
+step:1471/5560 train_time:352431ms step_avg:239.59ms
+step:1472/5560 train_time:352680ms step_avg:239.59ms
+step:1473/5560 train_time:352926ms step_avg:239.60ms
+step:1474/5560 train_time:353173ms step_avg:239.60ms
+step:1475/5560 train_time:353417ms step_avg:239.60ms
+step:1476/5560 train_time:353666ms step_avg:239.61ms
+step:1477/5560 train_time:353912ms step_avg:239.62ms
+step:1478/5560 train_time:354162ms step_avg:239.62ms
+step:1479/5560 train_time:354403ms step_avg:239.62ms
+step:1480/5560 train_time:354651ms step_avg:239.63ms
+step:1481/5560 train_time:354901ms step_avg:239.64ms
+step:1482/5560 train_time:355149ms step_avg:239.64ms
+step:1483/5560 train_time:355398ms step_avg:239.65ms
+step:1484/5560 train_time:355642ms step_avg:239.65ms
+step:1485/5560 train_time:355917ms step_avg:239.67ms
+step:1486/5560 train_time:356139ms step_avg:239.66ms
+step:1487/5560 train_time:356389ms step_avg:239.67ms
+step:1488/5560 train_time:356637ms step_avg:239.68ms
+step:1489/5560 train_time:356885ms step_avg:239.68ms
+step:1490/5560 train_time:357133ms step_avg:239.69ms
+step:1491/5560 train_time:357385ms step_avg:239.69ms
+step:1492/5560 train_time:357630ms step_avg:239.70ms
+step:1493/5560 train_time:357876ms step_avg:239.70ms
+step:1494/5560 train_time:358123ms step_avg:239.71ms
+step:1495/5560 train_time:358369ms step_avg:239.71ms
+step:1496/5560 train_time:358615ms step_avg:239.72ms
+step:1497/5560 train_time:358859ms step_avg:239.72ms
+step:1498/5560 train_time:359103ms step_avg:239.72ms
+step:1499/5560 train_time:359350ms step_avg:239.73ms
+step:1500/5560 train_time:359598ms step_avg:239.73ms
+step:1500/5560 val_loss:3.252418 train_time:359848ms step_avg:239.90ms
+step:1501/5560 train_time:359865ms step_avg:239.75ms
+step:1502/5560 train_time:360101ms step_avg:239.75ms
+step:1503/5560 train_time:360359ms step_avg:239.76ms
+step:1504/5560 train_time:360609ms step_avg:239.77ms
+step:1505/5560 train_time:360852ms step_avg:239.77ms
+step:1506/5560 train_time:361097ms step_avg:239.77ms
+step:1507/5560 train_time:361346ms step_avg:239.78ms
+step:1508/5560 train_time:361595ms step_avg:239.78ms
+step:1509/5560 train_time:361842ms step_avg:239.79ms
+step:1510/5560 train_time:362086ms step_avg:239.79ms
+step:1511/5560 train_time:362331ms step_avg:239.80ms
+step:1512/5560 train_time:362580ms step_avg:239.80ms
+step:1513/5560 train_time:362855ms step_avg:239.83ms
+step:1514/5560 train_time:363078ms step_avg:239.81ms
+step:1515/5560 train_time:363326ms step_avg:239.82ms
+step:1516/5560 train_time:363574ms step_avg:239.82ms
+step:1517/5560 train_time:363821ms step_avg:239.83ms
+step:1518/5560 train_time:364068ms step_avg:239.83ms
+step:1519/5560 train_time:364315ms step_avg:239.84ms
+step:1520/5560 train_time:364562ms step_avg:239.84ms
+step:1521/5560 train_time:364811ms step_avg:239.85ms
+step:1522/5560 train_time:365056ms step_avg:239.85ms
+step:1523/5560 train_time:365305ms step_avg:239.86ms
+step:1524/5560 train_time:365549ms step_avg:239.86ms
+step:1525/5560 train_time:365795ms step_avg:239.87ms
+step:1526/5560 train_time:366042ms step_avg:239.87ms
+step:1527/5560 train_time:366288ms step_avg:239.87ms
+step:1528/5560 train_time:366532ms step_avg:239.88ms
+step:1529/5560 train_time:366777ms step_avg:239.88ms
+step:1530/5560 train_time:367022ms step_avg:239.88ms
+step:1531/5560 train_time:367271ms step_avg:239.89ms
+step:1532/5560 train_time:367517ms step_avg:239.89ms
+step:1533/5560 train_time:367763ms step_avg:239.90ms
+step:1534/5560 train_time:368012ms step_avg:239.90ms
+step:1535/5560 train_time:368259ms step_avg:239.91ms
+step:1536/5560 train_time:368509ms step_avg:239.91ms
+step:1537/5560 train_time:368753ms step_avg:239.92ms
+step:1538/5560 train_time:368999ms step_avg:239.92ms
+step:1539/5560 train_time:369246ms step_avg:239.93ms
+step:1540/5560 train_time:369495ms step_avg:239.93ms
+step:1541/5560 train_time:369769ms step_avg:239.95ms
+step:1542/5560 train_time:369997ms step_avg:239.95ms
+step:1543/5560 train_time:370243ms step_avg:239.95ms
+step:1544/5560 train_time:370490ms step_avg:239.95ms
+step:1545/5560 train_time:370733ms step_avg:239.96ms
+step:1546/5560 train_time:370988ms step_avg:239.97ms
+step:1547/5560 train_time:371229ms step_avg:239.97ms
+step:1548/5560 train_time:371483ms step_avg:239.98ms
+step:1549/5560 train_time:371727ms step_avg:239.98ms
+step:1550/5560 train_time:371974ms step_avg:239.98ms
+step:1551/5560 train_time:372219ms step_avg:239.99ms
+step:1552/5560 train_time:372465ms step_avg:239.99ms
+step:1553/5560 train_time:372714ms step_avg:240.00ms
+step:1554/5560 train_time:372960ms step_avg:240.00ms
+step:1555/5560 train_time:373206ms step_avg:240.00ms
+step:1556/5560 train_time:373453ms step_avg:240.01ms
+step:1557/5560 train_time:373700ms step_avg:240.01ms
+step:1558/5560 train_time:373948ms step_avg:240.02ms
+step:1559/5560 train_time:374195ms step_avg:240.02ms
+step:1560/5560 train_time:374444ms step_avg:240.03ms
+step:1561/5560 train_time:374688ms step_avg:240.03ms
+step:1562/5560 train_time:374935ms step_avg:240.04ms
+step:1563/5560 train_time:375180ms step_avg:240.04ms
+step:1564/5560 train_time:375424ms step_avg:240.04ms
+step:1565/5560 train_time:375673ms step_avg:240.05ms
+step:1566/5560 train_time:375920ms step_avg:240.05ms
+step:1567/5560 train_time:376169ms step_avg:240.06ms
+step:1568/5560 train_time:376413ms step_avg:240.06ms
+step:1569/5560 train_time:376687ms step_avg:240.08ms
+step:1570/5560 train_time:376909ms step_avg:240.07ms
+step:1571/5560 train_time:377158ms step_avg:240.07ms
+step:1572/5560 train_time:377413ms step_avg:240.08ms
+step:1573/5560 train_time:377655ms step_avg:240.09ms
+step:1574/5560 train_time:377932ms step_avg:240.11ms
+step:1575/5560 train_time:378177ms step_avg:240.11ms
+step:1576/5560 train_time:378430ms step_avg:240.12ms
+step:1577/5560 train_time:378648ms step_avg:240.11ms
+step:1578/5560 train_time:378893ms step_avg:240.11ms
+step:1579/5560 train_time:379142ms step_avg:240.12ms
+step:1580/5560 train_time:379387ms step_avg:240.12ms
+step:1581/5560 train_time:379631ms step_avg:240.12ms
+step:1582/5560 train_time:379882ms step_avg:240.13ms
+step:1583/5560 train_time:380128ms step_avg:240.13ms
+step:1584/5560 train_time:380375ms step_avg:240.14ms
+step:1585/5560 train_time:380622ms step_avg:240.14ms
+step:1586/5560 train_time:380868ms step_avg:240.14ms
+step:1587/5560 train_time:381115ms step_avg:240.15ms
+step:1588/5560 train_time:381359ms step_avg:240.15ms
+step:1589/5560 train_time:381608ms step_avg:240.16ms
+step:1590/5560 train_time:381851ms step_avg:240.16ms
+step:1591/5560 train_time:382106ms step_avg:240.17ms
+step:1592/5560 train_time:382351ms step_avg:240.17ms
+step:1593/5560 train_time:382600ms step_avg:240.18ms
+step:1594/5560 train_time:382848ms step_avg:240.18ms
+step:1595/5560 train_time:383098ms step_avg:240.19ms
+step:1596/5560 train_time:383346ms step_avg:240.19ms
+step:1597/5560 train_time:383622ms step_avg:240.21ms
+step:1598/5560 train_time:383843ms step_avg:240.20ms
+step:1599/5560 train_time:384091ms step_avg:240.21ms
+step:1600/5560 train_time:384344ms step_avg:240.21ms
+step:1601/5560 train_time:384588ms step_avg:240.22ms
+step:1602/5560 train_time:384875ms step_avg:240.25ms
+step:1603/5560 train_time:385101ms step_avg:240.24ms
+step:1604/5560 train_time:385359ms step_avg:240.25ms
+step:1605/5560 train_time:385572ms step_avg:240.23ms
+step:1606/5560 train_time:385821ms step_avg:240.24ms
+step:1607/5560 train_time:386072ms step_avg:240.24ms
+step:1608/5560 train_time:386321ms step_avg:240.25ms
+step:1609/5560 train_time:386566ms step_avg:240.25ms
+step:1610/5560 train_time:386814ms step_avg:240.26ms
+step:1611/5560 train_time:387069ms step_avg:240.27ms
+step:1612/5560 train_time:387313ms step_avg:240.27ms
+step:1613/5560 train_time:387562ms step_avg:240.27ms
+step:1614/5560 train_time:387810ms step_avg:240.28ms
+step:1615/5560 train_time:388059ms step_avg:240.28ms
+step:1616/5560 train_time:388315ms step_avg:240.29ms
+step:1617/5560 train_time:388560ms step_avg:240.30ms
+step:1618/5560 train_time:388806ms step_avg:240.30ms
+step:1619/5560 train_time:389051ms step_avg:240.30ms
+step:1620/5560 train_time:389300ms step_avg:240.31ms
+step:1621/5560 train_time:389549ms step_avg:240.31ms
+step:1622/5560 train_time:389795ms step_avg:240.32ms
+step:1623/5560 train_time:390039ms step_avg:240.32ms
+step:1624/5560 train_time:390285ms step_avg:240.32ms
+step:1625/5560 train_time:390570ms step_avg:240.35ms
+step:1625/5560 val_loss:3.237617 train_time:390796ms step_avg:240.49ms
+step:1626/5560 train_time:390814ms step_avg:240.35ms
+step:1627/5560 train_time:391045ms step_avg:240.35ms
+step:1628/5560 train_time:391297ms step_avg:240.35ms
+step:1629/5560 train_time:391542ms step_avg:240.36ms
+step:1630/5560 train_time:391786ms step_avg:240.36ms
+step:1631/5560 train_time:392033ms step_avg:240.36ms
+step:1632/5560 train_time:392287ms step_avg:240.37ms
+step:1633/5560 train_time:392530ms step_avg:240.37ms
+step:1634/5560 train_time:392775ms step_avg:240.38ms
+step:1635/5560 train_time:393022ms step_avg:240.38ms
+step:1636/5560 train_time:393271ms step_avg:240.39ms
+step:1637/5560 train_time:393520ms step_avg:240.39ms
+step:1638/5560 train_time:393762ms step_avg:240.39ms
+step:1639/5560 train_time:394017ms step_avg:240.40ms
+step:1640/5560 train_time:394268ms step_avg:240.41ms
+step:1641/5560 train_time:394515ms step_avg:240.41ms
+step:1642/5560 train_time:394761ms step_avg:240.41ms
+step:1643/5560 train_time:395007ms step_avg:240.42ms
+step:1644/5560 train_time:395259ms step_avg:240.43ms
+step:1645/5560 train_time:395508ms step_avg:240.43ms
+step:1646/5560 train_time:395753ms step_avg:240.43ms
+step:1647/5560 train_time:396000ms step_avg:240.44ms
+step:1648/5560 train_time:396246ms step_avg:240.44ms
+step:1649/5560 train_time:396494ms step_avg:240.45ms
+step:1650/5560 train_time:396740ms step_avg:240.45ms
+step:1651/5560 train_time:396986ms step_avg:240.45ms
+step:1652/5560 train_time:397232ms step_avg:240.46ms
+step:1653/5560 train_time:397510ms step_avg:240.48ms
+step:1654/5560 train_time:397734ms step_avg:240.47ms
+step:1655/5560 train_time:397978ms step_avg:240.47ms
+step:1656/5560 train_time:398225ms step_avg:240.47ms
+step:1657/5560 train_time:398479ms step_avg:240.48ms
+step:1658/5560 train_time:398726ms step_avg:240.49ms
+step:1659/5560 train_time:398970ms step_avg:240.49ms
+step:1660/5560 train_time:399217ms step_avg:240.49ms
+step:1661/5560 train_time:399463ms step_avg:240.50ms
+step:1662/5560 train_time:399712ms step_avg:240.50ms
+step:1663/5560 train_time:399956ms step_avg:240.50ms
+step:1664/5560 train_time:400202ms step_avg:240.51ms
+step:1665/5560 train_time:400445ms step_avg:240.51ms
+step:1666/5560 train_time:400692ms step_avg:240.51ms
+step:1667/5560 train_time:400938ms step_avg:240.51ms
+step:1668/5560 train_time:401187ms step_avg:240.52ms
+step:1669/5560 train_time:401434ms step_avg:240.52ms
+step:1670/5560 train_time:401681ms step_avg:240.53ms
+step:1671/5560 train_time:401927ms step_avg:240.53ms
+step:1672/5560 train_time:402182ms step_avg:240.54ms
+step:1673/5560 train_time:402425ms step_avg:240.54ms
+step:1674/5560 train_time:402674ms step_avg:240.55ms
+step:1675/5560 train_time:402921ms step_avg:240.55ms
+step:1676/5560 train_time:403168ms step_avg:240.55ms
+step:1677/5560 train_time:403418ms step_avg:240.56ms
+step:1678/5560 train_time:403664ms step_avg:240.56ms
+step:1679/5560 train_time:403913ms step_avg:240.57ms
+step:1680/5560 train_time:404160ms step_avg:240.57ms
+step:1681/5560 train_time:404438ms step_avg:240.59ms
+step:1682/5560 train_time:404659ms step_avg:240.58ms
+step:1683/5560 train_time:404908ms step_avg:240.59ms
+step:1684/5560 train_time:405156ms step_avg:240.59ms
+step:1685/5560 train_time:405406ms step_avg:240.60ms
+step:1686/5560 train_time:405656ms step_avg:240.60ms
+step:1687/5560 train_time:405903ms step_avg:240.61ms
+step:1688/5560 train_time:406150ms step_avg:240.61ms
+step:1689/5560 train_time:406398ms step_avg:240.61ms
+step:1690/5560 train_time:406643ms step_avg:240.62ms
+step:1691/5560 train_time:406893ms step_avg:240.62ms
+step:1692/5560 train_time:407138ms step_avg:240.63ms
+step:1693/5560 train_time:407384ms step_avg:240.63ms
+step:1694/5560 train_time:407632ms step_avg:240.63ms
+step:1695/5560 train_time:407878ms step_avg:240.64ms
+step:1696/5560 train_time:408126ms step_avg:240.64ms
+step:1697/5560 train_time:408373ms step_avg:240.64ms
+step:1698/5560 train_time:408617ms step_avg:240.65ms
+step:1699/5560 train_time:408863ms step_avg:240.65ms
+step:1700/5560 train_time:409112ms step_avg:240.65ms
+step:1701/5560 train_time:409358ms step_avg:240.66ms
+step:1702/5560 train_time:409607ms step_avg:240.66ms
+step:1703/5560 train_time:409852ms step_avg:240.66ms
+step:1704/5560 train_time:410097ms step_avg:240.67ms
+step:1705/5560 train_time:410344ms step_avg:240.67ms
+step:1706/5560 train_time:410588ms step_avg:240.67ms
+step:1707/5560 train_time:410834ms step_avg:240.68ms
+step:1708/5560 train_time:411082ms step_avg:240.68ms
+step:1709/5560 train_time:411355ms step_avg:240.70ms
+step:1710/5560 train_time:411579ms step_avg:240.69ms
+step:1711/5560 train_time:411828ms step_avg:240.69ms
+step:1712/5560 train_time:412072ms step_avg:240.70ms
+step:1713/5560 train_time:412318ms step_avg:240.70ms
+step:1714/5560 train_time:412562ms step_avg:240.70ms
+step:1715/5560 train_time:412814ms step_avg:240.71ms
+step:1716/5560 train_time:413062ms step_avg:240.71ms
+step:1717/5560 train_time:413308ms step_avg:240.71ms
+step:1718/5560 train_time:413552ms step_avg:240.72ms
+step:1719/5560 train_time:413799ms step_avg:240.72ms
+step:1720/5560 train_time:414046ms step_avg:240.72ms
+step:1721/5560 train_time:414300ms step_avg:240.73ms
+step:1722/5560 train_time:414545ms step_avg:240.73ms
+step:1723/5560 train_time:414791ms step_avg:240.74ms
+step:1724/5560 train_time:415038ms step_avg:240.74ms
+step:1725/5560 train_time:415286ms step_avg:240.75ms
+step:1726/5560 train_time:415532ms step_avg:240.75ms
+step:1727/5560 train_time:415777ms step_avg:240.75ms
+step:1728/5560 train_time:416027ms step_avg:240.76ms
+step:1729/5560 train_time:416271ms step_avg:240.76ms
+step:1730/5560 train_time:416518ms step_avg:240.76ms
+step:1731/5560 train_time:416767ms step_avg:240.77ms
+step:1732/5560 train_time:417012ms step_avg:240.77ms
+step:1733/5560 train_time:417261ms step_avg:240.77ms
+step:1734/5560 train_time:417507ms step_avg:240.78ms
+step:1735/5560 train_time:417759ms step_avg:240.78ms
+step:1736/5560 train_time:418006ms step_avg:240.79ms
+step:1737/5560 train_time:418280ms step_avg:240.81ms
+step:1738/5560 train_time:418505ms step_avg:240.80ms
+step:1739/5560 train_time:418751ms step_avg:240.80ms
+step:1740/5560 train_time:418995ms step_avg:240.80ms
+step:1741/5560 train_time:419244ms step_avg:240.81ms
+step:1742/5560 train_time:419492ms step_avg:240.81ms
+step:1743/5560 train_time:419740ms step_avg:240.81ms
+step:1744/5560 train_time:419986ms step_avg:240.82ms
+step:1745/5560 train_time:420231ms step_avg:240.82ms
+step:1746/5560 train_time:420476ms step_avg:240.82ms
+step:1747/5560 train_time:420724ms step_avg:240.83ms
+step:1748/5560 train_time:420974ms step_avg:240.83ms
+step:1749/5560 train_time:421224ms step_avg:240.84ms
+step:1750/5560 train_time:421470ms step_avg:240.84ms
+step:1750/5560 val_loss:3.222570 train_time:421719ms step_avg:240.98ms
+step:1751/5560 train_time:421738ms step_avg:240.86ms
+step:1752/5560 train_time:421967ms step_avg:240.85ms
+step:1753/5560 train_time:422226ms step_avg:240.86ms
+step:1754/5560 train_time:422473ms step_avg:240.86ms
+step:1755/5560 train_time:422721ms step_avg:240.87ms
+step:1756/5560 train_time:422969ms step_avg:240.87ms
+step:1757/5560 train_time:423218ms step_avg:240.88ms
+step:1758/5560 train_time:423461ms step_avg:240.88ms
+step:1759/5560 train_time:423710ms step_avg:240.88ms
+step:1760/5560 train_time:423958ms step_avg:240.89ms
+step:1761/5560 train_time:424207ms step_avg:240.89ms
+step:1762/5560 train_time:424454ms step_avg:240.89ms
+step:1763/5560 train_time:424698ms step_avg:240.89ms
+step:1764/5560 train_time:424943ms step_avg:240.90ms
+step:1765/5560 train_time:425220ms step_avg:240.92ms
+step:1766/5560 train_time:425442ms step_avg:240.91ms
+step:1767/5560 train_time:425688ms step_avg:240.91ms
+step:1768/5560 train_time:425935ms step_avg:240.91ms
+step:1769/5560 train_time:426181ms step_avg:240.92ms
+step:1770/5560 train_time:426436ms step_avg:240.92ms
+step:1771/5560 train_time:426687ms step_avg:240.93ms
+step:1772/5560 train_time:426931ms step_avg:240.93ms
+step:1773/5560 train_time:427176ms step_avg:240.93ms
+step:1774/5560 train_time:427424ms step_avg:240.94ms
+step:1775/5560 train_time:427678ms step_avg:240.95ms
+step:1776/5560 train_time:427923ms step_avg:240.95ms
+step:1777/5560 train_time:428169ms step_avg:240.95ms
+step:1778/5560 train_time:428416ms step_avg:240.95ms
+step:1779/5560 train_time:428662ms step_avg:240.96ms
+step:1780/5560 train_time:428909ms step_avg:240.96ms
+step:1781/5560 train_time:429154ms step_avg:240.96ms
+step:1782/5560 train_time:429403ms step_avg:240.97ms
+step:1783/5560 train_time:429650ms step_avg:240.97ms
+step:1784/5560 train_time:429899ms step_avg:240.97ms
+step:1785/5560 train_time:430144ms step_avg:240.98ms
+step:1786/5560 train_time:430388ms step_avg:240.98ms
+step:1787/5560 train_time:430637ms step_avg:240.98ms
+step:1788/5560 train_time:430884ms step_avg:240.99ms
+step:1789/5560 train_time:431130ms step_avg:240.99ms
+step:1790/5560 train_time:431374ms step_avg:240.99ms
+step:1791/5560 train_time:431621ms step_avg:240.99ms
+step:1792/5560 train_time:431868ms step_avg:241.00ms
+step:1793/5560 train_time:432141ms step_avg:241.02ms
+step:1794/5560 train_time:432363ms step_avg:241.01ms
+step:1795/5560 train_time:432610ms step_avg:241.01ms
+step:1796/5560 train_time:432854ms step_avg:241.01ms
+step:1797/5560 train_time:433103ms step_avg:241.01ms
+step:1798/5560 train_time:433348ms step_avg:241.02ms
+step:1799/5560 train_time:433594ms step_avg:241.02ms
+step:1800/5560 train_time:433842ms step_avg:241.02ms
+step:1801/5560 train_time:434086ms step_avg:241.03ms
+step:1802/5560 train_time:434336ms step_avg:241.03ms
+step:1803/5560 train_time:434584ms step_avg:241.03ms
+step:1804/5560 train_time:434837ms step_avg:241.04ms
+step:1805/5560 train_time:435080ms step_avg:241.04ms
+step:1806/5560 train_time:435326ms step_avg:241.04ms
+step:1807/5560 train_time:435577ms step_avg:241.05ms
+step:1808/5560 train_time:435821ms step_avg:241.05ms
+step:1809/5560 train_time:436067ms step_avg:241.05ms
+step:1810/5560 train_time:436316ms step_avg:241.06ms
+step:1811/5560 train_time:436564ms step_avg:241.06ms
+step:1812/5560 train_time:436812ms step_avg:241.07ms
+step:1813/5560 train_time:437058ms step_avg:241.07ms
+step:1814/5560 train_time:437307ms step_avg:241.07ms
+step:1815/5560 train_time:437552ms step_avg:241.08ms
+step:1816/5560 train_time:437799ms step_avg:241.08ms
+step:1817/5560 train_time:438046ms step_avg:241.08ms
+step:1818/5560 train_time:438295ms step_avg:241.09ms
+step:1819/5560 train_time:438539ms step_avg:241.09ms
+step:1820/5560 train_time:438783ms step_avg:241.09ms
+step:1821/5560 train_time:439059ms step_avg:241.11ms
+step:1822/5560 train_time:439283ms step_avg:241.10ms
+step:1823/5560 train_time:439529ms step_avg:241.10ms
+step:1824/5560 train_time:439774ms step_avg:241.10ms
+step:1825/5560 train_time:440021ms step_avg:241.11ms
+step:1826/5560 train_time:440270ms step_avg:241.11ms
+step:1827/5560 train_time:440518ms step_avg:241.12ms
+step:1828/5560 train_time:440764ms step_avg:241.12ms
+step:1829/5560 train_time:441015ms step_avg:241.12ms
+step:1830/5560 train_time:441261ms step_avg:241.13ms
+step:1831/5560 train_time:441506ms step_avg:241.13ms
+step:1832/5560 train_time:441752ms step_avg:241.13ms
+step:1833/5560 train_time:441997ms step_avg:241.13ms
+step:1834/5560 train_time:442245ms step_avg:241.14ms
+step:1835/5560 train_time:442493ms step_avg:241.14ms
+step:1836/5560 train_time:442740ms step_avg:241.14ms
+step:1837/5560 train_time:442985ms step_avg:241.15ms
+step:1838/5560 train_time:443231ms step_avg:241.15ms
+step:1839/5560 train_time:443476ms step_avg:241.15ms
+step:1840/5560 train_time:443725ms step_avg:241.15ms
+step:1841/5560 train_time:443969ms step_avg:241.16ms
+step:1842/5560 train_time:444217ms step_avg:241.16ms
+step:1843/5560 train_time:444468ms step_avg:241.17ms
+step:1844/5560 train_time:444713ms step_avg:241.17ms
+step:1845/5560 train_time:444957ms step_avg:241.17ms
+step:1846/5560 train_time:445204ms step_avg:241.17ms
+step:1847/5560 train_time:445454ms step_avg:241.18ms
+step:1848/5560 train_time:445700ms step_avg:241.18ms
+step:1849/5560 train_time:445979ms step_avg:241.20ms
+step:1850/5560 train_time:446201ms step_avg:241.19ms
+step:1851/5560 train_time:446449ms step_avg:241.19ms
+step:1852/5560 train_time:446695ms step_avg:241.20ms
+step:1853/5560 train_time:446941ms step_avg:241.20ms
+step:1854/5560 train_time:447191ms step_avg:241.20ms
+step:1855/5560 train_time:447436ms step_avg:241.21ms
+step:1856/5560 train_time:447684ms step_avg:241.21ms
+step:1857/5560 train_time:447931ms step_avg:241.21ms
+step:1858/5560 train_time:448184ms step_avg:241.22ms
+step:1859/5560 train_time:448435ms step_avg:241.22ms
+step:1860/5560 train_time:448681ms step_avg:241.23ms
+step:1861/5560 train_time:448928ms step_avg:241.23ms
+step:1862/5560 train_time:449177ms step_avg:241.23ms
+step:1863/5560 train_time:449425ms step_avg:241.24ms
+step:1864/5560 train_time:449672ms step_avg:241.24ms
+step:1865/5560 train_time:449921ms step_avg:241.24ms
+step:1866/5560 train_time:450168ms step_avg:241.25ms
+step:1867/5560 train_time:450419ms step_avg:241.25ms
+step:1868/5560 train_time:450666ms step_avg:241.26ms
+step:1869/5560 train_time:450917ms step_avg:241.26ms
+step:1870/5560 train_time:451162ms step_avg:241.26ms
+step:1871/5560 train_time:451409ms step_avg:241.27ms
+step:1872/5560 train_time:451660ms step_avg:241.27ms
+step:1873/5560 train_time:451909ms step_avg:241.28ms
+step:1874/5560 train_time:452160ms step_avg:241.28ms
+step:1875/5560 train_time:452403ms step_avg:241.28ms
+step:1875/5560 val_loss:3.204628 train_time:452652ms step_avg:241.41ms
+step:1876/5560 train_time:452671ms step_avg:241.30ms
+step:1877/5560 train_time:452929ms step_avg:241.30ms
+step:1878/5560 train_time:453157ms step_avg:241.30ms
+step:1879/5560 train_time:453406ms step_avg:241.30ms
+step:1880/5560 train_time:453651ms step_avg:241.30ms
+step:1881/5560 train_time:453896ms step_avg:241.31ms
+step:1882/5560 train_time:454147ms step_avg:241.31ms
+step:1883/5560 train_time:454397ms step_avg:241.32ms
+step:1884/5560 train_time:454645ms step_avg:241.32ms
+step:1885/5560 train_time:454895ms step_avg:241.32ms
+step:1886/5560 train_time:455145ms step_avg:241.33ms
+step:1887/5560 train_time:455396ms step_avg:241.33ms
+step:1888/5560 train_time:455646ms step_avg:241.34ms
+step:1889/5560 train_time:455892ms step_avg:241.34ms
+step:1890/5560 train_time:456141ms step_avg:241.34ms
+step:1891/5560 train_time:456389ms step_avg:241.35ms
+step:1892/5560 train_time:456636ms step_avg:241.35ms
+step:1893/5560 train_time:456887ms step_avg:241.36ms
+step:1894/5560 train_time:457134ms step_avg:241.36ms
+step:1895/5560 train_time:457381ms step_avg:241.36ms
+step:1896/5560 train_time:457630ms step_avg:241.37ms
+step:1897/5560 train_time:457883ms step_avg:241.37ms
+step:1898/5560 train_time:458130ms step_avg:241.38ms
+step:1899/5560 train_time:458375ms step_avg:241.38ms
+step:1900/5560 train_time:458624ms step_avg:241.38ms
+step:1901/5560 train_time:458871ms step_avg:241.38ms
+step:1902/5560 train_time:459120ms step_avg:241.39ms
+step:1903/5560 train_time:459369ms step_avg:241.39ms
+step:1904/5560 train_time:459618ms step_avg:241.40ms
+step:1905/5560 train_time:459897ms step_avg:241.42ms
+step:1906/5560 train_time:460122ms step_avg:241.41ms
+step:1907/5560 train_time:460369ms step_avg:241.41ms
+step:1908/5560 train_time:460618ms step_avg:241.41ms
+step:1909/5560 train_time:460867ms step_avg:241.42ms
+step:1910/5560 train_time:461118ms step_avg:241.42ms
+step:1911/5560 train_time:461368ms step_avg:241.43ms
+step:1912/5560 train_time:461613ms step_avg:241.43ms
+step:1913/5560 train_time:461859ms step_avg:241.43ms
+step:1914/5560 train_time:462115ms step_avg:241.44ms
+step:1915/5560 train_time:462369ms step_avg:241.45ms
+step:1916/5560 train_time:462624ms step_avg:241.45ms
+step:1917/5560 train_time:462873ms step_avg:241.46ms
+step:1918/5560 train_time:463121ms step_avg:241.46ms
+step:1919/5560 train_time:463373ms step_avg:241.47ms
+step:1920/5560 train_time:463625ms step_avg:241.47ms
+step:1921/5560 train_time:463872ms step_avg:241.47ms
+step:1922/5560 train_time:464123ms step_avg:241.48ms
+step:1923/5560 train_time:464373ms step_avg:241.48ms
+step:1924/5560 train_time:464623ms step_avg:241.49ms
+step:1925/5560 train_time:464871ms step_avg:241.49ms
+step:1926/5560 train_time:465116ms step_avg:241.49ms
+step:1927/5560 train_time:465362ms step_avg:241.50ms
+step:1928/5560 train_time:465618ms step_avg:241.50ms
+step:1929/5560 train_time:465867ms step_avg:241.51ms
+step:1930/5560 train_time:466115ms step_avg:241.51ms
+step:1931/5560 train_time:466363ms step_avg:241.51ms
+step:1932/5560 train_time:466614ms step_avg:241.52ms
+step:1933/5560 train_time:466900ms step_avg:241.54ms
+step:1934/5560 train_time:467125ms step_avg:241.53ms
+step:1935/5560 train_time:467376ms step_avg:241.54ms
+step:1936/5560 train_time:467627ms step_avg:241.54ms
+step:1937/5560 train_time:467876ms step_avg:241.55ms
+step:1938/5560 train_time:468125ms step_avg:241.55ms
+step:1939/5560 train_time:468373ms step_avg:241.55ms
+step:1940/5560 train_time:468622ms step_avg:241.56ms
+step:1941/5560 train_time:468868ms step_avg:241.56ms
+step:1942/5560 train_time:469114ms step_avg:241.56ms
+step:1943/5560 train_time:469364ms step_avg:241.57ms
+step:1944/5560 train_time:469611ms step_avg:241.57ms
+step:1945/5560 train_time:469860ms step_avg:241.57ms
+step:1946/5560 train_time:470111ms step_avg:241.58ms
+step:1947/5560 train_time:470356ms step_avg:241.58ms
+step:1948/5560 train_time:470615ms step_avg:241.59ms
+step:1949/5560 train_time:470862ms step_avg:241.59ms
+step:1950/5560 train_time:471113ms step_avg:241.60ms
+step:1951/5560 train_time:471362ms step_avg:241.60ms
+step:1952/5560 train_time:471613ms step_avg:241.60ms
+step:1953/5560 train_time:471864ms step_avg:241.61ms
+step:1954/5560 train_time:472111ms step_avg:241.61ms
+step:1955/5560 train_time:472356ms step_avg:241.61ms
+step:1956/5560 train_time:472609ms step_avg:241.62ms
+step:1957/5560 train_time:472857ms step_avg:241.62ms
+step:1958/5560 train_time:473104ms step_avg:241.63ms
+step:1959/5560 train_time:473352ms step_avg:241.63ms
+step:1960/5560 train_time:473604ms step_avg:241.63ms
+step:1961/5560 train_time:473888ms step_avg:241.66ms
+step:1962/5560 train_time:474111ms step_avg:241.65ms
+step:1963/5560 train_time:474359ms step_avg:241.65ms
+step:1964/5560 train_time:474605ms step_avg:241.65ms
+step:1965/5560 train_time:474855ms step_avg:241.66ms
+step:1966/5560 train_time:475109ms step_avg:241.66ms
+step:1967/5560 train_time:475358ms step_avg:241.67ms
+step:1968/5560 train_time:475604ms step_avg:241.67ms
+step:1969/5560 train_time:475854ms step_avg:241.67ms
+step:1970/5560 train_time:476107ms step_avg:241.68ms
+step:1971/5560 train_time:476354ms step_avg:241.68ms
+step:1972/5560 train_time:476602ms step_avg:241.68ms
+step:1973/5560 train_time:476851ms step_avg:241.69ms
+step:1974/5560 train_time:477098ms step_avg:241.69ms
+step:1975/5560 train_time:477351ms step_avg:241.70ms
+step:1976/5560 train_time:477600ms step_avg:241.70ms
+step:1977/5560 train_time:477850ms step_avg:241.70ms
+step:1978/5560 train_time:478098ms step_avg:241.71ms
+step:1979/5560 train_time:478347ms step_avg:241.71ms
+step:1980/5560 train_time:478594ms step_avg:241.71ms
+step:1981/5560 train_time:478844ms step_avg:241.72ms
+step:1982/5560 train_time:479090ms step_avg:241.72ms
+step:1983/5560 train_time:479339ms step_avg:241.72ms
+step:1984/5560 train_time:479587ms step_avg:241.73ms
+step:1985/5560 train_time:479836ms step_avg:241.73ms
+step:1986/5560 train_time:480081ms step_avg:241.73ms
+step:1987/5560 train_time:480329ms step_avg:241.74ms
+step:1988/5560 train_time:480576ms step_avg:241.74ms
+step:1989/5560 train_time:480856ms step_avg:241.76ms
+step:1990/5560 train_time:481080ms step_avg:241.75ms
+step:1991/5560 train_time:481333ms step_avg:241.75ms
+step:1992/5560 train_time:481582ms step_avg:241.76ms
+step:1993/5560 train_time:481834ms step_avg:241.76ms
+step:1994/5560 train_time:482081ms step_avg:241.77ms
+step:1995/5560 train_time:482337ms step_avg:241.77ms
+step:1996/5560 train_time:482582ms step_avg:241.77ms
+step:1997/5560 train_time:482833ms step_avg:241.78ms
+step:1998/5560 train_time:483079ms step_avg:241.78ms
+step:1999/5560 train_time:483328ms step_avg:241.79ms
+step:2000/5560 train_time:483575ms step_avg:241.79ms
+step:2000/5560 val_loss:3.187847 train_time:483824ms step_avg:241.91ms
+step:2001/5560 train_time:483841ms step_avg:241.80ms
+step:2002/5560 train_time:484072ms step_avg:241.79ms
+step:2003/5560 train_time:484328ms step_avg:241.80ms
+step:2004/5560 train_time:484574ms step_avg:241.80ms
+step:2005/5560 train_time:484821ms step_avg:241.81ms
+step:2006/5560 train_time:485068ms step_avg:241.81ms
+step:2007/5560 train_time:485318ms step_avg:241.81ms
+step:2008/5560 train_time:485568ms step_avg:241.82ms
+step:2009/5560 train_time:485829ms step_avg:241.83ms
+step:2010/5560 train_time:486075ms step_avg:241.83ms
+step:2011/5560 train_time:486322ms step_avg:241.83ms
+step:2012/5560 train_time:486572ms step_avg:241.83ms
+step:2013/5560 train_time:486826ms step_avg:241.84ms
+step:2014/5560 train_time:487073ms step_avg:241.84ms
+step:2015/5560 train_time:487321ms step_avg:241.85ms
+step:2016/5560 train_time:487571ms step_avg:241.85ms
+step:2017/5560 train_time:487850ms step_avg:241.87ms
+step:2018/5560 train_time:488084ms step_avg:241.87ms
+step:2019/5560 train_time:488337ms step_avg:241.87ms
+step:2020/5560 train_time:488584ms step_avg:241.87ms
+step:2021/5560 train_time:488832ms step_avg:241.88ms
+step:2022/5560 train_time:489083ms step_avg:241.88ms
+step:2023/5560 train_time:489334ms step_avg:241.89ms
+step:2024/5560 train_time:489583ms step_avg:241.89ms
+step:2025/5560 train_time:489833ms step_avg:241.89ms
+step:2026/5560 train_time:490085ms step_avg:241.90ms
+step:2027/5560 train_time:490340ms step_avg:241.90ms
+step:2028/5560 train_time:490591ms step_avg:241.91ms
+step:2029/5560 train_time:490840ms step_avg:241.91ms
+step:2030/5560 train_time:491093ms step_avg:241.92ms
+step:2031/5560 train_time:491339ms step_avg:241.92ms
+step:2032/5560 train_time:491586ms step_avg:241.92ms
+step:2033/5560 train_time:491834ms step_avg:241.93ms
+step:2034/5560 train_time:492081ms step_avg:241.93ms
+step:2035/5560 train_time:492329ms step_avg:241.93ms
+step:2036/5560 train_time:492583ms step_avg:241.94ms
+step:2037/5560 train_time:492831ms step_avg:241.94ms
+step:2038/5560 train_time:493080ms step_avg:241.94ms
+step:2039/5560 train_time:493331ms step_avg:241.95ms
+step:2040/5560 train_time:493580ms step_avg:241.95ms
+step:2041/5560 train_time:493829ms step_avg:241.95ms
+step:2042/5560 train_time:494076ms step_avg:241.96ms
+step:2043/5560 train_time:494329ms step_avg:241.96ms
+step:2044/5560 train_time:494577ms step_avg:241.97ms
+step:2045/5560 train_time:494854ms step_avg:241.98ms
+step:2046/5560 train_time:495080ms step_avg:241.97ms
+step:2047/5560 train_time:495337ms step_avg:241.98ms
+step:2048/5560 train_time:495590ms step_avg:241.99ms
+step:2049/5560 train_time:495849ms step_avg:242.00ms
+step:2050/5560 train_time:496099ms step_avg:242.00ms
+step:2051/5560 train_time:496348ms step_avg:242.00ms
+step:2052/5560 train_time:496600ms step_avg:242.01ms
+step:2053/5560 train_time:496849ms step_avg:242.01ms
+step:2054/5560 train_time:497096ms step_avg:242.01ms
+step:2055/5560 train_time:497345ms step_avg:242.02ms
+step:2056/5560 train_time:497593ms step_avg:242.02ms
+step:2057/5560 train_time:497844ms step_avg:242.02ms
+step:2058/5560 train_time:498090ms step_avg:242.03ms
+step:2059/5560 train_time:498339ms step_avg:242.03ms
+step:2060/5560 train_time:498586ms step_avg:242.03ms
+step:2061/5560 train_time:498841ms step_avg:242.04ms
+step:2062/5560 train_time:499090ms step_avg:242.04ms
+step:2063/5560 train_time:499337ms step_avg:242.04ms
+step:2064/5560 train_time:499581ms step_avg:242.05ms
+step:2065/5560 train_time:499834ms step_avg:242.05ms
+step:2066/5560 train_time:500087ms step_avg:242.06ms
+step:2067/5560 train_time:500333ms step_avg:242.06ms
+step:2068/5560 train_time:500581ms step_avg:242.06ms
+step:2069/5560 train_time:500835ms step_avg:242.07ms
+step:2070/5560 train_time:501081ms step_avg:242.07ms
+step:2071/5560 train_time:501330ms step_avg:242.07ms
+step:2072/5560 train_time:501577ms step_avg:242.07ms
+step:2073/5560 train_time:501857ms step_avg:242.09ms
+step:2074/5560 train_time:502083ms step_avg:242.08ms
+step:2075/5560 train_time:502332ms step_avg:242.09ms
+step:2076/5560 train_time:502585ms step_avg:242.09ms
+step:2077/5560 train_time:502833ms step_avg:242.10ms
+step:2078/5560 train_time:503080ms step_avg:242.10ms
+step:2079/5560 train_time:503333ms step_avg:242.10ms
+step:2080/5560 train_time:503582ms step_avg:242.11ms
+step:2081/5560 train_time:503834ms step_avg:242.11ms
+step:2082/5560 train_time:504083ms step_avg:242.11ms
+step:2083/5560 train_time:504332ms step_avg:242.12ms
+step:2084/5560 train_time:504582ms step_avg:242.12ms
+step:2085/5560 train_time:504827ms step_avg:242.12ms
+step:2086/5560 train_time:505078ms step_avg:242.13ms
+step:2087/5560 train_time:505328ms step_avg:242.13ms
+step:2088/5560 train_time:505578ms step_avg:242.14ms
+step:2089/5560 train_time:505827ms step_avg:242.14ms
+step:2090/5560 train_time:506076ms step_avg:242.14ms
+step:2091/5560 train_time:506324ms step_avg:242.14ms
+step:2092/5560 train_time:506572ms step_avg:242.15ms
+step:2093/5560 train_time:506822ms step_avg:242.15ms
+step:2094/5560 train_time:507070ms step_avg:242.15ms
+step:2095/5560 train_time:507325ms step_avg:242.16ms
+step:2096/5560 train_time:507577ms step_avg:242.16ms
+step:2097/5560 train_time:507825ms step_avg:242.17ms
+step:2098/5560 train_time:508070ms step_avg:242.17ms
+step:2099/5560 train_time:508317ms step_avg:242.17ms
+step:2100/5560 train_time:508568ms step_avg:242.18ms
+step:2101/5560 train_time:508851ms step_avg:242.19ms
+step:2102/5560 train_time:509083ms step_avg:242.19ms
+step:2103/5560 train_time:509328ms step_avg:242.19ms
+step:2104/5560 train_time:509575ms step_avg:242.19ms
+step:2105/5560 train_time:509822ms step_avg:242.20ms
+step:2106/5560 train_time:510077ms step_avg:242.20ms
+step:2107/5560 train_time:510328ms step_avg:242.21ms
+step:2108/5560 train_time:510573ms step_avg:242.21ms
+step:2109/5560 train_time:510829ms step_avg:242.21ms
+step:2110/5560 train_time:511082ms step_avg:242.22ms
+step:2111/5560 train_time:511332ms step_avg:242.22ms
+step:2112/5560 train_time:511582ms step_avg:242.23ms
+step:2113/5560 train_time:511836ms step_avg:242.23ms
+step:2114/5560 train_time:512086ms step_avg:242.24ms
+step:2115/5560 train_time:512334ms step_avg:242.24ms
+step:2116/5560 train_time:512580ms step_avg:242.24ms
+step:2117/5560 train_time:512832ms step_avg:242.24ms
+step:2118/5560 train_time:513083ms step_avg:242.25ms
+step:2119/5560 train_time:513330ms step_avg:242.25ms
+step:2120/5560 train_time:513577ms step_avg:242.25ms
+step:2121/5560 train_time:513825ms step_avg:242.26ms
+step:2122/5560 train_time:514074ms step_avg:242.26ms
+step:2123/5560 train_time:514319ms step_avg:242.26ms
+step:2124/5560 train_time:514567ms step_avg:242.26ms
+step:2125/5560 train_time:514819ms step_avg:242.27ms
+step:2125/5560 val_loss:3.173286 train_time:515069ms step_avg:242.39ms
+step:2126/5560 train_time:515088ms step_avg:242.28ms
+step:2127/5560 train_time:515317ms step_avg:242.27ms
+step:2128/5560 train_time:515575ms step_avg:242.28ms
+step:2129/5560 train_time:515851ms step_avg:242.30ms
+step:2130/5560 train_time:516072ms step_avg:242.29ms
+step:2131/5560 train_time:516321ms step_avg:242.29ms
+step:2132/5560 train_time:516570ms step_avg:242.29ms
+step:2133/5560 train_time:516819ms step_avg:242.30ms
+step:2134/5560 train_time:517067ms step_avg:242.30ms
+step:2135/5560 train_time:517318ms step_avg:242.30ms
+step:2136/5560 train_time:517567ms step_avg:242.31ms
+step:2137/5560 train_time:517815ms step_avg:242.31ms
+step:2138/5560 train_time:518061ms step_avg:242.31ms
+step:2139/5560 train_time:518305ms step_avg:242.31ms
+step:2140/5560 train_time:518555ms step_avg:242.32ms
+step:2141/5560 train_time:518802ms step_avg:242.32ms
+step:2142/5560 train_time:519051ms step_avg:242.32ms
+step:2143/5560 train_time:519299ms step_avg:242.32ms
+step:2144/5560 train_time:519546ms step_avg:242.33ms
+step:2145/5560 train_time:519796ms step_avg:242.33ms
+step:2146/5560 train_time:520049ms step_avg:242.33ms
+step:2147/5560 train_time:520298ms step_avg:242.34ms
+step:2148/5560 train_time:520546ms step_avg:242.34ms
+step:2149/5560 train_time:520796ms step_avg:242.34ms
+step:2150/5560 train_time:521046ms step_avg:242.35ms
+step:2151/5560 train_time:521293ms step_avg:242.35ms
+step:2152/5560 train_time:521539ms step_avg:242.35ms
+step:2153/5560 train_time:521787ms step_avg:242.35ms
+step:2154/5560 train_time:522040ms step_avg:242.36ms
+step:2155/5560 train_time:522292ms step_avg:242.36ms
+step:2156/5560 train_time:522541ms step_avg:242.37ms
+step:2157/5560 train_time:522816ms step_avg:242.38ms
+step:2158/5560 train_time:523039ms step_avg:242.37ms
+step:2159/5560 train_time:523285ms step_avg:242.37ms
+step:2160/5560 train_time:523539ms step_avg:242.38ms
+step:2161/5560 train_time:523787ms step_avg:242.38ms
+step:2162/5560 train_time:524036ms step_avg:242.38ms
+step:2163/5560 train_time:524285ms step_avg:242.39ms
+step:2164/5560 train_time:524538ms step_avg:242.39ms
+step:2165/5560 train_time:524785ms step_avg:242.39ms
+step:2166/5560 train_time:525034ms step_avg:242.40ms
+step:2167/5560 train_time:525278ms step_avg:242.40ms
+step:2168/5560 train_time:525526ms step_avg:242.40ms
+step:2169/5560 train_time:525775ms step_avg:242.40ms
+step:2170/5560 train_time:526024ms step_avg:242.41ms
+step:2171/5560 train_time:526272ms step_avg:242.41ms
+step:2172/5560 train_time:526521ms step_avg:242.41ms
+step:2173/5560 train_time:526766ms step_avg:242.41ms
+step:2174/5560 train_time:527017ms step_avg:242.42ms
+step:2175/5560 train_time:527262ms step_avg:242.42ms
+step:2176/5560 train_time:527512ms step_avg:242.42ms
+step:2177/5560 train_time:527759ms step_avg:242.42ms
+step:2178/5560 train_time:528011ms step_avg:242.43ms
+step:2179/5560 train_time:528260ms step_avg:242.43ms
+step:2180/5560 train_time:528510ms step_avg:242.44ms
+step:2181/5560 train_time:528760ms step_avg:242.44ms
+step:2182/5560 train_time:529010ms step_avg:242.44ms
+step:2183/5560 train_time:529261ms step_avg:242.45ms
+step:2184/5560 train_time:529512ms step_avg:242.45ms
+step:2185/5560 train_time:529787ms step_avg:242.47ms
+step:2186/5560 train_time:530011ms step_avg:242.46ms
+step:2187/5560 train_time:530261ms step_avg:242.46ms
+step:2188/5560 train_time:530508ms step_avg:242.46ms
+step:2189/5560 train_time:530757ms step_avg:242.47ms
+step:2190/5560 train_time:531006ms step_avg:242.47ms
+step:2191/5560 train_time:531255ms step_avg:242.47ms
+step:2192/5560 train_time:531504ms step_avg:242.47ms
+step:2193/5560 train_time:531751ms step_avg:242.48ms
+step:2194/5560 train_time:532004ms step_avg:242.48ms
+step:2195/5560 train_time:532252ms step_avg:242.48ms
+step:2196/5560 train_time:532524ms step_avg:242.50ms
+step:2197/5560 train_time:532779ms step_avg:242.50ms
+step:2198/5560 train_time:533017ms step_avg:242.50ms
+step:2199/5560 train_time:533237ms step_avg:242.49ms
+step:2200/5560 train_time:533485ms step_avg:242.49ms
+step:2201/5560 train_time:533739ms step_avg:242.50ms
+step:2202/5560 train_time:533984ms step_avg:242.50ms
+step:2203/5560 train_time:534241ms step_avg:242.51ms
+step:2204/5560 train_time:534493ms step_avg:242.51ms
+step:2205/5560 train_time:534745ms step_avg:242.51ms
+step:2206/5560 train_time:534990ms step_avg:242.52ms
+step:2207/5560 train_time:535249ms step_avg:242.52ms
+step:2208/5560 train_time:535497ms step_avg:242.53ms
+step:2209/5560 train_time:535744ms step_avg:242.53ms
+step:2210/5560 train_time:535992ms step_avg:242.53ms
+step:2211/5560 train_time:536239ms step_avg:242.53ms
+step:2212/5560 train_time:536487ms step_avg:242.54ms
+step:2213/5560 train_time:536766ms step_avg:242.55ms
+step:2214/5560 train_time:536987ms step_avg:242.54ms
+step:2215/5560 train_time:537235ms step_avg:242.54ms
+step:2216/5560 train_time:537481ms step_avg:242.55ms
+step:2217/5560 train_time:537740ms step_avg:242.55ms
+step:2218/5560 train_time:537987ms step_avg:242.55ms
+step:2219/5560 train_time:538237ms step_avg:242.56ms
+step:2220/5560 train_time:538485ms step_avg:242.56ms
+step:2221/5560 train_time:538736ms step_avg:242.56ms
+step:2222/5560 train_time:538983ms step_avg:242.57ms
+step:2223/5560 train_time:539235ms step_avg:242.57ms
+step:2224/5560 train_time:539485ms step_avg:242.57ms
+step:2225/5560 train_time:539730ms step_avg:242.58ms
+step:2226/5560 train_time:539980ms step_avg:242.58ms
+step:2227/5560 train_time:540231ms step_avg:242.58ms
+step:2228/5560 train_time:540488ms step_avg:242.59ms
+step:2229/5560 train_time:540734ms step_avg:242.59ms
+step:2230/5560 train_time:540981ms step_avg:242.59ms
+step:2231/5560 train_time:541233ms step_avg:242.60ms
+step:2232/5560 train_time:541483ms step_avg:242.60ms
+step:2233/5560 train_time:541731ms step_avg:242.60ms
+step:2234/5560 train_time:541975ms step_avg:242.60ms
+step:2235/5560 train_time:542224ms step_avg:242.61ms
+step:2236/5560 train_time:542480ms step_avg:242.61ms
+step:2237/5560 train_time:542730ms step_avg:242.62ms
+step:2238/5560 train_time:542976ms step_avg:242.62ms
+step:2239/5560 train_time:543226ms step_avg:242.62ms
+step:2240/5560 train_time:543477ms step_avg:242.62ms
+step:2241/5560 train_time:543759ms step_avg:242.64ms
+step:2242/5560 train_time:543983ms step_avg:242.63ms
+step:2243/5560 train_time:544229ms step_avg:242.63ms
+step:2244/5560 train_time:544482ms step_avg:242.64ms
+step:2245/5560 train_time:544735ms step_avg:242.64ms
+step:2246/5560 train_time:544983ms step_avg:242.65ms
+step:2247/5560 train_time:545228ms step_avg:242.65ms
+step:2248/5560 train_time:545484ms step_avg:242.65ms
+step:2249/5560 train_time:545731ms step_avg:242.66ms
+step:2250/5560 train_time:545976ms step_avg:242.66ms
+step:2250/5560 val_loss:3.159346 train_time:546225ms step_avg:242.77ms
+step:2251/5560 train_time:546245ms step_avg:242.67ms
+step:2252/5560 train_time:546475ms step_avg:242.66ms
+step:2253/5560 train_time:546731ms step_avg:242.67ms
+step:2254/5560 train_time:546975ms step_avg:242.67ms
+step:2255/5560 train_time:547221ms step_avg:242.67ms
+step:2256/5560 train_time:547470ms step_avg:242.67ms
+step:2257/5560 train_time:547723ms step_avg:242.68ms
+step:2258/5560 train_time:547975ms step_avg:242.68ms
+step:2259/5560 train_time:548225ms step_avg:242.68ms
+step:2260/5560 train_time:548469ms step_avg:242.69ms
+step:2261/5560 train_time:548718ms step_avg:242.69ms
+step:2262/5560 train_time:548966ms step_avg:242.69ms
+step:2263/5560 train_time:549216ms step_avg:242.69ms
+step:2264/5560 train_time:549466ms step_avg:242.70ms
+step:2265/5560 train_time:549713ms step_avg:242.70ms
+step:2266/5560 train_time:549961ms step_avg:242.70ms
+step:2267/5560 train_time:550210ms step_avg:242.70ms
+step:2268/5560 train_time:550456ms step_avg:242.71ms
+step:2269/5560 train_time:550732ms step_avg:242.72ms
+step:2270/5560 train_time:550956ms step_avg:242.71ms
+step:2271/5560 train_time:551207ms step_avg:242.72ms
+step:2272/5560 train_time:551462ms step_avg:242.72ms
+step:2273/5560 train_time:551707ms step_avg:242.72ms
+step:2274/5560 train_time:551960ms step_avg:242.73ms
+step:2275/5560 train_time:552211ms step_avg:242.73ms
+step:2276/5560 train_time:552459ms step_avg:242.73ms
+step:2277/5560 train_time:552706ms step_avg:242.73ms
+step:2278/5560 train_time:552952ms step_avg:242.74ms
+step:2279/5560 train_time:553204ms step_avg:242.74ms
+step:2280/5560 train_time:553451ms step_avg:242.74ms
+step:2281/5560 train_time:553698ms step_avg:242.74ms
+step:2282/5560 train_time:553945ms step_avg:242.75ms
+step:2283/5560 train_time:554192ms step_avg:242.75ms
+step:2284/5560 train_time:554443ms step_avg:242.75ms
+step:2285/5560 train_time:554695ms step_avg:242.75ms
+step:2286/5560 train_time:554941ms step_avg:242.76ms
+step:2287/5560 train_time:555190ms step_avg:242.76ms
+step:2288/5560 train_time:555443ms step_avg:242.76ms
+step:2289/5560 train_time:555694ms step_avg:242.77ms
+step:2290/5560 train_time:555942ms step_avg:242.77ms
+step:2291/5560 train_time:556188ms step_avg:242.77ms
+step:2292/5560 train_time:556440ms step_avg:242.77ms
+step:2293/5560 train_time:556690ms step_avg:242.78ms
+step:2294/5560 train_time:556939ms step_avg:242.78ms
+step:2295/5560 train_time:557185ms step_avg:242.78ms
+step:2296/5560 train_time:557437ms step_avg:242.79ms
+step:2297/5560 train_time:557718ms step_avg:242.80ms
+step:2298/5560 train_time:557943ms step_avg:242.80ms
+step:2299/5560 train_time:558194ms step_avg:242.80ms
+step:2300/5560 train_time:558441ms step_avg:242.80ms
+step:2301/5560 train_time:558690ms step_avg:242.80ms
+step:2302/5560 train_time:558940ms step_avg:242.81ms
+step:2303/5560 train_time:559187ms step_avg:242.81ms
+step:2304/5560 train_time:559435ms step_avg:242.81ms
+step:2305/5560 train_time:559684ms step_avg:242.81ms
+step:2306/5560 train_time:559937ms step_avg:242.82ms
+step:2307/5560 train_time:560187ms step_avg:242.82ms
+step:2308/5560 train_time:560435ms step_avg:242.82ms
+step:2309/5560 train_time:560688ms step_avg:242.83ms
+step:2310/5560 train_time:560935ms step_avg:242.83ms
+step:2311/5560 train_time:561184ms step_avg:242.83ms
+step:2312/5560 train_time:561434ms step_avg:242.83ms
+step:2313/5560 train_time:561681ms step_avg:242.84ms
+step:2314/5560 train_time:561929ms step_avg:242.84ms
+step:2315/5560 train_time:562181ms step_avg:242.84ms
+step:2316/5560 train_time:562432ms step_avg:242.85ms
+step:2317/5560 train_time:562678ms step_avg:242.85ms
+step:2318/5560 train_time:562926ms step_avg:242.85ms
+step:2319/5560 train_time:563182ms step_avg:242.86ms
+step:2320/5560 train_time:563430ms step_avg:242.86ms
+step:2321/5560 train_time:563685ms step_avg:242.86ms
+step:2322/5560 train_time:563937ms step_avg:242.87ms
+step:2323/5560 train_time:564184ms step_avg:242.87ms
+step:2324/5560 train_time:564430ms step_avg:242.87ms
+step:2325/5560 train_time:564711ms step_avg:242.89ms
+step:2326/5560 train_time:564938ms step_avg:242.88ms
+step:2327/5560 train_time:565189ms step_avg:242.88ms
+step:2328/5560 train_time:565440ms step_avg:242.89ms
+step:2329/5560 train_time:565687ms step_avg:242.89ms
+step:2330/5560 train_time:565942ms step_avg:242.89ms
+step:2331/5560 train_time:566185ms step_avg:242.89ms
+step:2332/5560 train_time:566439ms step_avg:242.90ms
+step:2333/5560 train_time:566684ms step_avg:242.90ms
+step:2334/5560 train_time:566932ms step_avg:242.90ms
+step:2335/5560 train_time:567180ms step_avg:242.90ms
+step:2336/5560 train_time:567436ms step_avg:242.91ms
+step:2337/5560 train_time:567684ms step_avg:242.91ms
+step:2338/5560 train_time:567966ms step_avg:242.93ms
+step:2339/5560 train_time:568205ms step_avg:242.93ms
+step:2340/5560 train_time:568459ms step_avg:242.93ms
+step:2341/5560 train_time:568674ms step_avg:242.92ms
+step:2342/5560 train_time:568926ms step_avg:242.92ms
+step:2343/5560 train_time:569175ms step_avg:242.93ms
+step:2344/5560 train_time:569424ms step_avg:242.93ms
+step:2345/5560 train_time:569679ms step_avg:242.93ms
+step:2346/5560 train_time:569926ms step_avg:242.94ms
+step:2347/5560 train_time:570178ms step_avg:242.94ms
+step:2348/5560 train_time:570427ms step_avg:242.94ms
+step:2349/5560 train_time:570677ms step_avg:242.94ms
+step:2350/5560 train_time:570926ms step_avg:242.95ms
+step:2351/5560 train_time:571175ms step_avg:242.95ms
+step:2352/5560 train_time:571422ms step_avg:242.95ms
+step:2353/5560 train_time:571699ms step_avg:242.97ms
+step:2354/5560 train_time:571926ms step_avg:242.96ms
+step:2355/5560 train_time:572175ms step_avg:242.96ms
+step:2356/5560 train_time:572435ms step_avg:242.97ms
+step:2357/5560 train_time:572686ms step_avg:242.97ms
+step:2358/5560 train_time:572933ms step_avg:242.97ms
+step:2359/5560 train_time:573183ms step_avg:242.98ms
+step:2360/5560 train_time:573428ms step_avg:242.98ms
+step:2361/5560 train_time:573679ms step_avg:242.98ms
+step:2362/5560 train_time:573927ms step_avg:242.98ms
+step:2363/5560 train_time:574180ms step_avg:242.99ms
+step:2364/5560 train_time:574429ms step_avg:242.99ms
+step:2365/5560 train_time:574677ms step_avg:242.99ms
+step:2366/5560 train_time:574929ms step_avg:243.00ms
+step:2367/5560 train_time:575180ms step_avg:243.00ms
+step:2368/5560 train_time:575435ms step_avg:243.00ms
+step:2369/5560 train_time:575683ms step_avg:243.01ms
+step:2370/5560 train_time:575929ms step_avg:243.01ms
+step:2371/5560 train_time:576175ms step_avg:243.01ms
+step:2372/5560 train_time:576424ms step_avg:243.01ms
+step:2373/5560 train_time:576669ms step_avg:243.01ms
+step:2374/5560 train_time:576919ms step_avg:243.02ms
+step:2375/5560 train_time:577168ms step_avg:243.02ms
+step:2375/5560 val_loss:3.148065 train_time:577415ms step_avg:243.12ms
+step:2376/5560 train_time:577434ms step_avg:243.03ms
+step:2377/5560 train_time:577666ms step_avg:243.02ms
+step:2378/5560 train_time:577920ms step_avg:243.03ms
+step:2379/5560 train_time:578168ms step_avg:243.03ms
+step:2380/5560 train_time:578412ms step_avg:243.03ms
+step:2381/5560 train_time:578688ms step_avg:243.04ms
+step:2382/5560 train_time:578918ms step_avg:243.04ms
+step:2383/5560 train_time:579168ms step_avg:243.04ms
+step:2384/5560 train_time:579412ms step_avg:243.04ms
+step:2385/5560 train_time:579657ms step_avg:243.04ms
+step:2386/5560 train_time:579906ms step_avg:243.05ms
+step:2387/5560 train_time:580157ms step_avg:243.05ms
+step:2388/5560 train_time:580404ms step_avg:243.05ms
+step:2389/5560 train_time:580651ms step_avg:243.05ms
+step:2390/5560 train_time:580901ms step_avg:243.05ms
+step:2391/5560 train_time:581147ms step_avg:243.06ms
+step:2392/5560 train_time:581396ms step_avg:243.06ms
+step:2393/5560 train_time:581644ms step_avg:243.06ms
+step:2394/5560 train_time:581894ms step_avg:243.06ms
+step:2395/5560 train_time:582146ms step_avg:243.07ms
+step:2396/5560 train_time:582395ms step_avg:243.07ms
+step:2397/5560 train_time:582645ms step_avg:243.07ms
+step:2398/5560 train_time:582898ms step_avg:243.08ms
+step:2399/5560 train_time:583153ms step_avg:243.08ms
+step:2400/5560 train_time:583403ms step_avg:243.08ms
+step:2401/5560 train_time:583650ms step_avg:243.09ms
+step:2402/5560 train_time:583902ms step_avg:243.09ms
+step:2403/5560 train_time:584154ms step_avg:243.09ms
+step:2404/5560 train_time:584402ms step_avg:243.10ms
+step:2405/5560 train_time:584650ms step_avg:243.10ms
+step:2406/5560 train_time:584898ms step_avg:243.10ms
+step:2407/5560 train_time:585151ms step_avg:243.10ms
+step:2408/5560 train_time:585400ms step_avg:243.11ms
+step:2409/5560 train_time:585676ms step_avg:243.12ms
+step:2410/5560 train_time:585899ms step_avg:243.11ms
+step:2411/5560 train_time:586153ms step_avg:243.12ms
+step:2412/5560 train_time:586403ms step_avg:243.12ms
+step:2413/5560 train_time:586650ms step_avg:243.12ms
+step:2414/5560 train_time:586896ms step_avg:243.12ms
+step:2415/5560 train_time:587157ms step_avg:243.13ms
+step:2416/5560 train_time:587405ms step_avg:243.13ms
+step:2417/5560 train_time:587654ms step_avg:243.13ms
+step:2418/5560 train_time:587901ms step_avg:243.14ms
+step:2419/5560 train_time:588149ms step_avg:243.14ms
+step:2420/5560 train_time:588396ms step_avg:243.14ms
+step:2421/5560 train_time:588649ms step_avg:243.14ms
+step:2422/5560 train_time:588898ms step_avg:243.15ms
+step:2423/5560 train_time:589154ms step_avg:243.15ms
+step:2424/5560 train_time:589401ms step_avg:243.15ms
+step:2425/5560 train_time:589651ms step_avg:243.16ms
+step:2426/5560 train_time:589898ms step_avg:243.16ms
+step:2427/5560 train_time:590146ms step_avg:243.16ms
+step:2428/5560 train_time:590398ms step_avg:243.16ms
+step:2429/5560 train_time:590651ms step_avg:243.17ms
+step:2430/5560 train_time:590899ms step_avg:243.17ms
+step:2431/5560 train_time:591186ms step_avg:243.19ms
+step:2432/5560 train_time:591422ms step_avg:243.18ms
+step:2433/5560 train_time:591676ms step_avg:243.19ms
+step:2434/5560 train_time:591890ms step_avg:243.18ms
+step:2435/5560 train_time:592140ms step_avg:243.18ms
+step:2436/5560 train_time:592388ms step_avg:243.18ms
+step:2437/5560 train_time:592663ms step_avg:243.19ms
+step:2438/5560 train_time:592887ms step_avg:243.19ms
+step:2439/5560 train_time:593140ms step_avg:243.19ms
+step:2440/5560 train_time:593388ms step_avg:243.19ms
+step:2441/5560 train_time:593638ms step_avg:243.19ms
+step:2442/5560 train_time:593884ms step_avg:243.20ms
+step:2443/5560 train_time:594132ms step_avg:243.20ms
+step:2444/5560 train_time:594377ms step_avg:243.20ms
+step:2445/5560 train_time:594629ms step_avg:243.20ms
+step:2446/5560 train_time:594876ms step_avg:243.20ms
+step:2447/5560 train_time:595124ms step_avg:243.21ms
+step:2448/5560 train_time:595371ms step_avg:243.21ms
+step:2449/5560 train_time:595621ms step_avg:243.21ms
+step:2450/5560 train_time:595869ms step_avg:243.21ms
+step:2451/5560 train_time:596117ms step_avg:243.21ms
+step:2452/5560 train_time:596374ms step_avg:243.22ms
+step:2453/5560 train_time:596623ms step_avg:243.22ms
+step:2454/5560 train_time:596873ms step_avg:243.22ms
+step:2455/5560 train_time:597127ms step_avg:243.23ms
+step:2456/5560 train_time:597376ms step_avg:243.23ms
+step:2457/5560 train_time:597624ms step_avg:243.23ms
+step:2458/5560 train_time:597871ms step_avg:243.23ms
+step:2459/5560 train_time:598127ms step_avg:243.24ms
+step:2460/5560 train_time:598377ms step_avg:243.24ms
+step:2461/5560 train_time:598626ms step_avg:243.25ms
+step:2462/5560 train_time:598872ms step_avg:243.25ms
+step:2463/5560 train_time:599121ms step_avg:243.25ms
+step:2464/5560 train_time:599371ms step_avg:243.25ms
+step:2465/5560 train_time:599657ms step_avg:243.27ms
+step:2466/5560 train_time:599890ms step_avg:243.26ms
+step:2467/5560 train_time:600136ms step_avg:243.27ms
+step:2468/5560 train_time:600385ms step_avg:243.27ms
+step:2469/5560 train_time:600632ms step_avg:243.27ms
+step:2470/5560 train_time:600881ms step_avg:243.27ms
+step:2471/5560 train_time:601128ms step_avg:243.27ms
+step:2472/5560 train_time:601375ms step_avg:243.27ms
+step:2473/5560 train_time:601624ms step_avg:243.28ms
+step:2474/5560 train_time:601880ms step_avg:243.28ms
+step:2475/5560 train_time:602131ms step_avg:243.29ms
+step:2476/5560 train_time:602376ms step_avg:243.29ms
+step:2477/5560 train_time:602624ms step_avg:243.29ms
+step:2478/5560 train_time:602877ms step_avg:243.29ms
+step:2479/5560 train_time:603127ms step_avg:243.29ms
+step:2480/5560 train_time:603377ms step_avg:243.30ms
+step:2481/5560 train_time:603624ms step_avg:243.30ms
+step:2482/5560 train_time:603871ms step_avg:243.30ms
+step:2483/5560 train_time:604122ms step_avg:243.30ms
+step:2484/5560 train_time:604373ms step_avg:243.31ms
+step:2485/5560 train_time:604620ms step_avg:243.31ms
+step:2486/5560 train_time:604867ms step_avg:243.31ms
+step:2487/5560 train_time:605115ms step_avg:243.31ms
+step:2488/5560 train_time:605363ms step_avg:243.31ms
+step:2489/5560 train_time:605616ms step_avg:243.32ms
+step:2490/5560 train_time:605863ms step_avg:243.32ms
+step:2491/5560 train_time:606113ms step_avg:243.32ms
+step:2492/5560 train_time:606364ms step_avg:243.32ms
+step:2493/5560 train_time:606643ms step_avg:243.34ms
+step:2494/5560 train_time:606881ms step_avg:243.34ms
+step:2495/5560 train_time:607130ms step_avg:243.34ms
+step:2496/5560 train_time:607376ms step_avg:243.34ms
+step:2497/5560 train_time:607625ms step_avg:243.34ms
+step:2498/5560 train_time:607876ms step_avg:243.34ms
+step:2499/5560 train_time:608127ms step_avg:243.35ms
+step:2500/5560 train_time:608373ms step_avg:243.35ms
+step:2500/5560 val_loss:3.136405 train_time:608623ms step_avg:243.45ms
+step:2501/5560 train_time:608675ms step_avg:243.37ms
+step:2502/5560 train_time:608882ms step_avg:243.36ms
+step:2503/5560 train_time:609145ms step_avg:243.37ms
+step:2504/5560 train_time:609424ms step_avg:243.38ms
+step:2505/5560 train_time:609661ms step_avg:243.38ms
+step:2506/5560 train_time:609910ms step_avg:243.38ms
+step:2507/5560 train_time:610129ms step_avg:243.37ms
+step:2508/5560 train_time:610379ms step_avg:243.37ms
+step:2509/5560 train_time:610625ms step_avg:243.37ms
+step:2510/5560 train_time:610883ms step_avg:243.38ms
+step:2511/5560 train_time:611131ms step_avg:243.38ms
+step:2512/5560 train_time:611379ms step_avg:243.38ms
+step:2513/5560 train_time:611628ms step_avg:243.39ms
+step:2514/5560 train_time:611880ms step_avg:243.39ms
+step:2515/5560 train_time:612128ms step_avg:243.39ms
+step:2516/5560 train_time:612374ms step_avg:243.39ms
+step:2517/5560 train_time:612620ms step_avg:243.39ms
+step:2518/5560 train_time:612869ms step_avg:243.40ms
+step:2519/5560 train_time:613123ms step_avg:243.40ms
+step:2520/5560 train_time:613376ms step_avg:243.40ms
+step:2521/5560 train_time:613652ms step_avg:243.42ms
+step:2522/5560 train_time:613879ms step_avg:243.41ms
+step:2523/5560 train_time:614127ms step_avg:243.41ms
+step:2524/5560 train_time:614375ms step_avg:243.41ms
+step:2525/5560 train_time:614622ms step_avg:243.41ms
+step:2526/5560 train_time:614879ms step_avg:243.42ms
+step:2527/5560 train_time:615128ms step_avg:243.42ms
+step:2528/5560 train_time:615376ms step_avg:243.42ms
+step:2529/5560 train_time:615622ms step_avg:243.42ms
+step:2530/5560 train_time:615870ms step_avg:243.43ms
+step:2531/5560 train_time:616120ms step_avg:243.43ms
+step:2532/5560 train_time:616373ms step_avg:243.43ms
+step:2533/5560 train_time:616619ms step_avg:243.43ms
+step:2534/5560 train_time:616872ms step_avg:243.44ms
+step:2535/5560 train_time:617116ms step_avg:243.44ms
+step:2536/5560 train_time:617371ms step_avg:243.44ms
+step:2537/5560 train_time:617618ms step_avg:243.44ms
+step:2538/5560 train_time:617866ms step_avg:243.45ms
+step:2539/5560 train_time:618116ms step_avg:243.45ms
+step:2540/5560 train_time:618367ms step_avg:243.45ms
+step:2541/5560 train_time:618614ms step_avg:243.45ms
+step:2542/5560 train_time:618865ms step_avg:243.46ms
+step:2543/5560 train_time:619118ms step_avg:243.46ms
+step:2544/5560 train_time:619372ms step_avg:243.46ms
+step:2545/5560 train_time:619622ms step_avg:243.47ms
+step:2546/5560 train_time:619872ms step_avg:243.47ms
+step:2547/5560 train_time:620120ms step_avg:243.47ms
+step:2548/5560 train_time:620368ms step_avg:243.47ms
+step:2549/5560 train_time:620644ms step_avg:243.49ms
+step:2550/5560 train_time:620869ms step_avg:243.48ms
+step:2551/5560 train_time:621121ms step_avg:243.48ms
+step:2552/5560 train_time:621368ms step_avg:243.48ms
+step:2553/5560 train_time:621616ms step_avg:243.48ms
+step:2554/5560 train_time:621868ms step_avg:243.49ms
+step:2555/5560 train_time:622118ms step_avg:243.49ms
+step:2556/5560 train_time:622368ms step_avg:243.49ms
+step:2557/5560 train_time:622622ms step_avg:243.50ms
+step:2558/5560 train_time:622869ms step_avg:243.50ms
+step:2559/5560 train_time:623116ms step_avg:243.50ms
+step:2560/5560 train_time:623365ms step_avg:243.50ms
+step:2561/5560 train_time:623612ms step_avg:243.50ms
+step:2562/5560 train_time:623865ms step_avg:243.51ms
+step:2563/5560 train_time:624111ms step_avg:243.51ms
+step:2564/5560 train_time:624361ms step_avg:243.51ms
+step:2565/5560 train_time:624607ms step_avg:243.51ms
+step:2566/5560 train_time:624854ms step_avg:243.51ms
+step:2567/5560 train_time:625102ms step_avg:243.51ms
+step:2568/5560 train_time:625353ms step_avg:243.52ms
+step:2569/5560 train_time:625601ms step_avg:243.52ms
+step:2570/5560 train_time:625851ms step_avg:243.52ms
+step:2571/5560 train_time:626101ms step_avg:243.52ms
+step:2572/5560 train_time:626350ms step_avg:243.53ms
+step:2573/5560 train_time:626597ms step_avg:243.53ms
+step:2574/5560 train_time:626853ms step_avg:243.53ms
+step:2575/5560 train_time:627098ms step_avg:243.53ms
+step:2576/5560 train_time:627347ms step_avg:243.54ms
+step:2577/5560 train_time:627624ms step_avg:243.55ms
+step:2578/5560 train_time:627851ms step_avg:243.54ms
+step:2579/5560 train_time:628098ms step_avg:243.54ms
+step:2580/5560 train_time:628348ms step_avg:243.55ms
+step:2581/5560 train_time:628597ms step_avg:243.55ms
+step:2582/5560 train_time:628848ms step_avg:243.55ms
+step:2583/5560 train_time:629096ms step_avg:243.55ms
+step:2584/5560 train_time:629354ms step_avg:243.56ms
+step:2585/5560 train_time:629598ms step_avg:243.56ms
+step:2586/5560 train_time:629850ms step_avg:243.56ms
+step:2587/5560 train_time:630099ms step_avg:243.56ms
+step:2588/5560 train_time:630350ms step_avg:243.57ms
+step:2589/5560 train_time:630596ms step_avg:243.57ms
+step:2590/5560 train_time:630847ms step_avg:243.57ms
+step:2591/5560 train_time:631093ms step_avg:243.57ms
+step:2592/5560 train_time:631343ms step_avg:243.57ms
+step:2593/5560 train_time:631588ms step_avg:243.57ms
+step:2594/5560 train_time:631838ms step_avg:243.58ms
+step:2595/5560 train_time:632087ms step_avg:243.58ms
+step:2596/5560 train_time:632340ms step_avg:243.58ms
+step:2597/5560 train_time:632590ms step_avg:243.59ms
+step:2598/5560 train_time:632840ms step_avg:243.59ms
+step:2599/5560 train_time:633086ms step_avg:243.59ms
+step:2600/5560 train_time:633336ms step_avg:243.59ms
+step:2601/5560 train_time:633584ms step_avg:243.59ms
+step:2602/5560 train_time:633833ms step_avg:243.59ms
+step:2603/5560 train_time:634084ms step_avg:243.60ms
+step:2604/5560 train_time:634335ms step_avg:243.60ms
+step:2605/5560 train_time:634614ms step_avg:243.61ms
+step:2606/5560 train_time:634839ms step_avg:243.61ms
+step:2607/5560 train_time:635092ms step_avg:243.61ms
+step:2608/5560 train_time:635342ms step_avg:243.61ms
+step:2609/5560 train_time:635589ms step_avg:243.61ms
+step:2610/5560 train_time:635836ms step_avg:243.62ms
+step:2611/5560 train_time:636088ms step_avg:243.62ms
+step:2612/5560 train_time:636339ms step_avg:243.62ms
+step:2613/5560 train_time:636585ms step_avg:243.62ms
+step:2614/5560 train_time:636834ms step_avg:243.62ms
+step:2615/5560 train_time:637081ms step_avg:243.63ms
+step:2616/5560 train_time:637335ms step_avg:243.63ms
+step:2617/5560 train_time:637586ms step_avg:243.63ms
+step:2618/5560 train_time:637832ms step_avg:243.63ms
+step:2619/5560 train_time:638078ms step_avg:243.63ms
+step:2620/5560 train_time:638332ms step_avg:243.64ms
+step:2621/5560 train_time:638582ms step_avg:243.64ms
+step:2622/5560 train_time:638827ms step_avg:243.64ms
+step:2623/5560 train_time:639075ms step_avg:243.64ms
+step:2624/5560 train_time:639323ms step_avg:243.64ms
+step:2625/5560 train_time:639578ms step_avg:243.65ms
+step:2625/5560 val_loss:3.124990 train_time:639826ms step_avg:243.74ms
+step:2626/5560 train_time:639844ms step_avg:243.66ms
+step:2627/5560 train_time:640075ms step_avg:243.65ms
+step:2628/5560 train_time:640331ms step_avg:243.66ms
+step:2629/5560 train_time:640577ms step_avg:243.66ms
+step:2630/5560 train_time:640820ms step_avg:243.66ms
+step:2631/5560 train_time:641080ms step_avg:243.66ms
+step:2632/5560 train_time:641332ms step_avg:243.67ms
+step:2633/5560 train_time:641605ms step_avg:243.68ms
+step:2634/5560 train_time:641828ms step_avg:243.67ms
+step:2635/5560 train_time:642081ms step_avg:243.67ms
+step:2636/5560 train_time:642334ms step_avg:243.68ms
+step:2637/5560 train_time:642585ms step_avg:243.68ms
+step:2638/5560 train_time:642832ms step_avg:243.68ms
+step:2639/5560 train_time:643083ms step_avg:243.68ms
+step:2640/5560 train_time:643334ms step_avg:243.69ms
+step:2641/5560 train_time:643581ms step_avg:243.69ms
+step:2642/5560 train_time:643826ms step_avg:243.69ms
+step:2643/5560 train_time:644074ms step_avg:243.69ms
+step:2644/5560 train_time:644325ms step_avg:243.69ms
+step:2645/5560 train_time:644573ms step_avg:243.69ms
+step:2646/5560 train_time:644821ms step_avg:243.70ms
+step:2647/5560 train_time:645068ms step_avg:243.70ms
+step:2648/5560 train_time:645317ms step_avg:243.70ms
+step:2649/5560 train_time:645574ms step_avg:243.70ms
+step:2650/5560 train_time:645820ms step_avg:243.71ms
+step:2651/5560 train_time:646068ms step_avg:243.71ms
+step:2652/5560 train_time:646314ms step_avg:243.71ms
+step:2653/5560 train_time:646565ms step_avg:243.71ms
+step:2654/5560 train_time:646815ms step_avg:243.71ms
+step:2655/5560 train_time:647067ms step_avg:243.72ms
+step:2656/5560 train_time:647315ms step_avg:243.72ms
+step:2657/5560 train_time:647563ms step_avg:243.72ms
+step:2658/5560 train_time:647811ms step_avg:243.72ms
+step:2659/5560 train_time:648060ms step_avg:243.72ms
+step:2660/5560 train_time:648310ms step_avg:243.73ms
+step:2661/5560 train_time:648585ms step_avg:243.74ms
+step:2662/5560 train_time:648810ms step_avg:243.73ms
+step:2663/5560 train_time:649060ms step_avg:243.73ms
+step:2664/5560 train_time:649307ms step_avg:243.73ms
+step:2665/5560 train_time:649556ms step_avg:243.74ms
+step:2666/5560 train_time:649803ms step_avg:243.74ms
+step:2667/5560 train_time:650050ms step_avg:243.74ms
+step:2668/5560 train_time:650299ms step_avg:243.74ms
+step:2669/5560 train_time:650550ms step_avg:243.74ms
+step:2670/5560 train_time:650800ms step_avg:243.75ms
+step:2671/5560 train_time:651054ms step_avg:243.75ms
+step:2672/5560 train_time:651302ms step_avg:243.75ms
+step:2673/5560 train_time:651553ms step_avg:243.75ms
+step:2674/5560 train_time:651801ms step_avg:243.76ms
+step:2675/5560 train_time:652051ms step_avg:243.76ms
+step:2676/5560 train_time:652297ms step_avg:243.76ms
+step:2677/5560 train_time:652548ms step_avg:243.76ms
+step:2678/5560 train_time:652799ms step_avg:243.76ms
+step:2679/5560 train_time:653047ms step_avg:243.77ms
+step:2680/5560 train_time:653298ms step_avg:243.77ms
+step:2681/5560 train_time:653549ms step_avg:243.77ms
+step:2682/5560 train_time:653796ms step_avg:243.77ms
+step:2683/5560 train_time:654042ms step_avg:243.77ms
+step:2684/5560 train_time:654292ms step_avg:243.77ms
+step:2685/5560 train_time:654541ms step_avg:243.78ms
+step:2686/5560 train_time:654789ms step_avg:243.78ms
+step:2687/5560 train_time:655038ms step_avg:243.78ms
+step:2688/5560 train_time:655285ms step_avg:243.78ms
+step:2689/5560 train_time:655569ms step_avg:243.80ms
+step:2690/5560 train_time:655796ms step_avg:243.79ms
+step:2691/5560 train_time:656045ms step_avg:243.79ms
+step:2692/5560 train_time:656292ms step_avg:243.79ms
+step:2693/5560 train_time:656538ms step_avg:243.79ms
+step:2694/5560 train_time:656796ms step_avg:243.80ms
+step:2695/5560 train_time:657041ms step_avg:243.80ms
+step:2696/5560 train_time:657293ms step_avg:243.80ms
+step:2697/5560 train_time:657543ms step_avg:243.81ms
+step:2698/5560 train_time:657790ms step_avg:243.81ms
+step:2699/5560 train_time:658041ms step_avg:243.81ms
+step:2700/5560 train_time:658290ms step_avg:243.81ms
+step:2701/5560 train_time:658538ms step_avg:243.81ms
+step:2702/5560 train_time:658788ms step_avg:243.81ms
+step:2703/5560 train_time:659041ms step_avg:243.82ms
+step:2704/5560 train_time:659295ms step_avg:243.82ms
+step:2705/5560 train_time:659543ms step_avg:243.82ms
+step:2706/5560 train_time:659793ms step_avg:243.83ms
+step:2707/5560 train_time:660039ms step_avg:243.83ms
+step:2708/5560 train_time:660289ms step_avg:243.83ms
+step:2709/5560 train_time:660540ms step_avg:243.83ms
+step:2710/5560 train_time:660787ms step_avg:243.83ms
+step:2711/5560 train_time:661034ms step_avg:243.83ms
+step:2712/5560 train_time:661288ms step_avg:243.84ms
+step:2713/5560 train_time:661534ms step_avg:243.84ms
+step:2714/5560 train_time:661781ms step_avg:243.84ms
+step:2715/5560 train_time:662027ms step_avg:243.84ms
+step:2716/5560 train_time:662277ms step_avg:243.84ms
+step:2717/5560 train_time:662553ms step_avg:243.85ms
+step:2718/5560 train_time:662779ms step_avg:243.85ms
+step:2719/5560 train_time:663030ms step_avg:243.85ms
+step:2720/5560 train_time:663274ms step_avg:243.85ms
+step:2721/5560 train_time:663521ms step_avg:243.85ms
+step:2722/5560 train_time:663772ms step_avg:243.85ms
+step:2723/5560 train_time:664020ms step_avg:243.86ms
+step:2724/5560 train_time:664268ms step_avg:243.86ms
+step:2725/5560 train_time:664514ms step_avg:243.86ms
+step:2726/5560 train_time:664764ms step_avg:243.86ms
+step:2727/5560 train_time:665013ms step_avg:243.86ms
+step:2728/5560 train_time:665263ms step_avg:243.86ms
+step:2729/5560 train_time:665511ms step_avg:243.87ms
+step:2730/5560 train_time:665759ms step_avg:243.87ms
+step:2731/5560 train_time:666005ms step_avg:243.87ms
+step:2732/5560 train_time:666258ms step_avg:243.87ms
+step:2733/5560 train_time:666505ms step_avg:243.87ms
+step:2734/5560 train_time:666760ms step_avg:243.88ms
+step:2735/5560 train_time:667005ms step_avg:243.88ms
+step:2736/5560 train_time:667258ms step_avg:243.88ms
+step:2737/5560 train_time:667511ms step_avg:243.88ms
+step:2738/5560 train_time:667758ms step_avg:243.89ms
+step:2739/5560 train_time:668003ms step_avg:243.89ms
+step:2740/5560 train_time:668250ms step_avg:243.89ms
+step:2741/5560 train_time:668498ms step_avg:243.89ms
+step:2742/5560 train_time:668747ms step_avg:243.89ms
+step:2743/5560 train_time:668993ms step_avg:243.89ms
+step:2744/5560 train_time:669240ms step_avg:243.89ms
+step:2745/5560 train_time:669524ms step_avg:243.91ms
+step:2746/5560 train_time:669748ms step_avg:243.90ms
+step:2747/5560 train_time:669997ms step_avg:243.90ms
+step:2748/5560 train_time:670247ms step_avg:243.90ms
+step:2749/5560 train_time:670498ms step_avg:243.91ms
+step:2750/5560 train_time:670749ms step_avg:243.91ms
+step:2750/5560 val_loss:3.113713 train_time:670996ms step_avg:244.00ms
+step:2751/5560 train_time:671016ms step_avg:243.92ms
+step:2752/5560 train_time:671243ms step_avg:243.91ms
+step:2753/5560 train_time:671500ms step_avg:243.92ms
+step:2754/5560 train_time:671747ms step_avg:243.92ms
+step:2755/5560 train_time:671996ms step_avg:243.92ms
+step:2756/5560 train_time:672247ms step_avg:243.92ms
+step:2757/5560 train_time:672496ms step_avg:243.92ms
+step:2758/5560 train_time:672748ms step_avg:243.93ms
+step:2759/5560 train_time:672992ms step_avg:243.93ms
+step:2760/5560 train_time:673240ms step_avg:243.93ms
+step:2761/5560 train_time:673491ms step_avg:243.93ms
+step:2762/5560 train_time:673740ms step_avg:243.93ms
+step:2763/5560 train_time:673986ms step_avg:243.93ms
+step:2764/5560 train_time:674235ms step_avg:243.93ms
+step:2765/5560 train_time:674481ms step_avg:243.94ms
+step:2766/5560 train_time:674730ms step_avg:243.94ms
+step:2767/5560 train_time:674978ms step_avg:243.94ms
+step:2768/5560 train_time:675227ms step_avg:243.94ms
+step:2769/5560 train_time:675475ms step_avg:243.94ms
+step:2770/5560 train_time:675723ms step_avg:243.94ms
+step:2771/5560 train_time:675973ms step_avg:243.95ms
+step:2772/5560 train_time:676223ms step_avg:243.95ms
+step:2773/5560 train_time:676502ms step_avg:243.96ms
+step:2774/5560 train_time:676727ms step_avg:243.95ms
+step:2775/5560 train_time:676974ms step_avg:243.95ms
+step:2776/5560 train_time:677220ms step_avg:243.96ms
+step:2777/5560 train_time:677466ms step_avg:243.96ms
+step:2778/5560 train_time:677713ms step_avg:243.96ms
+step:2779/5560 train_time:677967ms step_avg:243.96ms
+step:2780/5560 train_time:678217ms step_avg:243.96ms
+step:2781/5560 train_time:678464ms step_avg:243.96ms
+step:2782/5560 train_time:678711ms step_avg:243.97ms
+step:2783/5560 train_time:678964ms step_avg:243.97ms
+step:2784/5560 train_time:679210ms step_avg:243.97ms
+step:2785/5560 train_time:679456ms step_avg:243.97ms
+step:2786/5560 train_time:679701ms step_avg:243.97ms
+step:2787/5560 train_time:679947ms step_avg:243.97ms
+step:2788/5560 train_time:680195ms step_avg:243.97ms
+step:2789/5560 train_time:680442ms step_avg:243.97ms
+step:2790/5560 train_time:680693ms step_avg:243.98ms
+step:2791/5560 train_time:680944ms step_avg:243.98ms
+step:2792/5560 train_time:681190ms step_avg:243.98ms
+step:2793/5560 train_time:681441ms step_avg:243.98ms
+step:2794/5560 train_time:681688ms step_avg:243.98ms
+step:2795/5560 train_time:681939ms step_avg:243.99ms
+step:2796/5560 train_time:682186ms step_avg:243.99ms
+step:2797/5560 train_time:682436ms step_avg:243.99ms
+step:2798/5560 train_time:682684ms step_avg:243.99ms
+step:2799/5560 train_time:682934ms step_avg:243.99ms
+step:2800/5560 train_time:683181ms step_avg:243.99ms
+step:2801/5560 train_time:683461ms step_avg:244.01ms
+step:2802/5560 train_time:683684ms step_avg:244.00ms
+step:2803/5560 train_time:683934ms step_avg:244.00ms
+step:2804/5560 train_time:684181ms step_avg:244.00ms
+step:2805/5560 train_time:684429ms step_avg:244.00ms
+step:2806/5560 train_time:684677ms step_avg:244.00ms
+step:2807/5560 train_time:684924ms step_avg:244.01ms
+step:2808/5560 train_time:685170ms step_avg:244.01ms
+step:2809/5560 train_time:685422ms step_avg:244.01ms
+step:2810/5560 train_time:685672ms step_avg:244.01ms
+step:2811/5560 train_time:685921ms step_avg:244.01ms
+step:2812/5560 train_time:686175ms step_avg:244.02ms
+step:2813/5560 train_time:686423ms step_avg:244.02ms
+step:2814/5560 train_time:686668ms step_avg:244.02ms
+step:2815/5560 train_time:686915ms step_avg:244.02ms
+step:2816/5560 train_time:687171ms step_avg:244.02ms
+step:2817/5560 train_time:687429ms step_avg:244.03ms
+step:2818/5560 train_time:687677ms step_avg:244.03ms
+step:2819/5560 train_time:687923ms step_avg:244.03ms
+step:2820/5560 train_time:688175ms step_avg:244.03ms
+step:2821/5560 train_time:688426ms step_avg:244.04ms
+step:2822/5560 train_time:688672ms step_avg:244.04ms
+step:2823/5560 train_time:688922ms step_avg:244.04ms
+step:2824/5560 train_time:689173ms step_avg:244.04ms
+step:2825/5560 train_time:689423ms step_avg:244.04ms
+step:2826/5560 train_time:689669ms step_avg:244.04ms
+step:2827/5560 train_time:689918ms step_avg:244.05ms
+step:2828/5560 train_time:690171ms step_avg:244.05ms
+step:2829/5560 train_time:690448ms step_avg:244.06ms
+step:2830/5560 train_time:690675ms step_avg:244.05ms
+step:2831/5560 train_time:690925ms step_avg:244.06ms
+step:2832/5560 train_time:691176ms step_avg:244.06ms
+step:2833/5560 train_time:691423ms step_avg:244.06ms
+step:2834/5560 train_time:691675ms step_avg:244.06ms
+step:2835/5560 train_time:691927ms step_avg:244.07ms
+step:2836/5560 train_time:692174ms step_avg:244.07ms
+step:2837/5560 train_time:692421ms step_avg:244.07ms
+step:2838/5560 train_time:692673ms step_avg:244.07ms
+step:2839/5560 train_time:692924ms step_avg:244.07ms
+step:2840/5560 train_time:693177ms step_avg:244.08ms
+step:2841/5560 train_time:693424ms step_avg:244.08ms
+step:2842/5560 train_time:693676ms step_avg:244.08ms
+step:2843/5560 train_time:693923ms step_avg:244.08ms
+step:2844/5560 train_time:694174ms step_avg:244.08ms
+step:2845/5560 train_time:694420ms step_avg:244.08ms
+step:2846/5560 train_time:694674ms step_avg:244.09ms
+step:2847/5560 train_time:694920ms step_avg:244.09ms
+step:2848/5560 train_time:695172ms step_avg:244.09ms
+step:2849/5560 train_time:695420ms step_avg:244.09ms
+step:2850/5560 train_time:695667ms step_avg:244.09ms
+step:2851/5560 train_time:695914ms step_avg:244.09ms
+step:2852/5560 train_time:696164ms step_avg:244.10ms
+step:2853/5560 train_time:696419ms step_avg:244.10ms
+step:2854/5560 train_time:696668ms step_avg:244.10ms
+step:2855/5560 train_time:696917ms step_avg:244.10ms
+step:2856/5560 train_time:697167ms step_avg:244.11ms
+step:2857/5560 train_time:697443ms step_avg:244.12ms
+step:2858/5560 train_time:697669ms step_avg:244.11ms
+step:2859/5560 train_time:697923ms step_avg:244.11ms
+step:2860/5560 train_time:698176ms step_avg:244.12ms
+step:2861/5560 train_time:698423ms step_avg:244.12ms
+step:2862/5560 train_time:698675ms step_avg:244.12ms
+step:2863/5560 train_time:698922ms step_avg:244.12ms
+step:2864/5560 train_time:699172ms step_avg:244.12ms
+step:2865/5560 train_time:699419ms step_avg:244.13ms
+step:2866/5560 train_time:699669ms step_avg:244.13ms
+step:2867/5560 train_time:699923ms step_avg:244.13ms
+step:2868/5560 train_time:700181ms step_avg:244.14ms
+step:2869/5560 train_time:700430ms step_avg:244.14ms
+step:2870/5560 train_time:700680ms step_avg:244.14ms
+step:2871/5560 train_time:700929ms step_avg:244.14ms
+step:2872/5560 train_time:701177ms step_avg:244.14ms
+step:2873/5560 train_time:701428ms step_avg:244.14ms
+step:2874/5560 train_time:701676ms step_avg:244.15ms
+step:2875/5560 train_time:701927ms step_avg:244.15ms
+step:2875/5560 val_loss:3.104543 train_time:702174ms step_avg:244.23ms
+step:2876/5560 train_time:702192ms step_avg:244.16ms
+step:2877/5560 train_time:702420ms step_avg:244.15ms
+step:2878/5560 train_time:702679ms step_avg:244.16ms
+step:2879/5560 train_time:702926ms step_avg:244.16ms
+step:2880/5560 train_time:703171ms step_avg:244.16ms
+step:2881/5560 train_time:703418ms step_avg:244.16ms
+step:2882/5560 train_time:703669ms step_avg:244.16ms
+step:2883/5560 train_time:703917ms step_avg:244.16ms
+step:2884/5560 train_time:704170ms step_avg:244.16ms
+step:2885/5560 train_time:704443ms step_avg:244.17ms
+step:2886/5560 train_time:704668ms step_avg:244.17ms
+step:2887/5560 train_time:704918ms step_avg:244.17ms
+step:2888/5560 train_time:705174ms step_avg:244.17ms
+step:2889/5560 train_time:705424ms step_avg:244.18ms
+step:2890/5560 train_time:705673ms step_avg:244.18ms
+step:2891/5560 train_time:705921ms step_avg:244.18ms
+step:2892/5560 train_time:706173ms step_avg:244.18ms
+step:2893/5560 train_time:706427ms step_avg:244.18ms
+step:2894/5560 train_time:706676ms step_avg:244.19ms
+step:2895/5560 train_time:706924ms step_avg:244.19ms
+step:2896/5560 train_time:707172ms step_avg:244.19ms
+step:2897/5560 train_time:707422ms step_avg:244.19ms
+step:2898/5560 train_time:707671ms step_avg:244.19ms
+step:2899/5560 train_time:707930ms step_avg:244.20ms
+step:2900/5560 train_time:708178ms step_avg:244.20ms
+step:2901/5560 train_time:708426ms step_avg:244.20ms
+step:2902/5560 train_time:708680ms step_avg:244.20ms
+step:2903/5560 train_time:708929ms step_avg:244.21ms
+step:2904/5560 train_time:709178ms step_avg:244.21ms
+step:2905/5560 train_time:709424ms step_avg:244.21ms
+step:2906/5560 train_time:709675ms step_avg:244.21ms
+step:2907/5560 train_time:709928ms step_avg:244.21ms
+step:2908/5560 train_time:710175ms step_avg:244.21ms
+step:2909/5560 train_time:710421ms step_avg:244.21ms
+step:2910/5560 train_time:710673ms step_avg:244.22ms
+step:2911/5560 train_time:710922ms step_avg:244.22ms
+step:2912/5560 train_time:711170ms step_avg:244.22ms
+step:2913/5560 train_time:711447ms step_avg:244.23ms
+step:2914/5560 train_time:711675ms step_avg:244.23ms
+step:2915/5560 train_time:711923ms step_avg:244.23ms
+step:2916/5560 train_time:712175ms step_avg:244.23ms
+step:2917/5560 train_time:712422ms step_avg:244.23ms
+step:2918/5560 train_time:712670ms step_avg:244.23ms
+step:2919/5560 train_time:712921ms step_avg:244.23ms
+step:2920/5560 train_time:713177ms step_avg:244.24ms
+step:2921/5560 train_time:713429ms step_avg:244.24ms
+step:2922/5560 train_time:713676ms step_avg:244.24ms
+step:2923/5560 train_time:713922ms step_avg:244.24ms
+step:2924/5560 train_time:714171ms step_avg:244.24ms
+step:2925/5560 train_time:714420ms step_avg:244.25ms
+step:2926/5560 train_time:714668ms step_avg:244.25ms
+step:2927/5560 train_time:714922ms step_avg:244.25ms
+step:2928/5560 train_time:715174ms step_avg:244.25ms
+step:2929/5560 train_time:715421ms step_avg:244.25ms
+step:2930/5560 train_time:715668ms step_avg:244.26ms
+step:2931/5560 train_time:715918ms step_avg:244.26ms
+step:2932/5560 train_time:716166ms step_avg:244.26ms
+step:2933/5560 train_time:716416ms step_avg:244.26ms
+step:2934/5560 train_time:716671ms step_avg:244.26ms
+step:2935/5560 train_time:716916ms step_avg:244.26ms
+step:2936/5560 train_time:717165ms step_avg:244.27ms
+step:2937/5560 train_time:717416ms step_avg:244.27ms
+step:2938/5560 train_time:717665ms step_avg:244.27ms
+step:2939/5560 train_time:717911ms step_avg:244.27ms
+step:2940/5560 train_time:718160ms step_avg:244.27ms
+step:2941/5560 train_time:718437ms step_avg:244.28ms
+step:2942/5560 train_time:718668ms step_avg:244.28ms
+step:2943/5560 train_time:718920ms step_avg:244.28ms
+step:2944/5560 train_time:719167ms step_avg:244.28ms
+step:2945/5560 train_time:719415ms step_avg:244.28ms
+step:2946/5560 train_time:719664ms step_avg:244.29ms
+step:2947/5560 train_time:719916ms step_avg:244.29ms
+step:2948/5560 train_time:720164ms step_avg:244.29ms
+step:2949/5560 train_time:720413ms step_avg:244.29ms
+step:2950/5560 train_time:720660ms step_avg:244.29ms
+step:2951/5560 train_time:720912ms step_avg:244.29ms
+step:2952/5560 train_time:721163ms step_avg:244.30ms
+step:2953/5560 train_time:721418ms step_avg:244.30ms
+step:2954/5560 train_time:721661ms step_avg:244.30ms
+step:2955/5560 train_time:721910ms step_avg:244.30ms
+step:2956/5560 train_time:722161ms step_avg:244.30ms
+step:2957/5560 train_time:722409ms step_avg:244.30ms
+step:2958/5560 train_time:722655ms step_avg:244.31ms
+step:2959/5560 train_time:722901ms step_avg:244.31ms
+step:2960/5560 train_time:723152ms step_avg:244.31ms
+step:2961/5560 train_time:723402ms step_avg:244.31ms
+step:2962/5560 train_time:723658ms step_avg:244.31ms
+step:2963/5560 train_time:723904ms step_avg:244.31ms
+step:2964/5560 train_time:724153ms step_avg:244.32ms
+step:2965/5560 train_time:724400ms step_avg:244.32ms
+step:2966/5560 train_time:724650ms step_avg:244.32ms
+step:2967/5560 train_time:724896ms step_avg:244.32ms
+step:2968/5560 train_time:725147ms step_avg:244.32ms
+step:2969/5560 train_time:725424ms step_avg:244.33ms
+step:2970/5560 train_time:725652ms step_avg:244.33ms
+step:2971/5560 train_time:725909ms step_avg:244.33ms
+step:2972/5560 train_time:726161ms step_avg:244.33ms
+step:2973/5560 train_time:726409ms step_avg:244.34ms
+step:2974/5560 train_time:726661ms step_avg:244.34ms
+step:2975/5560 train_time:726910ms step_avg:244.34ms
+step:2976/5560 train_time:727156ms step_avg:244.34ms
+step:2977/5560 train_time:727404ms step_avg:244.34ms
+step:2978/5560 train_time:727662ms step_avg:244.35ms
+step:2979/5560 train_time:727911ms step_avg:244.35ms
+step:2980/5560 train_time:728156ms step_avg:244.35ms
+step:2981/5560 train_time:728402ms step_avg:244.35ms
+step:2982/5560 train_time:728655ms step_avg:244.35ms
+step:2983/5560 train_time:728907ms step_avg:244.35ms
+step:2984/5560 train_time:729155ms step_avg:244.35ms
+step:2985/5560 train_time:729402ms step_avg:244.36ms
+step:2986/5560 train_time:729651ms step_avg:244.36ms
+step:2987/5560 train_time:729898ms step_avg:244.36ms
+step:2988/5560 train_time:730146ms step_avg:244.36ms
+step:2989/5560 train_time:730398ms step_avg:244.36ms
+step:2990/5560 train_time:730649ms step_avg:244.36ms
+step:2991/5560 train_time:730904ms step_avg:244.37ms
+step:2992/5560 train_time:731155ms step_avg:244.37ms
+step:2993/5560 train_time:731406ms step_avg:244.37ms
+step:2994/5560 train_time:731658ms step_avg:244.37ms
+step:2995/5560 train_time:731905ms step_avg:244.38ms
+step:2996/5560 train_time:732153ms step_avg:244.38ms
+step:2997/5560 train_time:732432ms step_avg:244.39ms
+step:2998/5560 train_time:732659ms step_avg:244.38ms
+step:2999/5560 train_time:732909ms step_avg:244.38ms
+step:3000/5560 train_time:733159ms step_avg:244.39ms
+step:3000/5560 val_loss:3.093420 train_time:733408ms step_avg:244.47ms
+step:3001/5560 train_time:733425ms step_avg:244.39ms
+step:3002/5560 train_time:733655ms step_avg:244.39ms
+step:3003/5560 train_time:733912ms step_avg:244.39ms
+step:3004/5560 train_time:734160ms step_avg:244.39ms
+step:3005/5560 train_time:734409ms step_avg:244.40ms
+step:3006/5560 train_time:734659ms step_avg:244.40ms
+step:3007/5560 train_time:734910ms step_avg:244.40ms
+step:3008/5560 train_time:735164ms step_avg:244.40ms
+step:3009/5560 train_time:735411ms step_avg:244.40ms
+step:3010/5560 train_time:735660ms step_avg:244.41ms
+step:3011/5560 train_time:735912ms step_avg:244.41ms
+step:3012/5560 train_time:736162ms step_avg:244.41ms
+step:3013/5560 train_time:736407ms step_avg:244.41ms
+step:3014/5560 train_time:736656ms step_avg:244.41ms
+step:3015/5560 train_time:736905ms step_avg:244.41ms
+step:3016/5560 train_time:737152ms step_avg:244.41ms
+step:3017/5560 train_time:737399ms step_avg:244.41ms
+step:3018/5560 train_time:737650ms step_avg:244.42ms
+step:3019/5560 train_time:737900ms step_avg:244.42ms
+step:3020/5560 train_time:738152ms step_avg:244.42ms
+step:3021/5560 train_time:738399ms step_avg:244.42ms
+step:3022/5560 train_time:738644ms step_avg:244.42ms
+step:3023/5560 train_time:738900ms step_avg:244.43ms
+step:3024/5560 train_time:739148ms step_avg:244.43ms
+step:3025/5560 train_time:739424ms step_avg:244.44ms
+step:3026/5560 train_time:739649ms step_avg:244.43ms
+step:3027/5560 train_time:739898ms step_avg:244.43ms
+step:3028/5560 train_time:740146ms step_avg:244.43ms
+step:3029/5560 train_time:740396ms step_avg:244.44ms
+step:3030/5560 train_time:740642ms step_avg:244.44ms
+step:3031/5560 train_time:740891ms step_avg:244.44ms
+step:3032/5560 train_time:741140ms step_avg:244.44ms
+step:3033/5560 train_time:741388ms step_avg:244.44ms
+step:3034/5560 train_time:741640ms step_avg:244.44ms
+step:3035/5560 train_time:741887ms step_avg:244.44ms
+step:3036/5560 train_time:742134ms step_avg:244.44ms
+step:3037/5560 train_time:742383ms step_avg:244.45ms
+step:3038/5560 train_time:742633ms step_avg:244.45ms
+step:3039/5560 train_time:742883ms step_avg:244.45ms
+step:3040/5560 train_time:743128ms step_avg:244.45ms
+step:3041/5560 train_time:743377ms step_avg:244.45ms
+step:3042/5560 train_time:743625ms step_avg:244.45ms
+step:3043/5560 train_time:743878ms step_avg:244.46ms
+step:3044/5560 train_time:744124ms step_avg:244.46ms
+step:3045/5560 train_time:744377ms step_avg:244.46ms
+step:3046/5560 train_time:744624ms step_avg:244.46ms
+step:3047/5560 train_time:744872ms step_avg:244.46ms
+step:3048/5560 train_time:745121ms step_avg:244.46ms
+step:3049/5560 train_time:745372ms step_avg:244.46ms
+step:3050/5560 train_time:745622ms step_avg:244.47ms
+step:3051/5560 train_time:745874ms step_avg:244.47ms
+step:3052/5560 train_time:746121ms step_avg:244.47ms
+step:3053/5560 train_time:746399ms step_avg:244.48ms
+step:3054/5560 train_time:746625ms step_avg:244.47ms
+step:3055/5560 train_time:746887ms step_avg:244.48ms
+step:3056/5560 train_time:747134ms step_avg:244.48ms
+step:3057/5560 train_time:747389ms step_avg:244.48ms
+step:3058/5560 train_time:747635ms step_avg:244.48ms
+step:3059/5560 train_time:747881ms step_avg:244.49ms
+step:3060/5560 train_time:748129ms step_avg:244.49ms
+step:3061/5560 train_time:748377ms step_avg:244.49ms
+step:3062/5560 train_time:748626ms step_avg:244.49ms
+step:3063/5560 train_time:748876ms step_avg:244.49ms
+step:3064/5560 train_time:749124ms step_avg:244.49ms
+step:3065/5560 train_time:749373ms step_avg:244.49ms
+step:3066/5560 train_time:749621ms step_avg:244.49ms
+step:3067/5560 train_time:749869ms step_avg:244.50ms
+step:3068/5560 train_time:750118ms step_avg:244.50ms
+step:3069/5560 train_time:750371ms step_avg:244.50ms
+step:3070/5560 train_time:750621ms step_avg:244.50ms
+step:3071/5560 train_time:750867ms step_avg:244.50ms
+step:3072/5560 train_time:751127ms step_avg:244.51ms
+step:3073/5560 train_time:751374ms step_avg:244.51ms
+step:3074/5560 train_time:751620ms step_avg:244.51ms
+step:3075/5560 train_time:751868ms step_avg:244.51ms
+step:3076/5560 train_time:752117ms step_avg:244.51ms
+step:3077/5560 train_time:752367ms step_avg:244.51ms
+step:3078/5560 train_time:752615ms step_avg:244.51ms
+step:3079/5560 train_time:752864ms step_avg:244.52ms
+step:3080/5560 train_time:753111ms step_avg:244.52ms
+step:3081/5560 train_time:753388ms step_avg:244.53ms
+step:3082/5560 train_time:753616ms step_avg:244.52ms
+step:3083/5560 train_time:753868ms step_avg:244.52ms
+step:3084/5560 train_time:754120ms step_avg:244.53ms
+step:3085/5560 train_time:754367ms step_avg:244.53ms
+step:3086/5560 train_time:754628ms step_avg:244.53ms
+step:3087/5560 train_time:754873ms step_avg:244.53ms
+step:3088/5560 train_time:755119ms step_avg:244.53ms
+step:3089/5560 train_time:755367ms step_avg:244.53ms
+step:3090/5560 train_time:755621ms step_avg:244.54ms
+step:3091/5560 train_time:755881ms step_avg:244.54ms
+step:3092/5560 train_time:756132ms step_avg:244.54ms
+step:3093/5560 train_time:756378ms step_avg:244.55ms
+step:3094/5560 train_time:756629ms step_avg:244.55ms
+step:3095/5560 train_time:756884ms step_avg:244.55ms
+step:3096/5560 train_time:757131ms step_avg:244.55ms
+step:3097/5560 train_time:757378ms step_avg:244.55ms
+step:3098/5560 train_time:757627ms step_avg:244.55ms
+step:3099/5560 train_time:757875ms step_avg:244.55ms
+step:3100/5560 train_time:758127ms step_avg:244.56ms
+step:3101/5560 train_time:758375ms step_avg:244.56ms
+step:3102/5560 train_time:758624ms step_avg:244.56ms
+step:3103/5560 train_time:758877ms step_avg:244.56ms
+step:3104/5560 train_time:759125ms step_avg:244.56ms
+step:3105/5560 train_time:759376ms step_avg:244.57ms
+step:3106/5560 train_time:759622ms step_avg:244.57ms
+step:3107/5560 train_time:759877ms step_avg:244.57ms
+step:3108/5560 train_time:760136ms step_avg:244.57ms
+step:3109/5560 train_time:760411ms step_avg:244.58ms
+step:3110/5560 train_time:760638ms step_avg:244.58ms
+step:3111/5560 train_time:760890ms step_avg:244.58ms
+step:3112/5560 train_time:761137ms step_avg:244.58ms
+step:3113/5560 train_time:761384ms step_avg:244.58ms
+step:3114/5560 train_time:761632ms step_avg:244.58ms
+step:3115/5560 train_time:761882ms step_avg:244.58ms
+step:3116/5560 train_time:762130ms step_avg:244.59ms
+step:3117/5560 train_time:762384ms step_avg:244.59ms
+step:3118/5560 train_time:762631ms step_avg:244.59ms
+step:3119/5560 train_time:762880ms step_avg:244.59ms
+step:3120/5560 train_time:763130ms step_avg:244.59ms
+step:3121/5560 train_time:763378ms step_avg:244.59ms
+step:3122/5560 train_time:763624ms step_avg:244.59ms
+step:3123/5560 train_time:763875ms step_avg:244.60ms
+step:3124/5560 train_time:764121ms step_avg:244.60ms
+step:3125/5560 train_time:764368ms step_avg:244.60ms
+step:3125/5560 val_loss:3.082899 train_time:764618ms step_avg:244.68ms
+step:3126/5560 train_time:764634ms step_avg:244.60ms
+step:3127/5560 train_time:764868ms step_avg:244.60ms
+step:3128/5560 train_time:765122ms step_avg:244.60ms
+step:3129/5560 train_time:765375ms step_avg:244.61ms
+step:3130/5560 train_time:765618ms step_avg:244.61ms
+step:3131/5560 train_time:765864ms step_avg:244.61ms
+step:3132/5560 train_time:766113ms step_avg:244.61ms
+step:3133/5560 train_time:766361ms step_avg:244.61ms
+step:3134/5560 train_time:766611ms step_avg:244.61ms
+step:3135/5560 train_time:766859ms step_avg:244.61ms
+step:3136/5560 train_time:767107ms step_avg:244.61ms
+step:3137/5560 train_time:767387ms step_avg:244.62ms
+step:3138/5560 train_time:767610ms step_avg:244.62ms
+step:3139/5560 train_time:767859ms step_avg:244.62ms
+step:3140/5560 train_time:768105ms step_avg:244.62ms
+step:3141/5560 train_time:768354ms step_avg:244.62ms
+step:3142/5560 train_time:768600ms step_avg:244.62ms
+step:3143/5560 train_time:768847ms step_avg:244.62ms
+step:3144/5560 train_time:769103ms step_avg:244.63ms
+step:3145/5560 train_time:769354ms step_avg:244.63ms
+step:3146/5560 train_time:769603ms step_avg:244.63ms
+step:3147/5560 train_time:769851ms step_avg:244.63ms
+step:3148/5560 train_time:770100ms step_avg:244.63ms
+step:3149/5560 train_time:770349ms step_avg:244.63ms
+step:3150/5560 train_time:770596ms step_avg:244.63ms
+step:3151/5560 train_time:770843ms step_avg:244.63ms
+step:3152/5560 train_time:771094ms step_avg:244.64ms
+step:3153/5560 train_time:771341ms step_avg:244.64ms
+step:3154/5560 train_time:771588ms step_avg:244.64ms
+step:3155/5560 train_time:771834ms step_avg:244.64ms
+step:3156/5560 train_time:772081ms step_avg:244.64ms
+step:3157/5560 train_time:772334ms step_avg:244.64ms
+step:3158/5560 train_time:772586ms step_avg:244.64ms
+step:3159/5560 train_time:772832ms step_avg:244.64ms
+step:3160/5560 train_time:773078ms step_avg:244.64ms
+step:3161/5560 train_time:773327ms step_avg:244.65ms
+step:3162/5560 train_time:773574ms step_avg:244.65ms
+step:3163/5560 train_time:773824ms step_avg:244.65ms
+step:3164/5560 train_time:774084ms step_avg:244.65ms
+step:3165/5560 train_time:774360ms step_avg:244.66ms
+step:3166/5560 train_time:774584ms step_avg:244.66ms
+step:3167/5560 train_time:774834ms step_avg:244.66ms
+step:3168/5560 train_time:775082ms step_avg:244.66ms
+step:3169/5560 train_time:775331ms step_avg:244.66ms
+step:3170/5560 train_time:775579ms step_avg:244.66ms
+step:3171/5560 train_time:775827ms step_avg:244.66ms
+step:3172/5560 train_time:776076ms step_avg:244.66ms
+step:3173/5560 train_time:776329ms step_avg:244.67ms
+step:3174/5560 train_time:776575ms step_avg:244.67ms
+step:3175/5560 train_time:776823ms step_avg:244.67ms
+step:3176/5560 train_time:777071ms step_avg:244.67ms
+step:3177/5560 train_time:777325ms step_avg:244.67ms
+step:3178/5560 train_time:777572ms step_avg:244.67ms
+step:3179/5560 train_time:777825ms step_avg:244.68ms
+step:3180/5560 train_time:778074ms step_avg:244.68ms
+step:3181/5560 train_time:778326ms step_avg:244.68ms
+step:3182/5560 train_time:778572ms step_avg:244.68ms
+step:3183/5560 train_time:778823ms step_avg:244.68ms
+step:3184/5560 train_time:779071ms step_avg:244.68ms
+step:3185/5560 train_time:779318ms step_avg:244.68ms
+step:3186/5560 train_time:779567ms step_avg:244.69ms
+step:3187/5560 train_time:779816ms step_avg:244.69ms
+step:3188/5560 train_time:780062ms step_avg:244.69ms
+step:3189/5560 train_time:780310ms step_avg:244.69ms
+step:3190/5560 train_time:780557ms step_avg:244.69ms
+step:3191/5560 train_time:780804ms step_avg:244.69ms
+step:3192/5560 train_time:781054ms step_avg:244.69ms
+step:3193/5560 train_time:781334ms step_avg:244.70ms
+step:3194/5560 train_time:781561ms step_avg:244.70ms
+step:3195/5560 train_time:781817ms step_avg:244.70ms
+step:3196/5560 train_time:782065ms step_avg:244.70ms
+step:3197/5560 train_time:782311ms step_avg:244.70ms
+step:3198/5560 train_time:782561ms step_avg:244.70ms
+step:3199/5560 train_time:782815ms step_avg:244.71ms
+step:3200/5560 train_time:783064ms step_avg:244.71ms
+step:3201/5560 train_time:783311ms step_avg:244.71ms
+step:3202/5560 train_time:783561ms step_avg:244.71ms
+step:3203/5560 train_time:783807ms step_avg:244.71ms
+step:3204/5560 train_time:784056ms step_avg:244.71ms
+step:3205/5560 train_time:784306ms step_avg:244.71ms
+step:3206/5560 train_time:784557ms step_avg:244.72ms
+step:3207/5560 train_time:784807ms step_avg:244.72ms
+step:3208/5560 train_time:785055ms step_avg:244.72ms
+step:3209/5560 train_time:785302ms step_avg:244.72ms
+step:3210/5560 train_time:785551ms step_avg:244.72ms
+step:3211/5560 train_time:785802ms step_avg:244.72ms
+step:3212/5560 train_time:786050ms step_avg:244.72ms
+step:3213/5560 train_time:786298ms step_avg:244.72ms
+step:3214/5560 train_time:786546ms step_avg:244.72ms
+step:3215/5560 train_time:786792ms step_avg:244.73ms
+step:3216/5560 train_time:787040ms step_avg:244.73ms
+step:3217/5560 train_time:787289ms step_avg:244.73ms
+step:3218/5560 train_time:787538ms step_avg:244.73ms
+step:3219/5560 train_time:787787ms step_avg:244.73ms
+step:3220/5560 train_time:788035ms step_avg:244.73ms
+step:3221/5560 train_time:788312ms step_avg:244.74ms
+step:3222/5560 train_time:788537ms step_avg:244.74ms
+step:3223/5560 train_time:788785ms step_avg:244.74ms
+step:3224/5560 train_time:789035ms step_avg:244.74ms
+step:3225/5560 train_time:789286ms step_avg:244.74ms
+step:3226/5560 train_time:789540ms step_avg:244.74ms
+step:3227/5560 train_time:789791ms step_avg:244.74ms
+step:3228/5560 train_time:790041ms step_avg:244.75ms
+step:3229/5560 train_time:790286ms step_avg:244.75ms
+step:3230/5560 train_time:790541ms step_avg:244.75ms
+step:3231/5560 train_time:790793ms step_avg:244.75ms
+step:3232/5560 train_time:791047ms step_avg:244.75ms
+step:3233/5560 train_time:791291ms step_avg:244.75ms
+step:3234/5560 train_time:791541ms step_avg:244.76ms
+step:3235/5560 train_time:791789ms step_avg:244.76ms
+step:3236/5560 train_time:792043ms step_avg:244.76ms
+step:3237/5560 train_time:792289ms step_avg:244.76ms
+step:3238/5560 train_time:792538ms step_avg:244.76ms
+step:3239/5560 train_time:792787ms step_avg:244.76ms
+step:3240/5560 train_time:793038ms step_avg:244.76ms
+step:3241/5560 train_time:793286ms step_avg:244.77ms
+step:3242/5560 train_time:793536ms step_avg:244.77ms
+step:3243/5560 train_time:793783ms step_avg:244.77ms
+step:3244/5560 train_time:794030ms step_avg:244.77ms
+step:3245/5560 train_time:794281ms step_avg:244.77ms
+step:3246/5560 train_time:794532ms step_avg:244.77ms
+step:3247/5560 train_time:794780ms step_avg:244.77ms
+step:3248/5560 train_time:795025ms step_avg:244.77ms
+step:3249/5560 train_time:795310ms step_avg:244.79ms
+step:3250/5560 train_time:795534ms step_avg:244.78ms
+step:3250/5560 val_loss:3.071094 train_time:795785ms step_avg:244.86ms
+step:3251/5560 train_time:795845ms step_avg:244.80ms
+step:3252/5560 train_time:796039ms step_avg:244.78ms
+step:3253/5560 train_time:796301ms step_avg:244.79ms
+step:3254/5560 train_time:796575ms step_avg:244.80ms
+step:3255/5560 train_time:796816ms step_avg:244.80ms
+step:3256/5560 train_time:797065ms step_avg:244.80ms
+step:3257/5560 train_time:797284ms step_avg:244.79ms
+step:3258/5560 train_time:797531ms step_avg:244.79ms
+step:3259/5560 train_time:797780ms step_avg:244.79ms
+step:3260/5560 train_time:798028ms step_avg:244.79ms
+step:3261/5560 train_time:798276ms step_avg:244.79ms
+step:3262/5560 train_time:798530ms step_avg:244.80ms
+step:3263/5560 train_time:798774ms step_avg:244.80ms
+step:3264/5560 train_time:799023ms step_avg:244.80ms
+step:3265/5560 train_time:799271ms step_avg:244.80ms
+step:3266/5560 train_time:799521ms step_avg:244.80ms
+step:3267/5560 train_time:799768ms step_avg:244.80ms
+step:3268/5560 train_time:800018ms step_avg:244.80ms
+step:3269/5560 train_time:800268ms step_avg:244.81ms
+step:3270/5560 train_time:800513ms step_avg:244.81ms
+step:3271/5560 train_time:800759ms step_avg:244.81ms
+step:3272/5560 train_time:801006ms step_avg:244.81ms
+step:3273/5560 train_time:801254ms step_avg:244.81ms
+step:3274/5560 train_time:801504ms step_avg:244.81ms
+step:3275/5560 train_time:801754ms step_avg:244.81ms
+step:3276/5560 train_time:801999ms step_avg:244.81ms
+step:3277/5560 train_time:802275ms step_avg:244.82ms
+step:3278/5560 train_time:802502ms step_avg:244.81ms
+step:3279/5560 train_time:802752ms step_avg:244.82ms
+step:3280/5560 train_time:803002ms step_avg:244.82ms
+step:3281/5560 train_time:803253ms step_avg:244.82ms
+step:3282/5560 train_time:803507ms step_avg:244.82ms
+step:3283/5560 train_time:803752ms step_avg:244.82ms
+step:3284/5560 train_time:804002ms step_avg:244.82ms
+step:3285/5560 train_time:804251ms step_avg:244.83ms
+step:3286/5560 train_time:804504ms step_avg:244.83ms
+step:3287/5560 train_time:804751ms step_avg:244.83ms
+step:3288/5560 train_time:805000ms step_avg:244.83ms
+step:3289/5560 train_time:805256ms step_avg:244.83ms
+step:3290/5560 train_time:805502ms step_avg:244.83ms
+step:3291/5560 train_time:805748ms step_avg:244.83ms
+step:3292/5560 train_time:805994ms step_avg:244.83ms
+step:3293/5560 train_time:806254ms step_avg:244.84ms
+step:3294/5560 train_time:806505ms step_avg:244.84ms
+step:3295/5560 train_time:806751ms step_avg:244.84ms
+step:3296/5560 train_time:806997ms step_avg:244.84ms
+step:3297/5560 train_time:807250ms step_avg:244.84ms
+step:3298/5560 train_time:807498ms step_avg:244.84ms
+step:3299/5560 train_time:807748ms step_avg:244.85ms
+step:3300/5560 train_time:807994ms step_avg:244.85ms
+step:3301/5560 train_time:808248ms step_avg:244.85ms
+step:3302/5560 train_time:808498ms step_avg:244.85ms
+step:3303/5560 train_time:808749ms step_avg:244.85ms
+step:3304/5560 train_time:808999ms step_avg:244.85ms
+step:3305/5560 train_time:809280ms step_avg:244.87ms
+step:3306/5560 train_time:809512ms step_avg:244.86ms
+step:3307/5560 train_time:809762ms step_avg:244.86ms
+step:3308/5560 train_time:810009ms step_avg:244.86ms
+step:3309/5560 train_time:810257ms step_avg:244.86ms
+step:3310/5560 train_time:810507ms step_avg:244.87ms
+step:3311/5560 train_time:810758ms step_avg:244.87ms
+step:3312/5560 train_time:811006ms step_avg:244.87ms
+step:3313/5560 train_time:811253ms step_avg:244.87ms
+step:3314/5560 train_time:811505ms step_avg:244.87ms
+step:3315/5560 train_time:811763ms step_avg:244.88ms
+step:3316/5560 train_time:812012ms step_avg:244.88ms
+step:3317/5560 train_time:812259ms step_avg:244.88ms
+step:3318/5560 train_time:812505ms step_avg:244.88ms
+step:3319/5560 train_time:812756ms step_avg:244.88ms
+step:3320/5560 train_time:813003ms step_avg:244.88ms
+step:3321/5560 train_time:813253ms step_avg:244.88ms
+step:3322/5560 train_time:813498ms step_avg:244.88ms
+step:3323/5560 train_time:813746ms step_avg:244.88ms
+step:3324/5560 train_time:813991ms step_avg:244.88ms
+step:3325/5560 train_time:814238ms step_avg:244.88ms
+step:3326/5560 train_time:814488ms step_avg:244.89ms
+step:3327/5560 train_time:814734ms step_avg:244.89ms
+step:3328/5560 train_time:814986ms step_avg:244.89ms
+step:3329/5560 train_time:815234ms step_avg:244.89ms
+step:3330/5560 train_time:815484ms step_avg:244.89ms
+step:3331/5560 train_time:815730ms step_avg:244.89ms
+step:3332/5560 train_time:815985ms step_avg:244.89ms
+step:3333/5560 train_time:816259ms step_avg:244.90ms
+step:3334/5560 train_time:816486ms step_avg:244.90ms
+step:3335/5560 train_time:816734ms step_avg:244.90ms
+step:3336/5560 train_time:816984ms step_avg:244.90ms
+step:3337/5560 train_time:817232ms step_avg:244.90ms
+step:3338/5560 train_time:817481ms step_avg:244.90ms
+step:3339/5560 train_time:817730ms step_avg:244.90ms
+step:3340/5560 train_time:817977ms step_avg:244.90ms
+step:3341/5560 train_time:818223ms step_avg:244.90ms
+step:3342/5560 train_time:818474ms step_avg:244.91ms
+step:3343/5560 train_time:818721ms step_avg:244.91ms
+step:3344/5560 train_time:818971ms step_avg:244.91ms
+step:3345/5560 train_time:819217ms step_avg:244.91ms
+step:3346/5560 train_time:819466ms step_avg:244.91ms
+step:3347/5560 train_time:819711ms step_avg:244.91ms
+step:3348/5560 train_time:819962ms step_avg:244.91ms
+step:3349/5560 train_time:820209ms step_avg:244.91ms
+step:3350/5560 train_time:820455ms step_avg:244.91ms
+step:3351/5560 train_time:820709ms step_avg:244.91ms
+step:3352/5560 train_time:820954ms step_avg:244.91ms
+step:3353/5560 train_time:821204ms step_avg:244.92ms
+step:3354/5560 train_time:821452ms step_avg:244.92ms
+step:3355/5560 train_time:821704ms step_avg:244.92ms
+step:3356/5560 train_time:821953ms step_avg:244.92ms
+step:3357/5560 train_time:822200ms step_avg:244.92ms
+step:3358/5560 train_time:822450ms step_avg:244.92ms
+step:3359/5560 train_time:822696ms step_avg:244.92ms
+step:3360/5560 train_time:822943ms step_avg:244.92ms
+step:3361/5560 train_time:823223ms step_avg:244.93ms
+step:3362/5560 train_time:823448ms step_avg:244.93ms
+step:3363/5560 train_time:823693ms step_avg:244.93ms
+step:3364/5560 train_time:823947ms step_avg:244.93ms
+step:3365/5560 train_time:824194ms step_avg:244.93ms
+step:3366/5560 train_time:824449ms step_avg:244.93ms
+step:3367/5560 train_time:824692ms step_avg:244.93ms
+step:3368/5560 train_time:824943ms step_avg:244.94ms
+step:3369/5560 train_time:825188ms step_avg:244.94ms
+step:3370/5560 train_time:825435ms step_avg:244.94ms
+step:3371/5560 train_time:825681ms step_avg:244.94ms
+step:3372/5560 train_time:825929ms step_avg:244.94ms
+step:3373/5560 train_time:826177ms step_avg:244.94ms
+step:3374/5560 train_time:826426ms step_avg:244.94ms
+step:3375/5560 train_time:826677ms step_avg:244.94ms
+step:3375/5560 val_loss:3.062399 train_time:826924ms step_avg:245.01ms
+step:3376/5560 train_time:826941ms step_avg:244.95ms
+step:3377/5560 train_time:827178ms step_avg:244.94ms
+step:3378/5560 train_time:827436ms step_avg:244.95ms
+step:3379/5560 train_time:827693ms step_avg:244.95ms
+step:3380/5560 train_time:827938ms step_avg:244.95ms
+step:3381/5560 train_time:828187ms step_avg:244.95ms
+step:3382/5560 train_time:828438ms step_avg:244.96ms
+step:3383/5560 train_time:828688ms step_avg:244.96ms
+step:3384/5560 train_time:828936ms step_avg:244.96ms
+step:3385/5560 train_time:829181ms step_avg:244.96ms
+step:3386/5560 train_time:829433ms step_avg:244.96ms
+step:3387/5560 train_time:829682ms step_avg:244.96ms
+step:3388/5560 train_time:829927ms step_avg:244.96ms
+step:3389/5560 train_time:830206ms step_avg:244.97ms
+step:3390/5560 train_time:830433ms step_avg:244.97ms
+step:3391/5560 train_time:830684ms step_avg:244.97ms
+step:3392/5560 train_time:830931ms step_avg:244.97ms
+step:3393/5560 train_time:831179ms step_avg:244.97ms
+step:3394/5560 train_time:831436ms step_avg:244.97ms
+step:3395/5560 train_time:831686ms step_avg:244.97ms
+step:3396/5560 train_time:831934ms step_avg:244.97ms
+step:3397/5560 train_time:832183ms step_avg:244.98ms
+step:3398/5560 train_time:832435ms step_avg:244.98ms
+step:3399/5560 train_time:832684ms step_avg:244.98ms
+step:3400/5560 train_time:832929ms step_avg:244.98ms
+step:3401/5560 train_time:833177ms step_avg:244.98ms
+step:3402/5560 train_time:833433ms step_avg:244.98ms
+step:3403/5560 train_time:833685ms step_avg:244.99ms
+step:3404/5560 train_time:833932ms step_avg:244.99ms
+step:3405/5560 train_time:834179ms step_avg:244.99ms
+step:3406/5560 train_time:834424ms step_avg:244.99ms
+step:3407/5560 train_time:834677ms step_avg:244.99ms
+step:3408/5560 train_time:834924ms step_avg:244.99ms
+step:3409/5560 train_time:835172ms step_avg:244.99ms
+step:3410/5560 train_time:835422ms step_avg:244.99ms
+step:3411/5560 train_time:835672ms step_avg:244.99ms
+step:3412/5560 train_time:835919ms step_avg:244.99ms
+step:3413/5560 train_time:836168ms step_avg:244.99ms
+step:3414/5560 train_time:836416ms step_avg:245.00ms
+step:3415/5560 train_time:836667ms step_avg:245.00ms
+step:3416/5560 train_time:836912ms step_avg:245.00ms
+step:3417/5560 train_time:837191ms step_avg:245.01ms
+step:3418/5560 train_time:837413ms step_avg:245.00ms
+step:3419/5560 train_time:837664ms step_avg:245.00ms
+step:3420/5560 train_time:837914ms step_avg:245.00ms
+step:3421/5560 train_time:838163ms step_avg:245.01ms
+step:3422/5560 train_time:838411ms step_avg:245.01ms
+step:3423/5560 train_time:838659ms step_avg:245.01ms
+step:3424/5560 train_time:838913ms step_avg:245.01ms
+step:3425/5560 train_time:839163ms step_avg:245.01ms
+step:3426/5560 train_time:839415ms step_avg:245.01ms
+step:3427/5560 train_time:839666ms step_avg:245.02ms
+step:3428/5560 train_time:839912ms step_avg:245.02ms
+step:3429/5560 train_time:840168ms step_avg:245.02ms
+step:3430/5560 train_time:840414ms step_avg:245.02ms
+step:3431/5560 train_time:840667ms step_avg:245.02ms
+step:3432/5560 train_time:840911ms step_avg:245.02ms
+step:3433/5560 train_time:841156ms step_avg:245.02ms
+step:3434/5560 train_time:841406ms step_avg:245.02ms
+step:3435/5560 train_time:841653ms step_avg:245.02ms
+step:3436/5560 train_time:841905ms step_avg:245.02ms
+step:3437/5560 train_time:842153ms step_avg:245.03ms
+step:3438/5560 train_time:842401ms step_avg:245.03ms
+step:3439/5560 train_time:842652ms step_avg:245.03ms
+step:3440/5560 train_time:842901ms step_avg:245.03ms
+step:3441/5560 train_time:843151ms step_avg:245.03ms
+step:3442/5560 train_time:843397ms step_avg:245.03ms
+step:3443/5560 train_time:843646ms step_avg:245.03ms
+step:3444/5560 train_time:843908ms step_avg:245.04ms
+step:3445/5560 train_time:844189ms step_avg:245.05ms
+step:3446/5560 train_time:844415ms step_avg:245.04ms
+step:3447/5560 train_time:844664ms step_avg:245.04ms
+step:3448/5560 train_time:844918ms step_avg:245.05ms
+step:3449/5560 train_time:845170ms step_avg:245.05ms
+step:3450/5560 train_time:845419ms step_avg:245.05ms
+step:3451/5560 train_time:845666ms step_avg:245.05ms
+step:3452/5560 train_time:845913ms step_avg:245.05ms
+step:3453/5560 train_time:846171ms step_avg:245.05ms
+step:3454/5560 train_time:846419ms step_avg:245.05ms
+step:3455/5560 train_time:846667ms step_avg:245.06ms
+step:3456/5560 train_time:846915ms step_avg:245.06ms
+step:3457/5560 train_time:847166ms step_avg:245.06ms
+step:3458/5560 train_time:847411ms step_avg:245.06ms
+step:3459/5560 train_time:847659ms step_avg:245.06ms
+step:3460/5560 train_time:847909ms step_avg:245.06ms
+step:3461/5560 train_time:848158ms step_avg:245.06ms
+step:3462/5560 train_time:848407ms step_avg:245.06ms
+step:3463/5560 train_time:848660ms step_avg:245.06ms
+step:3464/5560 train_time:848907ms step_avg:245.07ms
+step:3465/5560 train_time:849155ms step_avg:245.07ms
+step:3466/5560 train_time:849402ms step_avg:245.07ms
+step:3467/5560 train_time:849648ms step_avg:245.07ms
+step:3468/5560 train_time:849896ms step_avg:245.07ms
+step:3469/5560 train_time:850145ms step_avg:245.07ms
+step:3470/5560 train_time:850391ms step_avg:245.07ms
+step:3471/5560 train_time:850640ms step_avg:245.07ms
+step:3472/5560 train_time:850888ms step_avg:245.07ms
+step:3473/5560 train_time:851169ms step_avg:245.08ms
+step:3474/5560 train_time:851393ms step_avg:245.08ms
+step:3475/5560 train_time:851643ms step_avg:245.08ms
+step:3476/5560 train_time:851898ms step_avg:245.08ms
+step:3477/5560 train_time:852146ms step_avg:245.08ms
+step:3478/5560 train_time:852393ms step_avg:245.08ms
+step:3479/5560 train_time:852642ms step_avg:245.08ms
+step:3480/5560 train_time:852891ms step_avg:245.08ms
+step:3481/5560 train_time:853142ms step_avg:245.09ms
+step:3482/5560 train_time:853394ms step_avg:245.09ms
+step:3483/5560 train_time:853641ms step_avg:245.09ms
+step:3484/5560 train_time:853888ms step_avg:245.09ms
+step:3485/5560 train_time:854135ms step_avg:245.09ms
+step:3486/5560 train_time:854387ms step_avg:245.09ms
+step:3487/5560 train_time:854638ms step_avg:245.09ms
+step:3488/5560 train_time:854884ms step_avg:245.09ms
+step:3489/5560 train_time:855131ms step_avg:245.09ms
+step:3490/5560 train_time:855380ms step_avg:245.09ms
+step:3491/5560 train_time:855629ms step_avg:245.10ms
+step:3492/5560 train_time:855879ms step_avg:245.10ms
+step:3493/5560 train_time:856128ms step_avg:245.10ms
+step:3494/5560 train_time:856374ms step_avg:245.10ms
+step:3495/5560 train_time:856626ms step_avg:245.10ms
+step:3496/5560 train_time:856876ms step_avg:245.10ms
+step:3497/5560 train_time:857122ms step_avg:245.10ms
+step:3498/5560 train_time:857370ms step_avg:245.10ms
+step:3499/5560 train_time:857619ms step_avg:245.10ms
+step:3500/5560 train_time:857868ms step_avg:245.11ms
+step:3500/5560 val_loss:3.053674 train_time:858125ms step_avg:245.18ms
+step:3501/5560 train_time:858155ms step_avg:245.12ms
+step:3502/5560 train_time:858380ms step_avg:245.11ms
+step:3503/5560 train_time:858638ms step_avg:245.12ms
+step:3504/5560 train_time:858886ms step_avg:245.12ms
+step:3505/5560 train_time:859138ms step_avg:245.12ms
+step:3506/5560 train_time:859387ms step_avg:245.12ms
+step:3507/5560 train_time:859638ms step_avg:245.12ms
+step:3508/5560 train_time:859887ms step_avg:245.12ms
+step:3509/5560 train_time:860131ms step_avg:245.12ms
+step:3510/5560 train_time:860380ms step_avg:245.12ms
+step:3511/5560 train_time:860627ms step_avg:245.12ms
+step:3512/5560 train_time:860876ms step_avg:245.12ms
+step:3513/5560 train_time:861121ms step_avg:245.12ms
+step:3514/5560 train_time:861368ms step_avg:245.12ms
+step:3515/5560 train_time:861616ms step_avg:245.13ms
+step:3516/5560 train_time:861868ms step_avg:245.13ms
+step:3517/5560 train_time:862114ms step_avg:245.13ms
+step:3518/5560 train_time:862356ms step_avg:245.13ms
+step:3519/5560 train_time:862609ms step_avg:245.13ms
+step:3520/5560 train_time:862856ms step_avg:245.13ms
+step:3521/5560 train_time:863108ms step_avg:245.13ms
+step:3522/5560 train_time:863356ms step_avg:245.13ms
+step:3523/5560 train_time:863603ms step_avg:245.13ms
+step:3524/5560 train_time:863854ms step_avg:245.13ms
+step:3525/5560 train_time:864103ms step_avg:245.14ms
+step:3526/5560 train_time:864350ms step_avg:245.14ms
+step:3527/5560 train_time:864596ms step_avg:245.14ms
+step:3528/5560 train_time:864845ms step_avg:245.14ms
+step:3529/5560 train_time:865126ms step_avg:245.15ms
+step:3530/5560 train_time:865352ms step_avg:245.14ms
+step:3531/5560 train_time:865601ms step_avg:245.14ms
+step:3532/5560 train_time:865854ms step_avg:245.15ms
+step:3533/5560 train_time:866108ms step_avg:245.15ms
+step:3534/5560 train_time:866359ms step_avg:245.15ms
+step:3535/5560 train_time:866606ms step_avg:245.15ms
+step:3536/5560 train_time:866854ms step_avg:245.15ms
+step:3537/5560 train_time:867104ms step_avg:245.15ms
+step:3538/5560 train_time:867349ms step_avg:245.15ms
+step:3539/5560 train_time:867597ms step_avg:245.15ms
+step:3540/5560 train_time:867845ms step_avg:245.15ms
+step:3541/5560 train_time:868092ms step_avg:245.15ms
+step:3542/5560 train_time:868346ms step_avg:245.16ms
+step:3543/5560 train_time:868593ms step_avg:245.16ms
+step:3544/5560 train_time:868846ms step_avg:245.16ms
+step:3545/5560 train_time:869091ms step_avg:245.16ms
+step:3546/5560 train_time:869345ms step_avg:245.16ms
+step:3547/5560 train_time:869594ms step_avg:245.16ms
+step:3548/5560 train_time:869844ms step_avg:245.16ms
+step:3549/5560 train_time:870092ms step_avg:245.17ms
+step:3550/5560 train_time:870342ms step_avg:245.17ms
+step:3551/5560 train_time:870590ms step_avg:245.17ms
+step:3552/5560 train_time:870844ms step_avg:245.17ms
+step:3553/5560 train_time:871099ms step_avg:245.17ms
+step:3554/5560 train_time:871346ms step_avg:245.17ms
+step:3555/5560 train_time:871592ms step_avg:245.17ms
+step:3556/5560 train_time:871843ms step_avg:245.18ms
+step:3557/5560 train_time:872124ms step_avg:245.19ms
+step:3558/5560 train_time:872349ms step_avg:245.18ms
+step:3559/5560 train_time:872596ms step_avg:245.18ms
+step:3560/5560 train_time:872843ms step_avg:245.18ms
+step:3561/5560 train_time:873089ms step_avg:245.18ms
+step:3562/5560 train_time:873347ms step_avg:245.18ms
+step:3563/5560 train_time:873592ms step_avg:245.18ms
+step:3564/5560 train_time:873847ms step_avg:245.19ms
+step:3565/5560 train_time:874092ms step_avg:245.19ms
+step:3566/5560 train_time:874344ms step_avg:245.19ms
+step:3567/5560 train_time:874591ms step_avg:245.19ms
+step:3568/5560 train_time:874841ms step_avg:245.19ms
+step:3569/5560 train_time:875090ms step_avg:245.19ms
+step:3570/5560 train_time:875342ms step_avg:245.19ms
+step:3571/5560 train_time:875590ms step_avg:245.19ms
+step:3572/5560 train_time:875838ms step_avg:245.20ms
+step:3573/5560 train_time:876086ms step_avg:245.20ms
+step:3574/5560 train_time:876336ms step_avg:245.20ms
+step:3575/5560 train_time:876587ms step_avg:245.20ms
+step:3576/5560 train_time:876834ms step_avg:245.20ms
+step:3577/5560 train_time:877088ms step_avg:245.20ms
+step:3578/5560 train_time:877334ms step_avg:245.20ms
+step:3579/5560 train_time:877583ms step_avg:245.20ms
+step:3580/5560 train_time:877831ms step_avg:245.20ms
+step:3581/5560 train_time:878080ms step_avg:245.21ms
+step:3582/5560 train_time:878327ms step_avg:245.21ms
+step:3583/5560 train_time:878577ms step_avg:245.21ms
+step:3584/5560 train_time:878823ms step_avg:245.21ms
+step:3585/5560 train_time:879103ms step_avg:245.22ms
+step:3586/5560 train_time:879328ms step_avg:245.21ms
+step:3587/5560 train_time:879574ms step_avg:245.21ms
+step:3588/5560 train_time:879821ms step_avg:245.21ms
+step:3589/5560 train_time:880066ms step_avg:245.21ms
+step:3590/5560 train_time:880313ms step_avg:245.21ms
+step:3591/5560 train_time:880567ms step_avg:245.22ms
+step:3592/5560 train_time:880814ms step_avg:245.22ms
+step:3593/5560 train_time:881064ms step_avg:245.22ms
+step:3594/5560 train_time:881311ms step_avg:245.22ms
+step:3595/5560 train_time:881566ms step_avg:245.22ms
+step:3596/5560 train_time:881815ms step_avg:245.22ms
+step:3597/5560 train_time:882063ms step_avg:245.22ms
+step:3598/5560 train_time:882316ms step_avg:245.22ms
+step:3599/5560 train_time:882571ms step_avg:245.23ms
+step:3600/5560 train_time:882815ms step_avg:245.23ms
+step:3601/5560 train_time:883061ms step_avg:245.23ms
+step:3602/5560 train_time:883312ms step_avg:245.23ms
+step:3603/5560 train_time:883564ms step_avg:245.23ms
+step:3604/5560 train_time:883809ms step_avg:245.23ms
+step:3605/5560 train_time:884057ms step_avg:245.23ms
+step:3606/5560 train_time:884317ms step_avg:245.23ms
+step:3607/5560 train_time:884565ms step_avg:245.24ms
+step:3608/5560 train_time:884815ms step_avg:245.24ms
+step:3609/5560 train_time:885064ms step_avg:245.24ms
+step:3610/5560 train_time:885315ms step_avg:245.24ms
+step:3611/5560 train_time:885564ms step_avg:245.24ms
+step:3612/5560 train_time:885814ms step_avg:245.24ms
+step:3613/5560 train_time:886090ms step_avg:245.25ms
+step:3614/5560 train_time:886315ms step_avg:245.24ms
+step:3615/5560 train_time:886564ms step_avg:245.25ms
+step:3616/5560 train_time:886810ms step_avg:245.25ms
+step:3617/5560 train_time:887057ms step_avg:245.25ms
+step:3618/5560 train_time:887309ms step_avg:245.25ms
+step:3619/5560 train_time:887556ms step_avg:245.25ms
+step:3620/5560 train_time:887809ms step_avg:245.25ms
+step:3621/5560 train_time:888056ms step_avg:245.25ms
+step:3622/5560 train_time:888307ms step_avg:245.25ms
+step:3623/5560 train_time:888553ms step_avg:245.25ms
+step:3624/5560 train_time:888804ms step_avg:245.26ms
+step:3625/5560 train_time:889053ms step_avg:245.26ms
+step:3625/5560 val_loss:3.045440 train_time:889308ms step_avg:245.33ms
+step:3626/5560 train_time:889326ms step_avg:245.26ms
+step:3627/5560 train_time:889556ms step_avg:245.26ms
+step:3628/5560 train_time:889812ms step_avg:245.26ms
+step:3629/5560 train_time:890060ms step_avg:245.26ms
+step:3630/5560 train_time:890303ms step_avg:245.26ms
+step:3631/5560 train_time:890550ms step_avg:245.26ms
+step:3632/5560 train_time:890803ms step_avg:245.27ms
+step:3633/5560 train_time:891050ms step_avg:245.27ms
+step:3634/5560 train_time:891299ms step_avg:245.27ms
+step:3635/5560 train_time:891547ms step_avg:245.27ms
+step:3636/5560 train_time:891796ms step_avg:245.27ms
+step:3637/5560 train_time:892043ms step_avg:245.27ms
+step:3638/5560 train_time:892295ms step_avg:245.27ms
+step:3639/5560 train_time:892542ms step_avg:245.27ms
+step:3640/5560 train_time:892793ms step_avg:245.27ms
+step:3641/5560 train_time:893077ms step_avg:245.28ms
+step:3642/5560 train_time:893315ms step_avg:245.28ms
+step:3643/5560 train_time:893562ms step_avg:245.28ms
+step:3644/5560 train_time:893813ms step_avg:245.28ms
+step:3645/5560 train_time:894060ms step_avg:245.28ms
+step:3646/5560 train_time:894308ms step_avg:245.28ms
+step:3647/5560 train_time:894556ms step_avg:245.29ms
+step:3648/5560 train_time:894804ms step_avg:245.29ms
+step:3649/5560 train_time:895053ms step_avg:245.29ms
+step:3650/5560 train_time:895302ms step_avg:245.29ms
+step:3651/5560 train_time:895553ms step_avg:245.29ms
+step:3652/5560 train_time:895800ms step_avg:245.29ms
+step:3653/5560 train_time:896048ms step_avg:245.29ms
+step:3654/5560 train_time:896296ms step_avg:245.29ms
+step:3655/5560 train_time:896545ms step_avg:245.29ms
+step:3656/5560 train_time:896795ms step_avg:245.29ms
+step:3657/5560 train_time:897045ms step_avg:245.30ms
+step:3658/5560 train_time:897291ms step_avg:245.30ms
+step:3659/5560 train_time:897539ms step_avg:245.30ms
+step:3660/5560 train_time:897788ms step_avg:245.30ms
+step:3661/5560 train_time:898040ms step_avg:245.30ms
+step:3662/5560 train_time:898286ms step_avg:245.30ms
+step:3663/5560 train_time:898536ms step_avg:245.30ms
+step:3664/5560 train_time:898786ms step_avg:245.30ms
+step:3665/5560 train_time:899036ms step_avg:245.30ms
+step:3666/5560 train_time:899287ms step_avg:245.30ms
+step:3667/5560 train_time:899537ms step_avg:245.31ms
+step:3668/5560 train_time:899785ms step_avg:245.31ms
+step:3669/5560 train_time:900060ms step_avg:245.31ms
+step:3670/5560 train_time:900284ms step_avg:245.31ms
+step:3671/5560 train_time:900533ms step_avg:245.31ms
+step:3672/5560 train_time:900784ms step_avg:245.31ms
+step:3673/5560 train_time:901030ms step_avg:245.31ms
+step:3674/5560 train_time:901284ms step_avg:245.31ms
+step:3675/5560 train_time:901530ms step_avg:245.31ms
+step:3676/5560 train_time:901777ms step_avg:245.31ms
+step:3677/5560 train_time:902025ms step_avg:245.32ms
+step:3678/5560 train_time:902276ms step_avg:245.32ms
+step:3679/5560 train_time:902522ms step_avg:245.32ms
+step:3680/5560 train_time:902768ms step_avg:245.32ms
+step:3681/5560 train_time:903015ms step_avg:245.32ms
+step:3682/5560 train_time:903269ms step_avg:245.32ms
+step:3683/5560 train_time:903520ms step_avg:245.32ms
+step:3684/5560 train_time:903767ms step_avg:245.32ms
+step:3685/5560 train_time:904012ms step_avg:245.32ms
+step:3686/5560 train_time:904262ms step_avg:245.32ms
+step:3687/5560 train_time:904516ms step_avg:245.33ms
+step:3688/5560 train_time:904765ms step_avg:245.33ms
+step:3689/5560 train_time:905012ms step_avg:245.33ms
+step:3690/5560 train_time:905260ms step_avg:245.33ms
+step:3691/5560 train_time:905507ms step_avg:245.33ms
+step:3692/5560 train_time:905756ms step_avg:245.33ms
+step:3693/5560 train_time:906006ms step_avg:245.33ms
+step:3694/5560 train_time:906256ms step_avg:245.33ms
+step:3695/5560 train_time:906505ms step_avg:245.33ms
+step:3696/5560 train_time:906751ms step_avg:245.33ms
+step:3697/5560 train_time:907030ms step_avg:245.34ms
+step:3698/5560 train_time:907257ms step_avg:245.34ms
+step:3699/5560 train_time:907503ms step_avg:245.34ms
+step:3700/5560 train_time:907757ms step_avg:245.34ms
+step:3701/5560 train_time:908004ms step_avg:245.34ms
+step:3702/5560 train_time:908257ms step_avg:245.34ms
+step:3703/5560 train_time:908501ms step_avg:245.34ms
+step:3704/5560 train_time:908751ms step_avg:245.34ms
+step:3705/5560 train_time:909000ms step_avg:245.34ms
+step:3706/5560 train_time:909248ms step_avg:245.34ms
+step:3707/5560 train_time:909496ms step_avg:245.35ms
+step:3708/5560 train_time:909747ms step_avg:245.35ms
+step:3709/5560 train_time:909997ms step_avg:245.35ms
+step:3710/5560 train_time:910246ms step_avg:245.35ms
+step:3711/5560 train_time:910496ms step_avg:245.35ms
+step:3712/5560 train_time:910746ms step_avg:245.35ms
+step:3713/5560 train_time:910996ms step_avg:245.35ms
+step:3714/5560 train_time:911247ms step_avg:245.35ms
+step:3715/5560 train_time:911497ms step_avg:245.36ms
+step:3716/5560 train_time:911746ms step_avg:245.36ms
+step:3717/5560 train_time:912001ms step_avg:245.36ms
+step:3718/5560 train_time:912253ms step_avg:245.36ms
+step:3719/5560 train_time:912500ms step_avg:245.36ms
+step:3720/5560 train_time:912747ms step_avg:245.36ms
+step:3721/5560 train_time:913001ms step_avg:245.36ms
+step:3722/5560 train_time:913252ms step_avg:245.37ms
+step:3723/5560 train_time:913499ms step_avg:245.37ms
+step:3724/5560 train_time:913751ms step_avg:245.37ms
+step:3725/5560 train_time:914032ms step_avg:245.38ms
+step:3726/5560 train_time:914256ms step_avg:245.37ms
+step:3727/5560 train_time:914508ms step_avg:245.37ms
+step:3728/5560 train_time:914758ms step_avg:245.37ms
+step:3729/5560 train_time:915007ms step_avg:245.38ms
+step:3730/5560 train_time:915263ms step_avg:245.38ms
+step:3731/5560 train_time:915511ms step_avg:245.38ms
+step:3732/5560 train_time:915759ms step_avg:245.38ms
+step:3733/5560 train_time:916014ms step_avg:245.38ms
+step:3734/5560 train_time:916268ms step_avg:245.39ms
+step:3735/5560 train_time:916518ms step_avg:245.39ms
+step:3736/5560 train_time:916765ms step_avg:245.39ms
+step:3737/5560 train_time:917016ms step_avg:245.39ms
+step:3738/5560 train_time:917267ms step_avg:245.39ms
+step:3739/5560 train_time:917512ms step_avg:245.39ms
+step:3740/5560 train_time:917765ms step_avg:245.39ms
+step:3741/5560 train_time:918013ms step_avg:245.39ms
+step:3742/5560 train_time:918263ms step_avg:245.39ms
+step:3743/5560 train_time:918509ms step_avg:245.39ms
+step:3744/5560 train_time:918766ms step_avg:245.40ms
+step:3745/5560 train_time:919013ms step_avg:245.40ms
+step:3746/5560 train_time:919257ms step_avg:245.40ms
+step:3747/5560 train_time:919509ms step_avg:245.40ms
+step:3748/5560 train_time:919759ms step_avg:245.40ms
+step:3749/5560 train_time:920006ms step_avg:245.40ms
+step:3750/5560 train_time:920254ms step_avg:245.40ms
+step:3750/5560 val_loss:3.035601 train_time:920506ms step_avg:245.47ms
+step:3751/5560 train_time:920524ms step_avg:245.41ms
+step:3752/5560 train_time:920756ms step_avg:245.40ms
+step:3753/5560 train_time:921044ms step_avg:245.42ms
+step:3754/5560 train_time:921267ms step_avg:245.41ms
+step:3755/5560 train_time:921516ms step_avg:245.41ms
+step:3756/5560 train_time:921764ms step_avg:245.41ms
+step:3757/5560 train_time:922015ms step_avg:245.41ms
+step:3758/5560 train_time:922273ms step_avg:245.42ms
+step:3759/5560 train_time:922519ms step_avg:245.42ms
+step:3760/5560 train_time:922771ms step_avg:245.42ms
+step:3761/5560 train_time:923020ms step_avg:245.42ms
+step:3762/5560 train_time:923273ms step_avg:245.42ms
+step:3763/5560 train_time:923520ms step_avg:245.42ms
+step:3764/5560 train_time:923774ms step_avg:245.42ms
+step:3765/5560 train_time:924023ms step_avg:245.42ms
+step:3766/5560 train_time:924274ms step_avg:245.43ms
+step:3767/5560 train_time:924524ms step_avg:245.43ms
+step:3768/5560 train_time:924774ms step_avg:245.43ms
+step:3769/5560 train_time:925019ms step_avg:245.43ms
+step:3770/5560 train_time:925267ms step_avg:245.43ms
+step:3771/5560 train_time:925516ms step_avg:245.43ms
+step:3772/5560 train_time:925770ms step_avg:245.43ms
+step:3773/5560 train_time:926019ms step_avg:245.43ms
+step:3774/5560 train_time:926266ms step_avg:245.43ms
+step:3775/5560 train_time:926514ms step_avg:245.43ms
+step:3776/5560 train_time:926767ms step_avg:245.44ms
+step:3777/5560 train_time:927015ms step_avg:245.44ms
+step:3778/5560 train_time:927275ms step_avg:245.44ms
+step:3779/5560 train_time:927523ms step_avg:245.44ms
+step:3780/5560 train_time:927770ms step_avg:245.44ms
+step:3781/5560 train_time:928048ms step_avg:245.45ms
+step:3782/5560 train_time:928275ms step_avg:245.45ms
+step:3783/5560 train_time:928528ms step_avg:245.45ms
+step:3784/5560 train_time:928776ms step_avg:245.45ms
+step:3785/5560 train_time:929024ms step_avg:245.45ms
+step:3786/5560 train_time:929271ms step_avg:245.45ms
+step:3787/5560 train_time:929520ms step_avg:245.45ms
+step:3788/5560 train_time:929769ms step_avg:245.45ms
+step:3789/5560 train_time:930018ms step_avg:245.45ms
+step:3790/5560 train_time:930273ms step_avg:245.45ms
+step:3791/5560 train_time:930523ms step_avg:245.46ms
+step:3792/5560 train_time:930779ms step_avg:245.46ms
+step:3793/5560 train_time:931028ms step_avg:245.46ms
+step:3794/5560 train_time:931302ms step_avg:245.47ms
+step:3795/5560 train_time:931555ms step_avg:245.47ms
+step:3796/5560 train_time:931808ms step_avg:245.47ms
+step:3797/5560 train_time:932032ms step_avg:245.47ms
+step:3798/5560 train_time:932281ms step_avg:245.47ms
+step:3799/5560 train_time:932527ms step_avg:245.47ms
+step:3800/5560 train_time:932780ms step_avg:245.47ms
+step:3801/5560 train_time:933028ms step_avg:245.47ms
+step:3802/5560 train_time:933279ms step_avg:245.47ms
+step:3803/5560 train_time:933528ms step_avg:245.47ms
+step:3804/5560 train_time:933778ms step_avg:245.47ms
+step:3805/5560 train_time:934025ms step_avg:245.47ms
+step:3806/5560 train_time:934274ms step_avg:245.47ms
+step:3807/5560 train_time:934523ms step_avg:245.47ms
+step:3808/5560 train_time:934772ms step_avg:245.48ms
+step:3809/5560 train_time:935049ms step_avg:245.48ms
+step:3810/5560 train_time:935274ms step_avg:245.48ms
+step:3811/5560 train_time:935524ms step_avg:245.48ms
+step:3812/5560 train_time:935776ms step_avg:245.48ms
+step:3813/5560 train_time:936027ms step_avg:245.48ms
+step:3814/5560 train_time:936279ms step_avg:245.48ms
+step:3815/5560 train_time:936535ms step_avg:245.49ms
+step:3816/5560 train_time:936780ms step_avg:245.49ms
+step:3817/5560 train_time:937033ms step_avg:245.49ms
+step:3818/5560 train_time:937282ms step_avg:245.49ms
+step:3819/5560 train_time:937533ms step_avg:245.49ms
+step:3820/5560 train_time:937782ms step_avg:245.49ms
+step:3821/5560 train_time:938029ms step_avg:245.49ms
+step:3822/5560 train_time:938275ms step_avg:245.49ms
+step:3823/5560 train_time:938522ms step_avg:245.49ms
+step:3824/5560 train_time:938772ms step_avg:245.49ms
+step:3825/5560 train_time:939022ms step_avg:245.50ms
+step:3826/5560 train_time:939270ms step_avg:245.50ms
+step:3827/5560 train_time:939517ms step_avg:245.50ms
+step:3828/5560 train_time:939765ms step_avg:245.50ms
+step:3829/5560 train_time:940020ms step_avg:245.50ms
+step:3830/5560 train_time:940269ms step_avg:245.50ms
+step:3831/5560 train_time:940513ms step_avg:245.50ms
+step:3832/5560 train_time:940759ms step_avg:245.50ms
+step:3833/5560 train_time:941010ms step_avg:245.50ms
+step:3834/5560 train_time:941262ms step_avg:245.50ms
+step:3835/5560 train_time:941508ms step_avg:245.50ms
+step:3836/5560 train_time:941755ms step_avg:245.50ms
+step:3837/5560 train_time:942045ms step_avg:245.52ms
+step:3838/5560 train_time:942273ms step_avg:245.51ms
+step:3839/5560 train_time:942529ms step_avg:245.51ms
+step:3840/5560 train_time:942783ms step_avg:245.52ms
+step:3841/5560 train_time:943039ms step_avg:245.52ms
+step:3842/5560 train_time:943284ms step_avg:245.52ms
+step:3843/5560 train_time:943533ms step_avg:245.52ms
+step:3844/5560 train_time:943783ms step_avg:245.52ms
+step:3845/5560 train_time:944030ms step_avg:245.52ms
+step:3846/5560 train_time:944283ms step_avg:245.52ms
+step:3847/5560 train_time:944528ms step_avg:245.52ms
+step:3848/5560 train_time:944787ms step_avg:245.53ms
+step:3849/5560 train_time:945036ms step_avg:245.53ms
+step:3850/5560 train_time:945285ms step_avg:245.53ms
+step:3851/5560 train_time:945531ms step_avg:245.53ms
+step:3852/5560 train_time:945786ms step_avg:245.53ms
+step:3853/5560 train_time:946037ms step_avg:245.53ms
+step:3854/5560 train_time:946293ms step_avg:245.54ms
+step:3855/5560 train_time:946542ms step_avg:245.54ms
+step:3856/5560 train_time:946791ms step_avg:245.54ms
+step:3857/5560 train_time:947039ms step_avg:245.54ms
+step:3858/5560 train_time:947293ms step_avg:245.54ms
+step:3859/5560 train_time:947542ms step_avg:245.54ms
+step:3860/5560 train_time:947794ms step_avg:245.54ms
+step:3861/5560 train_time:948051ms step_avg:245.55ms
+step:3862/5560 train_time:948299ms step_avg:245.55ms
+step:3863/5560 train_time:948559ms step_avg:245.55ms
+step:3864/5560 train_time:948809ms step_avg:245.55ms
+step:3865/5560 train_time:949083ms step_avg:245.56ms
+step:3866/5560 train_time:949309ms step_avg:245.55ms
+step:3867/5560 train_time:949557ms step_avg:245.55ms
+step:3868/5560 train_time:949804ms step_avg:245.55ms
+step:3869/5560 train_time:950055ms step_avg:245.56ms
+step:3870/5560 train_time:950303ms step_avg:245.56ms
+step:3871/5560 train_time:950550ms step_avg:245.56ms
+step:3872/5560 train_time:950799ms step_avg:245.56ms
+step:3873/5560 train_time:951049ms step_avg:245.56ms
+step:3874/5560 train_time:951296ms step_avg:245.56ms
+step:3875/5560 train_time:951546ms step_avg:245.56ms
+step:3875/5560 val_loss:3.026505 train_time:951794ms step_avg:245.62ms
+step:3876/5560 train_time:951814ms step_avg:245.57ms
+step:3877/5560 train_time:952045ms step_avg:245.56ms
+step:3878/5560 train_time:952302ms step_avg:245.57ms
+step:3879/5560 train_time:952549ms step_avg:245.57ms
+step:3880/5560 train_time:952797ms step_avg:245.57ms
+step:3881/5560 train_time:953043ms step_avg:245.57ms
+step:3882/5560 train_time:953291ms step_avg:245.57ms
+step:3883/5560 train_time:953548ms step_avg:245.57ms
+step:3884/5560 train_time:953798ms step_avg:245.57ms
+step:3885/5560 train_time:954047ms step_avg:245.57ms
+step:3886/5560 train_time:954301ms step_avg:245.57ms
+step:3887/5560 train_time:954551ms step_avg:245.58ms
+step:3888/5560 train_time:954799ms step_avg:245.58ms
+step:3889/5560 train_time:955046ms step_avg:245.58ms
+step:3890/5560 train_time:955293ms step_avg:245.58ms
+step:3891/5560 train_time:955543ms step_avg:245.58ms
+step:3892/5560 train_time:955790ms step_avg:245.58ms
+step:3893/5560 train_time:956070ms step_avg:245.59ms
+step:3894/5560 train_time:956292ms step_avg:245.58ms
+step:3895/5560 train_time:956542ms step_avg:245.58ms
+step:3896/5560 train_time:956788ms step_avg:245.58ms
+step:3897/5560 train_time:957036ms step_avg:245.58ms
+step:3898/5560 train_time:957288ms step_avg:245.58ms
+step:3899/5560 train_time:957538ms step_avg:245.59ms
+step:3900/5560 train_time:957786ms step_avg:245.59ms
+step:3901/5560 train_time:958032ms step_avg:245.59ms
+step:3902/5560 train_time:958278ms step_avg:245.59ms
+step:3903/5560 train_time:958527ms step_avg:245.59ms
+step:3904/5560 train_time:958776ms step_avg:245.59ms
+step:3905/5560 train_time:959032ms step_avg:245.59ms
+step:3906/5560 train_time:959283ms step_avg:245.59ms
+step:3907/5560 train_time:959530ms step_avg:245.59ms
+step:3908/5560 train_time:959780ms step_avg:245.59ms
+step:3909/5560 train_time:960028ms step_avg:245.59ms
+step:3910/5560 train_time:960277ms step_avg:245.60ms
+step:3911/5560 train_time:960525ms step_avg:245.60ms
+step:3912/5560 train_time:960774ms step_avg:245.60ms
+step:3913/5560 train_time:961024ms step_avg:245.60ms
+step:3914/5560 train_time:961275ms step_avg:245.60ms
+step:3915/5560 train_time:961522ms step_avg:245.60ms
+step:3916/5560 train_time:961773ms step_avg:245.60ms
+step:3917/5560 train_time:962029ms step_avg:245.60ms
+step:3918/5560 train_time:962282ms step_avg:245.61ms
+step:3919/5560 train_time:962532ms step_avg:245.61ms
+step:3920/5560 train_time:962782ms step_avg:245.61ms
+step:3921/5560 train_time:963061ms step_avg:245.62ms
+step:3922/5560 train_time:963284ms step_avg:245.61ms
+step:3923/5560 train_time:963533ms step_avg:245.61ms
+step:3924/5560 train_time:963782ms step_avg:245.61ms
+step:3925/5560 train_time:964031ms step_avg:245.61ms
+step:3926/5560 train_time:964287ms step_avg:245.62ms
+step:3927/5560 train_time:964531ms step_avg:245.62ms
+step:3928/5560 train_time:964776ms step_avg:245.62ms
+step:3929/5560 train_time:965021ms step_avg:245.62ms
+step:3930/5560 train_time:965271ms step_avg:245.62ms
+step:3931/5560 train_time:965522ms step_avg:245.62ms
+step:3932/5560 train_time:965769ms step_avg:245.62ms
+step:3933/5560 train_time:966022ms step_avg:245.62ms
+step:3934/5560 train_time:966270ms step_avg:245.62ms
+step:3935/5560 train_time:966525ms step_avg:245.62ms
+step:3936/5560 train_time:966771ms step_avg:245.62ms
+step:3937/5560 train_time:967019ms step_avg:245.62ms
+step:3938/5560 train_time:967268ms step_avg:245.62ms
+step:3939/5560 train_time:967519ms step_avg:245.63ms
+step:3940/5560 train_time:967769ms step_avg:245.63ms
+step:3941/5560 train_time:968017ms step_avg:245.63ms
+step:3942/5560 train_time:968272ms step_avg:245.63ms
+step:3943/5560 train_time:968521ms step_avg:245.63ms
+step:3944/5560 train_time:968768ms step_avg:245.63ms
+step:3945/5560 train_time:969018ms step_avg:245.63ms
+step:3946/5560 train_time:969267ms step_avg:245.63ms
+step:3947/5560 train_time:969520ms step_avg:245.63ms
+step:3948/5560 train_time:969778ms step_avg:245.64ms
+step:3949/5560 train_time:970058ms step_avg:245.65ms
+step:3950/5560 train_time:970280ms step_avg:245.64ms
+step:3951/5560 train_time:970527ms step_avg:245.64ms
+step:3952/5560 train_time:970775ms step_avg:245.64ms
+step:3953/5560 train_time:971026ms step_avg:245.64ms
+step:3954/5560 train_time:971275ms step_avg:245.64ms
+step:3955/5560 train_time:971531ms step_avg:245.65ms
+step:3956/5560 train_time:971780ms step_avg:245.65ms
+step:3957/5560 train_time:972029ms step_avg:245.65ms
+step:3958/5560 train_time:972290ms step_avg:245.65ms
+step:3959/5560 train_time:972544ms step_avg:245.65ms
+step:3960/5560 train_time:972788ms step_avg:245.65ms
+step:3961/5560 train_time:973036ms step_avg:245.65ms
+step:3962/5560 train_time:973288ms step_avg:245.66ms
+step:3963/5560 train_time:973535ms step_avg:245.66ms
+step:3964/5560 train_time:973783ms step_avg:245.66ms
+step:3965/5560 train_time:974029ms step_avg:245.66ms
+step:3966/5560 train_time:974279ms step_avg:245.66ms
+step:3967/5560 train_time:974527ms step_avg:245.66ms
+step:3968/5560 train_time:974779ms step_avg:245.66ms
+step:3969/5560 train_time:975025ms step_avg:245.66ms
+step:3970/5560 train_time:975273ms step_avg:245.66ms
+step:3971/5560 train_time:975522ms step_avg:245.66ms
+step:3972/5560 train_time:975771ms step_avg:245.66ms
+step:3973/5560 train_time:976018ms step_avg:245.66ms
+step:3974/5560 train_time:976266ms step_avg:245.66ms
+step:3975/5560 train_time:976516ms step_avg:245.66ms
+step:3976/5560 train_time:976765ms step_avg:245.67ms
+step:3977/5560 train_time:977044ms step_avg:245.67ms
+step:3978/5560 train_time:977269ms step_avg:245.67ms
+step:3979/5560 train_time:977515ms step_avg:245.67ms
+step:3980/5560 train_time:977762ms step_avg:245.67ms
+step:3981/5560 train_time:978010ms step_avg:245.67ms
+step:3982/5560 train_time:978260ms step_avg:245.67ms
+step:3983/5560 train_time:978509ms step_avg:245.67ms
+step:3984/5560 train_time:978761ms step_avg:245.67ms
+step:3985/5560 train_time:979014ms step_avg:245.67ms
+step:3986/5560 train_time:979265ms step_avg:245.68ms
+step:3987/5560 train_time:979511ms step_avg:245.68ms
+step:3988/5560 train_time:979762ms step_avg:245.68ms
+step:3989/5560 train_time:980013ms step_avg:245.68ms
+step:3990/5560 train_time:980263ms step_avg:245.68ms
+step:3991/5560 train_time:980511ms step_avg:245.68ms
+step:3992/5560 train_time:980763ms step_avg:245.68ms
+step:3993/5560 train_time:981013ms step_avg:245.68ms
+step:3994/5560 train_time:981263ms step_avg:245.68ms
+step:3995/5560 train_time:981509ms step_avg:245.68ms
+step:3996/5560 train_time:981763ms step_avg:245.69ms
+step:3997/5560 train_time:982015ms step_avg:245.69ms
+step:3998/5560 train_time:982268ms step_avg:245.69ms
+step:3999/5560 train_time:982514ms step_avg:245.69ms
+step:4000/5560 train_time:982768ms step_avg:245.69ms
+step:4000/5560 val_loss:3.017215 train_time:983022ms step_avg:245.76ms
+step:4001/5560 train_time:983039ms step_avg:245.70ms
+step:4002/5560 train_time:983272ms step_avg:245.70ms
+step:4003/5560 train_time:983531ms step_avg:245.70ms
+step:4004/5560 train_time:983781ms step_avg:245.70ms
+step:4005/5560 train_time:984057ms step_avg:245.71ms
+step:4006/5560 train_time:984291ms step_avg:245.70ms
+step:4007/5560 train_time:984540ms step_avg:245.71ms
+step:4008/5560 train_time:984787ms step_avg:245.71ms
+step:4009/5560 train_time:985037ms step_avg:245.71ms
+step:4010/5560 train_time:985283ms step_avg:245.71ms
+step:4011/5560 train_time:985538ms step_avg:245.71ms
+step:4012/5560 train_time:985788ms step_avg:245.71ms
+step:4013/5560 train_time:986037ms step_avg:245.71ms
+step:4014/5560 train_time:986284ms step_avg:245.71ms
+step:4015/5560 train_time:986533ms step_avg:245.71ms
+step:4016/5560 train_time:986784ms step_avg:245.71ms
+step:4017/5560 train_time:987038ms step_avg:245.72ms
+step:4018/5560 train_time:987283ms step_avg:245.71ms
+step:4019/5560 train_time:987533ms step_avg:245.72ms
+step:4020/5560 train_time:987780ms step_avg:245.72ms
+step:4021/5560 train_time:988031ms step_avg:245.72ms
+step:4022/5560 train_time:988279ms step_avg:245.72ms
+step:4023/5560 train_time:988526ms step_avg:245.72ms
+step:4024/5560 train_time:988775ms step_avg:245.72ms
+step:4025/5560 train_time:989025ms step_avg:245.72ms
+step:4026/5560 train_time:989280ms step_avg:245.72ms
+step:4027/5560 train_time:989526ms step_avg:245.72ms
+step:4028/5560 train_time:989774ms step_avg:245.72ms
+step:4029/5560 train_time:990022ms step_avg:245.72ms
+step:4030/5560 train_time:990270ms step_avg:245.72ms
+step:4031/5560 train_time:990516ms step_avg:245.72ms
+step:4032/5560 train_time:990764ms step_avg:245.73ms
+step:4033/5560 train_time:991039ms step_avg:245.73ms
+step:4034/5560 train_time:991264ms step_avg:245.73ms
+step:4035/5560 train_time:991513ms step_avg:245.73ms
+step:4036/5560 train_time:991763ms step_avg:245.73ms
+step:4037/5560 train_time:992011ms step_avg:245.73ms
+step:4038/5560 train_time:992262ms step_avg:245.73ms
+step:4039/5560 train_time:992508ms step_avg:245.73ms
+step:4040/5560 train_time:992756ms step_avg:245.73ms
+step:4041/5560 train_time:993002ms step_avg:245.73ms
+step:4042/5560 train_time:993254ms step_avg:245.73ms
+step:4043/5560 train_time:993502ms step_avg:245.73ms
+step:4044/5560 train_time:993752ms step_avg:245.73ms
+step:4045/5560 train_time:993997ms step_avg:245.73ms
+step:4046/5560 train_time:994249ms step_avg:245.74ms
+step:4047/5560 train_time:994495ms step_avg:245.74ms
+step:4048/5560 train_time:994745ms step_avg:245.74ms
+step:4049/5560 train_time:994993ms step_avg:245.74ms
+step:4050/5560 train_time:995245ms step_avg:245.74ms
+step:4051/5560 train_time:995491ms step_avg:245.74ms
+step:4052/5560 train_time:995744ms step_avg:245.74ms
+step:4053/5560 train_time:995990ms step_avg:245.74ms
+step:4054/5560 train_time:996236ms step_avg:245.74ms
+step:4055/5560 train_time:996484ms step_avg:245.74ms
+step:4056/5560 train_time:996738ms step_avg:245.74ms
+step:4057/5560 train_time:996989ms step_avg:245.75ms
+step:4058/5560 train_time:997237ms step_avg:245.75ms
+step:4059/5560 train_time:997486ms step_avg:245.75ms
+step:4060/5560 train_time:997741ms step_avg:245.75ms
+step:4061/5560 train_time:998019ms step_avg:245.76ms
+step:4062/5560 train_time:998246ms step_avg:245.75ms
+step:4063/5560 train_time:998501ms step_avg:245.75ms
+step:4064/5560 train_time:998756ms step_avg:245.76ms
+step:4065/5560 train_time:999004ms step_avg:245.76ms
+step:4066/5560 train_time:999256ms step_avg:245.76ms
+step:4067/5560 train_time:999506ms step_avg:245.76ms
+step:4068/5560 train_time:999756ms step_avg:245.76ms
+step:4069/5560 train_time:1000004ms step_avg:245.76ms
+step:4070/5560 train_time:1000257ms step_avg:245.76ms
+step:4071/5560 train_time:1000508ms step_avg:245.76ms
+step:4072/5560 train_time:1000760ms step_avg:245.77ms
+step:4073/5560 train_time:1001005ms step_avg:245.77ms
+step:4074/5560 train_time:1001258ms step_avg:245.77ms
+step:4075/5560 train_time:1001505ms step_avg:245.77ms
+step:4076/5560 train_time:1001763ms step_avg:245.77ms
+step:4077/5560 train_time:1002009ms step_avg:245.77ms
+step:4078/5560 train_time:1002259ms step_avg:245.77ms
+step:4079/5560 train_time:1002507ms step_avg:245.77ms
+step:4080/5560 train_time:1002756ms step_avg:245.77ms
+step:4081/5560 train_time:1003003ms step_avg:245.77ms
+step:4082/5560 train_time:1003253ms step_avg:245.77ms
+step:4083/5560 train_time:1003499ms step_avg:245.77ms
+step:4084/5560 train_time:1003745ms step_avg:245.77ms
+step:4085/5560 train_time:1003997ms step_avg:245.78ms
+step:4086/5560 train_time:1004252ms step_avg:245.78ms
+step:4087/5560 train_time:1004500ms step_avg:245.78ms
+step:4088/5560 train_time:1004751ms step_avg:245.78ms
+step:4089/5560 train_time:1005029ms step_avg:245.79ms
+step:4090/5560 train_time:1005261ms step_avg:245.78ms
+step:4091/5560 train_time:1005506ms step_avg:245.78ms
+step:4092/5560 train_time:1005753ms step_avg:245.79ms
+step:4093/5560 train_time:1006002ms step_avg:245.79ms
+step:4094/5560 train_time:1006253ms step_avg:245.79ms
+step:4095/5560 train_time:1006501ms step_avg:245.79ms
+step:4096/5560 train_time:1006751ms step_avg:245.79ms
+step:4097/5560 train_time:1007001ms step_avg:245.79ms
+step:4098/5560 train_time:1007260ms step_avg:245.79ms
+step:4099/5560 train_time:1007509ms step_avg:245.79ms
+step:4100/5560 train_time:1007758ms step_avg:245.79ms
+step:4101/5560 train_time:1008008ms step_avg:245.80ms
+step:4102/5560 train_time:1008260ms step_avg:245.80ms
+step:4103/5560 train_time:1008512ms step_avg:245.80ms
+step:4104/5560 train_time:1008764ms step_avg:245.80ms
+step:4105/5560 train_time:1009010ms step_avg:245.80ms
+step:4106/5560 train_time:1009262ms step_avg:245.80ms
+step:4107/5560 train_time:1009508ms step_avg:245.80ms
+step:4108/5560 train_time:1009757ms step_avg:245.80ms
+step:4109/5560 train_time:1010005ms step_avg:245.80ms
+step:4110/5560 train_time:1010255ms step_avg:245.80ms
+step:4111/5560 train_time:1010516ms step_avg:245.81ms
+step:4112/5560 train_time:1010767ms step_avg:245.81ms
+step:4113/5560 train_time:1011014ms step_avg:245.81ms
+step:4114/5560 train_time:1011269ms step_avg:245.81ms
+step:4115/5560 train_time:1011517ms step_avg:245.81ms
+step:4116/5560 train_time:1011763ms step_avg:245.81ms
+step:4117/5560 train_time:1012048ms step_avg:245.82ms
+step:4118/5560 train_time:1012271ms step_avg:245.82ms
+step:4119/5560 train_time:1012525ms step_avg:245.82ms
+step:4120/5560 train_time:1012778ms step_avg:245.82ms
+step:4121/5560 train_time:1013029ms step_avg:245.82ms
+step:4122/5560 train_time:1013278ms step_avg:245.82ms
+step:4123/5560 train_time:1013531ms step_avg:245.82ms
+step:4124/5560 train_time:1013781ms step_avg:245.82ms
+step:4125/5560 train_time:1014029ms step_avg:245.83ms
+step:4125/5560 val_loss:3.007881 train_time:1014285ms step_avg:245.89ms
+step:4126/5560 train_time:1014302ms step_avg:245.83ms
+step:4127/5560 train_time:1014536ms step_avg:245.83ms
+step:4128/5560 train_time:1014797ms step_avg:245.83ms
+step:4129/5560 train_time:1015045ms step_avg:245.83ms
+step:4130/5560 train_time:1015290ms step_avg:245.83ms
+step:4131/5560 train_time:1015540ms step_avg:245.83ms
+step:4132/5560 train_time:1015791ms step_avg:245.84ms
+step:4133/5560 train_time:1016040ms step_avg:245.84ms
+step:4134/5560 train_time:1016292ms step_avg:245.84ms
+step:4135/5560 train_time:1016544ms step_avg:245.84ms
+step:4136/5560 train_time:1016803ms step_avg:245.84ms
+step:4137/5560 train_time:1017055ms step_avg:245.84ms
+step:4138/5560 train_time:1017301ms step_avg:245.84ms
+step:4139/5560 train_time:1017559ms step_avg:245.85ms
+step:4140/5560 train_time:1017810ms step_avg:245.85ms
+step:4141/5560 train_time:1018063ms step_avg:245.85ms
+step:4142/5560 train_time:1018311ms step_avg:245.85ms
+step:4143/5560 train_time:1018564ms step_avg:245.85ms
+step:4144/5560 train_time:1018816ms step_avg:245.85ms
+step:4145/5560 train_time:1019093ms step_avg:245.86ms
+step:4146/5560 train_time:1019320ms step_avg:245.86ms
+step:4147/5560 train_time:1019570ms step_avg:245.86ms
+step:4148/5560 train_time:1019823ms step_avg:245.86ms
+step:4149/5560 train_time:1020079ms step_avg:245.86ms
+step:4150/5560 train_time:1020330ms step_avg:245.86ms
+step:4151/5560 train_time:1020583ms step_avg:245.86ms
+step:4152/5560 train_time:1020835ms step_avg:245.87ms
+step:4153/5560 train_time:1021084ms step_avg:245.87ms
+step:4154/5560 train_time:1021336ms step_avg:245.87ms
+step:4155/5560 train_time:1021586ms step_avg:245.87ms
+step:4156/5560 train_time:1021849ms step_avg:245.87ms
+step:4157/5560 train_time:1022110ms step_avg:245.88ms
+step:4158/5560 train_time:1022368ms step_avg:245.88ms
+step:4159/5560 train_time:1022617ms step_avg:245.88ms
+step:4160/5560 train_time:1022871ms step_avg:245.88ms
+step:4161/5560 train_time:1023121ms step_avg:245.88ms
+step:4162/5560 train_time:1023373ms step_avg:245.88ms
+step:4163/5560 train_time:1023627ms step_avg:245.89ms
+step:4164/5560 train_time:1023888ms step_avg:245.89ms
+step:4165/5560 train_time:1024143ms step_avg:245.89ms
+step:4166/5560 train_time:1024394ms step_avg:245.89ms
+step:4167/5560 train_time:1024642ms step_avg:245.89ms
+step:4168/5560 train_time:1024891ms step_avg:245.90ms
+step:4169/5560 train_time:1025138ms step_avg:245.90ms
+step:4170/5560 train_time:1025390ms step_avg:245.90ms
+step:4171/5560 train_time:1025642ms step_avg:245.90ms
+step:4172/5560 train_time:1025892ms step_avg:245.90ms
+step:4173/5560 train_time:1026173ms step_avg:245.91ms
+step:4174/5560 train_time:1026398ms step_avg:245.90ms
+step:4175/5560 train_time:1026650ms step_avg:245.90ms
+step:4176/5560 train_time:1026899ms step_avg:245.91ms
+step:4177/5560 train_time:1027155ms step_avg:245.91ms
+step:4178/5560 train_time:1027406ms step_avg:245.91ms
+step:4179/5560 train_time:1027655ms step_avg:245.91ms
+step:4180/5560 train_time:1027904ms step_avg:245.91ms
+step:4181/5560 train_time:1028156ms step_avg:245.91ms
+step:4182/5560 train_time:1028409ms step_avg:245.91ms
+step:4183/5560 train_time:1028661ms step_avg:245.91ms
+step:4184/5560 train_time:1028916ms step_avg:245.92ms
+step:4185/5560 train_time:1029165ms step_avg:245.92ms
+step:4186/5560 train_time:1029423ms step_avg:245.92ms
+step:4187/5560 train_time:1029682ms step_avg:245.92ms
+step:4188/5560 train_time:1029932ms step_avg:245.92ms
+step:4189/5560 train_time:1030184ms step_avg:245.93ms
+step:4190/5560 train_time:1030435ms step_avg:245.93ms
+step:4191/5560 train_time:1030701ms step_avg:245.93ms
+step:4192/5560 train_time:1030949ms step_avg:245.93ms
+step:4193/5560 train_time:1031194ms step_avg:245.93ms
+step:4194/5560 train_time:1031445ms step_avg:245.93ms
+step:4195/5560 train_time:1031703ms step_avg:245.94ms
+step:4196/5560 train_time:1031957ms step_avg:245.94ms
+step:4197/5560 train_time:1032202ms step_avg:245.94ms
+step:4198/5560 train_time:1032451ms step_avg:245.94ms
+step:4199/5560 train_time:1032702ms step_avg:245.94ms
+step:4200/5560 train_time:1032959ms step_avg:245.94ms
+step:4201/5560 train_time:1033240ms step_avg:245.95ms
+step:4202/5560 train_time:1033466ms step_avg:245.95ms
+step:4203/5560 train_time:1033714ms step_avg:245.95ms
+step:4204/5560 train_time:1033963ms step_avg:245.95ms
+step:4205/5560 train_time:1034213ms step_avg:245.95ms
+step:4206/5560 train_time:1034469ms step_avg:245.95ms
+step:4207/5560 train_time:1034726ms step_avg:245.95ms
+step:4208/5560 train_time:1034980ms step_avg:245.96ms
+step:4209/5560 train_time:1035231ms step_avg:245.96ms
+step:4210/5560 train_time:1035477ms step_avg:245.96ms
+step:4211/5560 train_time:1035727ms step_avg:245.96ms
+step:4212/5560 train_time:1035977ms step_avg:245.96ms
+step:4213/5560 train_time:1036228ms step_avg:245.96ms
+step:4214/5560 train_time:1036478ms step_avg:245.96ms
+step:4215/5560 train_time:1036726ms step_avg:245.96ms
+step:4216/5560 train_time:1036978ms step_avg:245.96ms
+step:4217/5560 train_time:1037227ms step_avg:245.96ms
+step:4218/5560 train_time:1037479ms step_avg:245.96ms
+step:4219/5560 train_time:1037732ms step_avg:245.97ms
+step:4220/5560 train_time:1037981ms step_avg:245.97ms
+step:4221/5560 train_time:1038234ms step_avg:245.97ms
+step:4222/5560 train_time:1038485ms step_avg:245.97ms
+step:4223/5560 train_time:1038740ms step_avg:245.97ms
+step:4224/5560 train_time:1038988ms step_avg:245.97ms
+step:4225/5560 train_time:1039238ms step_avg:245.97ms
+step:4226/5560 train_time:1039489ms step_avg:245.97ms
+step:4227/5560 train_time:1039742ms step_avg:245.98ms
+step:4228/5560 train_time:1039989ms step_avg:245.98ms
+step:4229/5560 train_time:1040271ms step_avg:245.99ms
+step:4230/5560 train_time:1040499ms step_avg:245.98ms
+step:4231/5560 train_time:1040752ms step_avg:245.98ms
+step:4232/5560 train_time:1040998ms step_avg:245.98ms
+step:4233/5560 train_time:1041248ms step_avg:245.98ms
+step:4234/5560 train_time:1041501ms step_avg:245.99ms
+step:4235/5560 train_time:1041754ms step_avg:245.99ms
+step:4236/5560 train_time:1042007ms step_avg:245.99ms
+step:4237/5560 train_time:1042254ms step_avg:245.99ms
+step:4238/5560 train_time:1042504ms step_avg:245.99ms
+step:4239/5560 train_time:1042758ms step_avg:245.99ms
+step:4240/5560 train_time:1043013ms step_avg:245.99ms
+step:4241/5560 train_time:1043264ms step_avg:245.99ms
+step:4242/5560 train_time:1043515ms step_avg:246.00ms
+step:4243/5560 train_time:1043766ms step_avg:246.00ms
+step:4244/5560 train_time:1044017ms step_avg:246.00ms
+step:4245/5560 train_time:1044265ms step_avg:246.00ms
+step:4246/5560 train_time:1044512ms step_avg:246.00ms
+step:4247/5560 train_time:1044770ms step_avg:246.00ms
+step:4248/5560 train_time:1045019ms step_avg:246.00ms
+step:4249/5560 train_time:1045278ms step_avg:246.01ms
+step:4250/5560 train_time:1045537ms step_avg:246.01ms
+step:4250/5560 val_loss:2.999985 train_time:1045786ms step_avg:246.07ms
+step:4251/5560 train_time:1045803ms step_avg:246.01ms
+step:4252/5560 train_time:1046042ms step_avg:246.01ms
+step:4253/5560 train_time:1046298ms step_avg:246.01ms
+step:4254/5560 train_time:1046552ms step_avg:246.02ms
+step:4255/5560 train_time:1046807ms step_avg:246.02ms
+step:4256/5560 train_time:1047058ms step_avg:246.02ms
+step:4257/5560 train_time:1047336ms step_avg:246.03ms
+step:4258/5560 train_time:1047561ms step_avg:246.02ms
+step:4259/5560 train_time:1047811ms step_avg:246.02ms
+step:4260/5560 train_time:1048063ms step_avg:246.02ms
+step:4261/5560 train_time:1048315ms step_avg:246.03ms
+step:4262/5560 train_time:1048565ms step_avg:246.03ms
+step:4263/5560 train_time:1048814ms step_avg:246.03ms
+step:4264/5560 train_time:1049065ms step_avg:246.03ms
+step:4265/5560 train_time:1049317ms step_avg:246.03ms
+step:4266/5560 train_time:1049566ms step_avg:246.03ms
+step:4267/5560 train_time:1049819ms step_avg:246.03ms
+step:4268/5560 train_time:1050069ms step_avg:246.03ms
+step:4269/5560 train_time:1050328ms step_avg:246.04ms
+step:4270/5560 train_time:1050581ms step_avg:246.04ms
+step:4271/5560 train_time:1050833ms step_avg:246.04ms
+step:4272/5560 train_time:1051084ms step_avg:246.04ms
+step:4273/5560 train_time:1051335ms step_avg:246.04ms
+step:4274/5560 train_time:1051593ms step_avg:246.04ms
+step:4275/5560 train_time:1051844ms step_avg:246.05ms
+step:4276/5560 train_time:1052091ms step_avg:246.05ms
+step:4277/5560 train_time:1052346ms step_avg:246.05ms
+step:4278/5560 train_time:1052594ms step_avg:246.05ms
+step:4279/5560 train_time:1052847ms step_avg:246.05ms
+step:4280/5560 train_time:1053093ms step_avg:246.05ms
+step:4281/5560 train_time:1053344ms step_avg:246.05ms
+step:4282/5560 train_time:1053601ms step_avg:246.05ms
+step:4283/5560 train_time:1053851ms step_avg:246.05ms
+step:4284/5560 train_time:1054103ms step_avg:246.06ms
+step:4285/5560 train_time:1054382ms step_avg:246.06ms
+step:4286/5560 train_time:1054606ms step_avg:246.06ms
+step:4287/5560 train_time:1054862ms step_avg:246.06ms
+step:4288/5560 train_time:1055117ms step_avg:246.06ms
+step:4289/5560 train_time:1055375ms step_avg:246.07ms
+step:4290/5560 train_time:1055632ms step_avg:246.07ms
+step:4291/5560 train_time:1055881ms step_avg:246.07ms
+step:4292/5560 train_time:1056127ms step_avg:246.07ms
+step:4293/5560 train_time:1056380ms step_avg:246.07ms
+step:4294/5560 train_time:1056630ms step_avg:246.07ms
+step:4295/5560 train_time:1056880ms step_avg:246.07ms
+step:4296/5560 train_time:1057130ms step_avg:246.07ms
+step:4297/5560 train_time:1057382ms step_avg:246.07ms
+step:4298/5560 train_time:1057633ms step_avg:246.08ms
+step:4299/5560 train_time:1057883ms step_avg:246.08ms
+step:4300/5560 train_time:1058132ms step_avg:246.08ms
+step:4301/5560 train_time:1058385ms step_avg:246.08ms
+step:4302/5560 train_time:1058637ms step_avg:246.08ms
+step:4303/5560 train_time:1058889ms step_avg:246.08ms
+step:4304/5560 train_time:1059144ms step_avg:246.08ms
+step:4305/5560 train_time:1059394ms step_avg:246.08ms
+step:4306/5560 train_time:1059644ms step_avg:246.09ms
+step:4307/5560 train_time:1059894ms step_avg:246.09ms
+step:4308/5560 train_time:1060147ms step_avg:246.09ms
+step:4309/5560 train_time:1060400ms step_avg:246.09ms
+step:4310/5560 train_time:1060649ms step_avg:246.09ms
+step:4311/5560 train_time:1060898ms step_avg:246.09ms
+step:4312/5560 train_time:1061153ms step_avg:246.09ms
+step:4313/5560 train_time:1061437ms step_avg:246.10ms
+step:4314/5560 train_time:1061664ms step_avg:246.10ms
+step:4315/5560 train_time:1061917ms step_avg:246.10ms
+step:4316/5560 train_time:1062166ms step_avg:246.10ms
+step:4317/5560 train_time:1062418ms step_avg:246.10ms
+step:4318/5560 train_time:1062674ms step_avg:246.10ms
+step:4319/5560 train_time:1062925ms step_avg:246.10ms
+step:4320/5560 train_time:1063173ms step_avg:246.10ms
+step:4321/5560 train_time:1063424ms step_avg:246.11ms
+step:4322/5560 train_time:1063679ms step_avg:246.11ms
+step:4323/5560 train_time:1063931ms step_avg:246.11ms
+step:4324/5560 train_time:1064188ms step_avg:246.11ms
+step:4325/5560 train_time:1064452ms step_avg:246.12ms
+step:4326/5560 train_time:1064702ms step_avg:246.12ms
+step:4327/5560 train_time:1064951ms step_avg:246.12ms
+step:4328/5560 train_time:1065197ms step_avg:246.12ms
+step:4329/5560 train_time:1065454ms step_avg:246.12ms
+step:4330/5560 train_time:1065710ms step_avg:246.12ms
+step:4331/5560 train_time:1065958ms step_avg:246.12ms
+step:4332/5560 train_time:1066208ms step_avg:246.12ms
+step:4333/5560 train_time:1066466ms step_avg:246.13ms
+step:4334/5560 train_time:1066719ms step_avg:246.13ms
+step:4335/5560 train_time:1066969ms step_avg:246.13ms
+step:4336/5560 train_time:1067215ms step_avg:246.13ms
+step:4337/5560 train_time:1067479ms step_avg:246.13ms
+step:4338/5560 train_time:1067729ms step_avg:246.13ms
+step:4339/5560 train_time:1067978ms step_avg:246.13ms
+step:4340/5560 train_time:1068225ms step_avg:246.13ms
+step:4341/5560 train_time:1068502ms step_avg:246.14ms
+step:4342/5560 train_time:1068730ms step_avg:246.14ms
+step:4343/5560 train_time:1068979ms step_avg:246.14ms
+step:4344/5560 train_time:1069225ms step_avg:246.14ms
+step:4345/5560 train_time:1069475ms step_avg:246.14ms
+step:4346/5560 train_time:1069725ms step_avg:246.14ms
+step:4347/5560 train_time:1069975ms step_avg:246.14ms
+step:4348/5560 train_time:1070228ms step_avg:246.14ms
+step:4349/5560 train_time:1070481ms step_avg:246.14ms
+step:4350/5560 train_time:1070736ms step_avg:246.15ms
+step:4351/5560 train_time:1070987ms step_avg:246.15ms
+step:4352/5560 train_time:1071236ms step_avg:246.15ms
+step:4353/5560 train_time:1071488ms step_avg:246.15ms
+step:4354/5560 train_time:1071738ms step_avg:246.15ms
+step:4355/5560 train_time:1071991ms step_avg:246.15ms
+step:4356/5560 train_time:1072256ms step_avg:246.16ms
+step:4357/5560 train_time:1072506ms step_avg:246.16ms
+step:4358/5560 train_time:1072764ms step_avg:246.16ms
+step:4359/5560 train_time:1073012ms step_avg:246.16ms
+step:4360/5560 train_time:1073267ms step_avg:246.16ms
+step:4361/5560 train_time:1073515ms step_avg:246.16ms
+step:4362/5560 train_time:1073763ms step_avg:246.16ms
+step:4363/5560 train_time:1074016ms step_avg:246.16ms
+step:4364/5560 train_time:1074267ms step_avg:246.17ms
+step:4365/5560 train_time:1074517ms step_avg:246.17ms
+step:4366/5560 train_time:1074767ms step_avg:246.17ms
+step:4367/5560 train_time:1075025ms step_avg:246.17ms
+step:4368/5560 train_time:1075280ms step_avg:246.17ms
+step:4369/5560 train_time:1075561ms step_avg:246.18ms
+step:4370/5560 train_time:1075788ms step_avg:246.18ms
+step:4371/5560 train_time:1076040ms step_avg:246.18ms
+step:4372/5560 train_time:1076288ms step_avg:246.18ms
+step:4373/5560 train_time:1076546ms step_avg:246.18ms
+step:4374/5560 train_time:1076799ms step_avg:246.18ms
+step:4375/5560 train_time:1077049ms step_avg:246.18ms
+step:4375/5560 val_loss:2.990372 train_time:1077306ms step_avg:246.24ms
+step:4376/5560 train_time:1077374ms step_avg:246.20ms
+step:4377/5560 train_time:1077569ms step_avg:246.19ms
+step:4378/5560 train_time:1077831ms step_avg:246.19ms
+step:4379/5560 train_time:1078103ms step_avg:246.20ms
+step:4380/5560 train_time:1078358ms step_avg:246.20ms
+step:4381/5560 train_time:1078607ms step_avg:246.20ms
+step:4382/5560 train_time:1078828ms step_avg:246.20ms
+step:4383/5560 train_time:1079080ms step_avg:246.20ms
+step:4384/5560 train_time:1079329ms step_avg:246.20ms
+step:4385/5560 train_time:1079583ms step_avg:246.20ms
+step:4386/5560 train_time:1079850ms step_avg:246.20ms
+step:4387/5560 train_time:1080099ms step_avg:246.20ms
+step:4388/5560 train_time:1080345ms step_avg:246.20ms
+step:4389/5560 train_time:1080596ms step_avg:246.21ms
+step:4390/5560 train_time:1080845ms step_avg:246.21ms
+step:4391/5560 train_time:1081099ms step_avg:246.21ms
+step:4392/5560 train_time:1081351ms step_avg:246.21ms
+step:4393/5560 train_time:1081602ms step_avg:246.21ms
+step:4394/5560 train_time:1081855ms step_avg:246.21ms
+step:4395/5560 train_time:1082105ms step_avg:246.21ms
+step:4396/5560 train_time:1082356ms step_avg:246.21ms
+step:4397/5560 train_time:1082631ms step_avg:246.22ms
+step:4398/5560 train_time:1082866ms step_avg:246.22ms
+step:4399/5560 train_time:1083118ms step_avg:246.22ms
+step:4400/5560 train_time:1083368ms step_avg:246.22ms
+step:4401/5560 train_time:1083619ms step_avg:246.22ms
+step:4402/5560 train_time:1083877ms step_avg:246.22ms
+step:4403/5560 train_time:1084129ms step_avg:246.23ms
+step:4404/5560 train_time:1084376ms step_avg:246.23ms
+step:4405/5560 train_time:1084627ms step_avg:246.23ms
+step:4406/5560 train_time:1084878ms step_avg:246.23ms
+step:4407/5560 train_time:1085130ms step_avg:246.23ms
+step:4408/5560 train_time:1085381ms step_avg:246.23ms
+step:4409/5560 train_time:1085629ms step_avg:246.23ms
+step:4410/5560 train_time:1085880ms step_avg:246.23ms
+step:4411/5560 train_time:1086137ms step_avg:246.23ms
+step:4412/5560 train_time:1086388ms step_avg:246.23ms
+step:4413/5560 train_time:1086636ms step_avg:246.24ms
+step:4414/5560 train_time:1086888ms step_avg:246.24ms
+step:4415/5560 train_time:1087147ms step_avg:246.24ms
+step:4416/5560 train_time:1087398ms step_avg:246.24ms
+step:4417/5560 train_time:1087648ms step_avg:246.24ms
+step:4418/5560 train_time:1087900ms step_avg:246.24ms
+step:4419/5560 train_time:1088149ms step_avg:246.24ms
+step:4420/5560 train_time:1088398ms step_avg:246.24ms
+step:4421/5560 train_time:1088654ms step_avg:246.25ms
+step:4422/5560 train_time:1088904ms step_avg:246.25ms
+step:4423/5560 train_time:1089155ms step_avg:246.25ms
+step:4424/5560 train_time:1089405ms step_avg:246.25ms
+step:4425/5560 train_time:1089688ms step_avg:246.26ms
+step:4426/5560 train_time:1089916ms step_avg:246.25ms
+step:4427/5560 train_time:1090169ms step_avg:246.25ms
+step:4428/5560 train_time:1090420ms step_avg:246.26ms
+step:4429/5560 train_time:1090671ms step_avg:246.26ms
+step:4430/5560 train_time:1090929ms step_avg:246.26ms
+step:4431/5560 train_time:1091179ms step_avg:246.26ms
+step:4432/5560 train_time:1091427ms step_avg:246.26ms
+step:4433/5560 train_time:1091677ms step_avg:246.26ms
+step:4434/5560 train_time:1091925ms step_avg:246.26ms
+step:4435/5560 train_time:1092181ms step_avg:246.26ms
+step:4436/5560 train_time:1092434ms step_avg:246.27ms
+step:4437/5560 train_time:1092691ms step_avg:246.27ms
+step:4438/5560 train_time:1092951ms step_avg:246.27ms
+step:4439/5560 train_time:1093199ms step_avg:246.27ms
+step:4440/5560 train_time:1093455ms step_avg:246.27ms
+step:4441/5560 train_time:1093708ms step_avg:246.28ms
+step:4442/5560 train_time:1093960ms step_avg:246.28ms
+step:4443/5560 train_time:1094210ms step_avg:246.28ms
+step:4444/5560 train_time:1094462ms step_avg:246.28ms
+step:4445/5560 train_time:1094719ms step_avg:246.28ms
+step:4446/5560 train_time:1094973ms step_avg:246.28ms
+step:4447/5560 train_time:1095223ms step_avg:246.28ms
+step:4448/5560 train_time:1095472ms step_avg:246.28ms
+step:4449/5560 train_time:1095721ms step_avg:246.28ms
+step:4450/5560 train_time:1095976ms step_avg:246.29ms
+step:4451/5560 train_time:1096230ms step_avg:246.29ms
+step:4452/5560 train_time:1096482ms step_avg:246.29ms
+step:4453/5560 train_time:1096765ms step_avg:246.30ms
+step:4454/5560 train_time:1096991ms step_avg:246.29ms
+step:4455/5560 train_time:1097245ms step_avg:246.30ms
+step:4456/5560 train_time:1097500ms step_avg:246.30ms
+step:4457/5560 train_time:1097755ms step_avg:246.30ms
+step:4458/5560 train_time:1098013ms step_avg:246.30ms
+step:4459/5560 train_time:1098262ms step_avg:246.30ms
+step:4460/5560 train_time:1098517ms step_avg:246.30ms
+step:4461/5560 train_time:1098783ms step_avg:246.31ms
+step:4462/5560 train_time:1099037ms step_avg:246.31ms
+step:4463/5560 train_time:1099289ms step_avg:246.31ms
+step:4464/5560 train_time:1099540ms step_avg:246.31ms
+step:4465/5560 train_time:1099790ms step_avg:246.31ms
+step:4466/5560 train_time:1100048ms step_avg:246.32ms
+step:4467/5560 train_time:1100302ms step_avg:246.32ms
+step:4468/5560 train_time:1100551ms step_avg:246.32ms
+step:4469/5560 train_time:1100800ms step_avg:246.32ms
+step:4470/5560 train_time:1101063ms step_avg:246.32ms
+step:4471/5560 train_time:1101310ms step_avg:246.32ms
+step:4472/5560 train_time:1101576ms step_avg:246.33ms
+step:4473/5560 train_time:1101827ms step_avg:246.33ms
+step:4474/5560 train_time:1102080ms step_avg:246.33ms
+step:4475/5560 train_time:1102335ms step_avg:246.33ms
+step:4476/5560 train_time:1102583ms step_avg:246.33ms
+step:4477/5560 train_time:1102838ms step_avg:246.33ms
+step:4478/5560 train_time:1103083ms step_avg:246.33ms
+step:4479/5560 train_time:1103337ms step_avg:246.34ms
+step:4480/5560 train_time:1103595ms step_avg:246.34ms
+step:4481/5560 train_time:1103876ms step_avg:246.35ms
+step:4482/5560 train_time:1104101ms step_avg:246.34ms
+step:4483/5560 train_time:1104356ms step_avg:246.34ms
+step:4484/5560 train_time:1104606ms step_avg:246.34ms
+step:4485/5560 train_time:1104874ms step_avg:246.35ms
+step:4486/5560 train_time:1105130ms step_avg:246.35ms
+step:4487/5560 train_time:1105388ms step_avg:246.35ms
+step:4488/5560 train_time:1105639ms step_avg:246.35ms
+step:4489/5560 train_time:1105892ms step_avg:246.36ms
+step:4490/5560 train_time:1106144ms step_avg:246.36ms
+step:4491/5560 train_time:1106399ms step_avg:246.36ms
+step:4492/5560 train_time:1106648ms step_avg:246.36ms
+step:4493/5560 train_time:1106895ms step_avg:246.36ms
+step:4494/5560 train_time:1107151ms step_avg:246.36ms
+step:4495/5560 train_time:1107402ms step_avg:246.36ms
+step:4496/5560 train_time:1107651ms step_avg:246.36ms
+step:4497/5560 train_time:1107898ms step_avg:246.36ms
+step:4498/5560 train_time:1108148ms step_avg:246.36ms
+step:4499/5560 train_time:1108402ms step_avg:246.37ms
+step:4500/5560 train_time:1108656ms step_avg:246.37ms
+step:4500/5560 val_loss:2.982165 train_time:1108917ms step_avg:246.43ms
+step:4501/5560 train_time:1108978ms step_avg:246.38ms
+step:4502/5560 train_time:1109176ms step_avg:246.37ms
+step:4503/5560 train_time:1109438ms step_avg:246.38ms
+step:4504/5560 train_time:1109709ms step_avg:246.38ms
+step:4505/5560 train_time:1109967ms step_avg:246.39ms
+step:4506/5560 train_time:1110218ms step_avg:246.39ms
+step:4507/5560 train_time:1110441ms step_avg:246.38ms
+step:4508/5560 train_time:1110694ms step_avg:246.38ms
+step:4509/5560 train_time:1110979ms step_avg:246.39ms
+step:4510/5560 train_time:1111205ms step_avg:246.39ms
+step:4511/5560 train_time:1111456ms step_avg:246.39ms
+step:4512/5560 train_time:1111708ms step_avg:246.39ms
+step:4513/5560 train_time:1111960ms step_avg:246.39ms
+step:4514/5560 train_time:1112214ms step_avg:246.39ms
+step:4515/5560 train_time:1112464ms step_avg:246.39ms
+step:4516/5560 train_time:1112712ms step_avg:246.39ms
+step:4517/5560 train_time:1112965ms step_avg:246.39ms
+step:4518/5560 train_time:1113218ms step_avg:246.40ms
+step:4519/5560 train_time:1113471ms step_avg:246.40ms
+step:4520/5560 train_time:1113722ms step_avg:246.40ms
+step:4521/5560 train_time:1113972ms step_avg:246.40ms
+step:4522/5560 train_time:1114228ms step_avg:246.40ms
+step:4523/5560 train_time:1114488ms step_avg:246.40ms
+step:4524/5560 train_time:1114740ms step_avg:246.41ms
+step:4525/5560 train_time:1114985ms step_avg:246.41ms
+step:4526/5560 train_time:1115234ms step_avg:246.41ms
+step:4527/5560 train_time:1115486ms step_avg:246.41ms
+step:4528/5560 train_time:1115736ms step_avg:246.41ms
+step:4529/5560 train_time:1115996ms step_avg:246.41ms
+step:4530/5560 train_time:1116250ms step_avg:246.41ms
+step:4531/5560 train_time:1116498ms step_avg:246.41ms
+step:4532/5560 train_time:1116758ms step_avg:246.42ms
+step:4533/5560 train_time:1117018ms step_avg:246.42ms
+step:4534/5560 train_time:1117265ms step_avg:246.42ms
+step:4535/5560 train_time:1117514ms step_avg:246.42ms
+step:4536/5560 train_time:1117761ms step_avg:246.42ms
+step:4537/5560 train_time:1118044ms step_avg:246.43ms
+step:4538/5560 train_time:1118272ms step_avg:246.42ms
+step:4539/5560 train_time:1118528ms step_avg:246.43ms
+step:4540/5560 train_time:1118776ms step_avg:246.43ms
+step:4541/5560 train_time:1119032ms step_avg:246.43ms
+step:4542/5560 train_time:1119283ms step_avg:246.43ms
+step:4543/5560 train_time:1119531ms step_avg:246.43ms
+step:4544/5560 train_time:1119781ms step_avg:246.43ms
+step:4545/5560 train_time:1120035ms step_avg:246.43ms
+step:4546/5560 train_time:1120285ms step_avg:246.43ms
+step:4547/5560 train_time:1120534ms step_avg:246.43ms
+step:4548/5560 train_time:1120786ms step_avg:246.43ms
+step:4549/5560 train_time:1121038ms step_avg:246.44ms
+step:4550/5560 train_time:1121293ms step_avg:246.44ms
+step:4551/5560 train_time:1121543ms step_avg:246.44ms
+step:4552/5560 train_time:1121791ms step_avg:246.44ms
+step:4553/5560 train_time:1122043ms step_avg:246.44ms
+step:4554/5560 train_time:1122296ms step_avg:246.44ms
+step:4555/5560 train_time:1122549ms step_avg:246.44ms
+step:4556/5560 train_time:1122802ms step_avg:246.44ms
+step:4557/5560 train_time:1123050ms step_avg:246.45ms
+step:4558/5560 train_time:1123308ms step_avg:246.45ms
+step:4559/5560 train_time:1123560ms step_avg:246.45ms
+step:4560/5560 train_time:1123817ms step_avg:246.45ms
+step:4561/5560 train_time:1124079ms step_avg:246.45ms
+step:4562/5560 train_time:1124328ms step_avg:246.46ms
+step:4563/5560 train_time:1124589ms step_avg:246.46ms
+step:4564/5560 train_time:1124843ms step_avg:246.46ms
+step:4565/5560 train_time:1125126ms step_avg:246.47ms
+step:4566/5560 train_time:1125357ms step_avg:246.46ms
+step:4567/5560 train_time:1125610ms step_avg:246.47ms
+step:4568/5560 train_time:1125866ms step_avg:246.47ms
+step:4569/5560 train_time:1126117ms step_avg:246.47ms
+step:4570/5560 train_time:1126368ms step_avg:246.47ms
+step:4571/5560 train_time:1126636ms step_avg:246.47ms
+step:4572/5560 train_time:1126885ms step_avg:246.48ms
+step:4573/5560 train_time:1127139ms step_avg:246.48ms
+step:4574/5560 train_time:1127391ms step_avg:246.48ms
+step:4575/5560 train_time:1127645ms step_avg:246.48ms
+step:4576/5560 train_time:1127894ms step_avg:246.48ms
+step:4577/5560 train_time:1128146ms step_avg:246.48ms
+step:4578/5560 train_time:1128404ms step_avg:246.48ms
+step:4579/5560 train_time:1128654ms step_avg:246.48ms
+step:4580/5560 train_time:1128910ms step_avg:246.49ms
+step:4581/5560 train_time:1129170ms step_avg:246.49ms
+step:4582/5560 train_time:1129422ms step_avg:246.49ms
+step:4583/5560 train_time:1129669ms step_avg:246.49ms
+step:4584/5560 train_time:1129920ms step_avg:246.49ms
+step:4585/5560 train_time:1130178ms step_avg:246.49ms
+step:4586/5560 train_time:1130427ms step_avg:246.50ms
+step:4587/5560 train_time:1130676ms step_avg:246.50ms
+step:4588/5560 train_time:1130934ms step_avg:246.50ms
+step:4589/5560 train_time:1131190ms step_avg:246.50ms
+step:4590/5560 train_time:1131447ms step_avg:246.50ms
+step:4591/5560 train_time:1131708ms step_avg:246.51ms
+step:4592/5560 train_time:1131956ms step_avg:246.51ms
+step:4593/5560 train_time:1132238ms step_avg:246.51ms
+step:4594/5560 train_time:1132466ms step_avg:246.51ms
+step:4595/5560 train_time:1132715ms step_avg:246.51ms
+step:4596/5560 train_time:1132976ms step_avg:246.51ms
+step:4597/5560 train_time:1133240ms step_avg:246.52ms
+step:4598/5560 train_time:1133500ms step_avg:246.52ms
+step:4599/5560 train_time:1133750ms step_avg:246.52ms
+step:4600/5560 train_time:1134000ms step_avg:246.52ms
+step:4601/5560 train_time:1134251ms step_avg:246.52ms
+step:4602/5560 train_time:1134507ms step_avg:246.52ms
+step:4603/5560 train_time:1134757ms step_avg:246.53ms
+step:4604/5560 train_time:1135008ms step_avg:246.53ms
+step:4605/5560 train_time:1135260ms step_avg:246.53ms
+step:4606/5560 train_time:1135512ms step_avg:246.53ms
+step:4607/5560 train_time:1135762ms step_avg:246.53ms
+step:4608/5560 train_time:1136023ms step_avg:246.53ms
+step:4609/5560 train_time:1136271ms step_avg:246.53ms
+step:4610/5560 train_time:1136523ms step_avg:246.53ms
+step:4611/5560 train_time:1136772ms step_avg:246.53ms
+step:4612/5560 train_time:1137031ms step_avg:246.54ms
+step:4613/5560 train_time:1137281ms step_avg:246.54ms
+step:4614/5560 train_time:1137544ms step_avg:246.54ms
+step:4615/5560 train_time:1137799ms step_avg:246.54ms
+step:4616/5560 train_time:1138052ms step_avg:246.54ms
+step:4617/5560 train_time:1138309ms step_avg:246.55ms
+step:4618/5560 train_time:1138558ms step_avg:246.55ms
+step:4619/5560 train_time:1138811ms step_avg:246.55ms
+step:4620/5560 train_time:1139060ms step_avg:246.55ms
+step:4621/5560 train_time:1139343ms step_avg:246.56ms
+step:4622/5560 train_time:1139572ms step_avg:246.55ms
+step:4623/5560 train_time:1139826ms step_avg:246.56ms
+step:4624/5560 train_time:1140073ms step_avg:246.56ms
+step:4625/5560 train_time:1140325ms step_avg:246.56ms
+step:4625/5560 val_loss:2.973029 train_time:1140580ms step_avg:246.61ms
+step:4626/5560 train_time:1140598ms step_avg:246.56ms
+step:4627/5560 train_time:1140830ms step_avg:246.56ms
+step:4628/5560 train_time:1141089ms step_avg:246.56ms
+step:4629/5560 train_time:1141341ms step_avg:246.56ms
+step:4630/5560 train_time:1141587ms step_avg:246.56ms
+step:4631/5560 train_time:1141842ms step_avg:246.56ms
+step:4632/5560 train_time:1142101ms step_avg:246.57ms
+step:4633/5560 train_time:1142355ms step_avg:246.57ms
+step:4634/5560 train_time:1142609ms step_avg:246.57ms
+step:4635/5560 train_time:1142860ms step_avg:246.57ms
+step:4636/5560 train_time:1143123ms step_avg:246.58ms
+step:4637/5560 train_time:1143380ms step_avg:246.58ms
+step:4638/5560 train_time:1143628ms step_avg:246.58ms
+step:4639/5560 train_time:1143882ms step_avg:246.58ms
+step:4640/5560 train_time:1144135ms step_avg:246.58ms
+step:4641/5560 train_time:1144393ms step_avg:246.58ms
+step:4642/5560 train_time:1144642ms step_avg:246.58ms
+step:4643/5560 train_time:1144891ms step_avg:246.58ms
+step:4644/5560 train_time:1145155ms step_avg:246.59ms
+step:4645/5560 train_time:1145407ms step_avg:246.59ms
+step:4646/5560 train_time:1145663ms step_avg:246.59ms
+step:4647/5560 train_time:1145910ms step_avg:246.59ms
+step:4648/5560 train_time:1146175ms step_avg:246.60ms
+step:4649/5560 train_time:1146456ms step_avg:246.60ms
+step:4650/5560 train_time:1146687ms step_avg:246.60ms
+step:4651/5560 train_time:1146945ms step_avg:246.60ms
+step:4652/5560 train_time:1147197ms step_avg:246.60ms
+step:4653/5560 train_time:1147448ms step_avg:246.60ms
+step:4654/5560 train_time:1147703ms step_avg:246.61ms
+step:4655/5560 train_time:1147958ms step_avg:246.61ms
+step:4656/5560 train_time:1148214ms step_avg:246.61ms
+step:4657/5560 train_time:1148465ms step_avg:246.61ms
+step:4658/5560 train_time:1148719ms step_avg:246.61ms
+step:4659/5560 train_time:1148973ms step_avg:246.61ms
+step:4660/5560 train_time:1149227ms step_avg:246.62ms
+step:4661/5560 train_time:1149477ms step_avg:246.62ms
+step:4662/5560 train_time:1149735ms step_avg:246.62ms
+step:4663/5560 train_time:1149986ms step_avg:246.62ms
+step:4664/5560 train_time:1150244ms step_avg:246.62ms
+step:4665/5560 train_time:1150495ms step_avg:246.62ms
+step:4666/5560 train_time:1150758ms step_avg:246.63ms
+step:4667/5560 train_time:1151012ms step_avg:246.63ms
+step:4668/5560 train_time:1151264ms step_avg:246.63ms
+step:4669/5560 train_time:1151519ms step_avg:246.63ms
+step:4670/5560 train_time:1151777ms step_avg:246.63ms
+step:4671/5560 train_time:1152034ms step_avg:246.64ms
+step:4672/5560 train_time:1152286ms step_avg:246.64ms
+step:4673/5560 train_time:1152539ms step_avg:246.64ms
+step:4674/5560 train_time:1152793ms step_avg:246.64ms
+step:4675/5560 train_time:1153056ms step_avg:246.64ms
+step:4676/5560 train_time:1153310ms step_avg:246.64ms
+step:4677/5560 train_time:1153595ms step_avg:246.65ms
+step:4678/5560 train_time:1153820ms step_avg:246.65ms
+step:4679/5560 train_time:1154084ms step_avg:246.65ms
+step:4680/5560 train_time:1154350ms step_avg:246.66ms
+step:4681/5560 train_time:1154600ms step_avg:246.66ms
+step:4682/5560 train_time:1154851ms step_avg:246.66ms
+step:4683/5560 train_time:1155110ms step_avg:246.66ms
+step:4684/5560 train_time:1155362ms step_avg:246.66ms
+step:4685/5560 train_time:1155618ms step_avg:246.66ms
+step:4686/5560 train_time:1155877ms step_avg:246.67ms
+step:4687/5560 train_time:1156131ms step_avg:246.67ms
+step:4688/5560 train_time:1156386ms step_avg:246.67ms
+step:4689/5560 train_time:1156646ms step_avg:246.67ms
+step:4690/5560 train_time:1156896ms step_avg:246.67ms
+step:4691/5560 train_time:1157149ms step_avg:246.67ms
+step:4692/5560 train_time:1157410ms step_avg:246.68ms
+step:4693/5560 train_time:1157669ms step_avg:246.68ms
+step:4694/5560 train_time:1157921ms step_avg:246.68ms
+step:4695/5560 train_time:1158174ms step_avg:246.68ms
+step:4696/5560 train_time:1158435ms step_avg:246.69ms
+step:4697/5560 train_time:1158682ms step_avg:246.69ms
+step:4698/5560 train_time:1158934ms step_avg:246.69ms
+step:4699/5560 train_time:1159188ms step_avg:246.69ms
+step:4700/5560 train_time:1159440ms step_avg:246.69ms
+step:4701/5560 train_time:1159695ms step_avg:246.69ms
+step:4702/5560 train_time:1159953ms step_avg:246.69ms
+step:4703/5560 train_time:1160205ms step_avg:246.69ms
+step:4704/5560 train_time:1160456ms step_avg:246.70ms
+step:4705/5560 train_time:1160739ms step_avg:246.70ms
+step:4706/5560 train_time:1160965ms step_avg:246.70ms
+step:4707/5560 train_time:1161235ms step_avg:246.70ms
+step:4708/5560 train_time:1161487ms step_avg:246.71ms
+step:4709/5560 train_time:1161738ms step_avg:246.71ms
+step:4710/5560 train_time:1161999ms step_avg:246.71ms
+step:4711/5560 train_time:1162252ms step_avg:246.71ms
+step:4712/5560 train_time:1162504ms step_avg:246.71ms
+step:4713/5560 train_time:1162757ms step_avg:246.71ms
+step:4714/5560 train_time:1163022ms step_avg:246.72ms
+step:4715/5560 train_time:1163273ms step_avg:246.72ms
+step:4716/5560 train_time:1163529ms step_avg:246.72ms
+step:4717/5560 train_time:1163782ms step_avg:246.72ms
+step:4718/5560 train_time:1164037ms step_avg:246.72ms
+step:4719/5560 train_time:1164311ms step_avg:246.73ms
+step:4720/5560 train_time:1164562ms step_avg:246.73ms
+step:4721/5560 train_time:1164813ms step_avg:246.73ms
+step:4722/5560 train_time:1165060ms step_avg:246.73ms
+step:4723/5560 train_time:1165321ms step_avg:246.73ms
+step:4724/5560 train_time:1165574ms step_avg:246.73ms
+step:4725/5560 train_time:1165824ms step_avg:246.74ms
+step:4726/5560 train_time:1166080ms step_avg:246.74ms
+step:4727/5560 train_time:1166334ms step_avg:246.74ms
+step:4728/5560 train_time:1166595ms step_avg:246.74ms
+step:4729/5560 train_time:1166848ms step_avg:246.74ms
+step:4730/5560 train_time:1167101ms step_avg:246.74ms
+step:4731/5560 train_time:1167351ms step_avg:246.75ms
+step:4732/5560 train_time:1167606ms step_avg:246.75ms
+step:4733/5560 train_time:1167892ms step_avg:246.76ms
+step:4734/5560 train_time:1168124ms step_avg:246.75ms
+step:4735/5560 train_time:1168376ms step_avg:246.75ms
+step:4736/5560 train_time:1168626ms step_avg:246.75ms
+step:4737/5560 train_time:1168879ms step_avg:246.76ms
+step:4738/5560 train_time:1169142ms step_avg:246.76ms
+step:4739/5560 train_time:1169396ms step_avg:246.76ms
+step:4740/5560 train_time:1169647ms step_avg:246.76ms
+step:4741/5560 train_time:1169899ms step_avg:246.76ms
+step:4742/5560 train_time:1170154ms step_avg:246.76ms
+step:4743/5560 train_time:1170408ms step_avg:246.77ms
+step:4744/5560 train_time:1170666ms step_avg:246.77ms
+step:4745/5560 train_time:1170916ms step_avg:246.77ms
+step:4746/5560 train_time:1171168ms step_avg:246.77ms
+step:4747/5560 train_time:1171432ms step_avg:246.77ms
+step:4748/5560 train_time:1171684ms step_avg:246.77ms
+step:4749/5560 train_time:1171940ms step_avg:246.78ms
+step:4750/5560 train_time:1172195ms step_avg:246.78ms
+step:4750/5560 val_loss:2.963232 train_time:1172451ms step_avg:246.83ms
+step:4751/5560 train_time:1172563ms step_avg:246.80ms
+step:4752/5560 train_time:1172791ms step_avg:246.80ms
+step:4753/5560 train_time:1173037ms step_avg:246.80ms
+step:4754/5560 train_time:1173288ms step_avg:246.80ms
+step:4755/5560 train_time:1173547ms step_avg:246.80ms
+step:4756/5560 train_time:1173808ms step_avg:246.81ms
+step:4757/5560 train_time:1174063ms step_avg:246.81ms
+step:4758/5560 train_time:1174311ms step_avg:246.81ms
+step:4759/5560 train_time:1174569ms step_avg:246.81ms
+step:4760/5560 train_time:1174821ms step_avg:246.81ms
+step:4761/5560 train_time:1175103ms step_avg:246.82ms
+step:4762/5560 train_time:1175331ms step_avg:246.81ms
+step:4763/5560 train_time:1175586ms step_avg:246.82ms
+step:4764/5560 train_time:1175836ms step_avg:246.82ms
+step:4765/5560 train_time:1176090ms step_avg:246.82ms
+step:4766/5560 train_time:1176346ms step_avg:246.82ms
+step:4767/5560 train_time:1176600ms step_avg:246.82ms
+step:4768/5560 train_time:1176858ms step_avg:246.82ms
+step:4769/5560 train_time:1177108ms step_avg:246.83ms
+step:4770/5560 train_time:1177363ms step_avg:246.83ms
+step:4771/5560 train_time:1177615ms step_avg:246.83ms
+step:4772/5560 train_time:1177868ms step_avg:246.83ms
+step:4773/5560 train_time:1178118ms step_avg:246.83ms
+step:4774/5560 train_time:1178375ms step_avg:246.83ms
+step:4775/5560 train_time:1178625ms step_avg:246.83ms
+step:4776/5560 train_time:1178879ms step_avg:246.83ms
+step:4777/5560 train_time:1179130ms step_avg:246.83ms
+step:4778/5560 train_time:1179384ms step_avg:246.84ms
+step:4779/5560 train_time:1179638ms step_avg:246.84ms
+step:4780/5560 train_time:1179890ms step_avg:246.84ms
+step:4781/5560 train_time:1180149ms step_avg:246.84ms
+step:4782/5560 train_time:1180405ms step_avg:246.84ms
+step:4783/5560 train_time:1180663ms step_avg:246.85ms
+step:4784/5560 train_time:1180912ms step_avg:246.85ms
+step:4785/5560 train_time:1181162ms step_avg:246.85ms
+step:4786/5560 train_time:1181417ms step_avg:246.85ms
+step:4787/5560 train_time:1181676ms step_avg:246.85ms
+step:4788/5560 train_time:1181925ms step_avg:246.85ms
+step:4789/5560 train_time:1182213ms step_avg:246.86ms
+step:4790/5560 train_time:1182443ms step_avg:246.86ms
+step:4791/5560 train_time:1182711ms step_avg:246.86ms
+step:4792/5560 train_time:1182962ms step_avg:246.86ms
+step:4793/5560 train_time:1183217ms step_avg:246.86ms
+step:4794/5560 train_time:1183472ms step_avg:246.87ms
+step:4795/5560 train_time:1183725ms step_avg:246.87ms
+step:4796/5560 train_time:1183981ms step_avg:246.87ms
+step:4797/5560 train_time:1184236ms step_avg:246.87ms
+step:4798/5560 train_time:1184488ms step_avg:246.87ms
+step:4799/5560 train_time:1184739ms step_avg:246.87ms
+step:4800/5560 train_time:1184998ms step_avg:246.87ms
+step:4801/5560 train_time:1185254ms step_avg:246.88ms
+step:4802/5560 train_time:1185507ms step_avg:246.88ms
+step:4803/5560 train_time:1185758ms step_avg:246.88ms
+step:4804/5560 train_time:1186012ms step_avg:246.88ms
+step:4805/5560 train_time:1186274ms step_avg:246.88ms
+step:4806/5560 train_time:1186532ms step_avg:246.89ms
+step:4807/5560 train_time:1186785ms step_avg:246.89ms
+step:4808/5560 train_time:1187038ms step_avg:246.89ms
+step:4809/5560 train_time:1187295ms step_avg:246.89ms
+step:4810/5560 train_time:1187544ms step_avg:246.89ms
+step:4811/5560 train_time:1187802ms step_avg:246.89ms
+step:4812/5560 train_time:1188052ms step_avg:246.89ms
+step:4813/5560 train_time:1188307ms step_avg:246.90ms
+step:4814/5560 train_time:1188560ms step_avg:246.90ms
+step:4815/5560 train_time:1188820ms step_avg:246.90ms
+step:4816/5560 train_time:1189084ms step_avg:246.90ms
+step:4817/5560 train_time:1189365ms step_avg:246.91ms
+step:4818/5560 train_time:1189595ms step_avg:246.91ms
+step:4819/5560 train_time:1189847ms step_avg:246.91ms
+step:4820/5560 train_time:1190101ms step_avg:246.91ms
+step:4821/5560 train_time:1190360ms step_avg:246.91ms
+step:4822/5560 train_time:1190620ms step_avg:246.91ms
+step:4823/5560 train_time:1190874ms step_avg:246.92ms
+step:4824/5560 train_time:1191131ms step_avg:246.92ms
+step:4825/5560 train_time:1191389ms step_avg:246.92ms
+step:4826/5560 train_time:1191645ms step_avg:246.92ms
+step:4827/5560 train_time:1191895ms step_avg:246.92ms
+step:4828/5560 train_time:1192149ms step_avg:246.92ms
+step:4829/5560 train_time:1192402ms step_avg:246.93ms
+step:4830/5560 train_time:1192657ms step_avg:246.93ms
+step:4831/5560 train_time:1192910ms step_avg:246.93ms
+step:4832/5560 train_time:1193170ms step_avg:246.93ms
+step:4833/5560 train_time:1193421ms step_avg:246.93ms
+step:4834/5560 train_time:1193673ms step_avg:246.93ms
+step:4835/5560 train_time:1193923ms step_avg:246.93ms
+step:4836/5560 train_time:1194184ms step_avg:246.94ms
+step:4837/5560 train_time:1194443ms step_avg:246.94ms
+step:4838/5560 train_time:1194701ms step_avg:246.94ms
+step:4839/5560 train_time:1194952ms step_avg:246.94ms
+step:4840/5560 train_time:1195212ms step_avg:246.94ms
+step:4841/5560 train_time:1195469ms step_avg:246.95ms
+step:4842/5560 train_time:1195719ms step_avg:246.95ms
+step:4843/5560 train_time:1195974ms step_avg:246.95ms
+step:4844/5560 train_time:1196227ms step_avg:246.95ms
+step:4845/5560 train_time:1196514ms step_avg:246.96ms
+step:4846/5560 train_time:1196746ms step_avg:246.96ms
+step:4847/5560 train_time:1197005ms step_avg:246.96ms
+step:4848/5560 train_time:1197263ms step_avg:246.96ms
+step:4849/5560 train_time:1197517ms step_avg:246.96ms
+step:4850/5560 train_time:1197774ms step_avg:246.96ms
+step:4851/5560 train_time:1198027ms step_avg:246.96ms
+step:4852/5560 train_time:1198290ms step_avg:246.97ms
+step:4853/5560 train_time:1198562ms step_avg:246.97ms
+step:4854/5560 train_time:1198816ms step_avg:246.97ms
+step:4855/5560 train_time:1199070ms step_avg:246.98ms
+step:4856/5560 train_time:1199332ms step_avg:246.98ms
+step:4857/5560 train_time:1199587ms step_avg:246.98ms
+step:4858/5560 train_time:1199840ms step_avg:246.98ms
+step:4859/5560 train_time:1200097ms step_avg:246.98ms
+step:4860/5560 train_time:1200368ms step_avg:246.99ms
+step:4861/5560 train_time:1200624ms step_avg:246.99ms
+step:4862/5560 train_time:1200878ms step_avg:246.99ms
+step:4863/5560 train_time:1201132ms step_avg:246.99ms
+step:4864/5560 train_time:1201392ms step_avg:247.00ms
+step:4865/5560 train_time:1201649ms step_avg:247.00ms
+step:4866/5560 train_time:1201901ms step_avg:247.00ms
+step:4867/5560 train_time:1202158ms step_avg:247.00ms
+step:4868/5560 train_time:1202411ms step_avg:247.00ms
+step:4869/5560 train_time:1202667ms step_avg:247.00ms
+step:4870/5560 train_time:1202928ms step_avg:247.01ms
+step:4871/5560 train_time:1203184ms step_avg:247.01ms
+step:4872/5560 train_time:1203436ms step_avg:247.01ms
+step:4873/5560 train_time:1203729ms step_avg:247.02ms
+step:4874/5560 train_time:1203958ms step_avg:247.02ms
+step:4875/5560 train_time:1204217ms step_avg:247.02ms
+step:4875/5560 val_loss:2.954641 train_time:1204469ms step_avg:247.07ms
+step:4876/5560 train_time:1204488ms step_avg:247.02ms
+step:4877/5560 train_time:1204723ms step_avg:247.02ms
+step:4878/5560 train_time:1204983ms step_avg:247.02ms
+step:4879/5560 train_time:1205231ms step_avg:247.02ms
+step:4880/5560 train_time:1205485ms step_avg:247.03ms
+step:4881/5560 train_time:1205735ms step_avg:247.03ms
+step:4882/5560 train_time:1205995ms step_avg:247.03ms
+step:4883/5560 train_time:1206254ms step_avg:247.03ms
+step:4884/5560 train_time:1206547ms step_avg:247.04ms
+step:4885/5560 train_time:1206784ms step_avg:247.04ms
+step:4886/5560 train_time:1207025ms step_avg:247.04ms
+step:4887/5560 train_time:1207271ms step_avg:247.04ms
+step:4888/5560 train_time:1207525ms step_avg:247.04ms
+step:4889/5560 train_time:1207780ms step_avg:247.04ms
+step:4890/5560 train_time:1208034ms step_avg:247.04ms
+step:4891/5560 train_time:1208284ms step_avg:247.04ms
+step:4892/5560 train_time:1208544ms step_avg:247.05ms
+step:4893/5560 train_time:1208794ms step_avg:247.05ms
+step:4894/5560 train_time:1209046ms step_avg:247.05ms
+step:4895/5560 train_time:1209301ms step_avg:247.05ms
+step:4896/5560 train_time:1209559ms step_avg:247.05ms
+step:4897/5560 train_time:1209809ms step_avg:247.05ms
+step:4898/5560 train_time:1210079ms step_avg:247.06ms
+step:4899/5560 train_time:1210329ms step_avg:247.06ms
+step:4900/5560 train_time:1210594ms step_avg:247.06ms
+step:4901/5560 train_time:1210888ms step_avg:247.07ms
+step:4902/5560 train_time:1211116ms step_avg:247.07ms
+step:4903/5560 train_time:1211375ms step_avg:247.07ms
+step:4904/5560 train_time:1211631ms step_avg:247.07ms
+step:4905/5560 train_time:1211886ms step_avg:247.07ms
+step:4906/5560 train_time:1212143ms step_avg:247.07ms
+step:4907/5560 train_time:1212400ms step_avg:247.08ms
+step:4908/5560 train_time:1212651ms step_avg:247.08ms
+step:4909/5560 train_time:1212905ms step_avg:247.08ms
+step:4910/5560 train_time:1213161ms step_avg:247.08ms
+step:4911/5560 train_time:1213420ms step_avg:247.08ms
+step:4912/5560 train_time:1213673ms step_avg:247.08ms
+step:4913/5560 train_time:1213929ms step_avg:247.09ms
+step:4914/5560 train_time:1214186ms step_avg:247.09ms
+step:4915/5560 train_time:1214449ms step_avg:247.09ms
+step:4916/5560 train_time:1214701ms step_avg:247.09ms
+step:4917/5560 train_time:1214964ms step_avg:247.09ms
+step:4918/5560 train_time:1215218ms step_avg:247.10ms
+step:4919/5560 train_time:1215478ms step_avg:247.10ms
+step:4920/5560 train_time:1215730ms step_avg:247.10ms
+step:4921/5560 train_time:1215984ms step_avg:247.10ms
+step:4922/5560 train_time:1216239ms step_avg:247.10ms
+step:4923/5560 train_time:1216492ms step_avg:247.10ms
+step:4924/5560 train_time:1216745ms step_avg:247.11ms
+step:4925/5560 train_time:1217001ms step_avg:247.11ms
+step:4926/5560 train_time:1217257ms step_avg:247.11ms
+step:4927/5560 train_time:1217509ms step_avg:247.11ms
+step:4928/5560 train_time:1217766ms step_avg:247.11ms
+step:4929/5560 train_time:1218047ms step_avg:247.12ms
+step:4930/5560 train_time:1218287ms step_avg:247.12ms
+step:4931/5560 train_time:1218547ms step_avg:247.12ms
+step:4932/5560 train_time:1218797ms step_avg:247.12ms
+step:4933/5560 train_time:1219063ms step_avg:247.12ms
+step:4934/5560 train_time:1219328ms step_avg:247.13ms
+step:4935/5560 train_time:1219577ms step_avg:247.13ms
+step:4936/5560 train_time:1219835ms step_avg:247.13ms
+step:4937/5560 train_time:1220091ms step_avg:247.13ms
+step:4938/5560 train_time:1220351ms step_avg:247.13ms
+step:4939/5560 train_time:1220610ms step_avg:247.14ms
+step:4940/5560 train_time:1220865ms step_avg:247.14ms
+step:4941/5560 train_time:1221114ms step_avg:247.14ms
+step:4942/5560 train_time:1221372ms step_avg:247.14ms
+step:4943/5560 train_time:1221627ms step_avg:247.14ms
+step:4944/5560 train_time:1221884ms step_avg:247.14ms
+step:4945/5560 train_time:1222138ms step_avg:247.15ms
+step:4946/5560 train_time:1222394ms step_avg:247.15ms
+step:4947/5560 train_time:1222651ms step_avg:247.15ms
+step:4948/5560 train_time:1222907ms step_avg:247.15ms
+step:4949/5560 train_time:1223164ms step_avg:247.15ms
+step:4950/5560 train_time:1223417ms step_avg:247.15ms
+step:4951/5560 train_time:1223670ms step_avg:247.16ms
+step:4952/5560 train_time:1223920ms step_avg:247.16ms
+step:4953/5560 train_time:1224174ms step_avg:247.16ms
+step:4954/5560 train_time:1224428ms step_avg:247.16ms
+step:4955/5560 train_time:1224698ms step_avg:247.16ms
+step:4956/5560 train_time:1224948ms step_avg:247.16ms
+step:4957/5560 train_time:1225233ms step_avg:247.17ms
+step:4958/5560 train_time:1225461ms step_avg:247.17ms
+step:4959/5560 train_time:1225720ms step_avg:247.17ms
+step:4960/5560 train_time:1225978ms step_avg:247.17ms
+step:4961/5560 train_time:1226231ms step_avg:247.17ms
+step:4962/5560 train_time:1226487ms step_avg:247.18ms
+step:4963/5560 train_time:1226743ms step_avg:247.18ms
+step:4964/5560 train_time:1226996ms step_avg:247.18ms
+step:4965/5560 train_time:1227260ms step_avg:247.18ms
+step:4966/5560 train_time:1227529ms step_avg:247.19ms
+step:4967/5560 train_time:1227792ms step_avg:247.19ms
+step:4968/5560 train_time:1228044ms step_avg:247.19ms
+step:4969/5560 train_time:1228302ms step_avg:247.19ms
+step:4970/5560 train_time:1228562ms step_avg:247.20ms
+step:4971/5560 train_time:1228820ms step_avg:247.20ms
+step:4972/5560 train_time:1229079ms step_avg:247.20ms
+step:4973/5560 train_time:1229345ms step_avg:247.20ms
+step:4974/5560 train_time:1229615ms step_avg:247.21ms
+step:4975/5560 train_time:1229868ms step_avg:247.21ms
+step:4976/5560 train_time:1230122ms step_avg:247.21ms
+step:4977/5560 train_time:1230382ms step_avg:247.21ms
+step:4978/5560 train_time:1230647ms step_avg:247.22ms
+step:4979/5560 train_time:1230907ms step_avg:247.22ms
+step:4980/5560 train_time:1231162ms step_avg:247.22ms
+step:4981/5560 train_time:1231427ms step_avg:247.22ms
+step:4982/5560 train_time:1231683ms step_avg:247.23ms
+step:4983/5560 train_time:1231941ms step_avg:247.23ms
+step:4984/5560 train_time:1232192ms step_avg:247.23ms
+step:4985/5560 train_time:1232478ms step_avg:247.24ms
+step:4986/5560 train_time:1232710ms step_avg:247.23ms
+step:4987/5560 train_time:1232969ms step_avg:247.24ms
+step:4988/5560 train_time:1233219ms step_avg:247.24ms
+step:4989/5560 train_time:1233472ms step_avg:247.24ms
+step:4990/5560 train_time:1233731ms step_avg:247.24ms
+step:4991/5560 train_time:1233984ms step_avg:247.24ms
+step:4992/5560 train_time:1234238ms step_avg:247.24ms
+step:4993/5560 train_time:1234494ms step_avg:247.25ms
+step:4994/5560 train_time:1234754ms step_avg:247.25ms
+step:4995/5560 train_time:1235007ms step_avg:247.25ms
+step:4996/5560 train_time:1235264ms step_avg:247.25ms
+step:4997/5560 train_time:1235517ms step_avg:247.25ms
+step:4998/5560 train_time:1235770ms step_avg:247.25ms
+step:4999/5560 train_time:1236030ms step_avg:247.26ms
+step:5000/5560 train_time:1236286ms step_avg:247.26ms
+step:5000/5560 val_loss:2.946568 train_time:1236556ms step_avg:247.31ms
+step:5001/5560 train_time:1236576ms step_avg:247.27ms
+step:5002/5560 train_time:1236815ms step_avg:247.26ms
+step:5003/5560 train_time:1237075ms step_avg:247.27ms
+step:5004/5560 train_time:1237331ms step_avg:247.27ms
+step:5005/5560 train_time:1237586ms step_avg:247.27ms
+step:5006/5560 train_time:1237842ms step_avg:247.27ms
+step:5007/5560 train_time:1238102ms step_avg:247.27ms
+step:5008/5560 train_time:1238360ms step_avg:247.28ms
+step:5009/5560 train_time:1238620ms step_avg:247.28ms
+step:5010/5560 train_time:1238874ms step_avg:247.28ms
+step:5011/5560 train_time:1239128ms step_avg:247.28ms
+step:5012/5560 train_time:1239380ms step_avg:247.28ms
+step:5013/5560 train_time:1239664ms step_avg:247.29ms
+step:5014/5560 train_time:1239901ms step_avg:247.29ms
+step:5015/5560 train_time:1240159ms step_avg:247.29ms
+step:5016/5560 train_time:1240413ms step_avg:247.29ms
+step:5017/5560 train_time:1240667ms step_avg:247.29ms
+step:5018/5560 train_time:1240930ms step_avg:247.30ms
+step:5019/5560 train_time:1241180ms step_avg:247.30ms
+step:5020/5560 train_time:1241438ms step_avg:247.30ms
+step:5021/5560 train_time:1241693ms step_avg:247.30ms
+step:5022/5560 train_time:1241951ms step_avg:247.30ms
+step:5023/5560 train_time:1242206ms step_avg:247.30ms
+step:5024/5560 train_time:1242462ms step_avg:247.31ms
+step:5025/5560 train_time:1242715ms step_avg:247.31ms
+step:5026/5560 train_time:1242969ms step_avg:247.31ms
+step:5027/5560 train_time:1243224ms step_avg:247.31ms
+step:5028/5560 train_time:1243484ms step_avg:247.31ms
+step:5029/5560 train_time:1243743ms step_avg:247.31ms
+step:5030/5560 train_time:1243997ms step_avg:247.32ms
+step:5031/5560 train_time:1244253ms step_avg:247.32ms
+step:5032/5560 train_time:1244503ms step_avg:247.32ms
+step:5033/5560 train_time:1244765ms step_avg:247.32ms
+step:5034/5560 train_time:1245020ms step_avg:247.32ms
+step:5035/5560 train_time:1245271ms step_avg:247.32ms
+step:5036/5560 train_time:1245528ms step_avg:247.32ms
+step:5037/5560 train_time:1245783ms step_avg:247.33ms
+step:5038/5560 train_time:1246038ms step_avg:247.33ms
+step:5039/5560 train_time:1246294ms step_avg:247.33ms
+step:5040/5560 train_time:1246559ms step_avg:247.33ms
+step:5041/5560 train_time:1246842ms step_avg:247.34ms
+step:5042/5560 train_time:1247073ms step_avg:247.34ms
+step:5043/5560 train_time:1247326ms step_avg:247.34ms
+step:5044/5560 train_time:1247580ms step_avg:247.34ms
+step:5045/5560 train_time:1247835ms step_avg:247.34ms
+step:5046/5560 train_time:1248096ms step_avg:247.34ms
+step:5047/5560 train_time:1248348ms step_avg:247.34ms
+step:5048/5560 train_time:1248611ms step_avg:247.35ms
+step:5049/5560 train_time:1248863ms step_avg:247.35ms
+step:5050/5560 train_time:1249119ms step_avg:247.35ms
+step:5051/5560 train_time:1249377ms step_avg:247.35ms
+step:5052/5560 train_time:1249631ms step_avg:247.35ms
+step:5053/5560 train_time:1249884ms step_avg:247.35ms
+step:5054/5560 train_time:1250141ms step_avg:247.36ms
+step:5055/5560 train_time:1250400ms step_avg:247.36ms
+step:5056/5560 train_time:1250654ms step_avg:247.36ms
+step:5057/5560 train_time:1250909ms step_avg:247.36ms
+step:5058/5560 train_time:1251165ms step_avg:247.36ms
+step:5059/5560 train_time:1251428ms step_avg:247.37ms
+step:5060/5560 train_time:1251685ms step_avg:247.37ms
+step:5061/5560 train_time:1251950ms step_avg:247.37ms
+step:5062/5560 train_time:1252213ms step_avg:247.38ms
+step:5063/5560 train_time:1252464ms step_avg:247.38ms
+step:5064/5560 train_time:1252723ms step_avg:247.38ms
+step:5065/5560 train_time:1252981ms step_avg:247.38ms
+step:5066/5560 train_time:1253237ms step_avg:247.38ms
+step:5067/5560 train_time:1253493ms step_avg:247.38ms
+step:5068/5560 train_time:1253748ms step_avg:247.39ms
+step:5069/5560 train_time:1254036ms step_avg:247.39ms
+step:5070/5560 train_time:1254266ms step_avg:247.39ms
+step:5071/5560 train_time:1254525ms step_avg:247.39ms
+step:5072/5560 train_time:1254775ms step_avg:247.39ms
+step:5073/5560 train_time:1255033ms step_avg:247.39ms
+step:5074/5560 train_time:1255289ms step_avg:247.40ms
+step:5075/5560 train_time:1255555ms step_avg:247.40ms
+step:5076/5560 train_time:1255806ms step_avg:247.40ms
+step:5077/5560 train_time:1256059ms step_avg:247.40ms
+step:5078/5560 train_time:1256318ms step_avg:247.40ms
+step:5079/5560 train_time:1256592ms step_avg:247.41ms
+step:5080/5560 train_time:1256846ms step_avg:247.41ms
+step:5081/5560 train_time:1257102ms step_avg:247.41ms
+step:5082/5560 train_time:1257360ms step_avg:247.41ms
+step:5083/5560 train_time:1257630ms step_avg:247.42ms
+step:5084/5560 train_time:1257882ms step_avg:247.42ms
+step:5085/5560 train_time:1258139ms step_avg:247.42ms
+step:5086/5560 train_time:1258408ms step_avg:247.43ms
+step:5087/5560 train_time:1258661ms step_avg:247.43ms
+step:5088/5560 train_time:1258941ms step_avg:247.43ms
+step:5089/5560 train_time:1259190ms step_avg:247.43ms
+step:5090/5560 train_time:1259445ms step_avg:247.44ms
+step:5091/5560 train_time:1259702ms step_avg:247.44ms
+step:5092/5560 train_time:1259955ms step_avg:247.44ms
+step:5093/5560 train_time:1260211ms step_avg:247.44ms
+step:5094/5560 train_time:1260473ms step_avg:247.44ms
+step:5095/5560 train_time:1260728ms step_avg:247.44ms
+step:5096/5560 train_time:1260987ms step_avg:247.45ms
+step:5097/5560 train_time:1261278ms step_avg:247.45ms
+step:5098/5560 train_time:1261507ms step_avg:247.45ms
+step:5099/5560 train_time:1261773ms step_avg:247.45ms
+step:5100/5560 train_time:1262036ms step_avg:247.46ms
+step:5101/5560 train_time:1262299ms step_avg:247.46ms
+step:5102/5560 train_time:1262559ms step_avg:247.46ms
+step:5103/5560 train_time:1262818ms step_avg:247.47ms
+step:5104/5560 train_time:1263069ms step_avg:247.47ms
+step:5105/5560 train_time:1263324ms step_avg:247.47ms
+step:5106/5560 train_time:1263584ms step_avg:247.47ms
+step:5107/5560 train_time:1263851ms step_avg:247.47ms
+step:5108/5560 train_time:1264102ms step_avg:247.47ms
+step:5109/5560 train_time:1264361ms step_avg:247.48ms
+step:5110/5560 train_time:1264613ms step_avg:247.48ms
+step:5111/5560 train_time:1264873ms step_avg:247.48ms
+step:5112/5560 train_time:1265135ms step_avg:247.48ms
+step:5113/5560 train_time:1265394ms step_avg:247.49ms
+step:5114/5560 train_time:1265650ms step_avg:247.49ms
+step:5115/5560 train_time:1265902ms step_avg:247.49ms
+step:5116/5560 train_time:1266158ms step_avg:247.49ms
+step:5117/5560 train_time:1266418ms step_avg:247.49ms
+step:5118/5560 train_time:1266675ms step_avg:247.49ms
+step:5119/5560 train_time:1266929ms step_avg:247.50ms
+step:5120/5560 train_time:1267187ms step_avg:247.50ms
+step:5121/5560 train_time:1267462ms step_avg:247.50ms
+step:5122/5560 train_time:1267717ms step_avg:247.50ms
+step:5123/5560 train_time:1267973ms step_avg:247.51ms
+step:5124/5560 train_time:1268238ms step_avg:247.51ms
+step:5125/5560 train_time:1268526ms step_avg:247.52ms
+step:5125/5560 val_loss:2.938800 train_time:1268777ms step_avg:247.57ms
+step:5126/5560 train_time:1268797ms step_avg:247.52ms
+step:5127/5560 train_time:1269027ms step_avg:247.52ms
+step:5128/5560 train_time:1269297ms step_avg:247.52ms
+step:5129/5560 train_time:1269555ms step_avg:247.52ms
+step:5130/5560 train_time:1269804ms step_avg:247.53ms
+step:5131/5560 train_time:1270061ms step_avg:247.53ms
+step:5132/5560 train_time:1270330ms step_avg:247.53ms
+step:5133/5560 train_time:1270593ms step_avg:247.53ms
+step:5134/5560 train_time:1270854ms step_avg:247.54ms
+step:5135/5560 train_time:1271106ms step_avg:247.54ms
+step:5136/5560 train_time:1271378ms step_avg:247.54ms
+step:5137/5560 train_time:1271641ms step_avg:247.55ms
+step:5138/5560 train_time:1271918ms step_avg:247.55ms
+step:5139/5560 train_time:1272173ms step_avg:247.55ms
+step:5140/5560 train_time:1272435ms step_avg:247.56ms
+step:5141/5560 train_time:1272694ms step_avg:247.56ms
+step:5142/5560 train_time:1272951ms step_avg:247.56ms
+step:5143/5560 train_time:1273207ms step_avg:247.56ms
+step:5144/5560 train_time:1273467ms step_avg:247.56ms
+step:5145/5560 train_time:1273738ms step_avg:247.57ms
+step:5146/5560 train_time:1273993ms step_avg:247.57ms
+step:5147/5560 train_time:1274246ms step_avg:247.57ms
+step:5148/5560 train_time:1274512ms step_avg:247.57ms
+step:5149/5560 train_time:1274773ms step_avg:247.58ms
+step:5150/5560 train_time:1275032ms step_avg:247.58ms
+step:5151/5560 train_time:1275296ms step_avg:247.58ms
+step:5152/5560 train_time:1275555ms step_avg:247.58ms
+step:5153/5560 train_time:1275841ms step_avg:247.59ms
+step:5154/5560 train_time:1276072ms step_avg:247.59ms
+step:5155/5560 train_time:1276333ms step_avg:247.59ms
+step:5156/5560 train_time:1276589ms step_avg:247.59ms
+step:5157/5560 train_time:1276843ms step_avg:247.59ms
+step:5158/5560 train_time:1277106ms step_avg:247.60ms
+step:5159/5560 train_time:1277368ms step_avg:247.60ms
+step:5160/5560 train_time:1277621ms step_avg:247.60ms
+step:5161/5560 train_time:1277876ms step_avg:247.60ms
+step:5162/5560 train_time:1278134ms step_avg:247.60ms
+step:5163/5560 train_time:1278392ms step_avg:247.61ms
+step:5164/5560 train_time:1278649ms step_avg:247.61ms
+step:5165/5560 train_time:1278911ms step_avg:247.61ms
+step:5166/5560 train_time:1279164ms step_avg:247.61ms
+step:5167/5560 train_time:1279426ms step_avg:247.61ms
+step:5168/5560 train_time:1279691ms step_avg:247.62ms
+step:5169/5560 train_time:1279951ms step_avg:247.62ms
+step:5170/5560 train_time:1280209ms step_avg:247.62ms
+step:5171/5560 train_time:1280459ms step_avg:247.62ms
+step:5172/5560 train_time:1280715ms step_avg:247.62ms
+step:5173/5560 train_time:1280970ms step_avg:247.63ms
+step:5174/5560 train_time:1281228ms step_avg:247.63ms
+step:5175/5560 train_time:1281495ms step_avg:247.63ms
+step:5176/5560 train_time:1281760ms step_avg:247.64ms
+step:5177/5560 train_time:1282021ms step_avg:247.64ms
+step:5178/5560 train_time:1282269ms step_avg:247.64ms
+step:5179/5560 train_time:1282522ms step_avg:247.64ms
+step:5180/5560 train_time:1282809ms step_avg:247.65ms
+step:5181/5560 train_time:1283091ms step_avg:247.65ms
+step:5182/5560 train_time:1283319ms step_avg:247.65ms
+step:5183/5560 train_time:1283573ms step_avg:247.65ms
+step:5184/5560 train_time:1283836ms step_avg:247.65ms
+step:5185/5560 train_time:1284099ms step_avg:247.66ms
+step:5186/5560 train_time:1284353ms step_avg:247.66ms
+step:5187/5560 train_time:1284610ms step_avg:247.66ms
+step:5188/5560 train_time:1284869ms step_avg:247.66ms
+step:5189/5560 train_time:1285134ms step_avg:247.66ms
+step:5190/5560 train_time:1285392ms step_avg:247.67ms
+step:5191/5560 train_time:1285653ms step_avg:247.67ms
+step:5192/5560 train_time:1285911ms step_avg:247.67ms
+step:5193/5560 train_time:1286195ms step_avg:247.68ms
+step:5194/5560 train_time:1286454ms step_avg:247.68ms
+step:5195/5560 train_time:1286707ms step_avg:247.68ms
+step:5196/5560 train_time:1286962ms step_avg:247.68ms
+step:5197/5560 train_time:1287219ms step_avg:247.68ms
+step:5198/5560 train_time:1287492ms step_avg:247.69ms
+step:5199/5560 train_time:1287746ms step_avg:247.69ms
+step:5200/5560 train_time:1287998ms step_avg:247.69ms
+step:5201/5560 train_time:1288257ms step_avg:247.69ms
+step:5202/5560 train_time:1288516ms step_avg:247.70ms
+step:5203/5560 train_time:1288773ms step_avg:247.70ms
+step:5204/5560 train_time:1289031ms step_avg:247.70ms
+step:5205/5560 train_time:1289290ms step_avg:247.70ms
+step:5206/5560 train_time:1289546ms step_avg:247.70ms
+step:5207/5560 train_time:1289803ms step_avg:247.71ms
+step:5208/5560 train_time:1290063ms step_avg:247.71ms
+step:5209/5560 train_time:1290346ms step_avg:247.71ms
+step:5210/5560 train_time:1290582ms step_avg:247.71ms
+step:5211/5560 train_time:1290842ms step_avg:247.71ms
+step:5212/5560 train_time:1291098ms step_avg:247.72ms
+step:5213/5560 train_time:1291355ms step_avg:247.72ms
+step:5214/5560 train_time:1291614ms step_avg:247.72ms
+step:5215/5560 train_time:1291889ms step_avg:247.73ms
+step:5216/5560 train_time:1292147ms step_avg:247.73ms
+step:5217/5560 train_time:1292398ms step_avg:247.73ms
+step:5218/5560 train_time:1292666ms step_avg:247.73ms
+step:5219/5560 train_time:1292916ms step_avg:247.73ms
+step:5220/5560 train_time:1293176ms step_avg:247.73ms
+step:5221/5560 train_time:1293452ms step_avg:247.74ms
+step:5222/5560 train_time:1293709ms step_avg:247.74ms
+step:5223/5560 train_time:1293965ms step_avg:247.74ms
+step:5224/5560 train_time:1294223ms step_avg:247.75ms
+step:5225/5560 train_time:1294481ms step_avg:247.75ms
+step:5226/5560 train_time:1294733ms step_avg:247.75ms
+step:5227/5560 train_time:1294993ms step_avg:247.75ms
+step:5228/5560 train_time:1295252ms step_avg:247.75ms
+step:5229/5560 train_time:1295509ms step_avg:247.75ms
+step:5230/5560 train_time:1295766ms step_avg:247.76ms
+step:5231/5560 train_time:1296021ms step_avg:247.76ms
+step:5232/5560 train_time:1296276ms step_avg:247.76ms
+step:5233/5560 train_time:1296534ms step_avg:247.76ms
+step:5234/5560 train_time:1296802ms step_avg:247.76ms
+step:5235/5560 train_time:1297063ms step_avg:247.77ms
+step:5236/5560 train_time:1297334ms step_avg:247.77ms
+step:5237/5560 train_time:1297619ms step_avg:247.78ms
+step:5238/5560 train_time:1297848ms step_avg:247.78ms
+step:5239/5560 train_time:1298100ms step_avg:247.78ms
+step:5240/5560 train_time:1298362ms step_avg:247.78ms
+step:5241/5560 train_time:1298617ms step_avg:247.78ms
+step:5242/5560 train_time:1298873ms step_avg:247.78ms
+step:5243/5560 train_time:1299131ms step_avg:247.78ms
+step:5244/5560 train_time:1299389ms step_avg:247.79ms
+step:5245/5560 train_time:1299645ms step_avg:247.79ms
+step:5246/5560 train_time:1299903ms step_avg:247.79ms
+step:5247/5560 train_time:1300164ms step_avg:247.79ms
+step:5248/5560 train_time:1300419ms step_avg:247.79ms
+step:5249/5560 train_time:1300673ms step_avg:247.79ms
+step:5250/5560 train_time:1300930ms step_avg:247.80ms
+step:5250/5560 val_loss:2.931505 train_time:1301189ms step_avg:247.85ms
+step:5251/5560 train_time:1301208ms step_avg:247.80ms
+step:5252/5560 train_time:1301448ms step_avg:247.80ms
+step:5253/5560 train_time:1301706ms step_avg:247.80ms
+step:5254/5560 train_time:1301964ms step_avg:247.80ms
+step:5255/5560 train_time:1302236ms step_avg:247.81ms
+step:5256/5560 train_time:1302496ms step_avg:247.81ms
+step:5257/5560 train_time:1302755ms step_avg:247.81ms
+step:5258/5560 train_time:1303012ms step_avg:247.82ms
+step:5259/5560 train_time:1303277ms step_avg:247.82ms
+step:5260/5560 train_time:1303537ms step_avg:247.82ms
+step:5261/5560 train_time:1303794ms step_avg:247.82ms
+step:5262/5560 train_time:1304044ms step_avg:247.82ms
+step:5263/5560 train_time:1304303ms step_avg:247.83ms
+step:5264/5560 train_time:1304569ms step_avg:247.83ms
+step:5265/5560 train_time:1304851ms step_avg:247.83ms
+step:5266/5560 train_time:1305086ms step_avg:247.83ms
+step:5267/5560 train_time:1305344ms step_avg:247.83ms
+step:5268/5560 train_time:1305600ms step_avg:247.84ms
+step:5269/5560 train_time:1305860ms step_avg:247.84ms
+step:5270/5560 train_time:1306125ms step_avg:247.84ms
+step:5271/5560 train_time:1306379ms step_avg:247.84ms
+step:5272/5560 train_time:1306630ms step_avg:247.84ms
+step:5273/5560 train_time:1306890ms step_avg:247.85ms
+step:5274/5560 train_time:1307152ms step_avg:247.85ms
+step:5275/5560 train_time:1307415ms step_avg:247.85ms
+step:5276/5560 train_time:1307668ms step_avg:247.85ms
+step:5277/5560 train_time:1307923ms step_avg:247.85ms
+step:5278/5560 train_time:1308184ms step_avg:247.86ms
+step:5279/5560 train_time:1308446ms step_avg:247.86ms
+step:5280/5560 train_time:1308720ms step_avg:247.86ms
+step:5281/5560 train_time:1308975ms step_avg:247.87ms
+step:5282/5560 train_time:1309237ms step_avg:247.87ms
+step:5283/5560 train_time:1309503ms step_avg:247.87ms
+step:5284/5560 train_time:1309765ms step_avg:247.87ms
+step:5285/5560 train_time:1310029ms step_avg:247.88ms
+step:5286/5560 train_time:1310294ms step_avg:247.88ms
+step:5287/5560 train_time:1310551ms step_avg:247.88ms
+step:5288/5560 train_time:1310818ms step_avg:247.89ms
+step:5289/5560 train_time:1311072ms step_avg:247.89ms
+step:5290/5560 train_time:1311336ms step_avg:247.89ms
+step:5291/5560 train_time:1311598ms step_avg:247.89ms
+step:5292/5560 train_time:1311857ms step_avg:247.89ms
+step:5293/5560 train_time:1312143ms step_avg:247.90ms
+step:5294/5560 train_time:1312400ms step_avg:247.90ms
+step:5295/5560 train_time:1312659ms step_avg:247.91ms
+step:5296/5560 train_time:1312925ms step_avg:247.91ms
+step:5297/5560 train_time:1313181ms step_avg:247.91ms
+step:5298/5560 train_time:1313440ms step_avg:247.91ms
+step:5299/5560 train_time:1313694ms step_avg:247.91ms
+step:5300/5560 train_time:1313951ms step_avg:247.92ms
+step:5301/5560 train_time:1314211ms step_avg:247.92ms
+step:5302/5560 train_time:1314472ms step_avg:247.92ms
+step:5303/5560 train_time:1314728ms step_avg:247.92ms
+step:5304/5560 train_time:1314987ms step_avg:247.92ms
+step:5305/5560 train_time:1315248ms step_avg:247.93ms
+step:5306/5560 train_time:1315499ms step_avg:247.93ms
+step:5307/5560 train_time:1315756ms step_avg:247.93ms
+step:5308/5560 train_time:1316010ms step_avg:247.93ms
+step:5309/5560 train_time:1316279ms step_avg:247.93ms
+step:5310/5560 train_time:1316535ms step_avg:247.93ms
+step:5311/5560 train_time:1316792ms step_avg:247.94ms
+step:5312/5560 train_time:1317049ms step_avg:247.94ms
+step:5313/5560 train_time:1317331ms step_avg:247.94ms
+step:5314/5560 train_time:1317592ms step_avg:247.95ms
+step:5315/5560 train_time:1317843ms step_avg:247.95ms
+step:5316/5560 train_time:1318099ms step_avg:247.95ms
+step:5317/5560 train_time:1318363ms step_avg:247.95ms
+step:5318/5560 train_time:1318621ms step_avg:247.95ms
+step:5319/5560 train_time:1318888ms step_avg:247.96ms
+step:5320/5560 train_time:1319143ms step_avg:247.96ms
+step:5321/5560 train_time:1319428ms step_avg:247.97ms
+step:5322/5560 train_time:1319669ms step_avg:247.96ms
+step:5323/5560 train_time:1319931ms step_avg:247.97ms
+step:5324/5560 train_time:1320189ms step_avg:247.97ms
+step:5325/5560 train_time:1320449ms step_avg:247.97ms
+step:5326/5560 train_time:1320702ms step_avg:247.97ms
+step:5327/5560 train_time:1320960ms step_avg:247.97ms
+step:5328/5560 train_time:1321220ms step_avg:247.98ms
+step:5329/5560 train_time:1321484ms step_avg:247.98ms
+step:5330/5560 train_time:1321746ms step_avg:247.98ms
+step:5331/5560 train_time:1322008ms step_avg:247.99ms
+step:5332/5560 train_time:1322263ms step_avg:247.99ms
+step:5333/5560 train_time:1322522ms step_avg:247.99ms
+step:5334/5560 train_time:1322779ms step_avg:247.99ms
+step:5335/5560 train_time:1323063ms step_avg:248.00ms
+step:5336/5560 train_time:1323319ms step_avg:248.00ms
+step:5337/5560 train_time:1323576ms step_avg:248.00ms
+step:5338/5560 train_time:1323831ms step_avg:248.00ms
+step:5339/5560 train_time:1324089ms step_avg:248.00ms
+step:5340/5560 train_time:1324351ms step_avg:248.01ms
+step:5341/5560 train_time:1324603ms step_avg:248.01ms
+step:5342/5560 train_time:1324854ms step_avg:248.01ms
+step:5343/5560 train_time:1325114ms step_avg:248.01ms
+step:5344/5560 train_time:1325372ms step_avg:248.01ms
+step:5345/5560 train_time:1325632ms step_avg:248.01ms
+step:5346/5560 train_time:1325888ms step_avg:248.02ms
+step:5347/5560 train_time:1326152ms step_avg:248.02ms
+step:5348/5560 train_time:1326406ms step_avg:248.02ms
+step:5349/5560 train_time:1326706ms step_avg:248.03ms
+step:5350/5560 train_time:1326946ms step_avg:248.03ms
+step:5351/5560 train_time:1327207ms step_avg:248.03ms
+step:5352/5560 train_time:1327468ms step_avg:248.03ms
+step:5353/5560 train_time:1327724ms step_avg:248.03ms
+step:5354/5560 train_time:1327982ms step_avg:248.04ms
+step:5355/5560 train_time:1328244ms step_avg:248.04ms
+step:5356/5560 train_time:1328507ms step_avg:248.04ms
+step:5357/5560 train_time:1328762ms step_avg:248.04ms
+step:5358/5560 train_time:1329017ms step_avg:248.04ms
+step:5359/5560 train_time:1329271ms step_avg:248.04ms
+step:5360/5560 train_time:1329531ms step_avg:248.05ms
+step:5361/5560 train_time:1329802ms step_avg:248.05ms
+step:5362/5560 train_time:1330053ms step_avg:248.05ms
+step:5363/5560 train_time:1330317ms step_avg:248.05ms
+step:5364/5560 train_time:1330579ms step_avg:248.06ms
+step:5365/5560 train_time:1330852ms step_avg:248.06ms
+step:5366/5560 train_time:1331106ms step_avg:248.06ms
+step:5367/5560 train_time:1331368ms step_avg:248.07ms
+step:5368/5560 train_time:1331634ms step_avg:248.07ms
+step:5369/5560 train_time:1331897ms step_avg:248.07ms
+step:5370/5560 train_time:1332147ms step_avg:248.07ms
+step:5371/5560 train_time:1332411ms step_avg:248.08ms
+step:5372/5560 train_time:1332679ms step_avg:248.08ms
+step:5373/5560 train_time:1332941ms step_avg:248.08ms
+step:5374/5560 train_time:1333210ms step_avg:248.09ms
+step:5375/5560 train_time:1333469ms step_avg:248.09ms
+step:5375/5560 val_loss:2.925029 train_time:1333743ms step_avg:248.14ms
+step:5376/5560 train_time:1333761ms step_avg:248.10ms
+step:5377/5560 train_time:1334031ms step_avg:248.10ms
+step:5378/5560 train_time:1334273ms step_avg:248.10ms
+step:5379/5560 train_time:1334523ms step_avg:248.10ms
+step:5380/5560 train_time:1334779ms step_avg:248.10ms
+step:5381/5560 train_time:1335036ms step_avg:248.10ms
+step:5382/5560 train_time:1335315ms step_avg:248.11ms
+step:5383/5560 train_time:1335570ms step_avg:248.11ms
+step:5384/5560 train_time:1335832ms step_avg:248.11ms
+step:5385/5560 train_time:1336091ms step_avg:248.11ms
+step:5386/5560 train_time:1336349ms step_avg:248.12ms
+step:5387/5560 train_time:1336610ms step_avg:248.12ms
+step:5388/5560 train_time:1336869ms step_avg:248.12ms
+step:5389/5560 train_time:1337139ms step_avg:248.12ms
+step:5390/5560 train_time:1337393ms step_avg:248.12ms
+step:5391/5560 train_time:1337656ms step_avg:248.13ms
+step:5392/5560 train_time:1337919ms step_avg:248.13ms
+step:5393/5560 train_time:1338178ms step_avg:248.13ms
+step:5394/5560 train_time:1338432ms step_avg:248.13ms
+step:5395/5560 train_time:1338694ms step_avg:248.14ms
+step:5396/5560 train_time:1338956ms step_avg:248.14ms
+step:5397/5560 train_time:1339221ms step_avg:248.14ms
+step:5398/5560 train_time:1339481ms step_avg:248.14ms
+step:5399/5560 train_time:1339750ms step_avg:248.15ms
+step:5400/5560 train_time:1340007ms step_avg:248.15ms
+step:5401/5560 train_time:1340269ms step_avg:248.15ms
+step:5402/5560 train_time:1340525ms step_avg:248.15ms
+step:5403/5560 train_time:1340783ms step_avg:248.16ms
+step:5404/5560 train_time:1341048ms step_avg:248.16ms
+step:5405/5560 train_time:1341332ms step_avg:248.17ms
+step:5406/5560 train_time:1341565ms step_avg:248.16ms
+step:5407/5560 train_time:1341828ms step_avg:248.16ms
+step:5408/5560 train_time:1342085ms step_avg:248.17ms
+step:5409/5560 train_time:1342352ms step_avg:248.17ms
+step:5410/5560 train_time:1342606ms step_avg:248.17ms
+step:5411/5560 train_time:1342862ms step_avg:248.17ms
+step:5412/5560 train_time:1343126ms step_avg:248.18ms
+step:5413/5560 train_time:1343398ms step_avg:248.18ms
+step:5414/5560 train_time:1343648ms step_avg:248.18ms
+step:5415/5560 train_time:1343909ms step_avg:248.18ms
+step:5416/5560 train_time:1344170ms step_avg:248.19ms
+step:5417/5560 train_time:1344429ms step_avg:248.19ms
+step:5418/5560 train_time:1344684ms step_avg:248.19ms
+step:5419/5560 train_time:1344944ms step_avg:248.19ms
+step:5420/5560 train_time:1345208ms step_avg:248.19ms
+step:5421/5560 train_time:1345462ms step_avg:248.19ms
+step:5422/5560 train_time:1345722ms step_avg:248.20ms
+step:5423/5560 train_time:1345983ms step_avg:248.20ms
+step:5424/5560 train_time:1346275ms step_avg:248.21ms
+step:5425/5560 train_time:1346557ms step_avg:248.21ms
+step:5426/5560 train_time:1346820ms step_avg:248.22ms
+step:5427/5560 train_time:1347086ms step_avg:248.22ms
+step:5428/5560 train_time:1347348ms step_avg:248.22ms
+step:5429/5560 train_time:1347609ms step_avg:248.22ms
+step:5430/5560 train_time:1347861ms step_avg:248.22ms
+step:5431/5560 train_time:1348122ms step_avg:248.23ms
+step:5432/5560 train_time:1348380ms step_avg:248.23ms
+step:5433/5560 train_time:1348683ms step_avg:248.24ms
+step:5434/5560 train_time:1348920ms step_avg:248.24ms
+step:5435/5560 train_time:1349180ms step_avg:248.24ms
+step:5436/5560 train_time:1349436ms step_avg:248.24ms
+step:5437/5560 train_time:1349691ms step_avg:248.24ms
+step:5438/5560 train_time:1349982ms step_avg:248.25ms
+step:5439/5560 train_time:1350267ms step_avg:248.26ms
+step:5440/5560 train_time:1350524ms step_avg:248.26ms
+step:5441/5560 train_time:1350780ms step_avg:248.26ms
+step:5442/5560 train_time:1351038ms step_avg:248.26ms
+step:5443/5560 train_time:1351302ms step_avg:248.26ms
+step:5444/5560 train_time:1351561ms step_avg:248.27ms
+step:5445/5560 train_time:1351816ms step_avg:248.27ms
+step:5446/5560 train_time:1352076ms step_avg:248.27ms
+step:5447/5560 train_time:1352336ms step_avg:248.27ms
+step:5448/5560 train_time:1352593ms step_avg:248.27ms
+step:5449/5560 train_time:1352853ms step_avg:248.28ms
+step:5450/5560 train_time:1353120ms step_avg:248.28ms
+step:5451/5560 train_time:1353376ms step_avg:248.28ms
+step:5452/5560 train_time:1353646ms step_avg:248.28ms
+step:5453/5560 train_time:1353913ms step_avg:248.29ms
+step:5454/5560 train_time:1354184ms step_avg:248.29ms
+step:5455/5560 train_time:1354443ms step_avg:248.29ms
+step:5456/5560 train_time:1354699ms step_avg:248.30ms
+step:5457/5560 train_time:1354976ms step_avg:248.30ms
+step:5458/5560 train_time:1355233ms step_avg:248.30ms
+step:5459/5560 train_time:1355493ms step_avg:248.30ms
+step:5460/5560 train_time:1355751ms step_avg:248.31ms
+step:5461/5560 train_time:1356050ms step_avg:248.32ms
+step:5462/5560 train_time:1356302ms step_avg:248.32ms
+step:5463/5560 train_time:1356558ms step_avg:248.32ms
+step:5464/5560 train_time:1356830ms step_avg:248.32ms
+step:5465/5560 train_time:1357088ms step_avg:248.32ms
+step:5466/5560 train_time:1357354ms step_avg:248.33ms
+step:5467/5560 train_time:1357604ms step_avg:248.33ms
+step:5468/5560 train_time:1357861ms step_avg:248.33ms
+step:5469/5560 train_time:1358132ms step_avg:248.33ms
+step:5470/5560 train_time:1358393ms step_avg:248.34ms
+step:5471/5560 train_time:1358655ms step_avg:248.34ms
+step:5472/5560 train_time:1358912ms step_avg:248.34ms
+step:5473/5560 train_time:1359170ms step_avg:248.34ms
+step:5474/5560 train_time:1359447ms step_avg:248.35ms
+step:5475/5560 train_time:1359705ms step_avg:248.35ms
+step:5476/5560 train_time:1359967ms step_avg:248.35ms
+step:5477/5560 train_time:1360224ms step_avg:248.35ms
+step:5478/5560 train_time:1360485ms step_avg:248.35ms
+step:5479/5560 train_time:1360743ms step_avg:248.36ms
+step:5480/5560 train_time:1361005ms step_avg:248.36ms
+step:5481/5560 train_time:1361264ms step_avg:248.36ms
+step:5482/5560 train_time:1361540ms step_avg:248.37ms
+step:5483/5560 train_time:1361798ms step_avg:248.37ms
+step:5484/5560 train_time:1362082ms step_avg:248.37ms
+step:5485/5560 train_time:1362348ms step_avg:248.38ms
+step:5486/5560 train_time:1362604ms step_avg:248.38ms
+step:5487/5560 train_time:1362871ms step_avg:248.38ms
+step:5488/5560 train_time:1363132ms step_avg:248.38ms
+step:5489/5560 train_time:1363422ms step_avg:248.39ms
+step:5490/5560 train_time:1363653ms step_avg:248.39ms
+step:5491/5560 train_time:1363920ms step_avg:248.39ms
+step:5492/5560 train_time:1364176ms step_avg:248.39ms
+step:5493/5560 train_time:1364439ms step_avg:248.40ms
+step:5494/5560 train_time:1364701ms step_avg:248.40ms
+step:5495/5560 train_time:1364969ms step_avg:248.40ms
+step:5496/5560 train_time:1365225ms step_avg:248.40ms
+step:5497/5560 train_time:1365478ms step_avg:248.40ms
+step:5498/5560 train_time:1365739ms step_avg:248.41ms
+step:5499/5560 train_time:1366000ms step_avg:248.41ms
+step:5500/5560 train_time:1366261ms step_avg:248.41ms
+step:5500/5560 val_loss:2.920080 train_time:1366523ms step_avg:248.46ms
+step:5501/5560 train_time:1366540ms step_avg:248.42ms
+step:5502/5560 train_time:1366783ms step_avg:248.42ms
+step:5503/5560 train_time:1367054ms step_avg:248.42ms
+step:5504/5560 train_time:1367328ms step_avg:248.42ms
+step:5505/5560 train_time:1367583ms step_avg:248.43ms
+step:5506/5560 train_time:1367858ms step_avg:248.43ms
+step:5507/5560 train_time:1368115ms step_avg:248.43ms
+step:5508/5560 train_time:1368383ms step_avg:248.44ms
+step:5509/5560 train_time:1368642ms step_avg:248.44ms
+step:5510/5560 train_time:1368905ms step_avg:248.44ms
+step:5511/5560 train_time:1369179ms step_avg:248.44ms
+step:5512/5560 train_time:1369442ms step_avg:248.45ms
+step:5513/5560 train_time:1369709ms step_avg:248.45ms
+step:5514/5560 train_time:1369972ms step_avg:248.45ms
+step:5515/5560 train_time:1370238ms step_avg:248.46ms
+step:5516/5560 train_time:1370503ms step_avg:248.46ms
+step:5517/5560 train_time:1370797ms step_avg:248.47ms
+step:5518/5560 train_time:1371034ms step_avg:248.47ms
+step:5519/5560 train_time:1371291ms step_avg:248.47ms
+step:5520/5560 train_time:1371555ms step_avg:248.47ms
+step:5521/5560 train_time:1371813ms step_avg:248.47ms
+step:5522/5560 train_time:1372087ms step_avg:248.48ms
+step:5523/5560 train_time:1372344ms step_avg:248.48ms
+step:5524/5560 train_time:1372602ms step_avg:248.48ms
+step:5525/5560 train_time:1372893ms step_avg:248.49ms
+step:5526/5560 train_time:1373153ms step_avg:248.49ms
+step:5527/5560 train_time:1373405ms step_avg:248.49ms
+step:5528/5560 train_time:1373670ms step_avg:248.49ms
+step:5529/5560 train_time:1373931ms step_avg:248.50ms
+step:5530/5560 train_time:1374204ms step_avg:248.50ms
+step:5531/5560 train_time:1374466ms step_avg:248.50ms
+step:5532/5560 train_time:1374720ms step_avg:248.50ms
+step:5533/5560 train_time:1374985ms step_avg:248.51ms
+step:5534/5560 train_time:1375243ms step_avg:248.51ms
+step:5535/5560 train_time:1375501ms step_avg:248.51ms
+step:5536/5560 train_time:1375754ms step_avg:248.51ms
+step:5537/5560 train_time:1376011ms step_avg:248.51ms
+step:5538/5560 train_time:1376276ms step_avg:248.51ms
+step:5539/5560 train_time:1376541ms step_avg:248.52ms
+step:5540/5560 train_time:1376809ms step_avg:248.52ms
+step:5541/5560 train_time:1377063ms step_avg:248.52ms
+step:5542/5560 train_time:1377319ms step_avg:248.52ms
+step:5543/5560 train_time:1377588ms step_avg:248.53ms
+step:5544/5560 train_time:1377866ms step_avg:248.53ms
+step:5545/5560 train_time:1378156ms step_avg:248.54ms
+step:5546/5560 train_time:1378389ms step_avg:248.54ms
+step:5547/5560 train_time:1378650ms step_avg:248.54ms
+step:5548/5560 train_time:1378916ms step_avg:248.54ms
+step:5549/5560 train_time:1379187ms step_avg:248.55ms
+step:5550/5560 train_time:1379467ms step_avg:248.55ms
+step:5551/5560 train_time:1379718ms step_avg:248.55ms
+step:5552/5560 train_time:1379983ms step_avg:248.56ms
+step:5553/5560 train_time:1380234ms step_avg:248.56ms
+step:5554/5560 train_time:1380495ms step_avg:248.56ms
+step:5555/5560 train_time:1380768ms step_avg:248.56ms
+step:5556/5560 train_time:1381026ms step_avg:248.56ms
+step:5557/5560 train_time:1381291ms step_avg:248.57ms
+step:5558/5560 train_time:1381557ms step_avg:248.57ms
+step:5559/5560 train_time:1381817ms step_avg:248.57ms
+step:5560/5560 train_time:1382078ms step_avg:248.58ms
+step:5560/5560 val_loss:2.918589 train_time:1382337ms step_avg:248.62ms
+peak memory allocated: 56812 MiB reserved: 60528 MiB

--- a/records/100124_GPT2MediumLayerReuse/README.md
+++ b/records/100124_GPT2MediumLayerReuse/README.md
@@ -1,0 +1,37 @@
+# 2025-10-01 Medium Track Record
+
+I simply added the output of layer 11 (the 12'th layer) to the output of the final layer (layer 15, or the 16'th layer), in a weighted sum. The weights are scalars and are learned. This just means that right before applying the language head, I do this:
+
+```python
+skip_lambdas = self.scalars[-2:]
+x = norm(x) * skip_lambdas[0] + norm(skip_connections[11]) * skip_lambdas[1]
+```
+
+Where the `skip_connections` contain the output latents of each layer, at the corresponding position.
+
+These are the resulting final validation losses over 10 runs:
+
+```python
+[2.918849, 2.917008, 2.919394, 2.91776, 2.919522, 2.919678, 2.918775, 2.918111, 2.919395, 2.917938]
+```
+
+And here are simple stats about the final validation loss over these 10 runs:
+
+- Mean: 2.9186
+- Std: 0.0008985
+- P-value: 0.0005035724941803675
+
+The p-value is very low, so after only 10 runs we can be sure that the target loss is reached.
+
+Now here are the corresponding run times:
+
+```python
+[1378.689, 1378.504, 1378.622, 1379.238, 1379.0, 1379.444, 1378.426, 1379.337, 1378.254, 1379.127]
+```
+
+And here are some simple stats about the times:
+
+- Mean: 1378.8641 seconds ~= 22.98 minutes
+- Std: 0.4177 seconds
+
+The previous record's time is 1405.698 seconds, so this is a reduction of almost 27 seconds.

--- a/train_gpt_medium.py
+++ b/train_gpt_medium.py
@@ -1,27 +1,103 @@
 import os
 import sys
+
 with open(sys.argv[0]) as f:
-    code = f.read() # read the code of this file ASAP, for logging
-import uuid
-import time
+    code = f.read()  # read the code of this file ASAP, for logging
 import copy
+import time
+import uuid
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
 import torch
-torch.empty(1, device="cuda", requires_grad=True).backward() # prevents a bug on some systems
-from torch import Tensor, nn
-import torch.nn.functional as F
+
+torch.empty(
+    1, device="cuda", requires_grad=True
+).backward()  # prevents a bug on some systems
 import torch.distributed as dist
+import torch.nn.functional as F
+from torch import nn, Tensor
+
 # use of FlexAttention contributed by @KoszarskyB
 from torch.nn.attention.flex_attention import BlockMask, flex_attention
-torch._inductor.config.coordinate_descent_tuning = True # we allow this flag for medium track
-torch._dynamo.config.compiled_autograd = True
+
+
+torch._inductor.config.coordinate_descent_tuning = (
+    True  # we allow this flag for medium track
+)
+# torch._dynamo.config.compiled_autograd = True
+
+
+class Snoo:
+    """
+    @DominikKallusky, @vishal9-team, @vinaysrao
+
+    Sparse Nesterov Outer Optimizer (Snoo) is a momentum-based wrapper to any optimizer that can
+    improve the stability and smoothness of the optimization process and thus the quality
+    of large language models (LLM) and other models. Snoo implicitly adds temporal regularization
+    to the parameters, thus smoothing the training trajectory and instilling a bias towards flatter
+    minima and lower parameter norms. Snoo is computationally efficient, incurring minimal overhead
+    in compute and moderate memory usage.
+    """
+
+    @torch.no_grad()
+    def __init__(self, model: nn.Module, lr: float, momentum: float, k: int) -> None:
+        self.model = model
+        self.lr = lr
+        self.momentum = momentum
+        self.k = k
+        self.current_step = 0
+        self.outer_buf = [p.clone() for p in model.parameters()]
+        self.model_params = list(self.model.parameters())
+        self.optimizer = torch.optim.SGD(
+            self.model.parameters(),
+            lr=lr,
+            momentum=momentum,
+            nesterov=True,
+            fused=True,
+        )
+
+    @torch.no_grad()
+    def step(
+        self,
+    ) -> None:
+        if self.current_step % self.k == 0:
+            for p_new, p_old in zip(self.model_params, self.outer_buf):
+                p_new.grad = p_old.data - p_new.data
+                p_new.copy_(p_old, non_blocking=True)
+
+            self.optimizer.step()
+
+            for p_new, p_old in zip(self.model_params, self.outer_buf):
+                p_old.copy_(p_new, non_blocking=True)
+        self.current_step += 1
+
+    def state_dict(self):
+        state_dict = {
+            "current_step": self.current_step,
+            "lr": self.lr,
+            "momentum": self.momentum,
+            "k": self.k,
+            "outer_buf": [p.clone() for p in self.outer_buf],
+            "optimizer_state_dict": self.optimizer.state_dict(),
+        }
+        return state_dict
+
+    def load_state_dict(self, state_dict):
+        self.current_step = state_dict["current_step"]
+        self.lr = state_dict["lr"]
+        self.momentum = state_dict["momentum"]
+        self.k = state_dict["k"]
+        for p_src, p_dst in zip(state_dict["outer_buf"], self.outer_buf):
+            p_dst.copy_(p_src)
+        self.optimizer.load_state_dict(state_dict["optimizer_state_dict"])
+
 
 # -----------------------------------------------------------------------------
 # Muon optimizer
+
 
 def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
     """
@@ -33,7 +109,9 @@ def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
     where S' is diagonal with S_{ii}' ∈ [1 - l, 1 + r], which turns out not to hurt model
     performance at all relative to UV^T, where USV^T = G is the SVD.
     """
-    assert G.ndim >= 2 # batched Muon implementation by @scottjmaddox, and put into practice in the record by @YouJiacheng
+    assert (
+        G.ndim >= 2
+    )  # batched Muon implementation by @scottjmaddox, and put into practice in the record by @YouJiacheng
     X = G.bfloat16()
     if G.size(-2) > G.size(-1):
         X = X.mT
@@ -49,25 +127,42 @@ def zeropower_via_newtonschulz5(G: Tensor) -> Tensor:
         (2.8366, -3.0525, 1.2012),
     ]:
         A = X @ X.mT
-        B = b * A + c * A @ A # quintic computation strategy adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        B = (
+            b * A + c * A @ A
+        )  # quintic computation strategy adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
         X = a * X + B @ X
 
     if G.size(-2) > G.size(-1):
         X = X.mT
     return X
 
+
 @torch.compile
-def update(acc_bf16_view_u16: Tensor, mantissa: Tensor, momentum_buffer: Tensor, grad: Tensor, momentum: Tensor, eff_lr: Tensor, eff_weight_decay: Tensor):
+def update(
+    acc_bf16_view_u16: Tensor,
+    mantissa: Tensor,
+    momentum_buffer: Tensor,
+    update_smoothing_buffer: Tensor,
+    grad: Tensor,
+    momentum: Tensor,
+    update_smoothing: Tensor,
+    eff_lr: Tensor,
+    eff_weight_decay: Tensor,
+):
     assert acc_bf16_view_u16.dtype == mantissa.dtype == torch.uint16
     grad = grad.float()
     momentum_buffer.copy_(momentum * momentum_buffer + (1 - momentum) * grad)
     v = zeropower_via_newtonschulz5(momentum * momentum_buffer + (1 - momentum) * grad)
+
+    update_smoothing_buffer.copy_(update_smoothing * update_smoothing_buffer + (1 - update_smoothing) * v)
+    v = update_smoothing_buffer
 
     acc_m_u32 = (acc_bf16_view_u16.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
     acc_m_u32.view(torch.float32).mul_(1 - eff_weight_decay)
     acc_m_u32.view(torch.float32).add_(other=v, alpha=-eff_lr)
     acc_bf16_view_u16.copy_((acc_m_u32 >> 16).to(torch.uint16))
     mantissa.copy_(acc_m_u32.to(torch.uint16))
+
 
 class Muon(torch.optim.Optimizer):
     """
@@ -83,12 +178,19 @@ class Muon(torch.optim.Optimizer):
     Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
     or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
     """
-    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, rank=0, world_size=1):
+
+    def __init__(
+        self, params, lr=0.02, weight_decay=0.01, momentum=0.95, update_smoothing=0.0, rank=0, world_size=1
+    ):
         self.rank = rank
         self.world_size = world_size
-        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum)
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, update_smoothing=update_smoothing)
         super().__init__(params, defaults)
-        assert all(p.dtype == torch.bfloat16 for group in self.param_groups for p in group["params"])
+        assert all(
+            p.dtype == torch.bfloat16
+            for group in self.param_groups
+            for p in group["params"]
+        )
 
     @torch.no_grad()
     def step(self):
@@ -97,40 +199,69 @@ class Muon(torch.optim.Optimizer):
             params: list[Tensor] = group["params"]
             params_pad = params + [torch.empty_like(params[-1])] * self.world_size
             momentum = torch._as_tensor_fullprec(group["momentum"])
-            for base_i in range(len(params))[::self.world_size]:
+            update_smoothing = torch._as_tensor_fullprec(group["update_smoothing"])
+            for base_i in range(len(params))[:: self.world_size]:
                 if base_i + self.rank < len(params):
                     p = params[base_i + self.rank]
                     state = self.state[p]
                     if len(state) == 0:
                         state["mantissa"] = torch.zeros_like(p, dtype=torch.uint16)
-                        state["momentum_buffer"] = torch.zeros_like(p, dtype=torch.float32)
+                        state["momentum_buffer"] = torch.zeros_like(
+                            p, dtype=torch.float32
+                        )
+                        state["update_smoothing_buffer"] = torch.zeros_like(
+                            p, dtype=torch.bfloat16
+                        )
                     update(
-                        p.view(torch.uint16), state["mantissa"], state["momentum_buffer"],
-                        p.grad, momentum,
-                        eff_lr=torch._as_tensor_fullprec(group["lr"] * max(1, p.size(-2) / p.size(-1)) ** 0.5),
-                        eff_weight_decay=torch._as_tensor_fullprec(group["lr"] * group["weight_decay"] * getattr(p, "wd_mul", 1.0)),
+                        p.view(torch.uint16),
+                        state["mantissa"],
+                        state["momentum_buffer"],
+                        state["update_smoothing_buffer"],
+                        p.grad,
+                        momentum,
+                        update_smoothing,
+                        eff_lr=torch._as_tensor_fullprec(
+                            group["lr"] * max(1, p.size(-2) / p.size(-1)) ** 0.5
+                        ),
+                        eff_weight_decay=torch._as_tensor_fullprec(
+                            group["lr"]
+                            * group["weight_decay"]
+                            * getattr(p, "wd_mul", 1.0)
+                        ),
                     )
-                futures.append(dist.all_gather(params_pad[base_i:base_i + self.world_size], params_pad[base_i + self.rank], async_op=True).get_future())
+                futures.append(
+                    dist.all_gather(
+                        params_pad[base_i : base_i + self.world_size],
+                        params_pad[base_i + self.rank],
+                        async_op=True,
+                    ).get_future()
+                )
         torch.futures.collect_all(futures).wait()
+
 
 # -----------------------------------------------------------------------------
 # PyTorch nn.Module definitions for the model
 
+
 def norm(x: Tensor):
     return F.rms_norm(x, (x.size(-1),))
 
+
 @torch.no_grad()
 def init_linear(w: Tensor):
-    std = 0.5 * (w.size(-1) ** -0.5) # 0.5 is a bit better than the default 1/sqrt(3)
-    bound = (3 ** 0.5) * std
+    std = 0.5 * (w.size(-1) ** -0.5)  # 0.5 is a bit better than the default 1/sqrt(3)
+    bound = (3**0.5) * std
     return w.uniform_(-bound, bound)
+
 
 class Rotary(nn.Module):
     def __init__(self, dim: int, max_seq_len: int):
         super().__init__()
         # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
-        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
-        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(dim//4)])
+        angular_freq = (1 / 1024) ** torch.linspace(
+            0, 1, steps=dim // 4, dtype=torch.float32
+        )
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(dim // 4)])
         t = torch.arange(max_seq_len, dtype=torch.float32)
         theta = torch.einsum("i,j -> ij", t, angular_freq)
         self.cos = nn.Buffer(theta.cos(), persistent=False)
@@ -138,11 +269,15 @@ class Rotary(nn.Module):
 
     def forward(self, x_BTHD: Tensor):
         assert self.cos.size(0) >= x_BTHD.size(-3)
-        cos, sin = self.cos[None, :x_BTHD.size(-3), None, :], self.sin[None, :x_BTHD.size(-3), None, :]
+        cos, sin = (
+            self.cos[None, : x_BTHD.size(-3), None, :],
+            self.sin[None, : x_BTHD.size(-3), None, :],
+        )
         x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
         y1 = x1 * cos + x2 * sin
         y2 = x1 * (-sin) + x2 * cos
         return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
 
 class CausalSelfAttention(nn.Module):
     def __init__(self, dim: int, num_heads: int, max_seq_len: int, head_dim=128):
@@ -153,27 +288,44 @@ class CausalSelfAttention(nn.Module):
         # merged QKV weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
         # https://x.com/hi_tysam/status/1879699187107033311
         self.qkvo_w = nn.Parameter(init_linear(torch.empty(4, hdim, dim)).bfloat16())
-        self.qkvo_w.detach()[3].zero_() # out zero init suggested by @Grad62304977
+        self.qkvo_w.detach()[3].zero_()  # out zero init suggested by @Grad62304977
         self.rotary = Rotary(head_dim, max_seq_len)
         # scale the attention logits by given constant, instead of the default head_dim**-0.5, by @leloykun
         # inspired by learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
         self.attn_scale = 0.12
 
-    def forward(self, x: Tensor, ve: Tensor | None, block_mask: BlockMask, lambdas: Tensor):
-        B, T = x.size(0), x.size(1) # batch size, sequence length
+    def forward(
+        self, x: Tensor, ve: Tensor | None, block_mask: BlockMask, lambdas: Tensor
+    ):
+        B, T = x.size(0), x.size(1)  # batch size, sequence length
         assert B == 1, "Must use batch size = 1 for FlexAttention"
-        q, k, v = F.linear(x, self.qkvo_w[:3].flatten(end_dim=1)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
-        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k, v = (
+            F.linear(x, self.qkvo_w[:3].flatten(end_dim=1))
+            .view(B, T, 3 * self.num_heads, self.head_dim)
+            .chunk(3, dim=-2)
+        )
+        q, k = norm(q), norm(k)  # QK norm @Grad62304977
         q, k = self.rotary(q), self.rotary(k)
         v = norm(v)
         if ve is not None:
-            v = lambdas[0] * v + lambdas[1] * ve.view_as(v) # @KoszarskyB & @Grad62304977
-        else: # skip mid-layers token value embeddings by @YouJiacheng
+            v = lambdas[0] * v + lambdas[1] * ve.view_as(
+                v
+            )  # @KoszarskyB & @Grad62304977
+        else:  # skip mid-layers token value embeddings by @YouJiacheng
             v = lambdas[0] * v
-        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, scale=self.attn_scale).transpose(1, 2)
-        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = flex_attention(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            block_mask=block_mask,
+            scale=self.attn_scale,
+        ).transpose(1, 2)
+        y = y.contiguous().view(
+            B, T, self.num_heads * self.head_dim
+        )  # re-assemble all head outputs side by side
         y = F.linear(y, self.qkvo_w[3])
         return y
+
 
 class MLP(nn.Module):
     def __init__(self, dim: int):
@@ -186,48 +338,91 @@ class MLP(nn.Module):
 
     def forward(self, x: Tensor):
         x = F.linear(x, self.fc_w)
-        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.relu(
+            x
+        ).square()  # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
         x = F.linear(x, self.proj_w)
         return x
+
 
 class Block(nn.Module):
     def __init__(self, dim: int, num_heads: int, max_seq_len: int, layer_idx: int):
         super().__init__()
         # skip attention of blocks.7 (the 8th layer) by @YouJiacheng
-        self.attn = CausalSelfAttention(dim, num_heads, max_seq_len) if layer_idx != 7 else None
+        self.attn = (
+            CausalSelfAttention(dim, num_heads, max_seq_len) if layer_idx != 7 else None
+        )
         self.mlp = MLP(dim)
 
-    def forward(self, x: Tensor, ve: Tensor | None, x0: Tensor, block_mask: BlockMask, lambdas: Tensor, sa_lambdas: Tensor):
-        x = lambdas[0] * x + lambdas[1] * x0
+    def forward(
+        self,
+        x: Tensor,
+        ve: Tensor | None,
+        x00: Tensor,
+        x01: Tensor,
+        block_mask: BlockMask,
+        lambdas: Tensor,
+        sa_lambdas: Tensor,
+    ):
+        x = lambdas[0] * x + lambdas[1] * x00 + lambdas[2] * x01
         if self.attn is not None:
             x = x + self.attn(x, ve, block_mask, sa_lambdas)
         x = x + self.mlp(norm(x))
         return x
 
+
 # -----------------------------------------------------------------------------
 # The main model
+
 
 def next_multiple_of_n(v: float | int, *, n: int):
     return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
 
+
 class GPT(nn.Module):
-    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, model_dim: int, max_seq_len: int):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        num_heads: int,
+        model_dim: int,
+        max_seq_len: int,
+    ):
         super().__init__()
-        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed1 = nn.Embedding(vocab_size, model_dim)
+        self.embed2 = nn.Embedding(vocab_size, model_dim)
         # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
         # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
-        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
-        self.blocks = nn.ModuleList([Block(model_dim, num_heads, max_seq_len, i) for i in range(num_layers)])
+        self.value_embeds = nn.ModuleList(
+            [nn.Embedding(vocab_size, model_dim) for _ in range(5)]
+        )
+        self.blocks = nn.ModuleList(
+            [Block(model_dim, num_heads, max_seq_len, i) for i in range(num_layers)]
+        )
         # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
         # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
-        self.lm_head_w = nn.Parameter(torch.zeros(next_multiple_of_n(vocab_size, n=128), model_dim))
+        self.lm_head_w = nn.Parameter(
+            torch.zeros(next_multiple_of_n(vocab_size, n=128), model_dim)
+        )
         # Add learnable skip connection weights for decoder layers
         assert num_layers % 2 == 0
-        self.scalars = nn.Parameter(torch.cat([
-            torch.ones(num_layers), # skip_weights
-            *[torch.tensor([1.0, 0.0]) for _ in range(num_layers)], # block lambdas
-            *[torch.tensor([0.5, 0.5]) for _ in range(num_layers)], # SA lambdas
-        ]))
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    torch.ones(num_layers),  # skip_weights
+                    *[
+                        torch.tensor([1.0, 0.0, 0.0]) for _ in range(num_layers)
+                    ],  # block lambdas
+                    *[
+                        torch.tensor([0.5, 0.5]) for _ in range(num_layers)
+                    ],  # SA lambdas
+                    torch.tensor([1.0, 0.0]),  # skip-to-head lambdas
+                ]
+            )
+        )
+        for m in self.modules():
+            if isinstance(m, nn.Embedding):
+                m.bfloat16()
 
     def create_blockmasks(self, input_seq: Tensor, sliding_window_num_blocks: Tensor):
         BLOCK_SIZE = 128
@@ -240,7 +435,11 @@ class GPT(nn.Module):
 
         def dense_to_ordered(dense_blockmask: Tensor):
             num_blocks = dense_blockmask.sum(dim=-1, dtype=torch.int32)
-            indices = dense_blockmask.argsort(dim=-1, descending=False, stable=True).flip(-1).to(torch.int32)
+            indices = (
+                dense_blockmask.argsort(dim=-1, descending=False, stable=True)
+                .flip(-1)
+                .to(torch.int32)
+            )
             return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
 
         # manual block mask creation by @YouJiacheng
@@ -251,37 +450,76 @@ class GPT(nn.Module):
         causal_blockmask_all = block_idx[:, None] > block_idx
         docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
         docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
-        document_blockmask_any = (docs_low[:, None] <= docs_high) & (docs_high[:, None] >= docs_low)
-        document_blockmask_all = (docs_low[:, None] == docs_high) & (docs_high[:, None] == docs_low)
+        document_blockmask_any = (docs_low[:, None] <= docs_high) & (
+            docs_high[:, None] >= docs_low
+        )
+        document_blockmask_all = (docs_low[:, None] == docs_high) & (
+            docs_high[:, None] == docs_low
+        )
         blockmask_any = causal_blockmask_any & document_blockmask_any
         blockmask_all = causal_blockmask_all & document_blockmask_all
-        partial_kv_num_blocks, partial_kv_indices = dense_to_ordered(blockmask_any & ~blockmask_all)
+        partial_kv_num_blocks, partial_kv_indices = dense_to_ordered(
+            blockmask_any & ~blockmask_all
+        )
         full_kv_num_blocks, full_kv_indices = dense_to_ordered(blockmask_all)
+
         def build_bm(window_size_blocks: Tensor) -> BlockMask:
             return BlockMask.from_kv_blocks(
-                torch.clamp_max(partial_kv_num_blocks, torch.clamp_min(window_size_blocks - full_kv_num_blocks, 1)),
+                torch.clamp_max(
+                    partial_kv_num_blocks,
+                    torch.clamp_min(window_size_blocks - full_kv_num_blocks, 1),
+                ),
                 partial_kv_indices,
                 torch.clamp_max(full_kv_num_blocks, window_size_blocks - 1),
                 full_kv_indices,
                 BLOCK_SIZE=BLOCK_SIZE,
                 mask_mod=document_causal,
             )
-        # Long-short SWA block masks by @leloykun & @YouJiacheng, adapated from suggestion by @Grad62304977, following Gemma 2 paper
-        return build_bm(sliding_window_num_blocks), build_bm(sliding_window_num_blocks // 2)
 
-    def forward(self, input_seq: Tensor, target_seq: Tensor, sliding_window_num_blocks: Tensor):
+        # Long-short SWA block masks by @leloykun & @YouJiacheng, adapated from suggestion by @Grad62304977, following Gemma 2 paper
+        return build_bm(sliding_window_num_blocks), build_bm(
+            sliding_window_num_blocks // 2
+        )
+
+    def forward(
+        self, input_seq: Tensor, target_seq: Tensor, sliding_window_num_blocks: Tensor
+    ):
         assert input_seq.ndim == 1
 
         ve = [value_embed(input_seq) for value_embed in self.value_embeds]
         # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
-        ve = [ve[0], ve[1], ve[2]] + [None] * (len(self.blocks) - 6) + [ve[0], ve[1], ve[2]]
+        ve = (
+            [ve[0], ve[1], ve[2], ve[3], ve[4]]
+            + [None] * (len(self.blocks) - 10)
+            + [ve[0], ve[1], ve[2], ve[3], ve[4]]
+        )
         assert len(ve) == len(self.blocks)
 
         long_bm, short_bm = self.create_blockmasks(input_seq, sliding_window_num_blocks)
-        block_masks = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        block_masks = [
+            long_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            long_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            long_bm,
+            short_bm,
+            short_bm,
+            short_bm,
+            long_bm,
+        ]
         assert len(block_masks) == len(self.blocks)
 
-        x = x0 = norm(self.embed(input_seq)[None]) # use of norm here by @Grad62304977
+        x = x00 = norm(
+            self.embed1(input_seq)[None]
+        )  # use of norm here by @Grad62304977
+        x01 = norm(self.embed2(input_seq)[None])
 
         skip_connections = []
         skip_map = {
@@ -289,130 +527,205 @@ class GPT(nn.Module):
             10: 4,
             11: 2,
         }
-        skip_weights = self.scalars[:len(self.blocks)]
-        lambdas = self.scalars[1 * len(self.blocks): 3 * len(self.blocks)].view(-1, 2)
-        sa_lambdas = self.scalars[3 * len(self.blocks): 5 * len(self.blocks)].view(-1, 2)
+        skip_weights = self.scalars[: len(self.blocks)]
+        lambdas = self.scalars[1 * len(self.blocks) : 4 * len(self.blocks)].view(-1, 3)
+        sa_lambdas = self.scalars[4 * len(self.blocks) : 6 * len(self.blocks)].view(
+            -1, 2
+        )
         for i in range(len(self.blocks)):
             if i in skip_map:
                 x = x + skip_weights[skip_map[i]] * skip_connections[skip_map[i]]
-            x = self.blocks[i](x, ve[i], x0, block_masks[i], lambdas[i], sa_lambdas[i])
+            x = self.blocks[i](
+                x, ve[i], x00, x01, block_masks[i], lambdas[i], sa_lambdas[i]
+            )
             skip_connections.append(x)
 
-        x = norm(x)
+        skip_lambdas = self.scalars[-2:]
+        x = norm(x) * skip_lambdas[0] + norm(skip_connections[11]) * skip_lambdas[1]
         if self.training:
-            logits: Tensor = F.linear(x.flatten(end_dim=1), self.lm_head_w.bfloat16()).float()
-            loss = F.cross_entropy(15 * logits * torch.rsqrt(logits.square() + 225), target_seq)
+            logits: Tensor = F.linear(
+                x.flatten(end_dim=1), self.lm_head_w.bfloat16()
+            ).float()
+            loss = F.cross_entropy(
+                15 * logits * torch.rsqrt(logits.square() + 225), target_seq
+            )
             return loss
 
         loss = 0
         for i in range(4):
-            logits: Tensor = F.linear(x.flatten(end_dim=1).chunk(4)[i], self.lm_head_w.bfloat16()).float()
-            loss += F.cross_entropy(15 * logits * torch.rsqrt(logits.square() + 225), target_seq.chunk(4)[i]) / 4
+            logits: Tensor = F.linear(
+                x.flatten(end_dim=1).chunk(4)[i], self.lm_head_w.bfloat16()
+            ).float()
+            loss += (
+                F.cross_entropy(
+                    15 * logits * torch.rsqrt(logits.square() + 225),
+                    target_seq.chunk(4)[i],
+                )
+                / 4
+            )
         return loss
+
 
 # -----------------------------------------------------------------------------
 # Our own simple Distributed Data Loader
 
+
 def _load_data_shard(file: Path):
-    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    header = torch.from_file(
+        str(file), False, 256, dtype=torch.int32
+    )  # header is 256 int32
     assert header[0] == 20240520, "magic number mismatch in the data .bin file"
     assert header[1] == 1, "unsupported version"
-    num_tokens = int(header[2]) # number of tokens (claimed)
+    num_tokens = int(header[2])  # number of tokens (claimed)
     with file.open("rb", buffering=0) as f:
-        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        tokens = torch.empty(
+            num_tokens, dtype=torch.uint16, pin_memory=True
+        )  # avoid pin_memory copy by @YouJiacheng
         f.seek(256 * 4)
-        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        nbytes = f.readinto(tokens.numpy())  # avoid bytes->array copy by @YouJiacheng
         assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
     return tokens
 
-def distributed_data_generator(filename_pattern: str, batch_size: int, rank : int, world_size : int):
+
+def distributed_data_generator(
+    filename_pattern: str, batch_size: int, rank: int, world_size: int
+):
     files = sorted(Path.cwd().glob(filename_pattern))
     assert batch_size % world_size == 0
     local_batch_size = batch_size // world_size
-    file_iter = iter(files) # use itertools.cycle(files) instead if you want to do multi-epoch training
+    file_iter = iter(
+        files
+    )  # use itertools.cycle(files) instead if you want to do multi-epoch training
     tokens, pos = _load_data_shard(next(file_iter)), 0
     while True:
         if pos + batch_size + 1 >= len(tokens):
             tokens, pos = _load_data_shard(next(file_iter)), 0
-        buf = tokens[pos + rank * local_batch_size:][:local_batch_size + 1]
-        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # no sync on host side;
-        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # H2D in another stream isn't helpful.
+        buf = tokens[pos + rank * local_batch_size :][: local_batch_size + 1]
+        inputs = buf[:-1].to(
+            device="cuda", dtype=torch.int32, non_blocking=True
+        )  # no sync on host side;
+        targets = buf[1:].to(
+            device="cuda", dtype=torch.int64, non_blocking=True
+        )  # H2D in another stream isn't helpful.
         pos += batch_size
         yield inputs, targets
+
 
 # -----------------------------------------------------------------------------
 # int main
 
+
 @dataclass
 class Hyperparameters:
     # data
-    train_files = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
-    val_files = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
-    val_tokens = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
-    train_seq_len = 64*1024 # FlexAttention sequence length
-    val_seq_len = 4*64*1024 # FlexAttention sequence length for validation
+    train_files = "data/fineweb10B/fineweb_train_*.bin"  # input .bin to train on
+    val_files = (
+        "data/fineweb10B/fineweb_val_*.bin"  # input .bin to eval validation loss on
+    )
+    val_tokens = 10485760  # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    train_seq_len = 64 * 1024  # FlexAttention sequence length
+    val_seq_len = 4 * 64 * 1024  # FlexAttention sequence length for validation
     # optimization
-    num_iterations = 5960 # number of iterations to run
-    cooldown_frac = 0.7 # fraction of training spent cooling down the learning rate
+    num_iterations = 5560  # number of iterations to run
+    cooldown_frac = 0.7  # fraction of training spent cooling down the learning rate
+    final_lr_scale = 0.01
     # architecture
     vocab_size = 50257
     # evaluation and logging
-    val_loss_every = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    val_loss_every = (
+        125  # every how many steps to evaluate val loss? 0 for only at the end
+    )
     save_checkpoint = False
+
+
 args = Hyperparameters()
 
 run_id = int(os.environ.get("RUN_ID", 0))
 # torchrun sets these env variables
 rank = int(os.environ["RANK"])
 world_size = int(os.environ["WORLD_SIZE"])
-assert world_size == 8 # this code is designed for 8xH100
+assert world_size == 8  # this code is designed for 8xH100
 assert torch.cuda.is_available()
 device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
 torch.cuda.set_device(device)
 dist.init_process_group(backend="nccl", device_id=device)
 dist.barrier()
-master_process = (rank == 0) # this process will do logging, checkpointing etc.
+master_process = rank == 0  # this process will do logging, checkpointing etc.
 
 # begin logging
 if master_process:
     run_id_full = f"{run_id:03d}_{uuid.uuid4()}"
-    os.makedirs("logs", exist_ok=True)
-    logfile = f"logs/{run_id_full}.txt"
+    path = "logs"
+    os.makedirs(path, exist_ok=True)
+    logfile = f"{path}/{run_id_full}.txt"
     print(logfile)
+
+
 def print0(s, console=False):
     if master_process:
         with open(logfile, "a") as f:
             if console:
                 print(s)
             print(s, file=f)
-from torch._logging._internal import trace_structured # noqa: E402
-import torch._inductor.codecache # noqa: E402
-import torch._inductor.graph # noqa: E402
-def _patched_trace_structured(name, metadata_fn, **kwargs):
-    if name == "inductor_output_code":
-        print0(f"inductor_output_code: {metadata_fn().get("filename", "Unknown")}")
-    trace_structured(name, metadata_fn, **kwargs)
-torch._inductor.codecache.trace_structured = _patched_trace_structured
-torch._inductor.graph.trace_structured = _patched_trace_structured
+
 
 # begin by printing this file (the Python code)
 print0(code)
-print0("="*100)
+print0("=" * 100)
 # log information about the hardware/software environment this is running on
 print0(f"Running Python {sys.version}")
-print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(
+    f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}"
+)
+
+
 def nvidia_smi():
     import subprocess  # avoid top level import
-    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+
+    try:
+        return subprocess.run(
+            ["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        ).stdout
+    except FileNotFoundError:
+        print0("nvidia-smi not found. Using library functions instead.", console=True)
+    import pynvml
+
+    pynvml.nvmlInit()
+    device_count = pynvml.nvmlDeviceGetCount()
+    print0(
+        f"{'GPU':<3} {'Name':<25} {'Temp':<5} {'Power':<10} {'Mem Used':<15} {'Mem Total':<15} {'Util':<6}",
+        console=True,
+    )
+    for i in range(device_count):
+        handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+        name = pynvml.nvmlDeviceGetName(handle)
+        temp = pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
+        power = pynvml.nvmlDeviceGetPowerUsage(handle) // 1000  # mW to W
+        mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+        mem_used = mem_info.used // (1024 * 1024)
+        mem_total = mem_info.total // (1024 * 1024)
+        util = pynvml.nvmlDeviceGetUtilizationRates(handle).gpu
+        print0(
+            f"{i:<3} {name:<25} {temp:<5} {power:<10} {mem_used:<15} {mem_total:<15} {util:<6}%",
+            console=True,
+        )
+    pynvml.nvmlShutdown()
+
+
 print0(nvidia_smi())
-print0("="*100)
+print0("=" * 100)
 
 ########################################
 #    Construct model and optimizer     #
 ########################################
 
-model: nn.Module = GPT(vocab_size=args.vocab_size, num_layers=16, num_heads=8, model_dim=1024,
-                       max_seq_len=max(args.train_seq_len, args.val_seq_len)).cuda()
+model: nn.Module = GPT(
+    vocab_size=args.vocab_size,
+    num_layers=16,
+    num_heads=8,
+    model_dim=1024,
+    max_seq_len=max(args.train_seq_len, args.val_seq_len),
+).cuda()
 for m in model.modules():
     if isinstance(m, nn.Embedding):
         m.bfloat16()
@@ -420,8 +733,16 @@ for param in model.parameters():
     dist.broadcast(param.detach(), 0)
 
 # collect the parameters to optimize
-hidden_matrix_params = sorted((p for p in model.blocks.parameters() if p.ndim >= 2), key=lambda x: x.size(), reverse=True)
-embed_params = [*model.embed.parameters(), *model.value_embeds.parameters()]
+hidden_matrix_params = sorted(
+    (p for p in model.blocks.parameters() if p.ndim >= 2),
+    key=lambda x: x.size(),
+    reverse=True,
+)
+embed_params = [
+    *model.embed1.parameters(),
+    *model.embed2.parameters(),
+    *model.value_embeds.parameters(),
+]
 scalar_params = [model.scalars]
 head_params: list[nn.Parameter] = [model.lm_head_w]
 # sanity check
@@ -431,40 +752,62 @@ assert optimized_parameters_set == {*model.parameters()}
 assert len(optimized_parameters_set) == sum(len(lst) for lst in params_collections)
 
 # init the optimizer(s)
-adam_param_groups = [dict(params=head_params, lr=1/320), dict(params=embed_params, lr=0.3), dict(params=scalar_params, lr=0.015)]
+adam_param_groups = [
+    dict(params=head_params, lr=1 / 320),
+    dict(params=embed_params, lr=0.3),
+    dict(params=scalar_params, lr=0.015),
+]
 # small adam epsilon by @YouJiacheng. this is an alternate method of fixing the world_size dependence
 # discovered by @fernbear.bsky.social https://x.com/hi_tysam/status/1879692937589875094
-optimizer1 = torch.optim.AdamW(adam_param_groups, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.0, fused=True)
-optimizer2 = Muon(hidden_matrix_params, lr=0.025, momentum=0.95, rank=rank, world_size=world_size)
-optimizers: list[torch.optim.Optimizer] = [optimizer1, optimizer2]
+inner_optimizers = [
+    torch.optim.AdamW(
+        adam_param_groups, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.0, fused=True
+    )
+]
+inner_hidden_optim = Muon(
+    hidden_matrix_params, lr=0.03, momentum=0.95, update_smoothing=0.2, rank=rank, world_size=world_size
+)
+inner_optimizers += [inner_hidden_optim]
+outer_optim = Snoo(model, lr=0.68, momentum=0.37, k=28)
+all_optimizers: list[torch.optim.Optimizer] = [outer_optim] + inner_optimizers
+
+
 def opt_params(opt: torch.optim.Optimizer) -> list[nn.Parameter]:
     return [p for group in opt.param_groups for p in group["params"]]
-opt2params = {opt: opt_params(opt) for opt in optimizers}
-for opt in optimizers:
+
+
+opt2params = {opt: opt_params(opt) for opt in inner_optimizers}
+for opt in inner_optimizers:
     for group in opt.param_groups:
         group["initial_lr"] = group["lr"]
 
+
 # learning rate schedule: stable then decay
 def get_lr(step: int):
-    x = step / args.num_iterations # progress in training
+    x = step / args.num_iterations  # progress in training
     assert 0 <= x < 1
     if x < 1 - args.cooldown_frac:
         return 1.0
     else:
-        return (1 - x) / args.cooldown_frac
+        return (1 - x) / args.cooldown_frac * (1 - args.final_lr_scale) + args.final_lr_scale
 
 # attention window size schedule: linearly increase
 @lru_cache(1)
 def get_window_size_blocks_helper(window_size: int):
-    return torch.tensor(window_size // 128, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
+    return torch.tensor(window_size // 128, dtype=torch.int32, pin_memory=True).cuda(
+        non_blocking=True
+    )
+
+
 def get_window_size_blocks(step: int):
-    x = step / args.num_iterations # progress in training
+    x = step / args.num_iterations  # progress in training
     assert 0 <= x <= 1
     # Linearly increase the block-wise sliding window size over training 128 -> 1792
     # increase by @fernbear.bsky.social; block-wise by @YouJiacheng
-    factor = 4 * x ** 3 - 6 * x ** 2 + 3 * x # cubic schedule by @jadenj3o
+    factor = 4 * x**3 - 6 * x**2 + 3 * x  # cubic schedule by @jadenj3o
     window_size = next_multiple_of_n(3456 * factor, n=128)
     return get_window_size_blocks_helper(window_size)
+
 
 model: nn.Module = torch.compile(model, dynamic=False)
 
@@ -474,17 +817,25 @@ model: nn.Module = torch.compile(model, dynamic=False)
 
 # Warmup the training kernels, then re-initialize the state so we aren't cheating
 warmup_steps = 10
-initial_state = copy.deepcopy(dict(model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers]))
+initial_state = copy.deepcopy(
+    dict(
+        model=model.state_dict(),
+        optimizers=[opt.state_dict() for opt in all_optimizers],
+    )
+)
 for _ in range(warmup_steps):
-    inputs = targets = torch.randint(0, args.vocab_size, size=(args.train_seq_len,), device="cuda")
+    inputs = targets = torch.randint(
+        0, args.vocab_size, size=(args.train_seq_len,), device="cuda"
+    )
     model(inputs.to(torch.int32), targets, get_window_size_blocks(0)).backward()
     for param in model.parameters():
         dist.all_reduce(param.grad, op=dist.ReduceOp.AVG)
-    for opt in optimizers:
+    for opt in inner_optimizers:
         opt.step()
+    outer_optim.step()
     model.zero_grad(set_to_none=True)
 model.load_state_dict(initial_state["model"])
-for opt, opt_state in zip(optimizers, initial_state["optimizers"]):
+for opt, opt_state in zip(all_optimizers, initial_state["optimizers"]):
     opt.load_state_dict(opt_state)
 del initial_state
 
@@ -493,7 +844,9 @@ del initial_state
 ########################################
 
 torch.cuda.reset_peak_memory_stats()
-train_loader = distributed_data_generator(args.train_files, world_size * args.train_seq_len, rank, world_size)
+train_loader = distributed_data_generator(
+    args.train_files, world_size * args.train_seq_len, rank, world_size
+)
 training_time_ms = 0
 # start the clock
 dist.barrier()
@@ -501,7 +854,7 @@ t0 = time.perf_counter()
 # begin training
 train_steps = args.num_iterations
 for step in range(train_steps + 1):
-    last_step = (step == train_steps)
+    last_step = step == train_steps
 
     # --------------- VALIDATION SECTION -----------------
     if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
@@ -512,7 +865,9 @@ for step in range(train_steps + 1):
         val_batch_size = world_size * args.val_seq_len
         assert args.val_tokens % val_batch_size == 0
         val_steps = args.val_tokens // val_batch_size
-        val_loader = distributed_data_generator(args.val_files, val_batch_size, rank, world_size)
+        val_loader = distributed_data_generator(
+            args.val_files, val_batch_size, rank, world_size
+        )
         val_loss = 0
         with torch.no_grad():
             for _ in range(val_steps):
@@ -521,7 +876,10 @@ for step in range(train_steps + 1):
         val_loss /= val_steps
         del val_loader
         dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
-        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.6f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        print0(
+            f"step:{step}/{train_steps} val_loss:{val_loss:.6f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms",
+            console=True,
+        )
         model.train()
         # start the clock again
         dist.barrier()
@@ -529,7 +887,12 @@ for step in range(train_steps + 1):
 
     if last_step:
         if master_process and args.save_checkpoint:
-            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            log = dict(
+                step=step,
+                code=code,
+                model=model.state_dict(),
+                optimizers=[opt.state_dict() for opt in all_optimizers],
+            )
             os.makedirs(f"logs/{run_id_full}", exist_ok=True)
             torch.save(log, f"logs/{run_id_full}/state_step{step:06d}.pt")
         # the last step only has the validation loop, so break to avoid training
@@ -539,26 +902,37 @@ for step in range(train_steps + 1):
     inputs, targets = next(train_loader)
     model(inputs, targets, get_window_size_blocks(step)).backward()
     opt2futures = {
-        opt: [dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True).get_future() for p in params]
+        opt: [
+            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            for p in params
+        ]
         for opt, params in opt2params.items()
     }
     # set optimization hyperparameters
-    for opt in optimizers:
+    for opt in inner_optimizers:
         for group in opt.param_groups:
             group["lr"] = group["initial_lr"] * get_lr(step)
-    for group in optimizer2.param_groups:
-        frac = min(step / 300, 1) # momentum warmup for muon
+    for group in inner_hidden_optim.param_groups:
+        frac = min(step / 300, 1)  # momentum warmup for muon
         group["momentum"] = (1 - frac) * 0.85 + frac * 0.95
+
     # step the optimizers
-    for opt in optimizers:
+    for opt in inner_optimizers:
         torch.futures.collect_all(opt2futures[opt]).wait()
         opt.step()
+    outer_optim.step()
     # null the gradients
     model.zero_grad(set_to_none=True)
     # logging
     approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
-    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+    print0(
+        f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms",
+        console=True,
+    )
 
-print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
-    f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+print0(
+    f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+    f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB",
+    console=True,
+)
 dist.destroy_process_group()


### PR DESCRIPTION
I simply added the output of layer 11 (the 12'th layer) to the output of the final layer (layer 15, or the 16'th layer), in a weighted sum. The weights are scalars and are learned. This just means that right before applying the language head, I do this:

```python
skip_lambdas = self.scalars[-2:]
x = norm(x) * skip_lambdas[0] + norm(skip_connections[11]) * skip_lambdas[1]
```

Where the `skip_connections` contain the output latents of each layer, at the corresponding position.

This allowed me to reduce the step count to 5560 (-30 steps)

These are the resulting final validation losses over 10 runs:

```python
[2.918849, 2.917008, 2.919394, 2.91776, 2.919522, 2.919678, 2.918775, 2.918111, 2.919395, 2.917938]
```

And here are simple stats about the final validation loss over these 10 runs:

- Mean: 2.9186
- Std: 0.0008985
- P-value: 0.0005035724941803675

The p-value is very low, so after only 10 runs we can be sure that the target loss is reached.

Now here are the corresponding run times:

```python
[1378.689, 1378.504, 1378.622, 1379.238, 1379.0, 1379.444, 1378.426, 1379.337, 1378.254, 1379.127]
```

And here are some simple stats about the times:

- Mean: 1378.8641 seconds ~= 22.98 minutes
- Std: 0.4177 seconds

The previous record's time is 1405.698 seconds, so this is a reduction of almost 27 seconds. This seems like a lot for 30 steps, and may thus partially be an artifact of using different GPUs (though I have to say that a p-value this low after 10 runs indicates that I could maybe have reduced the step count even more).

The reason why I chose layer 11 is that I performed the following ablations over the layers:

<img width="2424" height="1470" alt="image" src="https://github.com/user-attachments/assets/68c8559c-7bd8-4596-865f-611f3663438a" />

And in that single run, layer 11 lead to the minimum loss.