### PR TITLE
Implement DREDGE routing bias system

### DIFF
--- a/Train Switch Dredge
+++ b/Train Switch Dredge
@@ -1,0 +1,118 @@
+# Branch: issue/184-train-switch-dredge
+# This patch introduces the DREDGE training-time routing bias system
+# and wires it into train_switch_bank.py in a fully optional, gated way.
+
+############################################
+# modded-nanogpt/dredge/__init__.py
+############################################
+from .dredge_controller import dredge_adjust_switch_scores
+
+############################################
+# modded-nanogpt/dredge/dredge_state.py
+############################################
+import torch
+
+class DredgeState:
+    def __init__(self, num_banks, ema_decay=0.98):
+        self.num_banks = num_banks
+        self.ema_decay = ema_decay
+        self.registered = False
+        self.bank_ema = None
+        self.step = 0
+
+    def _init_state(self, device, dtype):
+        self.bank_ema = torch.zeros(self.num_banks, device=device, dtype=dtype)
+        self.registered = True
+
+    def update(self, bank_indices, reward_signal):
+        if not self.registered:
+            self._init_state(bank_indices.device, reward_signal.dtype)
+
+        with torch.no_grad():
+            for b in bank_indices.unique():
+                mask = bank_indices == b
+                value = reward_signal[mask].mean()
+                self.bank_ema[b] = (
+                    self.ema_decay * self.bank_ema[b]
+                    + (1.0 - self.ema_decay) * value
+                )
+        self.step += 1
+
+############################################
+# modded-nanogpt/dredge/dredge_policy.py
+############################################
+import torch
+
+def compute_dredge_bias(bank_ema, strength):
+    # Normalize EMA to zero mean, unit variance for stability
+    if bank_ema.numel() == 0:
+        return bank_ema
+
+    mean = bank_ema.mean()
+    std = bank_ema.std(unbiased=False).clamp(min=1e-6)
+    normalized = (bank_ema - mean) / std
+    return strength * normalized
+
+############################################
+# modded-nanogpt/dredge/dredge_controller.py
+############################################
+from .dredge_state import DredgeState
+from .dredge_policy import compute_dredge_bias
+
+_dredge_state = None
+
+
+def dredge_adjust_switch_scores(
+    switch_scores,
+    bank_indices,
+    reward_signal,
+    cfg,
+):
+    global _dredge_state
+
+    if not cfg.dredge.enabled:
+        return switch_scores
+
+    if _dredge_state is None:
+        _dredge_state = DredgeState(
+            num_banks=switch_scores.shape[-1],
+            ema_decay=cfg.dredge.ema_decay,
+        )
+
+    if _dredge_state.step < cfg.dredge.warmup_steps:
+        _dredge_state.update(bank_indices, reward_signal)
+        return switch_scores
+
+    _dredge_state.update(bank_indices, reward_signal)
+    bias = compute_dredge_bias(_dredge_state.bank_ema, cfg.dredge.strength)
+
+    return switch_scores + bias
+
+############################################
+# PATCH: train_switch_bank.py (excerpt)
+############################################
+# Add import near top of file
+from dredge import dredge_adjust_switch_scores
+
+# Inside training step, after switch_scores are computed
+# (exact location depends on issue #184 attachment)
+
+# Example integration:
+# switch_scores = compute_switch_scores(...)
+# bank_indices = selected_banks
+# reward_signal = -loss.detach()
+
+switch_scores = dredge_adjust_switch_scores(
+    switch_scores,
+    bank_indices,
+    reward_signal,
+    cfg,
+)
+
+############################################
+# CONFIG ADDITION (example)
+############################################
+# cfg.dredge.enabled = False
+# cfg.dredge.strength = 0.1
+# cfg.dredge.ema_decay = 0.98
+# cfg.dredge.warmup_steps = 1000


### PR DESCRIPTION
This patch introduces the DREDGE training-time routing bias system and integrates it into train_switch_bank.py. It includes the DredgeState and dredge_adjust_switch_scores functionalities for managing switch scores based on reward signals.