### PR TITLE
Implement NorMuon

### DIFF
--- a/records/101225_NorMuon/115b1530-f861-4365-be25-72dae24798ab.txt
+++ b/records/101225_NorMuon/115b1530-f861-4365-be25-72dae24798ab.txt
@@ -1,0 +1,2512 @@
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+import copy
+import glob
+from dataclasses import dataclass
+from functools import lru_cache, partial # Added partial for hook registration
+from pathlib import Path
+
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+torch.empty(1, device="cuda", requires_grad=True).backward() # prevents a bug on some systems
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+# use of FlexAttention contributed by @KoszarskyB
+from torch.nn.attention.flex_attention import BlockMask, flex_attention
+#torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+@torch.compile
+def zeropower_via_newtonschulz5(G: Tensor, steps: int) -> Tensor:
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert G.ndim >= 2 # batched Muon implementation by @scottjmaddox, and put into practice in the record by @YouJiacheng
+    a, b, c = (3.4445, -4.7750,  2.0315)
+    X = G
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * A @ A # quintic computation strategy adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+class NorMuon(torch.optim.Optimizer):
+
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        params = list(params)
+        sizes = {p.shape for p in params}
+        # create one buffer per unique parameter-size
+        param_groups = []
+        for size in sizes:
+            group_params = [p for p in params if p.shape == size]
+            param_groups.append(dict(params=group_params))
+        super().__init__(param_groups, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient systems-wise implementation of step developed by @YouJiacheng,
+        # @KonstantinWilleke, @alexrgilbert, @adricarda, @tuttyfrutyee, @vdlad,
+        # @ryanyang0, and @vagrawal.
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        reduce_scatter_futures: list[torch.Future] = []
+        all_reduce_futures: list[torch.Future] = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            grad = torch.empty_like(params[-1])
+            grad_pad = [param.grad for param in params] + [torch.zeros_like(params[-1])] * world_size
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    grad = params[base_i + rank].grad
+                else:
+                    grad = torch.zeros_like(grad)
+                # This gives strange dynamo warnings
+                reduce_scatter_futures.append(dist.reduce_scatter(grad, grad_pad[base_i:base_i + world_size], op=dist.ReduceOp.AVG, async_op=True).get_future())
+
+        idx = 0
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * world_size
+            momentum = group["momentum"]
+            beta2 = group["beta2"]
+            for base_i in range(0, len(params), world_size):
+                reduce_scatter_futures[idx].wait()
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    grad = p.grad
+                    eff_lr = group["lr"] * max(1, p.size(-2) / p.size(-1)) ** 0.5 * getattr(p, "lr_mul", 1.0)
+                    eff_weight_decay = group["lr"] * group["weight_decay"] * getattr(p, "wd_mul", 1.0)
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum_buffer"] = torch.zeros_like(grad)
+                        state["second_momentum_buffer"] = torch.zeros_like(grad[..., 0:1]) if p.size(-2) >= p.size(-1) else torch.zeros_like(grad[0:1, ...])
+                    momentum_buffer = state["momentum_buffer"]
+                    second_momentum_buffer = state["second_momentum_buffer"]
+                    p.mul_(1 - eff_weight_decay)
+                    momentum_buffer.lerp_(grad, 1 - momentum)
+                    grad = grad.lerp_(momentum_buffer, momentum)
+                    v = zeropower_via_newtonschulz5(grad.bfloat16(), 5).float()
+                    ###################################
+                    vnorm = v.norm(dim=(-2,-1), keepdim=True)
+                    v_mean = torch.mean(v * v, dim=-1, keepdim=True) if p.size(-2) >= p.size(-1) else torch.mean(v * v, dim=-2, keepdim=True)
+                    second_momentum_buffer.lerp_(v_mean, 1 - beta2)
+                    step_size = 1 / second_momentum_buffer.sqrt().add_(1e-10)
+                    v.mul_(step_size)
+                    vnorm_new = v.norm(dim=(-2,-1), keepdim=True)
+                    v.mul_(vnorm / (vnorm_new + 1e-10))
+                    ####################################
+                    p.add_(other=v, alpha=-eff_lr)
+                idx += 1
+                all_reduce_futures.append(dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank], async_op=True).get_future())
+        torch.futures.collect_all(all_reduce_futures).wait()
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        sizes = {p.shape for p in params}
+        # create one buffer per unique parameter-size
+        param_groups = []
+        for size in sizes:
+            group_params = [p for p in params if p.shape == size]
+            param_groups.append(dict(params=group_params))
+        super().__init__(param_groups, defaults)
+        # DistributedAdam implementation by @vagrawal
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        reduce_scatter_futures: list[torch.Future] = []
+        all_reduce_futures: list[torch.Future] = []
+        grad_slices = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            grad = torch.empty_like(params[-1])
+            for base_i in range(len(params)):
+                grad = params[base_i].grad
+                rank_size = grad.shape[0] // world_size
+                grad_slice = torch.empty_like(grad[:rank_size])
+                reduce_scatter_futures.append(dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future())
+                grad_slices.append(grad_slice)
+
+        idx = 0
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            params = group['params']
+            for base in range(len(params)):
+                reduce_scatter_futures[idx].wait()
+                p = params[base]
+                rank_size = p.shape[0] // world_size
+                p_slice = p[rank * rank_size:(rank + 1) * rank_size]
+                lr = group['lr'] * getattr(p, "lr_mul", 1.0)
+                state = self.state[p]
+                g_slice = grad_slices[idx]
+                # State init
+                if not state:
+                    state['step'] = torch.tensor(0, dtype=torch.int64, device=p.device)
+                    state['exp_avg'] = torch.zeros_like(p_slice)
+                    state['exp_avg_sq'] = torch.zeros_like(p_slice)
+                exp_avg = state['exp_avg']
+                exp_avg_sq = state['exp_avg_sq']
+                state['step'] += 1
+                t = state['step']
+                # weight decay
+                if wd != 0:
+                    eff_weight_decay = lr * wd * getattr(p, "wd_mul", 1.0)
+                    p_slice.mul_(1 - eff_weight_decay)
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (torch.sqrt(bias2) / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                p_slice.add_(other=update, alpha=-1.0)
+                idx += 1
+                all_reduce_futures.append(dist.all_gather_into_tensor(p, p_slice, async_op=True).get_future())
+        torch.futures.collect_all(all_reduce_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        std = 0.5 * (self.in_features ** -0.5) # 0.5 is a bit better than the default 1/sqrt(3)
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.weight.uniform_(-bound, bound)
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, max_seq_len: int):
+        super().__init__()
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(dim//4)])
+        t = torch.arange(max_seq_len, dtype=torch.float32)
+        theta = torch.einsum("i,j -> ij", t, angular_freq)
+        self.cos = nn.Buffer(theta.cos(), persistent=False)
+        self.sin = nn.Buffer(theta.sin(), persistent=False)
+
+    def forward(self, x_BTHD: Tensor):
+        assert self.cos.size(0) >= x_BTHD.size(-3)
+        cos, sin = self.cos[None, :x_BTHD.size(-3), None, :], self.sin[None, :x_BTHD.size(-3), None, :]
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, head_dim=128):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        hdim = num_heads * head_dim
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKV weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        self.qkv_w = nn.Parameter(torch.empty(3, hdim, dim).uniform_(-bound, bound))
+        self.rotary = Rotary(head_dim, max_seq_len)
+        self.c_proj = CastedLinear(hdim, dim)
+        self.c_proj.weight.detach().zero_() # zero init suggested by @Grad62304977
+        # scale the attention logits by given constant, instead of the default head_dim**-0.5, by @leloykun
+        # inspired by learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.12
+
+    def forward(self, x: Tensor, ve: Tensor | None, lambdas: Tensor, block_mask: BlockMask):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q, k, v = F.linear(x, self.qkv_w.flatten(end_dim=1).type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        if ve is not None:
+            v = lambdas[0] * v + lambdas[1] * ve.view_as(v) # @KoszarskyB & @Grad62304977
+        else: # skip mid-layers token value embeddings by @YouJiacheng
+            v = lambdas[0] * v
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, scale=self.attn_scale).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = self.c_proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.c_fc = CastedLinear(dim, hdim)
+        self.c_proj = CastedLinear(hdim, dim)
+        self.c_proj.weight.detach().zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = self.c_fc(x)
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = self.c_proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.7 (the 8th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, num_heads, max_seq_len) if layer_idx != 7 else None
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, ve: Tensor | None, x0: Tensor, lambdas: Tensor, sa_lambdas: Tensor, block_mask: BlockMask):
+        x = lambdas[0] * x + lambdas[1] * x0
+        if self.attn is not None:
+            x = x + self.attn(norm(x), ve, sa_lambdas, block_mask)
+        x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        self.blocks = nn.ModuleList([Block(model_dim, num_heads, max_seq_len, i) for i in range(num_layers)])
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=True, x_s=(model_dim**0.5)/448, w_s=24/448, grad_s=1/448)
+        self.lm_head.weight.detach().zero_() # @Grad62304977
+        # Add learnable skip connection weights for decoder layers
+        assert num_layers % 2 == 0
+        pad = (-num_layers * 5) % dist.get_world_size()
+        self.scalars = nn.Parameter(torch.cat([
+            torch.ones(num_layers), # skip_weights
+            *[torch.tensor([1.0, 0.0]) for _ in range(num_layers)], # block lambdas
+            *[torch.tensor([0.5, 0.5]) for _ in range(num_layers)], # SA lambdas
+            torch.ones(pad),
+        ]))
+        # set learning rates
+        for param in self.embed.parameters():
+            param.lr_mul = 75.
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+        self.lm_head.weight.lr_mul = 27.5
+        self.scalars.lr_mul = 5.0
+
+    def create_blockmasks(self, input_seq: Tensor, sliding_window_num_blocks: Tensor):
+        BLOCK_SIZE = 128
+        docs = (input_seq == 50256).cumsum(0)
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_blockmask: Tensor):
+            num_blocks = dense_blockmask.sum(dim=-1, dtype=torch.int32)
+            indices = dense_blockmask.argsort(dim=-1, descending=False, stable=True).flip(-1).to(torch.int32)
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        # manual block mask creation by @YouJiacheng
+        assert len(input_seq) % BLOCK_SIZE == 0
+        NUM_BLOCKS = len(input_seq) // BLOCK_SIZE
+        block_idx = torch.arange(NUM_BLOCKS, dtype=torch.int32, device="cuda")
+        causal_blockmask_any = block_idx[:, None] >= block_idx
+        causal_blockmask_all = block_idx[:, None] > block_idx
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+        document_blockmask_any = (docs_low[:, None] <= docs_high) & (docs_high[:, None] >= docs_low)
+        document_blockmask_all = (docs_low[:, None] == docs_high) & (docs_high[:, None] == docs_low)
+        blockmask_any = causal_blockmask_any & document_blockmask_any
+        blockmask_all = causal_blockmask_all & document_blockmask_all
+        partial_kv_num_blocks, partial_kv_indices = dense_to_ordered(blockmask_any & ~blockmask_all)
+        full_kv_num_blocks, full_kv_indices = dense_to_ordered(blockmask_all)
+        def build_bm(window_size_blocks: Tensor) -> BlockMask:
+            return BlockMask.from_kv_blocks(
+                torch.clamp_max(partial_kv_num_blocks, torch.clamp_min(window_size_blocks - full_kv_num_blocks, 1)),
+                partial_kv_indices,
+                torch.clamp_max(full_kv_num_blocks, window_size_blocks - 1),
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+        # Long-short SWA block masks by @leloykun & @YouJiacheng, adapated from suggestion by @Grad62304977, following Gemma 2 paper
+        return build_bm(sliding_window_num_blocks), build_bm(sliding_window_num_blocks // 2)
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, sliding_window_num_blocks: Tensor):
+        assert input_seq.ndim == 1
+
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        ve = [ve[0], ve[1], ve[2]] + [None] * (len(self.blocks) - 6) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == len(self.blocks)
+
+        long_bm, short_bm = self.create_blockmasks(input_seq, sliding_window_num_blocks)
+        block_masks = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(block_masks) == len(self.blocks)
+
+        x = x0 = norm(self.embed(input_seq)[None]) # use of norm here by @Grad62304977
+
+        # U-net design by @brendanh0gan
+        skip_connections = []
+        skip_weights = self.scalars[:(len(self.blocks) // 2)]
+        lambdas = self.scalars[1 * len(self.blocks): 3 * len(self.blocks)].view(-1, 2)
+        sa_lambdas = self.scalars[3 * len(self.blocks): 5 * len(self.blocks)].view(-1, 2)
+
+        n = len(self.blocks) // 2
+
+        for i in range(len(self.blocks)):
+            if i >= n:
+                x = x + skip_weights[i - n] * skip_connections.pop()
+            x = self.blocks[i](x, ve[i], x0, lambdas[i], sa_lambdas[i], block_masks[i])
+            if i < n:
+                skip_connections.append(x)
+
+        x = norm(x)
+        logits = self.lm_head(x).float()
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15, @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1)
+        logits = 30 * torch.sigmoid(logits / (7.5 * x.size(-1)**0.5))
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq, reduction="sum" if self.training else "mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+# find world_size starting indicies, such that each begins with token 50256 and local_batches don't overlap
+def find_batch_starts(tokens: Tensor, pos: int, local_batch_size: int, max_batch_span: int):
+    boundary_mask = tokens[pos : pos + max_batch_span] == 50256
+    boundary_positions = torch.nonzero(boundary_mask, as_tuple=False).squeeze(-1) + pos
+    start = boundary_positions[0].item()
+    starts = []
+    for i in range(1, len(boundary_positions)):
+        end = boundary_positions[i].item() 
+        if end - start >= local_batch_size:
+            starts.append(start) # append start once end pos is confirmed
+            if len(starts) == dist.get_world_size():
+                return starts, end - pos
+            start = end
+    assert False # increase max_batch_span if necessary
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, align_to_bos: bool):
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files) # use itertools.cycle(files) instead if you want to do multi-epoch training
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    max_batch_span = 2 * batch_size if align_to_bos else batch_size # provide buffer to handle samples up to length local_batch_size
+    while True:
+        if pos + max_batch_span + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        if align_to_bos:
+            batch_starts, batch_span = find_batch_starts(tokens, pos, local_batch_size, max_batch_span)
+            start_idx = batch_starts[rank]
+        else:
+            batch_span = batch_size
+            start_idx = pos + rank * local_batch_size
+        buf = tokens[start_idx:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # no sync on host side;
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # H2D in another stream isn't helpful.
+        pos += batch_span
+        yield inputs, targets
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    train_seq_len = 48*1024 # FlexAttention sequence length
+    val_seq_len = 4*64*1024 # FlexAttention sequence length for validation
+    # optimization
+    num_iterations = 1700 # number of iterations to run
+    cooldown_frac = 0.45 # fraction of training spent cooling down the learning rate
+    # evaluation and logging
+    val_loss_every = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint = False
+args = Hyperparameters()
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert world_size == 8 # this code is designed for 8xH100
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = uuid.uuid4()
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(vocab_size=50257, num_layers=12, num_heads=6, model_dim=768, max_seq_len=max(args.train_seq_len, args.val_seq_len)).cuda()
+for m in model.modules():
+    if isinstance(m, nn.Embedding):
+        m.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+# collect the parameters to optimize
+hidden_matrix_params = [p for n, p in model.blocks.named_parameters() if p.ndim >= 2 and "embed" not in n]
+embed_params = [p for n, p in model.named_parameters() if "embed" in n]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+head_params = [model.lm_head.weight]
+
+# init the optimizer(s)
+# small adam epsilon by @YouJiacheng. this is an alternate method of fixing the world_size dependence
+# discovered by @fernbear.bsky.social https://x.com/hi_tysam/status/1879692937589875094
+optimizer1 = DistAdam(scalar_params + head_params + embed_params, lr=0.008, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.0)
+optimizer2 = NorMuon(hidden_matrix_params, lr=0.05, momentum=0.95, weight_decay=0.0, beta2=0.95)
+optimizers = [optimizer1, optimizer2]
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+
+# learning rate schedule: stable then decay
+def get_lr(step: int):
+    x = step / args.num_iterations # progress in training
+    assert 0 <= x < 1
+    if x < 1 - args.cooldown_frac:
+        return 1.0
+    else:
+        w = (1 - x) / args.cooldown_frac
+        return w * 1.0 + (1 - w) * 0.1
+
+# attention window size schedule: linearly increase
+@lru_cache(1)
+def get_window_size_blocks_helper(window_size: int):
+    return torch.tensor(window_size // 128, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
+def get_window_size_blocks(step: int):
+    x = step / args.num_iterations # progress in training
+    assert 0 <= x <= 1
+    # Linearly increase the block-wise sliding window size over training 128 -> 1792
+    # increase by @fernbear.bsky.social; block-wise by @YouJiacheng
+    window_size = next_multiple_of_n(1728 * x, n=128)
+    return get_window_size_blocks_helper(window_size)
+
+model: nn.Module = torch.compile(model, dynamic=False)
+
+########################################
+#            Warmup kernels            #
+########################################
+
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+warmup_steps = 10
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=[copy.deepcopy(opt.state_dict()) for opt in optimizers]) # save the initial state
+train_loader = distributed_data_generator(args.train_files, world_size * args.train_seq_len, align_to_bos=True)
+for _ in range(warmup_steps):
+    inputs, targets = next(train_loader)
+    model(inputs, targets, get_window_size_blocks(1)).backward()
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+for opt, opt_state in zip(optimizers, initial_state["optimizers"]):
+    opt.load_state_dict(opt_state)
+del train_loader, initial_state
+
+########################################
+#        Training and validation       #
+########################################
+
+train_loader = distributed_data_generator(args.train_files, world_size * args.train_seq_len, align_to_bos=True)
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        val_batch_size = world_size * args.val_seq_len
+        assert args.val_tokens % val_batch_size == 0
+        val_steps = args.val_tokens // val_batch_size
+        val_loader = distributed_data_generator(args.val_files, val_batch_size, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets = next(val_loader)
+                val_loss += model(inputs, targets, get_window_size_blocks(step))
+        val_loss /= val_steps
+        del val_loader
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    model(inputs, targets, get_window_size_blocks(step)).backward()
+    # set optimization hyperparameters
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["lr"] = group["initial_lr"] * get_lr(step)
+    for group in optimizer2.param_groups:
+        frac = min(step / 300, 1) # momentum warmup for muon
+        group["momentum"] = (1 - frac) * 0.85 + frac * 0.95
+    # step the optimizers
+    for opt in optimizers:
+        opt.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.12.7 (main, Oct 11 2025, 17:06:43) [GCC 13.2.0]
+Running PyTorch 2.10.0.dev20251011+cu126 compiled for CUDA 12.6
+Mon Oct 13 04:14:33 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000001:00:00.0 Off |                    0 |
+| N/A   32C    P0            113W /  700W |    5858MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000002:00:00.0 Off |                    0 |
+| N/A   32C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000003:00:00.0 Off |                    0 |
+| N/A   29C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000008:00:00.0 Off |                    0 |
+| N/A   29C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000009:00:00.0 Off |                    0 |
+| N/A   27C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   0000000A:00:00.0 Off |                    0 |
+| N/A   32C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   0000000B:00:00.0 Off |                    0 |
+| N/A   28C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   0000000C:00:00.0 Off |                    0 |
+| N/A   30C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+step:0/1700 val_loss:10.8258 train_time:0ms step_avg:0.01ms
+step:1/1700 train_time:137ms step_avg:137.40ms
+step:2/1700 train_time:160ms step_avg:79.94ms
+step:3/1700 train_time:246ms step_avg:82.01ms
+step:4/1700 train_time:337ms step_avg:84.28ms
+step:5/1700 train_time:429ms step_avg:85.89ms
+step:6/1700 train_time:522ms step_avg:86.94ms
+step:7/1700 train_time:614ms step_avg:87.77ms
+step:8/1700 train_time:706ms step_avg:88.28ms
+step:9/1700 train_time:798ms step_avg:88.71ms
+step:10/1700 train_time:891ms step_avg:89.10ms
+step:11/1700 train_time:983ms step_avg:89.36ms
+step:12/1700 train_time:1077ms step_avg:89.74ms
+step:13/1700 train_time:1173ms step_avg:90.27ms
+step:14/1700 train_time:1268ms step_avg:90.60ms
+step:15/1700 train_time:1362ms step_avg:90.80ms
+step:16/1700 train_time:1455ms step_avg:90.92ms
+step:17/1700 train_time:1547ms step_avg:91.03ms
+step:18/1700 train_time:1639ms step_avg:91.07ms
+step:19/1700 train_time:1732ms step_avg:91.15ms
+step:20/1700 train_time:1824ms step_avg:91.20ms
+step:21/1700 train_time:1917ms step_avg:91.28ms
+step:22/1700 train_time:2009ms step_avg:91.33ms
+step:23/1700 train_time:2103ms step_avg:91.43ms
+step:24/1700 train_time:2196ms step_avg:91.52ms
+step:25/1700 train_time:2291ms step_avg:91.63ms
+step:26/1700 train_time:2384ms step_avg:91.71ms
+step:27/1700 train_time:2478ms step_avg:91.77ms
+step:28/1700 train_time:2571ms step_avg:91.83ms
+step:29/1700 train_time:2663ms step_avg:91.83ms
+step:30/1700 train_time:2755ms step_avg:91.84ms
+step:31/1700 train_time:2847ms step_avg:91.85ms
+step:32/1700 train_time:2940ms step_avg:91.87ms
+step:33/1700 train_time:3033ms step_avg:91.91ms
+step:34/1700 train_time:3126ms step_avg:91.93ms
+step:35/1700 train_time:3219ms step_avg:91.97ms
+step:36/1700 train_time:3313ms step_avg:92.02ms
+step:37/1700 train_time:3406ms step_avg:92.06ms
+step:38/1700 train_time:3500ms step_avg:92.12ms
+step:39/1700 train_time:3593ms step_avg:92.14ms
+step:40/1700 train_time:3686ms step_avg:92.16ms
+step:41/1700 train_time:3779ms step_avg:92.16ms
+step:42/1700 train_time:3872ms step_avg:92.19ms
+step:43/1700 train_time:3964ms step_avg:92.18ms
+step:44/1700 train_time:4057ms step_avg:92.19ms
+step:45/1700 train_time:4150ms step_avg:92.22ms
+step:46/1700 train_time:4243ms step_avg:92.23ms
+step:47/1700 train_time:4336ms step_avg:92.25ms
+step:48/1700 train_time:4429ms step_avg:92.27ms
+step:49/1700 train_time:4523ms step_avg:92.30ms
+step:50/1700 train_time:4616ms step_avg:92.32ms
+step:51/1700 train_time:4709ms step_avg:92.33ms
+step:52/1700 train_time:4802ms step_avg:92.34ms
+step:53/1700 train_time:4895ms step_avg:92.36ms
+step:54/1700 train_time:4988ms step_avg:92.37ms
+step:55/1700 train_time:5080ms step_avg:92.37ms
+step:56/1700 train_time:5173ms step_avg:92.38ms
+step:57/1700 train_time:5266ms step_avg:92.39ms
+step:58/1700 train_time:5359ms step_avg:92.39ms
+step:59/1700 train_time:5452ms step_avg:92.40ms
+step:60/1700 train_time:5544ms step_avg:92.41ms
+step:61/1700 train_time:5637ms step_avg:92.41ms
+step:62/1700 train_time:5730ms step_avg:92.42ms
+step:63/1700 train_time:5823ms step_avg:92.42ms
+step:64/1700 train_time:5915ms step_avg:92.42ms
+step:65/1700 train_time:6007ms step_avg:92.42ms
+step:66/1700 train_time:6100ms step_avg:92.43ms
+step:67/1700 train_time:6193ms step_avg:92.44ms
+step:68/1700 train_time:6286ms step_avg:92.45ms
+step:69/1700 train_time:6378ms step_avg:92.44ms
+step:70/1700 train_time:6472ms step_avg:92.45ms
+step:71/1700 train_time:6564ms step_avg:92.45ms
+step:72/1700 train_time:6656ms step_avg:92.45ms
+step:73/1700 train_time:6749ms step_avg:92.46ms
+step:74/1700 train_time:6842ms step_avg:92.46ms
+step:75/1700 train_time:6935ms step_avg:92.46ms
+step:76/1700 train_time:7027ms step_avg:92.46ms
+step:77/1700 train_time:7120ms step_avg:92.47ms
+step:78/1700 train_time:7213ms step_avg:92.48ms
+step:79/1700 train_time:7306ms step_avg:92.48ms
+step:80/1700 train_time:7398ms step_avg:92.48ms
+step:81/1700 train_time:7491ms step_avg:92.48ms
+step:82/1700 train_time:7584ms step_avg:92.49ms
+step:83/1700 train_time:7676ms step_avg:92.49ms
+step:84/1700 train_time:7770ms step_avg:92.50ms
+step:85/1700 train_time:7863ms step_avg:92.50ms
+step:86/1700 train_time:7956ms step_avg:92.51ms
+step:87/1700 train_time:8049ms step_avg:92.51ms
+step:88/1700 train_time:8141ms step_avg:92.51ms
+step:89/1700 train_time:8234ms step_avg:92.52ms
+step:90/1700 train_time:8326ms step_avg:92.51ms
+step:91/1700 train_time:8419ms step_avg:92.51ms
+step:92/1700 train_time:8512ms step_avg:92.52ms
+step:93/1700 train_time:8605ms step_avg:92.53ms
+step:94/1700 train_time:8698ms step_avg:92.53ms
+step:95/1700 train_time:8791ms step_avg:92.53ms
+step:96/1700 train_time:8883ms step_avg:92.54ms
+step:97/1700 train_time:8976ms step_avg:92.54ms
+step:98/1700 train_time:9069ms step_avg:92.54ms
+step:99/1700 train_time:9162ms step_avg:92.54ms
+step:100/1700 train_time:9254ms step_avg:92.54ms
+step:101/1700 train_time:9347ms step_avg:92.55ms
+step:102/1700 train_time:9440ms step_avg:92.55ms
+step:103/1700 train_time:9533ms step_avg:92.55ms
+step:104/1700 train_time:9625ms step_avg:92.55ms
+step:105/1700 train_time:9717ms step_avg:92.55ms
+step:106/1700 train_time:9810ms step_avg:92.55ms
+step:107/1700 train_time:9903ms step_avg:92.55ms
+step:108/1700 train_time:9996ms step_avg:92.56ms
+step:109/1700 train_time:10089ms step_avg:92.56ms
+step:110/1700 train_time:10182ms step_avg:92.56ms
+step:111/1700 train_time:10275ms step_avg:92.57ms
+step:112/1700 train_time:10368ms step_avg:92.57ms
+step:113/1700 train_time:10461ms step_avg:92.58ms
+step:114/1700 train_time:10554ms step_avg:92.58ms
+step:115/1700 train_time:10646ms step_avg:92.58ms
+step:116/1700 train_time:10739ms step_avg:92.58ms
+step:117/1700 train_time:10832ms step_avg:92.58ms
+step:118/1700 train_time:10925ms step_avg:92.58ms
+step:119/1700 train_time:11017ms step_avg:92.58ms
+step:120/1700 train_time:11111ms step_avg:92.59ms
+step:121/1700 train_time:11203ms step_avg:92.59ms
+step:122/1700 train_time:11296ms step_avg:92.59ms
+step:123/1700 train_time:11389ms step_avg:92.59ms
+step:124/1700 train_time:11482ms step_avg:92.60ms
+step:125/1700 train_time:11576ms step_avg:92.60ms
+step:125/1700 val_loss:4.6092 train_time:11652ms step_avg:93.22ms
+step:126/1700 train_time:11676ms step_avg:92.67ms
+step:127/1700 train_time:11768ms step_avg:92.66ms
+step:128/1700 train_time:11869ms step_avg:92.73ms
+step:129/1700 train_time:11964ms step_avg:92.75ms
+step:130/1700 train_time:12057ms step_avg:92.75ms
+step:131/1700 train_time:12150ms step_avg:92.74ms
+step:132/1700 train_time:12243ms step_avg:92.75ms
+step:133/1700 train_time:12335ms step_avg:92.74ms
+step:134/1700 train_time:12427ms step_avg:92.74ms
+step:135/1700 train_time:12520ms step_avg:92.74ms
+step:136/1700 train_time:12613ms step_avg:92.74ms
+step:137/1700 train_time:12706ms step_avg:92.75ms
+step:138/1700 train_time:12801ms step_avg:92.76ms
+step:139/1700 train_time:12896ms step_avg:92.78ms
+step:140/1700 train_time:12990ms step_avg:92.78ms
+step:141/1700 train_time:13083ms step_avg:92.79ms
+step:142/1700 train_time:13176ms step_avg:92.79ms
+step:143/1700 train_time:13269ms step_avg:92.79ms
+step:144/1700 train_time:13363ms step_avg:92.80ms
+step:145/1700 train_time:13455ms step_avg:92.80ms
+step:146/1700 train_time:13548ms step_avg:92.79ms
+step:147/1700 train_time:13641ms step_avg:92.80ms
+step:148/1700 train_time:13734ms step_avg:92.80ms
+step:149/1700 train_time:13828ms step_avg:92.81ms
+step:150/1700 train_time:13923ms step_avg:92.82ms
+step:151/1700 train_time:14018ms step_avg:92.83ms
+step:152/1700 train_time:14111ms step_avg:92.83ms
+step:153/1700 train_time:14205ms step_avg:92.84ms
+step:154/1700 train_time:14298ms step_avg:92.84ms
+step:155/1700 train_time:14390ms step_avg:92.84ms
+step:156/1700 train_time:14484ms step_avg:92.84ms
+step:157/1700 train_time:14576ms step_avg:92.84ms
+step:158/1700 train_time:14669ms step_avg:92.84ms
+step:159/1700 train_time:14763ms step_avg:92.85ms
+step:160/1700 train_time:14857ms step_avg:92.85ms
+step:161/1700 train_time:14950ms step_avg:92.86ms
+step:162/1700 train_time:15045ms step_avg:92.87ms
+step:163/1700 train_time:15138ms step_avg:92.87ms
+step:164/1700 train_time:15231ms step_avg:92.87ms
+step:165/1700 train_time:15324ms step_avg:92.87ms
+step:166/1700 train_time:15417ms step_avg:92.87ms
+step:167/1700 train_time:15510ms step_avg:92.87ms
+step:168/1700 train_time:15604ms step_avg:92.88ms
+step:169/1700 train_time:15696ms step_avg:92.88ms
+step:170/1700 train_time:15790ms step_avg:92.88ms
+step:171/1700 train_time:15883ms step_avg:92.89ms
+step:172/1700 train_time:15977ms step_avg:92.89ms
+step:173/1700 train_time:16070ms step_avg:92.89ms
+step:174/1700 train_time:16164ms step_avg:92.90ms
+step:175/1700 train_time:16257ms step_avg:92.90ms
+step:176/1700 train_time:16351ms step_avg:92.90ms
+step:177/1700 train_time:16444ms step_avg:92.90ms
+step:178/1700 train_time:16537ms step_avg:92.90ms
+step:179/1700 train_time:16630ms step_avg:92.90ms
+step:180/1700 train_time:16724ms step_avg:92.91ms
+step:181/1700 train_time:16817ms step_avg:92.91ms
+step:182/1700 train_time:16911ms step_avg:92.91ms
+step:183/1700 train_time:17005ms step_avg:92.92ms
+step:184/1700 train_time:17098ms step_avg:92.93ms
+step:185/1700 train_time:17193ms step_avg:92.93ms
+step:186/1700 train_time:17286ms step_avg:92.93ms
+step:187/1700 train_time:17379ms step_avg:92.94ms
+step:188/1700 train_time:17472ms step_avg:92.94ms
+step:189/1700 train_time:17565ms step_avg:92.94ms
+step:190/1700 train_time:17658ms step_avg:92.94ms
+step:191/1700 train_time:17752ms step_avg:92.94ms
+step:192/1700 train_time:17846ms step_avg:92.95ms
+step:193/1700 train_time:17939ms step_avg:92.95ms
+step:194/1700 train_time:18033ms step_avg:92.95ms
+step:195/1700 train_time:18126ms step_avg:92.96ms
+step:196/1700 train_time:18219ms step_avg:92.96ms
+step:197/1700 train_time:18312ms step_avg:92.96ms
+step:198/1700 train_time:18406ms step_avg:92.96ms
+step:199/1700 train_time:18498ms step_avg:92.96ms
+step:200/1700 train_time:18591ms step_avg:92.96ms
+step:201/1700 train_time:18685ms step_avg:92.96ms
+step:202/1700 train_time:18777ms step_avg:92.96ms
+step:203/1700 train_time:18870ms step_avg:92.96ms
+step:204/1700 train_time:18964ms step_avg:92.96ms
+step:205/1700 train_time:19058ms step_avg:92.96ms
+step:206/1700 train_time:19151ms step_avg:92.97ms
+step:207/1700 train_time:19245ms step_avg:92.97ms
+step:208/1700 train_time:19338ms step_avg:92.97ms
+step:209/1700 train_time:19431ms step_avg:92.97ms
+step:210/1700 train_time:19524ms step_avg:92.97ms
+step:211/1700 train_time:19617ms step_avg:92.97ms
+step:212/1700 train_time:19710ms step_avg:92.97ms
+step:213/1700 train_time:19804ms step_avg:92.98ms
+step:214/1700 train_time:19897ms step_avg:92.98ms
+step:215/1700 train_time:19991ms step_avg:92.98ms
+step:216/1700 train_time:20084ms step_avg:92.98ms
+step:217/1700 train_time:20177ms step_avg:92.98ms
+step:218/1700 train_time:20270ms step_avg:92.98ms
+step:219/1700 train_time:20364ms step_avg:92.98ms
+step:220/1700 train_time:20457ms step_avg:92.99ms
+step:221/1700 train_time:20549ms step_avg:92.98ms
+step:222/1700 train_time:20644ms step_avg:92.99ms
+step:223/1700 train_time:20737ms step_avg:92.99ms
+step:224/1700 train_time:20830ms step_avg:92.99ms
+step:225/1700 train_time:20924ms step_avg:92.99ms
+step:226/1700 train_time:21017ms step_avg:92.99ms
+step:227/1700 train_time:21110ms step_avg:93.00ms
+step:228/1700 train_time:21204ms step_avg:93.00ms
+step:229/1700 train_time:21298ms step_avg:93.00ms
+step:230/1700 train_time:21391ms step_avg:93.01ms
+step:231/1700 train_time:21485ms step_avg:93.01ms
+step:232/1700 train_time:21578ms step_avg:93.01ms
+step:233/1700 train_time:21671ms step_avg:93.01ms
+step:234/1700 train_time:21765ms step_avg:93.01ms
+step:235/1700 train_time:21858ms step_avg:93.01ms
+step:236/1700 train_time:21951ms step_avg:93.01ms
+step:237/1700 train_time:22045ms step_avg:93.02ms
+step:238/1700 train_time:22138ms step_avg:93.02ms
+step:239/1700 train_time:22231ms step_avg:93.02ms
+step:240/1700 train_time:22326ms step_avg:93.02ms
+step:241/1700 train_time:22420ms step_avg:93.03ms
+step:242/1700 train_time:22513ms step_avg:93.03ms
+step:243/1700 train_time:22606ms step_avg:93.03ms
+step:244/1700 train_time:22700ms step_avg:93.03ms
+step:245/1700 train_time:22793ms step_avg:93.03ms
+step:246/1700 train_time:22886ms step_avg:93.03ms
+step:247/1700 train_time:22980ms step_avg:93.03ms
+step:248/1700 train_time:23073ms step_avg:93.04ms
+step:249/1700 train_time:23166ms step_avg:93.04ms
+step:250/1700 train_time:23260ms step_avg:93.04ms
+step:250/1700 val_loss:4.0719 train_time:23337ms step_avg:93.35ms
+step:251/1700 train_time:23361ms step_avg:93.07ms
+step:252/1700 train_time:23455ms step_avg:93.08ms
+step:253/1700 train_time:23554ms step_avg:93.10ms
+step:254/1700 train_time:23647ms step_avg:93.10ms
+step:255/1700 train_time:23740ms step_avg:93.10ms
+step:256/1700 train_time:23833ms step_avg:93.10ms
+step:257/1700 train_time:23927ms step_avg:93.10ms
+step:258/1700 train_time:24020ms step_avg:93.10ms
+step:259/1700 train_time:24113ms step_avg:93.10ms
+step:260/1700 train_time:24205ms step_avg:93.10ms
+step:261/1700 train_time:24300ms step_avg:93.10ms
+step:262/1700 train_time:24394ms step_avg:93.11ms
+step:263/1700 train_time:24489ms step_avg:93.12ms
+step:264/1700 train_time:24584ms step_avg:93.12ms
+step:265/1700 train_time:24678ms step_avg:93.12ms
+step:266/1700 train_time:24772ms step_avg:93.13ms
+step:267/1700 train_time:24865ms step_avg:93.13ms
+step:268/1700 train_time:24959ms step_avg:93.13ms
+step:269/1700 train_time:25053ms step_avg:93.13ms
+step:270/1700 train_time:25145ms step_avg:93.13ms
+step:271/1700 train_time:25239ms step_avg:93.13ms
+step:272/1700 train_time:25333ms step_avg:93.14ms
+step:273/1700 train_time:25427ms step_avg:93.14ms
+step:274/1700 train_time:25522ms step_avg:93.14ms
+step:275/1700 train_time:25616ms step_avg:93.15ms
+step:276/1700 train_time:25710ms step_avg:93.15ms
+step:277/1700 train_time:25804ms step_avg:93.15ms
+step:278/1700 train_time:25898ms step_avg:93.16ms
+step:279/1700 train_time:25991ms step_avg:93.16ms
+step:280/1700 train_time:26084ms step_avg:93.16ms
+step:281/1700 train_time:26178ms step_avg:93.16ms
+step:282/1700 train_time:26271ms step_avg:93.16ms
+step:283/1700 train_time:26364ms step_avg:93.16ms
+step:284/1700 train_time:26458ms step_avg:93.16ms
+step:285/1700 train_time:26553ms step_avg:93.17ms
+step:286/1700 train_time:26647ms step_avg:93.17ms
+step:287/1700 train_time:26741ms step_avg:93.17ms
+step:288/1700 train_time:26835ms step_avg:93.18ms
+step:289/1700 train_time:26928ms step_avg:93.18ms
+step:290/1700 train_time:27022ms step_avg:93.18ms
+step:291/1700 train_time:27116ms step_avg:93.18ms
+step:292/1700 train_time:27209ms step_avg:93.18ms
+step:293/1700 train_time:27302ms step_avg:93.18ms
+step:294/1700 train_time:27396ms step_avg:93.18ms
+step:295/1700 train_time:27490ms step_avg:93.19ms
+step:296/1700 train_time:27584ms step_avg:93.19ms
+step:297/1700 train_time:27678ms step_avg:93.19ms
+step:298/1700 train_time:27772ms step_avg:93.19ms
+step:299/1700 train_time:27866ms step_avg:93.20ms
+step:300/1700 train_time:27960ms step_avg:93.20ms
+step:301/1700 train_time:28054ms step_avg:93.20ms
+step:302/1700 train_time:28147ms step_avg:93.20ms
+step:303/1700 train_time:28240ms step_avg:93.20ms
+step:304/1700 train_time:28334ms step_avg:93.20ms
+step:305/1700 train_time:28427ms step_avg:93.20ms
+step:306/1700 train_time:28521ms step_avg:93.21ms
+step:307/1700 train_time:28615ms step_avg:93.21ms
+step:308/1700 train_time:28709ms step_avg:93.21ms
+step:309/1700 train_time:28803ms step_avg:93.21ms
+step:310/1700 train_time:28897ms step_avg:93.21ms
+step:311/1700 train_time:28991ms step_avg:93.22ms
+step:312/1700 train_time:29084ms step_avg:93.22ms
+step:313/1700 train_time:29178ms step_avg:93.22ms
+step:314/1700 train_time:29272ms step_avg:93.22ms
+step:315/1700 train_time:29364ms step_avg:93.22ms
+step:316/1700 train_time:29459ms step_avg:93.22ms
+step:317/1700 train_time:29553ms step_avg:93.23ms
+step:318/1700 train_time:29647ms step_avg:93.23ms
+step:319/1700 train_time:29740ms step_avg:93.23ms
+step:320/1700 train_time:29834ms step_avg:93.23ms
+step:321/1700 train_time:29928ms step_avg:93.23ms
+step:322/1700 train_time:30022ms step_avg:93.24ms
+step:323/1700 train_time:30116ms step_avg:93.24ms
+step:324/1700 train_time:30209ms step_avg:93.24ms
+step:325/1700 train_time:30303ms step_avg:93.24ms
+step:326/1700 train_time:30397ms step_avg:93.24ms
+step:327/1700 train_time:30490ms step_avg:93.24ms
+step:328/1700 train_time:30584ms step_avg:93.24ms
+step:329/1700 train_time:30678ms step_avg:93.25ms
+step:330/1700 train_time:30772ms step_avg:93.25ms
+step:331/1700 train_time:30867ms step_avg:93.25ms
+step:332/1700 train_time:30960ms step_avg:93.25ms
+step:333/1700 train_time:31054ms step_avg:93.25ms
+step:334/1700 train_time:31148ms step_avg:93.26ms
+step:335/1700 train_time:31242ms step_avg:93.26ms
+step:336/1700 train_time:31335ms step_avg:93.26ms
+step:337/1700 train_time:31429ms step_avg:93.26ms
+step:338/1700 train_time:31523ms step_avg:93.26ms
+step:339/1700 train_time:31617ms step_avg:93.26ms
+step:340/1700 train_time:31710ms step_avg:93.27ms
+step:341/1700 train_time:31804ms step_avg:93.27ms
+step:342/1700 train_time:31898ms step_avg:93.27ms
+step:343/1700 train_time:31992ms step_avg:93.27ms
+step:344/1700 train_time:32086ms step_avg:93.27ms
+step:345/1700 train_time:32179ms step_avg:93.27ms
+step:346/1700 train_time:32273ms step_avg:93.28ms
+step:347/1700 train_time:32367ms step_avg:93.28ms
+step:348/1700 train_time:32461ms step_avg:93.28ms
+step:349/1700 train_time:32555ms step_avg:93.28ms
+step:350/1700 train_time:32650ms step_avg:93.28ms
+step:351/1700 train_time:32744ms step_avg:93.29ms
+step:352/1700 train_time:32838ms step_avg:93.29ms
+step:353/1700 train_time:32932ms step_avg:93.29ms
+step:354/1700 train_time:33026ms step_avg:93.29ms
+step:355/1700 train_time:33120ms step_avg:93.29ms
+step:356/1700 train_time:33213ms step_avg:93.30ms
+step:357/1700 train_time:33307ms step_avg:93.30ms
+step:358/1700 train_time:33401ms step_avg:93.30ms
+step:359/1700 train_time:33494ms step_avg:93.30ms
+step:360/1700 train_time:33588ms step_avg:93.30ms
+step:361/1700 train_time:33682ms step_avg:93.30ms
+step:362/1700 train_time:33775ms step_avg:93.30ms
+step:363/1700 train_time:33869ms step_avg:93.30ms
+step:364/1700 train_time:33963ms step_avg:93.31ms
+step:365/1700 train_time:34057ms step_avg:93.31ms
+step:366/1700 train_time:34150ms step_avg:93.31ms
+step:367/1700 train_time:34244ms step_avg:93.31ms
+step:368/1700 train_time:34338ms step_avg:93.31ms
+step:369/1700 train_time:34432ms step_avg:93.31ms
+step:370/1700 train_time:34525ms step_avg:93.31ms
+step:371/1700 train_time:34618ms step_avg:93.31ms
+step:372/1700 train_time:34712ms step_avg:93.31ms
+step:373/1700 train_time:34806ms step_avg:93.31ms
+step:374/1700 train_time:34900ms step_avg:93.32ms
+step:375/1700 train_time:34994ms step_avg:93.32ms
+step:375/1700 val_loss:3.8785 train_time:35071ms step_avg:93.52ms
+step:376/1700 train_time:35094ms step_avg:93.34ms
+step:377/1700 train_time:35187ms step_avg:93.33ms
+step:378/1700 train_time:35283ms step_avg:93.34ms
+step:379/1700 train_time:35377ms step_avg:93.34ms
+step:380/1700 train_time:35472ms step_avg:93.35ms
+step:381/1700 train_time:35568ms step_avg:93.36ms
+step:382/1700 train_time:35663ms step_avg:93.36ms
+step:383/1700 train_time:35758ms step_avg:93.36ms
+step:384/1700 train_time:35853ms step_avg:93.37ms
+step:385/1700 train_time:35947ms step_avg:93.37ms
+step:386/1700 train_time:36043ms step_avg:93.38ms
+step:387/1700 train_time:36140ms step_avg:93.39ms
+step:388/1700 train_time:36237ms step_avg:93.39ms
+step:389/1700 train_time:36333ms step_avg:93.40ms
+step:390/1700 train_time:36429ms step_avg:93.41ms
+step:391/1700 train_time:36524ms step_avg:93.41ms
+step:392/1700 train_time:36620ms step_avg:93.42ms
+step:393/1700 train_time:36715ms step_avg:93.42ms
+step:394/1700 train_time:36809ms step_avg:93.42ms
+step:395/1700 train_time:36903ms step_avg:93.43ms
+step:396/1700 train_time:36999ms step_avg:93.43ms
+step:397/1700 train_time:37096ms step_avg:93.44ms
+step:398/1700 train_time:37192ms step_avg:93.45ms
+step:399/1700 train_time:37288ms step_avg:93.45ms
+step:400/1700 train_time:37384ms step_avg:93.46ms
+step:401/1700 train_time:37479ms step_avg:93.46ms
+step:402/1700 train_time:37575ms step_avg:93.47ms
+step:403/1700 train_time:37672ms step_avg:93.48ms
+step:404/1700 train_time:37767ms step_avg:93.48ms
+step:405/1700 train_time:37862ms step_avg:93.49ms
+step:406/1700 train_time:37957ms step_avg:93.49ms
+step:407/1700 train_time:38054ms step_avg:93.50ms
+step:408/1700 train_time:38151ms step_avg:93.51ms
+step:409/1700 train_time:38247ms step_avg:93.51ms
+step:410/1700 train_time:38342ms step_avg:93.52ms
+step:411/1700 train_time:38438ms step_avg:93.52ms
+step:412/1700 train_time:38535ms step_avg:93.53ms
+step:413/1700 train_time:38630ms step_avg:93.54ms
+step:414/1700 train_time:38725ms step_avg:93.54ms
+step:415/1700 train_time:38821ms step_avg:93.54ms
+step:416/1700 train_time:38916ms step_avg:93.55ms
+step:417/1700 train_time:39011ms step_avg:93.55ms
+step:418/1700 train_time:39106ms step_avg:93.56ms
+step:419/1700 train_time:39202ms step_avg:93.56ms
+step:420/1700 train_time:39298ms step_avg:93.57ms
+step:421/1700 train_time:39394ms step_avg:93.57ms
+step:422/1700 train_time:39490ms step_avg:93.58ms
+step:423/1700 train_time:39585ms step_avg:93.58ms
+step:424/1700 train_time:39681ms step_avg:93.59ms
+step:425/1700 train_time:39777ms step_avg:93.59ms
+step:426/1700 train_time:39872ms step_avg:93.60ms
+step:427/1700 train_time:39967ms step_avg:93.60ms
+step:428/1700 train_time:40063ms step_avg:93.60ms
+step:429/1700 train_time:40158ms step_avg:93.61ms
+step:430/1700 train_time:40254ms step_avg:93.61ms
+step:431/1700 train_time:40350ms step_avg:93.62ms
+step:432/1700 train_time:40446ms step_avg:93.63ms
+step:433/1700 train_time:40541ms step_avg:93.63ms
+step:434/1700 train_time:40637ms step_avg:93.63ms
+step:435/1700 train_time:40733ms step_avg:93.64ms
+step:436/1700 train_time:40828ms step_avg:93.64ms
+step:437/1700 train_time:40924ms step_avg:93.65ms
+step:438/1700 train_time:41019ms step_avg:93.65ms
+step:439/1700 train_time:41116ms step_avg:93.66ms
+step:440/1700 train_time:41212ms step_avg:93.66ms
+step:441/1700 train_time:41308ms step_avg:93.67ms
+step:442/1700 train_time:41404ms step_avg:93.67ms
+step:443/1700 train_time:41500ms step_avg:93.68ms
+step:444/1700 train_time:41596ms step_avg:93.68ms
+step:445/1700 train_time:41692ms step_avg:93.69ms
+step:446/1700 train_time:41788ms step_avg:93.69ms
+step:447/1700 train_time:41883ms step_avg:93.70ms
+step:448/1700 train_time:41979ms step_avg:93.70ms
+step:449/1700 train_time:42075ms step_avg:93.71ms
+step:450/1700 train_time:42171ms step_avg:93.71ms
+step:451/1700 train_time:42267ms step_avg:93.72ms
+step:452/1700 train_time:42362ms step_avg:93.72ms
+step:453/1700 train_time:42458ms step_avg:93.73ms
+step:454/1700 train_time:42554ms step_avg:93.73ms
+step:455/1700 train_time:42649ms step_avg:93.73ms
+step:456/1700 train_time:42745ms step_avg:93.74ms
+step:457/1700 train_time:42841ms step_avg:93.74ms
+step:458/1700 train_time:42937ms step_avg:93.75ms
+step:459/1700 train_time:43034ms step_avg:93.75ms
+step:460/1700 train_time:43128ms step_avg:93.76ms
+step:461/1700 train_time:43224ms step_avg:93.76ms
+step:462/1700 train_time:43320ms step_avg:93.77ms
+step:463/1700 train_time:43416ms step_avg:93.77ms
+step:464/1700 train_time:43513ms step_avg:93.78ms
+step:465/1700 train_time:43607ms step_avg:93.78ms
+step:466/1700 train_time:43703ms step_avg:93.78ms
+step:467/1700 train_time:43798ms step_avg:93.79ms
+step:468/1700 train_time:43894ms step_avg:93.79ms
+step:469/1700 train_time:43991ms step_avg:93.80ms
+step:470/1700 train_time:44086ms step_avg:93.80ms
+step:471/1700 train_time:44181ms step_avg:93.80ms
+step:472/1700 train_time:44278ms step_avg:93.81ms
+step:473/1700 train_time:44372ms step_avg:93.81ms
+step:474/1700 train_time:44468ms step_avg:93.81ms
+step:475/1700 train_time:44563ms step_avg:93.82ms
+step:476/1700 train_time:44658ms step_avg:93.82ms
+step:477/1700 train_time:44754ms step_avg:93.82ms
+step:478/1700 train_time:44850ms step_avg:93.83ms
+step:479/1700 train_time:44946ms step_avg:93.83ms
+step:480/1700 train_time:45042ms step_avg:93.84ms
+step:481/1700 train_time:45137ms step_avg:93.84ms
+step:482/1700 train_time:45234ms step_avg:93.85ms
+step:483/1700 train_time:45329ms step_avg:93.85ms
+step:484/1700 train_time:45424ms step_avg:93.85ms
+step:485/1700 train_time:45520ms step_avg:93.85ms
+step:486/1700 train_time:45615ms step_avg:93.86ms
+step:487/1700 train_time:45711ms step_avg:93.86ms
+step:488/1700 train_time:45806ms step_avg:93.87ms
+step:489/1700 train_time:45902ms step_avg:93.87ms
+step:490/1700 train_time:45997ms step_avg:93.87ms
+step:491/1700 train_time:46093ms step_avg:93.88ms
+step:492/1700 train_time:46188ms step_avg:93.88ms
+step:493/1700 train_time:46283ms step_avg:93.88ms
+step:494/1700 train_time:46379ms step_avg:93.88ms
+step:495/1700 train_time:46476ms step_avg:93.89ms
+step:496/1700 train_time:46573ms step_avg:93.90ms
+step:497/1700 train_time:46669ms step_avg:93.90ms
+step:498/1700 train_time:46764ms step_avg:93.90ms
+step:499/1700 train_time:46859ms step_avg:93.91ms
+step:500/1700 train_time:46954ms step_avg:93.91ms
+step:500/1700 val_loss:3.7307 train_time:47032ms step_avg:94.06ms
+step:501/1700 train_time:47056ms step_avg:93.92ms
+step:502/1700 train_time:47153ms step_avg:93.93ms
+step:503/1700 train_time:47251ms step_avg:93.94ms
+step:504/1700 train_time:47346ms step_avg:93.94ms
+step:505/1700 train_time:47442ms step_avg:93.94ms
+step:506/1700 train_time:47537ms step_avg:93.95ms
+step:507/1700 train_time:47632ms step_avg:93.95ms
+step:508/1700 train_time:47726ms step_avg:93.95ms
+step:509/1700 train_time:47821ms step_avg:93.95ms
+step:510/1700 train_time:47917ms step_avg:93.95ms
+step:511/1700 train_time:48014ms step_avg:93.96ms
+step:512/1700 train_time:48111ms step_avg:93.97ms
+step:513/1700 train_time:48208ms step_avg:93.97ms
+step:514/1700 train_time:48304ms step_avg:93.98ms
+step:515/1700 train_time:48400ms step_avg:93.98ms
+step:516/1700 train_time:48497ms step_avg:93.99ms
+step:517/1700 train_time:48593ms step_avg:93.99ms
+step:518/1700 train_time:48689ms step_avg:93.99ms
+step:519/1700 train_time:48785ms step_avg:94.00ms
+step:520/1700 train_time:48880ms step_avg:94.00ms
+step:521/1700 train_time:48975ms step_avg:94.00ms
+step:522/1700 train_time:49072ms step_avg:94.01ms
+step:523/1700 train_time:49168ms step_avg:94.01ms
+step:524/1700 train_time:49264ms step_avg:94.02ms
+step:525/1700 train_time:49361ms step_avg:94.02ms
+step:526/1700 train_time:49457ms step_avg:94.03ms
+step:527/1700 train_time:49554ms step_avg:94.03ms
+step:528/1700 train_time:49649ms step_avg:94.03ms
+step:529/1700 train_time:49744ms step_avg:94.03ms
+step:530/1700 train_time:49840ms step_avg:94.04ms
+step:531/1700 train_time:49936ms step_avg:94.04ms
+step:532/1700 train_time:50032ms step_avg:94.04ms
+step:533/1700 train_time:50128ms step_avg:94.05ms
+step:534/1700 train_time:50224ms step_avg:94.05ms
+step:535/1700 train_time:50320ms step_avg:94.06ms
+step:536/1700 train_time:50417ms step_avg:94.06ms
+step:537/1700 train_time:50514ms step_avg:94.07ms
+step:538/1700 train_time:50609ms step_avg:94.07ms
+step:539/1700 train_time:50704ms step_avg:94.07ms
+step:540/1700 train_time:50800ms step_avg:94.07ms
+step:541/1700 train_time:50897ms step_avg:94.08ms
+step:542/1700 train_time:50992ms step_avg:94.08ms
+step:543/1700 train_time:51088ms step_avg:94.08ms
+step:544/1700 train_time:51184ms step_avg:94.09ms
+step:545/1700 train_time:51280ms step_avg:94.09ms
+step:546/1700 train_time:51377ms step_avg:94.10ms
+step:547/1700 train_time:51473ms step_avg:94.10ms
+step:548/1700 train_time:51569ms step_avg:94.10ms
+step:549/1700 train_time:51665ms step_avg:94.11ms
+step:550/1700 train_time:51761ms step_avg:94.11ms
+step:551/1700 train_time:51857ms step_avg:94.11ms
+step:552/1700 train_time:51953ms step_avg:94.12ms
+step:553/1700 train_time:52049ms step_avg:94.12ms
+step:554/1700 train_time:52145ms step_avg:94.12ms
+step:555/1700 train_time:52241ms step_avg:94.13ms
+step:556/1700 train_time:52337ms step_avg:94.13ms
+step:557/1700 train_time:52435ms step_avg:94.14ms
+step:558/1700 train_time:52531ms step_avg:94.14ms
+step:559/1700 train_time:52627ms step_avg:94.14ms
+step:560/1700 train_time:52723ms step_avg:94.15ms
+step:561/1700 train_time:52819ms step_avg:94.15ms
+step:562/1700 train_time:52916ms step_avg:94.16ms
+step:563/1700 train_time:53012ms step_avg:94.16ms
+step:564/1700 train_time:53107ms step_avg:94.16ms
+step:565/1700 train_time:53203ms step_avg:94.16ms
+step:566/1700 train_time:53299ms step_avg:94.17ms
+step:567/1700 train_time:53395ms step_avg:94.17ms
+step:568/1700 train_time:53491ms step_avg:94.17ms
+step:569/1700 train_time:53587ms step_avg:94.18ms
+step:570/1700 train_time:53683ms step_avg:94.18ms
+step:571/1700 train_time:53778ms step_avg:94.18ms
+step:572/1700 train_time:53874ms step_avg:94.19ms
+step:573/1700 train_time:53970ms step_avg:94.19ms
+step:574/1700 train_time:54066ms step_avg:94.19ms
+step:575/1700 train_time:54162ms step_avg:94.19ms
+step:576/1700 train_time:54257ms step_avg:94.20ms
+step:577/1700 train_time:54354ms step_avg:94.20ms
+step:578/1700 train_time:54449ms step_avg:94.20ms
+step:579/1700 train_time:54545ms step_avg:94.21ms
+step:580/1700 train_time:54641ms step_avg:94.21ms
+step:581/1700 train_time:54736ms step_avg:94.21ms
+step:582/1700 train_time:54832ms step_avg:94.21ms
+step:583/1700 train_time:54928ms step_avg:94.22ms
+step:584/1700 train_time:55024ms step_avg:94.22ms
+step:585/1700 train_time:55119ms step_avg:94.22ms
+step:586/1700 train_time:55215ms step_avg:94.22ms
+step:587/1700 train_time:55311ms step_avg:94.23ms
+step:588/1700 train_time:55407ms step_avg:94.23ms
+step:589/1700 train_time:55503ms step_avg:94.23ms
+step:590/1700 train_time:55599ms step_avg:94.24ms
+step:591/1700 train_time:55696ms step_avg:94.24ms
+step:592/1700 train_time:55792ms step_avg:94.24ms
+step:593/1700 train_time:55888ms step_avg:94.25ms
+step:594/1700 train_time:55984ms step_avg:94.25ms
+step:595/1700 train_time:56079ms step_avg:94.25ms
+step:596/1700 train_time:56175ms step_avg:94.25ms
+step:597/1700 train_time:56271ms step_avg:94.26ms
+step:598/1700 train_time:56366ms step_avg:94.26ms
+step:599/1700 train_time:56463ms step_avg:94.26ms
+step:600/1700 train_time:56559ms step_avg:94.26ms
+step:601/1700 train_time:56655ms step_avg:94.27ms
+step:602/1700 train_time:56750ms step_avg:94.27ms
+step:603/1700 train_time:56846ms step_avg:94.27ms
+step:604/1700 train_time:56943ms step_avg:94.28ms
+step:605/1700 train_time:57038ms step_avg:94.28ms
+step:606/1700 train_time:57135ms step_avg:94.28ms
+step:607/1700 train_time:57231ms step_avg:94.28ms
+step:608/1700 train_time:57327ms step_avg:94.29ms
+step:609/1700 train_time:57423ms step_avg:94.29ms
+step:610/1700 train_time:57518ms step_avg:94.29ms
+step:611/1700 train_time:57615ms step_avg:94.30ms
+step:612/1700 train_time:57711ms step_avg:94.30ms
+step:613/1700 train_time:57807ms step_avg:94.30ms
+step:614/1700 train_time:57902ms step_avg:94.30ms
+step:615/1700 train_time:57998ms step_avg:94.31ms
+step:616/1700 train_time:58093ms step_avg:94.31ms
+step:617/1700 train_time:58189ms step_avg:94.31ms
+step:618/1700 train_time:58285ms step_avg:94.31ms
+step:619/1700 train_time:58381ms step_avg:94.32ms
+step:620/1700 train_time:58477ms step_avg:94.32ms
+step:621/1700 train_time:58573ms step_avg:94.32ms
+step:622/1700 train_time:58669ms step_avg:94.32ms
+step:623/1700 train_time:58764ms step_avg:94.32ms
+step:624/1700 train_time:58860ms step_avg:94.33ms
+step:625/1700 train_time:58956ms step_avg:94.33ms
+step:625/1700 val_loss:3.6474 train_time:59035ms step_avg:94.46ms
+step:626/1700 train_time:59058ms step_avg:94.34ms
+step:627/1700 train_time:59154ms step_avg:94.35ms
+step:628/1700 train_time:59252ms step_avg:94.35ms
+step:629/1700 train_time:59348ms step_avg:94.35ms
+step:630/1700 train_time:59444ms step_avg:94.36ms
+step:631/1700 train_time:59540ms step_avg:94.36ms
+step:632/1700 train_time:59636ms step_avg:94.36ms
+step:633/1700 train_time:59733ms step_avg:94.36ms
+step:634/1700 train_time:59829ms step_avg:94.37ms
+step:635/1700 train_time:59927ms step_avg:94.37ms
+step:636/1700 train_time:60024ms step_avg:94.38ms
+step:637/1700 train_time:60123ms step_avg:94.38ms
+step:638/1700 train_time:60222ms step_avg:94.39ms
+step:639/1700 train_time:60320ms step_avg:94.40ms
+step:640/1700 train_time:60418ms step_avg:94.40ms
+step:641/1700 train_time:60515ms step_avg:94.41ms
+step:642/1700 train_time:60613ms step_avg:94.41ms
+step:643/1700 train_time:60709ms step_avg:94.42ms
+step:644/1700 train_time:60805ms step_avg:94.42ms
+step:645/1700 train_time:60902ms step_avg:94.42ms
+step:646/1700 train_time:61000ms step_avg:94.43ms
+step:647/1700 train_time:61098ms step_avg:94.43ms
+step:648/1700 train_time:61196ms step_avg:94.44ms
+step:649/1700 train_time:61295ms step_avg:94.44ms
+step:650/1700 train_time:61393ms step_avg:94.45ms
+step:651/1700 train_time:61490ms step_avg:94.46ms
+step:652/1700 train_time:61587ms step_avg:94.46ms
+step:653/1700 train_time:61685ms step_avg:94.46ms
+step:654/1700 train_time:61782ms step_avg:94.47ms
+step:655/1700 train_time:61879ms step_avg:94.47ms
+step:656/1700 train_time:61976ms step_avg:94.48ms
+step:657/1700 train_time:62073ms step_avg:94.48ms
+step:658/1700 train_time:62170ms step_avg:94.48ms
+step:659/1700 train_time:62268ms step_avg:94.49ms
+step:660/1700 train_time:62367ms step_avg:94.50ms
+step:661/1700 train_time:62464ms step_avg:94.50ms
+step:662/1700 train_time:62562ms step_avg:94.50ms
+step:663/1700 train_time:62659ms step_avg:94.51ms
+step:664/1700 train_time:62755ms step_avg:94.51ms
+step:665/1700 train_time:62853ms step_avg:94.52ms
+step:666/1700 train_time:62950ms step_avg:94.52ms
+step:667/1700 train_time:63048ms step_avg:94.52ms
+step:668/1700 train_time:63145ms step_avg:94.53ms
+step:669/1700 train_time:63243ms step_avg:94.53ms
+step:670/1700 train_time:63342ms step_avg:94.54ms
+step:671/1700 train_time:63440ms step_avg:94.55ms
+step:672/1700 train_time:63538ms step_avg:94.55ms
+step:673/1700 train_time:63635ms step_avg:94.55ms
+step:674/1700 train_time:63732ms step_avg:94.56ms
+step:675/1700 train_time:63829ms step_avg:94.56ms
+step:676/1700 train_time:63926ms step_avg:94.56ms
+step:677/1700 train_time:64024ms step_avg:94.57ms
+step:678/1700 train_time:64121ms step_avg:94.57ms
+step:679/1700 train_time:64218ms step_avg:94.58ms
+step:680/1700 train_time:64316ms step_avg:94.58ms
+step:681/1700 train_time:64414ms step_avg:94.59ms
+step:682/1700 train_time:64512ms step_avg:94.59ms
+step:683/1700 train_time:64609ms step_avg:94.60ms
+step:684/1700 train_time:64707ms step_avg:94.60ms
+step:685/1700 train_time:64804ms step_avg:94.60ms
+step:686/1700 train_time:64901ms step_avg:94.61ms
+step:687/1700 train_time:64999ms step_avg:94.61ms
+step:688/1700 train_time:65096ms step_avg:94.62ms
+step:689/1700 train_time:65193ms step_avg:94.62ms
+step:690/1700 train_time:65291ms step_avg:94.62ms
+step:691/1700 train_time:65388ms step_avg:94.63ms
+step:692/1700 train_time:65485ms step_avg:94.63ms
+step:693/1700 train_time:65583ms step_avg:94.64ms
+step:694/1700 train_time:65681ms step_avg:94.64ms
+step:695/1700 train_time:65779ms step_avg:94.65ms
+step:696/1700 train_time:65877ms step_avg:94.65ms
+step:697/1700 train_time:65975ms step_avg:94.66ms
+step:698/1700 train_time:66072ms step_avg:94.66ms
+step:699/1700 train_time:66169ms step_avg:94.66ms
+step:700/1700 train_time:66266ms step_avg:94.67ms
+step:701/1700 train_time:66363ms step_avg:94.67ms
+step:702/1700 train_time:66462ms step_avg:94.68ms
+step:703/1700 train_time:66559ms step_avg:94.68ms
+step:704/1700 train_time:66656ms step_avg:94.68ms
+step:705/1700 train_time:66754ms step_avg:94.69ms
+step:706/1700 train_time:66852ms step_avg:94.69ms
+step:707/1700 train_time:66949ms step_avg:94.69ms
+step:708/1700 train_time:67046ms step_avg:94.70ms
+step:709/1700 train_time:67144ms step_avg:94.70ms
+step:710/1700 train_time:67242ms step_avg:94.71ms
+step:711/1700 train_time:67340ms step_avg:94.71ms
+step:712/1700 train_time:67437ms step_avg:94.72ms
+step:713/1700 train_time:67535ms step_avg:94.72ms
+step:714/1700 train_time:67633ms step_avg:94.72ms
+step:715/1700 train_time:67731ms step_avg:94.73ms
+step:716/1700 train_time:67828ms step_avg:94.73ms
+step:717/1700 train_time:67925ms step_avg:94.73ms
+step:718/1700 train_time:68022ms step_avg:94.74ms
+step:719/1700 train_time:68120ms step_avg:94.74ms
+step:720/1700 train_time:68217ms step_avg:94.75ms
+step:721/1700 train_time:68314ms step_avg:94.75ms
+step:722/1700 train_time:68411ms step_avg:94.75ms
+step:723/1700 train_time:68509ms step_avg:94.76ms
+step:724/1700 train_time:68607ms step_avg:94.76ms
+step:725/1700 train_time:68704ms step_avg:94.76ms
+step:726/1700 train_time:68801ms step_avg:94.77ms
+step:727/1700 train_time:68899ms step_avg:94.77ms
+step:728/1700 train_time:68996ms step_avg:94.78ms
+step:729/1700 train_time:69093ms step_avg:94.78ms
+step:730/1700 train_time:69190ms step_avg:94.78ms
+step:731/1700 train_time:69288ms step_avg:94.79ms
+step:732/1700 train_time:69386ms step_avg:94.79ms
+step:733/1700 train_time:69484ms step_avg:94.79ms
+step:734/1700 train_time:69582ms step_avg:94.80ms
+step:735/1700 train_time:69679ms step_avg:94.80ms
+step:736/1700 train_time:69776ms step_avg:94.80ms
+step:737/1700 train_time:69874ms step_avg:94.81ms
+step:738/1700 train_time:69971ms step_avg:94.81ms
+step:739/1700 train_time:70068ms step_avg:94.81ms
+step:740/1700 train_time:70166ms step_avg:94.82ms
+step:741/1700 train_time:70264ms step_avg:94.82ms
+step:742/1700 train_time:70362ms step_avg:94.83ms
+step:743/1700 train_time:70459ms step_avg:94.83ms
+step:744/1700 train_time:70557ms step_avg:94.83ms
+step:745/1700 train_time:70654ms step_avg:94.84ms
+step:746/1700 train_time:70751ms step_avg:94.84ms
+step:747/1700 train_time:70848ms step_avg:94.84ms
+step:748/1700 train_time:70947ms step_avg:94.85ms
+step:749/1700 train_time:71044ms step_avg:94.85ms
+step:750/1700 train_time:71142ms step_avg:94.86ms
+step:750/1700 val_loss:3.5838 train_time:71222ms step_avg:94.96ms
+step:751/1700 train_time:71245ms step_avg:94.87ms
+step:752/1700 train_time:71344ms step_avg:94.87ms
+step:753/1700 train_time:71443ms step_avg:94.88ms
+step:754/1700 train_time:71541ms step_avg:94.88ms
+step:755/1700 train_time:71638ms step_avg:94.88ms
+step:756/1700 train_time:71735ms step_avg:94.89ms
+step:757/1700 train_time:71831ms step_avg:94.89ms
+step:758/1700 train_time:71928ms step_avg:94.89ms
+step:759/1700 train_time:72025ms step_avg:94.89ms
+step:760/1700 train_time:72122ms step_avg:94.90ms
+step:761/1700 train_time:72221ms step_avg:94.90ms
+step:762/1700 train_time:72321ms step_avg:94.91ms
+step:763/1700 train_time:72418ms step_avg:94.91ms
+step:764/1700 train_time:72517ms step_avg:94.92ms
+step:765/1700 train_time:72615ms step_avg:94.92ms
+step:766/1700 train_time:72712ms step_avg:94.92ms
+step:767/1700 train_time:72809ms step_avg:94.93ms
+step:768/1700 train_time:72906ms step_avg:94.93ms
+step:769/1700 train_time:73002ms step_avg:94.93ms
+step:770/1700 train_time:73099ms step_avg:94.93ms
+step:771/1700 train_time:73198ms step_avg:94.94ms
+step:772/1700 train_time:73297ms step_avg:94.94ms
+step:773/1700 train_time:73395ms step_avg:94.95ms
+step:774/1700 train_time:73493ms step_avg:94.95ms
+step:775/1700 train_time:73590ms step_avg:94.95ms
+step:776/1700 train_time:73687ms step_avg:94.96ms
+step:777/1700 train_time:73785ms step_avg:94.96ms
+step:778/1700 train_time:73883ms step_avg:94.96ms
+step:779/1700 train_time:73981ms step_avg:94.97ms
+step:780/1700 train_time:74079ms step_avg:94.97ms
+step:781/1700 train_time:74176ms step_avg:94.98ms
+step:782/1700 train_time:74274ms step_avg:94.98ms
+step:783/1700 train_time:74371ms step_avg:94.98ms
+step:784/1700 train_time:74469ms step_avg:94.99ms
+step:785/1700 train_time:74567ms step_avg:94.99ms
+step:786/1700 train_time:74663ms step_avg:94.99ms
+step:787/1700 train_time:74762ms step_avg:95.00ms
+step:788/1700 train_time:74860ms step_avg:95.00ms
+step:789/1700 train_time:74958ms step_avg:95.00ms
+step:790/1700 train_time:75055ms step_avg:95.01ms
+step:791/1700 train_time:75152ms step_avg:95.01ms
+step:792/1700 train_time:75250ms step_avg:95.01ms
+step:793/1700 train_time:75348ms step_avg:95.02ms
+step:794/1700 train_time:75446ms step_avg:95.02ms
+step:795/1700 train_time:75543ms step_avg:95.02ms
+step:796/1700 train_time:75640ms step_avg:95.03ms
+step:797/1700 train_time:75737ms step_avg:95.03ms
+step:798/1700 train_time:75836ms step_avg:95.03ms
+step:799/1700 train_time:75934ms step_avg:95.04ms
+step:800/1700 train_time:76031ms step_avg:95.04ms
+step:801/1700 train_time:76128ms step_avg:95.04ms
+step:802/1700 train_time:76226ms step_avg:95.05ms
+step:803/1700 train_time:76324ms step_avg:95.05ms
+step:804/1700 train_time:76421ms step_avg:95.05ms
+step:805/1700 train_time:76519ms step_avg:95.05ms
+step:806/1700 train_time:76618ms step_avg:95.06ms
+step:807/1700 train_time:76716ms step_avg:95.06ms
+step:808/1700 train_time:76814ms step_avg:95.07ms
+step:809/1700 train_time:76912ms step_avg:95.07ms
+step:810/1700 train_time:77009ms step_avg:95.07ms
+step:811/1700 train_time:77107ms step_avg:95.08ms
+step:812/1700 train_time:77205ms step_avg:95.08ms
+step:813/1700 train_time:77302ms step_avg:95.08ms
+step:814/1700 train_time:77400ms step_avg:95.09ms
+step:815/1700 train_time:77498ms step_avg:95.09ms
+step:816/1700 train_time:77595ms step_avg:95.09ms
+step:817/1700 train_time:77693ms step_avg:95.09ms
+step:818/1700 train_time:77790ms step_avg:95.10ms
+step:819/1700 train_time:77888ms step_avg:95.10ms
+step:820/1700 train_time:77985ms step_avg:95.10ms
+step:821/1700 train_time:78082ms step_avg:95.11ms
+step:822/1700 train_time:78180ms step_avg:95.11ms
+step:823/1700 train_time:78278ms step_avg:95.11ms
+step:824/1700 train_time:78376ms step_avg:95.12ms
+step:825/1700 train_time:78474ms step_avg:95.12ms
+step:826/1700 train_time:78571ms step_avg:95.12ms
+step:827/1700 train_time:78669ms step_avg:95.13ms
+step:828/1700 train_time:78767ms step_avg:95.13ms
+step:829/1700 train_time:78864ms step_avg:95.13ms
+step:830/1700 train_time:78962ms step_avg:95.14ms
+step:831/1700 train_time:79060ms step_avg:95.14ms
+step:832/1700 train_time:79157ms step_avg:95.14ms
+step:833/1700 train_time:79256ms step_avg:95.14ms
+step:834/1700 train_time:79353ms step_avg:95.15ms
+step:835/1700 train_time:79451ms step_avg:95.15ms
+step:836/1700 train_time:79548ms step_avg:95.15ms
+step:837/1700 train_time:79647ms step_avg:95.16ms
+step:838/1700 train_time:79744ms step_avg:95.16ms
+step:839/1700 train_time:79843ms step_avg:95.16ms
+step:840/1700 train_time:79940ms step_avg:95.17ms
+step:841/1700 train_time:80038ms step_avg:95.17ms
+step:842/1700 train_time:80135ms step_avg:95.17ms
+step:843/1700 train_time:80232ms step_avg:95.17ms
+step:844/1700 train_time:80330ms step_avg:95.18ms
+step:845/1700 train_time:80428ms step_avg:95.18ms
+step:846/1700 train_time:80525ms step_avg:95.18ms
+step:847/1700 train_time:80623ms step_avg:95.19ms
+step:848/1700 train_time:80720ms step_avg:95.19ms
+step:849/1700 train_time:80819ms step_avg:95.19ms
+step:850/1700 train_time:80917ms step_avg:95.20ms
+step:851/1700 train_time:81014ms step_avg:95.20ms
+step:852/1700 train_time:81112ms step_avg:95.20ms
+step:853/1700 train_time:81208ms step_avg:95.20ms
+step:854/1700 train_time:81306ms step_avg:95.21ms
+step:855/1700 train_time:81403ms step_avg:95.21ms
+step:856/1700 train_time:81501ms step_avg:95.21ms
+step:857/1700 train_time:81599ms step_avg:95.21ms
+step:858/1700 train_time:81696ms step_avg:95.22ms
+step:859/1700 train_time:81795ms step_avg:95.22ms
+step:860/1700 train_time:81892ms step_avg:95.22ms
+step:861/1700 train_time:81990ms step_avg:95.23ms
+step:862/1700 train_time:82088ms step_avg:95.23ms
+step:863/1700 train_time:82186ms step_avg:95.23ms
+step:864/1700 train_time:82282ms step_avg:95.23ms
+step:865/1700 train_time:82380ms step_avg:95.24ms
+step:866/1700 train_time:82478ms step_avg:95.24ms
+step:867/1700 train_time:82577ms step_avg:95.24ms
+step:868/1700 train_time:82675ms step_avg:95.25ms
+step:869/1700 train_time:82773ms step_avg:95.25ms
+step:870/1700 train_time:82870ms step_avg:95.25ms
+step:871/1700 train_time:82968ms step_avg:95.26ms
+step:872/1700 train_time:83065ms step_avg:95.26ms
+step:873/1700 train_time:83162ms step_avg:95.26ms
+step:874/1700 train_time:83260ms step_avg:95.26ms
+step:875/1700 train_time:83357ms step_avg:95.27ms
+step:875/1700 val_loss:3.5377 train_time:83437ms step_avg:95.36ms
+step:876/1700 train_time:83461ms step_avg:95.27ms
+step:877/1700 train_time:83559ms step_avg:95.28ms
+step:878/1700 train_time:83658ms step_avg:95.28ms
+step:879/1700 train_time:83754ms step_avg:95.28ms
+step:880/1700 train_time:83851ms step_avg:95.29ms
+step:881/1700 train_time:83948ms step_avg:95.29ms
+step:882/1700 train_time:84045ms step_avg:95.29ms
+step:883/1700 train_time:84142ms step_avg:95.29ms
+step:884/1700 train_time:84241ms step_avg:95.30ms
+step:885/1700 train_time:84340ms step_avg:95.30ms
+step:886/1700 train_time:84439ms step_avg:95.30ms
+step:887/1700 train_time:84540ms step_avg:95.31ms
+step:888/1700 train_time:84641ms step_avg:95.32ms
+step:889/1700 train_time:84741ms step_avg:95.32ms
+step:890/1700 train_time:84840ms step_avg:95.33ms
+step:891/1700 train_time:84939ms step_avg:95.33ms
+step:892/1700 train_time:85038ms step_avg:95.33ms
+step:893/1700 train_time:85135ms step_avg:95.34ms
+step:894/1700 train_time:85234ms step_avg:95.34ms
+step:895/1700 train_time:85332ms step_avg:95.34ms
+step:896/1700 train_time:85431ms step_avg:95.35ms
+step:897/1700 train_time:85530ms step_avg:95.35ms
+step:898/1700 train_time:85630ms step_avg:95.36ms
+step:899/1700 train_time:85731ms step_avg:95.36ms
+step:900/1700 train_time:85830ms step_avg:95.37ms
+step:901/1700 train_time:85930ms step_avg:95.37ms
+step:902/1700 train_time:86029ms step_avg:95.38ms
+step:903/1700 train_time:86128ms step_avg:95.38ms
+step:904/1700 train_time:86227ms step_avg:95.38ms
+step:905/1700 train_time:86326ms step_avg:95.39ms
+step:906/1700 train_time:86424ms step_avg:95.39ms
+step:907/1700 train_time:86524ms step_avg:95.40ms
+step:908/1700 train_time:86624ms step_avg:95.40ms
+step:909/1700 train_time:86723ms step_avg:95.41ms
+step:910/1700 train_time:86823ms step_avg:95.41ms
+step:911/1700 train_time:86922ms step_avg:95.41ms
+step:912/1700 train_time:87021ms step_avg:95.42ms
+step:913/1700 train_time:87122ms step_avg:95.42ms
+step:914/1700 train_time:87221ms step_avg:95.43ms
+step:915/1700 train_time:87320ms step_avg:95.43ms
+step:916/1700 train_time:87419ms step_avg:95.44ms
+step:917/1700 train_time:87518ms step_avg:95.44ms
+step:918/1700 train_time:87618ms step_avg:95.44ms
+step:919/1700 train_time:87717ms step_avg:95.45ms
+step:920/1700 train_time:87816ms step_avg:95.45ms
+step:921/1700 train_time:87915ms step_avg:95.46ms
+step:922/1700 train_time:88013ms step_avg:95.46ms
+step:923/1700 train_time:88113ms step_avg:95.46ms
+step:924/1700 train_time:88213ms step_avg:95.47ms
+step:925/1700 train_time:88312ms step_avg:95.47ms
+step:926/1700 train_time:88412ms step_avg:95.48ms
+step:927/1700 train_time:88512ms step_avg:95.48ms
+step:928/1700 train_time:88611ms step_avg:95.49ms
+step:929/1700 train_time:88710ms step_avg:95.49ms
+step:930/1700 train_time:88809ms step_avg:95.49ms
+step:931/1700 train_time:88907ms step_avg:95.50ms
+step:932/1700 train_time:89005ms step_avg:95.50ms
+step:933/1700 train_time:89105ms step_avg:95.50ms
+step:934/1700 train_time:89205ms step_avg:95.51ms
+step:935/1700 train_time:89305ms step_avg:95.51ms
+step:936/1700 train_time:89404ms step_avg:95.52ms
+step:937/1700 train_time:89504ms step_avg:95.52ms
+step:938/1700 train_time:89603ms step_avg:95.53ms
+step:939/1700 train_time:89702ms step_avg:95.53ms
+step:940/1700 train_time:89801ms step_avg:95.53ms
+step:941/1700 train_time:89901ms step_avg:95.54ms
+step:942/1700 train_time:90000ms step_avg:95.54ms
+step:943/1700 train_time:90098ms step_avg:95.54ms
+step:944/1700 train_time:90198ms step_avg:95.55ms
+step:945/1700 train_time:90296ms step_avg:95.55ms
+step:946/1700 train_time:90395ms step_avg:95.56ms
+step:947/1700 train_time:90494ms step_avg:95.56ms
+step:948/1700 train_time:90594ms step_avg:95.56ms
+step:949/1700 train_time:90693ms step_avg:95.57ms
+step:950/1700 train_time:90794ms step_avg:95.57ms
+step:951/1700 train_time:90893ms step_avg:95.58ms
+step:952/1700 train_time:90993ms step_avg:95.58ms
+step:953/1700 train_time:91093ms step_avg:95.59ms
+step:954/1700 train_time:91192ms step_avg:95.59ms
+step:955/1700 train_time:91292ms step_avg:95.59ms
+step:956/1700 train_time:91390ms step_avg:95.60ms
+step:957/1700 train_time:91489ms step_avg:95.60ms
+step:958/1700 train_time:91588ms step_avg:95.60ms
+step:959/1700 train_time:91687ms step_avg:95.61ms
+step:960/1700 train_time:91786ms step_avg:95.61ms
+step:961/1700 train_time:91885ms step_avg:95.61ms
+step:962/1700 train_time:91985ms step_avg:95.62ms
+step:963/1700 train_time:92084ms step_avg:95.62ms
+step:964/1700 train_time:92183ms step_avg:95.63ms
+step:965/1700 train_time:92282ms step_avg:95.63ms
+step:966/1700 train_time:92382ms step_avg:95.63ms
+step:967/1700 train_time:92482ms step_avg:95.64ms
+step:968/1700 train_time:92582ms step_avg:95.64ms
+step:969/1700 train_time:92681ms step_avg:95.65ms
+step:970/1700 train_time:92781ms step_avg:95.65ms
+step:971/1700 train_time:92880ms step_avg:95.65ms
+step:972/1700 train_time:92979ms step_avg:95.66ms
+step:973/1700 train_time:93078ms step_avg:95.66ms
+step:974/1700 train_time:93178ms step_avg:95.66ms
+step:975/1700 train_time:93276ms step_avg:95.67ms
+step:976/1700 train_time:93376ms step_avg:95.67ms
+step:977/1700 train_time:93475ms step_avg:95.68ms
+step:978/1700 train_time:93574ms step_avg:95.68ms
+step:979/1700 train_time:93674ms step_avg:95.68ms
+step:980/1700 train_time:93773ms step_avg:95.69ms
+step:981/1700 train_time:93874ms step_avg:95.69ms
+step:982/1700 train_time:93974ms step_avg:95.70ms
+step:983/1700 train_time:94074ms step_avg:95.70ms
+step:984/1700 train_time:94173ms step_avg:95.70ms
+step:985/1700 train_time:94271ms step_avg:95.71ms
+step:986/1700 train_time:94372ms step_avg:95.71ms
+step:987/1700 train_time:94471ms step_avg:95.71ms
+step:988/1700 train_time:94570ms step_avg:95.72ms
+step:989/1700 train_time:94669ms step_avg:95.72ms
+step:990/1700 train_time:94768ms step_avg:95.72ms
+step:991/1700 train_time:94867ms step_avg:95.73ms
+step:992/1700 train_time:94966ms step_avg:95.73ms
+step:993/1700 train_time:95064ms step_avg:95.73ms
+step:994/1700 train_time:95164ms step_avg:95.74ms
+step:995/1700 train_time:95264ms step_avg:95.74ms
+step:996/1700 train_time:95363ms step_avg:95.75ms
+step:997/1700 train_time:95463ms step_avg:95.75ms
+step:998/1700 train_time:95562ms step_avg:95.75ms
+step:999/1700 train_time:95661ms step_avg:95.76ms
+step:1000/1700 train_time:95761ms step_avg:95.76ms
+step:1000/1700 val_loss:3.4917 train_time:95843ms step_avg:95.84ms
+step:1001/1700 train_time:95867ms step_avg:95.77ms
+step:1002/1700 train_time:95970ms step_avg:95.78ms
+step:1003/1700 train_time:96070ms step_avg:95.78ms
+step:1004/1700 train_time:96169ms step_avg:95.79ms
+step:1005/1700 train_time:96269ms step_avg:95.79ms
+step:1006/1700 train_time:96368ms step_avg:95.79ms
+step:1007/1700 train_time:96465ms step_avg:95.79ms
+step:1008/1700 train_time:96564ms step_avg:95.80ms
+step:1009/1700 train_time:96663ms step_avg:95.80ms
+step:1010/1700 train_time:96762ms step_avg:95.80ms
+step:1011/1700 train_time:96864ms step_avg:95.81ms
+step:1012/1700 train_time:96964ms step_avg:95.81ms
+step:1013/1700 train_time:97065ms step_avg:95.82ms
+step:1014/1700 train_time:97164ms step_avg:95.82ms
+step:1015/1700 train_time:97262ms step_avg:95.82ms
+step:1016/1700 train_time:97361ms step_avg:95.83ms
+step:1017/1700 train_time:97461ms step_avg:95.83ms
+step:1018/1700 train_time:97561ms step_avg:95.84ms
+step:1019/1700 train_time:97660ms step_avg:95.84ms
+step:1020/1700 train_time:97759ms step_avg:95.84ms
+step:1021/1700 train_time:97861ms step_avg:95.85ms
+step:1022/1700 train_time:97961ms step_avg:95.85ms
+step:1023/1700 train_time:98061ms step_avg:95.86ms
+step:1024/1700 train_time:98161ms step_avg:95.86ms
+step:1025/1700 train_time:98261ms step_avg:95.86ms
+step:1026/1700 train_time:98361ms step_avg:95.87ms
+step:1027/1700 train_time:98461ms step_avg:95.87ms
+step:1028/1700 train_time:98559ms step_avg:95.87ms
+step:1029/1700 train_time:98659ms step_avg:95.88ms
+step:1030/1700 train_time:98758ms step_avg:95.88ms
+step:1031/1700 train_time:98858ms step_avg:95.89ms
+step:1032/1700 train_time:98959ms step_avg:95.89ms
+step:1033/1700 train_time:99059ms step_avg:95.89ms
+step:1034/1700 train_time:99159ms step_avg:95.90ms
+step:1035/1700 train_time:99258ms step_avg:95.90ms
+step:1036/1700 train_time:99358ms step_avg:95.91ms
+step:1037/1700 train_time:99458ms step_avg:95.91ms
+step:1038/1700 train_time:99557ms step_avg:95.91ms
+step:1039/1700 train_time:99656ms step_avg:95.92ms
+step:1040/1700 train_time:99754ms step_avg:95.92ms
+step:1041/1700 train_time:99853ms step_avg:95.92ms
+step:1042/1700 train_time:99952ms step_avg:95.92ms
+step:1043/1700 train_time:100051ms step_avg:95.93ms
+step:1044/1700 train_time:100150ms step_avg:95.93ms
+step:1045/1700 train_time:100250ms step_avg:95.93ms
+step:1046/1700 train_time:100350ms step_avg:95.94ms
+step:1047/1700 train_time:100450ms step_avg:95.94ms
+step:1048/1700 train_time:100551ms step_avg:95.95ms
+step:1049/1700 train_time:100650ms step_avg:95.95ms
+step:1050/1700 train_time:100750ms step_avg:95.95ms
+step:1051/1700 train_time:100849ms step_avg:95.96ms
+step:1052/1700 train_time:100949ms step_avg:95.96ms
+step:1053/1700 train_time:101047ms step_avg:95.96ms
+step:1054/1700 train_time:101146ms step_avg:95.96ms
+step:1055/1700 train_time:101245ms step_avg:95.97ms
+step:1056/1700 train_time:101346ms step_avg:95.97ms
+step:1057/1700 train_time:101446ms step_avg:95.98ms
+step:1058/1700 train_time:101546ms step_avg:95.98ms
+step:1059/1700 train_time:101646ms step_avg:95.98ms
+step:1060/1700 train_time:101746ms step_avg:95.99ms
+step:1061/1700 train_time:101845ms step_avg:95.99ms
+step:1062/1700 train_time:101945ms step_avg:95.99ms
+step:1063/1700 train_time:102044ms step_avg:96.00ms
+step:1064/1700 train_time:102144ms step_avg:96.00ms
+step:1065/1700 train_time:102243ms step_avg:96.00ms
+step:1066/1700 train_time:102342ms step_avg:96.01ms
+step:1067/1700 train_time:102441ms step_avg:96.01ms
+step:1068/1700 train_time:102542ms step_avg:96.01ms
+step:1069/1700 train_time:102642ms step_avg:96.02ms
+step:1070/1700 train_time:102741ms step_avg:96.02ms
+step:1071/1700 train_time:102841ms step_avg:96.02ms
+step:1072/1700 train_time:102941ms step_avg:96.03ms
+step:1073/1700 train_time:103041ms step_avg:96.03ms
+step:1074/1700 train_time:103141ms step_avg:96.03ms
+step:1075/1700 train_time:103240ms step_avg:96.04ms
+step:1076/1700 train_time:103338ms step_avg:96.04ms
+step:1077/1700 train_time:103438ms step_avg:96.04ms
+step:1078/1700 train_time:103537ms step_avg:96.05ms
+step:1079/1700 train_time:103638ms step_avg:96.05ms
+step:1080/1700 train_time:103737ms step_avg:96.05ms
+step:1081/1700 train_time:103837ms step_avg:96.06ms
+step:1082/1700 train_time:103937ms step_avg:96.06ms
+step:1083/1700 train_time:104037ms step_avg:96.06ms
+step:1084/1700 train_time:104137ms step_avg:96.07ms
+step:1085/1700 train_time:104237ms step_avg:96.07ms
+step:1086/1700 train_time:104336ms step_avg:96.07ms
+step:1087/1700 train_time:104435ms step_avg:96.08ms
+step:1088/1700 train_time:104534ms step_avg:96.08ms
+step:1089/1700 train_time:104634ms step_avg:96.08ms
+step:1090/1700 train_time:104733ms step_avg:96.09ms
+step:1091/1700 train_time:104832ms step_avg:96.09ms
+step:1092/1700 train_time:104932ms step_avg:96.09ms
+step:1093/1700 train_time:105030ms step_avg:96.09ms
+step:1094/1700 train_time:105130ms step_avg:96.10ms
+step:1095/1700 train_time:105230ms step_avg:96.10ms
+step:1096/1700 train_time:105330ms step_avg:96.10ms
+step:1097/1700 train_time:105429ms step_avg:96.11ms
+step:1098/1700 train_time:105529ms step_avg:96.11ms
+step:1099/1700 train_time:105629ms step_avg:96.11ms
+step:1100/1700 train_time:105729ms step_avg:96.12ms
+step:1101/1700 train_time:105829ms step_avg:96.12ms
+step:1102/1700 train_time:105928ms step_avg:96.12ms
+step:1103/1700 train_time:106028ms step_avg:96.13ms
+step:1104/1700 train_time:106128ms step_avg:96.13ms
+step:1105/1700 train_time:106228ms step_avg:96.13ms
+step:1106/1700 train_time:106329ms step_avg:96.14ms
+step:1107/1700 train_time:106429ms step_avg:96.14ms
+step:1108/1700 train_time:106529ms step_avg:96.15ms
+step:1109/1700 train_time:106630ms step_avg:96.15ms
+step:1110/1700 train_time:106730ms step_avg:96.15ms
+step:1111/1700 train_time:106830ms step_avg:96.16ms
+step:1112/1700 train_time:106929ms step_avg:96.16ms
+step:1113/1700 train_time:107029ms step_avg:96.16ms
+step:1114/1700 train_time:107128ms step_avg:96.17ms
+step:1115/1700 train_time:107228ms step_avg:96.17ms
+step:1116/1700 train_time:107328ms step_avg:96.17ms
+step:1117/1700 train_time:107427ms step_avg:96.17ms
+step:1118/1700 train_time:107526ms step_avg:96.18ms
+step:1119/1700 train_time:107626ms step_avg:96.18ms
+step:1120/1700 train_time:107725ms step_avg:96.18ms
+step:1121/1700 train_time:107824ms step_avg:96.19ms
+step:1122/1700 train_time:107923ms step_avg:96.19ms
+step:1123/1700 train_time:108022ms step_avg:96.19ms
+step:1124/1700 train_time:108120ms step_avg:96.19ms
+step:1125/1700 train_time:108222ms step_avg:96.20ms
+step:1125/1700 val_loss:3.4417 train_time:108302ms step_avg:96.27ms
+step:1126/1700 train_time:108324ms step_avg:96.20ms
+step:1127/1700 train_time:108425ms step_avg:96.21ms
+step:1128/1700 train_time:108527ms step_avg:96.21ms
+step:1129/1700 train_time:108625ms step_avg:96.21ms
+step:1130/1700 train_time:108724ms step_avg:96.22ms
+step:1131/1700 train_time:108823ms step_avg:96.22ms
+step:1132/1700 train_time:108922ms step_avg:96.22ms
+step:1133/1700 train_time:109020ms step_avg:96.22ms
+step:1134/1700 train_time:109118ms step_avg:96.22ms
+step:1135/1700 train_time:109217ms step_avg:96.23ms
+step:1136/1700 train_time:109318ms step_avg:96.23ms
+step:1137/1700 train_time:109420ms step_avg:96.24ms
+step:1138/1700 train_time:109522ms step_avg:96.24ms
+step:1139/1700 train_time:109622ms step_avg:96.24ms
+step:1140/1700 train_time:109723ms step_avg:96.25ms
+step:1141/1700 train_time:109823ms step_avg:96.25ms
+step:1142/1700 train_time:109924ms step_avg:96.26ms
+step:1143/1700 train_time:110023ms step_avg:96.26ms
+step:1144/1700 train_time:110124ms step_avg:96.26ms
+step:1145/1700 train_time:110225ms step_avg:96.27ms
+step:1146/1700 train_time:110325ms step_avg:96.27ms
+step:1147/1700 train_time:110426ms step_avg:96.27ms
+step:1148/1700 train_time:110526ms step_avg:96.28ms
+step:1149/1700 train_time:110627ms step_avg:96.28ms
+step:1150/1700 train_time:110727ms step_avg:96.28ms
+step:1151/1700 train_time:110827ms step_avg:96.29ms
+step:1152/1700 train_time:110926ms step_avg:96.29ms
+step:1153/1700 train_time:111026ms step_avg:96.29ms
+step:1154/1700 train_time:111127ms step_avg:96.30ms
+step:1155/1700 train_time:111228ms step_avg:96.30ms
+step:1156/1700 train_time:111328ms step_avg:96.30ms
+step:1157/1700 train_time:111430ms step_avg:96.31ms
+step:1158/1700 train_time:111530ms step_avg:96.31ms
+step:1159/1700 train_time:111631ms step_avg:96.32ms
+step:1160/1700 train_time:111732ms step_avg:96.32ms
+step:1161/1700 train_time:111832ms step_avg:96.32ms
+step:1162/1700 train_time:111932ms step_avg:96.33ms
+step:1163/1700 train_time:112033ms step_avg:96.33ms
+step:1164/1700 train_time:112133ms step_avg:96.33ms
+step:1165/1700 train_time:112233ms step_avg:96.34ms
+step:1166/1700 train_time:112333ms step_avg:96.34ms
+step:1167/1700 train_time:112433ms step_avg:96.34ms
+step:1168/1700 train_time:112534ms step_avg:96.35ms
+step:1169/1700 train_time:112635ms step_avg:96.35ms
+step:1170/1700 train_time:112735ms step_avg:96.35ms
+step:1171/1700 train_time:112835ms step_avg:96.36ms
+step:1172/1700 train_time:112936ms step_avg:96.36ms
+step:1173/1700 train_time:113035ms step_avg:96.36ms
+step:1174/1700 train_time:113136ms step_avg:96.37ms
+step:1175/1700 train_time:113236ms step_avg:96.37ms
+step:1176/1700 train_time:113336ms step_avg:96.37ms
+step:1177/1700 train_time:113437ms step_avg:96.38ms
+step:1178/1700 train_time:113537ms step_avg:96.38ms
+step:1179/1700 train_time:113638ms step_avg:96.38ms
+step:1180/1700 train_time:113737ms step_avg:96.39ms
+step:1181/1700 train_time:113837ms step_avg:96.39ms
+step:1182/1700 train_time:113938ms step_avg:96.39ms
+step:1183/1700 train_time:114038ms step_avg:96.40ms
+step:1184/1700 train_time:114137ms step_avg:96.40ms
+step:1185/1700 train_time:114237ms step_avg:96.40ms
+step:1186/1700 train_time:114338ms step_avg:96.41ms
+step:1187/1700 train_time:114437ms step_avg:96.41ms
+step:1188/1700 train_time:114538ms step_avg:96.41ms
+step:1189/1700 train_time:114639ms step_avg:96.42ms
+step:1190/1700 train_time:114738ms step_avg:96.42ms
+step:1191/1700 train_time:114838ms step_avg:96.42ms
+step:1192/1700 train_time:114939ms step_avg:96.42ms
+step:1193/1700 train_time:115038ms step_avg:96.43ms
+step:1194/1700 train_time:115138ms step_avg:96.43ms
+step:1195/1700 train_time:115238ms step_avg:96.43ms
+step:1196/1700 train_time:115338ms step_avg:96.44ms
+step:1197/1700 train_time:115439ms step_avg:96.44ms
+step:1198/1700 train_time:115539ms step_avg:96.44ms
+step:1199/1700 train_time:115640ms step_avg:96.45ms
+step:1200/1700 train_time:115740ms step_avg:96.45ms
+step:1201/1700 train_time:115841ms step_avg:96.45ms
+step:1202/1700 train_time:115942ms step_avg:96.46ms
+step:1203/1700 train_time:116043ms step_avg:96.46ms
+step:1204/1700 train_time:116143ms step_avg:96.46ms
+step:1205/1700 train_time:116244ms step_avg:96.47ms
+step:1206/1700 train_time:116345ms step_avg:96.47ms
+step:1207/1700 train_time:116446ms step_avg:96.48ms
+step:1208/1700 train_time:116546ms step_avg:96.48ms
+step:1209/1700 train_time:116647ms step_avg:96.48ms
+step:1210/1700 train_time:116747ms step_avg:96.49ms
+step:1211/1700 train_time:116848ms step_avg:96.49ms
+step:1212/1700 train_time:116949ms step_avg:96.49ms
+step:1213/1700 train_time:117049ms step_avg:96.50ms
+step:1214/1700 train_time:117150ms step_avg:96.50ms
+step:1215/1700 train_time:117251ms step_avg:96.50ms
+step:1216/1700 train_time:117353ms step_avg:96.51ms
+step:1217/1700 train_time:117454ms step_avg:96.51ms
+step:1218/1700 train_time:117554ms step_avg:96.51ms
+step:1219/1700 train_time:117655ms step_avg:96.52ms
+step:1220/1700 train_time:117756ms step_avg:96.52ms
+step:1221/1700 train_time:117856ms step_avg:96.52ms
+step:1222/1700 train_time:117956ms step_avg:96.53ms
+step:1223/1700 train_time:118056ms step_avg:96.53ms
+step:1224/1700 train_time:118156ms step_avg:96.53ms
+step:1225/1700 train_time:118256ms step_avg:96.54ms
+step:1226/1700 train_time:118356ms step_avg:96.54ms
+step:1227/1700 train_time:118457ms step_avg:96.54ms
+step:1228/1700 train_time:118557ms step_avg:96.54ms
+step:1229/1700 train_time:118657ms step_avg:96.55ms
+step:1230/1700 train_time:118756ms step_avg:96.55ms
+step:1231/1700 train_time:118856ms step_avg:96.55ms
+step:1232/1700 train_time:118957ms step_avg:96.56ms
+step:1233/1700 train_time:119058ms step_avg:96.56ms
+step:1234/1700 train_time:119157ms step_avg:96.56ms
+step:1235/1700 train_time:119258ms step_avg:96.56ms
+step:1236/1700 train_time:119359ms step_avg:96.57ms
+step:1237/1700 train_time:119459ms step_avg:96.57ms
+step:1238/1700 train_time:119559ms step_avg:96.57ms
+step:1239/1700 train_time:119658ms step_avg:96.58ms
+step:1240/1700 train_time:119758ms step_avg:96.58ms
+step:1241/1700 train_time:119860ms step_avg:96.58ms
+step:1242/1700 train_time:119961ms step_avg:96.59ms
+step:1243/1700 train_time:120061ms step_avg:96.59ms
+step:1244/1700 train_time:120162ms step_avg:96.59ms
+step:1245/1700 train_time:120263ms step_avg:96.60ms
+step:1246/1700 train_time:120364ms step_avg:96.60ms
+step:1247/1700 train_time:120463ms step_avg:96.60ms
+step:1248/1700 train_time:120564ms step_avg:96.61ms
+step:1249/1700 train_time:120665ms step_avg:96.61ms
+step:1250/1700 train_time:120765ms step_avg:96.61ms
+step:1250/1700 val_loss:3.3962 train_time:120848ms step_avg:96.68ms
+step:1251/1700 train_time:120871ms step_avg:96.62ms
+step:1252/1700 train_time:120973ms step_avg:96.62ms
+step:1253/1700 train_time:121074ms step_avg:96.63ms
+step:1254/1700 train_time:121174ms step_avg:96.63ms
+step:1255/1700 train_time:121275ms step_avg:96.63ms
+step:1256/1700 train_time:121375ms step_avg:96.64ms
+step:1257/1700 train_time:121474ms step_avg:96.64ms
+step:1258/1700 train_time:121573ms step_avg:96.64ms
+step:1259/1700 train_time:121672ms step_avg:96.64ms
+step:1260/1700 train_time:121773ms step_avg:96.65ms
+step:1261/1700 train_time:121875ms step_avg:96.65ms
+step:1262/1700 train_time:121978ms step_avg:96.65ms
+step:1263/1700 train_time:122080ms step_avg:96.66ms
+step:1264/1700 train_time:122181ms step_avg:96.66ms
+step:1265/1700 train_time:122281ms step_avg:96.66ms
+step:1266/1700 train_time:122381ms step_avg:96.67ms
+step:1267/1700 train_time:122480ms step_avg:96.67ms
+step:1268/1700 train_time:122580ms step_avg:96.67ms
+step:1269/1700 train_time:122681ms step_avg:96.68ms
+step:1270/1700 train_time:122781ms step_avg:96.68ms
+step:1271/1700 train_time:122884ms step_avg:96.68ms
+step:1272/1700 train_time:122986ms step_avg:96.69ms
+step:1273/1700 train_time:123086ms step_avg:96.69ms
+step:1274/1700 train_time:123187ms step_avg:96.69ms
+step:1275/1700 train_time:123288ms step_avg:96.70ms
+step:1276/1700 train_time:123388ms step_avg:96.70ms
+step:1277/1700 train_time:123488ms step_avg:96.70ms
+step:1278/1700 train_time:123589ms step_avg:96.70ms
+step:1279/1700 train_time:123691ms step_avg:96.71ms
+step:1280/1700 train_time:123791ms step_avg:96.71ms
+step:1281/1700 train_time:123892ms step_avg:96.72ms
+step:1282/1700 train_time:123992ms step_avg:96.72ms
+step:1283/1700 train_time:124093ms step_avg:96.72ms
+step:1284/1700 train_time:124193ms step_avg:96.72ms
+step:1285/1700 train_time:124293ms step_avg:96.73ms
+step:1286/1700 train_time:124393ms step_avg:96.73ms
+step:1287/1700 train_time:124493ms step_avg:96.73ms
+step:1288/1700 train_time:124593ms step_avg:96.73ms
+step:1289/1700 train_time:124693ms step_avg:96.74ms
+step:1290/1700 train_time:124793ms step_avg:96.74ms
+step:1291/1700 train_time:124895ms step_avg:96.74ms
+step:1292/1700 train_time:124996ms step_avg:96.75ms
+step:1293/1700 train_time:125096ms step_avg:96.75ms
+step:1294/1700 train_time:125199ms step_avg:96.75ms
+step:1295/1700 train_time:125300ms step_avg:96.76ms
+step:1296/1700 train_time:125401ms step_avg:96.76ms
+step:1297/1700 train_time:125501ms step_avg:96.76ms
+step:1298/1700 train_time:125601ms step_avg:96.77ms
+step:1299/1700 train_time:125702ms step_avg:96.77ms
+step:1300/1700 train_time:125802ms step_avg:96.77ms
+step:1301/1700 train_time:125903ms step_avg:96.77ms
+step:1302/1700 train_time:126004ms step_avg:96.78ms
+step:1303/1700 train_time:126105ms step_avg:96.78ms
+step:1304/1700 train_time:126206ms step_avg:96.78ms
+step:1305/1700 train_time:126306ms step_avg:96.79ms
+step:1306/1700 train_time:126408ms step_avg:96.79ms
+step:1307/1700 train_time:126508ms step_avg:96.79ms
+step:1308/1700 train_time:126609ms step_avg:96.80ms
+step:1309/1700 train_time:126709ms step_avg:96.80ms
+step:1310/1700 train_time:126809ms step_avg:96.80ms
+step:1311/1700 train_time:126910ms step_avg:96.80ms
+step:1312/1700 train_time:127011ms step_avg:96.81ms
+step:1313/1700 train_time:127112ms step_avg:96.81ms
+step:1314/1700 train_time:127212ms step_avg:96.81ms
+step:1315/1700 train_time:127313ms step_avg:96.82ms
+step:1316/1700 train_time:127413ms step_avg:96.82ms
+step:1317/1700 train_time:127513ms step_avg:96.82ms
+step:1318/1700 train_time:127612ms step_avg:96.82ms
+step:1319/1700 train_time:127713ms step_avg:96.83ms
+step:1320/1700 train_time:127814ms step_avg:96.83ms
+step:1321/1700 train_time:127916ms step_avg:96.83ms
+step:1322/1700 train_time:128016ms step_avg:96.84ms
+step:1323/1700 train_time:128117ms step_avg:96.84ms
+step:1324/1700 train_time:128218ms step_avg:96.84ms
+step:1325/1700 train_time:128320ms step_avg:96.85ms
+step:1326/1700 train_time:128420ms step_avg:96.85ms
+step:1327/1700 train_time:128520ms step_avg:96.85ms
+step:1328/1700 train_time:128620ms step_avg:96.85ms
+step:1329/1700 train_time:128720ms step_avg:96.85ms
+step:1330/1700 train_time:128821ms step_avg:96.86ms
+step:1331/1700 train_time:128922ms step_avg:96.86ms
+step:1332/1700 train_time:129023ms step_avg:96.86ms
+step:1333/1700 train_time:129124ms step_avg:96.87ms
+step:1334/1700 train_time:129225ms step_avg:96.87ms
+step:1335/1700 train_time:129326ms step_avg:96.87ms
+step:1336/1700 train_time:129425ms step_avg:96.88ms
+step:1337/1700 train_time:129526ms step_avg:96.88ms
+step:1338/1700 train_time:129626ms step_avg:96.88ms
+step:1339/1700 train_time:129727ms step_avg:96.88ms
+step:1340/1700 train_time:129828ms step_avg:96.89ms
+step:1341/1700 train_time:129930ms step_avg:96.89ms
+step:1342/1700 train_time:130030ms step_avg:96.89ms
+step:1343/1700 train_time:130131ms step_avg:96.90ms
+step:1344/1700 train_time:130231ms step_avg:96.90ms
+step:1345/1700 train_time:130331ms step_avg:96.90ms
+step:1346/1700 train_time:130433ms step_avg:96.90ms
+step:1347/1700 train_time:130533ms step_avg:96.91ms
+step:1348/1700 train_time:130634ms step_avg:96.91ms
+step:1349/1700 train_time:130735ms step_avg:96.91ms
+step:1350/1700 train_time:130836ms step_avg:96.92ms
+step:1351/1700 train_time:130937ms step_avg:96.92ms
+step:1352/1700 train_time:131039ms step_avg:96.92ms
+step:1353/1700 train_time:131140ms step_avg:96.93ms
+step:1354/1700 train_time:131239ms step_avg:96.93ms
+step:1355/1700 train_time:131340ms step_avg:96.93ms
+step:1356/1700 train_time:131441ms step_avg:96.93ms
+step:1357/1700 train_time:131541ms step_avg:96.94ms
+step:1358/1700 train_time:131641ms step_avg:96.94ms
+step:1359/1700 train_time:131742ms step_avg:96.94ms
+step:1360/1700 train_time:131842ms step_avg:96.94ms
+step:1361/1700 train_time:131943ms step_avg:96.95ms
+step:1362/1700 train_time:132043ms step_avg:96.95ms
+step:1363/1700 train_time:132144ms step_avg:96.95ms
+step:1364/1700 train_time:132245ms step_avg:96.95ms
+step:1365/1700 train_time:132346ms step_avg:96.96ms
+step:1366/1700 train_time:132446ms step_avg:96.96ms
+step:1367/1700 train_time:132547ms step_avg:96.96ms
+step:1368/1700 train_time:132648ms step_avg:96.96ms
+step:1369/1700 train_time:132748ms step_avg:96.97ms
+step:1370/1700 train_time:132848ms step_avg:96.97ms
+step:1371/1700 train_time:132949ms step_avg:96.97ms
+step:1372/1700 train_time:133049ms step_avg:96.97ms
+step:1373/1700 train_time:133151ms step_avg:96.98ms
+step:1374/1700 train_time:133252ms step_avg:96.98ms
+step:1375/1700 train_time:133353ms step_avg:96.98ms
+step:1375/1700 val_loss:3.3566 train_time:133435ms step_avg:97.04ms
+step:1376/1700 train_time:133458ms step_avg:96.99ms
+step:1377/1700 train_time:133563ms step_avg:97.00ms
+step:1378/1700 train_time:133664ms step_avg:97.00ms
+step:1379/1700 train_time:133763ms step_avg:97.00ms
+step:1380/1700 train_time:133864ms step_avg:97.00ms
+step:1381/1700 train_time:133964ms step_avg:97.00ms
+step:1382/1700 train_time:134063ms step_avg:97.01ms
+step:1383/1700 train_time:134163ms step_avg:97.01ms
+step:1384/1700 train_time:134262ms step_avg:97.01ms
+step:1385/1700 train_time:134362ms step_avg:97.01ms
+step:1386/1700 train_time:134465ms step_avg:97.02ms
+step:1387/1700 train_time:134566ms step_avg:97.02ms
+step:1388/1700 train_time:134668ms step_avg:97.02ms
+step:1389/1700 train_time:134770ms step_avg:97.03ms
+step:1390/1700 train_time:134871ms step_avg:97.03ms
+step:1391/1700 train_time:134973ms step_avg:97.03ms
+step:1392/1700 train_time:135074ms step_avg:97.04ms
+step:1393/1700 train_time:135174ms step_avg:97.04ms
+step:1394/1700 train_time:135276ms step_avg:97.04ms
+step:1395/1700 train_time:135377ms step_avg:97.04ms
+step:1396/1700 train_time:135480ms step_avg:97.05ms
+step:1397/1700 train_time:135582ms step_avg:97.05ms
+step:1398/1700 train_time:135683ms step_avg:97.06ms
+step:1399/1700 train_time:135786ms step_avg:97.06ms
+step:1400/1700 train_time:135886ms step_avg:97.06ms
+step:1401/1700 train_time:135989ms step_avg:97.07ms
+step:1402/1700 train_time:136090ms step_avg:97.07ms
+step:1403/1700 train_time:136191ms step_avg:97.07ms
+step:1404/1700 train_time:136292ms step_avg:97.07ms
+step:1405/1700 train_time:136394ms step_avg:97.08ms
+step:1406/1700 train_time:136496ms step_avg:97.08ms
+step:1407/1700 train_time:136599ms step_avg:97.09ms
+step:1408/1700 train_time:136701ms step_avg:97.09ms
+step:1409/1700 train_time:136804ms step_avg:97.09ms
+step:1410/1700 train_time:136904ms step_avg:97.10ms
+step:1411/1700 train_time:137004ms step_avg:97.10ms
+step:1412/1700 train_time:137107ms step_avg:97.10ms
+step:1413/1700 train_time:137208ms step_avg:97.10ms
+step:1414/1700 train_time:137309ms step_avg:97.11ms
+step:1415/1700 train_time:137410ms step_avg:97.11ms
+step:1416/1700 train_time:137512ms step_avg:97.11ms
+step:1417/1700 train_time:137614ms step_avg:97.12ms
+step:1418/1700 train_time:137715ms step_avg:97.12ms
+step:1419/1700 train_time:137817ms step_avg:97.12ms
+step:1420/1700 train_time:137918ms step_avg:97.13ms
+step:1421/1700 train_time:138020ms step_avg:97.13ms
+step:1422/1700 train_time:138120ms step_avg:97.13ms
+step:1423/1700 train_time:138221ms step_avg:97.13ms
+step:1424/1700 train_time:138324ms step_avg:97.14ms
+step:1425/1700 train_time:138425ms step_avg:97.14ms
+step:1426/1700 train_time:138525ms step_avg:97.14ms
+step:1427/1700 train_time:138626ms step_avg:97.15ms
+step:1428/1700 train_time:138728ms step_avg:97.15ms
+step:1429/1700 train_time:138830ms step_avg:97.15ms
+step:1430/1700 train_time:138933ms step_avg:97.16ms
+step:1431/1700 train_time:139034ms step_avg:97.16ms
+step:1432/1700 train_time:139135ms step_avg:97.16ms
+step:1433/1700 train_time:139237ms step_avg:97.16ms
+step:1434/1700 train_time:139339ms step_avg:97.17ms
+step:1435/1700 train_time:139440ms step_avg:97.17ms
+step:1436/1700 train_time:139543ms step_avg:97.17ms
+step:1437/1700 train_time:139646ms step_avg:97.18ms
+step:1438/1700 train_time:139746ms step_avg:97.18ms
+step:1439/1700 train_time:139848ms step_avg:97.18ms
+step:1440/1700 train_time:139953ms step_avg:97.19ms
+step:1441/1700 train_time:140056ms step_avg:97.19ms
+step:1442/1700 train_time:140155ms step_avg:97.20ms
+step:1443/1700 train_time:140256ms step_avg:97.20ms
+step:1444/1700 train_time:140357ms step_avg:97.20ms
+step:1445/1700 train_time:140459ms step_avg:97.20ms
+step:1446/1700 train_time:140560ms step_avg:97.21ms
+step:1447/1700 train_time:140662ms step_avg:97.21ms
+step:1448/1700 train_time:140763ms step_avg:97.21ms
+step:1449/1700 train_time:140865ms step_avg:97.22ms
+step:1450/1700 train_time:140967ms step_avg:97.22ms
+step:1451/1700 train_time:141067ms step_avg:97.22ms
+step:1452/1700 train_time:141168ms step_avg:97.22ms
+step:1453/1700 train_time:141271ms step_avg:97.23ms
+step:1454/1700 train_time:141374ms step_avg:97.23ms
+step:1455/1700 train_time:141475ms step_avg:97.23ms
+step:1456/1700 train_time:141577ms step_avg:97.24ms
+step:1457/1700 train_time:141679ms step_avg:97.24ms
+step:1458/1700 train_time:141780ms step_avg:97.24ms
+step:1459/1700 train_time:141882ms step_avg:97.25ms
+step:1460/1700 train_time:141984ms step_avg:97.25ms
+step:1461/1700 train_time:142084ms step_avg:97.25ms
+step:1462/1700 train_time:142186ms step_avg:97.25ms
+step:1463/1700 train_time:142288ms step_avg:97.26ms
+step:1464/1700 train_time:142389ms step_avg:97.26ms
+step:1465/1700 train_time:142491ms step_avg:97.26ms
+step:1466/1700 train_time:142592ms step_avg:97.27ms
+step:1467/1700 train_time:142693ms step_avg:97.27ms
+step:1468/1700 train_time:142796ms step_avg:97.27ms
+step:1469/1700 train_time:142898ms step_avg:97.28ms
+step:1470/1700 train_time:143000ms step_avg:97.28ms
+step:1471/1700 train_time:143101ms step_avg:97.28ms
+step:1472/1700 train_time:143202ms step_avg:97.28ms
+step:1473/1700 train_time:143303ms step_avg:97.29ms
+step:1474/1700 train_time:143404ms step_avg:97.29ms
+step:1475/1700 train_time:143505ms step_avg:97.29ms
+step:1476/1700 train_time:143607ms step_avg:97.29ms
+step:1477/1700 train_time:143708ms step_avg:97.30ms
+step:1478/1700 train_time:143811ms step_avg:97.30ms
+step:1479/1700 train_time:143913ms step_avg:97.30ms
+step:1480/1700 train_time:144014ms step_avg:97.31ms
+step:1481/1700 train_time:144116ms step_avg:97.31ms
+step:1482/1700 train_time:144217ms step_avg:97.31ms
+step:1483/1700 train_time:144320ms step_avg:97.32ms
+step:1484/1700 train_time:144421ms step_avg:97.32ms
+step:1485/1700 train_time:144523ms step_avg:97.32ms
+step:1486/1700 train_time:144625ms step_avg:97.33ms
+step:1487/1700 train_time:144727ms step_avg:97.33ms
+step:1488/1700 train_time:144829ms step_avg:97.33ms
+step:1489/1700 train_time:144930ms step_avg:97.33ms
+step:1490/1700 train_time:145032ms step_avg:97.34ms
+step:1491/1700 train_time:145133ms step_avg:97.34ms
+step:1492/1700 train_time:145235ms step_avg:97.34ms
+step:1493/1700 train_time:145337ms step_avg:97.35ms
+step:1494/1700 train_time:145438ms step_avg:97.35ms
+step:1495/1700 train_time:145540ms step_avg:97.35ms
+step:1496/1700 train_time:145642ms step_avg:97.35ms
+step:1497/1700 train_time:145742ms step_avg:97.36ms
+step:1498/1700 train_time:145843ms step_avg:97.36ms
+step:1499/1700 train_time:145944ms step_avg:97.36ms
+step:1500/1700 train_time:146046ms step_avg:97.36ms
+step:1500/1700 val_loss:3.3219 train_time:146130ms step_avg:97.42ms
+step:1501/1700 train_time:146154ms step_avg:97.37ms
+step:1502/1700 train_time:146260ms step_avg:97.38ms
+step:1503/1700 train_time:146360ms step_avg:97.38ms
+step:1504/1700 train_time:146460ms step_avg:97.38ms
+step:1505/1700 train_time:146561ms step_avg:97.38ms
+step:1506/1700 train_time:146662ms step_avg:97.38ms
+step:1507/1700 train_time:146763ms step_avg:97.39ms
+step:1508/1700 train_time:146863ms step_avg:97.39ms
+step:1509/1700 train_time:146964ms step_avg:97.39ms
+step:1510/1700 train_time:147067ms step_avg:97.40ms
+step:1511/1700 train_time:147170ms step_avg:97.40ms
+step:1512/1700 train_time:147271ms step_avg:97.40ms
+step:1513/1700 train_time:147373ms step_avg:97.40ms
+step:1514/1700 train_time:147474ms step_avg:97.41ms
+step:1515/1700 train_time:147579ms step_avg:97.41ms
+step:1516/1700 train_time:147680ms step_avg:97.41ms
+step:1517/1700 train_time:147781ms step_avg:97.42ms
+step:1518/1700 train_time:147883ms step_avg:97.42ms
+step:1519/1700 train_time:147987ms step_avg:97.42ms
+step:1520/1700 train_time:148090ms step_avg:97.43ms
+step:1521/1700 train_time:148191ms step_avg:97.43ms
+step:1522/1700 train_time:148294ms step_avg:97.43ms
+step:1523/1700 train_time:148395ms step_avg:97.44ms
+step:1524/1700 train_time:148496ms step_avg:97.44ms
+step:1525/1700 train_time:148599ms step_avg:97.44ms
+step:1526/1700 train_time:148700ms step_avg:97.44ms
+step:1527/1700 train_time:148803ms step_avg:97.45ms
+step:1528/1700 train_time:148907ms step_avg:97.45ms
+step:1529/1700 train_time:149007ms step_avg:97.45ms
+step:1530/1700 train_time:149109ms step_avg:97.46ms
+step:1531/1700 train_time:149210ms step_avg:97.46ms
+step:1532/1700 train_time:149310ms step_avg:97.46ms
+step:1533/1700 train_time:149412ms step_avg:97.46ms
+step:1534/1700 train_time:149513ms step_avg:97.47ms
+step:1535/1700 train_time:149614ms step_avg:97.47ms
+step:1536/1700 train_time:149715ms step_avg:97.47ms
+step:1537/1700 train_time:149817ms step_avg:97.47ms
+step:1538/1700 train_time:149920ms step_avg:97.48ms
+step:1539/1700 train_time:150022ms step_avg:97.48ms
+step:1540/1700 train_time:150124ms step_avg:97.48ms
+step:1541/1700 train_time:150227ms step_avg:97.49ms
+step:1542/1700 train_time:150330ms step_avg:97.49ms
+step:1543/1700 train_time:150431ms step_avg:97.49ms
+step:1544/1700 train_time:150533ms step_avg:97.50ms
+step:1545/1700 train_time:150633ms step_avg:97.50ms
+step:1546/1700 train_time:150734ms step_avg:97.50ms
+step:1547/1700 train_time:150836ms step_avg:97.50ms
+step:1548/1700 train_time:150939ms step_avg:97.51ms
+step:1549/1700 train_time:151041ms step_avg:97.51ms
+step:1550/1700 train_time:151143ms step_avg:97.51ms
+step:1551/1700 train_time:151245ms step_avg:97.51ms
+step:1552/1700 train_time:151346ms step_avg:97.52ms
+step:1553/1700 train_time:151448ms step_avg:97.52ms
+step:1554/1700 train_time:151550ms step_avg:97.52ms
+step:1555/1700 train_time:151652ms step_avg:97.53ms
+step:1556/1700 train_time:151752ms step_avg:97.53ms
+step:1557/1700 train_time:151855ms step_avg:97.53ms
+step:1558/1700 train_time:151957ms step_avg:97.53ms
+step:1559/1700 train_time:152058ms step_avg:97.54ms
+step:1560/1700 train_time:152159ms step_avg:97.54ms
+step:1561/1700 train_time:152261ms step_avg:97.54ms
+step:1562/1700 train_time:152363ms step_avg:97.54ms
+step:1563/1700 train_time:152467ms step_avg:97.55ms
+step:1564/1700 train_time:152568ms step_avg:97.55ms
+step:1565/1700 train_time:152669ms step_avg:97.55ms
+step:1566/1700 train_time:152770ms step_avg:97.55ms
+step:1567/1700 train_time:152872ms step_avg:97.56ms
+step:1568/1700 train_time:152975ms step_avg:97.56ms
+step:1569/1700 train_time:153076ms step_avg:97.56ms
+step:1570/1700 train_time:153178ms step_avg:97.57ms
+step:1571/1700 train_time:153279ms step_avg:97.57ms
+step:1572/1700 train_time:153380ms step_avg:97.57ms
+step:1573/1700 train_time:153484ms step_avg:97.57ms
+step:1574/1700 train_time:153585ms step_avg:97.58ms
+step:1575/1700 train_time:153687ms step_avg:97.58ms
+step:1576/1700 train_time:153790ms step_avg:97.58ms
+step:1577/1700 train_time:153894ms step_avg:97.59ms
+step:1578/1700 train_time:153996ms step_avg:97.59ms
+step:1579/1700 train_time:154096ms step_avg:97.59ms
+step:1580/1700 train_time:154197ms step_avg:97.59ms
+step:1581/1700 train_time:154299ms step_avg:97.60ms
+step:1582/1700 train_time:154400ms step_avg:97.60ms
+step:1583/1700 train_time:154503ms step_avg:97.60ms
+step:1584/1700 train_time:154606ms step_avg:97.61ms
+step:1585/1700 train_time:154707ms step_avg:97.61ms
+step:1586/1700 train_time:154811ms step_avg:97.61ms
+step:1587/1700 train_time:154911ms step_avg:97.61ms
+step:1588/1700 train_time:155013ms step_avg:97.62ms
+step:1589/1700 train_time:155114ms step_avg:97.62ms
+step:1590/1700 train_time:155215ms step_avg:97.62ms
+step:1591/1700 train_time:155318ms step_avg:97.62ms
+step:1592/1700 train_time:155419ms step_avg:97.63ms
+step:1593/1700 train_time:155521ms step_avg:97.63ms
+step:1594/1700 train_time:155628ms step_avg:97.63ms
+step:1595/1700 train_time:155729ms step_avg:97.64ms
+step:1596/1700 train_time:155830ms step_avg:97.64ms
+step:1597/1700 train_time:155932ms step_avg:97.64ms
+step:1598/1700 train_time:156033ms step_avg:97.64ms
+step:1599/1700 train_time:156133ms step_avg:97.64ms
+step:1600/1700 train_time:156234ms step_avg:97.65ms
+step:1601/1700 train_time:156335ms step_avg:97.65ms
+step:1602/1700 train_time:156437ms step_avg:97.65ms
+step:1603/1700 train_time:156540ms step_avg:97.65ms
+step:1604/1700 train_time:156641ms step_avg:97.66ms
+step:1605/1700 train_time:156744ms step_avg:97.66ms
+step:1606/1700 train_time:156845ms step_avg:97.66ms
+step:1607/1700 train_time:156947ms step_avg:97.66ms
+step:1608/1700 train_time:157049ms step_avg:97.67ms
+step:1609/1700 train_time:157150ms step_avg:97.67ms
+step:1610/1700 train_time:157254ms step_avg:97.67ms
+step:1611/1700 train_time:157356ms step_avg:97.68ms
+step:1612/1700 train_time:157459ms step_avg:97.68ms
+step:1613/1700 train_time:157559ms step_avg:97.68ms
+step:1614/1700 train_time:157660ms step_avg:97.68ms
+step:1615/1700 train_time:157761ms step_avg:97.68ms
+step:1616/1700 train_time:157862ms step_avg:97.69ms
+step:1617/1700 train_time:157964ms step_avg:97.69ms
+step:1618/1700 train_time:158065ms step_avg:97.69ms
+step:1619/1700 train_time:158170ms step_avg:97.70ms
+step:1620/1700 train_time:158272ms step_avg:97.70ms
+step:1621/1700 train_time:158373ms step_avg:97.70ms
+step:1622/1700 train_time:158473ms step_avg:97.70ms
+step:1623/1700 train_time:158573ms step_avg:97.70ms
+step:1624/1700 train_time:158675ms step_avg:97.71ms
+step:1625/1700 train_time:158778ms step_avg:97.71ms
+step:1625/1700 val_loss:3.2929 train_time:158862ms step_avg:97.76ms
+step:1626/1700 train_time:158885ms step_avg:97.72ms
+step:1627/1700 train_time:158993ms step_avg:97.72ms
+step:1628/1700 train_time:159094ms step_avg:97.72ms
+step:1629/1700 train_time:159195ms step_avg:97.73ms
+step:1630/1700 train_time:159296ms step_avg:97.73ms
+step:1631/1700 train_time:159397ms step_avg:97.73ms
+step:1632/1700 train_time:159498ms step_avg:97.73ms
+step:1633/1700 train_time:159599ms step_avg:97.73ms
+step:1634/1700 train_time:159701ms step_avg:97.74ms
+step:1635/1700 train_time:159801ms step_avg:97.74ms
+step:1636/1700 train_time:159904ms step_avg:97.74ms
+step:1637/1700 train_time:160007ms step_avg:97.74ms
+step:1638/1700 train_time:160110ms step_avg:97.75ms
+step:1639/1700 train_time:160211ms step_avg:97.75ms
+step:1640/1700 train_time:160312ms step_avg:97.75ms
+step:1641/1700 train_time:160416ms step_avg:97.75ms
+step:1642/1700 train_time:160517ms step_avg:97.76ms
+step:1643/1700 train_time:160619ms step_avg:97.76ms
+step:1644/1700 train_time:160721ms step_avg:97.76ms
+step:1645/1700 train_time:160824ms step_avg:97.77ms
+step:1646/1700 train_time:160928ms step_avg:97.77ms
+step:1647/1700 train_time:161032ms step_avg:97.77ms
+step:1648/1700 train_time:161135ms step_avg:97.78ms
+step:1649/1700 train_time:161239ms step_avg:97.78ms
+step:1650/1700 train_time:161339ms step_avg:97.78ms
+step:1651/1700 train_time:161442ms step_avg:97.78ms
+step:1652/1700 train_time:161542ms step_avg:97.79ms
+step:1653/1700 train_time:161645ms step_avg:97.79ms
+step:1654/1700 train_time:161748ms step_avg:97.79ms
+step:1655/1700 train_time:161850ms step_avg:97.79ms
+step:1656/1700 train_time:161953ms step_avg:97.80ms
+step:1657/1700 train_time:162054ms step_avg:97.80ms
+step:1658/1700 train_time:162156ms step_avg:97.80ms
+step:1659/1700 train_time:162262ms step_avg:97.81ms
+step:1660/1700 train_time:162365ms step_avg:97.81ms
+step:1661/1700 train_time:162469ms step_avg:97.81ms
+step:1662/1700 train_time:162572ms step_avg:97.82ms
+step:1663/1700 train_time:162674ms step_avg:97.82ms
+step:1664/1700 train_time:162777ms step_avg:97.82ms
+step:1665/1700 train_time:162880ms step_avg:97.83ms
+step:1666/1700 train_time:162983ms step_avg:97.83ms
+step:1667/1700 train_time:163084ms step_avg:97.83ms
+step:1668/1700 train_time:163188ms step_avg:97.83ms
+step:1669/1700 train_time:163292ms step_avg:97.84ms
+step:1670/1700 train_time:163393ms step_avg:97.84ms
+step:1671/1700 train_time:163495ms step_avg:97.84ms
+step:1672/1700 train_time:163598ms step_avg:97.85ms
+step:1673/1700 train_time:163699ms step_avg:97.85ms
+step:1674/1700 train_time:163802ms step_avg:97.85ms
+step:1675/1700 train_time:163903ms step_avg:97.85ms
+step:1676/1700 train_time:164006ms step_avg:97.86ms
+step:1677/1700 train_time:164108ms step_avg:97.86ms
+step:1678/1700 train_time:164211ms step_avg:97.86ms
+step:1679/1700 train_time:164314ms step_avg:97.86ms
+step:1680/1700 train_time:164416ms step_avg:97.87ms
+step:1681/1700 train_time:164521ms step_avg:97.87ms
+step:1682/1700 train_time:164624ms step_avg:97.87ms
+step:1683/1700 train_time:164725ms step_avg:97.88ms
+step:1684/1700 train_time:164829ms step_avg:97.88ms
+step:1685/1700 train_time:164932ms step_avg:97.88ms
+step:1686/1700 train_time:165034ms step_avg:97.88ms
+step:1687/1700 train_time:165136ms step_avg:97.89ms
+step:1688/1700 train_time:165237ms step_avg:97.89ms
+step:1689/1700 train_time:165340ms step_avg:97.89ms
+step:1690/1700 train_time:165442ms step_avg:97.89ms
+step:1691/1700 train_time:165543ms step_avg:97.90ms
+step:1692/1700 train_time:165644ms step_avg:97.90ms
+step:1693/1700 train_time:165746ms step_avg:97.90ms
+step:1694/1700 train_time:165848ms step_avg:97.90ms
+step:1695/1700 train_time:165951ms step_avg:97.91ms
+step:1696/1700 train_time:166053ms step_avg:97.91ms
+step:1697/1700 train_time:166159ms step_avg:97.91ms
+step:1698/1700 train_time:166261ms step_avg:97.92ms
+step:1699/1700 train_time:166362ms step_avg:97.92ms
+step:1700/1700 train_time:166465ms step_avg:97.92ms
+step:1700/1700 val_loss:3.2793 train_time:166548ms step_avg:97.97ms
+peak memory allocated: 33278 MiB reserved: 49252 MiB

--- a/records/101225_NorMuon/77d606d2-0239-46d8-9975-98db377503c2.txt
+++ b/records/101225_NorMuon/77d606d2-0239-46d8-9975-98db377503c2.txt
@@ -1,0 +1,2512 @@
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+import copy
+import glob
+from dataclasses import dataclass
+from functools import lru_cache, partial # Added partial for hook registration
+from pathlib import Path
+
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+torch.empty(1, device="cuda", requires_grad=True).backward() # prevents a bug on some systems
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+# use of FlexAttention contributed by @KoszarskyB
+from torch.nn.attention.flex_attention import BlockMask, flex_attention
+#torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+@torch.compile
+def zeropower_via_newtonschulz5(G: Tensor, steps: int) -> Tensor:
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert G.ndim >= 2 # batched Muon implementation by @scottjmaddox, and put into practice in the record by @YouJiacheng
+    a, b, c = (3.4445, -4.7750,  2.0315)
+    X = G
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * A @ A # quintic computation strategy adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+class NorMuon(torch.optim.Optimizer):
+
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        params = list(params)
+        sizes = {p.shape for p in params}
+        # create one buffer per unique parameter-size
+        param_groups = []
+        for size in sizes:
+            group_params = [p for p in params if p.shape == size]
+            param_groups.append(dict(params=group_params))
+        super().__init__(param_groups, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient systems-wise implementation of step developed by @YouJiacheng,
+        # @KonstantinWilleke, @alexrgilbert, @adricarda, @tuttyfrutyee, @vdlad,
+        # @ryanyang0, and @vagrawal.
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        reduce_scatter_futures: list[torch.Future] = []
+        all_reduce_futures: list[torch.Future] = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            grad = torch.empty_like(params[-1])
+            grad_pad = [param.grad for param in params] + [torch.zeros_like(params[-1])] * world_size
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    grad = params[base_i + rank].grad
+                else:
+                    grad = torch.zeros_like(grad)
+                # This gives strange dynamo warnings
+                reduce_scatter_futures.append(dist.reduce_scatter(grad, grad_pad[base_i:base_i + world_size], op=dist.ReduceOp.AVG, async_op=True).get_future())
+
+        idx = 0
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * world_size
+            momentum = group["momentum"]
+            beta2 = group["beta2"]
+            for base_i in range(0, len(params), world_size):
+                reduce_scatter_futures[idx].wait()
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    grad = p.grad
+                    eff_lr = group["lr"] * max(1, p.size(-2) / p.size(-1)) ** 0.5 * getattr(p, "lr_mul", 1.0)
+                    eff_weight_decay = group["lr"] * group["weight_decay"] * getattr(p, "wd_mul", 1.0)
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum_buffer"] = torch.zeros_like(grad)
+                        state["second_momentum_buffer"] = torch.zeros_like(grad[..., 0:1]) if p.size(-2) >= p.size(-1) else torch.zeros_like(grad[0:1, ...])
+                    momentum_buffer = state["momentum_buffer"]
+                    second_momentum_buffer = state["second_momentum_buffer"]
+                    p.mul_(1 - eff_weight_decay)
+                    momentum_buffer.lerp_(grad, 1 - momentum)
+                    grad = grad.lerp_(momentum_buffer, momentum)
+                    v = zeropower_via_newtonschulz5(grad.bfloat16(), 5).float()
+                    ###################################
+                    vnorm = v.norm(dim=(-2,-1), keepdim=True)
+                    v_mean = torch.mean(v * v, dim=-1, keepdim=True) if p.size(-2) >= p.size(-1) else torch.mean(v * v, dim=-2, keepdim=True)
+                    second_momentum_buffer.lerp_(v_mean, 1 - beta2)
+                    step_size = 1 / second_momentum_buffer.sqrt().add_(1e-10)
+                    v.mul_(step_size)
+                    vnorm_new = v.norm(dim=(-2,-1), keepdim=True)
+                    v.mul_(vnorm / (vnorm_new + 1e-10))
+                    ####################################
+                    p.add_(other=v, alpha=-eff_lr)
+                idx += 1
+                all_reduce_futures.append(dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank], async_op=True).get_future())
+        torch.futures.collect_all(all_reduce_futures).wait()
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        sizes = {p.shape for p in params}
+        # create one buffer per unique parameter-size
+        param_groups = []
+        for size in sizes:
+            group_params = [p for p in params if p.shape == size]
+            param_groups.append(dict(params=group_params))
+        super().__init__(param_groups, defaults)
+        # DistributedAdam implementation by @vagrawal
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        reduce_scatter_futures: list[torch.Future] = []
+        all_reduce_futures: list[torch.Future] = []
+        grad_slices = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            grad = torch.empty_like(params[-1])
+            for base_i in range(len(params)):
+                grad = params[base_i].grad
+                rank_size = grad.shape[0] // world_size
+                grad_slice = torch.empty_like(grad[:rank_size])
+                reduce_scatter_futures.append(dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future())
+                grad_slices.append(grad_slice)
+
+        idx = 0
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            params = group['params']
+            for base in range(len(params)):
+                reduce_scatter_futures[idx].wait()
+                p = params[base]
+                rank_size = p.shape[0] // world_size
+                p_slice = p[rank * rank_size:(rank + 1) * rank_size]
+                lr = group['lr'] * getattr(p, "lr_mul", 1.0)
+                state = self.state[p]
+                g_slice = grad_slices[idx]
+                # State init
+                if not state:
+                    state['step'] = torch.tensor(0, dtype=torch.int64, device=p.device)
+                    state['exp_avg'] = torch.zeros_like(p_slice)
+                    state['exp_avg_sq'] = torch.zeros_like(p_slice)
+                exp_avg = state['exp_avg']
+                exp_avg_sq = state['exp_avg_sq']
+                state['step'] += 1
+                t = state['step']
+                # weight decay
+                if wd != 0:
+                    eff_weight_decay = lr * wd * getattr(p, "wd_mul", 1.0)
+                    p_slice.mul_(1 - eff_weight_decay)
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (torch.sqrt(bias2) / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                p_slice.add_(other=update, alpha=-1.0)
+                idx += 1
+                all_reduce_futures.append(dist.all_gather_into_tensor(p, p_slice, async_op=True).get_future())
+        torch.futures.collect_all(all_reduce_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        std = 0.5 * (self.in_features ** -0.5) # 0.5 is a bit better than the default 1/sqrt(3)
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.weight.uniform_(-bound, bound)
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, max_seq_len: int):
+        super().__init__()
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(dim//4)])
+        t = torch.arange(max_seq_len, dtype=torch.float32)
+        theta = torch.einsum("i,j -> ij", t, angular_freq)
+        self.cos = nn.Buffer(theta.cos(), persistent=False)
+        self.sin = nn.Buffer(theta.sin(), persistent=False)
+
+    def forward(self, x_BTHD: Tensor):
+        assert self.cos.size(0) >= x_BTHD.size(-3)
+        cos, sin = self.cos[None, :x_BTHD.size(-3), None, :], self.sin[None, :x_BTHD.size(-3), None, :]
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, head_dim=128):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        hdim = num_heads * head_dim
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKV weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        self.qkv_w = nn.Parameter(torch.empty(3, hdim, dim).uniform_(-bound, bound))
+        self.rotary = Rotary(head_dim, max_seq_len)
+        self.c_proj = CastedLinear(hdim, dim)
+        self.c_proj.weight.detach().zero_() # zero init suggested by @Grad62304977
+        # scale the attention logits by given constant, instead of the default head_dim**-0.5, by @leloykun
+        # inspired by learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.12
+
+    def forward(self, x: Tensor, ve: Tensor | None, lambdas: Tensor, block_mask: BlockMask):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q, k, v = F.linear(x, self.qkv_w.flatten(end_dim=1).type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        if ve is not None:
+            v = lambdas[0] * v + lambdas[1] * ve.view_as(v) # @KoszarskyB & @Grad62304977
+        else: # skip mid-layers token value embeddings by @YouJiacheng
+            v = lambdas[0] * v
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, scale=self.attn_scale).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = self.c_proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.c_fc = CastedLinear(dim, hdim)
+        self.c_proj = CastedLinear(hdim, dim)
+        self.c_proj.weight.detach().zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = self.c_fc(x)
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = self.c_proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.7 (the 8th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, num_heads, max_seq_len) if layer_idx != 7 else None
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, ve: Tensor | None, x0: Tensor, lambdas: Tensor, sa_lambdas: Tensor, block_mask: BlockMask):
+        x = lambdas[0] * x + lambdas[1] * x0
+        if self.attn is not None:
+            x = x + self.attn(norm(x), ve, sa_lambdas, block_mask)
+        x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        self.blocks = nn.ModuleList([Block(model_dim, num_heads, max_seq_len, i) for i in range(num_layers)])
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=True, x_s=(model_dim**0.5)/448, w_s=24/448, grad_s=1/448)
+        self.lm_head.weight.detach().zero_() # @Grad62304977
+        # Add learnable skip connection weights for decoder layers
+        assert num_layers % 2 == 0
+        pad = (-num_layers * 5) % dist.get_world_size()
+        self.scalars = nn.Parameter(torch.cat([
+            torch.ones(num_layers), # skip_weights
+            *[torch.tensor([1.0, 0.0]) for _ in range(num_layers)], # block lambdas
+            *[torch.tensor([0.5, 0.5]) for _ in range(num_layers)], # SA lambdas
+            torch.ones(pad),
+        ]))
+        # set learning rates
+        for param in self.embed.parameters():
+            param.lr_mul = 75.
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+        self.lm_head.weight.lr_mul = 27.5
+        self.scalars.lr_mul = 5.0
+
+    def create_blockmasks(self, input_seq: Tensor, sliding_window_num_blocks: Tensor):
+        BLOCK_SIZE = 128
+        docs = (input_seq == 50256).cumsum(0)
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_blockmask: Tensor):
+            num_blocks = dense_blockmask.sum(dim=-1, dtype=torch.int32)
+            indices = dense_blockmask.argsort(dim=-1, descending=False, stable=True).flip(-1).to(torch.int32)
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        # manual block mask creation by @YouJiacheng
+        assert len(input_seq) % BLOCK_SIZE == 0
+        NUM_BLOCKS = len(input_seq) // BLOCK_SIZE
+        block_idx = torch.arange(NUM_BLOCKS, dtype=torch.int32, device="cuda")
+        causal_blockmask_any = block_idx[:, None] >= block_idx
+        causal_blockmask_all = block_idx[:, None] > block_idx
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+        document_blockmask_any = (docs_low[:, None] <= docs_high) & (docs_high[:, None] >= docs_low)
+        document_blockmask_all = (docs_low[:, None] == docs_high) & (docs_high[:, None] == docs_low)
+        blockmask_any = causal_blockmask_any & document_blockmask_any
+        blockmask_all = causal_blockmask_all & document_blockmask_all
+        partial_kv_num_blocks, partial_kv_indices = dense_to_ordered(blockmask_any & ~blockmask_all)
+        full_kv_num_blocks, full_kv_indices = dense_to_ordered(blockmask_all)
+        def build_bm(window_size_blocks: Tensor) -> BlockMask:
+            return BlockMask.from_kv_blocks(
+                torch.clamp_max(partial_kv_num_blocks, torch.clamp_min(window_size_blocks - full_kv_num_blocks, 1)),
+                partial_kv_indices,
+                torch.clamp_max(full_kv_num_blocks, window_size_blocks - 1),
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+        # Long-short SWA block masks by @leloykun & @YouJiacheng, adapated from suggestion by @Grad62304977, following Gemma 2 paper
+        return build_bm(sliding_window_num_blocks), build_bm(sliding_window_num_blocks // 2)
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, sliding_window_num_blocks: Tensor):
+        assert input_seq.ndim == 1
+
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        ve = [ve[0], ve[1], ve[2]] + [None] * (len(self.blocks) - 6) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == len(self.blocks)
+
+        long_bm, short_bm = self.create_blockmasks(input_seq, sliding_window_num_blocks)
+        block_masks = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(block_masks) == len(self.blocks)
+
+        x = x0 = norm(self.embed(input_seq)[None]) # use of norm here by @Grad62304977
+
+        # U-net design by @brendanh0gan
+        skip_connections = []
+        skip_weights = self.scalars[:(len(self.blocks) // 2)]
+        lambdas = self.scalars[1 * len(self.blocks): 3 * len(self.blocks)].view(-1, 2)
+        sa_lambdas = self.scalars[3 * len(self.blocks): 5 * len(self.blocks)].view(-1, 2)
+
+        n = len(self.blocks) // 2
+
+        for i in range(len(self.blocks)):
+            if i >= n:
+                x = x + skip_weights[i - n] * skip_connections.pop()
+            x = self.blocks[i](x, ve[i], x0, lambdas[i], sa_lambdas[i], block_masks[i])
+            if i < n:
+                skip_connections.append(x)
+
+        x = norm(x)
+        logits = self.lm_head(x).float()
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15, @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1)
+        logits = 30 * torch.sigmoid(logits / (7.5 * x.size(-1)**0.5))
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq, reduction="sum" if self.training else "mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+# find world_size starting indicies, such that each begins with token 50256 and local_batches don't overlap
+def find_batch_starts(tokens: Tensor, pos: int, local_batch_size: int, max_batch_span: int):
+    boundary_mask = tokens[pos : pos + max_batch_span] == 50256
+    boundary_positions = torch.nonzero(boundary_mask, as_tuple=False).squeeze(-1) + pos
+    start = boundary_positions[0].item()
+    starts = []
+    for i in range(1, len(boundary_positions)):
+        end = boundary_positions[i].item() 
+        if end - start >= local_batch_size:
+            starts.append(start) # append start once end pos is confirmed
+            if len(starts) == dist.get_world_size():
+                return starts, end - pos
+            start = end
+    assert False # increase max_batch_span if necessary
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, align_to_bos: bool):
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files) # use itertools.cycle(files) instead if you want to do multi-epoch training
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    max_batch_span = 2 * batch_size if align_to_bos else batch_size # provide buffer to handle samples up to length local_batch_size
+    while True:
+        if pos + max_batch_span + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        if align_to_bos:
+            batch_starts, batch_span = find_batch_starts(tokens, pos, local_batch_size, max_batch_span)
+            start_idx = batch_starts[rank]
+        else:
+            batch_span = batch_size
+            start_idx = pos + rank * local_batch_size
+        buf = tokens[start_idx:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # no sync on host side;
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # H2D in another stream isn't helpful.
+        pos += batch_span
+        yield inputs, targets
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    train_seq_len = 48*1024 # FlexAttention sequence length
+    val_seq_len = 4*64*1024 # FlexAttention sequence length for validation
+    # optimization
+    num_iterations = 1700 # number of iterations to run
+    cooldown_frac = 0.45 # fraction of training spent cooling down the learning rate
+    # evaluation and logging
+    val_loss_every = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint = False
+args = Hyperparameters()
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert world_size == 8 # this code is designed for 8xH100
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = uuid.uuid4()
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(vocab_size=50257, num_layers=12, num_heads=6, model_dim=768, max_seq_len=max(args.train_seq_len, args.val_seq_len)).cuda()
+for m in model.modules():
+    if isinstance(m, nn.Embedding):
+        m.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+# collect the parameters to optimize
+hidden_matrix_params = [p for n, p in model.blocks.named_parameters() if p.ndim >= 2 and "embed" not in n]
+embed_params = [p for n, p in model.named_parameters() if "embed" in n]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+head_params = [model.lm_head.weight]
+
+# init the optimizer(s)
+# small adam epsilon by @YouJiacheng. this is an alternate method of fixing the world_size dependence
+# discovered by @fernbear.bsky.social https://x.com/hi_tysam/status/1879692937589875094
+optimizer1 = DistAdam(scalar_params + head_params + embed_params, lr=0.008, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.0)
+optimizer2 = NorMuon(hidden_matrix_params, lr=0.05, momentum=0.95, weight_decay=0.0, beta2=0.95)
+optimizers = [optimizer1, optimizer2]
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+
+# learning rate schedule: stable then decay
+def get_lr(step: int):
+    x = step / args.num_iterations # progress in training
+    assert 0 <= x < 1
+    if x < 1 - args.cooldown_frac:
+        return 1.0
+    else:
+        w = (1 - x) / args.cooldown_frac
+        return w * 1.0 + (1 - w) * 0.1
+
+# attention window size schedule: linearly increase
+@lru_cache(1)
+def get_window_size_blocks_helper(window_size: int):
+    return torch.tensor(window_size // 128, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
+def get_window_size_blocks(step: int):
+    x = step / args.num_iterations # progress in training
+    assert 0 <= x <= 1
+    # Linearly increase the block-wise sliding window size over training 128 -> 1792
+    # increase by @fernbear.bsky.social; block-wise by @YouJiacheng
+    window_size = next_multiple_of_n(1728 * x, n=128)
+    return get_window_size_blocks_helper(window_size)
+
+model: nn.Module = torch.compile(model, dynamic=False)
+
+########################################
+#            Warmup kernels            #
+########################################
+
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+warmup_steps = 10
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=[copy.deepcopy(opt.state_dict()) for opt in optimizers]) # save the initial state
+train_loader = distributed_data_generator(args.train_files, world_size * args.train_seq_len, align_to_bos=True)
+for _ in range(warmup_steps):
+    inputs, targets = next(train_loader)
+    model(inputs, targets, get_window_size_blocks(1)).backward()
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+for opt, opt_state in zip(optimizers, initial_state["optimizers"]):
+    opt.load_state_dict(opt_state)
+del train_loader, initial_state
+
+########################################
+#        Training and validation       #
+########################################
+
+train_loader = distributed_data_generator(args.train_files, world_size * args.train_seq_len, align_to_bos=True)
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        val_batch_size = world_size * args.val_seq_len
+        assert args.val_tokens % val_batch_size == 0
+        val_steps = args.val_tokens // val_batch_size
+        val_loader = distributed_data_generator(args.val_files, val_batch_size, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets = next(val_loader)
+                val_loss += model(inputs, targets, get_window_size_blocks(step))
+        val_loss /= val_steps
+        del val_loader
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    model(inputs, targets, get_window_size_blocks(step)).backward()
+    # set optimization hyperparameters
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["lr"] = group["initial_lr"] * get_lr(step)
+    for group in optimizer2.param_groups:
+        frac = min(step / 300, 1) # momentum warmup for muon
+        group["momentum"] = (1 - frac) * 0.85 + frac * 0.95
+    # step the optimizers
+    for opt in optimizers:
+        opt.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.12.7 (main, Oct 11 2025, 17:06:43) [GCC 13.2.0]
+Running PyTorch 2.10.0.dev20251011+cu126 compiled for CUDA 12.6
+Mon Oct 13 03:30:34 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000001:00:00.0 Off |                    0 |
+| N/A   32C    P0            113W /  700W |    5858MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000002:00:00.0 Off |                    0 |
+| N/A   33C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000003:00:00.0 Off |                    0 |
+| N/A   30C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000008:00:00.0 Off |                    0 |
+| N/A   29C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000009:00:00.0 Off |                    0 |
+| N/A   28C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   0000000A:00:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   0000000B:00:00.0 Off |                    0 |
+| N/A   29C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   0000000C:00:00.0 Off |                    0 |
+| N/A   31C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+step:0/1700 val_loss:10.8258 train_time:0ms step_avg:0.16ms
+step:1/1700 train_time:142ms step_avg:142.26ms
+step:2/1700 train_time:167ms step_avg:83.61ms
+step:3/1700 train_time:249ms step_avg:83.07ms
+step:4/1700 train_time:341ms step_avg:85.15ms
+step:5/1700 train_time:433ms step_avg:86.56ms
+step:6/1700 train_time:525ms step_avg:87.44ms
+step:7/1700 train_time:617ms step_avg:88.11ms
+step:8/1700 train_time:709ms step_avg:88.59ms
+step:9/1700 train_time:801ms step_avg:88.96ms
+step:10/1700 train_time:894ms step_avg:89.36ms
+step:11/1700 train_time:986ms step_avg:89.62ms
+step:12/1700 train_time:1081ms step_avg:90.05ms
+step:13/1700 train_time:1176ms step_avg:90.44ms
+step:14/1700 train_time:1270ms step_avg:90.70ms
+step:15/1700 train_time:1363ms step_avg:90.84ms
+step:16/1700 train_time:1456ms step_avg:90.98ms
+step:17/1700 train_time:1548ms step_avg:91.08ms
+step:18/1700 train_time:1641ms step_avg:91.15ms
+step:19/1700 train_time:1734ms step_avg:91.24ms
+step:20/1700 train_time:1826ms step_avg:91.29ms
+step:21/1700 train_time:1918ms step_avg:91.34ms
+step:22/1700 train_time:2012ms step_avg:91.43ms
+step:23/1700 train_time:2105ms step_avg:91.53ms
+step:24/1700 train_time:2199ms step_avg:91.61ms
+step:25/1700 train_time:2293ms step_avg:91.73ms
+step:26/1700 train_time:2386ms step_avg:91.77ms
+step:27/1700 train_time:2479ms step_avg:91.81ms
+step:28/1700 train_time:2572ms step_avg:91.87ms
+step:29/1700 train_time:2664ms step_avg:91.87ms
+step:30/1700 train_time:2757ms step_avg:91.89ms
+step:31/1700 train_time:2849ms step_avg:91.91ms
+step:32/1700 train_time:2942ms step_avg:91.95ms
+step:33/1700 train_time:3035ms step_avg:91.96ms
+step:34/1700 train_time:3128ms step_avg:92.00ms
+step:35/1700 train_time:3222ms step_avg:92.07ms
+step:36/1700 train_time:3316ms step_avg:92.11ms
+step:37/1700 train_time:3409ms step_avg:92.14ms
+step:38/1700 train_time:3502ms step_avg:92.16ms
+step:39/1700 train_time:3595ms step_avg:92.19ms
+step:40/1700 train_time:3688ms step_avg:92.19ms
+step:41/1700 train_time:3780ms step_avg:92.18ms
+step:42/1700 train_time:3873ms step_avg:92.21ms
+step:43/1700 train_time:3966ms step_avg:92.23ms
+step:44/1700 train_time:4058ms step_avg:92.24ms
+step:45/1700 train_time:4152ms step_avg:92.27ms
+step:46/1700 train_time:4245ms step_avg:92.28ms
+step:47/1700 train_time:4338ms step_avg:92.30ms
+step:48/1700 train_time:4432ms step_avg:92.32ms
+step:49/1700 train_time:4524ms step_avg:92.33ms
+step:50/1700 train_time:4618ms step_avg:92.35ms
+step:51/1700 train_time:4711ms step_avg:92.38ms
+step:52/1700 train_time:4803ms step_avg:92.37ms
+step:53/1700 train_time:4896ms step_avg:92.38ms
+step:54/1700 train_time:4989ms step_avg:92.39ms
+step:55/1700 train_time:5081ms step_avg:92.39ms
+step:56/1700 train_time:5174ms step_avg:92.39ms
+step:57/1700 train_time:5267ms step_avg:92.41ms
+step:58/1700 train_time:5360ms step_avg:92.41ms
+step:59/1700 train_time:5453ms step_avg:92.43ms
+step:60/1700 train_time:5546ms step_avg:92.44ms
+step:61/1700 train_time:5639ms step_avg:92.44ms
+step:62/1700 train_time:5732ms step_avg:92.46ms
+step:63/1700 train_time:5825ms step_avg:92.47ms
+step:64/1700 train_time:5918ms step_avg:92.47ms
+step:65/1700 train_time:6011ms step_avg:92.48ms
+step:66/1700 train_time:6104ms step_avg:92.48ms
+step:67/1700 train_time:6197ms step_avg:92.49ms
+step:68/1700 train_time:6290ms step_avg:92.50ms
+step:69/1700 train_time:6383ms step_avg:92.51ms
+step:70/1700 train_time:6476ms step_avg:92.51ms
+step:71/1700 train_time:6570ms step_avg:92.53ms
+step:72/1700 train_time:6662ms step_avg:92.53ms
+step:73/1700 train_time:6755ms step_avg:92.54ms
+step:74/1700 train_time:6848ms step_avg:92.54ms
+step:75/1700 train_time:6940ms step_avg:92.53ms
+step:76/1700 train_time:7034ms step_avg:92.55ms
+step:77/1700 train_time:7126ms step_avg:92.55ms
+step:78/1700 train_time:7219ms step_avg:92.56ms
+step:79/1700 train_time:7312ms step_avg:92.56ms
+step:80/1700 train_time:7405ms step_avg:92.56ms
+step:81/1700 train_time:7498ms step_avg:92.57ms
+step:82/1700 train_time:7591ms step_avg:92.57ms
+step:83/1700 train_time:7684ms step_avg:92.57ms
+step:84/1700 train_time:7776ms step_avg:92.57ms
+step:85/1700 train_time:7869ms step_avg:92.58ms
+step:86/1700 train_time:7961ms step_avg:92.57ms
+step:87/1700 train_time:8055ms step_avg:92.58ms
+step:88/1700 train_time:8147ms step_avg:92.58ms
+step:89/1700 train_time:8240ms step_avg:92.58ms
+step:90/1700 train_time:8333ms step_avg:92.58ms
+step:91/1700 train_time:8425ms step_avg:92.58ms
+step:92/1700 train_time:8518ms step_avg:92.58ms
+step:93/1700 train_time:8611ms step_avg:92.59ms
+step:94/1700 train_time:8704ms step_avg:92.59ms
+step:95/1700 train_time:8796ms step_avg:92.59ms
+step:96/1700 train_time:8889ms step_avg:92.60ms
+step:97/1700 train_time:8982ms step_avg:92.60ms
+step:98/1700 train_time:9075ms step_avg:92.61ms
+step:99/1700 train_time:9168ms step_avg:92.61ms
+step:100/1700 train_time:9261ms step_avg:92.61ms
+step:101/1700 train_time:9353ms step_avg:92.61ms
+step:102/1700 train_time:9447ms step_avg:92.61ms
+step:103/1700 train_time:9539ms step_avg:92.61ms
+step:104/1700 train_time:9632ms step_avg:92.61ms
+step:105/1700 train_time:9724ms step_avg:92.61ms
+step:106/1700 train_time:9817ms step_avg:92.62ms
+step:107/1700 train_time:9911ms step_avg:92.62ms
+step:108/1700 train_time:10003ms step_avg:92.62ms
+step:109/1700 train_time:10096ms step_avg:92.63ms
+step:110/1700 train_time:10189ms step_avg:92.63ms
+step:111/1700 train_time:10281ms step_avg:92.63ms
+step:112/1700 train_time:10375ms step_avg:92.63ms
+step:113/1700 train_time:10468ms step_avg:92.64ms
+step:114/1700 train_time:10561ms step_avg:92.64ms
+step:115/1700 train_time:10653ms step_avg:92.64ms
+step:116/1700 train_time:10746ms step_avg:92.64ms
+step:117/1700 train_time:10838ms step_avg:92.63ms
+step:118/1700 train_time:10931ms step_avg:92.64ms
+step:119/1700 train_time:11024ms step_avg:92.64ms
+step:120/1700 train_time:11117ms step_avg:92.64ms
+step:121/1700 train_time:11209ms step_avg:92.64ms
+step:122/1700 train_time:11302ms step_avg:92.64ms
+step:123/1700 train_time:11396ms step_avg:92.65ms
+step:124/1700 train_time:11488ms step_avg:92.65ms
+step:125/1700 train_time:11581ms step_avg:92.65ms
+step:125/1700 val_loss:4.6120 train_time:11657ms step_avg:93.26ms
+step:126/1700 train_time:11684ms step_avg:92.73ms
+step:127/1700 train_time:11772ms step_avg:92.69ms
+step:128/1700 train_time:11871ms step_avg:92.74ms
+step:129/1700 train_time:11966ms step_avg:92.76ms
+step:130/1700 train_time:12059ms step_avg:92.76ms
+step:131/1700 train_time:12151ms step_avg:92.76ms
+step:132/1700 train_time:12244ms step_avg:92.76ms
+step:133/1700 train_time:12337ms step_avg:92.76ms
+step:134/1700 train_time:12429ms step_avg:92.75ms
+step:135/1700 train_time:12522ms step_avg:92.75ms
+step:136/1700 train_time:12614ms step_avg:92.75ms
+step:137/1700 train_time:12708ms step_avg:92.76ms
+step:138/1700 train_time:12802ms step_avg:92.77ms
+step:139/1700 train_time:12896ms step_avg:92.78ms
+step:140/1700 train_time:12991ms step_avg:92.79ms
+step:141/1700 train_time:13085ms step_avg:92.80ms
+step:142/1700 train_time:13178ms step_avg:92.80ms
+step:143/1700 train_time:13271ms step_avg:92.80ms
+step:144/1700 train_time:13365ms step_avg:92.81ms
+step:145/1700 train_time:13457ms step_avg:92.81ms
+step:146/1700 train_time:13549ms step_avg:92.80ms
+step:147/1700 train_time:13643ms step_avg:92.81ms
+step:148/1700 train_time:13736ms step_avg:92.81ms
+step:149/1700 train_time:13830ms step_avg:92.82ms
+step:150/1700 train_time:13924ms step_avg:92.82ms
+step:151/1700 train_time:14018ms step_avg:92.84ms
+step:152/1700 train_time:14112ms step_avg:92.84ms
+step:153/1700 train_time:14206ms step_avg:92.85ms
+step:154/1700 train_time:14298ms step_avg:92.85ms
+step:155/1700 train_time:14391ms step_avg:92.84ms
+step:156/1700 train_time:14484ms step_avg:92.85ms
+step:157/1700 train_time:14578ms step_avg:92.85ms
+step:158/1700 train_time:14671ms step_avg:92.85ms
+step:159/1700 train_time:14765ms step_avg:92.86ms
+step:160/1700 train_time:14858ms step_avg:92.87ms
+step:161/1700 train_time:14952ms step_avg:92.87ms
+step:162/1700 train_time:15046ms step_avg:92.87ms
+step:163/1700 train_time:15139ms step_avg:92.88ms
+step:164/1700 train_time:15232ms step_avg:92.88ms
+step:165/1700 train_time:15326ms step_avg:92.88ms
+step:166/1700 train_time:15419ms step_avg:92.89ms
+step:167/1700 train_time:15512ms step_avg:92.88ms
+step:168/1700 train_time:15605ms step_avg:92.89ms
+step:169/1700 train_time:15699ms step_avg:92.89ms
+step:170/1700 train_time:15792ms step_avg:92.89ms
+step:171/1700 train_time:15885ms step_avg:92.90ms
+step:172/1700 train_time:15979ms step_avg:92.90ms
+step:173/1700 train_time:16072ms step_avg:92.90ms
+step:174/1700 train_time:16166ms step_avg:92.91ms
+step:175/1700 train_time:16260ms step_avg:92.91ms
+step:176/1700 train_time:16353ms step_avg:92.91ms
+step:177/1700 train_time:16446ms step_avg:92.92ms
+step:178/1700 train_time:16539ms step_avg:92.92ms
+step:179/1700 train_time:16632ms step_avg:92.92ms
+step:180/1700 train_time:16726ms step_avg:92.92ms
+step:181/1700 train_time:16819ms step_avg:92.92ms
+step:182/1700 train_time:16912ms step_avg:92.92ms
+step:183/1700 train_time:17006ms step_avg:92.93ms
+step:184/1700 train_time:17100ms step_avg:92.93ms
+step:185/1700 train_time:17193ms step_avg:92.93ms
+step:186/1700 train_time:17287ms step_avg:92.94ms
+step:187/1700 train_time:17380ms step_avg:92.94ms
+step:188/1700 train_time:17473ms step_avg:92.94ms
+step:189/1700 train_time:17567ms step_avg:92.95ms
+step:190/1700 train_time:17660ms step_avg:92.95ms
+step:191/1700 train_time:17753ms step_avg:92.95ms
+step:192/1700 train_time:17846ms step_avg:92.95ms
+step:193/1700 train_time:17940ms step_avg:92.95ms
+step:194/1700 train_time:18033ms step_avg:92.95ms
+step:195/1700 train_time:18127ms step_avg:92.96ms
+step:196/1700 train_time:18220ms step_avg:92.96ms
+step:197/1700 train_time:18314ms step_avg:92.96ms
+step:198/1700 train_time:18407ms step_avg:92.97ms
+step:199/1700 train_time:18501ms step_avg:92.97ms
+step:200/1700 train_time:18594ms step_avg:92.97ms
+step:201/1700 train_time:18687ms step_avg:92.97ms
+step:202/1700 train_time:18780ms step_avg:92.97ms
+step:203/1700 train_time:18872ms step_avg:92.97ms
+step:204/1700 train_time:18967ms step_avg:92.97ms
+step:205/1700 train_time:19060ms step_avg:92.98ms
+step:206/1700 train_time:19153ms step_avg:92.98ms
+step:207/1700 train_time:19247ms step_avg:92.98ms
+step:208/1700 train_time:19341ms step_avg:92.98ms
+step:209/1700 train_time:19433ms step_avg:92.98ms
+step:210/1700 train_time:19526ms step_avg:92.98ms
+step:211/1700 train_time:19620ms step_avg:92.99ms
+step:212/1700 train_time:19713ms step_avg:92.99ms
+step:213/1700 train_time:19807ms step_avg:92.99ms
+step:214/1700 train_time:19900ms step_avg:92.99ms
+step:215/1700 train_time:19993ms step_avg:92.99ms
+step:216/1700 train_time:20086ms step_avg:92.99ms
+step:217/1700 train_time:20180ms step_avg:93.00ms
+step:218/1700 train_time:20273ms step_avg:93.00ms
+step:219/1700 train_time:20367ms step_avg:93.00ms
+step:220/1700 train_time:20460ms step_avg:93.00ms
+step:221/1700 train_time:20553ms step_avg:93.00ms
+step:222/1700 train_time:20647ms step_avg:93.00ms
+step:223/1700 train_time:20740ms step_avg:93.01ms
+step:224/1700 train_time:20833ms step_avg:93.00ms
+step:225/1700 train_time:20926ms step_avg:93.01ms
+step:226/1700 train_time:21019ms step_avg:93.01ms
+step:227/1700 train_time:21112ms step_avg:93.01ms
+step:228/1700 train_time:21206ms step_avg:93.01ms
+step:229/1700 train_time:21300ms step_avg:93.01ms
+step:230/1700 train_time:21392ms step_avg:93.01ms
+step:231/1700 train_time:21486ms step_avg:93.01ms
+step:232/1700 train_time:21580ms step_avg:93.02ms
+step:233/1700 train_time:21673ms step_avg:93.02ms
+step:234/1700 train_time:21767ms step_avg:93.02ms
+step:235/1700 train_time:21860ms step_avg:93.02ms
+step:236/1700 train_time:21954ms step_avg:93.02ms
+step:237/1700 train_time:22047ms step_avg:93.03ms
+step:238/1700 train_time:22141ms step_avg:93.03ms
+step:239/1700 train_time:22234ms step_avg:93.03ms
+step:240/1700 train_time:22327ms step_avg:93.03ms
+step:241/1700 train_time:22421ms step_avg:93.03ms
+step:242/1700 train_time:22513ms step_avg:93.03ms
+step:243/1700 train_time:22607ms step_avg:93.03ms
+step:244/1700 train_time:22701ms step_avg:93.04ms
+step:245/1700 train_time:22794ms step_avg:93.04ms
+step:246/1700 train_time:22887ms step_avg:93.04ms
+step:247/1700 train_time:22981ms step_avg:93.04ms
+step:248/1700 train_time:23074ms step_avg:93.04ms
+step:249/1700 train_time:23168ms step_avg:93.04ms
+step:250/1700 train_time:23261ms step_avg:93.04ms
+step:250/1700 val_loss:4.0731 train_time:23337ms step_avg:93.35ms
+step:251/1700 train_time:23365ms step_avg:93.09ms
+step:252/1700 train_time:23455ms step_avg:93.08ms
+step:253/1700 train_time:23553ms step_avg:93.10ms
+step:254/1700 train_time:23647ms step_avg:93.10ms
+step:255/1700 train_time:23742ms step_avg:93.10ms
+step:256/1700 train_time:23835ms step_avg:93.11ms
+step:257/1700 train_time:23928ms step_avg:93.11ms
+step:258/1700 train_time:24022ms step_avg:93.11ms
+step:259/1700 train_time:24115ms step_avg:93.11ms
+step:260/1700 train_time:24208ms step_avg:93.11ms
+step:261/1700 train_time:24301ms step_avg:93.11ms
+step:262/1700 train_time:24396ms step_avg:93.12ms
+step:263/1700 train_time:24491ms step_avg:93.12ms
+step:264/1700 train_time:24586ms step_avg:93.13ms
+step:265/1700 train_time:24681ms step_avg:93.14ms
+step:266/1700 train_time:24774ms step_avg:93.14ms
+step:267/1700 train_time:24868ms step_avg:93.14ms
+step:268/1700 train_time:24961ms step_avg:93.14ms
+step:269/1700 train_time:25053ms step_avg:93.14ms
+step:270/1700 train_time:25147ms step_avg:93.14ms
+step:271/1700 train_time:25240ms step_avg:93.14ms
+step:272/1700 train_time:25334ms step_avg:93.14ms
+step:273/1700 train_time:25428ms step_avg:93.14ms
+step:274/1700 train_time:25523ms step_avg:93.15ms
+step:275/1700 train_time:25617ms step_avg:93.15ms
+step:276/1700 train_time:25711ms step_avg:93.16ms
+step:277/1700 train_time:25806ms step_avg:93.16ms
+step:278/1700 train_time:25899ms step_avg:93.16ms
+step:279/1700 train_time:25992ms step_avg:93.16ms
+step:280/1700 train_time:26085ms step_avg:93.16ms
+step:281/1700 train_time:26179ms step_avg:93.16ms
+step:282/1700 train_time:26272ms step_avg:93.16ms
+step:283/1700 train_time:26366ms step_avg:93.17ms
+step:284/1700 train_time:26460ms step_avg:93.17ms
+step:285/1700 train_time:26554ms step_avg:93.17ms
+step:286/1700 train_time:26648ms step_avg:93.17ms
+step:287/1700 train_time:26742ms step_avg:93.18ms
+step:288/1700 train_time:26836ms step_avg:93.18ms
+step:289/1700 train_time:26930ms step_avg:93.18ms
+step:290/1700 train_time:27024ms step_avg:93.18ms
+step:291/1700 train_time:27117ms step_avg:93.18ms
+step:292/1700 train_time:27210ms step_avg:93.19ms
+step:293/1700 train_time:27304ms step_avg:93.19ms
+step:294/1700 train_time:27397ms step_avg:93.19ms
+step:295/1700 train_time:27491ms step_avg:93.19ms
+step:296/1700 train_time:27585ms step_avg:93.19ms
+step:297/1700 train_time:27679ms step_avg:93.20ms
+step:298/1700 train_time:27773ms step_avg:93.20ms
+step:299/1700 train_time:27868ms step_avg:93.20ms
+step:300/1700 train_time:27961ms step_avg:93.20ms
+step:301/1700 train_time:28054ms step_avg:93.20ms
+step:302/1700 train_time:28148ms step_avg:93.21ms
+step:303/1700 train_time:28242ms step_avg:93.21ms
+step:304/1700 train_time:28335ms step_avg:93.21ms
+step:305/1700 train_time:28429ms step_avg:93.21ms
+step:306/1700 train_time:28523ms step_avg:93.21ms
+step:307/1700 train_time:28617ms step_avg:93.22ms
+step:308/1700 train_time:28711ms step_avg:93.22ms
+step:309/1700 train_time:28806ms step_avg:93.22ms
+step:310/1700 train_time:28900ms step_avg:93.23ms
+step:311/1700 train_time:28993ms step_avg:93.23ms
+step:312/1700 train_time:29087ms step_avg:93.23ms
+step:313/1700 train_time:29180ms step_avg:93.23ms
+step:314/1700 train_time:29274ms step_avg:93.23ms
+step:315/1700 train_time:29368ms step_avg:93.23ms
+step:316/1700 train_time:29461ms step_avg:93.23ms
+step:317/1700 train_time:29554ms step_avg:93.23ms
+step:318/1700 train_time:29648ms step_avg:93.23ms
+step:319/1700 train_time:29741ms step_avg:93.23ms
+step:320/1700 train_time:29836ms step_avg:93.24ms
+step:321/1700 train_time:29930ms step_avg:93.24ms
+step:322/1700 train_time:30024ms step_avg:93.24ms
+step:323/1700 train_time:30118ms step_avg:93.24ms
+step:324/1700 train_time:30211ms step_avg:93.24ms
+step:325/1700 train_time:30304ms step_avg:93.24ms
+step:326/1700 train_time:30397ms step_avg:93.24ms
+step:327/1700 train_time:30492ms step_avg:93.25ms
+step:328/1700 train_time:30585ms step_avg:93.25ms
+step:329/1700 train_time:30679ms step_avg:93.25ms
+step:330/1700 train_time:30773ms step_avg:93.25ms
+step:331/1700 train_time:30867ms step_avg:93.25ms
+step:332/1700 train_time:30961ms step_avg:93.25ms
+step:333/1700 train_time:31054ms step_avg:93.26ms
+step:334/1700 train_time:31148ms step_avg:93.26ms
+step:335/1700 train_time:31242ms step_avg:93.26ms
+step:336/1700 train_time:31334ms step_avg:93.26ms
+step:337/1700 train_time:31428ms step_avg:93.26ms
+step:338/1700 train_time:31523ms step_avg:93.26ms
+step:339/1700 train_time:31616ms step_avg:93.26ms
+step:340/1700 train_time:31709ms step_avg:93.26ms
+step:341/1700 train_time:31803ms step_avg:93.27ms
+step:342/1700 train_time:31897ms step_avg:93.27ms
+step:343/1700 train_time:31991ms step_avg:93.27ms
+step:344/1700 train_time:32084ms step_avg:93.27ms
+step:345/1700 train_time:32178ms step_avg:93.27ms
+step:346/1700 train_time:32271ms step_avg:93.27ms
+step:347/1700 train_time:32366ms step_avg:93.27ms
+step:348/1700 train_time:32460ms step_avg:93.28ms
+step:349/1700 train_time:32553ms step_avg:93.27ms
+step:350/1700 train_time:32647ms step_avg:93.28ms
+step:351/1700 train_time:32740ms step_avg:93.28ms
+step:352/1700 train_time:32834ms step_avg:93.28ms
+step:353/1700 train_time:32928ms step_avg:93.28ms
+step:354/1700 train_time:33021ms step_avg:93.28ms
+step:355/1700 train_time:33115ms step_avg:93.28ms
+step:356/1700 train_time:33209ms step_avg:93.28ms
+step:357/1700 train_time:33302ms step_avg:93.28ms
+step:358/1700 train_time:33396ms step_avg:93.28ms
+step:359/1700 train_time:33489ms step_avg:93.28ms
+step:360/1700 train_time:33583ms step_avg:93.29ms
+step:361/1700 train_time:33677ms step_avg:93.29ms
+step:362/1700 train_time:33771ms step_avg:93.29ms
+step:363/1700 train_time:33865ms step_avg:93.29ms
+step:364/1700 train_time:33959ms step_avg:93.29ms
+step:365/1700 train_time:34052ms step_avg:93.29ms
+step:366/1700 train_time:34147ms step_avg:93.30ms
+step:367/1700 train_time:34241ms step_avg:93.30ms
+step:368/1700 train_time:34334ms step_avg:93.30ms
+step:369/1700 train_time:34428ms step_avg:93.30ms
+step:370/1700 train_time:34522ms step_avg:93.30ms
+step:371/1700 train_time:34615ms step_avg:93.30ms
+step:372/1700 train_time:34709ms step_avg:93.30ms
+step:373/1700 train_time:34802ms step_avg:93.30ms
+step:374/1700 train_time:34896ms step_avg:93.31ms
+step:375/1700 train_time:34990ms step_avg:93.31ms
+step:375/1700 val_loss:3.8728 train_time:35067ms step_avg:93.51ms
+step:376/1700 train_time:35096ms step_avg:93.34ms
+step:377/1700 train_time:35186ms step_avg:93.33ms
+step:378/1700 train_time:35283ms step_avg:93.34ms
+step:379/1700 train_time:35378ms step_avg:93.34ms
+step:380/1700 train_time:35472ms step_avg:93.35ms
+step:381/1700 train_time:35567ms step_avg:93.35ms
+step:382/1700 train_time:35662ms step_avg:93.36ms
+step:383/1700 train_time:35758ms step_avg:93.36ms
+step:384/1700 train_time:35852ms step_avg:93.37ms
+step:385/1700 train_time:35947ms step_avg:93.37ms
+step:386/1700 train_time:36042ms step_avg:93.37ms
+step:387/1700 train_time:36139ms step_avg:93.38ms
+step:388/1700 train_time:36236ms step_avg:93.39ms
+step:389/1700 train_time:36332ms step_avg:93.40ms
+step:390/1700 train_time:36427ms step_avg:93.40ms
+step:391/1700 train_time:36524ms step_avg:93.41ms
+step:392/1700 train_time:36619ms step_avg:93.42ms
+step:393/1700 train_time:36715ms step_avg:93.42ms
+step:394/1700 train_time:36809ms step_avg:93.42ms
+step:395/1700 train_time:36904ms step_avg:93.43ms
+step:396/1700 train_time:37000ms step_avg:93.43ms
+step:397/1700 train_time:37096ms step_avg:93.44ms
+step:398/1700 train_time:37193ms step_avg:93.45ms
+step:399/1700 train_time:37289ms step_avg:93.45ms
+step:400/1700 train_time:37385ms step_avg:93.46ms
+step:401/1700 train_time:37481ms step_avg:93.47ms
+step:402/1700 train_time:37576ms step_avg:93.47ms
+step:403/1700 train_time:37671ms step_avg:93.48ms
+step:404/1700 train_time:37766ms step_avg:93.48ms
+step:405/1700 train_time:37861ms step_avg:93.49ms
+step:406/1700 train_time:37957ms step_avg:93.49ms
+step:407/1700 train_time:38052ms step_avg:93.49ms
+step:408/1700 train_time:38147ms step_avg:93.50ms
+step:409/1700 train_time:38244ms step_avg:93.51ms
+step:410/1700 train_time:38340ms step_avg:93.51ms
+step:411/1700 train_time:38436ms step_avg:93.52ms
+step:412/1700 train_time:38531ms step_avg:93.52ms
+step:413/1700 train_time:38627ms step_avg:93.53ms
+step:414/1700 train_time:38723ms step_avg:93.53ms
+step:415/1700 train_time:38818ms step_avg:93.54ms
+step:416/1700 train_time:38914ms step_avg:93.54ms
+step:417/1700 train_time:39009ms step_avg:93.55ms
+step:418/1700 train_time:39105ms step_avg:93.55ms
+step:419/1700 train_time:39201ms step_avg:93.56ms
+step:420/1700 train_time:39297ms step_avg:93.56ms
+step:421/1700 train_time:39393ms step_avg:93.57ms
+step:422/1700 train_time:39488ms step_avg:93.57ms
+step:423/1700 train_time:39584ms step_avg:93.58ms
+step:424/1700 train_time:39679ms step_avg:93.58ms
+step:425/1700 train_time:39775ms step_avg:93.59ms
+step:426/1700 train_time:39870ms step_avg:93.59ms
+step:427/1700 train_time:39965ms step_avg:93.59ms
+step:428/1700 train_time:40061ms step_avg:93.60ms
+step:429/1700 train_time:40157ms step_avg:93.61ms
+step:430/1700 train_time:40252ms step_avg:93.61ms
+step:431/1700 train_time:40347ms step_avg:93.61ms
+step:432/1700 train_time:40443ms step_avg:93.62ms
+step:433/1700 train_time:40540ms step_avg:93.63ms
+step:434/1700 train_time:40635ms step_avg:93.63ms
+step:435/1700 train_time:40730ms step_avg:93.63ms
+step:436/1700 train_time:40826ms step_avg:93.64ms
+step:437/1700 train_time:40921ms step_avg:93.64ms
+step:438/1700 train_time:41017ms step_avg:93.65ms
+step:439/1700 train_time:41113ms step_avg:93.65ms
+step:440/1700 train_time:41208ms step_avg:93.65ms
+step:441/1700 train_time:41304ms step_avg:93.66ms
+step:442/1700 train_time:41400ms step_avg:93.67ms
+step:443/1700 train_time:41496ms step_avg:93.67ms
+step:444/1700 train_time:41591ms step_avg:93.67ms
+step:445/1700 train_time:41686ms step_avg:93.68ms
+step:446/1700 train_time:41783ms step_avg:93.68ms
+step:447/1700 train_time:41878ms step_avg:93.69ms
+step:448/1700 train_time:41973ms step_avg:93.69ms
+step:449/1700 train_time:42068ms step_avg:93.69ms
+step:450/1700 train_time:42165ms step_avg:93.70ms
+step:451/1700 train_time:42260ms step_avg:93.70ms
+step:452/1700 train_time:42357ms step_avg:93.71ms
+step:453/1700 train_time:42452ms step_avg:93.71ms
+step:454/1700 train_time:42548ms step_avg:93.72ms
+step:455/1700 train_time:42643ms step_avg:93.72ms
+step:456/1700 train_time:42738ms step_avg:93.72ms
+step:457/1700 train_time:42834ms step_avg:93.73ms
+step:458/1700 train_time:42929ms step_avg:93.73ms
+step:459/1700 train_time:43025ms step_avg:93.74ms
+step:460/1700 train_time:43122ms step_avg:93.74ms
+step:461/1700 train_time:43217ms step_avg:93.75ms
+step:462/1700 train_time:43312ms step_avg:93.75ms
+step:463/1700 train_time:43408ms step_avg:93.75ms
+step:464/1700 train_time:43505ms step_avg:93.76ms
+step:465/1700 train_time:43602ms step_avg:93.77ms
+step:466/1700 train_time:43697ms step_avg:93.77ms
+step:467/1700 train_time:43792ms step_avg:93.77ms
+step:468/1700 train_time:43888ms step_avg:93.78ms
+step:469/1700 train_time:43985ms step_avg:93.78ms
+step:470/1700 train_time:44080ms step_avg:93.79ms
+step:471/1700 train_time:44175ms step_avg:93.79ms
+step:472/1700 train_time:44270ms step_avg:93.79ms
+step:473/1700 train_time:44366ms step_avg:93.80ms
+step:474/1700 train_time:44462ms step_avg:93.80ms
+step:475/1700 train_time:44558ms step_avg:93.81ms
+step:476/1700 train_time:44654ms step_avg:93.81ms
+step:477/1700 train_time:44749ms step_avg:93.81ms
+step:478/1700 train_time:44845ms step_avg:93.82ms
+step:479/1700 train_time:44942ms step_avg:93.82ms
+step:480/1700 train_time:45037ms step_avg:93.83ms
+step:481/1700 train_time:45132ms step_avg:93.83ms
+step:482/1700 train_time:45227ms step_avg:93.83ms
+step:483/1700 train_time:45324ms step_avg:93.84ms
+step:484/1700 train_time:45420ms step_avg:93.84ms
+step:485/1700 train_time:45515ms step_avg:93.85ms
+step:486/1700 train_time:45610ms step_avg:93.85ms
+step:487/1700 train_time:45706ms step_avg:93.85ms
+step:488/1700 train_time:45801ms step_avg:93.86ms
+step:489/1700 train_time:45897ms step_avg:93.86ms
+step:490/1700 train_time:45993ms step_avg:93.86ms
+step:491/1700 train_time:46088ms step_avg:93.87ms
+step:492/1700 train_time:46184ms step_avg:93.87ms
+step:493/1700 train_time:46279ms step_avg:93.87ms
+step:494/1700 train_time:46374ms step_avg:93.88ms
+step:495/1700 train_time:46469ms step_avg:93.88ms
+step:496/1700 train_time:46566ms step_avg:93.88ms
+step:497/1700 train_time:46661ms step_avg:93.89ms
+step:498/1700 train_time:46758ms step_avg:93.89ms
+step:499/1700 train_time:46853ms step_avg:93.89ms
+step:500/1700 train_time:46948ms step_avg:93.90ms
+step:500/1700 val_loss:3.7311 train_time:47027ms step_avg:94.05ms
+step:501/1700 train_time:47055ms step_avg:93.92ms
+step:502/1700 train_time:47145ms step_avg:93.92ms
+step:503/1700 train_time:47242ms step_avg:93.92ms
+step:504/1700 train_time:47338ms step_avg:93.92ms
+step:505/1700 train_time:47433ms step_avg:93.93ms
+step:506/1700 train_time:47527ms step_avg:93.93ms
+step:507/1700 train_time:47623ms step_avg:93.93ms
+step:508/1700 train_time:47719ms step_avg:93.93ms
+step:509/1700 train_time:47814ms step_avg:93.94ms
+step:510/1700 train_time:47910ms step_avg:93.94ms
+step:511/1700 train_time:48006ms step_avg:93.94ms
+step:512/1700 train_time:48103ms step_avg:93.95ms
+step:513/1700 train_time:48200ms step_avg:93.96ms
+step:514/1700 train_time:48297ms step_avg:93.96ms
+step:515/1700 train_time:48392ms step_avg:93.97ms
+step:516/1700 train_time:48487ms step_avg:93.97ms
+step:517/1700 train_time:48582ms step_avg:93.97ms
+step:518/1700 train_time:48678ms step_avg:93.97ms
+step:519/1700 train_time:48773ms step_avg:93.98ms
+step:520/1700 train_time:48869ms step_avg:93.98ms
+step:521/1700 train_time:48964ms step_avg:93.98ms
+step:522/1700 train_time:49061ms step_avg:93.99ms
+step:523/1700 train_time:49158ms step_avg:93.99ms
+step:524/1700 train_time:49255ms step_avg:94.00ms
+step:525/1700 train_time:49352ms step_avg:94.00ms
+step:526/1700 train_time:49448ms step_avg:94.01ms
+step:527/1700 train_time:49543ms step_avg:94.01ms
+step:528/1700 train_time:49638ms step_avg:94.01ms
+step:529/1700 train_time:49733ms step_avg:94.01ms
+step:530/1700 train_time:49829ms step_avg:94.02ms
+step:531/1700 train_time:49924ms step_avg:94.02ms
+step:532/1700 train_time:50019ms step_avg:94.02ms
+step:533/1700 train_time:50115ms step_avg:94.03ms
+step:534/1700 train_time:50211ms step_avg:94.03ms
+step:535/1700 train_time:50308ms step_avg:94.03ms
+step:536/1700 train_time:50404ms step_avg:94.04ms
+step:537/1700 train_time:50501ms step_avg:94.04ms
+step:538/1700 train_time:50597ms step_avg:94.05ms
+step:539/1700 train_time:50693ms step_avg:94.05ms
+step:540/1700 train_time:50789ms step_avg:94.05ms
+step:541/1700 train_time:50885ms step_avg:94.06ms
+step:542/1700 train_time:50981ms step_avg:94.06ms
+step:543/1700 train_time:51078ms step_avg:94.07ms
+step:544/1700 train_time:51174ms step_avg:94.07ms
+step:545/1700 train_time:51270ms step_avg:94.07ms
+step:546/1700 train_time:51365ms step_avg:94.08ms
+step:547/1700 train_time:51462ms step_avg:94.08ms
+step:548/1700 train_time:51558ms step_avg:94.08ms
+step:549/1700 train_time:51654ms step_avg:94.09ms
+step:550/1700 train_time:51750ms step_avg:94.09ms
+step:551/1700 train_time:51845ms step_avg:94.09ms
+step:552/1700 train_time:51941ms step_avg:94.10ms
+step:553/1700 train_time:52037ms step_avg:94.10ms
+step:554/1700 train_time:52134ms step_avg:94.10ms
+step:555/1700 train_time:52229ms step_avg:94.11ms
+step:556/1700 train_time:52325ms step_avg:94.11ms
+step:557/1700 train_time:52421ms step_avg:94.11ms
+step:558/1700 train_time:52517ms step_avg:94.12ms
+step:559/1700 train_time:52613ms step_avg:94.12ms
+step:560/1700 train_time:52709ms step_avg:94.12ms
+step:561/1700 train_time:52805ms step_avg:94.13ms
+step:562/1700 train_time:52901ms step_avg:94.13ms
+step:563/1700 train_time:52998ms step_avg:94.13ms
+step:564/1700 train_time:53094ms step_avg:94.14ms
+step:565/1700 train_time:53190ms step_avg:94.14ms
+step:566/1700 train_time:53286ms step_avg:94.15ms
+step:567/1700 train_time:53383ms step_avg:94.15ms
+step:568/1700 train_time:53479ms step_avg:94.15ms
+step:569/1700 train_time:53575ms step_avg:94.16ms
+step:570/1700 train_time:53671ms step_avg:94.16ms
+step:571/1700 train_time:53766ms step_avg:94.16ms
+step:572/1700 train_time:53862ms step_avg:94.16ms
+step:573/1700 train_time:53958ms step_avg:94.17ms
+step:574/1700 train_time:54054ms step_avg:94.17ms
+step:575/1700 train_time:54150ms step_avg:94.17ms
+step:576/1700 train_time:54246ms step_avg:94.18ms
+step:577/1700 train_time:54342ms step_avg:94.18ms
+step:578/1700 train_time:54439ms step_avg:94.18ms
+step:579/1700 train_time:54535ms step_avg:94.19ms
+step:580/1700 train_time:54631ms step_avg:94.19ms
+step:581/1700 train_time:54726ms step_avg:94.19ms
+step:582/1700 train_time:54822ms step_avg:94.20ms
+step:583/1700 train_time:54918ms step_avg:94.20ms
+step:584/1700 train_time:55014ms step_avg:94.20ms
+step:585/1700 train_time:55111ms step_avg:94.21ms
+step:586/1700 train_time:55206ms step_avg:94.21ms
+step:587/1700 train_time:55302ms step_avg:94.21ms
+step:588/1700 train_time:55398ms step_avg:94.21ms
+step:589/1700 train_time:55494ms step_avg:94.22ms
+step:590/1700 train_time:55590ms step_avg:94.22ms
+step:591/1700 train_time:55685ms step_avg:94.22ms
+step:592/1700 train_time:55781ms step_avg:94.23ms
+step:593/1700 train_time:55877ms step_avg:94.23ms
+step:594/1700 train_time:55972ms step_avg:94.23ms
+step:595/1700 train_time:56068ms step_avg:94.23ms
+step:596/1700 train_time:56164ms step_avg:94.23ms
+step:597/1700 train_time:56261ms step_avg:94.24ms
+step:598/1700 train_time:56357ms step_avg:94.24ms
+step:599/1700 train_time:56454ms step_avg:94.25ms
+step:600/1700 train_time:56551ms step_avg:94.25ms
+step:601/1700 train_time:56647ms step_avg:94.25ms
+step:602/1700 train_time:56743ms step_avg:94.26ms
+step:603/1700 train_time:56840ms step_avg:94.26ms
+step:604/1700 train_time:56936ms step_avg:94.26ms
+step:605/1700 train_time:57031ms step_avg:94.27ms
+step:606/1700 train_time:57127ms step_avg:94.27ms
+step:607/1700 train_time:57223ms step_avg:94.27ms
+step:608/1700 train_time:57320ms step_avg:94.28ms
+step:609/1700 train_time:57417ms step_avg:94.28ms
+step:610/1700 train_time:57513ms step_avg:94.28ms
+step:611/1700 train_time:57609ms step_avg:94.29ms
+step:612/1700 train_time:57705ms step_avg:94.29ms
+step:613/1700 train_time:57801ms step_avg:94.29ms
+step:614/1700 train_time:57898ms step_avg:94.30ms
+step:615/1700 train_time:57994ms step_avg:94.30ms
+step:616/1700 train_time:58090ms step_avg:94.30ms
+step:617/1700 train_time:58186ms step_avg:94.30ms
+step:618/1700 train_time:58281ms step_avg:94.31ms
+step:619/1700 train_time:58378ms step_avg:94.31ms
+step:620/1700 train_time:58474ms step_avg:94.31ms
+step:621/1700 train_time:58570ms step_avg:94.32ms
+step:622/1700 train_time:58666ms step_avg:94.32ms
+step:623/1700 train_time:58762ms step_avg:94.32ms
+step:624/1700 train_time:58859ms step_avg:94.33ms
+step:625/1700 train_time:58955ms step_avg:94.33ms
+step:625/1700 val_loss:3.6435 train_time:59034ms step_avg:94.45ms
+step:626/1700 train_time:59058ms step_avg:94.34ms
+step:627/1700 train_time:59154ms step_avg:94.34ms
+step:628/1700 train_time:59252ms step_avg:94.35ms
+step:629/1700 train_time:59348ms step_avg:94.35ms
+step:630/1700 train_time:59443ms step_avg:94.35ms
+step:631/1700 train_time:59539ms step_avg:94.36ms
+step:632/1700 train_time:59637ms step_avg:94.36ms
+step:633/1700 train_time:59733ms step_avg:94.37ms
+step:634/1700 train_time:59829ms step_avg:94.37ms
+step:635/1700 train_time:59926ms step_avg:94.37ms
+step:636/1700 train_time:60024ms step_avg:94.38ms
+step:637/1700 train_time:60123ms step_avg:94.38ms
+step:638/1700 train_time:60223ms step_avg:94.39ms
+step:639/1700 train_time:60322ms step_avg:94.40ms
+step:640/1700 train_time:60420ms step_avg:94.41ms
+step:641/1700 train_time:60517ms step_avg:94.41ms
+step:642/1700 train_time:60615ms step_avg:94.42ms
+step:643/1700 train_time:60711ms step_avg:94.42ms
+step:644/1700 train_time:60807ms step_avg:94.42ms
+step:645/1700 train_time:60904ms step_avg:94.43ms
+step:646/1700 train_time:61001ms step_avg:94.43ms
+step:647/1700 train_time:61100ms step_avg:94.44ms
+step:648/1700 train_time:61198ms step_avg:94.44ms
+step:649/1700 train_time:61296ms step_avg:94.45ms
+step:650/1700 train_time:61393ms step_avg:94.45ms
+step:651/1700 train_time:61491ms step_avg:94.46ms
+step:652/1700 train_time:61588ms step_avg:94.46ms
+step:653/1700 train_time:61686ms step_avg:94.47ms
+step:654/1700 train_time:61784ms step_avg:94.47ms
+step:655/1700 train_time:61881ms step_avg:94.47ms
+step:656/1700 train_time:61977ms step_avg:94.48ms
+step:657/1700 train_time:62075ms step_avg:94.48ms
+step:658/1700 train_time:62172ms step_avg:94.49ms
+step:659/1700 train_time:62270ms step_avg:94.49ms
+step:660/1700 train_time:62367ms step_avg:94.50ms
+step:661/1700 train_time:62465ms step_avg:94.50ms
+step:662/1700 train_time:62564ms step_avg:94.51ms
+step:663/1700 train_time:62661ms step_avg:94.51ms
+step:664/1700 train_time:62759ms step_avg:94.52ms
+step:665/1700 train_time:62857ms step_avg:94.52ms
+step:666/1700 train_time:62953ms step_avg:94.52ms
+step:667/1700 train_time:63050ms step_avg:94.53ms
+step:668/1700 train_time:63147ms step_avg:94.53ms
+step:669/1700 train_time:63245ms step_avg:94.54ms
+step:670/1700 train_time:63343ms step_avg:94.54ms
+step:671/1700 train_time:63441ms step_avg:94.55ms
+step:672/1700 train_time:63538ms step_avg:94.55ms
+step:673/1700 train_time:63635ms step_avg:94.55ms
+step:674/1700 train_time:63733ms step_avg:94.56ms
+step:675/1700 train_time:63830ms step_avg:94.56ms
+step:676/1700 train_time:63927ms step_avg:94.57ms
+step:677/1700 train_time:64026ms step_avg:94.57ms
+step:678/1700 train_time:64124ms step_avg:94.58ms
+step:679/1700 train_time:64223ms step_avg:94.58ms
+step:680/1700 train_time:64320ms step_avg:94.59ms
+step:681/1700 train_time:64417ms step_avg:94.59ms
+step:682/1700 train_time:64515ms step_avg:94.60ms
+step:683/1700 train_time:64612ms step_avg:94.60ms
+step:684/1700 train_time:64710ms step_avg:94.61ms
+step:685/1700 train_time:64807ms step_avg:94.61ms
+step:686/1700 train_time:64905ms step_avg:94.61ms
+step:687/1700 train_time:65003ms step_avg:94.62ms
+step:688/1700 train_time:65101ms step_avg:94.62ms
+step:689/1700 train_time:65199ms step_avg:94.63ms
+step:690/1700 train_time:65296ms step_avg:94.63ms
+step:691/1700 train_time:65392ms step_avg:94.63ms
+step:692/1700 train_time:65490ms step_avg:94.64ms
+step:693/1700 train_time:65588ms step_avg:94.64ms
+step:694/1700 train_time:65686ms step_avg:94.65ms
+step:695/1700 train_time:65785ms step_avg:94.65ms
+step:696/1700 train_time:65883ms step_avg:94.66ms
+step:697/1700 train_time:65980ms step_avg:94.66ms
+step:698/1700 train_time:66078ms step_avg:94.67ms
+step:699/1700 train_time:66176ms step_avg:94.67ms
+step:700/1700 train_time:66273ms step_avg:94.68ms
+step:701/1700 train_time:66370ms step_avg:94.68ms
+step:702/1700 train_time:66467ms step_avg:94.68ms
+step:703/1700 train_time:66565ms step_avg:94.69ms
+step:704/1700 train_time:66663ms step_avg:94.69ms
+step:705/1700 train_time:66761ms step_avg:94.70ms
+step:706/1700 train_time:66858ms step_avg:94.70ms
+step:707/1700 train_time:66955ms step_avg:94.70ms
+step:708/1700 train_time:67052ms step_avg:94.71ms
+step:709/1700 train_time:67150ms step_avg:94.71ms
+step:710/1700 train_time:67247ms step_avg:94.71ms
+step:711/1700 train_time:67345ms step_avg:94.72ms
+step:712/1700 train_time:67445ms step_avg:94.73ms
+step:713/1700 train_time:67542ms step_avg:94.73ms
+step:714/1700 train_time:67640ms step_avg:94.73ms
+step:715/1700 train_time:67737ms step_avg:94.74ms
+step:716/1700 train_time:67834ms step_avg:94.74ms
+step:717/1700 train_time:67930ms step_avg:94.74ms
+step:718/1700 train_time:68029ms step_avg:94.75ms
+step:719/1700 train_time:68127ms step_avg:94.75ms
+step:720/1700 train_time:68225ms step_avg:94.76ms
+step:721/1700 train_time:68323ms step_avg:94.76ms
+step:722/1700 train_time:68421ms step_avg:94.77ms
+step:723/1700 train_time:68519ms step_avg:94.77ms
+step:724/1700 train_time:68616ms step_avg:94.77ms
+step:725/1700 train_time:68713ms step_avg:94.78ms
+step:726/1700 train_time:68810ms step_avg:94.78ms
+step:727/1700 train_time:68907ms step_avg:94.78ms
+step:728/1700 train_time:69005ms step_avg:94.79ms
+step:729/1700 train_time:69104ms step_avg:94.79ms
+step:730/1700 train_time:69202ms step_avg:94.80ms
+step:731/1700 train_time:69299ms step_avg:94.80ms
+step:732/1700 train_time:69398ms step_avg:94.81ms
+step:733/1700 train_time:69495ms step_avg:94.81ms
+step:734/1700 train_time:69592ms step_avg:94.81ms
+step:735/1700 train_time:69690ms step_avg:94.82ms
+step:736/1700 train_time:69788ms step_avg:94.82ms
+step:737/1700 train_time:69886ms step_avg:94.82ms
+step:738/1700 train_time:69984ms step_avg:94.83ms
+step:739/1700 train_time:70082ms step_avg:94.83ms
+step:740/1700 train_time:70180ms step_avg:94.84ms
+step:741/1700 train_time:70278ms step_avg:94.84ms
+step:742/1700 train_time:70376ms step_avg:94.85ms
+step:743/1700 train_time:70473ms step_avg:94.85ms
+step:744/1700 train_time:70570ms step_avg:94.85ms
+step:745/1700 train_time:70667ms step_avg:94.86ms
+step:746/1700 train_time:70765ms step_avg:94.86ms
+step:747/1700 train_time:70863ms step_avg:94.86ms
+step:748/1700 train_time:70960ms step_avg:94.87ms
+step:749/1700 train_time:71058ms step_avg:94.87ms
+step:750/1700 train_time:71155ms step_avg:94.87ms
+step:750/1700 val_loss:3.5831 train_time:71235ms step_avg:94.98ms
+step:751/1700 train_time:71259ms step_avg:94.89ms
+step:752/1700 train_time:71359ms step_avg:94.89ms
+step:753/1700 train_time:71459ms step_avg:94.90ms
+step:754/1700 train_time:71558ms step_avg:94.90ms
+step:755/1700 train_time:71656ms step_avg:94.91ms
+step:756/1700 train_time:71753ms step_avg:94.91ms
+step:757/1700 train_time:71850ms step_avg:94.91ms
+step:758/1700 train_time:71947ms step_avg:94.92ms
+step:759/1700 train_time:72043ms step_avg:94.92ms
+step:760/1700 train_time:72140ms step_avg:94.92ms
+step:761/1700 train_time:72238ms step_avg:94.92ms
+step:762/1700 train_time:72338ms step_avg:94.93ms
+step:763/1700 train_time:72437ms step_avg:94.94ms
+step:764/1700 train_time:72536ms step_avg:94.94ms
+step:765/1700 train_time:72635ms step_avg:94.95ms
+step:766/1700 train_time:72733ms step_avg:94.95ms
+step:767/1700 train_time:72831ms step_avg:94.96ms
+step:768/1700 train_time:72928ms step_avg:94.96ms
+step:769/1700 train_time:73024ms step_avg:94.96ms
+step:770/1700 train_time:73121ms step_avg:94.96ms
+step:771/1700 train_time:73218ms step_avg:94.97ms
+step:772/1700 train_time:73318ms step_avg:94.97ms
+step:773/1700 train_time:73417ms step_avg:94.98ms
+step:774/1700 train_time:73516ms step_avg:94.98ms
+step:775/1700 train_time:73613ms step_avg:94.98ms
+step:776/1700 train_time:73711ms step_avg:94.99ms
+step:777/1700 train_time:73809ms step_avg:94.99ms
+step:778/1700 train_time:73907ms step_avg:95.00ms
+step:779/1700 train_time:74003ms step_avg:95.00ms
+step:780/1700 train_time:74101ms step_avg:95.00ms
+step:781/1700 train_time:74198ms step_avg:95.00ms
+step:782/1700 train_time:74296ms step_avg:95.01ms
+step:783/1700 train_time:74394ms step_avg:95.01ms
+step:784/1700 train_time:74493ms step_avg:95.02ms
+step:785/1700 train_time:74591ms step_avg:95.02ms
+step:786/1700 train_time:74688ms step_avg:95.02ms
+step:787/1700 train_time:74785ms step_avg:95.03ms
+step:788/1700 train_time:74883ms step_avg:95.03ms
+step:789/1700 train_time:74980ms step_avg:95.03ms
+step:790/1700 train_time:75078ms step_avg:95.04ms
+step:791/1700 train_time:75176ms step_avg:95.04ms
+step:792/1700 train_time:75274ms step_avg:95.04ms
+step:793/1700 train_time:75371ms step_avg:95.05ms
+step:794/1700 train_time:75470ms step_avg:95.05ms
+step:795/1700 train_time:75567ms step_avg:95.05ms
+step:796/1700 train_time:75665ms step_avg:95.06ms
+step:797/1700 train_time:75763ms step_avg:95.06ms
+step:798/1700 train_time:75862ms step_avg:95.06ms
+step:799/1700 train_time:75960ms step_avg:95.07ms
+step:800/1700 train_time:76058ms step_avg:95.07ms
+step:801/1700 train_time:76155ms step_avg:95.08ms
+step:802/1700 train_time:76253ms step_avg:95.08ms
+step:803/1700 train_time:76351ms step_avg:95.08ms
+step:804/1700 train_time:76448ms step_avg:95.08ms
+step:805/1700 train_time:76545ms step_avg:95.09ms
+step:806/1700 train_time:76643ms step_avg:95.09ms
+step:807/1700 train_time:76740ms step_avg:95.09ms
+step:808/1700 train_time:76838ms step_avg:95.10ms
+step:809/1700 train_time:76937ms step_avg:95.10ms
+step:810/1700 train_time:77037ms step_avg:95.11ms
+step:811/1700 train_time:77134ms step_avg:95.11ms
+step:812/1700 train_time:77232ms step_avg:95.11ms
+step:813/1700 train_time:77329ms step_avg:95.12ms
+step:814/1700 train_time:77426ms step_avg:95.12ms
+step:815/1700 train_time:77523ms step_avg:95.12ms
+step:816/1700 train_time:77620ms step_avg:95.12ms
+step:817/1700 train_time:77719ms step_avg:95.13ms
+step:818/1700 train_time:77818ms step_avg:95.13ms
+step:819/1700 train_time:77916ms step_avg:95.14ms
+step:820/1700 train_time:78014ms step_avg:95.14ms
+step:821/1700 train_time:78112ms step_avg:95.14ms
+step:822/1700 train_time:78209ms step_avg:95.15ms
+step:823/1700 train_time:78307ms step_avg:95.15ms
+step:824/1700 train_time:78404ms step_avg:95.15ms
+step:825/1700 train_time:78501ms step_avg:95.15ms
+step:826/1700 train_time:78600ms step_avg:95.16ms
+step:827/1700 train_time:78699ms step_avg:95.16ms
+step:828/1700 train_time:78797ms step_avg:95.17ms
+step:829/1700 train_time:78895ms step_avg:95.17ms
+step:830/1700 train_time:78992ms step_avg:95.17ms
+step:831/1700 train_time:79090ms step_avg:95.17ms
+step:832/1700 train_time:79187ms step_avg:95.18ms
+step:833/1700 train_time:79284ms step_avg:95.18ms
+step:834/1700 train_time:79382ms step_avg:95.18ms
+step:835/1700 train_time:79480ms step_avg:95.19ms
+step:836/1700 train_time:79578ms step_avg:95.19ms
+step:837/1700 train_time:79676ms step_avg:95.19ms
+step:838/1700 train_time:79775ms step_avg:95.20ms
+step:839/1700 train_time:79871ms step_avg:95.20ms
+step:840/1700 train_time:79969ms step_avg:95.20ms
+step:841/1700 train_time:80066ms step_avg:95.20ms
+step:842/1700 train_time:80163ms step_avg:95.21ms
+step:843/1700 train_time:80261ms step_avg:95.21ms
+step:844/1700 train_time:80359ms step_avg:95.21ms
+step:845/1700 train_time:80457ms step_avg:95.22ms
+step:846/1700 train_time:80555ms step_avg:95.22ms
+step:847/1700 train_time:80653ms step_avg:95.22ms
+step:848/1700 train_time:80752ms step_avg:95.23ms
+step:849/1700 train_time:80849ms step_avg:95.23ms
+step:850/1700 train_time:80946ms step_avg:95.23ms
+step:851/1700 train_time:81043ms step_avg:95.23ms
+step:852/1700 train_time:81141ms step_avg:95.24ms
+step:853/1700 train_time:81239ms step_avg:95.24ms
+step:854/1700 train_time:81337ms step_avg:95.24ms
+step:855/1700 train_time:81435ms step_avg:95.25ms
+step:856/1700 train_time:81533ms step_avg:95.25ms
+step:857/1700 train_time:81630ms step_avg:95.25ms
+step:858/1700 train_time:81728ms step_avg:95.25ms
+step:859/1700 train_time:81825ms step_avg:95.26ms
+step:860/1700 train_time:81922ms step_avg:95.26ms
+step:861/1700 train_time:82021ms step_avg:95.26ms
+step:862/1700 train_time:82119ms step_avg:95.27ms
+step:863/1700 train_time:82218ms step_avg:95.27ms
+step:864/1700 train_time:82315ms step_avg:95.27ms
+step:865/1700 train_time:82413ms step_avg:95.28ms
+step:866/1700 train_time:82511ms step_avg:95.28ms
+step:867/1700 train_time:82609ms step_avg:95.28ms
+step:868/1700 train_time:82707ms step_avg:95.28ms
+step:869/1700 train_time:82805ms step_avg:95.29ms
+step:870/1700 train_time:82902ms step_avg:95.29ms
+step:871/1700 train_time:82999ms step_avg:95.29ms
+step:872/1700 train_time:83098ms step_avg:95.30ms
+step:873/1700 train_time:83196ms step_avg:95.30ms
+step:874/1700 train_time:83294ms step_avg:95.30ms
+step:875/1700 train_time:83393ms step_avg:95.31ms
+step:875/1700 val_loss:3.5354 train_time:83473ms step_avg:95.40ms
+step:876/1700 train_time:83498ms step_avg:95.32ms
+step:877/1700 train_time:83597ms step_avg:95.32ms
+step:878/1700 train_time:83695ms step_avg:95.33ms
+step:879/1700 train_time:83793ms step_avg:95.33ms
+step:880/1700 train_time:83891ms step_avg:95.33ms
+step:881/1700 train_time:83988ms step_avg:95.33ms
+step:882/1700 train_time:84085ms step_avg:95.33ms
+step:883/1700 train_time:84182ms step_avg:95.34ms
+step:884/1700 train_time:84281ms step_avg:95.34ms
+step:885/1700 train_time:84379ms step_avg:95.34ms
+step:886/1700 train_time:84479ms step_avg:95.35ms
+step:887/1700 train_time:84580ms step_avg:95.36ms
+step:888/1700 train_time:84680ms step_avg:95.36ms
+step:889/1700 train_time:84780ms step_avg:95.37ms
+step:890/1700 train_time:84879ms step_avg:95.37ms
+step:891/1700 train_time:84978ms step_avg:95.37ms
+step:892/1700 train_time:85077ms step_avg:95.38ms
+step:893/1700 train_time:85174ms step_avg:95.38ms
+step:894/1700 train_time:85272ms step_avg:95.38ms
+step:895/1700 train_time:85371ms step_avg:95.39ms
+step:896/1700 train_time:85470ms step_avg:95.39ms
+step:897/1700 train_time:85570ms step_avg:95.40ms
+step:898/1700 train_time:85670ms step_avg:95.40ms
+step:899/1700 train_time:85771ms step_avg:95.41ms
+step:900/1700 train_time:85871ms step_avg:95.41ms
+step:901/1700 train_time:85971ms step_avg:95.42ms
+step:902/1700 train_time:86070ms step_avg:95.42ms
+step:903/1700 train_time:86170ms step_avg:95.43ms
+step:904/1700 train_time:86270ms step_avg:95.43ms
+step:905/1700 train_time:86369ms step_avg:95.44ms
+step:906/1700 train_time:86468ms step_avg:95.44ms
+step:907/1700 train_time:86568ms step_avg:95.44ms
+step:908/1700 train_time:86668ms step_avg:95.45ms
+step:909/1700 train_time:86769ms step_avg:95.45ms
+step:910/1700 train_time:86870ms step_avg:95.46ms
+step:911/1700 train_time:86969ms step_avg:95.47ms
+step:912/1700 train_time:87070ms step_avg:95.47ms
+step:913/1700 train_time:87171ms step_avg:95.48ms
+step:914/1700 train_time:87271ms step_avg:95.48ms
+step:915/1700 train_time:87370ms step_avg:95.49ms
+step:916/1700 train_time:87469ms step_avg:95.49ms
+step:917/1700 train_time:87569ms step_avg:95.50ms
+step:918/1700 train_time:87670ms step_avg:95.50ms
+step:919/1700 train_time:87771ms step_avg:95.51ms
+step:920/1700 train_time:87870ms step_avg:95.51ms
+step:921/1700 train_time:87970ms step_avg:95.52ms
+step:922/1700 train_time:88070ms step_avg:95.52ms
+step:923/1700 train_time:88170ms step_avg:95.53ms
+step:924/1700 train_time:88269ms step_avg:95.53ms
+step:925/1700 train_time:88369ms step_avg:95.53ms
+step:926/1700 train_time:88469ms step_avg:95.54ms
+step:927/1700 train_time:88569ms step_avg:95.54ms
+step:928/1700 train_time:88668ms step_avg:95.55ms
+step:929/1700 train_time:88768ms step_avg:95.55ms
+step:930/1700 train_time:88869ms step_avg:95.56ms
+step:931/1700 train_time:88970ms step_avg:95.56ms
+step:932/1700 train_time:89071ms step_avg:95.57ms
+step:933/1700 train_time:89172ms step_avg:95.58ms
+step:934/1700 train_time:89271ms step_avg:95.58ms
+step:935/1700 train_time:89371ms step_avg:95.58ms
+step:936/1700 train_time:89470ms step_avg:95.59ms
+step:937/1700 train_time:89570ms step_avg:95.59ms
+step:938/1700 train_time:89670ms step_avg:95.60ms
+step:939/1700 train_time:89770ms step_avg:95.60ms
+step:940/1700 train_time:89870ms step_avg:95.61ms
+step:941/1700 train_time:89971ms step_avg:95.61ms
+step:942/1700 train_time:90071ms step_avg:95.62ms
+step:943/1700 train_time:90170ms step_avg:95.62ms
+step:944/1700 train_time:90271ms step_avg:95.63ms
+step:945/1700 train_time:90370ms step_avg:95.63ms
+step:946/1700 train_time:90469ms step_avg:95.63ms
+step:947/1700 train_time:90569ms step_avg:95.64ms
+step:948/1700 train_time:90668ms step_avg:95.64ms
+step:949/1700 train_time:90769ms step_avg:95.65ms
+step:950/1700 train_time:90870ms step_avg:95.65ms
+step:951/1700 train_time:90970ms step_avg:95.66ms
+step:952/1700 train_time:91070ms step_avg:95.66ms
+step:953/1700 train_time:91170ms step_avg:95.67ms
+step:954/1700 train_time:91270ms step_avg:95.67ms
+step:955/1700 train_time:91369ms step_avg:95.67ms
+step:956/1700 train_time:91468ms step_avg:95.68ms
+step:957/1700 train_time:91569ms step_avg:95.68ms
+step:958/1700 train_time:91670ms step_avg:95.69ms
+step:959/1700 train_time:91770ms step_avg:95.69ms
+step:960/1700 train_time:91871ms step_avg:95.70ms
+step:961/1700 train_time:91970ms step_avg:95.70ms
+step:962/1700 train_time:92070ms step_avg:95.71ms
+step:963/1700 train_time:92171ms step_avg:95.71ms
+step:964/1700 train_time:92271ms step_avg:95.72ms
+step:965/1700 train_time:92371ms step_avg:95.72ms
+step:966/1700 train_time:92470ms step_avg:95.72ms
+step:967/1700 train_time:92571ms step_avg:95.73ms
+step:968/1700 train_time:92670ms step_avg:95.73ms
+step:969/1700 train_time:92770ms step_avg:95.74ms
+step:970/1700 train_time:92869ms step_avg:95.74ms
+step:971/1700 train_time:92969ms step_avg:95.75ms
+step:972/1700 train_time:93069ms step_avg:95.75ms
+step:973/1700 train_time:93170ms step_avg:95.76ms
+step:974/1700 train_time:93270ms step_avg:95.76ms
+step:975/1700 train_time:93370ms step_avg:95.76ms
+step:976/1700 train_time:93469ms step_avg:95.77ms
+step:977/1700 train_time:93570ms step_avg:95.77ms
+step:978/1700 train_time:93670ms step_avg:95.78ms
+step:979/1700 train_time:93769ms step_avg:95.78ms
+step:980/1700 train_time:93869ms step_avg:95.78ms
+step:981/1700 train_time:93969ms step_avg:95.79ms
+step:982/1700 train_time:94069ms step_avg:95.79ms
+step:983/1700 train_time:94169ms step_avg:95.80ms
+step:984/1700 train_time:94270ms step_avg:95.80ms
+step:985/1700 train_time:94370ms step_avg:95.81ms
+step:986/1700 train_time:94470ms step_avg:95.81ms
+step:987/1700 train_time:94570ms step_avg:95.82ms
+step:988/1700 train_time:94670ms step_avg:95.82ms
+step:989/1700 train_time:94770ms step_avg:95.82ms
+step:990/1700 train_time:94870ms step_avg:95.83ms
+step:991/1700 train_time:94970ms step_avg:95.83ms
+step:992/1700 train_time:95069ms step_avg:95.84ms
+step:993/1700 train_time:95170ms step_avg:95.84ms
+step:994/1700 train_time:95269ms step_avg:95.84ms
+step:995/1700 train_time:95369ms step_avg:95.85ms
+step:996/1700 train_time:95469ms step_avg:95.85ms
+step:997/1700 train_time:95570ms step_avg:95.86ms
+step:998/1700 train_time:95670ms step_avg:95.86ms
+step:999/1700 train_time:95770ms step_avg:95.87ms
+step:1000/1700 train_time:95870ms step_avg:95.87ms
+step:1000/1700 val_loss:3.4911 train_time:95953ms step_avg:95.95ms
+step:1001/1700 train_time:95978ms step_avg:95.88ms
+step:1002/1700 train_time:96080ms step_avg:95.89ms
+step:1003/1700 train_time:96179ms step_avg:95.89ms
+step:1004/1700 train_time:96278ms step_avg:95.89ms
+step:1005/1700 train_time:96377ms step_avg:95.90ms
+step:1006/1700 train_time:96474ms step_avg:95.90ms
+step:1007/1700 train_time:96573ms step_avg:95.90ms
+step:1008/1700 train_time:96670ms step_avg:95.90ms
+step:1009/1700 train_time:96769ms step_avg:95.91ms
+step:1010/1700 train_time:96867ms step_avg:95.91ms
+step:1011/1700 train_time:96969ms step_avg:95.91ms
+step:1012/1700 train_time:97069ms step_avg:95.92ms
+step:1013/1700 train_time:97170ms step_avg:95.92ms
+step:1014/1700 train_time:97268ms step_avg:95.93ms
+step:1015/1700 train_time:97369ms step_avg:95.93ms
+step:1016/1700 train_time:97469ms step_avg:95.93ms
+step:1017/1700 train_time:97569ms step_avg:95.94ms
+step:1018/1700 train_time:97668ms step_avg:95.94ms
+step:1019/1700 train_time:97766ms step_avg:95.94ms
+step:1020/1700 train_time:97866ms step_avg:95.95ms
+step:1021/1700 train_time:97965ms step_avg:95.95ms
+step:1022/1700 train_time:98064ms step_avg:95.95ms
+step:1023/1700 train_time:98163ms step_avg:95.96ms
+step:1024/1700 train_time:98262ms step_avg:95.96ms
+step:1025/1700 train_time:98362ms step_avg:95.96ms
+step:1026/1700 train_time:98462ms step_avg:95.97ms
+step:1027/1700 train_time:98561ms step_avg:95.97ms
+step:1028/1700 train_time:98661ms step_avg:95.97ms
+step:1029/1700 train_time:98761ms step_avg:95.98ms
+step:1030/1700 train_time:98860ms step_avg:95.98ms
+step:1031/1700 train_time:98958ms step_avg:95.98ms
+step:1032/1700 train_time:99057ms step_avg:95.99ms
+step:1033/1700 train_time:99157ms step_avg:95.99ms
+step:1034/1700 train_time:99255ms step_avg:95.99ms
+step:1035/1700 train_time:99355ms step_avg:96.00ms
+step:1036/1700 train_time:99456ms step_avg:96.00ms
+step:1037/1700 train_time:99555ms step_avg:96.00ms
+step:1038/1700 train_time:99656ms step_avg:96.01ms
+step:1039/1700 train_time:99755ms step_avg:96.01ms
+step:1040/1700 train_time:99855ms step_avg:96.01ms
+step:1041/1700 train_time:99954ms step_avg:96.02ms
+step:1042/1700 train_time:100054ms step_avg:96.02ms
+step:1043/1700 train_time:100154ms step_avg:96.02ms
+step:1044/1700 train_time:100253ms step_avg:96.03ms
+step:1045/1700 train_time:100354ms step_avg:96.03ms
+step:1046/1700 train_time:100454ms step_avg:96.04ms
+step:1047/1700 train_time:100553ms step_avg:96.04ms
+step:1048/1700 train_time:100654ms step_avg:96.04ms
+step:1049/1700 train_time:100755ms step_avg:96.05ms
+step:1050/1700 train_time:100856ms step_avg:96.05ms
+step:1051/1700 train_time:100955ms step_avg:96.06ms
+step:1052/1700 train_time:101054ms step_avg:96.06ms
+step:1053/1700 train_time:101154ms step_avg:96.06ms
+step:1054/1700 train_time:101253ms step_avg:96.07ms
+step:1055/1700 train_time:101353ms step_avg:96.07ms
+step:1056/1700 train_time:101454ms step_avg:96.07ms
+step:1057/1700 train_time:101554ms step_avg:96.08ms
+step:1058/1700 train_time:101654ms step_avg:96.08ms
+step:1059/1700 train_time:101754ms step_avg:96.09ms
+step:1060/1700 train_time:101854ms step_avg:96.09ms
+step:1061/1700 train_time:101954ms step_avg:96.09ms
+step:1062/1700 train_time:102055ms step_avg:96.10ms
+step:1063/1700 train_time:102155ms step_avg:96.10ms
+step:1064/1700 train_time:102256ms step_avg:96.10ms
+step:1065/1700 train_time:102356ms step_avg:96.11ms
+step:1066/1700 train_time:102455ms step_avg:96.11ms
+step:1067/1700 train_time:102556ms step_avg:96.12ms
+step:1068/1700 train_time:102656ms step_avg:96.12ms
+step:1069/1700 train_time:102755ms step_avg:96.12ms
+step:1070/1700 train_time:102855ms step_avg:96.13ms
+step:1071/1700 train_time:102956ms step_avg:96.13ms
+step:1072/1700 train_time:103056ms step_avg:96.13ms
+step:1073/1700 train_time:103155ms step_avg:96.14ms
+step:1074/1700 train_time:103255ms step_avg:96.14ms
+step:1075/1700 train_time:103355ms step_avg:96.14ms
+step:1076/1700 train_time:103455ms step_avg:96.15ms
+step:1077/1700 train_time:103555ms step_avg:96.15ms
+step:1078/1700 train_time:103655ms step_avg:96.15ms
+step:1079/1700 train_time:103754ms step_avg:96.16ms
+step:1080/1700 train_time:103855ms step_avg:96.16ms
+step:1081/1700 train_time:103955ms step_avg:96.17ms
+step:1082/1700 train_time:104055ms step_avg:96.17ms
+step:1083/1700 train_time:104155ms step_avg:96.17ms
+step:1084/1700 train_time:104254ms step_avg:96.18ms
+step:1085/1700 train_time:104356ms step_avg:96.18ms
+step:1086/1700 train_time:104455ms step_avg:96.18ms
+step:1087/1700 train_time:104555ms step_avg:96.19ms
+step:1088/1700 train_time:104654ms step_avg:96.19ms
+step:1089/1700 train_time:104753ms step_avg:96.19ms
+step:1090/1700 train_time:104855ms step_avg:96.20ms
+step:1091/1700 train_time:104956ms step_avg:96.20ms
+step:1092/1700 train_time:105055ms step_avg:96.20ms
+step:1093/1700 train_time:105155ms step_avg:96.21ms
+step:1094/1700 train_time:105255ms step_avg:96.21ms
+step:1095/1700 train_time:105356ms step_avg:96.22ms
+step:1096/1700 train_time:105456ms step_avg:96.22ms
+step:1097/1700 train_time:105555ms step_avg:96.22ms
+step:1098/1700 train_time:105655ms step_avg:96.23ms
+step:1099/1700 train_time:105756ms step_avg:96.23ms
+step:1100/1700 train_time:105855ms step_avg:96.23ms
+step:1101/1700 train_time:105956ms step_avg:96.24ms
+step:1102/1700 train_time:106056ms step_avg:96.24ms
+step:1103/1700 train_time:106156ms step_avg:96.24ms
+step:1104/1700 train_time:106256ms step_avg:96.25ms
+step:1105/1700 train_time:106358ms step_avg:96.25ms
+step:1106/1700 train_time:106457ms step_avg:96.25ms
+step:1107/1700 train_time:106557ms step_avg:96.26ms
+step:1108/1700 train_time:106657ms step_avg:96.26ms
+step:1109/1700 train_time:106756ms step_avg:96.26ms
+step:1110/1700 train_time:106857ms step_avg:96.27ms
+step:1111/1700 train_time:106958ms step_avg:96.27ms
+step:1112/1700 train_time:107058ms step_avg:96.28ms
+step:1113/1700 train_time:107159ms step_avg:96.28ms
+step:1114/1700 train_time:107258ms step_avg:96.28ms
+step:1115/1700 train_time:107357ms step_avg:96.28ms
+step:1116/1700 train_time:107459ms step_avg:96.29ms
+step:1117/1700 train_time:107558ms step_avg:96.29ms
+step:1118/1700 train_time:107657ms step_avg:96.29ms
+step:1119/1700 train_time:107756ms step_avg:96.30ms
+step:1120/1700 train_time:107856ms step_avg:96.30ms
+step:1121/1700 train_time:107956ms step_avg:96.30ms
+step:1122/1700 train_time:108056ms step_avg:96.31ms
+step:1123/1700 train_time:108156ms step_avg:96.31ms
+step:1124/1700 train_time:108256ms step_avg:96.31ms
+step:1125/1700 train_time:108356ms step_avg:96.32ms
+step:1125/1700 val_loss:3.4410 train_time:108437ms step_avg:96.39ms
+step:1126/1700 train_time:108463ms step_avg:96.33ms
+step:1127/1700 train_time:108561ms step_avg:96.33ms
+step:1128/1700 train_time:108661ms step_avg:96.33ms
+step:1129/1700 train_time:108760ms step_avg:96.33ms
+step:1130/1700 train_time:108859ms step_avg:96.34ms
+step:1131/1700 train_time:108957ms step_avg:96.34ms
+step:1132/1700 train_time:109056ms step_avg:96.34ms
+step:1133/1700 train_time:109154ms step_avg:96.34ms
+step:1134/1700 train_time:109252ms step_avg:96.34ms
+step:1135/1700 train_time:109351ms step_avg:96.34ms
+step:1136/1700 train_time:109452ms step_avg:96.35ms
+step:1137/1700 train_time:109556ms step_avg:96.36ms
+step:1138/1700 train_time:109658ms step_avg:96.36ms
+step:1139/1700 train_time:109758ms step_avg:96.36ms
+step:1140/1700 train_time:109859ms step_avg:96.37ms
+step:1141/1700 train_time:109959ms step_avg:96.37ms
+step:1142/1700 train_time:110058ms step_avg:96.37ms
+step:1143/1700 train_time:110157ms step_avg:96.38ms
+step:1144/1700 train_time:110257ms step_avg:96.38ms
+step:1145/1700 train_time:110358ms step_avg:96.38ms
+step:1146/1700 train_time:110459ms step_avg:96.39ms
+step:1147/1700 train_time:110560ms step_avg:96.39ms
+step:1148/1700 train_time:110660ms step_avg:96.39ms
+step:1149/1700 train_time:110761ms step_avg:96.40ms
+step:1150/1700 train_time:110861ms step_avg:96.40ms
+step:1151/1700 train_time:110960ms step_avg:96.40ms
+step:1152/1700 train_time:111059ms step_avg:96.41ms
+step:1153/1700 train_time:111160ms step_avg:96.41ms
+step:1154/1700 train_time:111259ms step_avg:96.41ms
+step:1155/1700 train_time:111359ms step_avg:96.41ms
+step:1156/1700 train_time:111460ms step_avg:96.42ms
+step:1157/1700 train_time:111560ms step_avg:96.42ms
+step:1158/1700 train_time:111661ms step_avg:96.43ms
+step:1159/1700 train_time:111761ms step_avg:96.43ms
+step:1160/1700 train_time:111861ms step_avg:96.43ms
+step:1161/1700 train_time:111961ms step_avg:96.44ms
+step:1162/1700 train_time:112061ms step_avg:96.44ms
+step:1163/1700 train_time:112160ms step_avg:96.44ms
+step:1164/1700 train_time:112261ms step_avg:96.44ms
+step:1165/1700 train_time:112361ms step_avg:96.45ms
+step:1166/1700 train_time:112462ms step_avg:96.45ms
+step:1167/1700 train_time:112563ms step_avg:96.45ms
+step:1168/1700 train_time:112663ms step_avg:96.46ms
+step:1169/1700 train_time:112763ms step_avg:96.46ms
+step:1170/1700 train_time:112863ms step_avg:96.46ms
+step:1171/1700 train_time:112963ms step_avg:96.47ms
+step:1172/1700 train_time:113064ms step_avg:96.47ms
+step:1173/1700 train_time:113163ms step_avg:96.47ms
+step:1174/1700 train_time:113263ms step_avg:96.48ms
+step:1175/1700 train_time:113363ms step_avg:96.48ms
+step:1176/1700 train_time:113463ms step_avg:96.48ms
+step:1177/1700 train_time:113563ms step_avg:96.49ms
+step:1178/1700 train_time:113664ms step_avg:96.49ms
+step:1179/1700 train_time:113763ms step_avg:96.49ms
+step:1180/1700 train_time:113864ms step_avg:96.50ms
+step:1181/1700 train_time:113966ms step_avg:96.50ms
+step:1182/1700 train_time:114068ms step_avg:96.50ms
+step:1183/1700 train_time:114168ms step_avg:96.51ms
+step:1184/1700 train_time:114268ms step_avg:96.51ms
+step:1185/1700 train_time:114369ms step_avg:96.51ms
+step:1186/1700 train_time:114470ms step_avg:96.52ms
+step:1187/1700 train_time:114569ms step_avg:96.52ms
+step:1188/1700 train_time:114670ms step_avg:96.52ms
+step:1189/1700 train_time:114770ms step_avg:96.53ms
+step:1190/1700 train_time:114870ms step_avg:96.53ms
+step:1191/1700 train_time:114973ms step_avg:96.53ms
+step:1192/1700 train_time:115073ms step_avg:96.54ms
+step:1193/1700 train_time:115174ms step_avg:96.54ms
+step:1194/1700 train_time:115274ms step_avg:96.54ms
+step:1195/1700 train_time:115375ms step_avg:96.55ms
+step:1196/1700 train_time:115476ms step_avg:96.55ms
+step:1197/1700 train_time:115577ms step_avg:96.56ms
+step:1198/1700 train_time:115678ms step_avg:96.56ms
+step:1199/1700 train_time:115778ms step_avg:96.56ms
+step:1200/1700 train_time:115878ms step_avg:96.56ms
+step:1201/1700 train_time:115978ms step_avg:96.57ms
+step:1202/1700 train_time:116079ms step_avg:96.57ms
+step:1203/1700 train_time:116179ms step_avg:96.57ms
+step:1204/1700 train_time:116278ms step_avg:96.58ms
+step:1205/1700 train_time:116379ms step_avg:96.58ms
+step:1206/1700 train_time:116479ms step_avg:96.58ms
+step:1207/1700 train_time:116579ms step_avg:96.59ms
+step:1208/1700 train_time:116679ms step_avg:96.59ms
+step:1209/1700 train_time:116780ms step_avg:96.59ms
+step:1210/1700 train_time:116880ms step_avg:96.60ms
+step:1211/1700 train_time:116981ms step_avg:96.60ms
+step:1212/1700 train_time:117081ms step_avg:96.60ms
+step:1213/1700 train_time:117181ms step_avg:96.60ms
+step:1214/1700 train_time:117281ms step_avg:96.61ms
+step:1215/1700 train_time:117382ms step_avg:96.61ms
+step:1216/1700 train_time:117482ms step_avg:96.61ms
+step:1217/1700 train_time:117582ms step_avg:96.62ms
+step:1218/1700 train_time:117684ms step_avg:96.62ms
+step:1219/1700 train_time:117786ms step_avg:96.62ms
+step:1220/1700 train_time:117886ms step_avg:96.63ms
+step:1221/1700 train_time:117985ms step_avg:96.63ms
+step:1222/1700 train_time:118085ms step_avg:96.63ms
+step:1223/1700 train_time:118187ms step_avg:96.64ms
+step:1224/1700 train_time:118287ms step_avg:96.64ms
+step:1225/1700 train_time:118388ms step_avg:96.64ms
+step:1226/1700 train_time:118489ms step_avg:96.65ms
+step:1227/1700 train_time:118588ms step_avg:96.65ms
+step:1228/1700 train_time:118689ms step_avg:96.65ms
+step:1229/1700 train_time:118790ms step_avg:96.66ms
+step:1230/1700 train_time:118890ms step_avg:96.66ms
+step:1231/1700 train_time:118990ms step_avg:96.66ms
+step:1232/1700 train_time:119089ms step_avg:96.66ms
+step:1233/1700 train_time:119189ms step_avg:96.67ms
+step:1234/1700 train_time:119289ms step_avg:96.67ms
+step:1235/1700 train_time:119389ms step_avg:96.67ms
+step:1236/1700 train_time:119490ms step_avg:96.67ms
+step:1237/1700 train_time:119590ms step_avg:96.68ms
+step:1238/1700 train_time:119690ms step_avg:96.68ms
+step:1239/1700 train_time:119789ms step_avg:96.68ms
+step:1240/1700 train_time:119890ms step_avg:96.69ms
+step:1241/1700 train_time:119991ms step_avg:96.69ms
+step:1242/1700 train_time:120092ms step_avg:96.69ms
+step:1243/1700 train_time:120194ms step_avg:96.70ms
+step:1244/1700 train_time:120294ms step_avg:96.70ms
+step:1245/1700 train_time:120396ms step_avg:96.70ms
+step:1246/1700 train_time:120496ms step_avg:96.71ms
+step:1247/1700 train_time:120596ms step_avg:96.71ms
+step:1248/1700 train_time:120697ms step_avg:96.71ms
+step:1249/1700 train_time:120797ms step_avg:96.71ms
+step:1250/1700 train_time:120897ms step_avg:96.72ms
+step:1250/1700 val_loss:3.3950 train_time:120979ms step_avg:96.78ms
+step:1251/1700 train_time:121004ms step_avg:96.73ms
+step:1252/1700 train_time:121106ms step_avg:96.73ms
+step:1253/1700 train_time:121208ms step_avg:96.73ms
+step:1254/1700 train_time:121307ms step_avg:96.74ms
+step:1255/1700 train_time:121407ms step_avg:96.74ms
+step:1256/1700 train_time:121507ms step_avg:96.74ms
+step:1257/1700 train_time:121607ms step_avg:96.74ms
+step:1258/1700 train_time:121707ms step_avg:96.75ms
+step:1259/1700 train_time:121806ms step_avg:96.75ms
+step:1260/1700 train_time:121907ms step_avg:96.75ms
+step:1261/1700 train_time:122009ms step_avg:96.76ms
+step:1262/1700 train_time:122111ms step_avg:96.76ms
+step:1263/1700 train_time:122211ms step_avg:96.76ms
+step:1264/1700 train_time:122311ms step_avg:96.77ms
+step:1265/1700 train_time:122410ms step_avg:96.77ms
+step:1266/1700 train_time:122510ms step_avg:96.77ms
+step:1267/1700 train_time:122610ms step_avg:96.77ms
+step:1268/1700 train_time:122710ms step_avg:96.77ms
+step:1269/1700 train_time:122810ms step_avg:96.78ms
+step:1270/1700 train_time:122911ms step_avg:96.78ms
+step:1271/1700 train_time:123015ms step_avg:96.79ms
+step:1272/1700 train_time:123114ms step_avg:96.79ms
+step:1273/1700 train_time:123214ms step_avg:96.79ms
+step:1274/1700 train_time:123314ms step_avg:96.79ms
+step:1275/1700 train_time:123413ms step_avg:96.79ms
+step:1276/1700 train_time:123514ms step_avg:96.80ms
+step:1277/1700 train_time:123614ms step_avg:96.80ms
+step:1278/1700 train_time:123714ms step_avg:96.80ms
+step:1279/1700 train_time:123814ms step_avg:96.81ms
+step:1280/1700 train_time:123916ms step_avg:96.81ms
+step:1281/1700 train_time:124017ms step_avg:96.81ms
+step:1282/1700 train_time:124117ms step_avg:96.82ms
+step:1283/1700 train_time:124218ms step_avg:96.82ms
+step:1284/1700 train_time:124318ms step_avg:96.82ms
+step:1285/1700 train_time:124417ms step_avg:96.82ms
+step:1286/1700 train_time:124517ms step_avg:96.82ms
+step:1287/1700 train_time:124618ms step_avg:96.83ms
+step:1288/1700 train_time:124718ms step_avg:96.83ms
+step:1289/1700 train_time:124819ms step_avg:96.83ms
+step:1290/1700 train_time:124921ms step_avg:96.84ms
+step:1291/1700 train_time:125021ms step_avg:96.84ms
+step:1292/1700 train_time:125121ms step_avg:96.84ms
+step:1293/1700 train_time:125222ms step_avg:96.85ms
+step:1294/1700 train_time:125323ms step_avg:96.85ms
+step:1295/1700 train_time:125423ms step_avg:96.85ms
+step:1296/1700 train_time:125524ms step_avg:96.85ms
+step:1297/1700 train_time:125624ms step_avg:96.86ms
+step:1298/1700 train_time:125726ms step_avg:96.86ms
+step:1299/1700 train_time:125826ms step_avg:96.86ms
+step:1300/1700 train_time:125928ms step_avg:96.87ms
+step:1301/1700 train_time:126028ms step_avg:96.87ms
+step:1302/1700 train_time:126128ms step_avg:96.87ms
+step:1303/1700 train_time:126229ms step_avg:96.88ms
+step:1304/1700 train_time:126329ms step_avg:96.88ms
+step:1305/1700 train_time:126429ms step_avg:96.88ms
+step:1306/1700 train_time:126529ms step_avg:96.88ms
+step:1307/1700 train_time:126630ms step_avg:96.89ms
+step:1308/1700 train_time:126731ms step_avg:96.89ms
+step:1309/1700 train_time:126832ms step_avg:96.89ms
+step:1310/1700 train_time:126933ms step_avg:96.90ms
+step:1311/1700 train_time:127033ms step_avg:96.90ms
+step:1312/1700 train_time:127133ms step_avg:96.90ms
+step:1313/1700 train_time:127233ms step_avg:96.90ms
+step:1314/1700 train_time:127333ms step_avg:96.90ms
+step:1315/1700 train_time:127433ms step_avg:96.91ms
+step:1316/1700 train_time:127533ms step_avg:96.91ms
+step:1317/1700 train_time:127633ms step_avg:96.91ms
+step:1318/1700 train_time:127734ms step_avg:96.91ms
+step:1319/1700 train_time:127834ms step_avg:96.92ms
+step:1320/1700 train_time:127935ms step_avg:96.92ms
+step:1321/1700 train_time:128036ms step_avg:96.92ms
+step:1322/1700 train_time:128136ms step_avg:96.93ms
+step:1323/1700 train_time:128237ms step_avg:96.93ms
+step:1324/1700 train_time:128338ms step_avg:96.93ms
+step:1325/1700 train_time:128439ms step_avg:96.93ms
+step:1326/1700 train_time:128539ms step_avg:96.94ms
+step:1327/1700 train_time:128639ms step_avg:96.94ms
+step:1328/1700 train_time:128739ms step_avg:96.94ms
+step:1329/1700 train_time:128839ms step_avg:96.94ms
+step:1330/1700 train_time:128940ms step_avg:96.95ms
+step:1331/1700 train_time:129040ms step_avg:96.95ms
+step:1332/1700 train_time:129141ms step_avg:96.95ms
+step:1333/1700 train_time:129242ms step_avg:96.96ms
+step:1334/1700 train_time:129343ms step_avg:96.96ms
+step:1335/1700 train_time:129444ms step_avg:96.96ms
+step:1336/1700 train_time:129546ms step_avg:96.97ms
+step:1337/1700 train_time:129646ms step_avg:96.97ms
+step:1338/1700 train_time:129746ms step_avg:96.97ms
+step:1339/1700 train_time:129847ms step_avg:96.97ms
+step:1340/1700 train_time:129947ms step_avg:96.98ms
+step:1341/1700 train_time:130048ms step_avg:96.98ms
+step:1342/1700 train_time:130148ms step_avg:96.98ms
+step:1343/1700 train_time:130248ms step_avg:96.98ms
+step:1344/1700 train_time:130348ms step_avg:96.99ms
+step:1345/1700 train_time:130449ms step_avg:96.99ms
+step:1346/1700 train_time:130551ms step_avg:96.99ms
+step:1347/1700 train_time:130652ms step_avg:96.99ms
+step:1348/1700 train_time:130752ms step_avg:97.00ms
+step:1349/1700 train_time:130852ms step_avg:97.00ms
+step:1350/1700 train_time:130953ms step_avg:97.00ms
+step:1351/1700 train_time:131053ms step_avg:97.00ms
+step:1352/1700 train_time:131153ms step_avg:97.01ms
+step:1353/1700 train_time:131253ms step_avg:97.01ms
+step:1354/1700 train_time:131353ms step_avg:97.01ms
+step:1355/1700 train_time:131453ms step_avg:97.01ms
+step:1356/1700 train_time:131553ms step_avg:97.02ms
+step:1357/1700 train_time:131653ms step_avg:97.02ms
+step:1358/1700 train_time:131753ms step_avg:97.02ms
+step:1359/1700 train_time:131854ms step_avg:97.02ms
+step:1360/1700 train_time:131954ms step_avg:97.02ms
+step:1361/1700 train_time:132054ms step_avg:97.03ms
+step:1362/1700 train_time:132153ms step_avg:97.03ms
+step:1363/1700 train_time:132254ms step_avg:97.03ms
+step:1364/1700 train_time:132355ms step_avg:97.03ms
+step:1365/1700 train_time:132457ms step_avg:97.04ms
+step:1366/1700 train_time:132558ms step_avg:97.04ms
+step:1367/1700 train_time:132659ms step_avg:97.04ms
+step:1368/1700 train_time:132760ms step_avg:97.05ms
+step:1369/1700 train_time:132860ms step_avg:97.05ms
+step:1370/1700 train_time:132960ms step_avg:97.05ms
+step:1371/1700 train_time:133061ms step_avg:97.05ms
+step:1372/1700 train_time:133161ms step_avg:97.06ms
+step:1373/1700 train_time:133262ms step_avg:97.06ms
+step:1374/1700 train_time:133364ms step_avg:97.06ms
+step:1375/1700 train_time:133466ms step_avg:97.07ms
+step:1375/1700 val_loss:3.3555 train_time:133549ms step_avg:97.13ms
+step:1376/1700 train_time:133573ms step_avg:97.07ms
+step:1377/1700 train_time:133675ms step_avg:97.08ms
+step:1378/1700 train_time:133778ms step_avg:97.08ms
+step:1379/1700 train_time:133879ms step_avg:97.08ms
+step:1380/1700 train_time:133979ms step_avg:97.09ms
+step:1381/1700 train_time:134079ms step_avg:97.09ms
+step:1382/1700 train_time:134179ms step_avg:97.09ms
+step:1383/1700 train_time:134278ms step_avg:97.09ms
+step:1384/1700 train_time:134377ms step_avg:97.09ms
+step:1385/1700 train_time:134477ms step_avg:97.10ms
+step:1386/1700 train_time:134580ms step_avg:97.10ms
+step:1387/1700 train_time:134683ms step_avg:97.10ms
+step:1388/1700 train_time:134785ms step_avg:97.11ms
+step:1389/1700 train_time:134886ms step_avg:97.11ms
+step:1390/1700 train_time:134987ms step_avg:97.11ms
+step:1391/1700 train_time:135088ms step_avg:97.12ms
+step:1392/1700 train_time:135190ms step_avg:97.12ms
+step:1393/1700 train_time:135290ms step_avg:97.12ms
+step:1394/1700 train_time:135390ms step_avg:97.12ms
+step:1395/1700 train_time:135493ms step_avg:97.13ms
+step:1396/1700 train_time:135595ms step_avg:97.13ms
+step:1397/1700 train_time:135696ms step_avg:97.13ms
+step:1398/1700 train_time:135796ms step_avg:97.14ms
+step:1399/1700 train_time:135899ms step_avg:97.14ms
+step:1400/1700 train_time:136001ms step_avg:97.14ms
+step:1401/1700 train_time:136103ms step_avg:97.15ms
+step:1402/1700 train_time:136204ms step_avg:97.15ms
+step:1403/1700 train_time:136305ms step_avg:97.15ms
+step:1404/1700 train_time:136407ms step_avg:97.16ms
+step:1405/1700 train_time:136510ms step_avg:97.16ms
+step:1406/1700 train_time:136611ms step_avg:97.16ms
+step:1407/1700 train_time:136712ms step_avg:97.17ms
+step:1408/1700 train_time:136813ms step_avg:97.17ms
+step:1409/1700 train_time:136919ms step_avg:97.17ms
+step:1410/1700 train_time:137020ms step_avg:97.18ms
+step:1411/1700 train_time:137121ms step_avg:97.18ms
+step:1412/1700 train_time:137222ms step_avg:97.18ms
+step:1413/1700 train_time:137323ms step_avg:97.19ms
+step:1414/1700 train_time:137424ms step_avg:97.19ms
+step:1415/1700 train_time:137525ms step_avg:97.19ms
+step:1416/1700 train_time:137627ms step_avg:97.19ms
+step:1417/1700 train_time:137728ms step_avg:97.20ms
+step:1418/1700 train_time:137829ms step_avg:97.20ms
+step:1419/1700 train_time:137930ms step_avg:97.20ms
+step:1420/1700 train_time:138032ms step_avg:97.21ms
+step:1421/1700 train_time:138135ms step_avg:97.21ms
+step:1422/1700 train_time:138234ms step_avg:97.21ms
+step:1423/1700 train_time:138335ms step_avg:97.21ms
+step:1424/1700 train_time:138438ms step_avg:97.22ms
+step:1425/1700 train_time:138541ms step_avg:97.22ms
+step:1426/1700 train_time:138642ms step_avg:97.22ms
+step:1427/1700 train_time:138743ms step_avg:97.23ms
+step:1428/1700 train_time:138845ms step_avg:97.23ms
+step:1429/1700 train_time:138946ms step_avg:97.23ms
+step:1430/1700 train_time:139048ms step_avg:97.24ms
+step:1431/1700 train_time:139149ms step_avg:97.24ms
+step:1432/1700 train_time:139249ms step_avg:97.24ms
+step:1433/1700 train_time:139351ms step_avg:97.24ms
+step:1434/1700 train_time:139452ms step_avg:97.25ms
+step:1435/1700 train_time:139557ms step_avg:97.25ms
+step:1436/1700 train_time:139659ms step_avg:97.26ms
+step:1437/1700 train_time:139762ms step_avg:97.26ms
+step:1438/1700 train_time:139862ms step_avg:97.26ms
+step:1439/1700 train_time:139964ms step_avg:97.26ms
+step:1440/1700 train_time:140067ms step_avg:97.27ms
+step:1441/1700 train_time:140169ms step_avg:97.27ms
+step:1442/1700 train_time:140269ms step_avg:97.27ms
+step:1443/1700 train_time:140370ms step_avg:97.28ms
+step:1444/1700 train_time:140471ms step_avg:97.28ms
+step:1445/1700 train_time:140573ms step_avg:97.28ms
+step:1446/1700 train_time:140674ms step_avg:97.28ms
+step:1447/1700 train_time:140774ms step_avg:97.29ms
+step:1448/1700 train_time:140876ms step_avg:97.29ms
+step:1449/1700 train_time:140975ms step_avg:97.29ms
+step:1450/1700 train_time:141078ms step_avg:97.29ms
+step:1451/1700 train_time:141179ms step_avg:97.30ms
+step:1452/1700 train_time:141282ms step_avg:97.30ms
+step:1453/1700 train_time:141385ms step_avg:97.31ms
+step:1454/1700 train_time:141488ms step_avg:97.31ms
+step:1455/1700 train_time:141589ms step_avg:97.31ms
+step:1456/1700 train_time:141689ms step_avg:97.31ms
+step:1457/1700 train_time:141790ms step_avg:97.32ms
+step:1458/1700 train_time:141891ms step_avg:97.32ms
+step:1459/1700 train_time:141993ms step_avg:97.32ms
+step:1460/1700 train_time:142093ms step_avg:97.32ms
+step:1461/1700 train_time:142195ms step_avg:97.33ms
+step:1462/1700 train_time:142296ms step_avg:97.33ms
+step:1463/1700 train_time:142398ms step_avg:97.33ms
+step:1464/1700 train_time:142501ms step_avg:97.34ms
+step:1465/1700 train_time:142602ms step_avg:97.34ms
+step:1466/1700 train_time:142704ms step_avg:97.34ms
+step:1467/1700 train_time:142805ms step_avg:97.34ms
+step:1468/1700 train_time:142907ms step_avg:97.35ms
+step:1469/1700 train_time:143008ms step_avg:97.35ms
+step:1470/1700 train_time:143109ms step_avg:97.35ms
+step:1471/1700 train_time:143211ms step_avg:97.36ms
+step:1472/1700 train_time:143313ms step_avg:97.36ms
+step:1473/1700 train_time:143415ms step_avg:97.36ms
+step:1474/1700 train_time:143516ms step_avg:97.37ms
+step:1475/1700 train_time:143616ms step_avg:97.37ms
+step:1476/1700 train_time:143719ms step_avg:97.37ms
+step:1477/1700 train_time:143821ms step_avg:97.37ms
+step:1478/1700 train_time:143923ms step_avg:97.38ms
+step:1479/1700 train_time:144025ms step_avg:97.38ms
+step:1480/1700 train_time:144127ms step_avg:97.38ms
+step:1481/1700 train_time:144229ms step_avg:97.39ms
+step:1482/1700 train_time:144333ms step_avg:97.39ms
+step:1483/1700 train_time:144433ms step_avg:97.39ms
+step:1484/1700 train_time:144535ms step_avg:97.40ms
+step:1485/1700 train_time:144637ms step_avg:97.40ms
+step:1486/1700 train_time:144740ms step_avg:97.40ms
+step:1487/1700 train_time:144841ms step_avg:97.40ms
+step:1488/1700 train_time:144943ms step_avg:97.41ms
+step:1489/1700 train_time:145044ms step_avg:97.41ms
+step:1490/1700 train_time:145145ms step_avg:97.41ms
+step:1491/1700 train_time:145247ms step_avg:97.42ms
+step:1492/1700 train_time:145350ms step_avg:97.42ms
+step:1493/1700 train_time:145451ms step_avg:97.42ms
+step:1494/1700 train_time:145552ms step_avg:97.42ms
+step:1495/1700 train_time:145653ms step_avg:97.43ms
+step:1496/1700 train_time:145756ms step_avg:97.43ms
+step:1497/1700 train_time:145855ms step_avg:97.43ms
+step:1498/1700 train_time:145957ms step_avg:97.43ms
+step:1499/1700 train_time:146058ms step_avg:97.44ms
+step:1500/1700 train_time:146160ms step_avg:97.44ms
+step:1500/1700 val_loss:3.3210 train_time:146245ms step_avg:97.50ms
+step:1501/1700 train_time:146270ms step_avg:97.45ms
+step:1502/1700 train_time:146372ms step_avg:97.45ms
+step:1503/1700 train_time:146474ms step_avg:97.45ms
+step:1504/1700 train_time:146573ms step_avg:97.46ms
+step:1505/1700 train_time:146674ms step_avg:97.46ms
+step:1506/1700 train_time:146776ms step_avg:97.46ms
+step:1507/1700 train_time:146876ms step_avg:97.46ms
+step:1508/1700 train_time:146977ms step_avg:97.46ms
+step:1509/1700 train_time:147078ms step_avg:97.47ms
+step:1510/1700 train_time:147180ms step_avg:97.47ms
+step:1511/1700 train_time:147282ms step_avg:97.47ms
+step:1512/1700 train_time:147385ms step_avg:97.48ms
+step:1513/1700 train_time:147488ms step_avg:97.48ms
+step:1514/1700 train_time:147590ms step_avg:97.48ms
+step:1515/1700 train_time:147694ms step_avg:97.49ms
+step:1516/1700 train_time:147796ms step_avg:97.49ms
+step:1517/1700 train_time:147897ms step_avg:97.49ms
+step:1518/1700 train_time:147997ms step_avg:97.49ms
+step:1519/1700 train_time:148100ms step_avg:97.50ms
+step:1520/1700 train_time:148201ms step_avg:97.50ms
+step:1521/1700 train_time:148302ms step_avg:97.50ms
+step:1522/1700 train_time:148406ms step_avg:97.51ms
+step:1523/1700 train_time:148507ms step_avg:97.51ms
+step:1524/1700 train_time:148609ms step_avg:97.51ms
+step:1525/1700 train_time:148712ms step_avg:97.52ms
+step:1526/1700 train_time:148813ms step_avg:97.52ms
+step:1527/1700 train_time:148914ms step_avg:97.52ms
+step:1528/1700 train_time:149016ms step_avg:97.52ms
+step:1529/1700 train_time:149117ms step_avg:97.53ms
+step:1530/1700 train_time:149218ms step_avg:97.53ms
+step:1531/1700 train_time:149320ms step_avg:97.53ms
+step:1532/1700 train_time:149422ms step_avg:97.53ms
+step:1533/1700 train_time:149524ms step_avg:97.54ms
+step:1534/1700 train_time:149625ms step_avg:97.54ms
+step:1535/1700 train_time:149729ms step_avg:97.54ms
+step:1536/1700 train_time:149830ms step_avg:97.55ms
+step:1537/1700 train_time:149931ms step_avg:97.55ms
+step:1538/1700 train_time:150033ms step_avg:97.55ms
+step:1539/1700 train_time:150135ms step_avg:97.55ms
+step:1540/1700 train_time:150236ms step_avg:97.56ms
+step:1541/1700 train_time:150339ms step_avg:97.56ms
+step:1542/1700 train_time:150441ms step_avg:97.56ms
+step:1543/1700 train_time:150542ms step_avg:97.56ms
+step:1544/1700 train_time:150644ms step_avg:97.57ms
+step:1545/1700 train_time:150746ms step_avg:97.57ms
+step:1546/1700 train_time:150846ms step_avg:97.57ms
+step:1547/1700 train_time:150950ms step_avg:97.58ms
+step:1548/1700 train_time:151052ms step_avg:97.58ms
+step:1549/1700 train_time:151154ms step_avg:97.58ms
+step:1550/1700 train_time:151255ms step_avg:97.58ms
+step:1551/1700 train_time:151357ms step_avg:97.59ms
+step:1552/1700 train_time:151458ms step_avg:97.59ms
+step:1553/1700 train_time:151560ms step_avg:97.59ms
+step:1554/1700 train_time:151662ms step_avg:97.59ms
+step:1555/1700 train_time:151763ms step_avg:97.60ms
+step:1556/1700 train_time:151864ms step_avg:97.60ms
+step:1557/1700 train_time:151968ms step_avg:97.60ms
+step:1558/1700 train_time:152071ms step_avg:97.61ms
+step:1559/1700 train_time:152173ms step_avg:97.61ms
+step:1560/1700 train_time:152274ms step_avg:97.61ms
+step:1561/1700 train_time:152375ms step_avg:97.61ms
+step:1562/1700 train_time:152477ms step_avg:97.62ms
+step:1563/1700 train_time:152580ms step_avg:97.62ms
+step:1564/1700 train_time:152680ms step_avg:97.62ms
+step:1565/1700 train_time:152780ms step_avg:97.62ms
+step:1566/1700 train_time:152881ms step_avg:97.63ms
+step:1567/1700 train_time:152984ms step_avg:97.63ms
+step:1568/1700 train_time:153085ms step_avg:97.63ms
+step:1569/1700 train_time:153188ms step_avg:97.63ms
+step:1570/1700 train_time:153289ms step_avg:97.64ms
+step:1571/1700 train_time:153390ms step_avg:97.64ms
+step:1572/1700 train_time:153491ms step_avg:97.64ms
+step:1573/1700 train_time:153593ms step_avg:97.64ms
+step:1574/1700 train_time:153695ms step_avg:97.65ms
+step:1575/1700 train_time:153796ms step_avg:97.65ms
+step:1576/1700 train_time:153898ms step_avg:97.65ms
+step:1577/1700 train_time:154000ms step_avg:97.65ms
+step:1578/1700 train_time:154102ms step_avg:97.66ms
+step:1579/1700 train_time:154203ms step_avg:97.66ms
+step:1580/1700 train_time:154306ms step_avg:97.66ms
+step:1581/1700 train_time:154408ms step_avg:97.66ms
+step:1582/1700 train_time:154509ms step_avg:97.67ms
+step:1583/1700 train_time:154612ms step_avg:97.67ms
+step:1584/1700 train_time:154715ms step_avg:97.67ms
+step:1585/1700 train_time:154815ms step_avg:97.68ms
+step:1586/1700 train_time:154917ms step_avg:97.68ms
+step:1587/1700 train_time:155018ms step_avg:97.68ms
+step:1588/1700 train_time:155119ms step_avg:97.68ms
+step:1589/1700 train_time:155221ms step_avg:97.68ms
+step:1590/1700 train_time:155324ms step_avg:97.69ms
+step:1591/1700 train_time:155427ms step_avg:97.69ms
+step:1592/1700 train_time:155529ms step_avg:97.69ms
+step:1593/1700 train_time:155630ms step_avg:97.70ms
+step:1594/1700 train_time:155736ms step_avg:97.70ms
+step:1595/1700 train_time:155837ms step_avg:97.70ms
+step:1596/1700 train_time:155937ms step_avg:97.70ms
+step:1597/1700 train_time:156039ms step_avg:97.71ms
+step:1598/1700 train_time:156140ms step_avg:97.71ms
+step:1599/1700 train_time:156241ms step_avg:97.71ms
+step:1600/1700 train_time:156343ms step_avg:97.71ms
+step:1601/1700 train_time:156445ms step_avg:97.72ms
+step:1602/1700 train_time:156547ms step_avg:97.72ms
+step:1603/1700 train_time:156650ms step_avg:97.72ms
+step:1604/1700 train_time:156751ms step_avg:97.72ms
+step:1605/1700 train_time:156853ms step_avg:97.73ms
+step:1606/1700 train_time:156954ms step_avg:97.73ms
+step:1607/1700 train_time:157055ms step_avg:97.73ms
+step:1608/1700 train_time:157157ms step_avg:97.73ms
+step:1609/1700 train_time:157258ms step_avg:97.74ms
+step:1610/1700 train_time:157360ms step_avg:97.74ms
+step:1611/1700 train_time:157462ms step_avg:97.74ms
+step:1612/1700 train_time:157566ms step_avg:97.75ms
+step:1613/1700 train_time:157668ms step_avg:97.75ms
+step:1614/1700 train_time:157769ms step_avg:97.75ms
+step:1615/1700 train_time:157870ms step_avg:97.75ms
+step:1616/1700 train_time:157971ms step_avg:97.75ms
+step:1617/1700 train_time:158072ms step_avg:97.76ms
+step:1618/1700 train_time:158173ms step_avg:97.76ms
+step:1619/1700 train_time:158275ms step_avg:97.76ms
+step:1620/1700 train_time:158377ms step_avg:97.76ms
+step:1621/1700 train_time:158478ms step_avg:97.77ms
+step:1622/1700 train_time:158581ms step_avg:97.77ms
+step:1623/1700 train_time:158683ms step_avg:97.77ms
+step:1624/1700 train_time:158786ms step_avg:97.77ms
+step:1625/1700 train_time:158889ms step_avg:97.78ms
+step:1625/1700 val_loss:3.2924 train_time:158971ms step_avg:97.83ms
+step:1626/1700 train_time:158995ms step_avg:97.78ms
+step:1627/1700 train_time:159094ms step_avg:97.78ms
+step:1628/1700 train_time:159197ms step_avg:97.79ms
+step:1629/1700 train_time:159297ms step_avg:97.79ms
+step:1630/1700 train_time:159397ms step_avg:97.79ms
+step:1631/1700 train_time:159498ms step_avg:97.79ms
+step:1632/1700 train_time:159599ms step_avg:97.79ms
+step:1633/1700 train_time:159699ms step_avg:97.79ms
+step:1634/1700 train_time:159802ms step_avg:97.80ms
+step:1635/1700 train_time:159902ms step_avg:97.80ms
+step:1636/1700 train_time:160005ms step_avg:97.80ms
+step:1637/1700 train_time:160110ms step_avg:97.81ms
+step:1638/1700 train_time:160210ms step_avg:97.81ms
+step:1639/1700 train_time:160311ms step_avg:97.81ms
+step:1640/1700 train_time:160412ms step_avg:97.81ms
+step:1641/1700 train_time:160514ms step_avg:97.81ms
+step:1642/1700 train_time:160615ms step_avg:97.82ms
+step:1643/1700 train_time:160717ms step_avg:97.82ms
+step:1644/1700 train_time:160819ms step_avg:97.82ms
+step:1645/1700 train_time:160922ms step_avg:97.83ms
+step:1646/1700 train_time:161024ms step_avg:97.83ms
+step:1647/1700 train_time:161130ms step_avg:97.83ms
+step:1648/1700 train_time:161233ms step_avg:97.84ms
+step:1649/1700 train_time:161335ms step_avg:97.84ms
+step:1650/1700 train_time:161436ms step_avg:97.84ms
+step:1651/1700 train_time:161537ms step_avg:97.84ms
+step:1652/1700 train_time:161638ms step_avg:97.84ms
+step:1653/1700 train_time:161740ms step_avg:97.85ms
+step:1654/1700 train_time:161841ms step_avg:97.85ms
+step:1655/1700 train_time:161945ms step_avg:97.85ms
+step:1656/1700 train_time:162048ms step_avg:97.86ms
+step:1657/1700 train_time:162150ms step_avg:97.86ms
+step:1658/1700 train_time:162254ms step_avg:97.86ms
+step:1659/1700 train_time:162359ms step_avg:97.87ms
+step:1660/1700 train_time:162461ms step_avg:97.87ms
+step:1661/1700 train_time:162566ms step_avg:97.87ms
+step:1662/1700 train_time:162668ms step_avg:97.88ms
+step:1663/1700 train_time:162771ms step_avg:97.88ms
+step:1664/1700 train_time:162874ms step_avg:97.88ms
+step:1665/1700 train_time:162980ms step_avg:97.89ms
+step:1666/1700 train_time:163082ms step_avg:97.89ms
+step:1667/1700 train_time:163183ms step_avg:97.89ms
+step:1668/1700 train_time:163287ms step_avg:97.89ms
+step:1669/1700 train_time:163392ms step_avg:97.90ms
+step:1670/1700 train_time:163494ms step_avg:97.90ms
+step:1671/1700 train_time:163596ms step_avg:97.90ms
+step:1672/1700 train_time:163698ms step_avg:97.91ms
+step:1673/1700 train_time:163800ms step_avg:97.91ms
+step:1674/1700 train_time:163901ms step_avg:97.91ms
+step:1675/1700 train_time:164003ms step_avg:97.91ms
+step:1676/1700 train_time:164106ms step_avg:97.92ms
+step:1677/1700 train_time:164208ms step_avg:97.92ms
+step:1678/1700 train_time:164311ms step_avg:97.92ms
+step:1679/1700 train_time:164413ms step_avg:97.92ms
+step:1680/1700 train_time:164515ms step_avg:97.93ms
+step:1681/1700 train_time:164619ms step_avg:97.93ms
+step:1682/1700 train_time:164722ms step_avg:97.93ms
+step:1683/1700 train_time:164823ms step_avg:97.93ms
+step:1684/1700 train_time:164928ms step_avg:97.94ms
+step:1685/1700 train_time:165031ms step_avg:97.94ms
+step:1686/1700 train_time:165132ms step_avg:97.94ms
+step:1687/1700 train_time:165234ms step_avg:97.95ms
+step:1688/1700 train_time:165336ms step_avg:97.95ms
+step:1689/1700 train_time:165438ms step_avg:97.95ms
+step:1690/1700 train_time:165539ms step_avg:97.95ms
+step:1691/1700 train_time:165641ms step_avg:97.95ms
+step:1692/1700 train_time:165744ms step_avg:97.96ms
+step:1693/1700 train_time:165847ms step_avg:97.96ms
+step:1694/1700 train_time:165949ms step_avg:97.96ms
+step:1695/1700 train_time:166052ms step_avg:97.97ms
+step:1696/1700 train_time:166155ms step_avg:97.97ms
+step:1697/1700 train_time:166262ms step_avg:97.97ms
+step:1698/1700 train_time:166363ms step_avg:97.98ms
+step:1699/1700 train_time:166464ms step_avg:97.98ms
+step:1700/1700 train_time:166566ms step_avg:97.98ms
+step:1700/1700 val_loss:3.2784 train_time:166649ms step_avg:98.03ms
+peak memory allocated: 33278 MiB reserved: 48132 MiB

--- a/records/101225_NorMuon/Muon_1700.txt
+++ b/records/101225_NorMuon/Muon_1700.txt
@@ -1,0 +1,2515 @@
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+import copy
+import glob
+from dataclasses import dataclass
+from functools import lru_cache, partial # Added partial for hook registration
+from pathlib import Path
+
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+torch.empty(1, device="cuda", requires_grad=True).backward() # prevents a bug on some systems
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+# use of FlexAttention contributed by @KoszarskyB
+from torch.nn.attention.flex_attention import BlockMask, flex_attention
+#torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+@torch.compile
+def zeropower_via_newtonschulz5(G: Tensor, steps: int) -> Tensor:
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert G.ndim >= 2 # batched Muon implementation by @scottjmaddox, and put into practice in the record by @YouJiacheng
+    a, b, c = (3.4445, -4.7750,  2.0315)
+    X = G
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * A @ A # quintic computation strategy adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum)
+        params = list(params)
+        sizes = {p.shape for p in params}
+        # create one buffer per unique parameter-size
+        param_groups = []
+        for size in sizes:
+            group_params = [p for p in params if p.shape == size]
+            param_groups.append(dict(params=group_params))
+        super().__init__(param_groups, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient systems-wise implementation of step developed by @YouJiacheng,
+        # @KonstantinWilleke, @alexrgilbert, @adricarda, @tuttyfrutyee, @vdlad,
+        # @ryanyang0, and @vagrawal.
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        reduce_scatter_futures: list[torch.Future] = []
+        all_reduce_futures: list[torch.Future] = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            grad = torch.empty_like(params[-1])
+            grad_pad = [param.grad for param in params] + [torch.zeros_like(params[-1])] * world_size
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    grad = params[base_i + rank].grad
+                else:
+                    grad = torch.zeros_like(grad)
+                # This gives strange dynamo warnings
+                reduce_scatter_futures.append(dist.reduce_scatter(grad, grad_pad[base_i:base_i + world_size], op=dist.ReduceOp.AVG, async_op=True).get_future())
+
+        idx = 0
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * world_size
+            momentum = group["momentum"]
+            for base_i in range(0, len(params), world_size):
+                reduce_scatter_futures[idx].wait()
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    grad = p.grad
+                    eff_lr = group["lr"] * max(1, p.size(-2) / p.size(-1)) ** 0.5 * getattr(p, "lr_mul", 1.0)
+                    eff_weight_decay = group["lr"] * group["weight_decay"] * getattr(p, "wd_mul", 1.0)
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum_buffer"] = torch.zeros_like(grad)
+                    momentum_buffer = state["momentum_buffer"]
+                    p.mul_(1 - eff_weight_decay)
+                    momentum_buffer.lerp_(grad, 1 - momentum)
+                    grad = grad.lerp_(momentum_buffer, momentum)
+                    v = zeropower_via_newtonschulz5(grad.bfloat16(), 5)
+                    p.add_(other=v, alpha=-eff_lr)
+                idx += 1
+                all_reduce_futures.append(dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank], async_op=True).get_future())
+        torch.futures.collect_all(all_reduce_futures).wait()
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        sizes = {p.shape for p in params}
+        # create one buffer per unique parameter-size
+        param_groups = []
+        for size in sizes:
+            group_params = [p for p in params if p.shape == size]
+            param_groups.append(dict(params=group_params))
+        super().__init__(param_groups, defaults)
+        # DistributedAdam implementation by @vagrawal
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        reduce_scatter_futures: list[torch.Future] = []
+        all_reduce_futures: list[torch.Future] = []
+        grad_slices = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            grad = torch.empty_like(params[-1])
+            for base_i in range(len(params)):
+                grad = params[base_i].grad
+                rank_size = grad.shape[0] // world_size
+                grad_slice = torch.empty_like(grad[:rank_size])
+                reduce_scatter_futures.append(dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future())
+                grad_slices.append(grad_slice)
+
+        idx = 0
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            params = group['params']
+            for base in range(len(params)):
+                reduce_scatter_futures[idx].wait()
+                p = params[base]
+                rank_size = p.shape[0] // world_size
+                p_slice = p[rank * rank_size:(rank + 1) * rank_size]
+                lr = group['lr'] * getattr(p, "lr_mul", 1.0)
+                state = self.state[p]
+                g_slice = grad_slices[idx]
+                # State init
+                if not state:
+                    state['step'] = torch.tensor(0, dtype=torch.int64, device=p.device)
+                    state['exp_avg'] = torch.zeros_like(p_slice)
+                    state['exp_avg_sq'] = torch.zeros_like(p_slice)
+                exp_avg = state['exp_avg']
+                exp_avg_sq = state['exp_avg_sq']
+                state['step'] += 1
+                t = state['step']
+                # weight decay
+                if wd != 0:
+                    eff_weight_decay = lr * wd * getattr(p, "wd_mul", 1.0)
+                    p_slice.mul_(1 - eff_weight_decay)
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (torch.sqrt(bias2) / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                p_slice.add_(other=update, alpha=-1.0)
+                idx += 1
+                all_reduce_futures.append(dist.all_gather_into_tensor(p, p_slice, async_op=True).get_future())
+        torch.futures.collect_all(all_reduce_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        std = 0.5 * (self.in_features ** -0.5) # 0.5 is a bit better than the default 1/sqrt(3)
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.weight.uniform_(-bound, bound)
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, max_seq_len: int):
+        super().__init__()
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(dim//4)])
+        t = torch.arange(max_seq_len, dtype=torch.float32)
+        theta = torch.einsum("i,j -> ij", t, angular_freq)
+        self.cos = nn.Buffer(theta.cos(), persistent=False)
+        self.sin = nn.Buffer(theta.sin(), persistent=False)
+
+    def forward(self, x_BTHD: Tensor):
+        assert self.cos.size(0) >= x_BTHD.size(-3)
+        cos, sin = self.cos[None, :x_BTHD.size(-3), None, :], self.sin[None, :x_BTHD.size(-3), None, :]
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, head_dim=128):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        hdim = num_heads * head_dim
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKV weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        self.qkv_w = nn.Parameter(torch.empty(3, hdim, dim).uniform_(-bound, bound))
+        self.rotary = Rotary(head_dim, max_seq_len)
+        self.c_proj = CastedLinear(hdim, dim)
+        self.c_proj.weight.detach().zero_() # zero init suggested by @Grad62304977
+        # scale the attention logits by given constant, instead of the default head_dim**-0.5, by @leloykun
+        # inspired by learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.12
+
+    def forward(self, x: Tensor, ve: Tensor | None, lambdas: Tensor, block_mask: BlockMask):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q, k, v = F.linear(x, self.qkv_w.flatten(end_dim=1).type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        if ve is not None:
+            v = lambdas[0] * v + lambdas[1] * ve.view_as(v) # @KoszarskyB & @Grad62304977
+        else: # skip mid-layers token value embeddings by @YouJiacheng
+            v = lambdas[0] * v
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, scale=self.attn_scale).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = self.c_proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.c_fc = CastedLinear(dim, hdim)
+        self.c_proj = CastedLinear(hdim, dim)
+        self.c_proj.weight.detach().zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = self.c_fc(x)
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = self.c_proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.7 (the 8th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, num_heads, max_seq_len) if layer_idx != 7 else None
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, ve: Tensor | None, x0: Tensor, lambdas: Tensor, sa_lambdas: Tensor, block_mask: BlockMask):
+        x = lambdas[0] * x + lambdas[1] * x0
+        if self.attn is not None:
+            x = x + self.attn(norm(x), ve, sa_lambdas, block_mask)
+        x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        self.blocks = nn.ModuleList([Block(model_dim, num_heads, max_seq_len, i) for i in range(num_layers)])
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=True, x_s=(model_dim**0.5)/448, w_s=24/448, grad_s=1/448)
+        self.lm_head.weight.detach().zero_() # @Grad62304977
+        # Add learnable skip connection weights for decoder layers
+        assert num_layers % 2 == 0
+        pad = (-num_layers * 5) % dist.get_world_size()
+        self.scalars = nn.Parameter(torch.cat([
+            torch.ones(num_layers), # skip_weights
+            *[torch.tensor([1.0, 0.0]) for _ in range(num_layers)], # block lambdas
+            *[torch.tensor([0.5, 0.5]) for _ in range(num_layers)], # SA lambdas
+            torch.ones(pad),
+        ]))
+        # set learning rates
+        for param in self.embed.parameters():
+            param.lr_mul = 75.
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+        self.lm_head.weight.lr_mul = 27.5
+        self.scalars.lr_mul = 5.0
+
+    def create_blockmasks(self, input_seq: Tensor, sliding_window_num_blocks: Tensor):
+        BLOCK_SIZE = 128
+        docs = (input_seq == 50256).cumsum(0)
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_blockmask: Tensor):
+            num_blocks = dense_blockmask.sum(dim=-1, dtype=torch.int32)
+            indices = dense_blockmask.argsort(dim=-1, descending=False, stable=True).flip(-1).to(torch.int32)
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        # manual block mask creation by @YouJiacheng
+        assert len(input_seq) % BLOCK_SIZE == 0
+        NUM_BLOCKS = len(input_seq) // BLOCK_SIZE
+        block_idx = torch.arange(NUM_BLOCKS, dtype=torch.int32, device="cuda")
+        causal_blockmask_any = block_idx[:, None] >= block_idx
+        causal_blockmask_all = block_idx[:, None] > block_idx
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+        document_blockmask_any = (docs_low[:, None] <= docs_high) & (docs_high[:, None] >= docs_low)
+        document_blockmask_all = (docs_low[:, None] == docs_high) & (docs_high[:, None] == docs_low)
+        blockmask_any = causal_blockmask_any & document_blockmask_any
+        blockmask_all = causal_blockmask_all & document_blockmask_all
+        partial_kv_num_blocks, partial_kv_indices = dense_to_ordered(blockmask_any & ~blockmask_all)
+        full_kv_num_blocks, full_kv_indices = dense_to_ordered(blockmask_all)
+        def build_bm(window_size_blocks: Tensor) -> BlockMask:
+            return BlockMask.from_kv_blocks(
+                torch.clamp_max(partial_kv_num_blocks, torch.clamp_min(window_size_blocks - full_kv_num_blocks, 1)),
+                partial_kv_indices,
+                torch.clamp_max(full_kv_num_blocks, window_size_blocks - 1),
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+        # Long-short SWA block masks by @leloykun & @YouJiacheng, adapated from suggestion by @Grad62304977, following Gemma 2 paper
+        return build_bm(sliding_window_num_blocks), build_bm(sliding_window_num_blocks // 2)
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, sliding_window_num_blocks: Tensor):
+        assert input_seq.ndim == 1
+
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        ve = [ve[0], ve[1], ve[2]] + [None] * (len(self.blocks) - 6) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == len(self.blocks)
+
+        long_bm, short_bm = self.create_blockmasks(input_seq, sliding_window_num_blocks)
+        block_masks = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(block_masks) == len(self.blocks)
+
+        x = x0 = norm(self.embed(input_seq)[None]) # use of norm here by @Grad62304977
+
+        # U-net design by @brendanh0gan
+        skip_connections = []
+        skip_weights = self.scalars[:(len(self.blocks) // 2)]
+        lambdas = self.scalars[1 * len(self.blocks): 3 * len(self.blocks)].view(-1, 2)
+        sa_lambdas = self.scalars[3 * len(self.blocks): 5 * len(self.blocks)].view(-1, 2)
+
+        n = len(self.blocks) // 2
+
+        for i in range(len(self.blocks)):
+            if i >= n:
+                x = x + skip_weights[i - n] * skip_connections.pop()
+            x = self.blocks[i](x, ve[i], x0, lambdas[i], sa_lambdas[i], block_masks[i])
+            if i < n:
+                skip_connections.append(x)
+
+        x = norm(x)
+        logits = self.lm_head(x).float()
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15, @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1)
+        logits = 30 * torch.sigmoid(logits / (7.5 * x.size(-1)**0.5))
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq, reduction="sum" if self.training else "mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+# find world_size starting indicies, such that each begins with token 50256 and local_batches don't overlap
+def find_batch_starts(tokens: Tensor, pos: int, local_batch_size: int, max_batch_span: int):
+    boundary_mask = tokens[pos : pos + max_batch_span] == 50256
+    boundary_positions = torch.nonzero(boundary_mask, as_tuple=False).squeeze(-1) + pos
+    start = boundary_positions[0].item()
+    starts = []
+    for i in range(1, len(boundary_positions)):
+        end = boundary_positions[i].item() 
+        if end - start >= local_batch_size:
+            starts.append(start) # append start once end pos is confirmed
+            if len(starts) == dist.get_world_size():
+                return starts, end - pos
+            start = end
+    assert False # increase max_batch_span if necessary
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, align_to_bos: bool):
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files) # use itertools.cycle(files) instead if you want to do multi-epoch training
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    max_batch_span = 2 * batch_size if align_to_bos else batch_size # provide buffer to handle samples up to length local_batch_size
+    while True:
+        if pos + max_batch_span + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        if align_to_bos:
+            batch_starts, batch_span = find_batch_starts(tokens, pos, local_batch_size, max_batch_span)
+            start_idx = batch_starts[rank]
+        else:
+            batch_span = batch_size
+            start_idx = pos + rank * local_batch_size
+        buf = tokens[start_idx:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # no sync on host side;
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # H2D in another stream isn't helpful.
+        pos += batch_span
+        yield inputs, targets
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    train_seq_len = 48*1024 # FlexAttention sequence length
+    val_seq_len = 4*64*1024 # FlexAttention sequence length for validation
+    # optimization
+    num_iterations = 1700 # number of iterations to run
+    cooldown_frac = 0.45 # fraction of training spent cooling down the learning rate
+    # evaluation and logging
+    val_loss_every = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint = False
+args = Hyperparameters()
+
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert world_size == 8 # this code is designed for 8xH100
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = uuid.uuid4()
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(vocab_size=50257, num_layers=12, num_heads=6, model_dim=768, max_seq_len=max(args.train_seq_len, args.val_seq_len)).cuda()
+for m in model.modules():
+    if isinstance(m, nn.Embedding):
+        m.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+# collect the parameters to optimize
+hidden_matrix_params = [p for n, p in model.blocks.named_parameters() if p.ndim >= 2 and "embed" not in n]
+embed_params = [p for n, p in model.named_parameters() if "embed" in n]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+head_params = [model.lm_head.weight]
+
+# init the optimizer(s)
+# small adam epsilon by @YouJiacheng. this is an alternate method of fixing the world_size dependence
+# discovered by @fernbear.bsky.social https://x.com/hi_tysam/status/1879692937589875094
+optimizer1 = DistAdam(scalar_params + head_params + embed_params, lr=0.008, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.0)
+optimizer2 = Muon(hidden_matrix_params, lr=0.05, momentum=0.95, weight_decay=0.0, beta2=0.95)
+optimizers = [optimizer1, optimizer2]
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+
+# learning rate schedule: stable then decay
+def get_lr(step: int):
+    x = step / args.num_iterations # progress in training
+    assert 0 <= x < 1
+    if x < 1 - args.cooldown_frac:
+        return 1.0
+    else:
+        w = (1 - x) / args.cooldown_frac
+        return w * 1.0 + (1 - w) * 0.1
+
+# attention window size schedule: linearly increase
+@lru_cache(1)
+def get_window_size_blocks_helper(window_size: int):
+    return torch.tensor(window_size // 128, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
+def get_window_size_blocks(step: int):
+    x = step / args.num_iterations # progress in training
+    assert 0 <= x <= 1
+    # Linearly increase the block-wise sliding window size over training 128 -> 1792
+    # increase by @fernbear.bsky.social; block-wise by @YouJiacheng
+    window_size = next_multiple_of_n(1728 * x, n=128)
+    return get_window_size_blocks_helper(window_size)
+
+model: nn.Module = torch.compile(model, dynamic=False)
+
+########################################
+#            Warmup kernels            #
+########################################
+
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+warmup_steps = 10
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=[copy.deepcopy(opt.state_dict()) for opt in optimizers]) # save the initial state
+print([opt.state_dict().keys() for opt in optimizers])
+train_loader = distributed_data_generator(args.train_files, world_size * args.train_seq_len, align_to_bos=True)
+for _ in range(warmup_steps):
+    inputs, targets = next(train_loader)
+    model(inputs, targets, get_window_size_blocks(1)).backward()
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+for opt, opt_state in zip(optimizers, initial_state["optimizers"]):
+    opt.load_state_dict(opt_state)
+del train_loader, initial_state
+
+########################################
+#        Training and validation       #
+########################################
+
+train_loader = distributed_data_generator(args.train_files, world_size * args.train_seq_len, align_to_bos=True)
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        val_batch_size = world_size * args.val_seq_len
+        assert args.val_tokens % val_batch_size == 0
+        val_steps = args.val_tokens // val_batch_size
+        val_loader = distributed_data_generator(args.val_files, val_batch_size, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets = next(val_loader)
+                val_loss += model(inputs, targets, get_window_size_blocks(step))
+        val_loss /= val_steps
+        del val_loader
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    model(inputs, targets, get_window_size_blocks(step)).backward()
+    # set optimization hyperparameters
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["lr"] = group["initial_lr"] * get_lr(step)
+    for group in optimizer2.param_groups:
+        frac = min(step / 300, 1) # momentum warmup for muon
+        group["momentum"] = (1 - frac) * 0.85 + frac * 0.95
+    # step the optimizers
+    for opt in optimizers:
+        opt.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.12.7 (main, Oct 11 2025, 17:06:43) [GCC 13.2.0]
+Running PyTorch 2.10.0.dev20251011+cu126 compiled for CUDA 12.6
+Mon Oct 13 01:00:06 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000001:00:00.0 Off |                    0 |
+| N/A   28C    P0            111W /  700W |    5858MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000002:00:00.0 Off |                    0 |
+| N/A   29C    P0            113W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000003:00:00.0 Off |                    0 |
+| N/A   28C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000008:00:00.0 Off |                    0 |
+| N/A   27C    P0            113W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000009:00:00.0 Off |                    0 |
+| N/A   26C    P0            111W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   0000000A:00:00.0 Off |                    0 |
+| N/A   29C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   0000000B:00:00.0 Off |                    0 |
+| N/A   26C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   0000000C:00:00.0 Off |                    0 |
+| N/A   27C    P0            113W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+step:0/1700 val_loss:10.8258 train_time:0ms step_avg:0.02ms
+step:1/1700 train_time:142ms step_avg:142.45ms
+step:2/1700 train_time:163ms step_avg:81.70ms
+step:3/1700 train_time:237ms step_avg:78.99ms
+step:4/1700 train_time:328ms step_avg:82.06ms
+step:5/1700 train_time:420ms step_avg:84.00ms
+step:6/1700 train_time:512ms step_avg:85.41ms
+step:7/1700 train_time:604ms step_avg:86.32ms
+step:8/1700 train_time:696ms step_avg:87.01ms
+step:9/1700 train_time:788ms step_avg:87.57ms
+step:10/1700 train_time:880ms step_avg:87.97ms
+step:11/1700 train_time:972ms step_avg:88.33ms
+step:12/1700 train_time:1065ms step_avg:88.73ms
+step:13/1700 train_time:1160ms step_avg:89.20ms
+step:14/1700 train_time:1253ms step_avg:89.53ms
+step:15/1700 train_time:1346ms step_avg:89.72ms
+step:16/1700 train_time:1439ms step_avg:89.93ms
+step:17/1700 train_time:1531ms step_avg:90.08ms
+step:18/1700 train_time:1623ms step_avg:90.19ms
+step:19/1700 train_time:1716ms step_avg:90.30ms
+step:20/1700 train_time:1808ms step_avg:90.38ms
+step:21/1700 train_time:1900ms step_avg:90.50ms
+step:22/1700 train_time:1993ms step_avg:90.59ms
+step:23/1700 train_time:2085ms step_avg:90.66ms
+step:24/1700 train_time:2179ms step_avg:90.79ms
+step:25/1700 train_time:2272ms step_avg:90.89ms
+step:26/1700 train_time:2365ms step_avg:90.95ms
+step:27/1700 train_time:2458ms step_avg:91.03ms
+step:28/1700 train_time:2552ms step_avg:91.13ms
+step:29/1700 train_time:2644ms step_avg:91.16ms
+step:30/1700 train_time:2736ms step_avg:91.21ms
+step:31/1700 train_time:2829ms step_avg:91.24ms
+step:32/1700 train_time:2921ms step_avg:91.29ms
+step:33/1700 train_time:3014ms step_avg:91.34ms
+step:34/1700 train_time:3107ms step_avg:91.39ms
+step:35/1700 train_time:3201ms step_avg:91.46ms
+step:36/1700 train_time:3294ms step_avg:91.50ms
+step:37/1700 train_time:3387ms step_avg:91.54ms
+step:38/1700 train_time:3480ms step_avg:91.58ms
+step:39/1700 train_time:3573ms step_avg:91.60ms
+step:40/1700 train_time:3665ms step_avg:91.62ms
+step:41/1700 train_time:3758ms step_avg:91.65ms
+step:42/1700 train_time:3850ms step_avg:91.68ms
+step:43/1700 train_time:3943ms step_avg:91.69ms
+step:44/1700 train_time:4036ms step_avg:91.73ms
+step:45/1700 train_time:4129ms step_avg:91.76ms
+step:46/1700 train_time:4222ms step_avg:91.77ms
+step:47/1700 train_time:4315ms step_avg:91.81ms
+step:48/1700 train_time:4407ms step_avg:91.82ms
+step:49/1700 train_time:4501ms step_avg:91.86ms
+step:50/1700 train_time:4594ms step_avg:91.87ms
+step:51/1700 train_time:4686ms step_avg:91.88ms
+step:52/1700 train_time:4778ms step_avg:91.89ms
+step:53/1700 train_time:4871ms step_avg:91.91ms
+step:54/1700 train_time:4964ms step_avg:91.92ms
+step:55/1700 train_time:5057ms step_avg:91.94ms
+step:56/1700 train_time:5149ms step_avg:91.95ms
+step:57/1700 train_time:5242ms step_avg:91.96ms
+step:58/1700 train_time:5335ms step_avg:91.98ms
+step:59/1700 train_time:5427ms step_avg:91.98ms
+step:60/1700 train_time:5519ms step_avg:91.99ms
+step:61/1700 train_time:5613ms step_avg:92.01ms
+step:62/1700 train_time:5705ms step_avg:92.01ms
+step:63/1700 train_time:5798ms step_avg:92.03ms
+step:64/1700 train_time:5891ms step_avg:92.04ms
+step:65/1700 train_time:5983ms step_avg:92.05ms
+step:66/1700 train_time:6076ms step_avg:92.06ms
+step:67/1700 train_time:6168ms step_avg:92.07ms
+step:68/1700 train_time:6262ms step_avg:92.08ms
+step:69/1700 train_time:6356ms step_avg:92.11ms
+step:70/1700 train_time:6449ms step_avg:92.13ms
+step:71/1700 train_time:6541ms step_avg:92.13ms
+step:72/1700 train_time:6634ms step_avg:92.14ms
+step:73/1700 train_time:6726ms step_avg:92.14ms
+step:74/1700 train_time:6819ms step_avg:92.15ms
+step:75/1700 train_time:6913ms step_avg:92.17ms
+step:76/1700 train_time:7005ms step_avg:92.17ms
+step:77/1700 train_time:7097ms step_avg:92.18ms
+step:78/1700 train_time:7190ms step_avg:92.18ms
+step:79/1700 train_time:7283ms step_avg:92.19ms
+step:80/1700 train_time:7376ms step_avg:92.21ms
+step:81/1700 train_time:7469ms step_avg:92.21ms
+step:82/1700 train_time:7561ms step_avg:92.21ms
+step:83/1700 train_time:7654ms step_avg:92.22ms
+step:84/1700 train_time:7746ms step_avg:92.22ms
+step:85/1700 train_time:7839ms step_avg:92.22ms
+step:86/1700 train_time:7932ms step_avg:92.23ms
+step:87/1700 train_time:8024ms step_avg:92.23ms
+step:88/1700 train_time:8118ms step_avg:92.24ms
+step:89/1700 train_time:8210ms step_avg:92.25ms
+step:90/1700 train_time:8303ms step_avg:92.25ms
+step:91/1700 train_time:8396ms step_avg:92.26ms
+step:92/1700 train_time:8488ms step_avg:92.26ms
+step:93/1700 train_time:8581ms step_avg:92.27ms
+step:94/1700 train_time:8674ms step_avg:92.27ms
+step:95/1700 train_time:8766ms step_avg:92.28ms
+step:96/1700 train_time:8859ms step_avg:92.28ms
+step:97/1700 train_time:8953ms step_avg:92.29ms
+step:98/1700 train_time:9045ms step_avg:92.29ms
+step:99/1700 train_time:9138ms step_avg:92.30ms
+step:100/1700 train_time:9231ms step_avg:92.31ms
+step:101/1700 train_time:9324ms step_avg:92.31ms
+step:102/1700 train_time:9417ms step_avg:92.32ms
+step:103/1700 train_time:9510ms step_avg:92.33ms
+step:104/1700 train_time:9602ms step_avg:92.33ms
+step:105/1700 train_time:9695ms step_avg:92.33ms
+step:106/1700 train_time:9787ms step_avg:92.33ms
+step:107/1700 train_time:9880ms step_avg:92.34ms
+step:108/1700 train_time:9973ms step_avg:92.34ms
+step:109/1700 train_time:10066ms step_avg:92.35ms
+step:110/1700 train_time:10159ms step_avg:92.35ms
+step:111/1700 train_time:10253ms step_avg:92.37ms
+step:112/1700 train_time:10345ms step_avg:92.37ms
+step:113/1700 train_time:10438ms step_avg:92.37ms
+step:114/1700 train_time:10531ms step_avg:92.38ms
+step:115/1700 train_time:10624ms step_avg:92.38ms
+step:116/1700 train_time:10717ms step_avg:92.39ms
+step:117/1700 train_time:10809ms step_avg:92.39ms
+step:118/1700 train_time:10902ms step_avg:92.39ms
+step:119/1700 train_time:10995ms step_avg:92.39ms
+step:120/1700 train_time:11087ms step_avg:92.39ms
+step:121/1700 train_time:11181ms step_avg:92.40ms
+step:122/1700 train_time:11273ms step_avg:92.41ms
+step:123/1700 train_time:11365ms step_avg:92.40ms
+step:124/1700 train_time:11458ms step_avg:92.40ms
+step:125/1700 train_time:11550ms step_avg:92.40ms
+step:125/1700 val_loss:4.6426 train_time:11639ms step_avg:93.11ms
+step:126/1700 train_time:11664ms step_avg:92.57ms
+step:127/1700 train_time:11743ms step_avg:92.46ms
+step:128/1700 train_time:11845ms step_avg:92.54ms
+step:129/1700 train_time:11941ms step_avg:92.56ms
+step:130/1700 train_time:12033ms step_avg:92.56ms
+step:131/1700 train_time:12126ms step_avg:92.56ms
+step:132/1700 train_time:12218ms step_avg:92.56ms
+step:133/1700 train_time:12311ms step_avg:92.56ms
+step:134/1700 train_time:12404ms step_avg:92.56ms
+step:135/1700 train_time:12496ms step_avg:92.56ms
+step:136/1700 train_time:12588ms step_avg:92.56ms
+step:137/1700 train_time:12682ms step_avg:92.57ms
+step:138/1700 train_time:12777ms step_avg:92.59ms
+step:139/1700 train_time:12871ms step_avg:92.60ms
+step:140/1700 train_time:12965ms step_avg:92.61ms
+step:141/1700 train_time:13059ms step_avg:92.62ms
+step:142/1700 train_time:13151ms step_avg:92.61ms
+step:143/1700 train_time:13244ms step_avg:92.62ms
+step:144/1700 train_time:13337ms step_avg:92.61ms
+step:145/1700 train_time:13429ms step_avg:92.61ms
+step:146/1700 train_time:13522ms step_avg:92.62ms
+step:147/1700 train_time:13615ms step_avg:92.62ms
+step:148/1700 train_time:13708ms step_avg:92.62ms
+step:149/1700 train_time:13803ms step_avg:92.64ms
+step:150/1700 train_time:13897ms step_avg:92.65ms
+step:151/1700 train_time:13990ms step_avg:92.65ms
+step:152/1700 train_time:14084ms step_avg:92.66ms
+step:153/1700 train_time:14177ms step_avg:92.66ms
+step:154/1700 train_time:14269ms step_avg:92.66ms
+step:155/1700 train_time:14362ms step_avg:92.66ms
+step:156/1700 train_time:14455ms step_avg:92.66ms
+step:157/1700 train_time:14548ms step_avg:92.66ms
+step:158/1700 train_time:14642ms step_avg:92.67ms
+step:159/1700 train_time:14735ms step_avg:92.67ms
+step:160/1700 train_time:14829ms step_avg:92.68ms
+step:161/1700 train_time:14923ms step_avg:92.69ms
+step:162/1700 train_time:15016ms step_avg:92.69ms
+step:163/1700 train_time:15109ms step_avg:92.70ms
+step:164/1700 train_time:15203ms step_avg:92.70ms
+step:165/1700 train_time:15296ms step_avg:92.70ms
+step:166/1700 train_time:15389ms step_avg:92.70ms
+step:167/1700 train_time:15482ms step_avg:92.71ms
+step:168/1700 train_time:15575ms step_avg:92.71ms
+step:169/1700 train_time:15669ms step_avg:92.71ms
+step:170/1700 train_time:15762ms step_avg:92.72ms
+step:171/1700 train_time:15855ms step_avg:92.72ms
+step:172/1700 train_time:15949ms step_avg:92.72ms
+step:173/1700 train_time:16042ms step_avg:92.73ms
+step:174/1700 train_time:16135ms step_avg:92.73ms
+step:175/1700 train_time:16229ms step_avg:92.74ms
+step:176/1700 train_time:16323ms step_avg:92.74ms
+step:177/1700 train_time:16415ms step_avg:92.74ms
+step:178/1700 train_time:16508ms step_avg:92.74ms
+step:179/1700 train_time:16602ms step_avg:92.75ms
+step:180/1700 train_time:16694ms step_avg:92.75ms
+step:181/1700 train_time:16788ms step_avg:92.75ms
+step:182/1700 train_time:16882ms step_avg:92.76ms
+step:183/1700 train_time:16975ms step_avg:92.76ms
+step:184/1700 train_time:17068ms step_avg:92.76ms
+step:185/1700 train_time:17163ms step_avg:92.77ms
+step:186/1700 train_time:17256ms step_avg:92.78ms
+step:187/1700 train_time:17350ms step_avg:92.78ms
+step:188/1700 train_time:17443ms step_avg:92.78ms
+step:189/1700 train_time:17536ms step_avg:92.78ms
+step:190/1700 train_time:17629ms step_avg:92.78ms
+step:191/1700 train_time:17722ms step_avg:92.78ms
+step:192/1700 train_time:17815ms step_avg:92.79ms
+step:193/1700 train_time:17908ms step_avg:92.79ms
+step:194/1700 train_time:18002ms step_avg:92.80ms
+step:195/1700 train_time:18095ms step_avg:92.80ms
+step:196/1700 train_time:18188ms step_avg:92.80ms
+step:197/1700 train_time:18283ms step_avg:92.80ms
+step:198/1700 train_time:18376ms step_avg:92.81ms
+step:199/1700 train_time:18469ms step_avg:92.81ms
+step:200/1700 train_time:18562ms step_avg:92.81ms
+step:201/1700 train_time:18656ms step_avg:92.81ms
+step:202/1700 train_time:18749ms step_avg:92.81ms
+step:203/1700 train_time:18843ms step_avg:92.82ms
+step:204/1700 train_time:18936ms step_avg:92.82ms
+step:205/1700 train_time:19029ms step_avg:92.83ms
+step:206/1700 train_time:19123ms step_avg:92.83ms
+step:207/1700 train_time:19216ms step_avg:92.83ms
+step:208/1700 train_time:19309ms step_avg:92.83ms
+step:209/1700 train_time:19403ms step_avg:92.84ms
+step:210/1700 train_time:19496ms step_avg:92.84ms
+step:211/1700 train_time:19589ms step_avg:92.84ms
+step:212/1700 train_time:19684ms step_avg:92.85ms
+step:213/1700 train_time:19777ms step_avg:92.85ms
+step:214/1700 train_time:19870ms step_avg:92.85ms
+step:215/1700 train_time:19964ms step_avg:92.86ms
+step:216/1700 train_time:20057ms step_avg:92.86ms
+step:217/1700 train_time:20151ms step_avg:92.86ms
+step:218/1700 train_time:20244ms step_avg:92.86ms
+step:219/1700 train_time:20338ms step_avg:92.87ms
+step:220/1700 train_time:20431ms step_avg:92.87ms
+step:221/1700 train_time:20524ms step_avg:92.87ms
+step:222/1700 train_time:20617ms step_avg:92.87ms
+step:223/1700 train_time:20710ms step_avg:92.87ms
+step:224/1700 train_time:20804ms step_avg:92.87ms
+step:225/1700 train_time:20898ms step_avg:92.88ms
+step:226/1700 train_time:20990ms step_avg:92.88ms
+step:227/1700 train_time:21084ms step_avg:92.88ms
+step:228/1700 train_time:21177ms step_avg:92.88ms
+step:229/1700 train_time:21270ms step_avg:92.88ms
+step:230/1700 train_time:21364ms step_avg:92.89ms
+step:231/1700 train_time:21457ms step_avg:92.89ms
+step:232/1700 train_time:21550ms step_avg:92.89ms
+step:233/1700 train_time:21643ms step_avg:92.89ms
+step:234/1700 train_time:21737ms step_avg:92.89ms
+step:235/1700 train_time:21830ms step_avg:92.89ms
+step:236/1700 train_time:21924ms step_avg:92.90ms
+step:237/1700 train_time:22017ms step_avg:92.90ms
+step:238/1700 train_time:22111ms step_avg:92.90ms
+step:239/1700 train_time:22204ms step_avg:92.90ms
+step:240/1700 train_time:22297ms step_avg:92.91ms
+step:241/1700 train_time:22390ms step_avg:92.91ms
+step:242/1700 train_time:22484ms step_avg:92.91ms
+step:243/1700 train_time:22578ms step_avg:92.91ms
+step:244/1700 train_time:22671ms step_avg:92.91ms
+step:245/1700 train_time:22764ms step_avg:92.91ms
+step:246/1700 train_time:22858ms step_avg:92.92ms
+step:247/1700 train_time:22951ms step_avg:92.92ms
+step:248/1700 train_time:23044ms step_avg:92.92ms
+step:249/1700 train_time:23138ms step_avg:92.92ms
+step:250/1700 train_time:23230ms step_avg:92.92ms
+step:250/1700 val_loss:4.0903 train_time:23321ms step_avg:93.28ms
+step:251/1700 train_time:23345ms step_avg:93.01ms
+step:252/1700 train_time:23423ms step_avg:92.95ms
+step:253/1700 train_time:23519ms step_avg:92.96ms
+step:254/1700 train_time:23613ms step_avg:92.96ms
+step:255/1700 train_time:23707ms step_avg:92.97ms
+step:256/1700 train_time:23799ms step_avg:92.97ms
+step:257/1700 train_time:23892ms step_avg:92.97ms
+step:258/1700 train_time:23985ms step_avg:92.97ms
+step:259/1700 train_time:24078ms step_avg:92.97ms
+step:260/1700 train_time:24171ms step_avg:92.97ms
+step:261/1700 train_time:24265ms step_avg:92.97ms
+step:262/1700 train_time:24359ms step_avg:92.98ms
+step:263/1700 train_time:24455ms step_avg:92.98ms
+step:264/1700 train_time:24549ms step_avg:92.99ms
+step:265/1700 train_time:24643ms step_avg:92.99ms
+step:266/1700 train_time:24736ms step_avg:92.99ms
+step:267/1700 train_time:24831ms step_avg:93.00ms
+step:268/1700 train_time:24924ms step_avg:93.00ms
+step:269/1700 train_time:25016ms step_avg:93.00ms
+step:270/1700 train_time:25110ms step_avg:93.00ms
+step:271/1700 train_time:25204ms step_avg:93.00ms
+step:272/1700 train_time:25298ms step_avg:93.01ms
+step:273/1700 train_time:25392ms step_avg:93.01ms
+step:274/1700 train_time:25487ms step_avg:93.02ms
+step:275/1700 train_time:25581ms step_avg:93.02ms
+step:276/1700 train_time:25675ms step_avg:93.03ms
+step:277/1700 train_time:25769ms step_avg:93.03ms
+step:278/1700 train_time:25863ms step_avg:93.03ms
+step:279/1700 train_time:25956ms step_avg:93.03ms
+step:280/1700 train_time:26049ms step_avg:93.03ms
+step:281/1700 train_time:26143ms step_avg:93.03ms
+step:282/1700 train_time:26237ms step_avg:93.04ms
+step:283/1700 train_time:26330ms step_avg:93.04ms
+step:284/1700 train_time:26424ms step_avg:93.04ms
+step:285/1700 train_time:26518ms step_avg:93.05ms
+step:286/1700 train_time:26613ms step_avg:93.05ms
+step:287/1700 train_time:26707ms step_avg:93.06ms
+step:288/1700 train_time:26801ms step_avg:93.06ms
+step:289/1700 train_time:26895ms step_avg:93.06ms
+step:290/1700 train_time:26988ms step_avg:93.06ms
+step:291/1700 train_time:27082ms step_avg:93.06ms
+step:292/1700 train_time:27175ms step_avg:93.07ms
+step:293/1700 train_time:27269ms step_avg:93.07ms
+step:294/1700 train_time:27363ms step_avg:93.07ms
+step:295/1700 train_time:27457ms step_avg:93.07ms
+step:296/1700 train_time:27551ms step_avg:93.08ms
+step:297/1700 train_time:27645ms step_avg:93.08ms
+step:298/1700 train_time:27739ms step_avg:93.08ms
+step:299/1700 train_time:27832ms step_avg:93.08ms
+step:300/1700 train_time:27926ms step_avg:93.09ms
+step:301/1700 train_time:28019ms step_avg:93.09ms
+step:302/1700 train_time:28113ms step_avg:93.09ms
+step:303/1700 train_time:28207ms step_avg:93.09ms
+step:304/1700 train_time:28300ms step_avg:93.09ms
+step:305/1700 train_time:28394ms step_avg:93.09ms
+step:306/1700 train_time:28487ms step_avg:93.10ms
+step:307/1700 train_time:28581ms step_avg:93.10ms
+step:308/1700 train_time:28675ms step_avg:93.10ms
+step:309/1700 train_time:28770ms step_avg:93.11ms
+step:310/1700 train_time:28864ms step_avg:93.11ms
+step:311/1700 train_time:28957ms step_avg:93.11ms
+step:312/1700 train_time:29051ms step_avg:93.11ms
+step:313/1700 train_time:29145ms step_avg:93.11ms
+step:314/1700 train_time:29239ms step_avg:93.12ms
+step:315/1700 train_time:29332ms step_avg:93.12ms
+step:316/1700 train_time:29426ms step_avg:93.12ms
+step:317/1700 train_time:29519ms step_avg:93.12ms
+step:318/1700 train_time:29614ms step_avg:93.12ms
+step:319/1700 train_time:29708ms step_avg:93.13ms
+step:320/1700 train_time:29802ms step_avg:93.13ms
+step:321/1700 train_time:29896ms step_avg:93.13ms
+step:322/1700 train_time:29990ms step_avg:93.14ms
+step:323/1700 train_time:30084ms step_avg:93.14ms
+step:324/1700 train_time:30178ms step_avg:93.14ms
+step:325/1700 train_time:30271ms step_avg:93.14ms
+step:326/1700 train_time:30365ms step_avg:93.14ms
+step:327/1700 train_time:30458ms step_avg:93.14ms
+step:328/1700 train_time:30552ms step_avg:93.15ms
+step:329/1700 train_time:30646ms step_avg:93.15ms
+step:330/1700 train_time:30739ms step_avg:93.15ms
+step:331/1700 train_time:30833ms step_avg:93.15ms
+step:332/1700 train_time:30927ms step_avg:93.15ms
+step:333/1700 train_time:31020ms step_avg:93.15ms
+step:334/1700 train_time:31114ms step_avg:93.16ms
+step:335/1700 train_time:31208ms step_avg:93.16ms
+step:336/1700 train_time:31301ms step_avg:93.16ms
+step:337/1700 train_time:31395ms step_avg:93.16ms
+step:338/1700 train_time:31489ms step_avg:93.16ms
+step:339/1700 train_time:31582ms step_avg:93.16ms
+step:340/1700 train_time:31676ms step_avg:93.17ms
+step:341/1700 train_time:31770ms step_avg:93.17ms
+step:342/1700 train_time:31865ms step_avg:93.17ms
+step:343/1700 train_time:31958ms step_avg:93.17ms
+step:344/1700 train_time:32052ms step_avg:93.17ms
+step:345/1700 train_time:32146ms step_avg:93.18ms
+step:346/1700 train_time:32240ms step_avg:93.18ms
+step:347/1700 train_time:32334ms step_avg:93.18ms
+step:348/1700 train_time:32428ms step_avg:93.18ms
+step:349/1700 train_time:32522ms step_avg:93.19ms
+step:350/1700 train_time:32616ms step_avg:93.19ms
+step:351/1700 train_time:32710ms step_avg:93.19ms
+step:352/1700 train_time:32804ms step_avg:93.19ms
+step:353/1700 train_time:32897ms step_avg:93.19ms
+step:354/1700 train_time:32991ms step_avg:93.20ms
+step:355/1700 train_time:33084ms step_avg:93.20ms
+step:356/1700 train_time:33178ms step_avg:93.20ms
+step:357/1700 train_time:33272ms step_avg:93.20ms
+step:358/1700 train_time:33366ms step_avg:93.20ms
+step:359/1700 train_time:33460ms step_avg:93.20ms
+step:360/1700 train_time:33554ms step_avg:93.20ms
+step:361/1700 train_time:33648ms step_avg:93.21ms
+step:362/1700 train_time:33741ms step_avg:93.21ms
+step:363/1700 train_time:33835ms step_avg:93.21ms
+step:364/1700 train_time:33929ms step_avg:93.21ms
+step:365/1700 train_time:34023ms step_avg:93.21ms
+step:366/1700 train_time:34116ms step_avg:93.21ms
+step:367/1700 train_time:34210ms step_avg:93.21ms
+step:368/1700 train_time:34303ms step_avg:93.22ms
+step:369/1700 train_time:34397ms step_avg:93.22ms
+step:370/1700 train_time:34491ms step_avg:93.22ms
+step:371/1700 train_time:34585ms step_avg:93.22ms
+step:372/1700 train_time:34678ms step_avg:93.22ms
+step:373/1700 train_time:34772ms step_avg:93.22ms
+step:374/1700 train_time:34866ms step_avg:93.23ms
+step:375/1700 train_time:34960ms step_avg:93.23ms
+step:375/1700 val_loss:3.8937 train_time:35050ms step_avg:93.47ms
+step:376/1700 train_time:35072ms step_avg:93.28ms
+step:377/1700 train_time:35156ms step_avg:93.25ms
+step:378/1700 train_time:35252ms step_avg:93.26ms
+step:379/1700 train_time:35347ms step_avg:93.26ms
+step:380/1700 train_time:35442ms step_avg:93.27ms
+step:381/1700 train_time:35536ms step_avg:93.27ms
+step:382/1700 train_time:35631ms step_avg:93.27ms
+step:383/1700 train_time:35726ms step_avg:93.28ms
+step:384/1700 train_time:35821ms step_avg:93.28ms
+step:385/1700 train_time:35916ms step_avg:93.29ms
+step:386/1700 train_time:36012ms step_avg:93.29ms
+step:387/1700 train_time:36111ms step_avg:93.31ms
+step:388/1700 train_time:36209ms step_avg:93.32ms
+step:389/1700 train_time:36305ms step_avg:93.33ms
+step:390/1700 train_time:36400ms step_avg:93.33ms
+step:391/1700 train_time:36496ms step_avg:93.34ms
+step:392/1700 train_time:36591ms step_avg:93.34ms
+step:393/1700 train_time:36687ms step_avg:93.35ms
+step:394/1700 train_time:36782ms step_avg:93.35ms
+step:395/1700 train_time:36876ms step_avg:93.36ms
+step:396/1700 train_time:36971ms step_avg:93.36ms
+step:397/1700 train_time:37067ms step_avg:93.37ms
+step:398/1700 train_time:37164ms step_avg:93.38ms
+step:399/1700 train_time:37259ms step_avg:93.38ms
+step:400/1700 train_time:37355ms step_avg:93.39ms
+step:401/1700 train_time:37451ms step_avg:93.39ms
+step:402/1700 train_time:37547ms step_avg:93.40ms
+step:403/1700 train_time:37643ms step_avg:93.41ms
+step:404/1700 train_time:37738ms step_avg:93.41ms
+step:405/1700 train_time:37834ms step_avg:93.42ms
+step:406/1700 train_time:37929ms step_avg:93.42ms
+step:407/1700 train_time:38025ms step_avg:93.43ms
+step:408/1700 train_time:38121ms step_avg:93.43ms
+step:409/1700 train_time:38217ms step_avg:93.44ms
+step:410/1700 train_time:38313ms step_avg:93.45ms
+step:411/1700 train_time:38409ms step_avg:93.45ms
+step:412/1700 train_time:38505ms step_avg:93.46ms
+step:413/1700 train_time:38600ms step_avg:93.46ms
+step:414/1700 train_time:38695ms step_avg:93.47ms
+step:415/1700 train_time:38790ms step_avg:93.47ms
+step:416/1700 train_time:38886ms step_avg:93.48ms
+step:417/1700 train_time:38981ms step_avg:93.48ms
+step:418/1700 train_time:39077ms step_avg:93.49ms
+step:419/1700 train_time:39173ms step_avg:93.49ms
+step:420/1700 train_time:39270ms step_avg:93.50ms
+step:421/1700 train_time:39366ms step_avg:93.51ms
+step:422/1700 train_time:39462ms step_avg:93.51ms
+step:423/1700 train_time:39558ms step_avg:93.52ms
+step:424/1700 train_time:39653ms step_avg:93.52ms
+step:425/1700 train_time:39749ms step_avg:93.53ms
+step:426/1700 train_time:39844ms step_avg:93.53ms
+step:427/1700 train_time:39939ms step_avg:93.53ms
+step:428/1700 train_time:40034ms step_avg:93.54ms
+step:429/1700 train_time:40130ms step_avg:93.54ms
+step:430/1700 train_time:40226ms step_avg:93.55ms
+step:431/1700 train_time:40322ms step_avg:93.55ms
+step:432/1700 train_time:40417ms step_avg:93.56ms
+step:433/1700 train_time:40513ms step_avg:93.56ms
+step:434/1700 train_time:40610ms step_avg:93.57ms
+step:435/1700 train_time:40707ms step_avg:93.58ms
+step:436/1700 train_time:40802ms step_avg:93.58ms
+step:437/1700 train_time:40898ms step_avg:93.59ms
+step:438/1700 train_time:40994ms step_avg:93.59ms
+step:439/1700 train_time:41089ms step_avg:93.60ms
+step:440/1700 train_time:41185ms step_avg:93.60ms
+step:441/1700 train_time:41280ms step_avg:93.61ms
+step:442/1700 train_time:41375ms step_avg:93.61ms
+step:443/1700 train_time:41471ms step_avg:93.61ms
+step:444/1700 train_time:41568ms step_avg:93.62ms
+step:445/1700 train_time:41663ms step_avg:93.63ms
+step:446/1700 train_time:41758ms step_avg:93.63ms
+step:447/1700 train_time:41854ms step_avg:93.63ms
+step:448/1700 train_time:41950ms step_avg:93.64ms
+step:449/1700 train_time:42046ms step_avg:93.64ms
+step:450/1700 train_time:42141ms step_avg:93.65ms
+step:451/1700 train_time:42236ms step_avg:93.65ms
+step:452/1700 train_time:42332ms step_avg:93.65ms
+step:453/1700 train_time:42428ms step_avg:93.66ms
+step:454/1700 train_time:42523ms step_avg:93.66ms
+step:455/1700 train_time:42618ms step_avg:93.67ms
+step:456/1700 train_time:42714ms step_avg:93.67ms
+step:457/1700 train_time:42810ms step_avg:93.68ms
+step:458/1700 train_time:42906ms step_avg:93.68ms
+step:459/1700 train_time:43002ms step_avg:93.69ms
+step:460/1700 train_time:43096ms step_avg:93.69ms
+step:461/1700 train_time:43192ms step_avg:93.69ms
+step:462/1700 train_time:43288ms step_avg:93.70ms
+step:463/1700 train_time:43384ms step_avg:93.70ms
+step:464/1700 train_time:43480ms step_avg:93.71ms
+step:465/1700 train_time:43576ms step_avg:93.71ms
+step:466/1700 train_time:43672ms step_avg:93.72ms
+step:467/1700 train_time:43768ms step_avg:93.72ms
+step:468/1700 train_time:43864ms step_avg:93.73ms
+step:469/1700 train_time:43959ms step_avg:93.73ms
+step:470/1700 train_time:44055ms step_avg:93.73ms
+step:471/1700 train_time:44150ms step_avg:93.74ms
+step:472/1700 train_time:44246ms step_avg:93.74ms
+step:473/1700 train_time:44341ms step_avg:93.74ms
+step:474/1700 train_time:44437ms step_avg:93.75ms
+step:475/1700 train_time:44532ms step_avg:93.75ms
+step:476/1700 train_time:44628ms step_avg:93.76ms
+step:477/1700 train_time:44724ms step_avg:93.76ms
+step:478/1700 train_time:44819ms step_avg:93.76ms
+step:479/1700 train_time:44915ms step_avg:93.77ms
+step:480/1700 train_time:45010ms step_avg:93.77ms
+step:481/1700 train_time:45105ms step_avg:93.77ms
+step:482/1700 train_time:45201ms step_avg:93.78ms
+step:483/1700 train_time:45296ms step_avg:93.78ms
+step:484/1700 train_time:45392ms step_avg:93.78ms
+step:485/1700 train_time:45488ms step_avg:93.79ms
+step:486/1700 train_time:45583ms step_avg:93.79ms
+step:487/1700 train_time:45679ms step_avg:93.80ms
+step:488/1700 train_time:45775ms step_avg:93.80ms
+step:489/1700 train_time:45870ms step_avg:93.80ms
+step:490/1700 train_time:45966ms step_avg:93.81ms
+step:491/1700 train_time:46062ms step_avg:93.81ms
+step:492/1700 train_time:46157ms step_avg:93.81ms
+step:493/1700 train_time:46253ms step_avg:93.82ms
+step:494/1700 train_time:46348ms step_avg:93.82ms
+step:495/1700 train_time:46443ms step_avg:93.83ms
+step:496/1700 train_time:46539ms step_avg:93.83ms
+step:497/1700 train_time:46634ms step_avg:93.83ms
+step:498/1700 train_time:46730ms step_avg:93.84ms
+step:499/1700 train_time:46827ms step_avg:93.84ms
+step:500/1700 train_time:46923ms step_avg:93.85ms
+step:500/1700 val_loss:3.7468 train_time:47015ms step_avg:94.03ms
+step:501/1700 train_time:47039ms step_avg:93.89ms
+step:502/1700 train_time:47119ms step_avg:93.86ms
+step:503/1700 train_time:47216ms step_avg:93.87ms
+step:504/1700 train_time:47312ms step_avg:93.87ms
+step:505/1700 train_time:47407ms step_avg:93.87ms
+step:506/1700 train_time:47503ms step_avg:93.88ms
+step:507/1700 train_time:47598ms step_avg:93.88ms
+step:508/1700 train_time:47693ms step_avg:93.88ms
+step:509/1700 train_time:47789ms step_avg:93.89ms
+step:510/1700 train_time:47884ms step_avg:93.89ms
+step:511/1700 train_time:47980ms step_avg:93.89ms
+step:512/1700 train_time:48077ms step_avg:93.90ms
+step:513/1700 train_time:48174ms step_avg:93.91ms
+step:514/1700 train_time:48271ms step_avg:93.91ms
+step:515/1700 train_time:48367ms step_avg:93.92ms
+step:516/1700 train_time:48462ms step_avg:93.92ms
+step:517/1700 train_time:48558ms step_avg:93.92ms
+step:518/1700 train_time:48654ms step_avg:93.93ms
+step:519/1700 train_time:48749ms step_avg:93.93ms
+step:520/1700 train_time:48844ms step_avg:93.93ms
+step:521/1700 train_time:48940ms step_avg:93.93ms
+step:522/1700 train_time:49035ms step_avg:93.94ms
+step:523/1700 train_time:49133ms step_avg:93.94ms
+step:524/1700 train_time:49230ms step_avg:93.95ms
+step:525/1700 train_time:49326ms step_avg:93.95ms
+step:526/1700 train_time:49421ms step_avg:93.96ms
+step:527/1700 train_time:49516ms step_avg:93.96ms
+step:528/1700 train_time:49613ms step_avg:93.96ms
+step:529/1700 train_time:49708ms step_avg:93.97ms
+step:530/1700 train_time:49804ms step_avg:93.97ms
+step:531/1700 train_time:49899ms step_avg:93.97ms
+step:532/1700 train_time:49995ms step_avg:93.98ms
+step:533/1700 train_time:50092ms step_avg:93.98ms
+step:534/1700 train_time:50188ms step_avg:93.99ms
+step:535/1700 train_time:50284ms step_avg:93.99ms
+step:536/1700 train_time:50380ms step_avg:93.99ms
+step:537/1700 train_time:50476ms step_avg:94.00ms
+step:538/1700 train_time:50572ms step_avg:94.00ms
+step:539/1700 train_time:50668ms step_avg:94.00ms
+step:540/1700 train_time:50763ms step_avg:94.01ms
+step:541/1700 train_time:50859ms step_avg:94.01ms
+step:542/1700 train_time:50954ms step_avg:94.01ms
+step:543/1700 train_time:51050ms step_avg:94.02ms
+step:544/1700 train_time:51146ms step_avg:94.02ms
+step:545/1700 train_time:51242ms step_avg:94.02ms
+step:546/1700 train_time:51338ms step_avg:94.02ms
+step:547/1700 train_time:51434ms step_avg:94.03ms
+step:548/1700 train_time:51530ms step_avg:94.03ms
+step:549/1700 train_time:51625ms step_avg:94.04ms
+step:550/1700 train_time:51721ms step_avg:94.04ms
+step:551/1700 train_time:51817ms step_avg:94.04ms
+step:552/1700 train_time:51913ms step_avg:94.05ms
+step:553/1700 train_time:52008ms step_avg:94.05ms
+step:554/1700 train_time:52104ms step_avg:94.05ms
+step:555/1700 train_time:52200ms step_avg:94.05ms
+step:556/1700 train_time:52296ms step_avg:94.06ms
+step:557/1700 train_time:52393ms step_avg:94.06ms
+step:558/1700 train_time:52488ms step_avg:94.07ms
+step:559/1700 train_time:52584ms step_avg:94.07ms
+step:560/1700 train_time:52680ms step_avg:94.07ms
+step:561/1700 train_time:52775ms step_avg:94.07ms
+step:562/1700 train_time:52871ms step_avg:94.08ms
+step:563/1700 train_time:52967ms step_avg:94.08ms
+step:564/1700 train_time:53063ms step_avg:94.08ms
+step:565/1700 train_time:53159ms step_avg:94.09ms
+step:566/1700 train_time:53255ms step_avg:94.09ms
+step:567/1700 train_time:53352ms step_avg:94.09ms
+step:568/1700 train_time:53448ms step_avg:94.10ms
+step:569/1700 train_time:53544ms step_avg:94.10ms
+step:570/1700 train_time:53639ms step_avg:94.10ms
+step:571/1700 train_time:53735ms step_avg:94.11ms
+step:572/1700 train_time:53831ms step_avg:94.11ms
+step:573/1700 train_time:53926ms step_avg:94.11ms
+step:574/1700 train_time:54022ms step_avg:94.12ms
+step:575/1700 train_time:54118ms step_avg:94.12ms
+step:576/1700 train_time:54214ms step_avg:94.12ms
+step:577/1700 train_time:54311ms step_avg:94.13ms
+step:578/1700 train_time:54406ms step_avg:94.13ms
+step:579/1700 train_time:54502ms step_avg:94.13ms
+step:580/1700 train_time:54598ms step_avg:94.13ms
+step:581/1700 train_time:54693ms step_avg:94.14ms
+step:582/1700 train_time:54790ms step_avg:94.14ms
+step:583/1700 train_time:54886ms step_avg:94.14ms
+step:584/1700 train_time:54982ms step_avg:94.15ms
+step:585/1700 train_time:55077ms step_avg:94.15ms
+step:586/1700 train_time:55173ms step_avg:94.15ms
+step:587/1700 train_time:55269ms step_avg:94.16ms
+step:588/1700 train_time:55365ms step_avg:94.16ms
+step:589/1700 train_time:55461ms step_avg:94.16ms
+step:590/1700 train_time:55557ms step_avg:94.16ms
+step:591/1700 train_time:55653ms step_avg:94.17ms
+step:592/1700 train_time:55750ms step_avg:94.17ms
+step:593/1700 train_time:55845ms step_avg:94.17ms
+step:594/1700 train_time:55940ms step_avg:94.18ms
+step:595/1700 train_time:56036ms step_avg:94.18ms
+step:596/1700 train_time:56132ms step_avg:94.18ms
+step:597/1700 train_time:56228ms step_avg:94.18ms
+step:598/1700 train_time:56325ms step_avg:94.19ms
+step:599/1700 train_time:56421ms step_avg:94.19ms
+step:600/1700 train_time:56517ms step_avg:94.19ms
+step:601/1700 train_time:56614ms step_avg:94.20ms
+step:602/1700 train_time:56710ms step_avg:94.20ms
+step:603/1700 train_time:56806ms step_avg:94.21ms
+step:604/1700 train_time:56902ms step_avg:94.21ms
+step:605/1700 train_time:56997ms step_avg:94.21ms
+step:606/1700 train_time:57093ms step_avg:94.21ms
+step:607/1700 train_time:57189ms step_avg:94.22ms
+step:608/1700 train_time:57284ms step_avg:94.22ms
+step:609/1700 train_time:57380ms step_avg:94.22ms
+step:610/1700 train_time:57476ms step_avg:94.22ms
+step:611/1700 train_time:57572ms step_avg:94.23ms
+step:612/1700 train_time:57668ms step_avg:94.23ms
+step:613/1700 train_time:57764ms step_avg:94.23ms
+step:614/1700 train_time:57860ms step_avg:94.23ms
+step:615/1700 train_time:57956ms step_avg:94.24ms
+step:616/1700 train_time:58052ms step_avg:94.24ms
+step:617/1700 train_time:58148ms step_avg:94.24ms
+step:618/1700 train_time:58244ms step_avg:94.25ms
+step:619/1700 train_time:58339ms step_avg:94.25ms
+step:620/1700 train_time:58435ms step_avg:94.25ms
+step:621/1700 train_time:58531ms step_avg:94.25ms
+step:622/1700 train_time:58627ms step_avg:94.26ms
+step:623/1700 train_time:58723ms step_avg:94.26ms
+step:624/1700 train_time:58819ms step_avg:94.26ms
+step:625/1700 train_time:58915ms step_avg:94.26ms
+step:625/1700 val_loss:3.6578 train_time:59008ms step_avg:94.41ms
+step:626/1700 train_time:59029ms step_avg:94.30ms
+step:627/1700 train_time:59117ms step_avg:94.29ms
+step:628/1700 train_time:59215ms step_avg:94.29ms
+step:629/1700 train_time:59311ms step_avg:94.29ms
+step:630/1700 train_time:59406ms step_avg:94.30ms
+step:631/1700 train_time:59501ms step_avg:94.30ms
+step:632/1700 train_time:59599ms step_avg:94.30ms
+step:633/1700 train_time:59695ms step_avg:94.31ms
+step:634/1700 train_time:59792ms step_avg:94.31ms
+step:635/1700 train_time:59888ms step_avg:94.31ms
+step:636/1700 train_time:59986ms step_avg:94.32ms
+step:637/1700 train_time:60086ms step_avg:94.33ms
+step:638/1700 train_time:60184ms step_avg:94.33ms
+step:639/1700 train_time:60283ms step_avg:94.34ms
+step:640/1700 train_time:60380ms step_avg:94.34ms
+step:641/1700 train_time:60478ms step_avg:94.35ms
+step:642/1700 train_time:60575ms step_avg:94.35ms
+step:643/1700 train_time:60672ms step_avg:94.36ms
+step:644/1700 train_time:60768ms step_avg:94.36ms
+step:645/1700 train_time:60865ms step_avg:94.36ms
+step:646/1700 train_time:60962ms step_avg:94.37ms
+step:647/1700 train_time:61061ms step_avg:94.38ms
+step:648/1700 train_time:61159ms step_avg:94.38ms
+step:649/1700 train_time:61259ms step_avg:94.39ms
+step:650/1700 train_time:61357ms step_avg:94.39ms
+step:651/1700 train_time:61454ms step_avg:94.40ms
+step:652/1700 train_time:61550ms step_avg:94.40ms
+step:653/1700 train_time:61647ms step_avg:94.41ms
+step:654/1700 train_time:61743ms step_avg:94.41ms
+step:655/1700 train_time:61841ms step_avg:94.41ms
+step:656/1700 train_time:61939ms step_avg:94.42ms
+step:657/1700 train_time:62038ms step_avg:94.43ms
+step:658/1700 train_time:62136ms step_avg:94.43ms
+step:659/1700 train_time:62234ms step_avg:94.44ms
+step:660/1700 train_time:62332ms step_avg:94.44ms
+step:661/1700 train_time:62429ms step_avg:94.45ms
+step:662/1700 train_time:62526ms step_avg:94.45ms
+step:663/1700 train_time:62623ms step_avg:94.45ms
+step:664/1700 train_time:62720ms step_avg:94.46ms
+step:665/1700 train_time:62818ms step_avg:94.46ms
+step:666/1700 train_time:62916ms step_avg:94.47ms
+step:667/1700 train_time:63013ms step_avg:94.47ms
+step:668/1700 train_time:63110ms step_avg:94.48ms
+step:669/1700 train_time:63207ms step_avg:94.48ms
+step:670/1700 train_time:63305ms step_avg:94.49ms
+step:671/1700 train_time:63402ms step_avg:94.49ms
+step:672/1700 train_time:63500ms step_avg:94.49ms
+step:673/1700 train_time:63598ms step_avg:94.50ms
+step:674/1700 train_time:63696ms step_avg:94.50ms
+step:675/1700 train_time:63793ms step_avg:94.51ms
+step:676/1700 train_time:63890ms step_avg:94.51ms
+step:677/1700 train_time:63986ms step_avg:94.51ms
+step:678/1700 train_time:64084ms step_avg:94.52ms
+step:679/1700 train_time:64182ms step_avg:94.52ms
+step:680/1700 train_time:64280ms step_avg:94.53ms
+step:681/1700 train_time:64378ms step_avg:94.53ms
+step:682/1700 train_time:64476ms step_avg:94.54ms
+step:683/1700 train_time:64573ms step_avg:94.54ms
+step:684/1700 train_time:64670ms step_avg:94.55ms
+step:685/1700 train_time:64767ms step_avg:94.55ms
+step:686/1700 train_time:64864ms step_avg:94.55ms
+step:687/1700 train_time:64961ms step_avg:94.56ms
+step:688/1700 train_time:65059ms step_avg:94.56ms
+step:689/1700 train_time:65157ms step_avg:94.57ms
+step:690/1700 train_time:65255ms step_avg:94.57ms
+step:691/1700 train_time:65352ms step_avg:94.58ms
+step:692/1700 train_time:65448ms step_avg:94.58ms
+step:693/1700 train_time:65546ms step_avg:94.58ms
+step:694/1700 train_time:65644ms step_avg:94.59ms
+step:695/1700 train_time:65741ms step_avg:94.59ms
+step:696/1700 train_time:65840ms step_avg:94.60ms
+step:697/1700 train_time:65938ms step_avg:94.60ms
+step:698/1700 train_time:66037ms step_avg:94.61ms
+step:699/1700 train_time:66134ms step_avg:94.61ms
+step:700/1700 train_time:66231ms step_avg:94.62ms
+step:701/1700 train_time:66328ms step_avg:94.62ms
+step:702/1700 train_time:66425ms step_avg:94.62ms
+step:703/1700 train_time:66523ms step_avg:94.63ms
+step:704/1700 train_time:66620ms step_avg:94.63ms
+step:705/1700 train_time:66719ms step_avg:94.64ms
+step:706/1700 train_time:66817ms step_avg:94.64ms
+step:707/1700 train_time:66915ms step_avg:94.65ms
+step:708/1700 train_time:67011ms step_avg:94.65ms
+step:709/1700 train_time:67108ms step_avg:94.65ms
+step:710/1700 train_time:67206ms step_avg:94.66ms
+step:711/1700 train_time:67303ms step_avg:94.66ms
+step:712/1700 train_time:67400ms step_avg:94.66ms
+step:713/1700 train_time:67498ms step_avg:94.67ms
+step:714/1700 train_time:67595ms step_avg:94.67ms
+step:715/1700 train_time:67693ms step_avg:94.68ms
+step:716/1700 train_time:67790ms step_avg:94.68ms
+step:717/1700 train_time:67887ms step_avg:94.68ms
+step:718/1700 train_time:67985ms step_avg:94.69ms
+step:719/1700 train_time:68082ms step_avg:94.69ms
+step:720/1700 train_time:68180ms step_avg:94.69ms
+step:721/1700 train_time:68277ms step_avg:94.70ms
+step:722/1700 train_time:68376ms step_avg:94.70ms
+step:723/1700 train_time:68473ms step_avg:94.71ms
+step:724/1700 train_time:68569ms step_avg:94.71ms
+step:725/1700 train_time:68666ms step_avg:94.71ms
+step:726/1700 train_time:68764ms step_avg:94.72ms
+step:727/1700 train_time:68861ms step_avg:94.72ms
+step:728/1700 train_time:68958ms step_avg:94.72ms
+step:729/1700 train_time:69056ms step_avg:94.73ms
+step:730/1700 train_time:69154ms step_avg:94.73ms
+step:731/1700 train_time:69250ms step_avg:94.73ms
+step:732/1700 train_time:69348ms step_avg:94.74ms
+step:733/1700 train_time:69445ms step_avg:94.74ms
+step:734/1700 train_time:69543ms step_avg:94.75ms
+step:735/1700 train_time:69640ms step_avg:94.75ms
+step:736/1700 train_time:69739ms step_avg:94.75ms
+step:737/1700 train_time:69838ms step_avg:94.76ms
+step:738/1700 train_time:69935ms step_avg:94.76ms
+step:739/1700 train_time:70033ms step_avg:94.77ms
+step:740/1700 train_time:70131ms step_avg:94.77ms
+step:741/1700 train_time:70227ms step_avg:94.77ms
+step:742/1700 train_time:70324ms step_avg:94.78ms
+step:743/1700 train_time:70422ms step_avg:94.78ms
+step:744/1700 train_time:70519ms step_avg:94.78ms
+step:745/1700 train_time:70617ms step_avg:94.79ms
+step:746/1700 train_time:70714ms step_avg:94.79ms
+step:747/1700 train_time:70811ms step_avg:94.79ms
+step:748/1700 train_time:70908ms step_avg:94.80ms
+step:749/1700 train_time:71006ms step_avg:94.80ms
+step:750/1700 train_time:71103ms step_avg:94.80ms
+step:750/1700 val_loss:3.5945 train_time:71197ms step_avg:94.93ms
+step:751/1700 train_time:71218ms step_avg:94.83ms
+step:752/1700 train_time:71306ms step_avg:94.82ms
+step:753/1700 train_time:71405ms step_avg:94.83ms
+step:754/1700 train_time:71503ms step_avg:94.83ms
+step:755/1700 train_time:71600ms step_avg:94.83ms
+step:756/1700 train_time:71696ms step_avg:94.84ms
+step:757/1700 train_time:71794ms step_avg:94.84ms
+step:758/1700 train_time:71891ms step_avg:94.84ms
+step:759/1700 train_time:71988ms step_avg:94.85ms
+step:760/1700 train_time:72084ms step_avg:94.85ms
+step:761/1700 train_time:72182ms step_avg:94.85ms
+step:762/1700 train_time:72280ms step_avg:94.86ms
+step:763/1700 train_time:72379ms step_avg:94.86ms
+step:764/1700 train_time:72477ms step_avg:94.87ms
+step:765/1700 train_time:72575ms step_avg:94.87ms
+step:766/1700 train_time:72673ms step_avg:94.87ms
+step:767/1700 train_time:72771ms step_avg:94.88ms
+step:768/1700 train_time:72868ms step_avg:94.88ms
+step:769/1700 train_time:72965ms step_avg:94.88ms
+step:770/1700 train_time:73061ms step_avg:94.88ms
+step:771/1700 train_time:73159ms step_avg:94.89ms
+step:772/1700 train_time:73257ms step_avg:94.89ms
+step:773/1700 train_time:73356ms step_avg:94.90ms
+step:774/1700 train_time:73455ms step_avg:94.90ms
+step:775/1700 train_time:73553ms step_avg:94.91ms
+step:776/1700 train_time:73651ms step_avg:94.91ms
+step:777/1700 train_time:73750ms step_avg:94.92ms
+step:778/1700 train_time:73846ms step_avg:94.92ms
+step:779/1700 train_time:73944ms step_avg:94.92ms
+step:780/1700 train_time:74041ms step_avg:94.92ms
+step:781/1700 train_time:74139ms step_avg:94.93ms
+step:782/1700 train_time:74236ms step_avg:94.93ms
+step:783/1700 train_time:74335ms step_avg:94.94ms
+step:784/1700 train_time:74433ms step_avg:94.94ms
+step:785/1700 train_time:74532ms step_avg:94.94ms
+step:786/1700 train_time:74630ms step_avg:94.95ms
+step:787/1700 train_time:74727ms step_avg:94.95ms
+step:788/1700 train_time:74824ms step_avg:94.95ms
+step:789/1700 train_time:74921ms step_avg:94.96ms
+step:790/1700 train_time:75019ms step_avg:94.96ms
+step:791/1700 train_time:75116ms step_avg:94.96ms
+step:792/1700 train_time:75214ms step_avg:94.97ms
+step:793/1700 train_time:75312ms step_avg:94.97ms
+step:794/1700 train_time:75410ms step_avg:94.97ms
+step:795/1700 train_time:75508ms step_avg:94.98ms
+step:796/1700 train_time:75605ms step_avg:94.98ms
+step:797/1700 train_time:75703ms step_avg:94.98ms
+step:798/1700 train_time:75801ms step_avg:94.99ms
+step:799/1700 train_time:75898ms step_avg:94.99ms
+step:800/1700 train_time:75996ms step_avg:95.00ms
+step:801/1700 train_time:76094ms step_avg:95.00ms
+step:802/1700 train_time:76192ms step_avg:95.00ms
+step:803/1700 train_time:76290ms step_avg:95.01ms
+step:804/1700 train_time:76388ms step_avg:95.01ms
+step:805/1700 train_time:76485ms step_avg:95.01ms
+step:806/1700 train_time:76582ms step_avg:95.01ms
+step:807/1700 train_time:76681ms step_avg:95.02ms
+step:808/1700 train_time:76778ms step_avg:95.02ms
+step:809/1700 train_time:76876ms step_avg:95.03ms
+step:810/1700 train_time:76974ms step_avg:95.03ms
+step:811/1700 train_time:77072ms step_avg:95.03ms
+step:812/1700 train_time:77169ms step_avg:95.04ms
+step:813/1700 train_time:77266ms step_avg:95.04ms
+step:814/1700 train_time:77363ms step_avg:95.04ms
+step:815/1700 train_time:77461ms step_avg:95.04ms
+step:816/1700 train_time:77558ms step_avg:95.05ms
+step:817/1700 train_time:77656ms step_avg:95.05ms
+step:818/1700 train_time:77756ms step_avg:95.06ms
+step:819/1700 train_time:77854ms step_avg:95.06ms
+step:820/1700 train_time:77952ms step_avg:95.06ms
+step:821/1700 train_time:78050ms step_avg:95.07ms
+step:822/1700 train_time:78147ms step_avg:95.07ms
+step:823/1700 train_time:78245ms step_avg:95.07ms
+step:824/1700 train_time:78342ms step_avg:95.08ms
+step:825/1700 train_time:78439ms step_avg:95.08ms
+step:826/1700 train_time:78537ms step_avg:95.08ms
+step:827/1700 train_time:78635ms step_avg:95.08ms
+step:828/1700 train_time:78733ms step_avg:95.09ms
+step:829/1700 train_time:78832ms step_avg:95.09ms
+step:830/1700 train_time:78929ms step_avg:95.10ms
+step:831/1700 train_time:79027ms step_avg:95.10ms
+step:832/1700 train_time:79124ms step_avg:95.10ms
+step:833/1700 train_time:79221ms step_avg:95.10ms
+step:834/1700 train_time:79319ms step_avg:95.11ms
+step:835/1700 train_time:79417ms step_avg:95.11ms
+step:836/1700 train_time:79515ms step_avg:95.11ms
+step:837/1700 train_time:79614ms step_avg:95.12ms
+step:838/1700 train_time:79712ms step_avg:95.12ms
+step:839/1700 train_time:79810ms step_avg:95.13ms
+step:840/1700 train_time:79908ms step_avg:95.13ms
+step:841/1700 train_time:80005ms step_avg:95.13ms
+step:842/1700 train_time:80103ms step_avg:95.13ms
+step:843/1700 train_time:80200ms step_avg:95.14ms
+step:844/1700 train_time:80297ms step_avg:95.14ms
+step:845/1700 train_time:80395ms step_avg:95.14ms
+step:846/1700 train_time:80493ms step_avg:95.15ms
+step:847/1700 train_time:80591ms step_avg:95.15ms
+step:848/1700 train_time:80689ms step_avg:95.15ms
+step:849/1700 train_time:80786ms step_avg:95.15ms
+step:850/1700 train_time:80884ms step_avg:95.16ms
+step:851/1700 train_time:80982ms step_avg:95.16ms
+step:852/1700 train_time:81079ms step_avg:95.16ms
+step:853/1700 train_time:81177ms step_avg:95.17ms
+step:854/1700 train_time:81275ms step_avg:95.17ms
+step:855/1700 train_time:81373ms step_avg:95.17ms
+step:856/1700 train_time:81470ms step_avg:95.18ms
+step:857/1700 train_time:81567ms step_avg:95.18ms
+step:858/1700 train_time:81664ms step_avg:95.18ms
+step:859/1700 train_time:81762ms step_avg:95.18ms
+step:860/1700 train_time:81859ms step_avg:95.18ms
+step:861/1700 train_time:81957ms step_avg:95.19ms
+step:862/1700 train_time:82056ms step_avg:95.19ms
+step:863/1700 train_time:82154ms step_avg:95.20ms
+step:864/1700 train_time:82252ms step_avg:95.20ms
+step:865/1700 train_time:82350ms step_avg:95.20ms
+step:866/1700 train_time:82447ms step_avg:95.20ms
+step:867/1700 train_time:82544ms step_avg:95.21ms
+step:868/1700 train_time:82642ms step_avg:95.21ms
+step:869/1700 train_time:82740ms step_avg:95.21ms
+step:870/1700 train_time:82837ms step_avg:95.22ms
+step:871/1700 train_time:82936ms step_avg:95.22ms
+step:872/1700 train_time:83034ms step_avg:95.22ms
+step:873/1700 train_time:83133ms step_avg:95.23ms
+step:874/1700 train_time:83231ms step_avg:95.23ms
+step:875/1700 train_time:83329ms step_avg:95.23ms
+step:875/1700 val_loss:3.5474 train_time:83423ms step_avg:95.34ms
+step:876/1700 train_time:83445ms step_avg:95.26ms
+step:877/1700 train_time:83530ms step_avg:95.24ms
+step:878/1700 train_time:83628ms step_avg:95.25ms
+step:879/1700 train_time:83725ms step_avg:95.25ms
+step:880/1700 train_time:83823ms step_avg:95.25ms
+step:881/1700 train_time:83920ms step_avg:95.26ms
+step:882/1700 train_time:84017ms step_avg:95.26ms
+step:883/1700 train_time:84114ms step_avg:95.26ms
+step:884/1700 train_time:84212ms step_avg:95.26ms
+step:885/1700 train_time:84310ms step_avg:95.27ms
+step:886/1700 train_time:84410ms step_avg:95.27ms
+step:887/1700 train_time:84510ms step_avg:95.28ms
+step:888/1700 train_time:84610ms step_avg:95.28ms
+step:889/1700 train_time:84709ms step_avg:95.29ms
+step:890/1700 train_time:84808ms step_avg:95.29ms
+step:891/1700 train_time:84907ms step_avg:95.29ms
+step:892/1700 train_time:85006ms step_avg:95.30ms
+step:893/1700 train_time:85105ms step_avg:95.30ms
+step:894/1700 train_time:85205ms step_avg:95.31ms
+step:895/1700 train_time:85305ms step_avg:95.31ms
+step:896/1700 train_time:85405ms step_avg:95.32ms
+step:897/1700 train_time:85505ms step_avg:95.32ms
+step:898/1700 train_time:85606ms step_avg:95.33ms
+step:899/1700 train_time:85706ms step_avg:95.33ms
+step:900/1700 train_time:85805ms step_avg:95.34ms
+step:901/1700 train_time:85905ms step_avg:95.34ms
+step:902/1700 train_time:86004ms step_avg:95.35ms
+step:903/1700 train_time:86103ms step_avg:95.35ms
+step:904/1700 train_time:86202ms step_avg:95.36ms
+step:905/1700 train_time:86301ms step_avg:95.36ms
+step:906/1700 train_time:86401ms step_avg:95.37ms
+step:907/1700 train_time:86501ms step_avg:95.37ms
+step:908/1700 train_time:86601ms step_avg:95.38ms
+step:909/1700 train_time:86701ms step_avg:95.38ms
+step:910/1700 train_time:86800ms step_avg:95.38ms
+step:911/1700 train_time:86898ms step_avg:95.39ms
+step:912/1700 train_time:86996ms step_avg:95.39ms
+step:913/1700 train_time:87094ms step_avg:95.39ms
+step:914/1700 train_time:87192ms step_avg:95.40ms
+step:915/1700 train_time:87291ms step_avg:95.40ms
+step:916/1700 train_time:87391ms step_avg:95.41ms
+step:917/1700 train_time:87491ms step_avg:95.41ms
+step:918/1700 train_time:87591ms step_avg:95.42ms
+step:919/1700 train_time:87692ms step_avg:95.42ms
+step:920/1700 train_time:87792ms step_avg:95.43ms
+step:921/1700 train_time:87891ms step_avg:95.43ms
+step:922/1700 train_time:87989ms step_avg:95.43ms
+step:923/1700 train_time:88088ms step_avg:95.44ms
+step:924/1700 train_time:88187ms step_avg:95.44ms
+step:925/1700 train_time:88287ms step_avg:95.45ms
+step:926/1700 train_time:88387ms step_avg:95.45ms
+step:927/1700 train_time:88486ms step_avg:95.45ms
+step:928/1700 train_time:88586ms step_avg:95.46ms
+step:929/1700 train_time:88686ms step_avg:95.46ms
+step:930/1700 train_time:88786ms step_avg:95.47ms
+step:931/1700 train_time:88886ms step_avg:95.47ms
+step:932/1700 train_time:88985ms step_avg:95.48ms
+step:933/1700 train_time:89085ms step_avg:95.48ms
+step:934/1700 train_time:89185ms step_avg:95.49ms
+step:935/1700 train_time:89285ms step_avg:95.49ms
+step:936/1700 train_time:89385ms step_avg:95.50ms
+step:937/1700 train_time:89485ms step_avg:95.50ms
+step:938/1700 train_time:89586ms step_avg:95.51ms
+step:939/1700 train_time:89686ms step_avg:95.51ms
+step:940/1700 train_time:89786ms step_avg:95.52ms
+step:941/1700 train_time:89886ms step_avg:95.52ms
+step:942/1700 train_time:89985ms step_avg:95.53ms
+step:943/1700 train_time:90084ms step_avg:95.53ms
+step:944/1700 train_time:90184ms step_avg:95.53ms
+step:945/1700 train_time:90284ms step_avg:95.54ms
+step:946/1700 train_time:90383ms step_avg:95.54ms
+step:947/1700 train_time:90482ms step_avg:95.55ms
+step:948/1700 train_time:90582ms step_avg:95.55ms
+step:949/1700 train_time:90683ms step_avg:95.56ms
+step:950/1700 train_time:90784ms step_avg:95.56ms
+step:951/1700 train_time:90884ms step_avg:95.57ms
+step:952/1700 train_time:90983ms step_avg:95.57ms
+step:953/1700 train_time:91083ms step_avg:95.58ms
+step:954/1700 train_time:91182ms step_avg:95.58ms
+step:955/1700 train_time:91281ms step_avg:95.58ms
+step:956/1700 train_time:91380ms step_avg:95.59ms
+step:957/1700 train_time:91479ms step_avg:95.59ms
+step:958/1700 train_time:91577ms step_avg:95.59ms
+step:959/1700 train_time:91677ms step_avg:95.60ms
+step:960/1700 train_time:91776ms step_avg:95.60ms
+step:961/1700 train_time:91873ms step_avg:95.60ms
+step:962/1700 train_time:91972ms step_avg:95.61ms
+step:963/1700 train_time:92071ms step_avg:95.61ms
+step:964/1700 train_time:92170ms step_avg:95.61ms
+step:965/1700 train_time:92269ms step_avg:95.62ms
+step:966/1700 train_time:92367ms step_avg:95.62ms
+step:967/1700 train_time:92467ms step_avg:95.62ms
+step:968/1700 train_time:92567ms step_avg:95.63ms
+step:969/1700 train_time:92666ms step_avg:95.63ms
+step:970/1700 train_time:92766ms step_avg:95.64ms
+step:971/1700 train_time:92866ms step_avg:95.64ms
+step:972/1700 train_time:92966ms step_avg:95.64ms
+step:973/1700 train_time:93066ms step_avg:95.65ms
+step:974/1700 train_time:93166ms step_avg:95.65ms
+step:975/1700 train_time:93265ms step_avg:95.66ms
+step:976/1700 train_time:93365ms step_avg:95.66ms
+step:977/1700 train_time:93464ms step_avg:95.66ms
+step:978/1700 train_time:93563ms step_avg:95.67ms
+step:979/1700 train_time:93662ms step_avg:95.67ms
+step:980/1700 train_time:93762ms step_avg:95.68ms
+step:981/1700 train_time:93862ms step_avg:95.68ms
+step:982/1700 train_time:93962ms step_avg:95.68ms
+step:983/1700 train_time:94063ms step_avg:95.69ms
+step:984/1700 train_time:94163ms step_avg:95.69ms
+step:985/1700 train_time:94262ms step_avg:95.70ms
+step:986/1700 train_time:94362ms step_avg:95.70ms
+step:987/1700 train_time:94462ms step_avg:95.71ms
+step:988/1700 train_time:94561ms step_avg:95.71ms
+step:989/1700 train_time:94660ms step_avg:95.71ms
+step:990/1700 train_time:94759ms step_avg:95.72ms
+step:991/1700 train_time:94860ms step_avg:95.72ms
+step:992/1700 train_time:94958ms step_avg:95.72ms
+step:993/1700 train_time:95057ms step_avg:95.73ms
+step:994/1700 train_time:95156ms step_avg:95.73ms
+step:995/1700 train_time:95254ms step_avg:95.73ms
+step:996/1700 train_time:95352ms step_avg:95.73ms
+step:997/1700 train_time:95450ms step_avg:95.74ms
+step:998/1700 train_time:95549ms step_avg:95.74ms
+step:999/1700 train_time:95648ms step_avg:95.74ms
+step:1000/1700 train_time:95748ms step_avg:95.75ms
+step:1000/1700 val_loss:3.5029 train_time:95844ms step_avg:95.84ms
+step:1001/1700 train_time:95867ms step_avg:95.77ms
+step:1002/1700 train_time:95952ms step_avg:95.76ms
+step:1003/1700 train_time:96051ms step_avg:95.76ms
+step:1004/1700 train_time:96150ms step_avg:95.77ms
+step:1005/1700 train_time:96249ms step_avg:95.77ms
+step:1006/1700 train_time:96347ms step_avg:95.77ms
+step:1007/1700 train_time:96445ms step_avg:95.78ms
+step:1008/1700 train_time:96544ms step_avg:95.78ms
+step:1009/1700 train_time:96644ms step_avg:95.78ms
+step:1010/1700 train_time:96743ms step_avg:95.78ms
+step:1011/1700 train_time:96845ms step_avg:95.79ms
+step:1012/1700 train_time:96947ms step_avg:95.80ms
+step:1013/1700 train_time:97047ms step_avg:95.80ms
+step:1014/1700 train_time:97146ms step_avg:95.80ms
+step:1015/1700 train_time:97246ms step_avg:95.81ms
+step:1016/1700 train_time:97345ms step_avg:95.81ms
+step:1017/1700 train_time:97445ms step_avg:95.82ms
+step:1018/1700 train_time:97544ms step_avg:95.82ms
+step:1019/1700 train_time:97643ms step_avg:95.82ms
+step:1020/1700 train_time:97742ms step_avg:95.83ms
+step:1021/1700 train_time:97843ms step_avg:95.83ms
+step:1022/1700 train_time:97944ms step_avg:95.84ms
+step:1023/1700 train_time:98045ms step_avg:95.84ms
+step:1024/1700 train_time:98146ms step_avg:95.85ms
+step:1025/1700 train_time:98246ms step_avg:95.85ms
+step:1026/1700 train_time:98345ms step_avg:95.85ms
+step:1027/1700 train_time:98446ms step_avg:95.86ms
+step:1028/1700 train_time:98545ms step_avg:95.86ms
+step:1029/1700 train_time:98644ms step_avg:95.86ms
+step:1030/1700 train_time:98744ms step_avg:95.87ms
+step:1031/1700 train_time:98844ms step_avg:95.87ms
+step:1032/1700 train_time:98944ms step_avg:95.88ms
+step:1033/1700 train_time:99044ms step_avg:95.88ms
+step:1034/1700 train_time:99144ms step_avg:95.88ms
+step:1035/1700 train_time:99244ms step_avg:95.89ms
+step:1036/1700 train_time:99344ms step_avg:95.89ms
+step:1037/1700 train_time:99444ms step_avg:95.90ms
+step:1038/1700 train_time:99544ms step_avg:95.90ms
+step:1039/1700 train_time:99642ms step_avg:95.90ms
+step:1040/1700 train_time:99741ms step_avg:95.90ms
+step:1041/1700 train_time:99840ms step_avg:95.91ms
+step:1042/1700 train_time:99940ms step_avg:95.91ms
+step:1043/1700 train_time:100041ms step_avg:95.92ms
+step:1044/1700 train_time:100142ms step_avg:95.92ms
+step:1045/1700 train_time:100243ms step_avg:95.93ms
+step:1046/1700 train_time:100343ms step_avg:95.93ms
+step:1047/1700 train_time:100442ms step_avg:95.93ms
+step:1048/1700 train_time:100541ms step_avg:95.94ms
+step:1049/1700 train_time:100641ms step_avg:95.94ms
+step:1050/1700 train_time:100741ms step_avg:95.94ms
+step:1051/1700 train_time:100840ms step_avg:95.95ms
+step:1052/1700 train_time:100939ms step_avg:95.95ms
+step:1053/1700 train_time:101038ms step_avg:95.95ms
+step:1054/1700 train_time:101137ms step_avg:95.96ms
+step:1055/1700 train_time:101236ms step_avg:95.96ms
+step:1056/1700 train_time:101335ms step_avg:95.96ms
+step:1057/1700 train_time:101433ms step_avg:95.96ms
+step:1058/1700 train_time:101531ms step_avg:95.97ms
+step:1059/1700 train_time:101631ms step_avg:95.97ms
+step:1060/1700 train_time:101731ms step_avg:95.97ms
+step:1061/1700 train_time:101832ms step_avg:95.98ms
+step:1062/1700 train_time:101932ms step_avg:95.98ms
+step:1063/1700 train_time:102034ms step_avg:95.99ms
+step:1064/1700 train_time:102133ms step_avg:95.99ms
+step:1065/1700 train_time:102233ms step_avg:95.99ms
+step:1066/1700 train_time:102332ms step_avg:96.00ms
+step:1067/1700 train_time:102430ms step_avg:96.00ms
+step:1068/1700 train_time:102529ms step_avg:96.00ms
+step:1069/1700 train_time:102627ms step_avg:96.00ms
+step:1070/1700 train_time:102725ms step_avg:96.00ms
+step:1071/1700 train_time:102825ms step_avg:96.01ms
+step:1072/1700 train_time:102926ms step_avg:96.01ms
+step:1073/1700 train_time:103026ms step_avg:96.02ms
+step:1074/1700 train_time:103125ms step_avg:96.02ms
+step:1075/1700 train_time:103226ms step_avg:96.02ms
+step:1076/1700 train_time:103326ms step_avg:96.03ms
+step:1077/1700 train_time:103426ms step_avg:96.03ms
+step:1078/1700 train_time:103525ms step_avg:96.03ms
+step:1079/1700 train_time:103624ms step_avg:96.04ms
+step:1080/1700 train_time:103723ms step_avg:96.04ms
+step:1081/1700 train_time:103824ms step_avg:96.04ms
+step:1082/1700 train_time:103924ms step_avg:96.05ms
+step:1083/1700 train_time:104024ms step_avg:96.05ms
+step:1084/1700 train_time:104125ms step_avg:96.06ms
+step:1085/1700 train_time:104225ms step_avg:96.06ms
+step:1086/1700 train_time:104325ms step_avg:96.06ms
+step:1087/1700 train_time:104425ms step_avg:96.07ms
+step:1088/1700 train_time:104525ms step_avg:96.07ms
+step:1089/1700 train_time:104624ms step_avg:96.07ms
+step:1090/1700 train_time:104724ms step_avg:96.08ms
+step:1091/1700 train_time:104824ms step_avg:96.08ms
+step:1092/1700 train_time:104924ms step_avg:96.08ms
+step:1093/1700 train_time:105024ms step_avg:96.09ms
+step:1094/1700 train_time:105125ms step_avg:96.09ms
+step:1095/1700 train_time:105225ms step_avg:96.10ms
+step:1096/1700 train_time:105325ms step_avg:96.10ms
+step:1097/1700 train_time:105426ms step_avg:96.10ms
+step:1098/1700 train_time:105525ms step_avg:96.11ms
+step:1099/1700 train_time:105625ms step_avg:96.11ms
+step:1100/1700 train_time:105724ms step_avg:96.11ms
+step:1101/1700 train_time:105824ms step_avg:96.12ms
+step:1102/1700 train_time:105924ms step_avg:96.12ms
+step:1103/1700 train_time:106024ms step_avg:96.12ms
+step:1104/1700 train_time:106124ms step_avg:96.13ms
+step:1105/1700 train_time:106224ms step_avg:96.13ms
+step:1106/1700 train_time:106325ms step_avg:96.13ms
+step:1107/1700 train_time:106426ms step_avg:96.14ms
+step:1108/1700 train_time:106526ms step_avg:96.14ms
+step:1109/1700 train_time:106626ms step_avg:96.15ms
+step:1110/1700 train_time:106727ms step_avg:96.15ms
+step:1111/1700 train_time:106827ms step_avg:96.15ms
+step:1112/1700 train_time:106926ms step_avg:96.16ms
+step:1113/1700 train_time:107026ms step_avg:96.16ms
+step:1114/1700 train_time:107126ms step_avg:96.16ms
+step:1115/1700 train_time:107226ms step_avg:96.17ms
+step:1116/1700 train_time:107327ms step_avg:96.17ms
+step:1117/1700 train_time:107427ms step_avg:96.17ms
+step:1118/1700 train_time:107527ms step_avg:96.18ms
+step:1119/1700 train_time:107626ms step_avg:96.18ms
+step:1120/1700 train_time:107725ms step_avg:96.18ms
+step:1121/1700 train_time:107825ms step_avg:96.19ms
+step:1122/1700 train_time:107925ms step_avg:96.19ms
+step:1123/1700 train_time:108026ms step_avg:96.19ms
+step:1124/1700 train_time:108126ms step_avg:96.20ms
+step:1125/1700 train_time:108226ms step_avg:96.20ms
+step:1125/1700 val_loss:3.4494 train_time:108323ms step_avg:96.29ms
+step:1126/1700 train_time:108344ms step_avg:96.22ms
+step:1127/1700 train_time:108432ms step_avg:96.21ms
+step:1128/1700 train_time:108531ms step_avg:96.22ms
+step:1129/1700 train_time:108631ms step_avg:96.22ms
+step:1130/1700 train_time:108730ms step_avg:96.22ms
+step:1131/1700 train_time:108829ms step_avg:96.22ms
+step:1132/1700 train_time:108927ms step_avg:96.23ms
+step:1133/1700 train_time:109026ms step_avg:96.23ms
+step:1134/1700 train_time:109124ms step_avg:96.23ms
+step:1135/1700 train_time:109223ms step_avg:96.23ms
+step:1136/1700 train_time:109325ms step_avg:96.24ms
+step:1137/1700 train_time:109429ms step_avg:96.24ms
+step:1138/1700 train_time:109530ms step_avg:96.25ms
+step:1139/1700 train_time:109630ms step_avg:96.25ms
+step:1140/1700 train_time:109731ms step_avg:96.25ms
+step:1141/1700 train_time:109830ms step_avg:96.26ms
+step:1142/1700 train_time:109930ms step_avg:96.26ms
+step:1143/1700 train_time:110029ms step_avg:96.26ms
+step:1144/1700 train_time:110128ms step_avg:96.27ms
+step:1145/1700 train_time:110228ms step_avg:96.27ms
+step:1146/1700 train_time:110328ms step_avg:96.27ms
+step:1147/1700 train_time:110429ms step_avg:96.28ms
+step:1148/1700 train_time:110531ms step_avg:96.28ms
+step:1149/1700 train_time:110631ms step_avg:96.28ms
+step:1150/1700 train_time:110731ms step_avg:96.29ms
+step:1151/1700 train_time:110831ms step_avg:96.29ms
+step:1152/1700 train_time:110931ms step_avg:96.29ms
+step:1153/1700 train_time:111031ms step_avg:96.30ms
+step:1154/1700 train_time:111130ms step_avg:96.30ms
+step:1155/1700 train_time:111230ms step_avg:96.30ms
+step:1156/1700 train_time:111330ms step_avg:96.31ms
+step:1157/1700 train_time:111432ms step_avg:96.31ms
+step:1158/1700 train_time:111532ms step_avg:96.31ms
+step:1159/1700 train_time:111633ms step_avg:96.32ms
+step:1160/1700 train_time:111733ms step_avg:96.32ms
+step:1161/1700 train_time:111833ms step_avg:96.32ms
+step:1162/1700 train_time:111932ms step_avg:96.33ms
+step:1163/1700 train_time:112031ms step_avg:96.33ms
+step:1164/1700 train_time:112131ms step_avg:96.33ms
+step:1165/1700 train_time:112231ms step_avg:96.34ms
+step:1166/1700 train_time:112331ms step_avg:96.34ms
+step:1167/1700 train_time:112432ms step_avg:96.34ms
+step:1168/1700 train_time:112533ms step_avg:96.35ms
+step:1169/1700 train_time:112634ms step_avg:96.35ms
+step:1170/1700 train_time:112734ms step_avg:96.35ms
+step:1171/1700 train_time:112834ms step_avg:96.36ms
+step:1172/1700 train_time:112935ms step_avg:96.36ms
+step:1173/1700 train_time:113033ms step_avg:96.36ms
+step:1174/1700 train_time:113134ms step_avg:96.37ms
+step:1175/1700 train_time:113232ms step_avg:96.37ms
+step:1176/1700 train_time:113333ms step_avg:96.37ms
+step:1177/1700 train_time:113433ms step_avg:96.37ms
+step:1178/1700 train_time:113534ms step_avg:96.38ms
+step:1179/1700 train_time:113635ms step_avg:96.38ms
+step:1180/1700 train_time:113735ms step_avg:96.39ms
+step:1181/1700 train_time:113836ms step_avg:96.39ms
+step:1182/1700 train_time:113936ms step_avg:96.39ms
+step:1183/1700 train_time:114035ms step_avg:96.39ms
+step:1184/1700 train_time:114136ms step_avg:96.40ms
+step:1185/1700 train_time:114236ms step_avg:96.40ms
+step:1186/1700 train_time:114337ms step_avg:96.41ms
+step:1187/1700 train_time:114436ms step_avg:96.41ms
+step:1188/1700 train_time:114536ms step_avg:96.41ms
+step:1189/1700 train_time:114636ms step_avg:96.41ms
+step:1190/1700 train_time:114735ms step_avg:96.42ms
+step:1191/1700 train_time:114835ms step_avg:96.42ms
+step:1192/1700 train_time:114935ms step_avg:96.42ms
+step:1193/1700 train_time:115034ms step_avg:96.42ms
+step:1194/1700 train_time:115135ms step_avg:96.43ms
+step:1195/1700 train_time:115234ms step_avg:96.43ms
+step:1196/1700 train_time:115333ms step_avg:96.43ms
+step:1197/1700 train_time:115433ms step_avg:96.44ms
+step:1198/1700 train_time:115533ms step_avg:96.44ms
+step:1199/1700 train_time:115635ms step_avg:96.44ms
+step:1200/1700 train_time:115735ms step_avg:96.45ms
+step:1201/1700 train_time:115834ms step_avg:96.45ms
+step:1202/1700 train_time:115934ms step_avg:96.45ms
+step:1203/1700 train_time:116035ms step_avg:96.45ms
+step:1204/1700 train_time:116135ms step_avg:96.46ms
+step:1205/1700 train_time:116235ms step_avg:96.46ms
+step:1206/1700 train_time:116335ms step_avg:96.46ms
+step:1207/1700 train_time:116434ms step_avg:96.47ms
+step:1208/1700 train_time:116534ms step_avg:96.47ms
+step:1209/1700 train_time:116634ms step_avg:96.47ms
+step:1210/1700 train_time:116734ms step_avg:96.47ms
+step:1211/1700 train_time:116834ms step_avg:96.48ms
+step:1212/1700 train_time:116934ms step_avg:96.48ms
+step:1213/1700 train_time:117034ms step_avg:96.48ms
+step:1214/1700 train_time:117134ms step_avg:96.49ms
+step:1215/1700 train_time:117234ms step_avg:96.49ms
+step:1216/1700 train_time:117333ms step_avg:96.49ms
+step:1217/1700 train_time:117433ms step_avg:96.49ms
+step:1218/1700 train_time:117533ms step_avg:96.50ms
+step:1219/1700 train_time:117634ms step_avg:96.50ms
+step:1220/1700 train_time:117735ms step_avg:96.50ms
+step:1221/1700 train_time:117834ms step_avg:96.51ms
+step:1222/1700 train_time:117934ms step_avg:96.51ms
+step:1223/1700 train_time:118036ms step_avg:96.51ms
+step:1224/1700 train_time:118135ms step_avg:96.52ms
+step:1225/1700 train_time:118235ms step_avg:96.52ms
+step:1226/1700 train_time:118335ms step_avg:96.52ms
+step:1227/1700 train_time:118434ms step_avg:96.52ms
+step:1228/1700 train_time:118534ms step_avg:96.53ms
+step:1229/1700 train_time:118634ms step_avg:96.53ms
+step:1230/1700 train_time:118734ms step_avg:96.53ms
+step:1231/1700 train_time:118833ms step_avg:96.53ms
+step:1232/1700 train_time:118935ms step_avg:96.54ms
+step:1233/1700 train_time:119034ms step_avg:96.54ms
+step:1234/1700 train_time:119134ms step_avg:96.54ms
+step:1235/1700 train_time:119234ms step_avg:96.55ms
+step:1236/1700 train_time:119334ms step_avg:96.55ms
+step:1237/1700 train_time:119434ms step_avg:96.55ms
+step:1238/1700 train_time:119533ms step_avg:96.55ms
+step:1239/1700 train_time:119633ms step_avg:96.56ms
+step:1240/1700 train_time:119733ms step_avg:96.56ms
+step:1241/1700 train_time:119834ms step_avg:96.56ms
+step:1242/1700 train_time:119936ms step_avg:96.57ms
+step:1243/1700 train_time:120036ms step_avg:96.57ms
+step:1244/1700 train_time:120136ms step_avg:96.57ms
+step:1245/1700 train_time:120235ms step_avg:96.57ms
+step:1246/1700 train_time:120335ms step_avg:96.58ms
+step:1247/1700 train_time:120435ms step_avg:96.58ms
+step:1248/1700 train_time:120535ms step_avg:96.58ms
+step:1249/1700 train_time:120635ms step_avg:96.58ms
+step:1250/1700 train_time:120735ms step_avg:96.59ms
+step:1250/1700 val_loss:3.4037 train_time:120830ms step_avg:96.66ms
+step:1251/1700 train_time:120853ms step_avg:96.61ms
+step:1252/1700 train_time:120940ms step_avg:96.60ms
+step:1253/1700 train_time:121041ms step_avg:96.60ms
+step:1254/1700 train_time:121141ms step_avg:96.60ms
+step:1255/1700 train_time:121241ms step_avg:96.61ms
+step:1256/1700 train_time:121341ms step_avg:96.61ms
+step:1257/1700 train_time:121441ms step_avg:96.61ms
+step:1258/1700 train_time:121541ms step_avg:96.61ms
+step:1259/1700 train_time:121641ms step_avg:96.62ms
+step:1260/1700 train_time:121741ms step_avg:96.62ms
+step:1261/1700 train_time:121844ms step_avg:96.62ms
+step:1262/1700 train_time:121945ms step_avg:96.63ms
+step:1263/1700 train_time:122045ms step_avg:96.63ms
+step:1264/1700 train_time:122144ms step_avg:96.63ms
+step:1265/1700 train_time:122244ms step_avg:96.64ms
+step:1266/1700 train_time:122343ms step_avg:96.64ms
+step:1267/1700 train_time:122442ms step_avg:96.64ms
+step:1268/1700 train_time:122541ms step_avg:96.64ms
+step:1269/1700 train_time:122641ms step_avg:96.64ms
+step:1270/1700 train_time:122741ms step_avg:96.65ms
+step:1271/1700 train_time:122844ms step_avg:96.65ms
+step:1272/1700 train_time:122944ms step_avg:96.65ms
+step:1273/1700 train_time:123044ms step_avg:96.66ms
+step:1274/1700 train_time:123144ms step_avg:96.66ms
+step:1275/1700 train_time:123242ms step_avg:96.66ms
+step:1276/1700 train_time:123342ms step_avg:96.66ms
+step:1277/1700 train_time:123442ms step_avg:96.67ms
+step:1278/1700 train_time:123541ms step_avg:96.67ms
+step:1279/1700 train_time:123641ms step_avg:96.67ms
+step:1280/1700 train_time:123741ms step_avg:96.67ms
+step:1281/1700 train_time:123841ms step_avg:96.68ms
+step:1282/1700 train_time:123942ms step_avg:96.68ms
+step:1283/1700 train_time:124044ms step_avg:96.68ms
+step:1284/1700 train_time:124144ms step_avg:96.69ms
+step:1285/1700 train_time:124243ms step_avg:96.69ms
+step:1286/1700 train_time:124342ms step_avg:96.69ms
+step:1287/1700 train_time:124442ms step_avg:96.69ms
+step:1288/1700 train_time:124542ms step_avg:96.69ms
+step:1289/1700 train_time:124642ms step_avg:96.70ms
+step:1290/1700 train_time:124742ms step_avg:96.70ms
+step:1291/1700 train_time:124842ms step_avg:96.70ms
+step:1292/1700 train_time:124943ms step_avg:96.71ms
+step:1293/1700 train_time:125044ms step_avg:96.71ms
+step:1294/1700 train_time:125145ms step_avg:96.71ms
+step:1295/1700 train_time:125246ms step_avg:96.71ms
+step:1296/1700 train_time:125345ms step_avg:96.72ms
+step:1297/1700 train_time:125445ms step_avg:96.72ms
+step:1298/1700 train_time:125545ms step_avg:96.72ms
+step:1299/1700 train_time:125645ms step_avg:96.72ms
+step:1300/1700 train_time:125745ms step_avg:96.73ms
+step:1301/1700 train_time:125845ms step_avg:96.73ms
+step:1302/1700 train_time:125944ms step_avg:96.73ms
+step:1303/1700 train_time:126045ms step_avg:96.73ms
+step:1304/1700 train_time:126145ms step_avg:96.74ms
+step:1305/1700 train_time:126245ms step_avg:96.74ms
+step:1306/1700 train_time:126345ms step_avg:96.74ms
+step:1307/1700 train_time:126444ms step_avg:96.74ms
+step:1308/1700 train_time:126544ms step_avg:96.75ms
+step:1309/1700 train_time:126643ms step_avg:96.75ms
+step:1310/1700 train_time:126743ms step_avg:96.75ms
+step:1311/1700 train_time:126843ms step_avg:96.75ms
+step:1312/1700 train_time:126943ms step_avg:96.76ms
+step:1313/1700 train_time:127044ms step_avg:96.76ms
+step:1314/1700 train_time:127144ms step_avg:96.76ms
+step:1315/1700 train_time:127244ms step_avg:96.76ms
+step:1316/1700 train_time:127343ms step_avg:96.77ms
+step:1317/1700 train_time:127443ms step_avg:96.77ms
+step:1318/1700 train_time:127542ms step_avg:96.77ms
+step:1319/1700 train_time:127643ms step_avg:96.77ms
+step:1320/1700 train_time:127744ms step_avg:96.78ms
+step:1321/1700 train_time:127843ms step_avg:96.78ms
+step:1322/1700 train_time:127942ms step_avg:96.78ms
+step:1323/1700 train_time:128043ms step_avg:96.78ms
+step:1324/1700 train_time:128144ms step_avg:96.79ms
+step:1325/1700 train_time:128244ms step_avg:96.79ms
+step:1326/1700 train_time:128345ms step_avg:96.79ms
+step:1327/1700 train_time:128445ms step_avg:96.79ms
+step:1328/1700 train_time:128544ms step_avg:96.80ms
+step:1329/1700 train_time:128643ms step_avg:96.80ms
+step:1330/1700 train_time:128743ms step_avg:96.80ms
+step:1331/1700 train_time:128842ms step_avg:96.80ms
+step:1332/1700 train_time:128942ms step_avg:96.80ms
+step:1333/1700 train_time:129043ms step_avg:96.81ms
+step:1334/1700 train_time:129142ms step_avg:96.81ms
+step:1335/1700 train_time:129242ms step_avg:96.81ms
+step:1336/1700 train_time:129344ms step_avg:96.81ms
+step:1337/1700 train_time:129444ms step_avg:96.82ms
+step:1338/1700 train_time:129544ms step_avg:96.82ms
+step:1339/1700 train_time:129644ms step_avg:96.82ms
+step:1340/1700 train_time:129744ms step_avg:96.82ms
+step:1341/1700 train_time:129844ms step_avg:96.83ms
+step:1342/1700 train_time:129943ms step_avg:96.83ms
+step:1343/1700 train_time:130042ms step_avg:96.83ms
+step:1344/1700 train_time:130143ms step_avg:96.83ms
+step:1345/1700 train_time:130243ms step_avg:96.83ms
+step:1346/1700 train_time:130344ms step_avg:96.84ms
+step:1347/1700 train_time:130445ms step_avg:96.84ms
+step:1348/1700 train_time:130544ms step_avg:96.84ms
+step:1349/1700 train_time:130644ms step_avg:96.84ms
+step:1350/1700 train_time:130744ms step_avg:96.85ms
+step:1351/1700 train_time:130844ms step_avg:96.85ms
+step:1352/1700 train_time:130943ms step_avg:96.85ms
+step:1353/1700 train_time:131043ms step_avg:96.85ms
+step:1354/1700 train_time:131143ms step_avg:96.86ms
+step:1355/1700 train_time:131243ms step_avg:96.86ms
+step:1356/1700 train_time:131343ms step_avg:96.86ms
+step:1357/1700 train_time:131442ms step_avg:96.86ms
+step:1358/1700 train_time:131544ms step_avg:96.87ms
+step:1359/1700 train_time:131644ms step_avg:96.87ms
+step:1360/1700 train_time:131745ms step_avg:96.87ms
+step:1361/1700 train_time:131844ms step_avg:96.87ms
+step:1362/1700 train_time:131944ms step_avg:96.87ms
+step:1363/1700 train_time:132044ms step_avg:96.88ms
+step:1364/1700 train_time:132143ms step_avg:96.88ms
+step:1365/1700 train_time:132242ms step_avg:96.88ms
+step:1366/1700 train_time:132342ms step_avg:96.88ms
+step:1367/1700 train_time:132442ms step_avg:96.88ms
+step:1368/1700 train_time:132542ms step_avg:96.89ms
+step:1369/1700 train_time:132642ms step_avg:96.89ms
+step:1370/1700 train_time:132742ms step_avg:96.89ms
+step:1371/1700 train_time:132842ms step_avg:96.89ms
+step:1372/1700 train_time:132942ms step_avg:96.90ms
+step:1373/1700 train_time:133043ms step_avg:96.90ms
+step:1374/1700 train_time:133142ms step_avg:96.90ms
+step:1375/1700 train_time:133243ms step_avg:96.90ms
+step:1375/1700 val_loss:3.3645 train_time:133339ms step_avg:96.97ms
+step:1376/1700 train_time:133361ms step_avg:96.92ms
+step:1377/1700 train_time:133452ms step_avg:96.92ms
+step:1378/1700 train_time:133553ms step_avg:96.92ms
+step:1379/1700 train_time:133652ms step_avg:96.92ms
+step:1380/1700 train_time:133753ms step_avg:96.92ms
+step:1381/1700 train_time:133852ms step_avg:96.92ms
+step:1382/1700 train_time:133951ms step_avg:96.93ms
+step:1383/1700 train_time:134051ms step_avg:96.93ms
+step:1384/1700 train_time:134151ms step_avg:96.93ms
+step:1385/1700 train_time:134250ms step_avg:96.93ms
+step:1386/1700 train_time:134353ms step_avg:96.94ms
+step:1387/1700 train_time:134454ms step_avg:96.94ms
+step:1388/1700 train_time:134555ms step_avg:96.94ms
+step:1389/1700 train_time:134657ms step_avg:96.95ms
+step:1390/1700 train_time:134757ms step_avg:96.95ms
+step:1391/1700 train_time:134859ms step_avg:96.95ms
+step:1392/1700 train_time:134961ms step_avg:96.95ms
+step:1393/1700 train_time:135063ms step_avg:96.96ms
+step:1394/1700 train_time:135166ms step_avg:96.96ms
+step:1395/1700 train_time:135268ms step_avg:96.97ms
+step:1396/1700 train_time:135370ms step_avg:96.97ms
+step:1397/1700 train_time:135471ms step_avg:96.97ms
+step:1398/1700 train_time:135572ms step_avg:96.98ms
+step:1399/1700 train_time:135673ms step_avg:96.98ms
+step:1400/1700 train_time:135774ms step_avg:96.98ms
+step:1401/1700 train_time:135875ms step_avg:96.98ms
+step:1402/1700 train_time:135975ms step_avg:96.99ms
+step:1403/1700 train_time:136077ms step_avg:96.99ms
+step:1404/1700 train_time:136178ms step_avg:96.99ms
+step:1405/1700 train_time:136280ms step_avg:97.00ms
+step:1406/1700 train_time:136382ms step_avg:97.00ms
+step:1407/1700 train_time:136485ms step_avg:97.00ms
+step:1408/1700 train_time:136588ms step_avg:97.01ms
+step:1409/1700 train_time:136691ms step_avg:97.01ms
+step:1410/1700 train_time:136792ms step_avg:97.02ms
+step:1411/1700 train_time:136892ms step_avg:97.02ms
+step:1412/1700 train_time:136994ms step_avg:97.02ms
+step:1413/1700 train_time:137094ms step_avg:97.02ms
+step:1414/1700 train_time:137195ms step_avg:97.03ms
+step:1415/1700 train_time:137296ms step_avg:97.03ms
+step:1416/1700 train_time:137396ms step_avg:97.03ms
+step:1417/1700 train_time:137497ms step_avg:97.03ms
+step:1418/1700 train_time:137597ms step_avg:97.04ms
+step:1419/1700 train_time:137699ms step_avg:97.04ms
+step:1420/1700 train_time:137801ms step_avg:97.04ms
+step:1421/1700 train_time:137902ms step_avg:97.05ms
+step:1422/1700 train_time:138004ms step_avg:97.05ms
+step:1423/1700 train_time:138106ms step_avg:97.05ms
+step:1424/1700 train_time:138209ms step_avg:97.06ms
+step:1425/1700 train_time:138311ms step_avg:97.06ms
+step:1426/1700 train_time:138411ms step_avg:97.06ms
+step:1427/1700 train_time:138511ms step_avg:97.06ms
+step:1428/1700 train_time:138613ms step_avg:97.07ms
+step:1429/1700 train_time:138713ms step_avg:97.07ms
+step:1430/1700 train_time:138816ms step_avg:97.07ms
+step:1431/1700 train_time:138918ms step_avg:97.08ms
+step:1432/1700 train_time:139018ms step_avg:97.08ms
+step:1433/1700 train_time:139118ms step_avg:97.08ms
+step:1434/1700 train_time:139219ms step_avg:97.08ms
+step:1435/1700 train_time:139321ms step_avg:97.09ms
+step:1436/1700 train_time:139425ms step_avg:97.09ms
+step:1437/1700 train_time:139529ms step_avg:97.10ms
+step:1438/1700 train_time:139629ms step_avg:97.10ms
+step:1439/1700 train_time:139731ms step_avg:97.10ms
+step:1440/1700 train_time:139833ms step_avg:97.11ms
+step:1441/1700 train_time:139935ms step_avg:97.11ms
+step:1442/1700 train_time:140034ms step_avg:97.11ms
+step:1443/1700 train_time:140135ms step_avg:97.11ms
+step:1444/1700 train_time:140236ms step_avg:97.12ms
+step:1445/1700 train_time:140337ms step_avg:97.12ms
+step:1446/1700 train_time:140437ms step_avg:97.12ms
+step:1447/1700 train_time:140538ms step_avg:97.12ms
+step:1448/1700 train_time:140638ms step_avg:97.13ms
+step:1449/1700 train_time:140739ms step_avg:97.13ms
+step:1450/1700 train_time:140841ms step_avg:97.13ms
+step:1451/1700 train_time:140943ms step_avg:97.13ms
+step:1452/1700 train_time:141045ms step_avg:97.14ms
+step:1453/1700 train_time:141147ms step_avg:97.14ms
+step:1454/1700 train_time:141252ms step_avg:97.15ms
+step:1455/1700 train_time:141353ms step_avg:97.15ms
+step:1456/1700 train_time:141453ms step_avg:97.15ms
+step:1457/1700 train_time:141554ms step_avg:97.15ms
+step:1458/1700 train_time:141655ms step_avg:97.16ms
+step:1459/1700 train_time:141755ms step_avg:97.16ms
+step:1460/1700 train_time:141856ms step_avg:97.16ms
+step:1461/1700 train_time:141956ms step_avg:97.16ms
+step:1462/1700 train_time:142056ms step_avg:97.17ms
+step:1463/1700 train_time:142159ms step_avg:97.17ms
+step:1464/1700 train_time:142260ms step_avg:97.17ms
+step:1465/1700 train_time:142362ms step_avg:97.18ms
+step:1466/1700 train_time:142464ms step_avg:97.18ms
+step:1467/1700 train_time:142567ms step_avg:97.18ms
+step:1468/1700 train_time:142669ms step_avg:97.19ms
+step:1469/1700 train_time:142771ms step_avg:97.19ms
+step:1470/1700 train_time:142871ms step_avg:97.19ms
+step:1471/1700 train_time:142972ms step_avg:97.19ms
+step:1472/1700 train_time:143072ms step_avg:97.20ms
+step:1473/1700 train_time:143173ms step_avg:97.20ms
+step:1474/1700 train_time:143274ms step_avg:97.20ms
+step:1475/1700 train_time:143374ms step_avg:97.20ms
+step:1476/1700 train_time:143476ms step_avg:97.21ms
+step:1477/1700 train_time:143578ms step_avg:97.21ms
+step:1478/1700 train_time:143679ms step_avg:97.21ms
+step:1479/1700 train_time:143783ms step_avg:97.22ms
+step:1480/1700 train_time:143886ms step_avg:97.22ms
+step:1481/1700 train_time:143988ms step_avg:97.22ms
+step:1482/1700 train_time:144091ms step_avg:97.23ms
+step:1483/1700 train_time:144191ms step_avg:97.23ms
+step:1484/1700 train_time:144292ms step_avg:97.23ms
+step:1485/1700 train_time:144393ms step_avg:97.23ms
+step:1486/1700 train_time:144494ms step_avg:97.24ms
+step:1487/1700 train_time:144596ms step_avg:97.24ms
+step:1488/1700 train_time:144697ms step_avg:97.24ms
+step:1489/1700 train_time:144798ms step_avg:97.25ms
+step:1490/1700 train_time:144900ms step_avg:97.25ms
+step:1491/1700 train_time:145003ms step_avg:97.25ms
+step:1492/1700 train_time:145106ms step_avg:97.26ms
+step:1493/1700 train_time:145208ms step_avg:97.26ms
+step:1494/1700 train_time:145309ms step_avg:97.26ms
+step:1495/1700 train_time:145409ms step_avg:97.26ms
+step:1496/1700 train_time:145510ms step_avg:97.27ms
+step:1497/1700 train_time:145610ms step_avg:97.27ms
+step:1498/1700 train_time:145712ms step_avg:97.27ms
+step:1499/1700 train_time:145812ms step_avg:97.27ms
+step:1500/1700 train_time:145913ms step_avg:97.28ms
+step:1500/1700 val_loss:3.3293 train_time:146012ms step_avg:97.34ms
+step:1501/1700 train_time:146034ms step_avg:97.29ms
+step:1502/1700 train_time:146124ms step_avg:97.29ms
+step:1503/1700 train_time:146225ms step_avg:97.29ms
+step:1504/1700 train_time:146327ms step_avg:97.29ms
+step:1505/1700 train_time:146428ms step_avg:97.29ms
+step:1506/1700 train_time:146529ms step_avg:97.30ms
+step:1507/1700 train_time:146630ms step_avg:97.30ms
+step:1508/1700 train_time:146730ms step_avg:97.30ms
+step:1509/1700 train_time:146832ms step_avg:97.30ms
+step:1510/1700 train_time:146934ms step_avg:97.31ms
+step:1511/1700 train_time:147038ms step_avg:97.31ms
+step:1512/1700 train_time:147140ms step_avg:97.32ms
+step:1513/1700 train_time:147241ms step_avg:97.32ms
+step:1514/1700 train_time:147343ms step_avg:97.32ms
+step:1515/1700 train_time:147447ms step_avg:97.32ms
+step:1516/1700 train_time:147550ms step_avg:97.33ms
+step:1517/1700 train_time:147650ms step_avg:97.33ms
+step:1518/1700 train_time:147751ms step_avg:97.33ms
+step:1519/1700 train_time:147855ms step_avg:97.34ms
+step:1520/1700 train_time:147956ms step_avg:97.34ms
+step:1521/1700 train_time:148057ms step_avg:97.34ms
+step:1522/1700 train_time:148159ms step_avg:97.34ms
+step:1523/1700 train_time:148260ms step_avg:97.35ms
+step:1524/1700 train_time:148361ms step_avg:97.35ms
+step:1525/1700 train_time:148463ms step_avg:97.35ms
+step:1526/1700 train_time:148563ms step_avg:97.35ms
+step:1527/1700 train_time:148666ms step_avg:97.36ms
+step:1528/1700 train_time:148768ms step_avg:97.36ms
+step:1529/1700 train_time:148870ms step_avg:97.36ms
+step:1530/1700 train_time:148972ms step_avg:97.37ms
+step:1531/1700 train_time:149073ms step_avg:97.37ms
+step:1532/1700 train_time:149174ms step_avg:97.37ms
+step:1533/1700 train_time:149274ms step_avg:97.37ms
+step:1534/1700 train_time:149376ms step_avg:97.38ms
+step:1535/1700 train_time:149476ms step_avg:97.38ms
+step:1536/1700 train_time:149577ms step_avg:97.38ms
+step:1537/1700 train_time:149677ms step_avg:97.38ms
+step:1538/1700 train_time:149777ms step_avg:97.38ms
+step:1539/1700 train_time:149878ms step_avg:97.39ms
+step:1540/1700 train_time:149979ms step_avg:97.39ms
+step:1541/1700 train_time:150083ms step_avg:97.39ms
+step:1542/1700 train_time:150188ms step_avg:97.40ms
+step:1543/1700 train_time:150290ms step_avg:97.40ms
+step:1544/1700 train_time:150392ms step_avg:97.40ms
+step:1545/1700 train_time:150493ms step_avg:97.41ms
+step:1546/1700 train_time:150593ms step_avg:97.41ms
+step:1547/1700 train_time:150696ms step_avg:97.41ms
+step:1548/1700 train_time:150797ms step_avg:97.41ms
+step:1549/1700 train_time:150899ms step_avg:97.42ms
+step:1550/1700 train_time:151001ms step_avg:97.42ms
+step:1551/1700 train_time:151104ms step_avg:97.42ms
+step:1552/1700 train_time:151203ms step_avg:97.42ms
+step:1553/1700 train_time:151307ms step_avg:97.43ms
+step:1554/1700 train_time:151409ms step_avg:97.43ms
+step:1555/1700 train_time:151511ms step_avg:97.43ms
+step:1556/1700 train_time:151613ms step_avg:97.44ms
+step:1557/1700 train_time:151716ms step_avg:97.44ms
+step:1558/1700 train_time:151819ms step_avg:97.44ms
+step:1559/1700 train_time:151919ms step_avg:97.45ms
+step:1560/1700 train_time:152021ms step_avg:97.45ms
+step:1561/1700 train_time:152121ms step_avg:97.45ms
+step:1562/1700 train_time:152222ms step_avg:97.45ms
+step:1563/1700 train_time:152325ms step_avg:97.46ms
+step:1564/1700 train_time:152426ms step_avg:97.46ms
+step:1565/1700 train_time:152529ms step_avg:97.46ms
+step:1566/1700 train_time:152632ms step_avg:97.47ms
+step:1567/1700 train_time:152734ms step_avg:97.47ms
+step:1568/1700 train_time:152835ms step_avg:97.47ms
+step:1569/1700 train_time:152937ms step_avg:97.47ms
+step:1570/1700 train_time:153039ms step_avg:97.48ms
+step:1571/1700 train_time:153140ms step_avg:97.48ms
+step:1572/1700 train_time:153241ms step_avg:97.48ms
+step:1573/1700 train_time:153340ms step_avg:97.48ms
+step:1574/1700 train_time:153442ms step_avg:97.49ms
+step:1575/1700 train_time:153543ms step_avg:97.49ms
+step:1576/1700 train_time:153646ms step_avg:97.49ms
+step:1577/1700 train_time:153752ms step_avg:97.50ms
+step:1578/1700 train_time:153854ms step_avg:97.50ms
+step:1579/1700 train_time:153955ms step_avg:97.50ms
+step:1580/1700 train_time:154056ms step_avg:97.50ms
+step:1581/1700 train_time:154156ms step_avg:97.51ms
+step:1582/1700 train_time:154256ms step_avg:97.51ms
+step:1583/1700 train_time:154361ms step_avg:97.51ms
+step:1584/1700 train_time:154462ms step_avg:97.51ms
+step:1585/1700 train_time:154562ms step_avg:97.52ms
+step:1586/1700 train_time:154666ms step_avg:97.52ms
+step:1587/1700 train_time:154767ms step_avg:97.52ms
+step:1588/1700 train_time:154870ms step_avg:97.53ms
+step:1589/1700 train_time:154971ms step_avg:97.53ms
+step:1590/1700 train_time:155074ms step_avg:97.53ms
+step:1591/1700 train_time:155175ms step_avg:97.53ms
+step:1592/1700 train_time:155276ms step_avg:97.54ms
+step:1593/1700 train_time:155378ms step_avg:97.54ms
+step:1594/1700 train_time:155481ms step_avg:97.54ms
+step:1595/1700 train_time:155582ms step_avg:97.54ms
+step:1596/1700 train_time:155683ms step_avg:97.55ms
+step:1597/1700 train_time:155786ms step_avg:97.55ms
+step:1598/1700 train_time:155889ms step_avg:97.55ms
+step:1599/1700 train_time:155990ms step_avg:97.56ms
+step:1600/1700 train_time:156093ms step_avg:97.56ms
+step:1601/1700 train_time:156194ms step_avg:97.56ms
+step:1602/1700 train_time:156295ms step_avg:97.56ms
+step:1603/1700 train_time:156396ms step_avg:97.56ms
+step:1604/1700 train_time:156497ms step_avg:97.57ms
+step:1605/1700 train_time:156599ms step_avg:97.57ms
+step:1606/1700 train_time:156700ms step_avg:97.57ms
+step:1607/1700 train_time:156799ms step_avg:97.57ms
+step:1608/1700 train_time:156901ms step_avg:97.58ms
+step:1609/1700 train_time:157002ms step_avg:97.58ms
+step:1610/1700 train_time:157105ms step_avg:97.58ms
+step:1611/1700 train_time:157209ms step_avg:97.58ms
+step:1612/1700 train_time:157313ms step_avg:97.59ms
+step:1613/1700 train_time:157415ms step_avg:97.59ms
+step:1614/1700 train_time:157515ms step_avg:97.59ms
+step:1615/1700 train_time:157615ms step_avg:97.59ms
+step:1616/1700 train_time:157717ms step_avg:97.60ms
+step:1617/1700 train_time:157819ms step_avg:97.60ms
+step:1618/1700 train_time:157919ms step_avg:97.60ms
+step:1619/1700 train_time:158020ms step_avg:97.60ms
+step:1620/1700 train_time:158121ms step_avg:97.61ms
+step:1621/1700 train_time:158222ms step_avg:97.61ms
+step:1622/1700 train_time:158324ms step_avg:97.61ms
+step:1623/1700 train_time:158426ms step_avg:97.61ms
+step:1624/1700 train_time:158530ms step_avg:97.62ms
+step:1625/1700 train_time:158633ms step_avg:97.62ms
+step:1625/1700 val_loss:3.2999 train_time:158730ms step_avg:97.68ms
+step:1626/1700 train_time:158751ms step_avg:97.63ms
+step:1627/1700 train_time:158843ms step_avg:97.63ms
+step:1628/1700 train_time:158943ms step_avg:97.63ms
+step:1629/1700 train_time:159044ms step_avg:97.63ms
+step:1630/1700 train_time:159145ms step_avg:97.64ms
+step:1631/1700 train_time:159245ms step_avg:97.64ms
+step:1632/1700 train_time:159346ms step_avg:97.64ms
+step:1633/1700 train_time:159446ms step_avg:97.64ms
+step:1634/1700 train_time:159548ms step_avg:97.64ms
+step:1635/1700 train_time:159647ms step_avg:97.64ms
+step:1636/1700 train_time:159748ms step_avg:97.65ms
+step:1637/1700 train_time:159851ms step_avg:97.65ms
+step:1638/1700 train_time:159952ms step_avg:97.65ms
+step:1639/1700 train_time:160055ms step_avg:97.65ms
+step:1640/1700 train_time:160157ms step_avg:97.66ms
+step:1641/1700 train_time:160260ms step_avg:97.66ms
+step:1642/1700 train_time:160361ms step_avg:97.66ms
+step:1643/1700 train_time:160462ms step_avg:97.66ms
+step:1644/1700 train_time:160565ms step_avg:97.67ms
+step:1645/1700 train_time:160666ms step_avg:97.67ms
+step:1646/1700 train_time:160768ms step_avg:97.67ms
+step:1647/1700 train_time:160872ms step_avg:97.68ms
+step:1648/1700 train_time:160976ms step_avg:97.68ms
+step:1649/1700 train_time:161079ms step_avg:97.68ms
+step:1650/1700 train_time:161181ms step_avg:97.69ms
+step:1651/1700 train_time:161283ms step_avg:97.69ms
+step:1652/1700 train_time:161384ms step_avg:97.69ms
+step:1653/1700 train_time:161488ms step_avg:97.69ms
+step:1654/1700 train_time:161588ms step_avg:97.70ms
+step:1655/1700 train_time:161691ms step_avg:97.70ms
+step:1656/1700 train_time:161793ms step_avg:97.70ms
+step:1657/1700 train_time:161894ms step_avg:97.70ms
+step:1658/1700 train_time:161998ms step_avg:97.71ms
+step:1659/1700 train_time:162103ms step_avg:97.71ms
+step:1660/1700 train_time:162206ms step_avg:97.71ms
+step:1661/1700 train_time:162310ms step_avg:97.72ms
+step:1662/1700 train_time:162414ms step_avg:97.72ms
+step:1663/1700 train_time:162517ms step_avg:97.73ms
+step:1664/1700 train_time:162618ms step_avg:97.73ms
+step:1665/1700 train_time:162722ms step_avg:97.73ms
+step:1666/1700 train_time:162826ms step_avg:97.73ms
+step:1667/1700 train_time:162928ms step_avg:97.74ms
+step:1668/1700 train_time:163030ms step_avg:97.74ms
+step:1669/1700 train_time:163134ms step_avg:97.74ms
+step:1670/1700 train_time:163237ms step_avg:97.75ms
+step:1671/1700 train_time:163338ms step_avg:97.75ms
+step:1672/1700 train_time:163442ms step_avg:97.75ms
+step:1673/1700 train_time:163543ms step_avg:97.75ms
+step:1674/1700 train_time:163646ms step_avg:97.76ms
+step:1675/1700 train_time:163747ms step_avg:97.76ms
+step:1676/1700 train_time:163849ms step_avg:97.76ms
+step:1677/1700 train_time:163949ms step_avg:97.76ms
+step:1678/1700 train_time:164052ms step_avg:97.77ms
+step:1679/1700 train_time:164155ms step_avg:97.77ms
+step:1680/1700 train_time:164259ms step_avg:97.77ms
+step:1681/1700 train_time:164363ms step_avg:97.78ms
+step:1682/1700 train_time:164466ms step_avg:97.78ms
+step:1683/1700 train_time:164566ms step_avg:97.78ms
+step:1684/1700 train_time:164670ms step_avg:97.78ms
+step:1685/1700 train_time:164772ms step_avg:97.79ms
+step:1686/1700 train_time:164874ms step_avg:97.79ms
+step:1687/1700 train_time:164977ms step_avg:97.79ms
+step:1688/1700 train_time:165078ms step_avg:97.80ms
+step:1689/1700 train_time:165180ms step_avg:97.80ms
+step:1690/1700 train_time:165283ms step_avg:97.80ms
+step:1691/1700 train_time:165384ms step_avg:97.80ms
+step:1692/1700 train_time:165486ms step_avg:97.80ms
+step:1693/1700 train_time:165588ms step_avg:97.81ms
+step:1694/1700 train_time:165689ms step_avg:97.81ms
+step:1695/1700 train_time:165792ms step_avg:97.81ms
+step:1696/1700 train_time:165893ms step_avg:97.81ms
+step:1697/1700 train_time:166001ms step_avg:97.82ms
+step:1698/1700 train_time:166102ms step_avg:97.82ms
+step:1699/1700 train_time:166204ms step_avg:97.82ms
+step:1700/1700 train_time:166306ms step_avg:97.83ms
+step:1700/1700 val_loss:3.2859 train_time:166404ms step_avg:97.88ms
+peak memory allocated: 33583 MiB reserved: 49012 MiB

--- a/records/101225_NorMuon/f74d6381-cba5-4fa1-ad09-6faf7b0c055a.txt
+++ b/records/101225_NorMuon/f74d6381-cba5-4fa1-ad09-6faf7b0c055a.txt
@@ -1,0 +1,2512 @@
+import os
+import sys
+with open(sys.argv[0]) as f:
+    code = f.read() # read the code of this file ASAP, for logging
+import uuid
+import time
+import copy
+import glob
+from dataclasses import dataclass
+from functools import lru_cache, partial # Added partial for hook registration
+from pathlib import Path
+
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+torch.empty(1, device="cuda", requires_grad=True).backward() # prevents a bug on some systems
+from torch import Tensor, nn
+import torch.nn.functional as F
+import torch.distributed as dist
+# use of FlexAttention contributed by @KoszarskyB
+from torch.nn.attention.flex_attention import BlockMask, flex_attention
+#torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Muon optimizer
+
+@torch.compile
+def zeropower_via_newtonschulz5(G: Tensor, steps: int) -> Tensor:
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
+    quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
+    of minimizing steps, it turns out to be empirically effective to keep increasing the slope at
+    zero even beyond the point where the iteration no longer converges all the way to one everywhere
+    on the interval. This iteration therefore does not produce UV^T but rather something like US'V^T
+    where S' is diagonal with S_{ii}' ~ Uniform(0.5, 1.5), which turns out not to hurt model
+    performance at all relative to UV^T, where USV^T = G is the SVD.
+    """
+    assert G.ndim >= 2 # batched Muon implementation by @scottjmaddox, and put into practice in the record by @YouJiacheng
+    a, b, c = (3.4445, -4.7750,  2.0315)
+    X = G
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + 1e-7)
+    # Perform the NS iterations
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * A @ A # quintic computation strategy adapted from suggestion by @jxbz, @leloykun, and @YouJiacheng
+        X = a * X + B @ X
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+class NorMuon(torch.optim.Optimizer):
+
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        params = list(params)
+        sizes = {p.shape for p in params}
+        # create one buffer per unique parameter-size
+        param_groups = []
+        for size in sizes:
+            group_params = [p for p in params if p.shape == size]
+            param_groups.append(dict(params=group_params))
+        super().__init__(param_groups, defaults)
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient systems-wise implementation of step developed by @YouJiacheng,
+        # @KonstantinWilleke, @alexrgilbert, @adricarda, @tuttyfrutyee, @vdlad,
+        # @ryanyang0, and @vagrawal.
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        reduce_scatter_futures: list[torch.Future] = []
+        all_reduce_futures: list[torch.Future] = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            grad = torch.empty_like(params[-1])
+            grad_pad = [param.grad for param in params] + [torch.zeros_like(params[-1])] * world_size
+            for base_i in range(0, len(params), world_size):
+                if base_i + rank < len(params):
+                    grad = params[base_i + rank].grad
+                else:
+                    grad = torch.zeros_like(grad)
+                # This gives strange dynamo warnings
+                reduce_scatter_futures.append(dist.reduce_scatter(grad, grad_pad[base_i:base_i + world_size], op=dist.ReduceOp.AVG, async_op=True).get_future())
+
+        idx = 0
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            params_pad = params + [torch.empty_like(params[-1])] * world_size
+            momentum = group["momentum"]
+            beta2 = group["beta2"]
+            for base_i in range(0, len(params), world_size):
+                reduce_scatter_futures[idx].wait()
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    grad = p.grad
+                    eff_lr = group["lr"] * max(1, p.size(-2) / p.size(-1)) ** 0.5 * getattr(p, "lr_mul", 1.0)
+                    eff_weight_decay = group["lr"] * group["weight_decay"] * getattr(p, "wd_mul", 1.0)
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum_buffer"] = torch.zeros_like(grad)
+                        state["second_momentum_buffer"] = torch.zeros_like(grad[..., 0:1]) if p.size(-2) >= p.size(-1) else torch.zeros_like(grad[0:1, ...])
+                    momentum_buffer = state["momentum_buffer"]
+                    second_momentum_buffer = state["second_momentum_buffer"]
+                    p.mul_(1 - eff_weight_decay)
+                    momentum_buffer.lerp_(grad, 1 - momentum)
+                    grad = grad.lerp_(momentum_buffer, momentum)
+                    v = zeropower_via_newtonschulz5(grad.bfloat16(), 5).float()
+                    ###################################
+                    vnorm = v.norm(dim=(-2,-1), keepdim=True)
+                    v_mean = torch.mean(v * v, dim=-1, keepdim=True) if p.size(-2) >= p.size(-1) else torch.mean(v * v, dim=-2, keepdim=True)
+                    second_momentum_buffer.lerp_(v_mean, 1 - beta2)
+                    step_size = 1 / second_momentum_buffer.sqrt().add_(1e-10)
+                    v.mul_(step_size)
+                    vnorm_new = v.norm(dim=(-2,-1), keepdim=True)
+                    v.mul_(vnorm / (vnorm_new + 1e-10))
+                    ####################################
+                    p.add_(other=v, alpha=-eff_lr)
+                idx += 1
+                all_reduce_futures.append(dist.all_gather(params_pad[base_i:base_i + world_size], params_pad[base_i + rank], async_op=True).get_future())
+        torch.futures.collect_all(all_reduce_futures).wait()
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        sizes = {p.shape for p in params}
+        # create one buffer per unique parameter-size
+        param_groups = []
+        for size in sizes:
+            group_params = [p for p in params if p.shape == size]
+            param_groups.append(dict(params=group_params))
+        super().__init__(param_groups, defaults)
+        # DistributedAdam implementation by @vagrawal
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        reduce_scatter_futures: list[torch.Future] = []
+        all_reduce_futures: list[torch.Future] = []
+        grad_slices = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            grad = torch.empty_like(params[-1])
+            for base_i in range(len(params)):
+                grad = params[base_i].grad
+                rank_size = grad.shape[0] // world_size
+                grad_slice = torch.empty_like(grad[:rank_size])
+                reduce_scatter_futures.append(dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future())
+                grad_slices.append(grad_slice)
+
+        idx = 0
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            params = group['params']
+            for base in range(len(params)):
+                reduce_scatter_futures[idx].wait()
+                p = params[base]
+                rank_size = p.shape[0] // world_size
+                p_slice = p[rank * rank_size:(rank + 1) * rank_size]
+                lr = group['lr'] * getattr(p, "lr_mul", 1.0)
+                state = self.state[p]
+                g_slice = grad_slices[idx]
+                # State init
+                if not state:
+                    state['step'] = torch.tensor(0, dtype=torch.int64, device=p.device)
+                    state['exp_avg'] = torch.zeros_like(p_slice)
+                    state['exp_avg_sq'] = torch.zeros_like(p_slice)
+                exp_avg = state['exp_avg']
+                exp_avg_sq = state['exp_avg_sq']
+                state['step'] += 1
+                t = state['step']
+                # weight decay
+                if wd != 0:
+                    eff_weight_decay = lr * wd * getattr(p, "wd_mul", 1.0)
+                    p_slice.mul_(1 - eff_weight_decay)
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (torch.sqrt(bias2) / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                p_slice.add_(other=update, alpha=-1.0)
+                idx += 1
+                all_reduce_futures.append(dist.all_gather_into_tensor(p, p_slice, async_op=True).get_future())
+        torch.futures.collect_all(all_reduce_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        std = 0.5 * (self.in_features ** -0.5) # 0.5 is a bit better than the default 1/sqrt(3)
+        bound = (3 ** 0.5) * std
+        with torch.no_grad():
+            self.weight.uniform_(-bound, bound)
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, max_seq_len: int):
+        super().__init__()
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=dim//4, dtype=torch.float32)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(dim//4)])
+        t = torch.arange(max_seq_len, dtype=torch.float32)
+        theta = torch.einsum("i,j -> ij", t, angular_freq)
+        self.cos = nn.Buffer(theta.cos(), persistent=False)
+        self.sin = nn.Buffer(theta.sin(), persistent=False)
+
+    def forward(self, x_BTHD: Tensor):
+        assert self.cos.size(0) >= x_BTHD.size(-3)
+        cos, sin = self.cos[None, :x_BTHD.size(-3), None, :], self.sin[None, :x_BTHD.size(-3), None, :]
+        x1, x2 = x_BTHD.to(dtype=torch.float32).chunk(2, dim=-1)
+        y1 = x1 * cos + x2 * sin
+        y2 = x1 * (-sin) + x2 * cos
+        return torch.cat((y1, y2), 3).type_as(x_BTHD)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, head_dim=128):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        hdim = num_heads * head_dim
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKV weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        self.qkv_w = nn.Parameter(torch.empty(3, hdim, dim).uniform_(-bound, bound))
+        self.rotary = Rotary(head_dim, max_seq_len)
+        self.c_proj = CastedLinear(hdim, dim)
+        self.c_proj.weight.detach().zero_() # zero init suggested by @Grad62304977
+        # scale the attention logits by given constant, instead of the default head_dim**-0.5, by @leloykun
+        # inspired by learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.12
+
+    def forward(self, x: Tensor, ve: Tensor | None, lambdas: Tensor, block_mask: BlockMask):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "Must use batch size = 1 for FlexAttention"
+        q, k, v = F.linear(x, self.qkv_w.flatten(end_dim=1).type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = self.rotary(q), self.rotary(k)
+        if ve is not None:
+            v = lambdas[0] * v + lambdas[1] * ve.view_as(v) # @KoszarskyB & @Grad62304977
+        else: # skip mid-layers token value embeddings by @YouJiacheng
+            v = lambdas[0] * v
+        y = flex_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), block_mask=block_mask, scale=self.attn_scale).transpose(1, 2)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = self.c_proj(y)
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        self.c_fc = CastedLinear(dim, hdim)
+        self.c_proj = CastedLinear(hdim, dim)
+        self.c_proj.weight.detach().zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = self.c_fc(x)
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = self.c_proj(x)
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, max_seq_len: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.7 (the 8th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, num_heads, max_seq_len) if layer_idx != 7 else None
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, ve: Tensor | None, x0: Tensor, lambdas: Tensor, sa_lambdas: Tensor, block_mask: BlockMask):
+        x = lambdas[0] * x + lambdas[1] * x0
+        if self.attn is not None:
+            x = x + self.attn(norm(x), ve, sa_lambdas, block_mask)
+        x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        self.blocks = nn.ModuleList([Block(model_dim, num_heads, max_seq_len, i) for i in range(num_layers)])
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=True, x_s=(model_dim**0.5)/448, w_s=24/448, grad_s=1/448)
+        self.lm_head.weight.detach().zero_() # @Grad62304977
+        # Add learnable skip connection weights for decoder layers
+        assert num_layers % 2 == 0
+        pad = (-num_layers * 5) % dist.get_world_size()
+        self.scalars = nn.Parameter(torch.cat([
+            torch.ones(num_layers), # skip_weights
+            *[torch.tensor([1.0, 0.0]) for _ in range(num_layers)], # block lambdas
+            *[torch.tensor([0.5, 0.5]) for _ in range(num_layers)], # SA lambdas
+            torch.ones(pad),
+        ]))
+        # set learning rates
+        for param in self.embed.parameters():
+            param.lr_mul = 75.
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+        self.lm_head.weight.lr_mul = 27.5
+        self.scalars.lr_mul = 5.0
+
+    def create_blockmasks(self, input_seq: Tensor, sliding_window_num_blocks: Tensor):
+        BLOCK_SIZE = 128
+        docs = (input_seq == 50256).cumsum(0)
+
+        def document_causal(b, h, q_idx, kv_idx):
+            causal_mask = q_idx >= kv_idx
+            document_mask = docs[q_idx] == docs[kv_idx]
+            return causal_mask & document_mask
+
+        def dense_to_ordered(dense_blockmask: Tensor):
+            num_blocks = dense_blockmask.sum(dim=-1, dtype=torch.int32)
+            indices = dense_blockmask.argsort(dim=-1, descending=False, stable=True).flip(-1).to(torch.int32)
+            return num_blocks[None, None].contiguous(), indices[None, None].contiguous()
+
+        # manual block mask creation by @YouJiacheng
+        assert len(input_seq) % BLOCK_SIZE == 0
+        NUM_BLOCKS = len(input_seq) // BLOCK_SIZE
+        block_idx = torch.arange(NUM_BLOCKS, dtype=torch.int32, device="cuda")
+        causal_blockmask_any = block_idx[:, None] >= block_idx
+        causal_blockmask_all = block_idx[:, None] > block_idx
+        docs_low = docs.view(-1, BLOCK_SIZE)[:, 0].contiguous()
+        docs_high = docs.view(-1, BLOCK_SIZE)[:, -1].contiguous()
+        document_blockmask_any = (docs_low[:, None] <= docs_high) & (docs_high[:, None] >= docs_low)
+        document_blockmask_all = (docs_low[:, None] == docs_high) & (docs_high[:, None] == docs_low)
+        blockmask_any = causal_blockmask_any & document_blockmask_any
+        blockmask_all = causal_blockmask_all & document_blockmask_all
+        partial_kv_num_blocks, partial_kv_indices = dense_to_ordered(blockmask_any & ~blockmask_all)
+        full_kv_num_blocks, full_kv_indices = dense_to_ordered(blockmask_all)
+        def build_bm(window_size_blocks: Tensor) -> BlockMask:
+            return BlockMask.from_kv_blocks(
+                torch.clamp_max(partial_kv_num_blocks, torch.clamp_min(window_size_blocks - full_kv_num_blocks, 1)),
+                partial_kv_indices,
+                torch.clamp_max(full_kv_num_blocks, window_size_blocks - 1),
+                full_kv_indices,
+                BLOCK_SIZE=BLOCK_SIZE,
+                mask_mod=document_causal,
+            )
+        # Long-short SWA block masks by @leloykun & @YouJiacheng, adapated from suggestion by @Grad62304977, following Gemma 2 paper
+        return build_bm(sliding_window_num_blocks), build_bm(sliding_window_num_blocks // 2)
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, sliding_window_num_blocks: Tensor):
+        assert input_seq.ndim == 1
+
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        ve = [ve[0], ve[1], ve[2]] + [None] * (len(self.blocks) - 6) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == len(self.blocks)
+
+        long_bm, short_bm = self.create_blockmasks(input_seq, sliding_window_num_blocks)
+        block_masks = [long_bm, short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, long_bm, short_bm, short_bm, short_bm, long_bm]
+        assert len(block_masks) == len(self.blocks)
+
+        x = x0 = norm(self.embed(input_seq)[None]) # use of norm here by @Grad62304977
+
+        # U-net design by @brendanh0gan
+        skip_connections = []
+        skip_weights = self.scalars[:(len(self.blocks) // 2)]
+        lambdas = self.scalars[1 * len(self.blocks): 3 * len(self.blocks)].view(-1, 2)
+        sa_lambdas = self.scalars[3 * len(self.blocks): 5 * len(self.blocks)].view(-1, 2)
+
+        n = len(self.blocks) // 2
+
+        for i in range(len(self.blocks)):
+            if i >= n:
+                x = x + skip_weights[i - n] * skip_connections.pop()
+            x = self.blocks[i](x, ve[i], x0, lambdas[i], sa_lambdas[i], block_masks[i])
+            if i < n:
+                skip_connections.append(x)
+
+        x = norm(x)
+        logits = self.lm_head(x).float()
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15, @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1)
+        logits = 30 * torch.sigmoid(logits / (7.5 * x.size(-1)**0.5))
+        loss = F.cross_entropy(logits.view(-1, logits.size(-1)), target_seq, reduction="sum" if self.training else "mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+# find world_size starting indicies, such that each begins with token 50256 and local_batches don't overlap
+def find_batch_starts(tokens: Tensor, pos: int, local_batch_size: int, max_batch_span: int):
+    boundary_mask = tokens[pos : pos + max_batch_span] == 50256
+    boundary_positions = torch.nonzero(boundary_mask, as_tuple=False).squeeze(-1) + pos
+    start = boundary_positions[0].item()
+    starts = []
+    for i in range(1, len(boundary_positions)):
+        end = boundary_positions[i].item() 
+        if end - start >= local_batch_size:
+            starts.append(start) # append start once end pos is confirmed
+            if len(starts) == dist.get_world_size():
+                return starts, end - pos
+            start = end
+    assert False # increase max_batch_span if necessary
+
+def distributed_data_generator(filename_pattern: str, batch_size: int, align_to_bos: bool):
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    assert batch_size % world_size == 0
+    local_batch_size = batch_size // world_size
+    file_iter = iter(files) # use itertools.cycle(files) instead if you want to do multi-epoch training
+    tokens, pos = _load_data_shard(next(file_iter)), 0
+    max_batch_span = 2 * batch_size if align_to_bos else batch_size # provide buffer to handle samples up to length local_batch_size
+    while True:
+        if pos + max_batch_span + 1 >= len(tokens):
+            tokens, pos = _load_data_shard(next(file_iter)), 0
+        if align_to_bos:
+            batch_starts, batch_span = find_batch_starts(tokens, pos, local_batch_size, max_batch_span)
+            start_idx = batch_starts[rank]
+        else:
+            batch_span = batch_size
+            start_idx = pos + rank * local_batch_size
+        buf = tokens[start_idx:][:local_batch_size + 1]
+        inputs = buf[:-1].to(device="cuda", dtype=torch.int32, non_blocking=True) # no sync on host side;
+        targets = buf[1:].to(device="cuda", dtype=torch.int64, non_blocking=True) # H2D in another stream isn't helpful.
+        pos += batch_span
+        yield inputs, targets
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    train_seq_len = 48*1024 # FlexAttention sequence length
+    val_seq_len = 4*64*1024 # FlexAttention sequence length for validation
+    # optimization
+    num_iterations = 1700 # number of iterations to run
+    cooldown_frac = 0.45 # fraction of training spent cooling down the learning rate
+    # evaluation and logging
+    val_loss_every = 125 # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint = False
+args = Hyperparameters()
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert world_size == 8 # this code is designed for 8xH100
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = uuid.uuid4()
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(vocab_size=50257, num_layers=12, num_heads=6, model_dim=768, max_seq_len=max(args.train_seq_len, args.val_seq_len)).cuda()
+for m in model.modules():
+    if isinstance(m, nn.Embedding):
+        m.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+# collect the parameters to optimize
+hidden_matrix_params = [p for n, p in model.blocks.named_parameters() if p.ndim >= 2 and "embed" not in n]
+embed_params = [p for n, p in model.named_parameters() if "embed" in n]
+scalar_params = [p for p in model.parameters() if p.ndim < 2]
+head_params = [model.lm_head.weight]
+
+# init the optimizer(s)
+# small adam epsilon by @YouJiacheng. this is an alternate method of fixing the world_size dependence
+# discovered by @fernbear.bsky.social https://x.com/hi_tysam/status/1879692937589875094
+optimizer1 = DistAdam(scalar_params + head_params + embed_params, lr=0.008, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.0)
+optimizer2 = NorMuon(hidden_matrix_params, lr=0.05, momentum=0.95, weight_decay=0.0, beta2=0.95)
+optimizers = [optimizer1, optimizer2]
+for opt in optimizers:
+    for group in opt.param_groups:
+        group["initial_lr"] = group["lr"]
+
+# learning rate schedule: stable then decay
+def get_lr(step: int):
+    x = step / args.num_iterations # progress in training
+    assert 0 <= x < 1
+    if x < 1 - args.cooldown_frac:
+        return 1.0
+    else:
+        w = (1 - x) / args.cooldown_frac
+        return w * 1.0 + (1 - w) * 0.1
+
+# attention window size schedule: linearly increase
+@lru_cache(1)
+def get_window_size_blocks_helper(window_size: int):
+    return torch.tensor(window_size // 128, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
+def get_window_size_blocks(step: int):
+    x = step / args.num_iterations # progress in training
+    assert 0 <= x <= 1
+    # Linearly increase the block-wise sliding window size over training 128 -> 1792
+    # increase by @fernbear.bsky.social; block-wise by @YouJiacheng
+    window_size = next_multiple_of_n(1728 * x, n=128)
+    return get_window_size_blocks_helper(window_size)
+
+model: nn.Module = torch.compile(model, dynamic=False)
+
+########################################
+#            Warmup kernels            #
+########################################
+
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+warmup_steps = 10
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=[copy.deepcopy(opt.state_dict()) for opt in optimizers]) # save the initial state
+train_loader = distributed_data_generator(args.train_files, world_size * args.train_seq_len, align_to_bos=True)
+for _ in range(warmup_steps):
+    inputs, targets = next(train_loader)
+    model(inputs, targets, get_window_size_blocks(1)).backward()
+    for opt in optimizers:
+        opt.step()
+    model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+for opt, opt_state in zip(optimizers, initial_state["optimizers"]):
+    opt.load_state_dict(opt_state)
+del train_loader, initial_state
+
+########################################
+#        Training and validation       #
+########################################
+
+train_loader = distributed_data_generator(args.train_files, world_size * args.train_seq_len, align_to_bos=True)
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        val_batch_size = world_size * args.val_seq_len
+        assert args.val_tokens % val_batch_size == 0
+        val_steps = args.val_tokens // val_batch_size
+        val_loader = distributed_data_generator(args.val_files, val_batch_size, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets = next(val_loader)
+                val_loss += model(inputs, targets, get_window_size_blocks(step))
+        val_loss /= val_steps
+        del val_loader
+        dist.all_reduce(val_loss, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    inputs, targets = next(train_loader)
+    model(inputs, targets, get_window_size_blocks(step)).backward()
+    # set optimization hyperparameters
+    for opt in optimizers:
+        for group in opt.param_groups:
+            group["lr"] = group["initial_lr"] * get_lr(step)
+    for group in optimizer2.param_groups:
+        frac = min(step / 300, 1) # momentum warmup for muon
+        group["momentum"] = (1 - frac) * 0.85 + frac * 0.95
+    # step the optimizers
+    for opt in optimizers:
+        opt.step()
+    # null the gradients
+    model.zero_grad(set_to_none=True)
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.12.7 (main, Oct 11 2025, 17:06:43) [GCC 13.2.0]
+Running PyTorch 2.10.0.dev20251011+cu126 compiled for CUDA 12.6
+Mon Oct 13 03:36:21 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000001:00:00.0 Off |                    0 |
+| N/A   32C    P0            115W /  700W |    5858MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000002:00:00.0 Off |                    0 |
+| N/A   33C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000003:00:00.0 Off |                    0 |
+| N/A   30C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000008:00:00.0 Off |                    0 |
+| N/A   29C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000009:00:00.0 Off |                    0 |
+| N/A   28C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   0000000A:00:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   0000000B:00:00.0 Off |                    0 |
+| N/A   29C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   0000000C:00:00.0 Off |                    0 |
+| N/A   31C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+step:0/1700 val_loss:10.8258 train_time:0ms step_avg:0.16ms
+step:1/1700 train_time:142ms step_avg:142.47ms
+step:2/1700 train_time:166ms step_avg:83.17ms
+step:3/1700 train_time:251ms step_avg:83.56ms
+step:4/1700 train_time:342ms step_avg:85.61ms
+step:5/1700 train_time:435ms step_avg:86.98ms
+step:6/1700 train_time:527ms step_avg:87.90ms
+step:7/1700 train_time:620ms step_avg:88.51ms
+step:8/1700 train_time:712ms step_avg:88.96ms
+step:9/1700 train_time:804ms step_avg:89.32ms
+step:10/1700 train_time:896ms step_avg:89.58ms
+step:11/1700 train_time:988ms step_avg:89.80ms
+step:12/1700 train_time:1080ms step_avg:90.04ms
+step:13/1700 train_time:1175ms step_avg:90.41ms
+step:14/1700 train_time:1270ms step_avg:90.68ms
+step:15/1700 train_time:1363ms step_avg:90.85ms
+step:16/1700 train_time:1456ms step_avg:90.97ms
+step:17/1700 train_time:1548ms step_avg:91.07ms
+step:18/1700 train_time:1640ms step_avg:91.12ms
+step:19/1700 train_time:1733ms step_avg:91.19ms
+step:20/1700 train_time:1826ms step_avg:91.29ms
+step:21/1700 train_time:1918ms step_avg:91.31ms
+step:22/1700 train_time:2011ms step_avg:91.39ms
+step:23/1700 train_time:2104ms step_avg:91.46ms
+step:24/1700 train_time:2197ms step_avg:91.55ms
+step:25/1700 train_time:2292ms step_avg:91.69ms
+step:26/1700 train_time:2385ms step_avg:91.74ms
+step:27/1700 train_time:2478ms step_avg:91.77ms
+step:28/1700 train_time:2571ms step_avg:91.82ms
+step:29/1700 train_time:2664ms step_avg:91.86ms
+step:30/1700 train_time:2757ms step_avg:91.89ms
+step:31/1700 train_time:2849ms step_avg:91.91ms
+step:32/1700 train_time:2942ms step_avg:91.94ms
+step:33/1700 train_time:3035ms step_avg:91.97ms
+step:34/1700 train_time:3129ms step_avg:92.02ms
+step:35/1700 train_time:3222ms step_avg:92.07ms
+step:36/1700 train_time:3315ms step_avg:92.09ms
+step:37/1700 train_time:3408ms step_avg:92.11ms
+step:38/1700 train_time:3500ms step_avg:92.11ms
+step:39/1700 train_time:3593ms step_avg:92.12ms
+step:40/1700 train_time:3686ms step_avg:92.14ms
+step:41/1700 train_time:3778ms step_avg:92.14ms
+step:42/1700 train_time:3871ms step_avg:92.17ms
+step:43/1700 train_time:3964ms step_avg:92.18ms
+step:44/1700 train_time:4057ms step_avg:92.21ms
+step:45/1700 train_time:4151ms step_avg:92.24ms
+step:46/1700 train_time:4244ms step_avg:92.27ms
+step:47/1700 train_time:4338ms step_avg:92.29ms
+step:48/1700 train_time:4431ms step_avg:92.31ms
+step:49/1700 train_time:4524ms step_avg:92.32ms
+step:50/1700 train_time:4616ms step_avg:92.33ms
+step:51/1700 train_time:4709ms step_avg:92.34ms
+step:52/1700 train_time:4802ms step_avg:92.35ms
+step:53/1700 train_time:4895ms step_avg:92.35ms
+step:54/1700 train_time:4988ms step_avg:92.36ms
+step:55/1700 train_time:5081ms step_avg:92.37ms
+step:56/1700 train_time:5174ms step_avg:92.39ms
+step:57/1700 train_time:5267ms step_avg:92.40ms
+step:58/1700 train_time:5361ms step_avg:92.43ms
+step:59/1700 train_time:5454ms step_avg:92.43ms
+step:60/1700 train_time:5546ms step_avg:92.43ms
+step:61/1700 train_time:5638ms step_avg:92.42ms
+step:62/1700 train_time:5730ms step_avg:92.42ms
+step:63/1700 train_time:5823ms step_avg:92.43ms
+step:64/1700 train_time:5916ms step_avg:92.43ms
+step:65/1700 train_time:6009ms step_avg:92.44ms
+step:66/1700 train_time:6101ms step_avg:92.45ms
+step:67/1700 train_time:6194ms step_avg:92.46ms
+step:68/1700 train_time:6288ms step_avg:92.47ms
+step:69/1700 train_time:6381ms step_avg:92.47ms
+step:70/1700 train_time:6474ms step_avg:92.48ms
+step:71/1700 train_time:6566ms step_avg:92.48ms
+step:72/1700 train_time:6658ms step_avg:92.48ms
+step:73/1700 train_time:6751ms step_avg:92.49ms
+step:74/1700 train_time:6843ms step_avg:92.48ms
+step:75/1700 train_time:6936ms step_avg:92.49ms
+step:76/1700 train_time:7029ms step_avg:92.49ms
+step:77/1700 train_time:7122ms step_avg:92.49ms
+step:78/1700 train_time:7214ms step_avg:92.49ms
+step:79/1700 train_time:7307ms step_avg:92.49ms
+step:80/1700 train_time:7400ms step_avg:92.50ms
+step:81/1700 train_time:7492ms step_avg:92.50ms
+step:82/1700 train_time:7586ms step_avg:92.51ms
+step:83/1700 train_time:7678ms step_avg:92.50ms
+step:84/1700 train_time:7770ms step_avg:92.51ms
+step:85/1700 train_time:7864ms step_avg:92.51ms
+step:86/1700 train_time:7956ms step_avg:92.52ms
+step:87/1700 train_time:8049ms step_avg:92.51ms
+step:88/1700 train_time:8141ms step_avg:92.51ms
+step:89/1700 train_time:8233ms step_avg:92.51ms
+step:90/1700 train_time:8327ms step_avg:92.52ms
+step:91/1700 train_time:8419ms step_avg:92.52ms
+step:92/1700 train_time:8512ms step_avg:92.52ms
+step:93/1700 train_time:8605ms step_avg:92.53ms
+step:94/1700 train_time:8697ms step_avg:92.52ms
+step:95/1700 train_time:8790ms step_avg:92.53ms
+step:96/1700 train_time:8883ms step_avg:92.53ms
+step:97/1700 train_time:8976ms step_avg:92.53ms
+step:98/1700 train_time:9069ms step_avg:92.54ms
+step:99/1700 train_time:9161ms step_avg:92.54ms
+step:100/1700 train_time:9254ms step_avg:92.54ms
+step:101/1700 train_time:9347ms step_avg:92.55ms
+step:102/1700 train_time:9440ms step_avg:92.55ms
+step:103/1700 train_time:9533ms step_avg:92.55ms
+step:104/1700 train_time:9625ms step_avg:92.55ms
+step:105/1700 train_time:9717ms step_avg:92.55ms
+step:106/1700 train_time:9810ms step_avg:92.54ms
+step:107/1700 train_time:9903ms step_avg:92.55ms
+step:108/1700 train_time:9996ms step_avg:92.55ms
+step:109/1700 train_time:10088ms step_avg:92.55ms
+step:110/1700 train_time:10181ms step_avg:92.55ms
+step:111/1700 train_time:10273ms step_avg:92.55ms
+step:112/1700 train_time:10366ms step_avg:92.55ms
+step:113/1700 train_time:10458ms step_avg:92.55ms
+step:114/1700 train_time:10551ms step_avg:92.55ms
+step:115/1700 train_time:10644ms step_avg:92.56ms
+step:116/1700 train_time:10736ms step_avg:92.56ms
+step:117/1700 train_time:10829ms step_avg:92.56ms
+step:118/1700 train_time:10922ms step_avg:92.56ms
+step:119/1700 train_time:11015ms step_avg:92.56ms
+step:120/1700 train_time:11107ms step_avg:92.56ms
+step:121/1700 train_time:11200ms step_avg:92.56ms
+step:122/1700 train_time:11293ms step_avg:92.56ms
+step:123/1700 train_time:11385ms step_avg:92.56ms
+step:124/1700 train_time:11477ms step_avg:92.56ms
+step:125/1700 train_time:11571ms step_avg:92.56ms
+step:125/1700 val_loss:4.6120 train_time:11647ms step_avg:93.18ms
+step:126/1700 train_time:11670ms step_avg:92.62ms
+step:127/1700 train_time:11763ms step_avg:92.62ms
+step:128/1700 train_time:11863ms step_avg:92.68ms
+step:129/1700 train_time:11957ms step_avg:92.69ms
+step:130/1700 train_time:12052ms step_avg:92.70ms
+step:131/1700 train_time:12144ms step_avg:92.70ms
+step:132/1700 train_time:12237ms step_avg:92.70ms
+step:133/1700 train_time:12329ms step_avg:92.70ms
+step:134/1700 train_time:12422ms step_avg:92.70ms
+step:135/1700 train_time:12515ms step_avg:92.70ms
+step:136/1700 train_time:12607ms step_avg:92.70ms
+step:137/1700 train_time:12700ms step_avg:92.70ms
+step:138/1700 train_time:12795ms step_avg:92.72ms
+step:139/1700 train_time:12889ms step_avg:92.73ms
+step:140/1700 train_time:12983ms step_avg:92.74ms
+step:141/1700 train_time:13077ms step_avg:92.74ms
+step:142/1700 train_time:13170ms step_avg:92.75ms
+step:143/1700 train_time:13263ms step_avg:92.75ms
+step:144/1700 train_time:13356ms step_avg:92.75ms
+step:145/1700 train_time:13448ms step_avg:92.75ms
+step:146/1700 train_time:13540ms step_avg:92.74ms
+step:147/1700 train_time:13634ms step_avg:92.75ms
+step:148/1700 train_time:13728ms step_avg:92.76ms
+step:149/1700 train_time:13822ms step_avg:92.77ms
+step:150/1700 train_time:13916ms step_avg:92.78ms
+step:151/1700 train_time:14010ms step_avg:92.78ms
+step:152/1700 train_time:14103ms step_avg:92.78ms
+step:153/1700 train_time:14197ms step_avg:92.79ms
+step:154/1700 train_time:14290ms step_avg:92.79ms
+step:155/1700 train_time:14383ms step_avg:92.79ms
+step:156/1700 train_time:14476ms step_avg:92.79ms
+step:157/1700 train_time:14568ms step_avg:92.79ms
+step:158/1700 train_time:14661ms step_avg:92.79ms
+step:159/1700 train_time:14755ms step_avg:92.80ms
+step:160/1700 train_time:14849ms step_avg:92.81ms
+step:161/1700 train_time:14942ms step_avg:92.81ms
+step:162/1700 train_time:15036ms step_avg:92.82ms
+step:163/1700 train_time:15130ms step_avg:92.82ms
+step:164/1700 train_time:15223ms step_avg:92.82ms
+step:165/1700 train_time:15317ms step_avg:92.83ms
+step:166/1700 train_time:15410ms step_avg:92.83ms
+step:167/1700 train_time:15502ms step_avg:92.83ms
+step:168/1700 train_time:15596ms step_avg:92.83ms
+step:169/1700 train_time:15689ms step_avg:92.83ms
+step:170/1700 train_time:15783ms step_avg:92.84ms
+step:171/1700 train_time:15876ms step_avg:92.84ms
+step:172/1700 train_time:15969ms step_avg:92.84ms
+step:173/1700 train_time:16063ms step_avg:92.85ms
+step:174/1700 train_time:16156ms step_avg:92.85ms
+step:175/1700 train_time:16250ms step_avg:92.86ms
+step:176/1700 train_time:16343ms step_avg:92.86ms
+step:177/1700 train_time:16436ms step_avg:92.86ms
+step:178/1700 train_time:16529ms step_avg:92.86ms
+step:179/1700 train_time:16622ms step_avg:92.86ms
+step:180/1700 train_time:16715ms step_avg:92.86ms
+step:181/1700 train_time:16808ms step_avg:92.86ms
+step:182/1700 train_time:16901ms step_avg:92.86ms
+step:183/1700 train_time:16995ms step_avg:92.87ms
+step:184/1700 train_time:17088ms step_avg:92.87ms
+step:185/1700 train_time:17182ms step_avg:92.88ms
+step:186/1700 train_time:17276ms step_avg:92.88ms
+step:187/1700 train_time:17369ms step_avg:92.88ms
+step:188/1700 train_time:17462ms step_avg:92.88ms
+step:189/1700 train_time:17555ms step_avg:92.88ms
+step:190/1700 train_time:17648ms step_avg:92.89ms
+step:191/1700 train_time:17741ms step_avg:92.89ms
+step:192/1700 train_time:17835ms step_avg:92.89ms
+step:193/1700 train_time:17928ms step_avg:92.89ms
+step:194/1700 train_time:18021ms step_avg:92.89ms
+step:195/1700 train_time:18115ms step_avg:92.90ms
+step:196/1700 train_time:18208ms step_avg:92.90ms
+step:197/1700 train_time:18301ms step_avg:92.90ms
+step:198/1700 train_time:18395ms step_avg:92.90ms
+step:199/1700 train_time:18488ms step_avg:92.91ms
+step:200/1700 train_time:18581ms step_avg:92.91ms
+step:201/1700 train_time:18675ms step_avg:92.91ms
+step:202/1700 train_time:18768ms step_avg:92.91ms
+step:203/1700 train_time:18861ms step_avg:92.91ms
+step:204/1700 train_time:18955ms step_avg:92.92ms
+step:205/1700 train_time:19049ms step_avg:92.92ms
+step:206/1700 train_time:19142ms step_avg:92.92ms
+step:207/1700 train_time:19235ms step_avg:92.92ms
+step:208/1700 train_time:19329ms step_avg:92.93ms
+step:209/1700 train_time:19422ms step_avg:92.93ms
+step:210/1700 train_time:19515ms step_avg:92.93ms
+step:211/1700 train_time:19609ms step_avg:92.93ms
+step:212/1700 train_time:19702ms step_avg:92.93ms
+step:213/1700 train_time:19795ms step_avg:92.93ms
+step:214/1700 train_time:19889ms step_avg:92.94ms
+step:215/1700 train_time:19981ms step_avg:92.94ms
+step:216/1700 train_time:20075ms step_avg:92.94ms
+step:217/1700 train_time:20169ms step_avg:92.94ms
+step:218/1700 train_time:20263ms step_avg:92.95ms
+step:219/1700 train_time:20357ms step_avg:92.95ms
+step:220/1700 train_time:20450ms step_avg:92.95ms
+step:221/1700 train_time:20542ms step_avg:92.95ms
+step:222/1700 train_time:20637ms step_avg:92.96ms
+step:223/1700 train_time:20730ms step_avg:92.96ms
+step:224/1700 train_time:20823ms step_avg:92.96ms
+step:225/1700 train_time:20917ms step_avg:92.96ms
+step:226/1700 train_time:21010ms step_avg:92.96ms
+step:227/1700 train_time:21103ms step_avg:92.97ms
+step:228/1700 train_time:21197ms step_avg:92.97ms
+step:229/1700 train_time:21290ms step_avg:92.97ms
+step:230/1700 train_time:21383ms step_avg:92.97ms
+step:231/1700 train_time:21477ms step_avg:92.97ms
+step:232/1700 train_time:21570ms step_avg:92.98ms
+step:233/1700 train_time:21664ms step_avg:92.98ms
+step:234/1700 train_time:21757ms step_avg:92.98ms
+step:235/1700 train_time:21850ms step_avg:92.98ms
+step:236/1700 train_time:21944ms step_avg:92.98ms
+step:237/1700 train_time:22037ms step_avg:92.98ms
+step:238/1700 train_time:22130ms step_avg:92.99ms
+step:239/1700 train_time:22223ms step_avg:92.98ms
+step:240/1700 train_time:22317ms step_avg:92.99ms
+step:241/1700 train_time:22410ms step_avg:92.99ms
+step:242/1700 train_time:22503ms step_avg:92.99ms
+step:243/1700 train_time:22597ms step_avg:92.99ms
+step:244/1700 train_time:22690ms step_avg:92.99ms
+step:245/1700 train_time:22784ms step_avg:92.99ms
+step:246/1700 train_time:22877ms step_avg:93.00ms
+step:247/1700 train_time:22971ms step_avg:93.00ms
+step:248/1700 train_time:23064ms step_avg:93.00ms
+step:249/1700 train_time:23157ms step_avg:93.00ms
+step:250/1700 train_time:23251ms step_avg:93.00ms
+step:250/1700 val_loss:4.0746 train_time:23327ms step_avg:93.31ms
+step:251/1700 train_time:23351ms step_avg:93.03ms
+step:252/1700 train_time:23443ms step_avg:93.03ms
+step:253/1700 train_time:23538ms step_avg:93.04ms
+step:254/1700 train_time:23633ms step_avg:93.04ms
+step:255/1700 train_time:23726ms step_avg:93.04ms
+step:256/1700 train_time:23818ms step_avg:93.04ms
+step:257/1700 train_time:23911ms step_avg:93.04ms
+step:258/1700 train_time:24004ms step_avg:93.04ms
+step:259/1700 train_time:24098ms step_avg:93.04ms
+step:260/1700 train_time:24190ms step_avg:93.04ms
+step:261/1700 train_time:24284ms step_avg:93.04ms
+step:262/1700 train_time:24378ms step_avg:93.05ms
+step:263/1700 train_time:24473ms step_avg:93.05ms
+step:264/1700 train_time:24568ms step_avg:93.06ms
+step:265/1700 train_time:24662ms step_avg:93.06ms
+step:266/1700 train_time:24756ms step_avg:93.07ms
+step:267/1700 train_time:24849ms step_avg:93.07ms
+step:268/1700 train_time:24943ms step_avg:93.07ms
+step:269/1700 train_time:25037ms step_avg:93.07ms
+step:270/1700 train_time:25130ms step_avg:93.07ms
+step:271/1700 train_time:25223ms step_avg:93.07ms
+step:272/1700 train_time:25317ms step_avg:93.08ms
+step:273/1700 train_time:25411ms step_avg:93.08ms
+step:274/1700 train_time:25505ms step_avg:93.08ms
+step:275/1700 train_time:25600ms step_avg:93.09ms
+step:276/1700 train_time:25694ms step_avg:93.09ms
+step:277/1700 train_time:25787ms step_avg:93.09ms
+step:278/1700 train_time:25881ms step_avg:93.10ms
+step:279/1700 train_time:25974ms step_avg:93.10ms
+step:280/1700 train_time:26067ms step_avg:93.10ms
+step:281/1700 train_time:26161ms step_avg:93.10ms
+step:282/1700 train_time:26255ms step_avg:93.10ms
+step:283/1700 train_time:26348ms step_avg:93.10ms
+step:284/1700 train_time:26442ms step_avg:93.11ms
+step:285/1700 train_time:26536ms step_avg:93.11ms
+step:286/1700 train_time:26631ms step_avg:93.11ms
+step:287/1700 train_time:26724ms step_avg:93.12ms
+step:288/1700 train_time:26819ms step_avg:93.12ms
+step:289/1700 train_time:26912ms step_avg:93.12ms
+step:290/1700 train_time:27005ms step_avg:93.12ms
+step:291/1700 train_time:27099ms step_avg:93.12ms
+step:292/1700 train_time:27192ms step_avg:93.12ms
+step:293/1700 train_time:27286ms step_avg:93.13ms
+step:294/1700 train_time:27380ms step_avg:93.13ms
+step:295/1700 train_time:27473ms step_avg:93.13ms
+step:296/1700 train_time:27567ms step_avg:93.13ms
+step:297/1700 train_time:27660ms step_avg:93.13ms
+step:298/1700 train_time:27754ms step_avg:93.14ms
+step:299/1700 train_time:27848ms step_avg:93.14ms
+step:300/1700 train_time:27942ms step_avg:93.14ms
+step:301/1700 train_time:28037ms step_avg:93.14ms
+step:302/1700 train_time:28130ms step_avg:93.15ms
+step:303/1700 train_time:28224ms step_avg:93.15ms
+step:304/1700 train_time:28318ms step_avg:93.15ms
+step:305/1700 train_time:28412ms step_avg:93.15ms
+step:306/1700 train_time:28505ms step_avg:93.15ms
+step:307/1700 train_time:28599ms step_avg:93.16ms
+step:308/1700 train_time:28693ms step_avg:93.16ms
+step:309/1700 train_time:28787ms step_avg:93.16ms
+step:310/1700 train_time:28880ms step_avg:93.16ms
+step:311/1700 train_time:28974ms step_avg:93.16ms
+step:312/1700 train_time:29067ms step_avg:93.16ms
+step:313/1700 train_time:29161ms step_avg:93.17ms
+step:314/1700 train_time:29254ms step_avg:93.17ms
+step:315/1700 train_time:29347ms step_avg:93.17ms
+step:316/1700 train_time:29440ms step_avg:93.17ms
+step:317/1700 train_time:29534ms step_avg:93.17ms
+step:318/1700 train_time:29628ms step_avg:93.17ms
+step:319/1700 train_time:29722ms step_avg:93.17ms
+step:320/1700 train_time:29816ms step_avg:93.17ms
+step:321/1700 train_time:29910ms step_avg:93.18ms
+step:322/1700 train_time:30004ms step_avg:93.18ms
+step:323/1700 train_time:30097ms step_avg:93.18ms
+step:324/1700 train_time:30191ms step_avg:93.18ms
+step:325/1700 train_time:30284ms step_avg:93.18ms
+step:326/1700 train_time:30378ms step_avg:93.18ms
+step:327/1700 train_time:30472ms step_avg:93.19ms
+step:328/1700 train_time:30565ms step_avg:93.19ms
+step:329/1700 train_time:30659ms step_avg:93.19ms
+step:330/1700 train_time:30752ms step_avg:93.19ms
+step:331/1700 train_time:30846ms step_avg:93.19ms
+step:332/1700 train_time:30940ms step_avg:93.19ms
+step:333/1700 train_time:31034ms step_avg:93.20ms
+step:334/1700 train_time:31127ms step_avg:93.20ms
+step:335/1700 train_time:31221ms step_avg:93.20ms
+step:336/1700 train_time:31315ms step_avg:93.20ms
+step:337/1700 train_time:31409ms step_avg:93.20ms
+step:338/1700 train_time:31502ms step_avg:93.20ms
+step:339/1700 train_time:31597ms step_avg:93.21ms
+step:340/1700 train_time:31691ms step_avg:93.21ms
+step:341/1700 train_time:31784ms step_avg:93.21ms
+step:342/1700 train_time:31878ms step_avg:93.21ms
+step:343/1700 train_time:31972ms step_avg:93.21ms
+step:344/1700 train_time:32065ms step_avg:93.21ms
+step:345/1700 train_time:32159ms step_avg:93.21ms
+step:346/1700 train_time:32252ms step_avg:93.21ms
+step:347/1700 train_time:32346ms step_avg:93.22ms
+step:348/1700 train_time:32440ms step_avg:93.22ms
+step:349/1700 train_time:32534ms step_avg:93.22ms
+step:350/1700 train_time:32627ms step_avg:93.22ms
+step:351/1700 train_time:32720ms step_avg:93.22ms
+step:352/1700 train_time:32814ms step_avg:93.22ms
+step:353/1700 train_time:32908ms step_avg:93.22ms
+step:354/1700 train_time:33002ms step_avg:93.23ms
+step:355/1700 train_time:33096ms step_avg:93.23ms
+step:356/1700 train_time:33189ms step_avg:93.23ms
+step:357/1700 train_time:33282ms step_avg:93.23ms
+step:358/1700 train_time:33376ms step_avg:93.23ms
+step:359/1700 train_time:33470ms step_avg:93.23ms
+step:360/1700 train_time:33563ms step_avg:93.23ms
+step:361/1700 train_time:33658ms step_avg:93.24ms
+step:362/1700 train_time:33752ms step_avg:93.24ms
+step:363/1700 train_time:33845ms step_avg:93.24ms
+step:364/1700 train_time:33939ms step_avg:93.24ms
+step:365/1700 train_time:34033ms step_avg:93.24ms
+step:366/1700 train_time:34127ms step_avg:93.24ms
+step:367/1700 train_time:34221ms step_avg:93.24ms
+step:368/1700 train_time:34314ms step_avg:93.25ms
+step:369/1700 train_time:34408ms step_avg:93.25ms
+step:370/1700 train_time:34502ms step_avg:93.25ms
+step:371/1700 train_time:34596ms step_avg:93.25ms
+step:372/1700 train_time:34689ms step_avg:93.25ms
+step:373/1700 train_time:34783ms step_avg:93.25ms
+step:374/1700 train_time:34877ms step_avg:93.25ms
+step:375/1700 train_time:34970ms step_avg:93.25ms
+step:375/1700 val_loss:3.8787 train_time:35047ms step_avg:93.46ms
+step:376/1700 train_time:35070ms step_avg:93.27ms
+step:377/1700 train_time:35163ms step_avg:93.27ms
+step:378/1700 train_time:35258ms step_avg:93.28ms
+step:379/1700 train_time:35354ms step_avg:93.28ms
+step:380/1700 train_time:35449ms step_avg:93.29ms
+step:381/1700 train_time:35544ms step_avg:93.29ms
+step:382/1700 train_time:35638ms step_avg:93.29ms
+step:383/1700 train_time:35733ms step_avg:93.30ms
+step:384/1700 train_time:35828ms step_avg:93.30ms
+step:385/1700 train_time:35923ms step_avg:93.31ms
+step:386/1700 train_time:36019ms step_avg:93.31ms
+step:387/1700 train_time:36116ms step_avg:93.32ms
+step:388/1700 train_time:36212ms step_avg:93.33ms
+step:389/1700 train_time:36308ms step_avg:93.34ms
+step:390/1700 train_time:36404ms step_avg:93.34ms
+step:391/1700 train_time:36499ms step_avg:93.35ms
+step:392/1700 train_time:36595ms step_avg:93.35ms
+step:393/1700 train_time:36690ms step_avg:93.36ms
+step:394/1700 train_time:36784ms step_avg:93.36ms
+step:395/1700 train_time:36879ms step_avg:93.37ms
+step:396/1700 train_time:36975ms step_avg:93.37ms
+step:397/1700 train_time:37072ms step_avg:93.38ms
+step:398/1700 train_time:37168ms step_avg:93.39ms
+step:399/1700 train_time:37265ms step_avg:93.40ms
+step:400/1700 train_time:37360ms step_avg:93.40ms
+step:401/1700 train_time:37456ms step_avg:93.41ms
+step:402/1700 train_time:37551ms step_avg:93.41ms
+step:403/1700 train_time:37646ms step_avg:93.42ms
+step:404/1700 train_time:37741ms step_avg:93.42ms
+step:405/1700 train_time:37837ms step_avg:93.42ms
+step:406/1700 train_time:37932ms step_avg:93.43ms
+step:407/1700 train_time:38027ms step_avg:93.43ms
+step:408/1700 train_time:38123ms step_avg:93.44ms
+step:409/1700 train_time:38220ms step_avg:93.45ms
+step:410/1700 train_time:38316ms step_avg:93.45ms
+step:411/1700 train_time:38411ms step_avg:93.46ms
+step:412/1700 train_time:38506ms step_avg:93.46ms
+step:413/1700 train_time:38601ms step_avg:93.47ms
+step:414/1700 train_time:38696ms step_avg:93.47ms
+step:415/1700 train_time:38792ms step_avg:93.47ms
+step:416/1700 train_time:38887ms step_avg:93.48ms
+step:417/1700 train_time:38982ms step_avg:93.48ms
+step:418/1700 train_time:39078ms step_avg:93.49ms
+step:419/1700 train_time:39173ms step_avg:93.49ms
+step:420/1700 train_time:39270ms step_avg:93.50ms
+step:421/1700 train_time:39365ms step_avg:93.50ms
+step:422/1700 train_time:39460ms step_avg:93.51ms
+step:423/1700 train_time:39556ms step_avg:93.51ms
+step:424/1700 train_time:39652ms step_avg:93.52ms
+step:425/1700 train_time:39747ms step_avg:93.52ms
+step:426/1700 train_time:39842ms step_avg:93.53ms
+step:427/1700 train_time:39938ms step_avg:93.53ms
+step:428/1700 train_time:40033ms step_avg:93.54ms
+step:429/1700 train_time:40130ms step_avg:93.54ms
+step:430/1700 train_time:40225ms step_avg:93.55ms
+step:431/1700 train_time:40321ms step_avg:93.55ms
+step:432/1700 train_time:40417ms step_avg:93.56ms
+step:433/1700 train_time:40513ms step_avg:93.56ms
+step:434/1700 train_time:40609ms step_avg:93.57ms
+step:435/1700 train_time:40704ms step_avg:93.57ms
+step:436/1700 train_time:40799ms step_avg:93.58ms
+step:437/1700 train_time:40895ms step_avg:93.58ms
+step:438/1700 train_time:40991ms step_avg:93.59ms
+step:439/1700 train_time:41086ms step_avg:93.59ms
+step:440/1700 train_time:41181ms step_avg:93.59ms
+step:441/1700 train_time:41277ms step_avg:93.60ms
+step:442/1700 train_time:41373ms step_avg:93.60ms
+step:443/1700 train_time:41468ms step_avg:93.61ms
+step:444/1700 train_time:41564ms step_avg:93.61ms
+step:445/1700 train_time:41659ms step_avg:93.62ms
+step:446/1700 train_time:41755ms step_avg:93.62ms
+step:447/1700 train_time:41851ms step_avg:93.63ms
+step:448/1700 train_time:41946ms step_avg:93.63ms
+step:449/1700 train_time:42041ms step_avg:93.63ms
+step:450/1700 train_time:42137ms step_avg:93.64ms
+step:451/1700 train_time:42233ms step_avg:93.64ms
+step:452/1700 train_time:42330ms step_avg:93.65ms
+step:453/1700 train_time:42425ms step_avg:93.65ms
+step:454/1700 train_time:42521ms step_avg:93.66ms
+step:455/1700 train_time:42617ms step_avg:93.66ms
+step:456/1700 train_time:42713ms step_avg:93.67ms
+step:457/1700 train_time:42808ms step_avg:93.67ms
+step:458/1700 train_time:42903ms step_avg:93.68ms
+step:459/1700 train_time:42999ms step_avg:93.68ms
+step:460/1700 train_time:43095ms step_avg:93.68ms
+step:461/1700 train_time:43191ms step_avg:93.69ms
+step:462/1700 train_time:43286ms step_avg:93.69ms
+step:463/1700 train_time:43382ms step_avg:93.70ms
+step:464/1700 train_time:43477ms step_avg:93.70ms
+step:465/1700 train_time:43572ms step_avg:93.70ms
+step:466/1700 train_time:43667ms step_avg:93.71ms
+step:467/1700 train_time:43762ms step_avg:93.71ms
+step:468/1700 train_time:43859ms step_avg:93.71ms
+step:469/1700 train_time:43955ms step_avg:93.72ms
+step:470/1700 train_time:44051ms step_avg:93.72ms
+step:471/1700 train_time:44145ms step_avg:93.73ms
+step:472/1700 train_time:44241ms step_avg:93.73ms
+step:473/1700 train_time:44337ms step_avg:93.74ms
+step:474/1700 train_time:44433ms step_avg:93.74ms
+step:475/1700 train_time:44529ms step_avg:93.75ms
+step:476/1700 train_time:44624ms step_avg:93.75ms
+step:477/1700 train_time:44719ms step_avg:93.75ms
+step:478/1700 train_time:44815ms step_avg:93.75ms
+step:479/1700 train_time:44911ms step_avg:93.76ms
+step:480/1700 train_time:45006ms step_avg:93.76ms
+step:481/1700 train_time:45102ms step_avg:93.77ms
+step:482/1700 train_time:45198ms step_avg:93.77ms
+step:483/1700 train_time:45294ms step_avg:93.78ms
+step:484/1700 train_time:45389ms step_avg:93.78ms
+step:485/1700 train_time:45485ms step_avg:93.78ms
+step:486/1700 train_time:45580ms step_avg:93.79ms
+step:487/1700 train_time:45675ms step_avg:93.79ms
+step:488/1700 train_time:45771ms step_avg:93.79ms
+step:489/1700 train_time:45866ms step_avg:93.80ms
+step:490/1700 train_time:45961ms step_avg:93.80ms
+step:491/1700 train_time:46057ms step_avg:93.80ms
+step:492/1700 train_time:46152ms step_avg:93.81ms
+step:493/1700 train_time:46248ms step_avg:93.81ms
+step:494/1700 train_time:46344ms step_avg:93.81ms
+step:495/1700 train_time:46439ms step_avg:93.82ms
+step:496/1700 train_time:46535ms step_avg:93.82ms
+step:497/1700 train_time:46631ms step_avg:93.83ms
+step:498/1700 train_time:46727ms step_avg:93.83ms
+step:499/1700 train_time:46822ms step_avg:93.83ms
+step:500/1700 train_time:46918ms step_avg:93.84ms
+step:500/1700 val_loss:3.7318 train_time:46996ms step_avg:93.99ms
+step:501/1700 train_time:47021ms step_avg:93.85ms
+step:502/1700 train_time:47115ms step_avg:93.85ms
+step:503/1700 train_time:47211ms step_avg:93.86ms
+step:504/1700 train_time:47308ms step_avg:93.86ms
+step:505/1700 train_time:47403ms step_avg:93.87ms
+step:506/1700 train_time:47499ms step_avg:93.87ms
+step:507/1700 train_time:47594ms step_avg:93.87ms
+step:508/1700 train_time:47689ms step_avg:93.88ms
+step:509/1700 train_time:47784ms step_avg:93.88ms
+step:510/1700 train_time:47879ms step_avg:93.88ms
+step:511/1700 train_time:47976ms step_avg:93.89ms
+step:512/1700 train_time:48072ms step_avg:93.89ms
+step:513/1700 train_time:48169ms step_avg:93.90ms
+step:514/1700 train_time:48265ms step_avg:93.90ms
+step:515/1700 train_time:48361ms step_avg:93.90ms
+step:516/1700 train_time:48457ms step_avg:93.91ms
+step:517/1700 train_time:48553ms step_avg:93.91ms
+step:518/1700 train_time:48648ms step_avg:93.92ms
+step:519/1700 train_time:48744ms step_avg:93.92ms
+step:520/1700 train_time:48839ms step_avg:93.92ms
+step:521/1700 train_time:48935ms step_avg:93.93ms
+step:522/1700 train_time:49031ms step_avg:93.93ms
+step:523/1700 train_time:49128ms step_avg:93.93ms
+step:524/1700 train_time:49224ms step_avg:93.94ms
+step:525/1700 train_time:49321ms step_avg:93.94ms
+step:526/1700 train_time:49417ms step_avg:93.95ms
+step:527/1700 train_time:49512ms step_avg:93.95ms
+step:528/1700 train_time:49607ms step_avg:93.95ms
+step:529/1700 train_time:49703ms step_avg:93.96ms
+step:530/1700 train_time:49798ms step_avg:93.96ms
+step:531/1700 train_time:49894ms step_avg:93.96ms
+step:532/1700 train_time:49990ms step_avg:93.97ms
+step:533/1700 train_time:50086ms step_avg:93.97ms
+step:534/1700 train_time:50182ms step_avg:93.97ms
+step:535/1700 train_time:50278ms step_avg:93.98ms
+step:536/1700 train_time:50374ms step_avg:93.98ms
+step:537/1700 train_time:50469ms step_avg:93.98ms
+step:538/1700 train_time:50566ms step_avg:93.99ms
+step:539/1700 train_time:50661ms step_avg:93.99ms
+step:540/1700 train_time:50757ms step_avg:93.99ms
+step:541/1700 train_time:50852ms step_avg:94.00ms
+step:542/1700 train_time:50948ms step_avg:94.00ms
+step:543/1700 train_time:51043ms step_avg:94.00ms
+step:544/1700 train_time:51139ms step_avg:94.01ms
+step:545/1700 train_time:51235ms step_avg:94.01ms
+step:546/1700 train_time:51331ms step_avg:94.01ms
+step:547/1700 train_time:51427ms step_avg:94.02ms
+step:548/1700 train_time:51523ms step_avg:94.02ms
+step:549/1700 train_time:51618ms step_avg:94.02ms
+step:550/1700 train_time:51713ms step_avg:94.02ms
+step:551/1700 train_time:51809ms step_avg:94.03ms
+step:552/1700 train_time:51905ms step_avg:94.03ms
+step:553/1700 train_time:52000ms step_avg:94.03ms
+step:554/1700 train_time:52096ms step_avg:94.04ms
+step:555/1700 train_time:52192ms step_avg:94.04ms
+step:556/1700 train_time:52288ms step_avg:94.04ms
+step:557/1700 train_time:52384ms step_avg:94.05ms
+step:558/1700 train_time:52480ms step_avg:94.05ms
+step:559/1700 train_time:52575ms step_avg:94.05ms
+step:560/1700 train_time:52670ms step_avg:94.05ms
+step:561/1700 train_time:52766ms step_avg:94.06ms
+step:562/1700 train_time:52861ms step_avg:94.06ms
+step:563/1700 train_time:52957ms step_avg:94.06ms
+step:564/1700 train_time:53053ms step_avg:94.07ms
+step:565/1700 train_time:53148ms step_avg:94.07ms
+step:566/1700 train_time:53245ms step_avg:94.07ms
+step:567/1700 train_time:53340ms step_avg:94.07ms
+step:568/1700 train_time:53437ms step_avg:94.08ms
+step:569/1700 train_time:53533ms step_avg:94.08ms
+step:570/1700 train_time:53629ms step_avg:94.09ms
+step:571/1700 train_time:53725ms step_avg:94.09ms
+step:572/1700 train_time:53821ms step_avg:94.09ms
+step:573/1700 train_time:53917ms step_avg:94.10ms
+step:574/1700 train_time:54012ms step_avg:94.10ms
+step:575/1700 train_time:54107ms step_avg:94.10ms
+step:576/1700 train_time:54204ms step_avg:94.10ms
+step:577/1700 train_time:54300ms step_avg:94.11ms
+step:578/1700 train_time:54396ms step_avg:94.11ms
+step:579/1700 train_time:54492ms step_avg:94.11ms
+step:580/1700 train_time:54587ms step_avg:94.12ms
+step:581/1700 train_time:54683ms step_avg:94.12ms
+step:582/1700 train_time:54779ms step_avg:94.12ms
+step:583/1700 train_time:54874ms step_avg:94.12ms
+step:584/1700 train_time:54969ms step_avg:94.13ms
+step:585/1700 train_time:55065ms step_avg:94.13ms
+step:586/1700 train_time:55160ms step_avg:94.13ms
+step:587/1700 train_time:55257ms step_avg:94.13ms
+step:588/1700 train_time:55352ms step_avg:94.14ms
+step:589/1700 train_time:55448ms step_avg:94.14ms
+step:590/1700 train_time:55543ms step_avg:94.14ms
+step:591/1700 train_time:55639ms step_avg:94.14ms
+step:592/1700 train_time:55736ms step_avg:94.15ms
+step:593/1700 train_time:55831ms step_avg:94.15ms
+step:594/1700 train_time:55927ms step_avg:94.15ms
+step:595/1700 train_time:56023ms step_avg:94.16ms
+step:596/1700 train_time:56119ms step_avg:94.16ms
+step:597/1700 train_time:56214ms step_avg:94.16ms
+step:598/1700 train_time:56310ms step_avg:94.16ms
+step:599/1700 train_time:56406ms step_avg:94.17ms
+step:600/1700 train_time:56502ms step_avg:94.17ms
+step:601/1700 train_time:56598ms step_avg:94.17ms
+step:602/1700 train_time:56693ms step_avg:94.18ms
+step:603/1700 train_time:56789ms step_avg:94.18ms
+step:604/1700 train_time:56885ms step_avg:94.18ms
+step:605/1700 train_time:56981ms step_avg:94.18ms
+step:606/1700 train_time:57077ms step_avg:94.19ms
+step:607/1700 train_time:57173ms step_avg:94.19ms
+step:608/1700 train_time:57268ms step_avg:94.19ms
+step:609/1700 train_time:57364ms step_avg:94.19ms
+step:610/1700 train_time:57460ms step_avg:94.20ms
+step:611/1700 train_time:57555ms step_avg:94.20ms
+step:612/1700 train_time:57651ms step_avg:94.20ms
+step:613/1700 train_time:57746ms step_avg:94.20ms
+step:614/1700 train_time:57842ms step_avg:94.20ms
+step:615/1700 train_time:57938ms step_avg:94.21ms
+step:616/1700 train_time:58034ms step_avg:94.21ms
+step:617/1700 train_time:58130ms step_avg:94.21ms
+step:618/1700 train_time:58226ms step_avg:94.22ms
+step:619/1700 train_time:58322ms step_avg:94.22ms
+step:620/1700 train_time:58418ms step_avg:94.22ms
+step:621/1700 train_time:58514ms step_avg:94.22ms
+step:622/1700 train_time:58610ms step_avg:94.23ms
+step:623/1700 train_time:58705ms step_avg:94.23ms
+step:624/1700 train_time:58801ms step_avg:94.23ms
+step:625/1700 train_time:58896ms step_avg:94.23ms
+step:625/1700 val_loss:3.6481 train_time:58975ms step_avg:94.36ms
+step:626/1700 train_time:59000ms step_avg:94.25ms
+step:627/1700 train_time:59094ms step_avg:94.25ms
+step:628/1700 train_time:59192ms step_avg:94.26ms
+step:629/1700 train_time:59288ms step_avg:94.26ms
+step:630/1700 train_time:59384ms step_avg:94.26ms
+step:631/1700 train_time:59480ms step_avg:94.26ms
+step:632/1700 train_time:59576ms step_avg:94.27ms
+step:633/1700 train_time:59673ms step_avg:94.27ms
+step:634/1700 train_time:59770ms step_avg:94.28ms
+step:635/1700 train_time:59868ms step_avg:94.28ms
+step:636/1700 train_time:59965ms step_avg:94.29ms
+step:637/1700 train_time:60064ms step_avg:94.29ms
+step:638/1700 train_time:60163ms step_avg:94.30ms
+step:639/1700 train_time:60262ms step_avg:94.31ms
+step:640/1700 train_time:60359ms step_avg:94.31ms
+step:641/1700 train_time:60455ms step_avg:94.31ms
+step:642/1700 train_time:60552ms step_avg:94.32ms
+step:643/1700 train_time:60649ms step_avg:94.32ms
+step:644/1700 train_time:60746ms step_avg:94.33ms
+step:645/1700 train_time:60842ms step_avg:94.33ms
+step:646/1700 train_time:60939ms step_avg:94.33ms
+step:647/1700 train_time:61036ms step_avg:94.34ms
+step:648/1700 train_time:61134ms step_avg:94.34ms
+step:649/1700 train_time:61232ms step_avg:94.35ms
+step:650/1700 train_time:61329ms step_avg:94.35ms
+step:651/1700 train_time:61428ms step_avg:94.36ms
+step:652/1700 train_time:61524ms step_avg:94.36ms
+step:653/1700 train_time:61622ms step_avg:94.37ms
+step:654/1700 train_time:61719ms step_avg:94.37ms
+step:655/1700 train_time:61815ms step_avg:94.37ms
+step:656/1700 train_time:61912ms step_avg:94.38ms
+step:657/1700 train_time:62009ms step_avg:94.38ms
+step:658/1700 train_time:62108ms step_avg:94.39ms
+step:659/1700 train_time:62206ms step_avg:94.39ms
+step:660/1700 train_time:62303ms step_avg:94.40ms
+step:661/1700 train_time:62402ms step_avg:94.41ms
+step:662/1700 train_time:62499ms step_avg:94.41ms
+step:663/1700 train_time:62596ms step_avg:94.41ms
+step:664/1700 train_time:62693ms step_avg:94.42ms
+step:665/1700 train_time:62790ms step_avg:94.42ms
+step:666/1700 train_time:62888ms step_avg:94.43ms
+step:667/1700 train_time:62984ms step_avg:94.43ms
+step:668/1700 train_time:63081ms step_avg:94.43ms
+step:669/1700 train_time:63179ms step_avg:94.44ms
+step:670/1700 train_time:63276ms step_avg:94.44ms
+step:671/1700 train_time:63373ms step_avg:94.45ms
+step:672/1700 train_time:63471ms step_avg:94.45ms
+step:673/1700 train_time:63569ms step_avg:94.46ms
+step:674/1700 train_time:63667ms step_avg:94.46ms
+step:675/1700 train_time:63764ms step_avg:94.47ms
+step:676/1700 train_time:63862ms step_avg:94.47ms
+step:677/1700 train_time:63959ms step_avg:94.47ms
+step:678/1700 train_time:64056ms step_avg:94.48ms
+step:679/1700 train_time:64154ms step_avg:94.48ms
+step:680/1700 train_time:64251ms step_avg:94.49ms
+step:681/1700 train_time:64348ms step_avg:94.49ms
+step:682/1700 train_time:64446ms step_avg:94.50ms
+step:683/1700 train_time:64544ms step_avg:94.50ms
+step:684/1700 train_time:64641ms step_avg:94.50ms
+step:685/1700 train_time:64740ms step_avg:94.51ms
+step:686/1700 train_time:64836ms step_avg:94.51ms
+step:687/1700 train_time:64933ms step_avg:94.52ms
+step:688/1700 train_time:65031ms step_avg:94.52ms
+step:689/1700 train_time:65128ms step_avg:94.53ms
+step:690/1700 train_time:65225ms step_avg:94.53ms
+step:691/1700 train_time:65323ms step_avg:94.53ms
+step:692/1700 train_time:65422ms step_avg:94.54ms
+step:693/1700 train_time:65519ms step_avg:94.54ms
+step:694/1700 train_time:65616ms step_avg:94.55ms
+step:695/1700 train_time:65713ms step_avg:94.55ms
+step:696/1700 train_time:65810ms step_avg:94.55ms
+step:697/1700 train_time:65906ms step_avg:94.56ms
+step:698/1700 train_time:66003ms step_avg:94.56ms
+step:699/1700 train_time:66102ms step_avg:94.57ms
+step:700/1700 train_time:66199ms step_avg:94.57ms
+step:701/1700 train_time:66295ms step_avg:94.57ms
+step:702/1700 train_time:66392ms step_avg:94.58ms
+step:703/1700 train_time:66490ms step_avg:94.58ms
+step:704/1700 train_time:66588ms step_avg:94.59ms
+step:705/1700 train_time:66686ms step_avg:94.59ms
+step:706/1700 train_time:66784ms step_avg:94.60ms
+step:707/1700 train_time:66881ms step_avg:94.60ms
+step:708/1700 train_time:66978ms step_avg:94.60ms
+step:709/1700 train_time:67075ms step_avg:94.60ms
+step:710/1700 train_time:67172ms step_avg:94.61ms
+step:711/1700 train_time:67270ms step_avg:94.61ms
+step:712/1700 train_time:67368ms step_avg:94.62ms
+step:713/1700 train_time:67465ms step_avg:94.62ms
+step:714/1700 train_time:67563ms step_avg:94.63ms
+step:715/1700 train_time:67660ms step_avg:94.63ms
+step:716/1700 train_time:67757ms step_avg:94.63ms
+step:717/1700 train_time:67854ms step_avg:94.64ms
+step:718/1700 train_time:67951ms step_avg:94.64ms
+step:719/1700 train_time:68049ms step_avg:94.64ms
+step:720/1700 train_time:68146ms step_avg:94.65ms
+step:721/1700 train_time:68244ms step_avg:94.65ms
+step:722/1700 train_time:68342ms step_avg:94.66ms
+step:723/1700 train_time:68439ms step_avg:94.66ms
+step:724/1700 train_time:68536ms step_avg:94.66ms
+step:725/1700 train_time:68633ms step_avg:94.67ms
+step:726/1700 train_time:68731ms step_avg:94.67ms
+step:727/1700 train_time:68828ms step_avg:94.67ms
+step:728/1700 train_time:68925ms step_avg:94.68ms
+step:729/1700 train_time:69023ms step_avg:94.68ms
+step:730/1700 train_time:69120ms step_avg:94.69ms
+step:731/1700 train_time:69217ms step_avg:94.69ms
+step:732/1700 train_time:69315ms step_avg:94.69ms
+step:733/1700 train_time:69412ms step_avg:94.70ms
+step:734/1700 train_time:69510ms step_avg:94.70ms
+step:735/1700 train_time:69607ms step_avg:94.70ms
+step:736/1700 train_time:69705ms step_avg:94.71ms
+step:737/1700 train_time:69802ms step_avg:94.71ms
+step:738/1700 train_time:69900ms step_avg:94.71ms
+step:739/1700 train_time:69997ms step_avg:94.72ms
+step:740/1700 train_time:70095ms step_avg:94.72ms
+step:741/1700 train_time:70192ms step_avg:94.73ms
+step:742/1700 train_time:70289ms step_avg:94.73ms
+step:743/1700 train_time:70388ms step_avg:94.73ms
+step:744/1700 train_time:70485ms step_avg:94.74ms
+step:745/1700 train_time:70582ms step_avg:94.74ms
+step:746/1700 train_time:70678ms step_avg:94.74ms
+step:747/1700 train_time:70775ms step_avg:94.75ms
+step:748/1700 train_time:70872ms step_avg:94.75ms
+step:749/1700 train_time:70970ms step_avg:94.75ms
+step:750/1700 train_time:71069ms step_avg:94.76ms
+step:750/1700 val_loss:3.5869 train_time:71149ms step_avg:94.86ms
+step:751/1700 train_time:71173ms step_avg:94.77ms
+step:752/1700 train_time:71270ms step_avg:94.77ms
+step:753/1700 train_time:71370ms step_avg:94.78ms
+step:754/1700 train_time:71467ms step_avg:94.78ms
+step:755/1700 train_time:71563ms step_avg:94.79ms
+step:756/1700 train_time:71660ms step_avg:94.79ms
+step:757/1700 train_time:71756ms step_avg:94.79ms
+step:758/1700 train_time:71853ms step_avg:94.79ms
+step:759/1700 train_time:71950ms step_avg:94.80ms
+step:760/1700 train_time:72047ms step_avg:94.80ms
+step:761/1700 train_time:72146ms step_avg:94.80ms
+step:762/1700 train_time:72245ms step_avg:94.81ms
+step:763/1700 train_time:72345ms step_avg:94.82ms
+step:764/1700 train_time:72444ms step_avg:94.82ms
+step:765/1700 train_time:72541ms step_avg:94.83ms
+step:766/1700 train_time:72639ms step_avg:94.83ms
+step:767/1700 train_time:72736ms step_avg:94.83ms
+step:768/1700 train_time:72832ms step_avg:94.83ms
+step:769/1700 train_time:72929ms step_avg:94.84ms
+step:770/1700 train_time:73026ms step_avg:94.84ms
+step:771/1700 train_time:73125ms step_avg:94.84ms
+step:772/1700 train_time:73224ms step_avg:94.85ms
+step:773/1700 train_time:73324ms step_avg:94.86ms
+step:774/1700 train_time:73423ms step_avg:94.86ms
+step:775/1700 train_time:73520ms step_avg:94.87ms
+step:776/1700 train_time:73617ms step_avg:94.87ms
+step:777/1700 train_time:73715ms step_avg:94.87ms
+step:778/1700 train_time:73812ms step_avg:94.87ms
+step:779/1700 train_time:73909ms step_avg:94.88ms
+step:780/1700 train_time:74006ms step_avg:94.88ms
+step:781/1700 train_time:74105ms step_avg:94.88ms
+step:782/1700 train_time:74203ms step_avg:94.89ms
+step:783/1700 train_time:74301ms step_avg:94.89ms
+step:784/1700 train_time:74399ms step_avg:94.90ms
+step:785/1700 train_time:74497ms step_avg:94.90ms
+step:786/1700 train_time:74595ms step_avg:94.90ms
+step:787/1700 train_time:74691ms step_avg:94.91ms
+step:788/1700 train_time:74788ms step_avg:94.91ms
+step:789/1700 train_time:74885ms step_avg:94.91ms
+step:790/1700 train_time:74983ms step_avg:94.92ms
+step:791/1700 train_time:75081ms step_avg:94.92ms
+step:792/1700 train_time:75179ms step_avg:94.92ms
+step:793/1700 train_time:75277ms step_avg:94.93ms
+step:794/1700 train_time:75375ms step_avg:94.93ms
+step:795/1700 train_time:75474ms step_avg:94.94ms
+step:796/1700 train_time:75571ms step_avg:94.94ms
+step:797/1700 train_time:75668ms step_avg:94.94ms
+step:798/1700 train_time:75766ms step_avg:94.94ms
+step:799/1700 train_time:75863ms step_avg:94.95ms
+step:800/1700 train_time:75960ms step_avg:94.95ms
+step:801/1700 train_time:76058ms step_avg:94.95ms
+step:802/1700 train_time:76156ms step_avg:94.96ms
+step:803/1700 train_time:76253ms step_avg:94.96ms
+step:804/1700 train_time:76351ms step_avg:94.96ms
+step:805/1700 train_time:76449ms step_avg:94.97ms
+step:806/1700 train_time:76546ms step_avg:94.97ms
+step:807/1700 train_time:76644ms step_avg:94.97ms
+step:808/1700 train_time:76742ms step_avg:94.98ms
+step:809/1700 train_time:76840ms step_avg:94.98ms
+step:810/1700 train_time:76938ms step_avg:94.98ms
+step:811/1700 train_time:77035ms step_avg:94.99ms
+step:812/1700 train_time:77133ms step_avg:94.99ms
+step:813/1700 train_time:77230ms step_avg:94.99ms
+step:814/1700 train_time:77328ms step_avg:95.00ms
+step:815/1700 train_time:77426ms step_avg:95.00ms
+step:816/1700 train_time:77524ms step_avg:95.00ms
+step:817/1700 train_time:77621ms step_avg:95.01ms
+step:818/1700 train_time:77719ms step_avg:95.01ms
+step:819/1700 train_time:77816ms step_avg:95.01ms
+step:820/1700 train_time:77913ms step_avg:95.02ms
+step:821/1700 train_time:78011ms step_avg:95.02ms
+step:822/1700 train_time:78108ms step_avg:95.02ms
+step:823/1700 train_time:78206ms step_avg:95.03ms
+step:824/1700 train_time:78304ms step_avg:95.03ms
+step:825/1700 train_time:78402ms step_avg:95.03ms
+step:826/1700 train_time:78500ms step_avg:95.04ms
+step:827/1700 train_time:78598ms step_avg:95.04ms
+step:828/1700 train_time:78695ms step_avg:95.04ms
+step:829/1700 train_time:78793ms step_avg:95.05ms
+step:830/1700 train_time:78890ms step_avg:95.05ms
+step:831/1700 train_time:78988ms step_avg:95.05ms
+step:832/1700 train_time:79085ms step_avg:95.05ms
+step:833/1700 train_time:79182ms step_avg:95.06ms
+step:834/1700 train_time:79279ms step_avg:95.06ms
+step:835/1700 train_time:79376ms step_avg:95.06ms
+step:836/1700 train_time:79475ms step_avg:95.07ms
+step:837/1700 train_time:79573ms step_avg:95.07ms
+step:838/1700 train_time:79671ms step_avg:95.07ms
+step:839/1700 train_time:79769ms step_avg:95.08ms
+step:840/1700 train_time:79867ms step_avg:95.08ms
+step:841/1700 train_time:79965ms step_avg:95.08ms
+step:842/1700 train_time:80063ms step_avg:95.09ms
+step:843/1700 train_time:80160ms step_avg:95.09ms
+step:844/1700 train_time:80257ms step_avg:95.09ms
+step:845/1700 train_time:80354ms step_avg:95.09ms
+step:846/1700 train_time:80451ms step_avg:95.10ms
+step:847/1700 train_time:80549ms step_avg:95.10ms
+step:848/1700 train_time:80647ms step_avg:95.10ms
+step:849/1700 train_time:80745ms step_avg:95.11ms
+step:850/1700 train_time:80843ms step_avg:95.11ms
+step:851/1700 train_time:80940ms step_avg:95.11ms
+step:852/1700 train_time:81039ms step_avg:95.12ms
+step:853/1700 train_time:81137ms step_avg:95.12ms
+step:854/1700 train_time:81234ms step_avg:95.12ms
+step:855/1700 train_time:81331ms step_avg:95.12ms
+step:856/1700 train_time:81429ms step_avg:95.13ms
+step:857/1700 train_time:81526ms step_avg:95.13ms
+step:858/1700 train_time:81624ms step_avg:95.13ms
+step:859/1700 train_time:81723ms step_avg:95.14ms
+step:860/1700 train_time:81821ms step_avg:95.14ms
+step:861/1700 train_time:81918ms step_avg:95.14ms
+step:862/1700 train_time:82016ms step_avg:95.15ms
+step:863/1700 train_time:82112ms step_avg:95.15ms
+step:864/1700 train_time:82210ms step_avg:95.15ms
+step:865/1700 train_time:82306ms step_avg:95.15ms
+step:866/1700 train_time:82405ms step_avg:95.16ms
+step:867/1700 train_time:82503ms step_avg:95.16ms
+step:868/1700 train_time:82600ms step_avg:95.16ms
+step:869/1700 train_time:82698ms step_avg:95.16ms
+step:870/1700 train_time:82795ms step_avg:95.17ms
+step:871/1700 train_time:82893ms step_avg:95.17ms
+step:872/1700 train_time:82990ms step_avg:95.17ms
+step:873/1700 train_time:83088ms step_avg:95.18ms
+step:874/1700 train_time:83185ms step_avg:95.18ms
+step:875/1700 train_time:83283ms step_avg:95.18ms
+step:875/1700 val_loss:3.5383 train_time:83363ms step_avg:95.27ms
+step:876/1700 train_time:83386ms step_avg:95.19ms
+step:877/1700 train_time:83490ms step_avg:95.20ms
+step:878/1700 train_time:83587ms step_avg:95.20ms
+step:879/1700 train_time:83685ms step_avg:95.20ms
+step:880/1700 train_time:83783ms step_avg:95.21ms
+step:881/1700 train_time:83880ms step_avg:95.21ms
+step:882/1700 train_time:83976ms step_avg:95.21ms
+step:883/1700 train_time:84074ms step_avg:95.21ms
+step:884/1700 train_time:84173ms step_avg:95.22ms
+step:885/1700 train_time:84271ms step_avg:95.22ms
+step:886/1700 train_time:84372ms step_avg:95.23ms
+step:887/1700 train_time:84473ms step_avg:95.23ms
+step:888/1700 train_time:84573ms step_avg:95.24ms
+step:889/1700 train_time:84673ms step_avg:95.25ms
+step:890/1700 train_time:84773ms step_avg:95.25ms
+step:891/1700 train_time:84873ms step_avg:95.26ms
+step:892/1700 train_time:84972ms step_avg:95.26ms
+step:893/1700 train_time:85070ms step_avg:95.26ms
+step:894/1700 train_time:85169ms step_avg:95.27ms
+step:895/1700 train_time:85267ms step_avg:95.27ms
+step:896/1700 train_time:85366ms step_avg:95.28ms
+step:897/1700 train_time:85466ms step_avg:95.28ms
+step:898/1700 train_time:85566ms step_avg:95.29ms
+step:899/1700 train_time:85666ms step_avg:95.29ms
+step:900/1700 train_time:85764ms step_avg:95.29ms
+step:901/1700 train_time:85864ms step_avg:95.30ms
+step:902/1700 train_time:85964ms step_avg:95.30ms
+step:903/1700 train_time:86063ms step_avg:95.31ms
+step:904/1700 train_time:86161ms step_avg:95.31ms
+step:905/1700 train_time:86259ms step_avg:95.31ms
+step:906/1700 train_time:86357ms step_avg:95.32ms
+step:907/1700 train_time:86455ms step_avg:95.32ms
+step:908/1700 train_time:86555ms step_avg:95.33ms
+step:909/1700 train_time:86655ms step_avg:95.33ms
+step:910/1700 train_time:86755ms step_avg:95.34ms
+step:911/1700 train_time:86854ms step_avg:95.34ms
+step:912/1700 train_time:86954ms step_avg:95.34ms
+step:913/1700 train_time:87054ms step_avg:95.35ms
+step:914/1700 train_time:87154ms step_avg:95.35ms
+step:915/1700 train_time:87254ms step_avg:95.36ms
+step:916/1700 train_time:87353ms step_avg:95.36ms
+step:917/1700 train_time:87453ms step_avg:95.37ms
+step:918/1700 train_time:87552ms step_avg:95.37ms
+step:919/1700 train_time:87651ms step_avg:95.38ms
+step:920/1700 train_time:87751ms step_avg:95.38ms
+step:921/1700 train_time:87849ms step_avg:95.38ms
+step:922/1700 train_time:87948ms step_avg:95.39ms
+step:923/1700 train_time:88047ms step_avg:95.39ms
+step:924/1700 train_time:88147ms step_avg:95.40ms
+step:925/1700 train_time:88247ms step_avg:95.40ms
+step:926/1700 train_time:88346ms step_avg:95.41ms
+step:927/1700 train_time:88446ms step_avg:95.41ms
+step:928/1700 train_time:88546ms step_avg:95.42ms
+step:929/1700 train_time:88645ms step_avg:95.42ms
+step:930/1700 train_time:88745ms step_avg:95.42ms
+step:931/1700 train_time:88844ms step_avg:95.43ms
+step:932/1700 train_time:88943ms step_avg:95.43ms
+step:933/1700 train_time:89042ms step_avg:95.44ms
+step:934/1700 train_time:89141ms step_avg:95.44ms
+step:935/1700 train_time:89241ms step_avg:95.44ms
+step:936/1700 train_time:89340ms step_avg:95.45ms
+step:937/1700 train_time:89439ms step_avg:95.45ms
+step:938/1700 train_time:89537ms step_avg:95.46ms
+step:939/1700 train_time:89636ms step_avg:95.46ms
+step:940/1700 train_time:89735ms step_avg:95.46ms
+step:941/1700 train_time:89835ms step_avg:95.47ms
+step:942/1700 train_time:89934ms step_avg:95.47ms
+step:943/1700 train_time:90034ms step_avg:95.48ms
+step:944/1700 train_time:90134ms step_avg:95.48ms
+step:945/1700 train_time:90233ms step_avg:95.48ms
+step:946/1700 train_time:90333ms step_avg:95.49ms
+step:947/1700 train_time:90432ms step_avg:95.49ms
+step:948/1700 train_time:90531ms step_avg:95.50ms
+step:949/1700 train_time:90629ms step_avg:95.50ms
+step:950/1700 train_time:90727ms step_avg:95.50ms
+step:951/1700 train_time:90825ms step_avg:95.50ms
+step:952/1700 train_time:90923ms step_avg:95.51ms
+step:953/1700 train_time:91024ms step_avg:95.51ms
+step:954/1700 train_time:91122ms step_avg:95.52ms
+step:955/1700 train_time:91221ms step_avg:95.52ms
+step:956/1700 train_time:91321ms step_avg:95.52ms
+step:957/1700 train_time:91420ms step_avg:95.53ms
+step:958/1700 train_time:91519ms step_avg:95.53ms
+step:959/1700 train_time:91617ms step_avg:95.53ms
+step:960/1700 train_time:91717ms step_avg:95.54ms
+step:961/1700 train_time:91815ms step_avg:95.54ms
+step:962/1700 train_time:91914ms step_avg:95.54ms
+step:963/1700 train_time:92013ms step_avg:95.55ms
+step:964/1700 train_time:92114ms step_avg:95.55ms
+step:965/1700 train_time:92215ms step_avg:95.56ms
+step:966/1700 train_time:92314ms step_avg:95.56ms
+step:967/1700 train_time:92414ms step_avg:95.57ms
+step:968/1700 train_time:92514ms step_avg:95.57ms
+step:969/1700 train_time:92614ms step_avg:95.58ms
+step:970/1700 train_time:92713ms step_avg:95.58ms
+step:971/1700 train_time:92811ms step_avg:95.58ms
+step:972/1700 train_time:92910ms step_avg:95.59ms
+step:973/1700 train_time:93009ms step_avg:95.59ms
+step:974/1700 train_time:93107ms step_avg:95.59ms
+step:975/1700 train_time:93207ms step_avg:95.60ms
+step:976/1700 train_time:93305ms step_avg:95.60ms
+step:977/1700 train_time:93404ms step_avg:95.60ms
+step:978/1700 train_time:93503ms step_avg:95.61ms
+step:979/1700 train_time:93603ms step_avg:95.61ms
+step:980/1700 train_time:93702ms step_avg:95.61ms
+step:981/1700 train_time:93800ms step_avg:95.62ms
+step:982/1700 train_time:93899ms step_avg:95.62ms
+step:983/1700 train_time:93999ms step_avg:95.62ms
+step:984/1700 train_time:94097ms step_avg:95.63ms
+step:985/1700 train_time:94197ms step_avg:95.63ms
+step:986/1700 train_time:94297ms step_avg:95.64ms
+step:987/1700 train_time:94397ms step_avg:95.64ms
+step:988/1700 train_time:94496ms step_avg:95.64ms
+step:989/1700 train_time:94596ms step_avg:95.65ms
+step:990/1700 train_time:94696ms step_avg:95.65ms
+step:991/1700 train_time:94797ms step_avg:95.66ms
+step:992/1700 train_time:94896ms step_avg:95.66ms
+step:993/1700 train_time:94995ms step_avg:95.66ms
+step:994/1700 train_time:95094ms step_avg:95.67ms
+step:995/1700 train_time:95194ms step_avg:95.67ms
+step:996/1700 train_time:95293ms step_avg:95.68ms
+step:997/1700 train_time:95393ms step_avg:95.68ms
+step:998/1700 train_time:95492ms step_avg:95.68ms
+step:999/1700 train_time:95592ms step_avg:95.69ms
+step:1000/1700 train_time:95691ms step_avg:95.69ms
+step:1000/1700 val_loss:3.4926 train_time:95774ms step_avg:95.77ms
+step:1001/1700 train_time:95797ms step_avg:95.70ms
+step:1002/1700 train_time:95899ms step_avg:95.71ms
+step:1003/1700 train_time:96000ms step_avg:95.71ms
+step:1004/1700 train_time:96098ms step_avg:95.72ms
+step:1005/1700 train_time:96197ms step_avg:95.72ms
+step:1006/1700 train_time:96296ms step_avg:95.72ms
+step:1007/1700 train_time:96395ms step_avg:95.73ms
+step:1008/1700 train_time:96493ms step_avg:95.73ms
+step:1009/1700 train_time:96590ms step_avg:95.73ms
+step:1010/1700 train_time:96689ms step_avg:95.73ms
+step:1011/1700 train_time:96791ms step_avg:95.74ms
+step:1012/1700 train_time:96891ms step_avg:95.74ms
+step:1013/1700 train_time:96991ms step_avg:95.75ms
+step:1014/1700 train_time:97090ms step_avg:95.75ms
+step:1015/1700 train_time:97189ms step_avg:95.75ms
+step:1016/1700 train_time:97290ms step_avg:95.76ms
+step:1017/1700 train_time:97389ms step_avg:95.76ms
+step:1018/1700 train_time:97488ms step_avg:95.76ms
+step:1019/1700 train_time:97586ms step_avg:95.77ms
+step:1020/1700 train_time:97684ms step_avg:95.77ms
+step:1021/1700 train_time:97783ms step_avg:95.77ms
+step:1022/1700 train_time:97883ms step_avg:95.78ms
+step:1023/1700 train_time:97981ms step_avg:95.78ms
+step:1024/1700 train_time:98081ms step_avg:95.78ms
+step:1025/1700 train_time:98181ms step_avg:95.79ms
+step:1026/1700 train_time:98280ms step_avg:95.79ms
+step:1027/1700 train_time:98379ms step_avg:95.79ms
+step:1028/1700 train_time:98479ms step_avg:95.80ms
+step:1029/1700 train_time:98578ms step_avg:95.80ms
+step:1030/1700 train_time:98677ms step_avg:95.80ms
+step:1031/1700 train_time:98778ms step_avg:95.81ms
+step:1032/1700 train_time:98877ms step_avg:95.81ms
+step:1033/1700 train_time:98977ms step_avg:95.82ms
+step:1034/1700 train_time:99077ms step_avg:95.82ms
+step:1035/1700 train_time:99177ms step_avg:95.82ms
+step:1036/1700 train_time:99277ms step_avg:95.83ms
+step:1037/1700 train_time:99377ms step_avg:95.83ms
+step:1038/1700 train_time:99476ms step_avg:95.83ms
+step:1039/1700 train_time:99575ms step_avg:95.84ms
+step:1040/1700 train_time:99675ms step_avg:95.84ms
+step:1041/1700 train_time:99775ms step_avg:95.85ms
+step:1042/1700 train_time:99875ms step_avg:95.85ms
+step:1043/1700 train_time:99975ms step_avg:95.85ms
+step:1044/1700 train_time:100075ms step_avg:95.86ms
+step:1045/1700 train_time:100175ms step_avg:95.86ms
+step:1046/1700 train_time:100274ms step_avg:95.86ms
+step:1047/1700 train_time:100374ms step_avg:95.87ms
+step:1048/1700 train_time:100474ms step_avg:95.87ms
+step:1049/1700 train_time:100573ms step_avg:95.88ms
+step:1050/1700 train_time:100672ms step_avg:95.88ms
+step:1051/1700 train_time:100771ms step_avg:95.88ms
+step:1052/1700 train_time:100869ms step_avg:95.88ms
+step:1053/1700 train_time:100969ms step_avg:95.89ms
+step:1054/1700 train_time:101069ms step_avg:95.89ms
+step:1055/1700 train_time:101169ms step_avg:95.89ms
+step:1056/1700 train_time:101268ms step_avg:95.90ms
+step:1057/1700 train_time:101368ms step_avg:95.90ms
+step:1058/1700 train_time:101467ms step_avg:95.90ms
+step:1059/1700 train_time:101565ms step_avg:95.91ms
+step:1060/1700 train_time:101665ms step_avg:95.91ms
+step:1061/1700 train_time:101764ms step_avg:95.91ms
+step:1062/1700 train_time:101862ms step_avg:95.92ms
+step:1063/1700 train_time:101961ms step_avg:95.92ms
+step:1064/1700 train_time:102060ms step_avg:95.92ms
+step:1065/1700 train_time:102160ms step_avg:95.92ms
+step:1066/1700 train_time:102258ms step_avg:95.93ms
+step:1067/1700 train_time:102358ms step_avg:95.93ms
+step:1068/1700 train_time:102457ms step_avg:95.93ms
+step:1069/1700 train_time:102555ms step_avg:95.94ms
+step:1070/1700 train_time:102655ms step_avg:95.94ms
+step:1071/1700 train_time:102756ms step_avg:95.94ms
+step:1072/1700 train_time:102856ms step_avg:95.95ms
+step:1073/1700 train_time:102955ms step_avg:95.95ms
+step:1074/1700 train_time:103055ms step_avg:95.95ms
+step:1075/1700 train_time:103155ms step_avg:95.96ms
+step:1076/1700 train_time:103255ms step_avg:95.96ms
+step:1077/1700 train_time:103354ms step_avg:95.96ms
+step:1078/1700 train_time:103452ms step_avg:95.97ms
+step:1079/1700 train_time:103552ms step_avg:95.97ms
+step:1080/1700 train_time:103651ms step_avg:95.97ms
+step:1081/1700 train_time:103750ms step_avg:95.98ms
+step:1082/1700 train_time:103849ms step_avg:95.98ms
+step:1083/1700 train_time:103948ms step_avg:95.98ms
+step:1084/1700 train_time:104048ms step_avg:95.99ms
+step:1085/1700 train_time:104149ms step_avg:95.99ms
+step:1086/1700 train_time:104248ms step_avg:95.99ms
+step:1087/1700 train_time:104348ms step_avg:96.00ms
+step:1088/1700 train_time:104448ms step_avg:96.00ms
+step:1089/1700 train_time:104547ms step_avg:96.00ms
+step:1090/1700 train_time:104646ms step_avg:96.01ms
+step:1091/1700 train_time:104745ms step_avg:96.01ms
+step:1092/1700 train_time:104843ms step_avg:96.01ms
+step:1093/1700 train_time:104942ms step_avg:96.01ms
+step:1094/1700 train_time:105040ms step_avg:96.01ms
+step:1095/1700 train_time:105139ms step_avg:96.02ms
+step:1096/1700 train_time:105239ms step_avg:96.02ms
+step:1097/1700 train_time:105338ms step_avg:96.02ms
+step:1098/1700 train_time:105438ms step_avg:96.03ms
+step:1099/1700 train_time:105537ms step_avg:96.03ms
+step:1100/1700 train_time:105636ms step_avg:96.03ms
+step:1101/1700 train_time:105736ms step_avg:96.04ms
+step:1102/1700 train_time:105836ms step_avg:96.04ms
+step:1103/1700 train_time:105936ms step_avg:96.04ms
+step:1104/1700 train_time:106035ms step_avg:96.05ms
+step:1105/1700 train_time:106136ms step_avg:96.05ms
+step:1106/1700 train_time:106236ms step_avg:96.05ms
+step:1107/1700 train_time:106336ms step_avg:96.06ms
+step:1108/1700 train_time:106435ms step_avg:96.06ms
+step:1109/1700 train_time:106535ms step_avg:96.06ms
+step:1110/1700 train_time:106635ms step_avg:96.07ms
+step:1111/1700 train_time:106736ms step_avg:96.07ms
+step:1112/1700 train_time:106836ms step_avg:96.08ms
+step:1113/1700 train_time:106936ms step_avg:96.08ms
+step:1114/1700 train_time:107036ms step_avg:96.08ms
+step:1115/1700 train_time:107135ms step_avg:96.09ms
+step:1116/1700 train_time:107235ms step_avg:96.09ms
+step:1117/1700 train_time:107335ms step_avg:96.09ms
+step:1118/1700 train_time:107435ms step_avg:96.10ms
+step:1119/1700 train_time:107534ms step_avg:96.10ms
+step:1120/1700 train_time:107634ms step_avg:96.10ms
+step:1121/1700 train_time:107734ms step_avg:96.11ms
+step:1122/1700 train_time:107833ms step_avg:96.11ms
+step:1123/1700 train_time:107933ms step_avg:96.11ms
+step:1124/1700 train_time:108032ms step_avg:96.11ms
+step:1125/1700 train_time:108131ms step_avg:96.12ms
+step:1125/1700 val_loss:3.4415 train_time:108213ms step_avg:96.19ms
+step:1126/1700 train_time:108236ms step_avg:96.12ms
+step:1127/1700 train_time:108339ms step_avg:96.13ms
+step:1128/1700 train_time:108439ms step_avg:96.13ms
+step:1129/1700 train_time:108539ms step_avg:96.14ms
+step:1130/1700 train_time:108638ms step_avg:96.14ms
+step:1131/1700 train_time:108737ms step_avg:96.14ms
+step:1132/1700 train_time:108836ms step_avg:96.14ms
+step:1133/1700 train_time:108934ms step_avg:96.15ms
+step:1134/1700 train_time:109032ms step_avg:96.15ms
+step:1135/1700 train_time:109131ms step_avg:96.15ms
+step:1136/1700 train_time:109233ms step_avg:96.16ms
+step:1137/1700 train_time:109334ms step_avg:96.16ms
+step:1138/1700 train_time:109435ms step_avg:96.16ms
+step:1139/1700 train_time:109536ms step_avg:96.17ms
+step:1140/1700 train_time:109636ms step_avg:96.17ms
+step:1141/1700 train_time:109736ms step_avg:96.18ms
+step:1142/1700 train_time:109836ms step_avg:96.18ms
+step:1143/1700 train_time:109935ms step_avg:96.18ms
+step:1144/1700 train_time:110035ms step_avg:96.18ms
+step:1145/1700 train_time:110135ms step_avg:96.19ms
+step:1146/1700 train_time:110236ms step_avg:96.19ms
+step:1147/1700 train_time:110337ms step_avg:96.20ms
+step:1148/1700 train_time:110438ms step_avg:96.20ms
+step:1149/1700 train_time:110540ms step_avg:96.21ms
+step:1150/1700 train_time:110641ms step_avg:96.21ms
+step:1151/1700 train_time:110741ms step_avg:96.21ms
+step:1152/1700 train_time:110841ms step_avg:96.22ms
+step:1153/1700 train_time:110941ms step_avg:96.22ms
+step:1154/1700 train_time:111040ms step_avg:96.22ms
+step:1155/1700 train_time:111140ms step_avg:96.23ms
+step:1156/1700 train_time:111240ms step_avg:96.23ms
+step:1157/1700 train_time:111342ms step_avg:96.23ms
+step:1158/1700 train_time:111442ms step_avg:96.24ms
+step:1159/1700 train_time:111544ms step_avg:96.24ms
+step:1160/1700 train_time:111645ms step_avg:96.25ms
+step:1161/1700 train_time:111745ms step_avg:96.25ms
+step:1162/1700 train_time:111844ms step_avg:96.25ms
+step:1163/1700 train_time:111945ms step_avg:96.26ms
+step:1164/1700 train_time:112044ms step_avg:96.26ms
+step:1165/1700 train_time:112144ms step_avg:96.26ms
+step:1166/1700 train_time:112245ms step_avg:96.26ms
+step:1167/1700 train_time:112345ms step_avg:96.27ms
+step:1168/1700 train_time:112446ms step_avg:96.27ms
+step:1169/1700 train_time:112546ms step_avg:96.28ms
+step:1170/1700 train_time:112646ms step_avg:96.28ms
+step:1171/1700 train_time:112746ms step_avg:96.28ms
+step:1172/1700 train_time:112847ms step_avg:96.29ms
+step:1173/1700 train_time:112947ms step_avg:96.29ms
+step:1174/1700 train_time:113046ms step_avg:96.29ms
+step:1175/1700 train_time:113147ms step_avg:96.30ms
+step:1176/1700 train_time:113248ms step_avg:96.30ms
+step:1177/1700 train_time:113347ms step_avg:96.30ms
+step:1178/1700 train_time:113448ms step_avg:96.31ms
+step:1179/1700 train_time:113547ms step_avg:96.31ms
+step:1180/1700 train_time:113647ms step_avg:96.31ms
+step:1181/1700 train_time:113747ms step_avg:96.31ms
+step:1182/1700 train_time:113848ms step_avg:96.32ms
+step:1183/1700 train_time:113949ms step_avg:96.32ms
+step:1184/1700 train_time:114051ms step_avg:96.33ms
+step:1185/1700 train_time:114152ms step_avg:96.33ms
+step:1186/1700 train_time:114253ms step_avg:96.33ms
+step:1187/1700 train_time:114353ms step_avg:96.34ms
+step:1188/1700 train_time:114453ms step_avg:96.34ms
+step:1189/1700 train_time:114552ms step_avg:96.34ms
+step:1190/1700 train_time:114653ms step_avg:96.35ms
+step:1191/1700 train_time:114753ms step_avg:96.35ms
+step:1192/1700 train_time:114853ms step_avg:96.35ms
+step:1193/1700 train_time:114954ms step_avg:96.36ms
+step:1194/1700 train_time:115056ms step_avg:96.36ms
+step:1195/1700 train_time:115156ms step_avg:96.36ms
+step:1196/1700 train_time:115257ms step_avg:96.37ms
+step:1197/1700 train_time:115359ms step_avg:96.37ms
+step:1198/1700 train_time:115459ms step_avg:96.38ms
+step:1199/1700 train_time:115560ms step_avg:96.38ms
+step:1200/1700 train_time:115659ms step_avg:96.38ms
+step:1201/1700 train_time:115760ms step_avg:96.39ms
+step:1202/1700 train_time:115861ms step_avg:96.39ms
+step:1203/1700 train_time:115962ms step_avg:96.39ms
+step:1204/1700 train_time:116062ms step_avg:96.40ms
+step:1205/1700 train_time:116162ms step_avg:96.40ms
+step:1206/1700 train_time:116264ms step_avg:96.40ms
+step:1207/1700 train_time:116364ms step_avg:96.41ms
+step:1208/1700 train_time:116465ms step_avg:96.41ms
+step:1209/1700 train_time:116566ms step_avg:96.42ms
+step:1210/1700 train_time:116666ms step_avg:96.42ms
+step:1211/1700 train_time:116766ms step_avg:96.42ms
+step:1212/1700 train_time:116865ms step_avg:96.42ms
+step:1213/1700 train_time:116965ms step_avg:96.43ms
+step:1214/1700 train_time:117064ms step_avg:96.43ms
+step:1215/1700 train_time:117165ms step_avg:96.43ms
+step:1216/1700 train_time:117265ms step_avg:96.43ms
+step:1217/1700 train_time:117365ms step_avg:96.44ms
+step:1218/1700 train_time:117466ms step_avg:96.44ms
+step:1219/1700 train_time:117567ms step_avg:96.45ms
+step:1220/1700 train_time:117667ms step_avg:96.45ms
+step:1221/1700 train_time:117767ms step_avg:96.45ms
+step:1222/1700 train_time:117868ms step_avg:96.45ms
+step:1223/1700 train_time:117969ms step_avg:96.46ms
+step:1224/1700 train_time:118070ms step_avg:96.46ms
+step:1225/1700 train_time:118171ms step_avg:96.47ms
+step:1226/1700 train_time:118273ms step_avg:96.47ms
+step:1227/1700 train_time:118372ms step_avg:96.47ms
+step:1228/1700 train_time:118471ms step_avg:96.48ms
+step:1229/1700 train_time:118571ms step_avg:96.48ms
+step:1230/1700 train_time:118673ms step_avg:96.48ms
+step:1231/1700 train_time:118773ms step_avg:96.49ms
+step:1232/1700 train_time:118874ms step_avg:96.49ms
+step:1233/1700 train_time:118973ms step_avg:96.49ms
+step:1234/1700 train_time:119073ms step_avg:96.49ms
+step:1235/1700 train_time:119173ms step_avg:96.50ms
+step:1236/1700 train_time:119275ms step_avg:96.50ms
+step:1237/1700 train_time:119376ms step_avg:96.50ms
+step:1238/1700 train_time:119476ms step_avg:96.51ms
+step:1239/1700 train_time:119575ms step_avg:96.51ms
+step:1240/1700 train_time:119675ms step_avg:96.51ms
+step:1241/1700 train_time:119776ms step_avg:96.52ms
+step:1242/1700 train_time:119878ms step_avg:96.52ms
+step:1243/1700 train_time:119978ms step_avg:96.52ms
+step:1244/1700 train_time:120080ms step_avg:96.53ms
+step:1245/1700 train_time:120180ms step_avg:96.53ms
+step:1246/1700 train_time:120281ms step_avg:96.53ms
+step:1247/1700 train_time:120381ms step_avg:96.54ms
+step:1248/1700 train_time:120481ms step_avg:96.54ms
+step:1249/1700 train_time:120581ms step_avg:96.54ms
+step:1250/1700 train_time:120681ms step_avg:96.55ms
+step:1250/1700 val_loss:3.3970 train_time:120764ms step_avg:96.61ms
+step:1251/1700 train_time:120787ms step_avg:96.55ms
+step:1252/1700 train_time:120888ms step_avg:96.56ms
+step:1253/1700 train_time:120990ms step_avg:96.56ms
+step:1254/1700 train_time:121090ms step_avg:96.56ms
+step:1255/1700 train_time:121190ms step_avg:96.57ms
+step:1256/1700 train_time:121290ms step_avg:96.57ms
+step:1257/1700 train_time:121390ms step_avg:96.57ms
+step:1258/1700 train_time:121489ms step_avg:96.57ms
+step:1259/1700 train_time:121589ms step_avg:96.58ms
+step:1260/1700 train_time:121689ms step_avg:96.58ms
+step:1261/1700 train_time:121791ms step_avg:96.58ms
+step:1262/1700 train_time:121892ms step_avg:96.59ms
+step:1263/1700 train_time:121993ms step_avg:96.59ms
+step:1264/1700 train_time:122094ms step_avg:96.59ms
+step:1265/1700 train_time:122194ms step_avg:96.60ms
+step:1266/1700 train_time:122293ms step_avg:96.60ms
+step:1267/1700 train_time:122393ms step_avg:96.60ms
+step:1268/1700 train_time:122492ms step_avg:96.60ms
+step:1269/1700 train_time:122592ms step_avg:96.61ms
+step:1270/1700 train_time:122692ms step_avg:96.61ms
+step:1271/1700 train_time:122795ms step_avg:96.61ms
+step:1272/1700 train_time:122895ms step_avg:96.62ms
+step:1273/1700 train_time:122996ms step_avg:96.62ms
+step:1274/1700 train_time:123096ms step_avg:96.62ms
+step:1275/1700 train_time:123195ms step_avg:96.62ms
+step:1276/1700 train_time:123296ms step_avg:96.63ms
+step:1277/1700 train_time:123397ms step_avg:96.63ms
+step:1278/1700 train_time:123497ms step_avg:96.63ms
+step:1279/1700 train_time:123597ms step_avg:96.64ms
+step:1280/1700 train_time:123698ms step_avg:96.64ms
+step:1281/1700 train_time:123798ms step_avg:96.64ms
+step:1282/1700 train_time:123899ms step_avg:96.64ms
+step:1283/1700 train_time:123999ms step_avg:96.65ms
+step:1284/1700 train_time:124099ms step_avg:96.65ms
+step:1285/1700 train_time:124197ms step_avg:96.65ms
+step:1286/1700 train_time:124297ms step_avg:96.65ms
+step:1287/1700 train_time:124398ms step_avg:96.66ms
+step:1288/1700 train_time:124498ms step_avg:96.66ms
+step:1289/1700 train_time:124598ms step_avg:96.66ms
+step:1290/1700 train_time:124698ms step_avg:96.67ms
+step:1291/1700 train_time:124800ms step_avg:96.67ms
+step:1292/1700 train_time:124900ms step_avg:96.67ms
+step:1293/1700 train_time:125000ms step_avg:96.67ms
+step:1294/1700 train_time:125102ms step_avg:96.68ms
+step:1295/1700 train_time:125203ms step_avg:96.68ms
+step:1296/1700 train_time:125304ms step_avg:96.69ms
+step:1297/1700 train_time:125405ms step_avg:96.69ms
+step:1298/1700 train_time:125504ms step_avg:96.69ms
+step:1299/1700 train_time:125604ms step_avg:96.69ms
+step:1300/1700 train_time:125705ms step_avg:96.70ms
+step:1301/1700 train_time:125805ms step_avg:96.70ms
+step:1302/1700 train_time:125905ms step_avg:96.70ms
+step:1303/1700 train_time:126007ms step_avg:96.71ms
+step:1304/1700 train_time:126107ms step_avg:96.71ms
+step:1305/1700 train_time:126207ms step_avg:96.71ms
+step:1306/1700 train_time:126308ms step_avg:96.71ms
+step:1307/1700 train_time:126407ms step_avg:96.72ms
+step:1308/1700 train_time:126509ms step_avg:96.72ms
+step:1309/1700 train_time:126610ms step_avg:96.72ms
+step:1310/1700 train_time:126711ms step_avg:96.73ms
+step:1311/1700 train_time:126811ms step_avg:96.73ms
+step:1312/1700 train_time:126913ms step_avg:96.73ms
+step:1313/1700 train_time:127013ms step_avg:96.73ms
+step:1314/1700 train_time:127113ms step_avg:96.74ms
+step:1315/1700 train_time:127213ms step_avg:96.74ms
+step:1316/1700 train_time:127312ms step_avg:96.74ms
+step:1317/1700 train_time:127412ms step_avg:96.74ms
+step:1318/1700 train_time:127511ms step_avg:96.75ms
+step:1319/1700 train_time:127613ms step_avg:96.75ms
+step:1320/1700 train_time:127714ms step_avg:96.75ms
+step:1321/1700 train_time:127814ms step_avg:96.76ms
+step:1322/1700 train_time:127914ms step_avg:96.76ms
+step:1323/1700 train_time:128014ms step_avg:96.76ms
+step:1324/1700 train_time:128115ms step_avg:96.76ms
+step:1325/1700 train_time:128217ms step_avg:96.77ms
+step:1326/1700 train_time:128317ms step_avg:96.77ms
+step:1327/1700 train_time:128417ms step_avg:96.77ms
+step:1328/1700 train_time:128517ms step_avg:96.78ms
+step:1329/1700 train_time:128618ms step_avg:96.78ms
+step:1330/1700 train_time:128718ms step_avg:96.78ms
+step:1331/1700 train_time:128818ms step_avg:96.78ms
+step:1332/1700 train_time:128919ms step_avg:96.79ms
+step:1333/1700 train_time:129020ms step_avg:96.79ms
+step:1334/1700 train_time:129121ms step_avg:96.79ms
+step:1335/1700 train_time:129222ms step_avg:96.80ms
+step:1336/1700 train_time:129323ms step_avg:96.80ms
+step:1337/1700 train_time:129425ms step_avg:96.80ms
+step:1338/1700 train_time:129524ms step_avg:96.80ms
+step:1339/1700 train_time:129625ms step_avg:96.81ms
+step:1340/1700 train_time:129724ms step_avg:96.81ms
+step:1341/1700 train_time:129825ms step_avg:96.81ms
+step:1342/1700 train_time:129924ms step_avg:96.81ms
+step:1343/1700 train_time:130024ms step_avg:96.82ms
+step:1344/1700 train_time:130125ms step_avg:96.82ms
+step:1345/1700 train_time:130225ms step_avg:96.82ms
+step:1346/1700 train_time:130326ms step_avg:96.82ms
+step:1347/1700 train_time:130425ms step_avg:96.83ms
+step:1348/1700 train_time:130525ms step_avg:96.83ms
+step:1349/1700 train_time:130625ms step_avg:96.83ms
+step:1350/1700 train_time:130726ms step_avg:96.83ms
+step:1351/1700 train_time:130826ms step_avg:96.84ms
+step:1352/1700 train_time:130926ms step_avg:96.84ms
+step:1353/1700 train_time:131026ms step_avg:96.84ms
+step:1354/1700 train_time:131126ms step_avg:96.84ms
+step:1355/1700 train_time:131227ms step_avg:96.85ms
+step:1356/1700 train_time:131327ms step_avg:96.85ms
+step:1357/1700 train_time:131428ms step_avg:96.85ms
+step:1358/1700 train_time:131528ms step_avg:96.85ms
+step:1359/1700 train_time:131629ms step_avg:96.86ms
+step:1360/1700 train_time:131731ms step_avg:96.86ms
+step:1361/1700 train_time:131832ms step_avg:96.86ms
+step:1362/1700 train_time:131932ms step_avg:96.87ms
+step:1363/1700 train_time:132034ms step_avg:96.87ms
+step:1364/1700 train_time:132134ms step_avg:96.87ms
+step:1365/1700 train_time:132235ms step_avg:96.88ms
+step:1366/1700 train_time:132335ms step_avg:96.88ms
+step:1367/1700 train_time:132435ms step_avg:96.88ms
+step:1368/1700 train_time:132536ms step_avg:96.88ms
+step:1369/1700 train_time:132637ms step_avg:96.89ms
+step:1370/1700 train_time:132737ms step_avg:96.89ms
+step:1371/1700 train_time:132839ms step_avg:96.89ms
+step:1372/1700 train_time:132939ms step_avg:96.89ms
+step:1373/1700 train_time:133039ms step_avg:96.90ms
+step:1374/1700 train_time:133139ms step_avg:96.90ms
+step:1375/1700 train_time:133240ms step_avg:96.90ms
+step:1375/1700 val_loss:3.3574 train_time:133322ms step_avg:96.96ms
+step:1376/1700 train_time:133345ms step_avg:96.91ms
+step:1377/1700 train_time:133447ms step_avg:96.91ms
+step:1378/1700 train_time:133548ms step_avg:96.91ms
+step:1379/1700 train_time:133648ms step_avg:96.92ms
+step:1380/1700 train_time:133748ms step_avg:96.92ms
+step:1381/1700 train_time:133846ms step_avg:96.92ms
+step:1382/1700 train_time:133945ms step_avg:96.92ms
+step:1383/1700 train_time:134044ms step_avg:96.92ms
+step:1384/1700 train_time:134143ms step_avg:96.92ms
+step:1385/1700 train_time:134243ms step_avg:96.93ms
+step:1386/1700 train_time:134345ms step_avg:96.93ms
+step:1387/1700 train_time:134448ms step_avg:96.93ms
+step:1388/1700 train_time:134550ms step_avg:96.94ms
+step:1389/1700 train_time:134653ms step_avg:96.94ms
+step:1390/1700 train_time:134752ms step_avg:96.94ms
+step:1391/1700 train_time:134853ms step_avg:96.95ms
+step:1392/1700 train_time:134956ms step_avg:96.95ms
+step:1393/1700 train_time:135058ms step_avg:96.95ms
+step:1394/1700 train_time:135159ms step_avg:96.96ms
+step:1395/1700 train_time:135260ms step_avg:96.96ms
+step:1396/1700 train_time:135363ms step_avg:96.96ms
+step:1397/1700 train_time:135464ms step_avg:96.97ms
+step:1398/1700 train_time:135567ms step_avg:96.97ms
+step:1399/1700 train_time:135668ms step_avg:96.97ms
+step:1400/1700 train_time:135769ms step_avg:96.98ms
+step:1401/1700 train_time:135871ms step_avg:96.98ms
+step:1402/1700 train_time:135972ms step_avg:96.98ms
+step:1403/1700 train_time:136074ms step_avg:96.99ms
+step:1404/1700 train_time:136175ms step_avg:96.99ms
+step:1405/1700 train_time:136278ms step_avg:96.99ms
+step:1406/1700 train_time:136380ms step_avg:97.00ms
+step:1407/1700 train_time:136482ms step_avg:97.00ms
+step:1408/1700 train_time:136584ms step_avg:97.01ms
+step:1409/1700 train_time:136686ms step_avg:97.01ms
+step:1410/1700 train_time:136786ms step_avg:97.01ms
+step:1411/1700 train_time:136887ms step_avg:97.01ms
+step:1412/1700 train_time:136989ms step_avg:97.02ms
+step:1413/1700 train_time:137092ms step_avg:97.02ms
+step:1414/1700 train_time:137194ms step_avg:97.03ms
+step:1415/1700 train_time:137295ms step_avg:97.03ms
+step:1416/1700 train_time:137395ms step_avg:97.03ms
+step:1417/1700 train_time:137497ms step_avg:97.03ms
+step:1418/1700 train_time:137598ms step_avg:97.04ms
+step:1419/1700 train_time:137701ms step_avg:97.04ms
+step:1420/1700 train_time:137802ms step_avg:97.04ms
+step:1421/1700 train_time:137904ms step_avg:97.05ms
+step:1422/1700 train_time:138005ms step_avg:97.05ms
+step:1423/1700 train_time:138106ms step_avg:97.05ms
+step:1424/1700 train_time:138208ms step_avg:97.06ms
+step:1425/1700 train_time:138309ms step_avg:97.06ms
+step:1426/1700 train_time:138410ms step_avg:97.06ms
+step:1427/1700 train_time:138513ms step_avg:97.07ms
+step:1428/1700 train_time:138614ms step_avg:97.07ms
+step:1429/1700 train_time:138714ms step_avg:97.07ms
+step:1430/1700 train_time:138816ms step_avg:97.07ms
+step:1431/1700 train_time:138918ms step_avg:97.08ms
+step:1432/1700 train_time:139021ms step_avg:97.08ms
+step:1433/1700 train_time:139121ms step_avg:97.08ms
+step:1434/1700 train_time:139222ms step_avg:97.09ms
+step:1435/1700 train_time:139323ms step_avg:97.09ms
+step:1436/1700 train_time:139425ms step_avg:97.09ms
+step:1437/1700 train_time:139527ms step_avg:97.10ms
+step:1438/1700 train_time:139627ms step_avg:97.10ms
+step:1439/1700 train_time:139729ms step_avg:97.10ms
+step:1440/1700 train_time:139833ms step_avg:97.11ms
+step:1441/1700 train_time:139935ms step_avg:97.11ms
+step:1442/1700 train_time:140036ms step_avg:97.11ms
+step:1443/1700 train_time:140137ms step_avg:97.11ms
+step:1444/1700 train_time:140238ms step_avg:97.12ms
+step:1445/1700 train_time:140340ms step_avg:97.12ms
+step:1446/1700 train_time:140442ms step_avg:97.12ms
+step:1447/1700 train_time:140543ms step_avg:97.13ms
+step:1448/1700 train_time:140644ms step_avg:97.13ms
+step:1449/1700 train_time:140744ms step_avg:97.13ms
+step:1450/1700 train_time:140847ms step_avg:97.14ms
+step:1451/1700 train_time:140950ms step_avg:97.14ms
+step:1452/1700 train_time:141051ms step_avg:97.14ms
+step:1453/1700 train_time:141153ms step_avg:97.15ms
+step:1454/1700 train_time:141256ms step_avg:97.15ms
+step:1455/1700 train_time:141357ms step_avg:97.15ms
+step:1456/1700 train_time:141458ms step_avg:97.16ms
+step:1457/1700 train_time:141560ms step_avg:97.16ms
+step:1458/1700 train_time:141661ms step_avg:97.16ms
+step:1459/1700 train_time:141762ms step_avg:97.16ms
+step:1460/1700 train_time:141863ms step_avg:97.17ms
+step:1461/1700 train_time:141964ms step_avg:97.17ms
+step:1462/1700 train_time:142066ms step_avg:97.17ms
+step:1463/1700 train_time:142168ms step_avg:97.18ms
+step:1464/1700 train_time:142269ms step_avg:97.18ms
+step:1465/1700 train_time:142372ms step_avg:97.18ms
+step:1466/1700 train_time:142473ms step_avg:97.18ms
+step:1467/1700 train_time:142573ms step_avg:97.19ms
+step:1468/1700 train_time:142675ms step_avg:97.19ms
+step:1469/1700 train_time:142777ms step_avg:97.19ms
+step:1470/1700 train_time:142880ms step_avg:97.20ms
+step:1471/1700 train_time:142981ms step_avg:97.20ms
+step:1472/1700 train_time:143082ms step_avg:97.20ms
+step:1473/1700 train_time:143183ms step_avg:97.20ms
+step:1474/1700 train_time:143285ms step_avg:97.21ms
+step:1475/1700 train_time:143386ms step_avg:97.21ms
+step:1476/1700 train_time:143489ms step_avg:97.21ms
+step:1477/1700 train_time:143591ms step_avg:97.22ms
+step:1478/1700 train_time:143692ms step_avg:97.22ms
+step:1479/1700 train_time:143793ms step_avg:97.22ms
+step:1480/1700 train_time:143893ms step_avg:97.23ms
+step:1481/1700 train_time:143995ms step_avg:97.23ms
+step:1482/1700 train_time:144097ms step_avg:97.23ms
+step:1483/1700 train_time:144200ms step_avg:97.24ms
+step:1484/1700 train_time:144301ms step_avg:97.24ms
+step:1485/1700 train_time:144403ms step_avg:97.24ms
+step:1486/1700 train_time:144505ms step_avg:97.24ms
+step:1487/1700 train_time:144606ms step_avg:97.25ms
+step:1488/1700 train_time:144709ms step_avg:97.25ms
+step:1489/1700 train_time:144810ms step_avg:97.25ms
+step:1490/1700 train_time:144912ms step_avg:97.26ms
+step:1491/1700 train_time:145013ms step_avg:97.26ms
+step:1492/1700 train_time:145115ms step_avg:97.26ms
+step:1493/1700 train_time:145216ms step_avg:97.26ms
+step:1494/1700 train_time:145318ms step_avg:97.27ms
+step:1495/1700 train_time:145419ms step_avg:97.27ms
+step:1496/1700 train_time:145521ms step_avg:97.27ms
+step:1497/1700 train_time:145622ms step_avg:97.28ms
+step:1498/1700 train_time:145723ms step_avg:97.28ms
+step:1499/1700 train_time:145824ms step_avg:97.28ms
+step:1500/1700 train_time:145925ms step_avg:97.28ms
+step:1500/1700 val_loss:3.3228 train_time:146008ms step_avg:97.34ms
+step:1501/1700 train_time:146031ms step_avg:97.29ms
+step:1502/1700 train_time:146134ms step_avg:97.29ms
+step:1503/1700 train_time:146235ms step_avg:97.30ms
+step:1504/1700 train_time:146336ms step_avg:97.30ms
+step:1505/1700 train_time:146438ms step_avg:97.30ms
+step:1506/1700 train_time:146538ms step_avg:97.30ms
+step:1507/1700 train_time:146639ms step_avg:97.31ms
+step:1508/1700 train_time:146739ms step_avg:97.31ms
+step:1509/1700 train_time:146840ms step_avg:97.31ms
+step:1510/1700 train_time:146942ms step_avg:97.31ms
+step:1511/1700 train_time:147044ms step_avg:97.32ms
+step:1512/1700 train_time:147146ms step_avg:97.32ms
+step:1513/1700 train_time:147248ms step_avg:97.32ms
+step:1514/1700 train_time:147350ms step_avg:97.32ms
+step:1515/1700 train_time:147454ms step_avg:97.33ms
+step:1516/1700 train_time:147554ms step_avg:97.33ms
+step:1517/1700 train_time:147655ms step_avg:97.33ms
+step:1518/1700 train_time:147755ms step_avg:97.34ms
+step:1519/1700 train_time:147858ms step_avg:97.34ms
+step:1520/1700 train_time:147960ms step_avg:97.34ms
+step:1521/1700 train_time:148061ms step_avg:97.34ms
+step:1522/1700 train_time:148163ms step_avg:97.35ms
+step:1523/1700 train_time:148265ms step_avg:97.35ms
+step:1524/1700 train_time:148368ms step_avg:97.35ms
+step:1525/1700 train_time:148470ms step_avg:97.36ms
+step:1526/1700 train_time:148571ms step_avg:97.36ms
+step:1527/1700 train_time:148672ms step_avg:97.36ms
+step:1528/1700 train_time:148775ms step_avg:97.37ms
+step:1529/1700 train_time:148876ms step_avg:97.37ms
+step:1530/1700 train_time:148977ms step_avg:97.37ms
+step:1531/1700 train_time:149078ms step_avg:97.37ms
+step:1532/1700 train_time:149181ms step_avg:97.38ms
+step:1533/1700 train_time:149282ms step_avg:97.38ms
+step:1534/1700 train_time:149384ms step_avg:97.38ms
+step:1535/1700 train_time:149485ms step_avg:97.38ms
+step:1536/1700 train_time:149587ms step_avg:97.39ms
+step:1537/1700 train_time:149688ms step_avg:97.39ms
+step:1538/1700 train_time:149789ms step_avg:97.39ms
+step:1539/1700 train_time:149891ms step_avg:97.40ms
+step:1540/1700 train_time:149992ms step_avg:97.40ms
+step:1541/1700 train_time:150093ms step_avg:97.40ms
+step:1542/1700 train_time:150196ms step_avg:97.40ms
+step:1543/1700 train_time:150299ms step_avg:97.41ms
+step:1544/1700 train_time:150401ms step_avg:97.41ms
+step:1545/1700 train_time:150501ms step_avg:97.41ms
+step:1546/1700 train_time:150603ms step_avg:97.41ms
+step:1547/1700 train_time:150707ms step_avg:97.42ms
+step:1548/1700 train_time:150809ms step_avg:97.42ms
+step:1549/1700 train_time:150911ms step_avg:97.42ms
+step:1550/1700 train_time:151012ms step_avg:97.43ms
+step:1551/1700 train_time:151114ms step_avg:97.43ms
+step:1552/1700 train_time:151214ms step_avg:97.43ms
+step:1553/1700 train_time:151315ms step_avg:97.43ms
+step:1554/1700 train_time:151417ms step_avg:97.44ms
+step:1555/1700 train_time:151518ms step_avg:97.44ms
+step:1556/1700 train_time:151622ms step_avg:97.44ms
+step:1557/1700 train_time:151723ms step_avg:97.45ms
+step:1558/1700 train_time:151826ms step_avg:97.45ms
+step:1559/1700 train_time:151928ms step_avg:97.45ms
+step:1560/1700 train_time:152029ms step_avg:97.45ms
+step:1561/1700 train_time:152130ms step_avg:97.46ms
+step:1562/1700 train_time:152232ms step_avg:97.46ms
+step:1563/1700 train_time:152335ms step_avg:97.46ms
+step:1564/1700 train_time:152436ms step_avg:97.47ms
+step:1565/1700 train_time:152536ms step_avg:97.47ms
+step:1566/1700 train_time:152639ms step_avg:97.47ms
+step:1567/1700 train_time:152740ms step_avg:97.47ms
+step:1568/1700 train_time:152841ms step_avg:97.47ms
+step:1569/1700 train_time:152942ms step_avg:97.48ms
+step:1570/1700 train_time:153045ms step_avg:97.48ms
+step:1571/1700 train_time:153148ms step_avg:97.48ms
+step:1572/1700 train_time:153250ms step_avg:97.49ms
+step:1573/1700 train_time:153350ms step_avg:97.49ms
+step:1574/1700 train_time:153452ms step_avg:97.49ms
+step:1575/1700 train_time:153553ms step_avg:97.49ms
+step:1576/1700 train_time:153656ms step_avg:97.50ms
+step:1577/1700 train_time:153759ms step_avg:97.50ms
+step:1578/1700 train_time:153860ms step_avg:97.50ms
+step:1579/1700 train_time:153961ms step_avg:97.51ms
+step:1580/1700 train_time:154061ms step_avg:97.51ms
+step:1581/1700 train_time:154163ms step_avg:97.51ms
+step:1582/1700 train_time:154265ms step_avg:97.51ms
+step:1583/1700 train_time:154370ms step_avg:97.52ms
+step:1584/1700 train_time:154472ms step_avg:97.52ms
+step:1585/1700 train_time:154573ms step_avg:97.52ms
+step:1586/1700 train_time:154676ms step_avg:97.53ms
+step:1587/1700 train_time:154778ms step_avg:97.53ms
+step:1588/1700 train_time:154878ms step_avg:97.53ms
+step:1589/1700 train_time:154979ms step_avg:97.53ms
+step:1590/1700 train_time:155080ms step_avg:97.53ms
+step:1591/1700 train_time:155181ms step_avg:97.54ms
+step:1592/1700 train_time:155282ms step_avg:97.54ms
+step:1593/1700 train_time:155384ms step_avg:97.54ms
+step:1594/1700 train_time:155488ms step_avg:97.55ms
+step:1595/1700 train_time:155589ms step_avg:97.55ms
+step:1596/1700 train_time:155690ms step_avg:97.55ms
+step:1597/1700 train_time:155792ms step_avg:97.55ms
+step:1598/1700 train_time:155894ms step_avg:97.56ms
+step:1599/1700 train_time:155995ms step_avg:97.56ms
+step:1600/1700 train_time:156097ms step_avg:97.56ms
+step:1601/1700 train_time:156200ms step_avg:97.56ms
+step:1602/1700 train_time:156301ms step_avg:97.57ms
+step:1603/1700 train_time:156402ms step_avg:97.57ms
+step:1604/1700 train_time:156503ms step_avg:97.57ms
+step:1605/1700 train_time:156606ms step_avg:97.57ms
+step:1606/1700 train_time:156708ms step_avg:97.58ms
+step:1607/1700 train_time:156809ms step_avg:97.58ms
+step:1608/1700 train_time:156911ms step_avg:97.58ms
+step:1609/1700 train_time:157012ms step_avg:97.58ms
+step:1610/1700 train_time:157115ms step_avg:97.59ms
+step:1611/1700 train_time:157217ms step_avg:97.59ms
+step:1612/1700 train_time:157318ms step_avg:97.59ms
+step:1613/1700 train_time:157419ms step_avg:97.59ms
+step:1614/1700 train_time:157520ms step_avg:97.60ms
+step:1615/1700 train_time:157620ms step_avg:97.60ms
+step:1616/1700 train_time:157722ms step_avg:97.60ms
+step:1617/1700 train_time:157825ms step_avg:97.60ms
+step:1618/1700 train_time:157928ms step_avg:97.61ms
+step:1619/1700 train_time:158029ms step_avg:97.61ms
+step:1620/1700 train_time:158131ms step_avg:97.61ms
+step:1621/1700 train_time:158231ms step_avg:97.61ms
+step:1622/1700 train_time:158332ms step_avg:97.62ms
+step:1623/1700 train_time:158432ms step_avg:97.62ms
+step:1624/1700 train_time:158536ms step_avg:97.62ms
+step:1625/1700 train_time:158639ms step_avg:97.62ms
+step:1625/1700 val_loss:3.2935 train_time:158723ms step_avg:97.68ms
+step:1626/1700 train_time:158745ms step_avg:97.63ms
+step:1627/1700 train_time:158853ms step_avg:97.64ms
+step:1628/1700 train_time:158954ms step_avg:97.64ms
+step:1629/1700 train_time:159054ms step_avg:97.64ms
+step:1630/1700 train_time:159155ms step_avg:97.64ms
+step:1631/1700 train_time:159255ms step_avg:97.64ms
+step:1632/1700 train_time:159356ms step_avg:97.64ms
+step:1633/1700 train_time:159456ms step_avg:97.65ms
+step:1634/1700 train_time:159557ms step_avg:97.65ms
+step:1635/1700 train_time:159657ms step_avg:97.65ms
+step:1636/1700 train_time:159763ms step_avg:97.65ms
+step:1637/1700 train_time:159865ms step_avg:97.66ms
+step:1638/1700 train_time:159969ms step_avg:97.66ms
+step:1639/1700 train_time:160070ms step_avg:97.66ms
+step:1640/1700 train_time:160172ms step_avg:97.67ms
+step:1641/1700 train_time:160274ms step_avg:97.67ms
+step:1642/1700 train_time:160376ms step_avg:97.67ms
+step:1643/1700 train_time:160478ms step_avg:97.67ms
+step:1644/1700 train_time:160579ms step_avg:97.68ms
+step:1645/1700 train_time:160681ms step_avg:97.68ms
+step:1646/1700 train_time:160783ms step_avg:97.68ms
+step:1647/1700 train_time:160888ms step_avg:97.69ms
+step:1648/1700 train_time:160990ms step_avg:97.69ms
+step:1649/1700 train_time:161092ms step_avg:97.69ms
+step:1650/1700 train_time:161194ms step_avg:97.69ms
+step:1651/1700 train_time:161296ms step_avg:97.70ms
+step:1652/1700 train_time:161397ms step_avg:97.70ms
+step:1653/1700 train_time:161499ms step_avg:97.70ms
+step:1654/1700 train_time:161601ms step_avg:97.70ms
+step:1655/1700 train_time:161704ms step_avg:97.71ms
+step:1656/1700 train_time:161808ms step_avg:97.71ms
+step:1657/1700 train_time:161908ms step_avg:97.71ms
+step:1658/1700 train_time:162011ms step_avg:97.71ms
+step:1659/1700 train_time:162118ms step_avg:97.72ms
+step:1660/1700 train_time:162220ms step_avg:97.72ms
+step:1661/1700 train_time:162324ms step_avg:97.73ms
+step:1662/1700 train_time:162427ms step_avg:97.73ms
+step:1663/1700 train_time:162529ms step_avg:97.73ms
+step:1664/1700 train_time:162631ms step_avg:97.73ms
+step:1665/1700 train_time:162734ms step_avg:97.74ms
+step:1666/1700 train_time:162837ms step_avg:97.74ms
+step:1667/1700 train_time:162939ms step_avg:97.74ms
+step:1668/1700 train_time:163042ms step_avg:97.75ms
+step:1669/1700 train_time:163146ms step_avg:97.75ms
+step:1670/1700 train_time:163246ms step_avg:97.75ms
+step:1671/1700 train_time:163347ms step_avg:97.75ms
+step:1672/1700 train_time:163450ms step_avg:97.76ms
+step:1673/1700 train_time:163551ms step_avg:97.76ms
+step:1674/1700 train_time:163655ms step_avg:97.76ms
+step:1675/1700 train_time:163756ms step_avg:97.76ms
+step:1676/1700 train_time:163858ms step_avg:97.77ms
+step:1677/1700 train_time:163959ms step_avg:97.77ms
+step:1678/1700 train_time:164062ms step_avg:97.77ms
+step:1679/1700 train_time:164166ms step_avg:97.78ms
+step:1680/1700 train_time:164269ms step_avg:97.78ms
+step:1681/1700 train_time:164371ms step_avg:97.78ms
+step:1682/1700 train_time:164475ms step_avg:97.79ms
+step:1683/1700 train_time:164576ms step_avg:97.79ms
+step:1684/1700 train_time:164679ms step_avg:97.79ms
+step:1685/1700 train_time:164781ms step_avg:97.79ms
+step:1686/1700 train_time:164882ms step_avg:97.79ms
+step:1687/1700 train_time:164985ms step_avg:97.80ms
+step:1688/1700 train_time:165087ms step_avg:97.80ms
+step:1689/1700 train_time:165189ms step_avg:97.80ms
+step:1690/1700 train_time:165291ms step_avg:97.81ms
+step:1691/1700 train_time:165393ms step_avg:97.81ms
+step:1692/1700 train_time:165495ms step_avg:97.81ms
+step:1693/1700 train_time:165596ms step_avg:97.81ms
+step:1694/1700 train_time:165699ms step_avg:97.82ms
+step:1695/1700 train_time:165800ms step_avg:97.82ms
+step:1696/1700 train_time:165904ms step_avg:97.82ms
+step:1697/1700 train_time:166008ms step_avg:97.82ms
+step:1698/1700 train_time:166110ms step_avg:97.83ms
+step:1699/1700 train_time:166212ms step_avg:97.83ms
+step:1700/1700 train_time:166315ms step_avg:97.83ms
+step:1700/1700 val_loss:3.2795 train_time:166397ms step_avg:97.88ms
+peak memory allocated: 33278 MiB reserved: 48912 MiB


### PR DESCRIPTION
### 🚀 Add NorMuon Optimizer (Neuron-wise Normalized Muon)

This PR adds **[NorMuon](https://arxiv.org/pdf/2510.05491)**, a variant of the Muon optimizer that introduces **neuron-wise normalization** to improve stability and convergence efficiency.

#### Results
Built on the current master branch (excluding recent PRs), NorMuon reaches the **3.28 loss cutoff in 1700 steps**, 50 steps faster than Muon with identical per-step time.
 With 1700 steps schedule, Muon achieves a validation loss of **3.2859**, while NorMuon achieves **3.2784 / 3.2795 / 3.2793** across three runs.

#### Hyperparameters
We keep the same hyperparameters and have not tuned them for NorMuon. The performance might be further improved with tuning.

#### Notes
This implementation includes two slight modifications from the paper version:

1. The update is rescaled to match the norm of the pre-normalized update.
2. In the algorithm from the paper (line 7), we average the second-order momentum across columns. In this implementation we average across columns if m ≥ n and across rows otherwise, which performs slightly better.

