### PR TITLE
fix: use per-rank device for dummy backward to avoid wasted GPU memory on rank 0

### DIFF
--- a/train_gpt.py
+++ b/train_gpt.py
@@ -18,7 +18,7 @@ os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
 import torch
 
 torch.empty(
-    1, device="cuda", requires_grad=True
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
 ).backward()  # prevents a bug on some systems
 import torch._dynamo as dynamo
 import torch.distributed as dist


### PR DESCRIPTION
This PR fixes an issue where each rank calls `torch.empty(..., device="cuda")`, which defaults to cuda:0.
This causes every worker to create a CUDA context on GPU 0 (~600 MiB per rank).

The fix ensures the dummy backward runs on the correct device, preventing unnecessary memory usage.