### PR TITLE
New Record: Value Embed and Skip Gates (-35 steps, -1.3s)

### DIFF
--- a/records/track_1_short/2025-12-29_VeSkipGates/2851d7dc-d6a5-4e74-8623-57031425db16.txt
+++ b/records/track_1_short/2025-12-29_VeSkipGates/2851d7dc-d6a5-4e74-8623-57031425db16.txt
@@ -1,0 +1,3691 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, v, wd_tensor, lr_tensor):
+    """Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors."""
+    mask = (v * p) >= 0
+    wd_factor = wd_tensor.to(p.dtype)
+    lr_factor = lr_tensor.to(p.dtype)
+    p.copy_(p - (p * mask * wd_factor * lr_factor) - (v * lr_factor))
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn_gate (10 params 6 padding params)
+        2. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        3. reduce scatter attn/mlp round 2 (16 mlp params)
+        4. wait on step 1, then compute update of 1 and schedule all gather
+        5. wait on step 2, then compute update of 2 and schedule all gather
+        6. wait on step 3, then compute update of 3 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        7. wait on 4, then compute update of 4 and schedule all gather
+        8. wait for each all gather to complete and update params
+    Empirically, leading with small params provides an additional 0.2s improvement.
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        group_sizes = [15, 16, 16]
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+
+        all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"]
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params])
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            # The below shape-based heuristic assumes that matrices have their input along the
+            # row dimension and their output along the columns. Gates are an exception.
+            is_gate = 'gate' in ref_param.label
+
+            if "second_momentum_buffer" not in group:
+                if is_gate:
+                    group["second_momentum_buffer"] = torch.zeros_like(updated_grads[..., :, :1])
+                else:
+                    group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1])
+                        if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                    )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if (is_gate or param_shape[-2] >= param_shape[-1]) else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx],
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete and copy results back into original parameter tensors.
+        for info in all_gather_infos:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str],lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for label in label_order:
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.bfloat16, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-1]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+
+                exp_avg = state["exp_avg"]
+                exp_avg_sq = state["exp_avg_sq"]
+                state["step"] += 1
+                t = state["step"]
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (bias2 ** 0.5 / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                # cautious weight decay
+                mask = (update * p_slice) > 0
+                # lr as weight decay schedule
+                eff_weight_decay = lr * wd * getattr(param, "wd_mul", 1.0)
+                update.addcmul_(p_slice, mask, value=eff_weight_decay * lr)
+
+                p_slice.add_(other=update, alpha=-1.0)
+
+                if not is_small:
+                    all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+
+        self._reduce_scatter_futures.clear()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        self.attn_gate = CastedLinear(12, num_heads)
+        self.attn_gate.weight.label = 'attn_gate'
+
+        # only include gates on layers with value embeds used on forward pass
+        if layer_idx in [0,1,8,9,10]:
+            self.value_embed_gate = CastedLinear(12, num_heads)
+            self.value_embed_gate.weight.label = 'value_embed_gate'
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(self.value_embed_gate(x[..., :self.value_embed_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(self.attn_gate(x[..., :self.attn_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset = key_offset[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        adam_labels = ['lm_head', 'value_embed', 'smear_gate', 'skip_gate', 'x0_lambdas', 'embed']
+        scalar_labels = ['scalars']
+        muon_labels = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        scalar_params = [p for p in model.parameters() if getattr(p, 'label', None) in scalar_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + scalar_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, lr=0.008, betas=(0.65, 0.95), eps=1e-8, weight_decay=0.005)
+        self.scalar_opt = DistAdam(scalar_params, scalar_labels, lr=0.008, betas=(0.9, 0.99), eps=1e-8, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.scalar_opt, self.muon_opt]
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.freeze_timer = 0
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+        self.scalar_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            if opt.freeze_timer > 0:
+                opt.freeze_timer -= 1
+                opt.zero_grad(set_to_none=True)
+            else:
+                if self._is_active_step(opt, step):
+                    for group in opt.param_groups:
+                        group["lr"] = group["initial_lr"] * step_lr
+                    opt.step()
+                    opt.zero_grad(set_to_none=True)
+                    if opt.odd_step_only:
+                        opt.should_sync = False
+        
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+
+    def start_transition(self, freeze_count=40):
+        # freeze scalar weights during transition
+        self.scalar_opt.freeze_timer = freeze_count
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1805  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Dec 29 06:07:24 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.90.07              Driver Version: 550.90.07      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   26C    P0            110W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            107W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   39C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   27C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   29C    P0            111W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   29C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 601, 602, 603, 1203, 1204, 1205, 1804, 1805, 1806] for warmup
+Resetting Model
+step:0/1845 val_loss:10.8300 train_time:0ms step_avg:0.03ms
+step:1/1845 train_time:89ms step_avg:88.70ms
+step:2/1845 train_time:113ms step_avg:56.28ms
+step:3/1845 train_time:136ms step_avg:45.26ms
+step:4/1845 train_time:170ms step_avg:42.45ms
+step:5/1845 train_time:204ms step_avg:40.87ms
+step:6/1845 train_time:285ms step_avg:47.44ms
+step:7/1845 train_time:309ms step_avg:44.08ms
+step:8/1845 train_time:342ms step_avg:42.79ms
+step:9/1845 train_time:377ms step_avg:41.85ms
+step:10/1845 train_time:411ms step_avg:41.07ms
+step:11/1845 train_time:446ms step_avg:40.51ms
+step:12/1845 train_time:480ms step_avg:39.98ms
+step:13/1845 train_time:514ms step_avg:39.57ms
+step:14/1845 train_time:549ms step_avg:39.18ms
+step:15/1845 train_time:583ms step_avg:38.88ms
+step:16/1845 train_time:617ms step_avg:38.58ms
+step:17/1845 train_time:652ms step_avg:38.35ms
+step:18/1845 train_time:686ms step_avg:38.11ms
+step:19/1845 train_time:721ms step_avg:37.93ms
+step:20/1845 train_time:755ms step_avg:37.74ms
+step:21/1845 train_time:789ms step_avg:37.59ms
+step:22/1845 train_time:823ms step_avg:37.43ms
+step:23/1845 train_time:858ms step_avg:37.30ms
+step:24/1845 train_time:892ms step_avg:37.18ms
+step:25/1845 train_time:927ms step_avg:37.09ms
+step:26/1845 train_time:962ms step_avg:36.98ms
+step:27/1845 train_time:996ms step_avg:36.90ms
+step:28/1845 train_time:1031ms step_avg:36.81ms
+step:29/1845 train_time:1065ms step_avg:36.73ms
+step:30/1845 train_time:1099ms step_avg:36.64ms
+step:31/1845 train_time:1134ms step_avg:36.57ms
+step:32/1845 train_time:1168ms step_avg:36.50ms
+step:33/1845 train_time:1203ms step_avg:36.45ms
+step:34/1845 train_time:1237ms step_avg:36.39ms
+step:35/1845 train_time:1273ms step_avg:36.37ms
+step:36/1845 train_time:1307ms step_avg:36.31ms
+step:37/1845 train_time:1342ms step_avg:36.27ms
+step:38/1845 train_time:1376ms step_avg:36.21ms
+step:39/1845 train_time:1411ms step_avg:36.18ms
+step:40/1845 train_time:1445ms step_avg:36.12ms
+step:41/1845 train_time:1480ms step_avg:36.09ms
+step:42/1845 train_time:1514ms step_avg:36.05ms
+step:43/1845 train_time:1549ms step_avg:36.02ms
+step:44/1845 train_time:1583ms step_avg:35.98ms
+step:45/1845 train_time:1618ms step_avg:35.95ms
+step:46/1845 train_time:1652ms step_avg:35.92ms
+step:47/1845 train_time:1687ms step_avg:35.90ms
+step:48/1845 train_time:1721ms step_avg:35.86ms
+step:49/1845 train_time:1756ms step_avg:35.84ms
+step:50/1845 train_time:1790ms step_avg:35.80ms
+step:51/1845 train_time:1825ms step_avg:35.78ms
+step:52/1845 train_time:1859ms step_avg:35.75ms
+step:53/1845 train_time:1894ms step_avg:35.73ms
+step:54/1845 train_time:1928ms step_avg:35.71ms
+step:55/1845 train_time:1963ms step_avg:35.70ms
+step:56/1845 train_time:1998ms step_avg:35.67ms
+step:57/1845 train_time:2032ms step_avg:35.66ms
+step:58/1845 train_time:2067ms step_avg:35.63ms
+step:59/1845 train_time:2101ms step_avg:35.61ms
+step:60/1845 train_time:2135ms step_avg:35.59ms
+step:61/1845 train_time:2170ms step_avg:35.58ms
+step:62/1845 train_time:2204ms step_avg:35.55ms
+step:63/1845 train_time:2239ms step_avg:35.54ms
+step:64/1845 train_time:2273ms step_avg:35.52ms
+step:65/1845 train_time:2308ms step_avg:35.51ms
+step:66/1845 train_time:2342ms step_avg:35.49ms
+step:67/1845 train_time:2377ms step_avg:35.48ms
+step:68/1845 train_time:2411ms step_avg:35.46ms
+step:69/1845 train_time:2446ms step_avg:35.45ms
+step:70/1845 train_time:2480ms step_avg:35.44ms
+step:71/1845 train_time:2515ms step_avg:35.43ms
+step:72/1845 train_time:2550ms step_avg:35.41ms
+step:73/1845 train_time:2584ms step_avg:35.40ms
+step:74/1845 train_time:2619ms step_avg:35.39ms
+step:75/1845 train_time:2653ms step_avg:35.38ms
+step:76/1845 train_time:2687ms step_avg:35.36ms
+step:77/1845 train_time:2722ms step_avg:35.35ms
+step:78/1845 train_time:2756ms step_avg:35.33ms
+step:79/1845 train_time:2791ms step_avg:35.33ms
+step:80/1845 train_time:2825ms step_avg:35.31ms
+step:81/1845 train_time:2860ms step_avg:35.30ms
+step:82/1845 train_time:2894ms step_avg:35.29ms
+step:83/1845 train_time:2929ms step_avg:35.29ms
+step:84/1845 train_time:2963ms step_avg:35.27ms
+step:85/1845 train_time:2998ms step_avg:35.27ms
+step:86/1845 train_time:3032ms step_avg:35.25ms
+step:87/1845 train_time:3067ms step_avg:35.25ms
+step:88/1845 train_time:3101ms step_avg:35.24ms
+step:89/1845 train_time:3136ms step_avg:35.23ms
+step:90/1845 train_time:3170ms step_avg:35.22ms
+step:91/1845 train_time:3205ms step_avg:35.22ms
+step:92/1845 train_time:3239ms step_avg:35.20ms
+step:93/1845 train_time:3274ms step_avg:35.20ms
+step:94/1845 train_time:3308ms step_avg:35.19ms
+step:95/1845 train_time:3343ms step_avg:35.19ms
+step:96/1845 train_time:3377ms step_avg:35.17ms
+step:97/1845 train_time:3412ms step_avg:35.17ms
+step:98/1845 train_time:3446ms step_avg:35.16ms
+step:99/1845 train_time:3481ms step_avg:35.16ms
+step:100/1845 train_time:3515ms step_avg:35.15ms
+step:101/1845 train_time:3549ms step_avg:35.14ms
+step:102/1845 train_time:3584ms step_avg:35.13ms
+step:103/1845 train_time:3618ms step_avg:35.13ms
+step:104/1845 train_time:3652ms step_avg:35.12ms
+step:105/1845 train_time:3688ms step_avg:35.12ms
+step:106/1845 train_time:3722ms step_avg:35.11ms
+step:107/1845 train_time:3757ms step_avg:35.11ms
+step:108/1845 train_time:3791ms step_avg:35.10ms
+step:109/1845 train_time:3826ms step_avg:35.10ms
+step:110/1845 train_time:3860ms step_avg:35.09ms
+step:111/1845 train_time:3894ms step_avg:35.09ms
+step:112/1845 train_time:3929ms step_avg:35.08ms
+step:113/1845 train_time:3963ms step_avg:35.07ms
+step:114/1845 train_time:3997ms step_avg:35.07ms
+step:115/1845 train_time:4032ms step_avg:35.06ms
+step:116/1845 train_time:4067ms step_avg:35.06ms
+step:117/1845 train_time:4102ms step_avg:35.06ms
+step:118/1845 train_time:4136ms step_avg:35.05ms
+step:119/1845 train_time:4170ms step_avg:35.05ms
+step:120/1845 train_time:4204ms step_avg:35.04ms
+step:121/1845 train_time:4239ms step_avg:35.03ms
+step:122/1845 train_time:4273ms step_avg:35.03ms
+step:123/1845 train_time:4308ms step_avg:35.02ms
+step:124/1845 train_time:4342ms step_avg:35.02ms
+step:125/1845 train_time:4377ms step_avg:35.01ms
+step:126/1845 train_time:4411ms step_avg:35.01ms
+step:127/1845 train_time:4445ms step_avg:35.00ms
+step:128/1845 train_time:4479ms step_avg:35.00ms
+step:129/1845 train_time:4514ms step_avg:34.99ms
+step:130/1845 train_time:4548ms step_avg:34.99ms
+step:131/1845 train_time:4583ms step_avg:34.98ms
+step:132/1845 train_time:4617ms step_avg:34.98ms
+step:133/1845 train_time:4652ms step_avg:34.98ms
+step:134/1845 train_time:4686ms step_avg:34.97ms
+step:135/1845 train_time:4720ms step_avg:34.97ms
+step:136/1845 train_time:4754ms step_avg:34.96ms
+step:137/1845 train_time:4789ms step_avg:34.96ms
+step:138/1845 train_time:4823ms step_avg:34.95ms
+step:139/1845 train_time:4858ms step_avg:34.95ms
+step:140/1845 train_time:4892ms step_avg:34.94ms
+step:141/1845 train_time:4927ms step_avg:34.94ms
+step:142/1845 train_time:4961ms step_avg:34.93ms
+step:143/1845 train_time:4995ms step_avg:34.93ms
+step:144/1845 train_time:5029ms step_avg:34.93ms
+step:145/1845 train_time:5064ms step_avg:34.92ms
+step:146/1845 train_time:5098ms step_avg:34.92ms
+step:147/1845 train_time:5133ms step_avg:34.92ms
+step:148/1845 train_time:5167ms step_avg:34.91ms
+step:149/1845 train_time:5201ms step_avg:34.91ms
+step:150/1845 train_time:5236ms step_avg:34.90ms
+step:151/1845 train_time:5270ms step_avg:34.90ms
+step:152/1845 train_time:5304ms step_avg:34.90ms
+step:153/1845 train_time:5339ms step_avg:34.89ms
+step:154/1845 train_time:5373ms step_avg:34.89ms
+step:155/1845 train_time:5408ms step_avg:34.89ms
+step:156/1845 train_time:5442ms step_avg:34.88ms
+step:157/1845 train_time:5477ms step_avg:34.88ms
+step:158/1845 train_time:5511ms step_avg:34.88ms
+step:159/1845 train_time:5546ms step_avg:34.88ms
+step:160/1845 train_time:5580ms step_avg:34.87ms
+step:161/1845 train_time:5615ms step_avg:34.87ms
+step:162/1845 train_time:5649ms step_avg:34.87ms
+step:163/1845 train_time:5683ms step_avg:34.87ms
+step:164/1845 train_time:5717ms step_avg:34.86ms
+step:165/1845 train_time:5752ms step_avg:34.86ms
+step:166/1845 train_time:5786ms step_avg:34.86ms
+step:167/1845 train_time:5820ms step_avg:34.85ms
+step:168/1845 train_time:5855ms step_avg:34.85ms
+step:169/1845 train_time:5890ms step_avg:34.85ms
+step:170/1845 train_time:5924ms step_avg:34.85ms
+step:171/1845 train_time:5959ms step_avg:34.85ms
+step:172/1845 train_time:5993ms step_avg:34.84ms
+step:173/1845 train_time:6028ms step_avg:34.84ms
+step:174/1845 train_time:6062ms step_avg:34.84ms
+step:175/1845 train_time:6096ms step_avg:34.84ms
+step:176/1845 train_time:6130ms step_avg:34.83ms
+step:177/1845 train_time:6165ms step_avg:34.83ms
+step:178/1845 train_time:6199ms step_avg:34.83ms
+step:179/1845 train_time:6234ms step_avg:34.83ms
+step:180/1845 train_time:6268ms step_avg:34.82ms
+step:181/1845 train_time:6303ms step_avg:34.82ms
+step:182/1845 train_time:6337ms step_avg:34.82ms
+step:183/1845 train_time:6371ms step_avg:34.82ms
+step:184/1845 train_time:6405ms step_avg:34.81ms
+step:185/1845 train_time:6440ms step_avg:34.81ms
+step:186/1845 train_time:6474ms step_avg:34.81ms
+step:187/1845 train_time:6509ms step_avg:34.81ms
+step:188/1845 train_time:6543ms step_avg:34.80ms
+step:189/1845 train_time:6577ms step_avg:34.80ms
+step:190/1845 train_time:6611ms step_avg:34.80ms
+step:191/1845 train_time:6646ms step_avg:34.80ms
+step:192/1845 train_time:6680ms step_avg:34.79ms
+step:193/1845 train_time:6715ms step_avg:34.79ms
+step:194/1845 train_time:6749ms step_avg:34.79ms
+step:195/1845 train_time:6783ms step_avg:34.79ms
+step:196/1845 train_time:6817ms step_avg:34.78ms
+step:197/1845 train_time:6852ms step_avg:34.78ms
+step:198/1845 train_time:6886ms step_avg:34.78ms
+step:199/1845 train_time:6921ms step_avg:34.78ms
+step:200/1845 train_time:6955ms step_avg:34.77ms
+step:201/1845 train_time:6989ms step_avg:34.77ms
+step:202/1845 train_time:7023ms step_avg:34.77ms
+step:203/1845 train_time:7058ms step_avg:34.77ms
+step:204/1845 train_time:7092ms step_avg:34.77ms
+step:205/1845 train_time:7127ms step_avg:34.77ms
+step:206/1845 train_time:7161ms step_avg:34.76ms
+step:207/1845 train_time:7196ms step_avg:34.76ms
+step:208/1845 train_time:7230ms step_avg:34.76ms
+step:209/1845 train_time:7264ms step_avg:34.76ms
+step:210/1845 train_time:7298ms step_avg:34.75ms
+step:211/1845 train_time:7333ms step_avg:34.75ms
+step:212/1845 train_time:7367ms step_avg:34.75ms
+step:213/1845 train_time:7401ms step_avg:34.75ms
+step:214/1845 train_time:7435ms step_avg:34.74ms
+step:215/1845 train_time:7470ms step_avg:34.74ms
+step:216/1845 train_time:7504ms step_avg:34.74ms
+step:217/1845 train_time:7538ms step_avg:34.74ms
+step:218/1845 train_time:7573ms step_avg:34.74ms
+step:219/1845 train_time:7607ms step_avg:34.74ms
+step:220/1845 train_time:7642ms step_avg:34.73ms
+step:221/1845 train_time:7676ms step_avg:34.73ms
+step:222/1845 train_time:7710ms step_avg:34.73ms
+step:223/1845 train_time:7745ms step_avg:34.73ms
+step:224/1845 train_time:7779ms step_avg:34.73ms
+step:225/1845 train_time:7813ms step_avg:34.73ms
+step:226/1845 train_time:7847ms step_avg:34.72ms
+step:227/1845 train_time:7882ms step_avg:34.72ms
+step:228/1845 train_time:7916ms step_avg:34.72ms
+step:229/1845 train_time:7951ms step_avg:34.72ms
+step:230/1845 train_time:7985ms step_avg:34.72ms
+step:231/1845 train_time:8019ms step_avg:34.72ms
+step:232/1845 train_time:8053ms step_avg:34.71ms
+step:233/1845 train_time:8088ms step_avg:34.71ms
+step:234/1845 train_time:8122ms step_avg:34.71ms
+step:235/1845 train_time:8156ms step_avg:34.71ms
+step:236/1845 train_time:8191ms step_avg:34.71ms
+step:237/1845 train_time:8225ms step_avg:34.71ms
+step:238/1845 train_time:8259ms step_avg:34.70ms
+step:239/1845 train_time:8293ms step_avg:34.70ms
+step:240/1845 train_time:8328ms step_avg:34.70ms
+step:241/1845 train_time:8362ms step_avg:34.70ms
+step:242/1845 train_time:8396ms step_avg:34.70ms
+step:243/1845 train_time:8431ms step_avg:34.69ms
+step:244/1845 train_time:8465ms step_avg:34.69ms
+step:245/1845 train_time:8499ms step_avg:34.69ms
+step:246/1845 train_time:8533ms step_avg:34.69ms
+step:247/1845 train_time:8568ms step_avg:34.69ms
+step:248/1845 train_time:8602ms step_avg:34.69ms
+step:249/1845 train_time:8637ms step_avg:34.69ms
+step:250/1845 train_time:8671ms step_avg:34.68ms
+step:250/1845 val_loss:4.6033 train_time:8707ms step_avg:34.83ms
+step:251/1845 train_time:8728ms step_avg:34.77ms
+step:252/1845 train_time:8747ms step_avg:34.71ms
+step:253/1845 train_time:8776ms step_avg:34.69ms
+step:254/1845 train_time:8811ms step_avg:34.69ms
+step:255/1845 train_time:8847ms step_avg:34.69ms
+step:256/1845 train_time:8882ms step_avg:34.69ms
+step:257/1845 train_time:8917ms step_avg:34.70ms
+step:258/1845 train_time:8951ms step_avg:34.69ms
+step:259/1845 train_time:8985ms step_avg:34.69ms
+step:260/1845 train_time:9020ms step_avg:34.69ms
+step:261/1845 train_time:9054ms step_avg:34.69ms
+step:262/1845 train_time:9088ms step_avg:34.69ms
+step:263/1845 train_time:9122ms step_avg:34.68ms
+step:264/1845 train_time:9156ms step_avg:34.68ms
+step:265/1845 train_time:9190ms step_avg:34.68ms
+step:266/1845 train_time:9225ms step_avg:34.68ms
+step:267/1845 train_time:9259ms step_avg:34.68ms
+step:268/1845 train_time:9293ms step_avg:34.68ms
+step:269/1845 train_time:9327ms step_avg:34.67ms
+step:270/1845 train_time:9361ms step_avg:34.67ms
+step:271/1845 train_time:9395ms step_avg:34.67ms
+step:272/1845 train_time:9429ms step_avg:34.67ms
+step:273/1845 train_time:9464ms step_avg:34.67ms
+step:274/1845 train_time:9498ms step_avg:34.66ms
+step:275/1845 train_time:9532ms step_avg:34.66ms
+step:276/1845 train_time:9566ms step_avg:34.66ms
+step:277/1845 train_time:9600ms step_avg:34.66ms
+step:278/1845 train_time:9634ms step_avg:34.66ms
+step:279/1845 train_time:9669ms step_avg:34.66ms
+step:280/1845 train_time:9703ms step_avg:34.65ms
+step:281/1845 train_time:9737ms step_avg:34.65ms
+step:282/1845 train_time:9771ms step_avg:34.65ms
+step:283/1845 train_time:9806ms step_avg:34.65ms
+step:284/1845 train_time:9840ms step_avg:34.65ms
+step:285/1845 train_time:9875ms step_avg:34.65ms
+step:286/1845 train_time:9908ms step_avg:34.65ms
+step:287/1845 train_time:9943ms step_avg:34.65ms
+step:288/1845 train_time:9977ms step_avg:34.64ms
+step:289/1845 train_time:10012ms step_avg:34.64ms
+step:290/1845 train_time:10046ms step_avg:34.64ms
+step:291/1845 train_time:10081ms step_avg:34.64ms
+step:292/1845 train_time:10115ms step_avg:34.64ms
+step:293/1845 train_time:10149ms step_avg:34.64ms
+step:294/1845 train_time:10183ms step_avg:34.64ms
+step:295/1845 train_time:10218ms step_avg:34.64ms
+step:296/1845 train_time:10251ms step_avg:34.63ms
+step:297/1845 train_time:10286ms step_avg:34.63ms
+step:298/1845 train_time:10320ms step_avg:34.63ms
+step:299/1845 train_time:10354ms step_avg:34.63ms
+step:300/1845 train_time:10388ms step_avg:34.63ms
+step:301/1845 train_time:10423ms step_avg:34.63ms
+step:302/1845 train_time:10457ms step_avg:34.63ms
+step:303/1845 train_time:10491ms step_avg:34.62ms
+step:304/1845 train_time:10525ms step_avg:34.62ms
+step:305/1845 train_time:10560ms step_avg:34.62ms
+step:306/1845 train_time:10594ms step_avg:34.62ms
+step:307/1845 train_time:10628ms step_avg:34.62ms
+step:308/1845 train_time:10662ms step_avg:34.62ms
+step:309/1845 train_time:10697ms step_avg:34.62ms
+step:310/1845 train_time:10731ms step_avg:34.61ms
+step:311/1845 train_time:10765ms step_avg:34.61ms
+step:312/1845 train_time:10799ms step_avg:34.61ms
+step:313/1845 train_time:10833ms step_avg:34.61ms
+step:314/1845 train_time:10867ms step_avg:34.61ms
+step:315/1845 train_time:10901ms step_avg:34.61ms
+step:316/1845 train_time:10936ms step_avg:34.61ms
+step:317/1845 train_time:10970ms step_avg:34.61ms
+step:318/1845 train_time:11004ms step_avg:34.60ms
+step:319/1845 train_time:11039ms step_avg:34.60ms
+step:320/1845 train_time:11073ms step_avg:34.60ms
+step:321/1845 train_time:11107ms step_avg:34.60ms
+step:322/1845 train_time:11141ms step_avg:34.60ms
+step:323/1845 train_time:11175ms step_avg:34.60ms
+step:324/1845 train_time:11209ms step_avg:34.60ms
+step:325/1845 train_time:11244ms step_avg:34.60ms
+step:326/1845 train_time:11278ms step_avg:34.59ms
+step:327/1845 train_time:11312ms step_avg:34.59ms
+step:328/1845 train_time:11346ms step_avg:34.59ms
+step:329/1845 train_time:11380ms step_avg:34.59ms
+step:330/1845 train_time:11414ms step_avg:34.59ms
+step:331/1845 train_time:11449ms step_avg:34.59ms
+step:332/1845 train_time:11483ms step_avg:34.59ms
+step:333/1845 train_time:11517ms step_avg:34.59ms
+step:334/1845 train_time:11551ms step_avg:34.58ms
+step:335/1845 train_time:11585ms step_avg:34.58ms
+step:336/1845 train_time:11620ms step_avg:34.58ms
+step:337/1845 train_time:11654ms step_avg:34.58ms
+step:338/1845 train_time:11688ms step_avg:34.58ms
+step:339/1845 train_time:11723ms step_avg:34.58ms
+step:340/1845 train_time:11757ms step_avg:34.58ms
+step:341/1845 train_time:11791ms step_avg:34.58ms
+step:342/1845 train_time:11825ms step_avg:34.58ms
+step:343/1845 train_time:11860ms step_avg:34.58ms
+step:344/1845 train_time:11894ms step_avg:34.57ms
+step:345/1845 train_time:11928ms step_avg:34.57ms
+step:346/1845 train_time:11962ms step_avg:34.57ms
+step:347/1845 train_time:11997ms step_avg:34.57ms
+step:348/1845 train_time:12031ms step_avg:34.57ms
+step:349/1845 train_time:12065ms step_avg:34.57ms
+step:350/1845 train_time:12099ms step_avg:34.57ms
+step:351/1845 train_time:12134ms step_avg:34.57ms
+step:352/1845 train_time:12168ms step_avg:34.57ms
+step:353/1845 train_time:12202ms step_avg:34.57ms
+step:354/1845 train_time:12236ms step_avg:34.57ms
+step:355/1845 train_time:12271ms step_avg:34.57ms
+step:356/1845 train_time:12305ms step_avg:34.56ms
+step:357/1845 train_time:12339ms step_avg:34.56ms
+step:358/1845 train_time:12373ms step_avg:34.56ms
+step:359/1845 train_time:12408ms step_avg:34.56ms
+step:360/1845 train_time:12442ms step_avg:34.56ms
+step:361/1845 train_time:12477ms step_avg:34.56ms
+step:362/1845 train_time:12511ms step_avg:34.56ms
+step:363/1845 train_time:12545ms step_avg:34.56ms
+step:364/1845 train_time:12579ms step_avg:34.56ms
+step:365/1845 train_time:12614ms step_avg:34.56ms
+step:366/1845 train_time:12648ms step_avg:34.56ms
+step:367/1845 train_time:12683ms step_avg:34.56ms
+step:368/1845 train_time:12716ms step_avg:34.56ms
+step:369/1845 train_time:12751ms step_avg:34.56ms
+step:370/1845 train_time:12785ms step_avg:34.55ms
+step:371/1845 train_time:12819ms step_avg:34.55ms
+step:372/1845 train_time:12853ms step_avg:34.55ms
+step:373/1845 train_time:12888ms step_avg:34.55ms
+step:374/1845 train_time:12922ms step_avg:34.55ms
+step:375/1845 train_time:12956ms step_avg:34.55ms
+step:376/1845 train_time:12991ms step_avg:34.55ms
+step:377/1845 train_time:13025ms step_avg:34.55ms
+step:378/1845 train_time:13059ms step_avg:34.55ms
+step:379/1845 train_time:13093ms step_avg:34.55ms
+step:380/1845 train_time:13127ms step_avg:34.54ms
+step:381/1845 train_time:13161ms step_avg:34.54ms
+step:382/1845 train_time:13195ms step_avg:34.54ms
+step:383/1845 train_time:13230ms step_avg:34.54ms
+step:384/1845 train_time:13264ms step_avg:34.54ms
+step:385/1845 train_time:13298ms step_avg:34.54ms
+step:386/1845 train_time:13332ms step_avg:34.54ms
+step:387/1845 train_time:13366ms step_avg:34.54ms
+step:388/1845 train_time:13400ms step_avg:34.54ms
+step:389/1845 train_time:13435ms step_avg:34.54ms
+step:390/1845 train_time:13469ms step_avg:34.54ms
+step:391/1845 train_time:13503ms step_avg:34.54ms
+step:392/1845 train_time:13537ms step_avg:34.53ms
+step:393/1845 train_time:13572ms step_avg:34.53ms
+step:394/1845 train_time:13606ms step_avg:34.53ms
+step:395/1845 train_time:13640ms step_avg:34.53ms
+step:396/1845 train_time:13674ms step_avg:34.53ms
+step:397/1845 train_time:13709ms step_avg:34.53ms
+step:398/1845 train_time:13743ms step_avg:34.53ms
+step:399/1845 train_time:13777ms step_avg:34.53ms
+step:400/1845 train_time:13811ms step_avg:34.53ms
+step:401/1845 train_time:13846ms step_avg:34.53ms
+step:402/1845 train_time:13880ms step_avg:34.53ms
+step:403/1845 train_time:13915ms step_avg:34.53ms
+step:404/1845 train_time:13949ms step_avg:34.53ms
+step:405/1845 train_time:13983ms step_avg:34.53ms
+step:406/1845 train_time:14017ms step_avg:34.53ms
+step:407/1845 train_time:14052ms step_avg:34.53ms
+step:408/1845 train_time:14086ms step_avg:34.52ms
+step:409/1845 train_time:14120ms step_avg:34.52ms
+step:410/1845 train_time:14154ms step_avg:34.52ms
+step:411/1845 train_time:14189ms step_avg:34.52ms
+step:412/1845 train_time:14223ms step_avg:34.52ms
+step:413/1845 train_time:14257ms step_avg:34.52ms
+step:414/1845 train_time:14291ms step_avg:34.52ms
+step:415/1845 train_time:14325ms step_avg:34.52ms
+step:416/1845 train_time:14359ms step_avg:34.52ms
+step:417/1845 train_time:14394ms step_avg:34.52ms
+step:418/1845 train_time:14428ms step_avg:34.52ms
+step:419/1845 train_time:14462ms step_avg:34.52ms
+step:420/1845 train_time:14496ms step_avg:34.52ms
+step:421/1845 train_time:14531ms step_avg:34.51ms
+step:422/1845 train_time:14565ms step_avg:34.51ms
+step:423/1845 train_time:14599ms step_avg:34.51ms
+step:424/1845 train_time:14633ms step_avg:34.51ms
+step:425/1845 train_time:14667ms step_avg:34.51ms
+step:426/1845 train_time:14701ms step_avg:34.51ms
+step:427/1845 train_time:14736ms step_avg:34.51ms
+step:428/1845 train_time:14770ms step_avg:34.51ms
+step:429/1845 train_time:14804ms step_avg:34.51ms
+step:430/1845 train_time:14838ms step_avg:34.51ms
+step:431/1845 train_time:14872ms step_avg:34.51ms
+step:432/1845 train_time:14906ms step_avg:34.51ms
+step:433/1845 train_time:14941ms step_avg:34.50ms
+step:434/1845 train_time:14975ms step_avg:34.50ms
+step:435/1845 train_time:15009ms step_avg:34.50ms
+step:436/1845 train_time:15043ms step_avg:34.50ms
+step:437/1845 train_time:15078ms step_avg:34.50ms
+step:438/1845 train_time:15112ms step_avg:34.50ms
+step:439/1845 train_time:15146ms step_avg:34.50ms
+step:440/1845 train_time:15180ms step_avg:34.50ms
+step:441/1845 train_time:15214ms step_avg:34.50ms
+step:442/1845 train_time:15248ms step_avg:34.50ms
+step:443/1845 train_time:15283ms step_avg:34.50ms
+step:444/1845 train_time:15317ms step_avg:34.50ms
+step:445/1845 train_time:15351ms step_avg:34.50ms
+step:446/1845 train_time:15385ms step_avg:34.50ms
+step:447/1845 train_time:15419ms step_avg:34.49ms
+step:448/1845 train_time:15453ms step_avg:34.49ms
+step:449/1845 train_time:15488ms step_avg:34.49ms
+step:450/1845 train_time:15521ms step_avg:34.49ms
+step:451/1845 train_time:15556ms step_avg:34.49ms
+step:452/1845 train_time:15590ms step_avg:34.49ms
+step:453/1845 train_time:15624ms step_avg:34.49ms
+step:454/1845 train_time:15658ms step_avg:34.49ms
+step:455/1845 train_time:15693ms step_avg:34.49ms
+step:456/1845 train_time:15727ms step_avg:34.49ms
+step:457/1845 train_time:15761ms step_avg:34.49ms
+step:458/1845 train_time:15795ms step_avg:34.49ms
+step:459/1845 train_time:15829ms step_avg:34.49ms
+step:460/1845 train_time:15863ms step_avg:34.49ms
+step:461/1845 train_time:15897ms step_avg:34.48ms
+step:462/1845 train_time:15931ms step_avg:34.48ms
+step:463/1845 train_time:15966ms step_avg:34.48ms
+step:464/1845 train_time:16000ms step_avg:34.48ms
+step:465/1845 train_time:16034ms step_avg:34.48ms
+step:466/1845 train_time:16069ms step_avg:34.48ms
+step:467/1845 train_time:16103ms step_avg:34.48ms
+step:468/1845 train_time:16137ms step_avg:34.48ms
+step:469/1845 train_time:16171ms step_avg:34.48ms
+step:470/1845 train_time:16205ms step_avg:34.48ms
+step:471/1845 train_time:16240ms step_avg:34.48ms
+step:472/1845 train_time:16274ms step_avg:34.48ms
+step:473/1845 train_time:16308ms step_avg:34.48ms
+step:474/1845 train_time:16342ms step_avg:34.48ms
+step:475/1845 train_time:16377ms step_avg:34.48ms
+step:476/1845 train_time:16411ms step_avg:34.48ms
+step:477/1845 train_time:16445ms step_avg:34.48ms
+step:478/1845 train_time:16479ms step_avg:34.47ms
+step:479/1845 train_time:16513ms step_avg:34.47ms
+step:480/1845 train_time:16547ms step_avg:34.47ms
+step:481/1845 train_time:16582ms step_avg:34.47ms
+step:482/1845 train_time:16616ms step_avg:34.47ms
+step:483/1845 train_time:16650ms step_avg:34.47ms
+step:484/1845 train_time:16684ms step_avg:34.47ms
+step:485/1845 train_time:16718ms step_avg:34.47ms
+step:486/1845 train_time:16753ms step_avg:34.47ms
+step:487/1845 train_time:16787ms step_avg:34.47ms
+step:488/1845 train_time:16821ms step_avg:34.47ms
+step:489/1845 train_time:16856ms step_avg:34.47ms
+step:490/1845 train_time:16890ms step_avg:34.47ms
+step:491/1845 train_time:16924ms step_avg:34.47ms
+step:492/1845 train_time:16958ms step_avg:34.47ms
+step:493/1845 train_time:16992ms step_avg:34.47ms
+step:494/1845 train_time:17026ms step_avg:34.47ms
+step:495/1845 train_time:17061ms step_avg:34.47ms
+step:496/1845 train_time:17095ms step_avg:34.47ms
+step:497/1845 train_time:17129ms step_avg:34.47ms
+step:498/1845 train_time:17163ms step_avg:34.46ms
+step:499/1845 train_time:17198ms step_avg:34.46ms
+step:500/1845 train_time:17232ms step_avg:34.46ms
+step:500/1845 val_loss:4.2987 train_time:17268ms step_avg:34.54ms
+step:501/1845 train_time:17287ms step_avg:34.50ms
+step:502/1845 train_time:17306ms step_avg:34.47ms
+step:503/1845 train_time:17338ms step_avg:34.47ms
+step:504/1845 train_time:17373ms step_avg:34.47ms
+step:505/1845 train_time:17409ms step_avg:34.47ms
+step:506/1845 train_time:17444ms step_avg:34.47ms
+step:507/1845 train_time:17480ms step_avg:34.48ms
+step:508/1845 train_time:17514ms step_avg:34.48ms
+step:509/1845 train_time:17549ms step_avg:34.48ms
+step:510/1845 train_time:17583ms step_avg:34.48ms
+step:511/1845 train_time:17617ms step_avg:34.48ms
+step:512/1845 train_time:17651ms step_avg:34.48ms
+step:513/1845 train_time:17686ms step_avg:34.48ms
+step:514/1845 train_time:17720ms step_avg:34.47ms
+step:515/1845 train_time:17754ms step_avg:34.47ms
+step:516/1845 train_time:17788ms step_avg:34.47ms
+step:517/1845 train_time:17823ms step_avg:34.47ms
+step:518/1845 train_time:17857ms step_avg:34.47ms
+step:519/1845 train_time:17891ms step_avg:34.47ms
+step:520/1845 train_time:17925ms step_avg:34.47ms
+step:521/1845 train_time:17959ms step_avg:34.47ms
+step:522/1845 train_time:17993ms step_avg:34.47ms
+step:523/1845 train_time:18028ms step_avg:34.47ms
+step:524/1845 train_time:18062ms step_avg:34.47ms
+step:525/1845 train_time:18096ms step_avg:34.47ms
+step:526/1845 train_time:18130ms step_avg:34.47ms
+step:527/1845 train_time:18164ms step_avg:34.47ms
+step:528/1845 train_time:18198ms step_avg:34.47ms
+step:529/1845 train_time:18232ms step_avg:34.47ms
+step:530/1845 train_time:18266ms step_avg:34.47ms
+step:531/1845 train_time:18301ms step_avg:34.46ms
+step:532/1845 train_time:18335ms step_avg:34.46ms
+step:533/1845 train_time:18369ms step_avg:34.46ms
+step:534/1845 train_time:18403ms step_avg:34.46ms
+step:535/1845 train_time:18437ms step_avg:34.46ms
+step:536/1845 train_time:18471ms step_avg:34.46ms
+step:537/1845 train_time:18506ms step_avg:34.46ms
+step:538/1845 train_time:18540ms step_avg:34.46ms
+step:539/1845 train_time:18575ms step_avg:34.46ms
+step:540/1845 train_time:18609ms step_avg:34.46ms
+step:541/1845 train_time:18643ms step_avg:34.46ms
+step:542/1845 train_time:18677ms step_avg:34.46ms
+step:543/1845 train_time:18712ms step_avg:34.46ms
+step:544/1845 train_time:18746ms step_avg:34.46ms
+step:545/1845 train_time:18780ms step_avg:34.46ms
+step:546/1845 train_time:18814ms step_avg:34.46ms
+step:547/1845 train_time:18848ms step_avg:34.46ms
+step:548/1845 train_time:18882ms step_avg:34.46ms
+step:549/1845 train_time:18917ms step_avg:34.46ms
+step:550/1845 train_time:18951ms step_avg:34.46ms
+step:551/1845 train_time:18985ms step_avg:34.46ms
+step:552/1845 train_time:19019ms step_avg:34.46ms
+step:553/1845 train_time:19054ms step_avg:34.46ms
+step:554/1845 train_time:19088ms step_avg:34.45ms
+step:555/1845 train_time:19122ms step_avg:34.45ms
+step:556/1845 train_time:19157ms step_avg:34.45ms
+step:557/1845 train_time:19191ms step_avg:34.45ms
+step:558/1845 train_time:19225ms step_avg:34.45ms
+step:559/1845 train_time:19259ms step_avg:34.45ms
+step:560/1845 train_time:19293ms step_avg:34.45ms
+step:561/1845 train_time:19328ms step_avg:34.45ms
+step:562/1845 train_time:19362ms step_avg:34.45ms
+step:563/1845 train_time:19396ms step_avg:34.45ms
+step:564/1845 train_time:19430ms step_avg:34.45ms
+step:565/1845 train_time:19464ms step_avg:34.45ms
+step:566/1845 train_time:19499ms step_avg:34.45ms
+step:567/1845 train_time:19533ms step_avg:34.45ms
+step:568/1845 train_time:19567ms step_avg:34.45ms
+step:569/1845 train_time:19602ms step_avg:34.45ms
+step:570/1845 train_time:19636ms step_avg:34.45ms
+step:571/1845 train_time:19670ms step_avg:34.45ms
+step:572/1845 train_time:19704ms step_avg:34.45ms
+step:573/1845 train_time:19738ms step_avg:34.45ms
+step:574/1845 train_time:19772ms step_avg:34.45ms
+step:575/1845 train_time:19807ms step_avg:34.45ms
+step:576/1845 train_time:19841ms step_avg:34.45ms
+step:577/1845 train_time:19875ms step_avg:34.45ms
+step:578/1845 train_time:19909ms step_avg:34.44ms
+step:579/1845 train_time:19943ms step_avg:34.44ms
+step:580/1845 train_time:19977ms step_avg:34.44ms
+step:581/1845 train_time:20012ms step_avg:34.44ms
+step:582/1845 train_time:20045ms step_avg:34.44ms
+step:583/1845 train_time:20080ms step_avg:34.44ms
+step:584/1845 train_time:20114ms step_avg:34.44ms
+step:585/1845 train_time:20149ms step_avg:34.44ms
+step:586/1845 train_time:20182ms step_avg:34.44ms
+step:587/1845 train_time:20217ms step_avg:34.44ms
+step:588/1845 train_time:20251ms step_avg:34.44ms
+step:589/1845 train_time:20286ms step_avg:34.44ms
+step:590/1845 train_time:20320ms step_avg:34.44ms
+step:591/1845 train_time:20354ms step_avg:34.44ms
+step:592/1845 train_time:20388ms step_avg:34.44ms
+step:593/1845 train_time:20423ms step_avg:34.44ms
+step:594/1845 train_time:20457ms step_avg:34.44ms
+step:595/1845 train_time:20491ms step_avg:34.44ms
+step:596/1845 train_time:20525ms step_avg:34.44ms
+step:597/1845 train_time:20559ms step_avg:34.44ms
+step:598/1845 train_time:20593ms step_avg:34.44ms
+step:599/1845 train_time:20628ms step_avg:34.44ms
+step:600/1845 train_time:20662ms step_avg:34.44ms
+step:601/1845 train_time:20696ms step_avg:34.44ms
+step:602/1845 train_time:20730ms step_avg:34.44ms
+step:603/1845 train_time:20765ms step_avg:34.44ms
+step:604/1845 train_time:20826ms step_avg:34.48ms
+step:605/1845 train_time:20888ms step_avg:34.52ms
+step:606/1845 train_time:20948ms step_avg:34.57ms
+step:607/1845 train_time:21010ms step_avg:34.61ms
+step:608/1845 train_time:21070ms step_avg:34.66ms
+step:609/1845 train_time:21132ms step_avg:34.70ms
+step:610/1845 train_time:21193ms step_avg:34.74ms
+step:611/1845 train_time:21256ms step_avg:34.79ms
+step:612/1845 train_time:21318ms step_avg:34.83ms
+step:613/1845 train_time:21382ms step_avg:34.88ms
+step:614/1845 train_time:21442ms step_avg:34.92ms
+step:615/1845 train_time:21505ms step_avg:34.97ms
+step:616/1845 train_time:21565ms step_avg:35.01ms
+step:617/1845 train_time:21629ms step_avg:35.05ms
+step:618/1845 train_time:21689ms step_avg:35.10ms
+step:619/1845 train_time:21751ms step_avg:35.14ms
+step:620/1845 train_time:21812ms step_avg:35.18ms
+step:621/1845 train_time:21875ms step_avg:35.22ms
+step:622/1845 train_time:21936ms step_avg:35.27ms
+step:623/1845 train_time:21999ms step_avg:35.31ms
+step:624/1845 train_time:22060ms step_avg:35.35ms
+step:625/1845 train_time:22123ms step_avg:35.40ms
+step:626/1845 train_time:22184ms step_avg:35.44ms
+step:627/1845 train_time:22247ms step_avg:35.48ms
+step:628/1845 train_time:22308ms step_avg:35.52ms
+step:629/1845 train_time:22370ms step_avg:35.56ms
+step:630/1845 train_time:22431ms step_avg:35.61ms
+step:631/1845 train_time:22494ms step_avg:35.65ms
+step:632/1845 train_time:22556ms step_avg:35.69ms
+step:633/1845 train_time:22619ms step_avg:35.73ms
+step:634/1845 train_time:22679ms step_avg:35.77ms
+step:635/1845 train_time:22742ms step_avg:35.81ms
+step:636/1845 train_time:22803ms step_avg:35.85ms
+step:637/1845 train_time:22866ms step_avg:35.90ms
+step:638/1845 train_time:22928ms step_avg:35.94ms
+step:639/1845 train_time:22990ms step_avg:35.98ms
+step:640/1845 train_time:23051ms step_avg:36.02ms
+step:641/1845 train_time:23113ms step_avg:36.06ms
+step:642/1845 train_time:23174ms step_avg:36.10ms
+step:643/1845 train_time:23236ms step_avg:36.14ms
+step:644/1845 train_time:23297ms step_avg:36.18ms
+step:645/1845 train_time:23360ms step_avg:36.22ms
+step:646/1845 train_time:23421ms step_avg:36.25ms
+step:647/1845 train_time:23483ms step_avg:36.30ms
+step:648/1845 train_time:23544ms step_avg:36.33ms
+step:649/1845 train_time:23606ms step_avg:36.37ms
+step:650/1845 train_time:23667ms step_avg:36.41ms
+step:651/1845 train_time:23729ms step_avg:36.45ms
+step:652/1845 train_time:23790ms step_avg:36.49ms
+step:653/1845 train_time:23852ms step_avg:36.53ms
+step:654/1845 train_time:23913ms step_avg:36.56ms
+step:655/1845 train_time:23975ms step_avg:36.60ms
+step:656/1845 train_time:24037ms step_avg:36.64ms
+step:657/1845 train_time:24099ms step_avg:36.68ms
+step:658/1845 train_time:24160ms step_avg:36.72ms
+step:659/1845 train_time:24223ms step_avg:36.76ms
+step:660/1845 train_time:24283ms step_avg:36.79ms
+step:661/1845 train_time:24346ms step_avg:36.83ms
+step:662/1845 train_time:24406ms step_avg:36.87ms
+step:663/1845 train_time:24469ms step_avg:36.91ms
+step:664/1845 train_time:24530ms step_avg:36.94ms
+step:665/1845 train_time:24593ms step_avg:36.98ms
+step:666/1845 train_time:24655ms step_avg:37.02ms
+step:667/1845 train_time:24718ms step_avg:37.06ms
+step:668/1845 train_time:24779ms step_avg:37.09ms
+step:669/1845 train_time:24842ms step_avg:37.13ms
+step:670/1845 train_time:24903ms step_avg:37.17ms
+step:671/1845 train_time:24965ms step_avg:37.21ms
+step:672/1845 train_time:25026ms step_avg:37.24ms
+step:673/1845 train_time:25088ms step_avg:37.28ms
+step:674/1845 train_time:25149ms step_avg:37.31ms
+step:675/1845 train_time:25211ms step_avg:37.35ms
+step:676/1845 train_time:25272ms step_avg:37.38ms
+step:677/1845 train_time:25335ms step_avg:37.42ms
+step:678/1845 train_time:25396ms step_avg:37.46ms
+step:679/1845 train_time:25459ms step_avg:37.50ms
+step:680/1845 train_time:25521ms step_avg:37.53ms
+step:681/1845 train_time:25583ms step_avg:37.57ms
+step:682/1845 train_time:25643ms step_avg:37.60ms
+step:683/1845 train_time:25706ms step_avg:37.64ms
+step:684/1845 train_time:25767ms step_avg:37.67ms
+step:685/1845 train_time:25830ms step_avg:37.71ms
+step:686/1845 train_time:25890ms step_avg:37.74ms
+step:687/1845 train_time:25953ms step_avg:37.78ms
+step:688/1845 train_time:26013ms step_avg:37.81ms
+step:689/1845 train_time:26075ms step_avg:37.84ms
+step:690/1845 train_time:26137ms step_avg:37.88ms
+step:691/1845 train_time:26199ms step_avg:37.91ms
+step:692/1845 train_time:26259ms step_avg:37.95ms
+step:693/1845 train_time:26322ms step_avg:37.98ms
+step:694/1845 train_time:26383ms step_avg:38.02ms
+step:695/1845 train_time:26445ms step_avg:38.05ms
+step:696/1845 train_time:26506ms step_avg:38.08ms
+step:697/1845 train_time:26568ms step_avg:38.12ms
+step:698/1845 train_time:26629ms step_avg:38.15ms
+step:699/1845 train_time:26692ms step_avg:38.19ms
+step:700/1845 train_time:26753ms step_avg:38.22ms
+step:701/1845 train_time:26816ms step_avg:38.25ms
+step:702/1845 train_time:26877ms step_avg:38.29ms
+step:703/1845 train_time:26940ms step_avg:38.32ms
+step:704/1845 train_time:27001ms step_avg:38.35ms
+step:705/1845 train_time:27063ms step_avg:38.39ms
+step:706/1845 train_time:27124ms step_avg:38.42ms
+step:707/1845 train_time:27187ms step_avg:38.45ms
+step:708/1845 train_time:27247ms step_avg:38.49ms
+step:709/1845 train_time:27310ms step_avg:38.52ms
+step:710/1845 train_time:27371ms step_avg:38.55ms
+step:711/1845 train_time:27433ms step_avg:38.58ms
+step:712/1845 train_time:27493ms step_avg:38.61ms
+step:713/1845 train_time:27555ms step_avg:38.65ms
+step:714/1845 train_time:27617ms step_avg:38.68ms
+step:715/1845 train_time:27680ms step_avg:38.71ms
+step:716/1845 train_time:27740ms step_avg:38.74ms
+step:717/1845 train_time:27803ms step_avg:38.78ms
+step:718/1845 train_time:27864ms step_avg:38.81ms
+step:719/1845 train_time:27927ms step_avg:38.84ms
+step:720/1845 train_time:27988ms step_avg:38.87ms
+step:721/1845 train_time:28050ms step_avg:38.90ms
+step:722/1845 train_time:28111ms step_avg:38.93ms
+step:723/1845 train_time:28173ms step_avg:38.97ms
+step:724/1845 train_time:28235ms step_avg:39.00ms
+step:725/1845 train_time:28297ms step_avg:39.03ms
+step:726/1845 train_time:28358ms step_avg:39.06ms
+step:727/1845 train_time:28420ms step_avg:39.09ms
+step:728/1845 train_time:28481ms step_avg:39.12ms
+step:729/1845 train_time:28543ms step_avg:39.15ms
+step:730/1845 train_time:28604ms step_avg:39.18ms
+step:731/1845 train_time:28667ms step_avg:39.22ms
+step:732/1845 train_time:28728ms step_avg:39.25ms
+step:733/1845 train_time:28791ms step_avg:39.28ms
+step:734/1845 train_time:28852ms step_avg:39.31ms
+step:735/1845 train_time:28915ms step_avg:39.34ms
+step:736/1845 train_time:28976ms step_avg:39.37ms
+step:737/1845 train_time:29038ms step_avg:39.40ms
+step:738/1845 train_time:29099ms step_avg:39.43ms
+step:739/1845 train_time:29162ms step_avg:39.46ms
+step:740/1845 train_time:29223ms step_avg:39.49ms
+step:741/1845 train_time:29286ms step_avg:39.52ms
+step:742/1845 train_time:29347ms step_avg:39.55ms
+step:743/1845 train_time:29410ms step_avg:39.58ms
+step:744/1845 train_time:29470ms step_avg:39.61ms
+step:745/1845 train_time:29532ms step_avg:39.64ms
+step:746/1845 train_time:29593ms step_avg:39.67ms
+step:747/1845 train_time:29656ms step_avg:39.70ms
+step:748/1845 train_time:29717ms step_avg:39.73ms
+step:749/1845 train_time:29780ms step_avg:39.76ms
+step:750/1845 train_time:29841ms step_avg:39.79ms
+step:750/1845 val_loss:4.0175 train_time:29905ms step_avg:39.87ms
+step:751/1845 train_time:29924ms step_avg:39.85ms
+step:752/1845 train_time:29967ms step_avg:39.85ms
+step:753/1845 train_time:30033ms step_avg:39.88ms
+step:754/1845 train_time:30096ms step_avg:39.92ms
+step:755/1845 train_time:30160ms step_avg:39.95ms
+step:756/1845 train_time:30222ms step_avg:39.98ms
+step:757/1845 train_time:30284ms step_avg:40.01ms
+step:758/1845 train_time:30345ms step_avg:40.03ms
+step:759/1845 train_time:30407ms step_avg:40.06ms
+step:760/1845 train_time:30467ms step_avg:40.09ms
+step:761/1845 train_time:30529ms step_avg:40.12ms
+step:762/1845 train_time:30589ms step_avg:40.14ms
+step:763/1845 train_time:30651ms step_avg:40.17ms
+step:764/1845 train_time:30711ms step_avg:40.20ms
+step:765/1845 train_time:30773ms step_avg:40.23ms
+step:766/1845 train_time:30834ms step_avg:40.25ms
+step:767/1845 train_time:30897ms step_avg:40.28ms
+step:768/1845 train_time:30959ms step_avg:40.31ms
+step:769/1845 train_time:31022ms step_avg:40.34ms
+step:770/1845 train_time:31083ms step_avg:40.37ms
+step:771/1845 train_time:31146ms step_avg:40.40ms
+step:772/1845 train_time:31207ms step_avg:40.42ms
+step:773/1845 train_time:31270ms step_avg:40.45ms
+step:774/1845 train_time:31331ms step_avg:40.48ms
+step:775/1845 train_time:31394ms step_avg:40.51ms
+step:776/1845 train_time:31455ms step_avg:40.53ms
+step:777/1845 train_time:31517ms step_avg:40.56ms
+step:778/1845 train_time:31577ms step_avg:40.59ms
+step:779/1845 train_time:31640ms step_avg:40.62ms
+step:780/1845 train_time:31700ms step_avg:40.64ms
+step:781/1845 train_time:31763ms step_avg:40.67ms
+step:782/1845 train_time:31824ms step_avg:40.70ms
+step:783/1845 train_time:31887ms step_avg:40.72ms
+step:784/1845 train_time:31948ms step_avg:40.75ms
+step:785/1845 train_time:32011ms step_avg:40.78ms
+step:786/1845 train_time:32073ms step_avg:40.80ms
+step:787/1845 train_time:32136ms step_avg:40.83ms
+step:788/1845 train_time:32197ms step_avg:40.86ms
+step:789/1845 train_time:32260ms step_avg:40.89ms
+step:790/1845 train_time:32322ms step_avg:40.91ms
+step:791/1845 train_time:32384ms step_avg:40.94ms
+step:792/1845 train_time:32445ms step_avg:40.97ms
+step:793/1845 train_time:32507ms step_avg:40.99ms
+step:794/1845 train_time:32568ms step_avg:41.02ms
+step:795/1845 train_time:32630ms step_avg:41.04ms
+step:796/1845 train_time:32690ms step_avg:41.07ms
+step:797/1845 train_time:32752ms step_avg:41.09ms
+step:798/1845 train_time:32814ms step_avg:41.12ms
+step:799/1845 train_time:32876ms step_avg:41.15ms
+step:800/1845 train_time:32938ms step_avg:41.17ms
+step:801/1845 train_time:33000ms step_avg:41.20ms
+step:802/1845 train_time:33061ms step_avg:41.22ms
+step:803/1845 train_time:33123ms step_avg:41.25ms
+step:804/1845 train_time:33184ms step_avg:41.27ms
+step:805/1845 train_time:33247ms step_avg:41.30ms
+step:806/1845 train_time:33307ms step_avg:41.32ms
+step:807/1845 train_time:33370ms step_avg:41.35ms
+step:808/1845 train_time:33432ms step_avg:41.38ms
+step:809/1845 train_time:33494ms step_avg:41.40ms
+step:810/1845 train_time:33555ms step_avg:41.43ms
+step:811/1845 train_time:33617ms step_avg:41.45ms
+step:812/1845 train_time:33678ms step_avg:41.48ms
+step:813/1845 train_time:33740ms step_avg:41.50ms
+step:814/1845 train_time:33801ms step_avg:41.52ms
+step:815/1845 train_time:33864ms step_avg:41.55ms
+step:816/1845 train_time:33924ms step_avg:41.57ms
+step:817/1845 train_time:33987ms step_avg:41.60ms
+step:818/1845 train_time:34047ms step_avg:41.62ms
+step:819/1845 train_time:34110ms step_avg:41.65ms
+step:820/1845 train_time:34171ms step_avg:41.67ms
+step:821/1845 train_time:34234ms step_avg:41.70ms
+step:822/1845 train_time:34296ms step_avg:41.72ms
+step:823/1845 train_time:34359ms step_avg:41.75ms
+step:824/1845 train_time:34419ms step_avg:41.77ms
+step:825/1845 train_time:34482ms step_avg:41.80ms
+step:826/1845 train_time:34543ms step_avg:41.82ms
+step:827/1845 train_time:34606ms step_avg:41.84ms
+step:828/1845 train_time:34666ms step_avg:41.87ms
+step:829/1845 train_time:34728ms step_avg:41.89ms
+step:830/1845 train_time:34789ms step_avg:41.91ms
+step:831/1845 train_time:34852ms step_avg:41.94ms
+step:832/1845 train_time:34913ms step_avg:41.96ms
+step:833/1845 train_time:34976ms step_avg:41.99ms
+step:834/1845 train_time:35037ms step_avg:42.01ms
+step:835/1845 train_time:35099ms step_avg:42.03ms
+step:836/1845 train_time:35160ms step_avg:42.06ms
+step:837/1845 train_time:35222ms step_avg:42.08ms
+step:838/1845 train_time:35283ms step_avg:42.10ms
+step:839/1845 train_time:35345ms step_avg:42.13ms
+step:840/1845 train_time:35406ms step_avg:42.15ms
+step:841/1845 train_time:35468ms step_avg:42.17ms
+step:842/1845 train_time:35528ms step_avg:42.20ms
+step:843/1845 train_time:35592ms step_avg:42.22ms
+step:844/1845 train_time:35653ms step_avg:42.24ms
+step:845/1845 train_time:35715ms step_avg:42.27ms
+step:846/1845 train_time:35776ms step_avg:42.29ms
+step:847/1845 train_time:35839ms step_avg:42.31ms
+step:848/1845 train_time:35899ms step_avg:42.33ms
+step:849/1845 train_time:35962ms step_avg:42.36ms
+step:850/1845 train_time:36023ms step_avg:42.38ms
+step:851/1845 train_time:36085ms step_avg:42.40ms
+step:852/1845 train_time:36146ms step_avg:42.43ms
+step:853/1845 train_time:36209ms step_avg:42.45ms
+step:854/1845 train_time:36271ms step_avg:42.47ms
+step:855/1845 train_time:36334ms step_avg:42.50ms
+step:856/1845 train_time:36396ms step_avg:42.52ms
+step:857/1845 train_time:36458ms step_avg:42.54ms
+step:858/1845 train_time:36519ms step_avg:42.56ms
+step:859/1845 train_time:36582ms step_avg:42.59ms
+step:860/1845 train_time:36643ms step_avg:42.61ms
+step:861/1845 train_time:36706ms step_avg:42.63ms
+step:862/1845 train_time:36767ms step_avg:42.65ms
+step:863/1845 train_time:36829ms step_avg:42.68ms
+step:864/1845 train_time:36890ms step_avg:42.70ms
+step:865/1845 train_time:36952ms step_avg:42.72ms
+step:866/1845 train_time:37013ms step_avg:42.74ms
+step:867/1845 train_time:37076ms step_avg:42.76ms
+step:868/1845 train_time:37138ms step_avg:42.79ms
+step:869/1845 train_time:37200ms step_avg:42.81ms
+step:870/1845 train_time:37261ms step_avg:42.83ms
+step:871/1845 train_time:37323ms step_avg:42.85ms
+step:872/1845 train_time:37384ms step_avg:42.87ms
+step:873/1845 train_time:37447ms step_avg:42.89ms
+step:874/1845 train_time:37508ms step_avg:42.91ms
+step:875/1845 train_time:37570ms step_avg:42.94ms
+step:876/1845 train_time:37631ms step_avg:42.96ms
+step:877/1845 train_time:37693ms step_avg:42.98ms
+step:878/1845 train_time:37754ms step_avg:43.00ms
+step:879/1845 train_time:37817ms step_avg:43.02ms
+step:880/1845 train_time:37878ms step_avg:43.04ms
+step:881/1845 train_time:37941ms step_avg:43.07ms
+step:882/1845 train_time:38001ms step_avg:43.09ms
+step:883/1845 train_time:38063ms step_avg:43.11ms
+step:884/1845 train_time:38124ms step_avg:43.13ms
+step:885/1845 train_time:38186ms step_avg:43.15ms
+step:886/1845 train_time:38246ms step_avg:43.17ms
+step:887/1845 train_time:38309ms step_avg:43.19ms
+step:888/1845 train_time:38370ms step_avg:43.21ms
+step:889/1845 train_time:38432ms step_avg:43.23ms
+step:890/1845 train_time:38494ms step_avg:43.25ms
+step:891/1845 train_time:38557ms step_avg:43.27ms
+step:892/1845 train_time:38618ms step_avg:43.29ms
+step:893/1845 train_time:38680ms step_avg:43.31ms
+step:894/1845 train_time:38740ms step_avg:43.33ms
+step:895/1845 train_time:38803ms step_avg:43.35ms
+step:896/1845 train_time:38864ms step_avg:43.38ms
+step:897/1845 train_time:38926ms step_avg:43.40ms
+step:898/1845 train_time:38986ms step_avg:43.41ms
+step:899/1845 train_time:39049ms step_avg:43.44ms
+step:900/1845 train_time:39109ms step_avg:43.45ms
+step:901/1845 train_time:39172ms step_avg:43.48ms
+step:902/1845 train_time:39232ms step_avg:43.49ms
+step:903/1845 train_time:39295ms step_avg:43.52ms
+step:904/1845 train_time:39358ms step_avg:43.54ms
+step:905/1845 train_time:39419ms step_avg:43.56ms
+step:906/1845 train_time:39480ms step_avg:43.58ms
+step:907/1845 train_time:39542ms step_avg:43.60ms
+step:908/1845 train_time:39603ms step_avg:43.62ms
+step:909/1845 train_time:39666ms step_avg:43.64ms
+step:910/1845 train_time:39726ms step_avg:43.66ms
+step:911/1845 train_time:39788ms step_avg:43.68ms
+step:912/1845 train_time:39849ms step_avg:43.69ms
+step:913/1845 train_time:39911ms step_avg:43.71ms
+step:914/1845 train_time:39972ms step_avg:43.73ms
+step:915/1845 train_time:40035ms step_avg:43.75ms
+step:916/1845 train_time:40096ms step_avg:43.77ms
+step:917/1845 train_time:40159ms step_avg:43.79ms
+step:918/1845 train_time:40219ms step_avg:43.81ms
+step:919/1845 train_time:40282ms step_avg:43.83ms
+step:920/1845 train_time:40343ms step_avg:43.85ms
+step:921/1845 train_time:40406ms step_avg:43.87ms
+step:922/1845 train_time:40467ms step_avg:43.89ms
+step:923/1845 train_time:40529ms step_avg:43.91ms
+step:924/1845 train_time:40590ms step_avg:43.93ms
+step:925/1845 train_time:40654ms step_avg:43.95ms
+step:926/1845 train_time:40715ms step_avg:43.97ms
+step:927/1845 train_time:40778ms step_avg:43.99ms
+step:928/1845 train_time:40839ms step_avg:44.01ms
+step:929/1845 train_time:40901ms step_avg:44.03ms
+step:930/1845 train_time:40963ms step_avg:44.05ms
+step:931/1845 train_time:41026ms step_avg:44.07ms
+step:932/1845 train_time:41086ms step_avg:44.08ms
+step:933/1845 train_time:41148ms step_avg:44.10ms
+step:934/1845 train_time:41209ms step_avg:44.12ms
+step:935/1845 train_time:41271ms step_avg:44.14ms
+step:936/1845 train_time:41333ms step_avg:44.16ms
+step:937/1845 train_time:41396ms step_avg:44.18ms
+step:938/1845 train_time:41458ms step_avg:44.20ms
+step:939/1845 train_time:41520ms step_avg:44.22ms
+step:940/1845 train_time:41581ms step_avg:44.24ms
+step:941/1845 train_time:41645ms step_avg:44.26ms
+step:942/1845 train_time:41705ms step_avg:44.27ms
+step:943/1845 train_time:41768ms step_avg:44.29ms
+step:944/1845 train_time:41828ms step_avg:44.31ms
+step:945/1845 train_time:41890ms step_avg:44.33ms
+step:946/1845 train_time:41951ms step_avg:44.35ms
+step:947/1845 train_time:42014ms step_avg:44.37ms
+step:948/1845 train_time:42076ms step_avg:44.38ms
+step:949/1845 train_time:42138ms step_avg:44.40ms
+step:950/1845 train_time:42198ms step_avg:44.42ms
+step:951/1845 train_time:42261ms step_avg:44.44ms
+step:952/1845 train_time:42321ms step_avg:44.46ms
+step:953/1845 train_time:42384ms step_avg:44.47ms
+step:954/1845 train_time:42444ms step_avg:44.49ms
+step:955/1845 train_time:42506ms step_avg:44.51ms
+step:956/1845 train_time:42568ms step_avg:44.53ms
+step:957/1845 train_time:42629ms step_avg:44.54ms
+step:958/1845 train_time:42690ms step_avg:44.56ms
+step:959/1845 train_time:42753ms step_avg:44.58ms
+step:960/1845 train_time:42814ms step_avg:44.60ms
+step:961/1845 train_time:42875ms step_avg:44.62ms
+step:962/1845 train_time:42937ms step_avg:44.63ms
+step:963/1845 train_time:42999ms step_avg:44.65ms
+step:964/1845 train_time:43060ms step_avg:44.67ms
+step:965/1845 train_time:43122ms step_avg:44.69ms
+step:966/1845 train_time:43183ms step_avg:44.70ms
+step:967/1845 train_time:43245ms step_avg:44.72ms
+step:968/1845 train_time:43306ms step_avg:44.74ms
+step:969/1845 train_time:43368ms step_avg:44.76ms
+step:970/1845 train_time:43428ms step_avg:44.77ms
+step:971/1845 train_time:43491ms step_avg:44.79ms
+step:972/1845 train_time:43552ms step_avg:44.81ms
+step:973/1845 train_time:43615ms step_avg:44.82ms
+step:974/1845 train_time:43676ms step_avg:44.84ms
+step:975/1845 train_time:43738ms step_avg:44.86ms
+step:976/1845 train_time:43799ms step_avg:44.88ms
+step:977/1845 train_time:43861ms step_avg:44.89ms
+step:978/1845 train_time:43922ms step_avg:44.91ms
+step:979/1845 train_time:43985ms step_avg:44.93ms
+step:980/1845 train_time:44046ms step_avg:44.94ms
+step:981/1845 train_time:44108ms step_avg:44.96ms
+step:982/1845 train_time:44169ms step_avg:44.98ms
+step:983/1845 train_time:44232ms step_avg:45.00ms
+step:984/1845 train_time:44294ms step_avg:45.01ms
+step:985/1845 train_time:44356ms step_avg:45.03ms
+step:986/1845 train_time:44417ms step_avg:45.05ms
+step:987/1845 train_time:44479ms step_avg:45.06ms
+step:988/1845 train_time:44540ms step_avg:45.08ms
+step:989/1845 train_time:44602ms step_avg:45.10ms
+step:990/1845 train_time:44662ms step_avg:45.11ms
+step:991/1845 train_time:44725ms step_avg:45.13ms
+step:992/1845 train_time:44785ms step_avg:45.15ms
+step:993/1845 train_time:44847ms step_avg:45.16ms
+step:994/1845 train_time:44908ms step_avg:45.18ms
+step:995/1845 train_time:44970ms step_avg:45.20ms
+step:996/1845 train_time:45031ms step_avg:45.21ms
+step:997/1845 train_time:45094ms step_avg:45.23ms
+step:998/1845 train_time:45155ms step_avg:45.25ms
+step:999/1845 train_time:45218ms step_avg:45.26ms
+step:1000/1845 train_time:45279ms step_avg:45.28ms
+step:1000/1845 val_loss:3.7828 train_time:45342ms step_avg:45.34ms
+step:1001/1845 train_time:45361ms step_avg:45.32ms
+step:1002/1845 train_time:45404ms step_avg:45.31ms
+step:1003/1845 train_time:45469ms step_avg:45.33ms
+step:1004/1845 train_time:45532ms step_avg:45.35ms
+step:1005/1845 train_time:45595ms step_avg:45.37ms
+step:1006/1845 train_time:45657ms step_avg:45.38ms
+step:1007/1845 train_time:45719ms step_avg:45.40ms
+step:1008/1845 train_time:45780ms step_avg:45.42ms
+step:1009/1845 train_time:45842ms step_avg:45.43ms
+step:1010/1845 train_time:45902ms step_avg:45.45ms
+step:1011/1845 train_time:45964ms step_avg:45.46ms
+step:1012/1845 train_time:46024ms step_avg:45.48ms
+step:1013/1845 train_time:46086ms step_avg:45.49ms
+step:1014/1845 train_time:46146ms step_avg:45.51ms
+step:1015/1845 train_time:46208ms step_avg:45.53ms
+step:1016/1845 train_time:46269ms step_avg:45.54ms
+step:1017/1845 train_time:46332ms step_avg:45.56ms
+step:1018/1845 train_time:46395ms step_avg:45.57ms
+step:1019/1845 train_time:46458ms step_avg:45.59ms
+step:1020/1845 train_time:46520ms step_avg:45.61ms
+step:1021/1845 train_time:46583ms step_avg:45.62ms
+step:1022/1845 train_time:46644ms step_avg:45.64ms
+step:1023/1845 train_time:46706ms step_avg:45.66ms
+step:1024/1845 train_time:46767ms step_avg:45.67ms
+step:1025/1845 train_time:46830ms step_avg:45.69ms
+step:1026/1845 train_time:46891ms step_avg:45.70ms
+step:1027/1845 train_time:46954ms step_avg:45.72ms
+step:1028/1845 train_time:47014ms step_avg:45.73ms
+step:1029/1845 train_time:47076ms step_avg:45.75ms
+step:1030/1845 train_time:47137ms step_avg:45.76ms
+step:1031/1845 train_time:47200ms step_avg:45.78ms
+step:1032/1845 train_time:47261ms step_avg:45.80ms
+step:1033/1845 train_time:47324ms step_avg:45.81ms
+step:1034/1845 train_time:47385ms step_avg:45.83ms
+step:1035/1845 train_time:47448ms step_avg:45.84ms
+step:1036/1845 train_time:47510ms step_avg:45.86ms
+step:1037/1845 train_time:47573ms step_avg:45.88ms
+step:1038/1845 train_time:47635ms step_avg:45.89ms
+step:1039/1845 train_time:47697ms step_avg:45.91ms
+step:1040/1845 train_time:47758ms step_avg:45.92ms
+step:1041/1845 train_time:47820ms step_avg:45.94ms
+step:1042/1845 train_time:47881ms step_avg:45.95ms
+step:1043/1845 train_time:47943ms step_avg:45.97ms
+step:1044/1845 train_time:48004ms step_avg:45.98ms
+step:1045/1845 train_time:48066ms step_avg:46.00ms
+step:1046/1845 train_time:48126ms step_avg:46.01ms
+step:1047/1845 train_time:48188ms step_avg:46.02ms
+step:1048/1845 train_time:48249ms step_avg:46.04ms
+step:1049/1845 train_time:48311ms step_avg:46.05ms
+step:1050/1845 train_time:48372ms step_avg:46.07ms
+step:1051/1845 train_time:48435ms step_avg:46.08ms
+step:1052/1845 train_time:48496ms step_avg:46.10ms
+step:1053/1845 train_time:48559ms step_avg:46.12ms
+step:1054/1845 train_time:48621ms step_avg:46.13ms
+step:1055/1845 train_time:48683ms step_avg:46.15ms
+step:1056/1845 train_time:48745ms step_avg:46.16ms
+step:1057/1845 train_time:48807ms step_avg:46.17ms
+step:1058/1845 train_time:48868ms step_avg:46.19ms
+step:1059/1845 train_time:48930ms step_avg:46.20ms
+step:1060/1845 train_time:48992ms step_avg:46.22ms
+step:1061/1845 train_time:49054ms step_avg:46.23ms
+step:1062/1845 train_time:49115ms step_avg:46.25ms
+step:1063/1845 train_time:49177ms step_avg:46.26ms
+step:1064/1845 train_time:49238ms step_avg:46.28ms
+step:1065/1845 train_time:49301ms step_avg:46.29ms
+step:1066/1845 train_time:49362ms step_avg:46.31ms
+step:1067/1845 train_time:49424ms step_avg:46.32ms
+step:1068/1845 train_time:49485ms step_avg:46.33ms
+step:1069/1845 train_time:49547ms step_avg:46.35ms
+step:1070/1845 train_time:49608ms step_avg:46.36ms
+step:1071/1845 train_time:49671ms step_avg:46.38ms
+step:1072/1845 train_time:49732ms step_avg:46.39ms
+step:1073/1845 train_time:49795ms step_avg:46.41ms
+step:1074/1845 train_time:49856ms step_avg:46.42ms
+step:1075/1845 train_time:49918ms step_avg:46.44ms
+step:1076/1845 train_time:49980ms step_avg:46.45ms
+step:1077/1845 train_time:50041ms step_avg:46.46ms
+step:1078/1845 train_time:50102ms step_avg:46.48ms
+step:1079/1845 train_time:50164ms step_avg:46.49ms
+step:1080/1845 train_time:50224ms step_avg:46.50ms
+step:1081/1845 train_time:50286ms step_avg:46.52ms
+step:1082/1845 train_time:50348ms step_avg:46.53ms
+step:1083/1845 train_time:50411ms step_avg:46.55ms
+step:1084/1845 train_time:50472ms step_avg:46.56ms
+step:1085/1845 train_time:50534ms step_avg:46.58ms
+step:1086/1845 train_time:50595ms step_avg:46.59ms
+step:1087/1845 train_time:50658ms step_avg:46.60ms
+step:1088/1845 train_time:50719ms step_avg:46.62ms
+step:1089/1845 train_time:50781ms step_avg:46.63ms
+step:1090/1845 train_time:50842ms step_avg:46.64ms
+step:1091/1845 train_time:50904ms step_avg:46.66ms
+step:1092/1845 train_time:50964ms step_avg:46.67ms
+step:1093/1845 train_time:51026ms step_avg:46.68ms
+step:1094/1845 train_time:51087ms step_avg:46.70ms
+step:1095/1845 train_time:51150ms step_avg:46.71ms
+step:1096/1845 train_time:51212ms step_avg:46.73ms
+step:1097/1845 train_time:51274ms step_avg:46.74ms
+step:1098/1845 train_time:51335ms step_avg:46.75ms
+step:1099/1845 train_time:51398ms step_avg:46.77ms
+step:1100/1845 train_time:51459ms step_avg:46.78ms
+step:1101/1845 train_time:51521ms step_avg:46.79ms
+step:1102/1845 train_time:51582ms step_avg:46.81ms
+step:1103/1845 train_time:51644ms step_avg:46.82ms
+step:1104/1845 train_time:51705ms step_avg:46.83ms
+step:1105/1845 train_time:51767ms step_avg:46.85ms
+step:1106/1845 train_time:51828ms step_avg:46.86ms
+step:1107/1845 train_time:51890ms step_avg:46.87ms
+step:1108/1845 train_time:51951ms step_avg:46.89ms
+step:1109/1845 train_time:52014ms step_avg:46.90ms
+step:1110/1845 train_time:52075ms step_avg:46.91ms
+step:1111/1845 train_time:52137ms step_avg:46.93ms
+step:1112/1845 train_time:52198ms step_avg:46.94ms
+step:1113/1845 train_time:52260ms step_avg:46.95ms
+step:1114/1845 train_time:52321ms step_avg:46.97ms
+step:1115/1845 train_time:52383ms step_avg:46.98ms
+step:1116/1845 train_time:52444ms step_avg:46.99ms
+step:1117/1845 train_time:52506ms step_avg:47.01ms
+step:1118/1845 train_time:52567ms step_avg:47.02ms
+step:1119/1845 train_time:52630ms step_avg:47.03ms
+step:1120/1845 train_time:52691ms step_avg:47.05ms
+step:1121/1845 train_time:52753ms step_avg:47.06ms
+step:1122/1845 train_time:52814ms step_avg:47.07ms
+step:1123/1845 train_time:52877ms step_avg:47.09ms
+step:1124/1845 train_time:52939ms step_avg:47.10ms
+step:1125/1845 train_time:53001ms step_avg:47.11ms
+step:1126/1845 train_time:53061ms step_avg:47.12ms
+step:1127/1845 train_time:53124ms step_avg:47.14ms
+step:1128/1845 train_time:53184ms step_avg:47.15ms
+step:1129/1845 train_time:53246ms step_avg:47.16ms
+step:1130/1845 train_time:53307ms step_avg:47.17ms
+step:1131/1845 train_time:53370ms step_avg:47.19ms
+step:1132/1845 train_time:53431ms step_avg:47.20ms
+step:1133/1845 train_time:53493ms step_avg:47.21ms
+step:1134/1845 train_time:53554ms step_avg:47.23ms
+step:1135/1845 train_time:53617ms step_avg:47.24ms
+step:1136/1845 train_time:53677ms step_avg:47.25ms
+step:1137/1845 train_time:53739ms step_avg:47.26ms
+step:1138/1845 train_time:53800ms step_avg:47.28ms
+step:1139/1845 train_time:53863ms step_avg:47.29ms
+step:1140/1845 train_time:53924ms step_avg:47.30ms
+step:1141/1845 train_time:53986ms step_avg:47.31ms
+step:1142/1845 train_time:54047ms step_avg:47.33ms
+step:1143/1845 train_time:54109ms step_avg:47.34ms
+step:1144/1845 train_time:54170ms step_avg:47.35ms
+step:1145/1845 train_time:54233ms step_avg:47.37ms
+step:1146/1845 train_time:54295ms step_avg:47.38ms
+step:1147/1845 train_time:54357ms step_avg:47.39ms
+step:1148/1845 train_time:54418ms step_avg:47.40ms
+step:1149/1845 train_time:54480ms step_avg:47.41ms
+step:1150/1845 train_time:54540ms step_avg:47.43ms
+step:1151/1845 train_time:54603ms step_avg:47.44ms
+step:1152/1845 train_time:54663ms step_avg:47.45ms
+step:1153/1845 train_time:54726ms step_avg:47.46ms
+step:1154/1845 train_time:54787ms step_avg:47.48ms
+step:1155/1845 train_time:54850ms step_avg:47.49ms
+step:1156/1845 train_time:54911ms step_avg:47.50ms
+step:1157/1845 train_time:54974ms step_avg:47.51ms
+step:1158/1845 train_time:55035ms step_avg:47.53ms
+step:1159/1845 train_time:55097ms step_avg:47.54ms
+step:1160/1845 train_time:55158ms step_avg:47.55ms
+step:1161/1845 train_time:55221ms step_avg:47.56ms
+step:1162/1845 train_time:55282ms step_avg:47.57ms
+step:1163/1845 train_time:55345ms step_avg:47.59ms
+step:1164/1845 train_time:55406ms step_avg:47.60ms
+step:1165/1845 train_time:55468ms step_avg:47.61ms
+step:1166/1845 train_time:55530ms step_avg:47.62ms
+step:1167/1845 train_time:55592ms step_avg:47.64ms
+step:1168/1845 train_time:55654ms step_avg:47.65ms
+step:1169/1845 train_time:55716ms step_avg:47.66ms
+step:1170/1845 train_time:55777ms step_avg:47.67ms
+step:1171/1845 train_time:55839ms step_avg:47.69ms
+step:1172/1845 train_time:55901ms step_avg:47.70ms
+step:1173/1845 train_time:55963ms step_avg:47.71ms
+step:1174/1845 train_time:56023ms step_avg:47.72ms
+step:1175/1845 train_time:56085ms step_avg:47.73ms
+step:1176/1845 train_time:56146ms step_avg:47.74ms
+step:1177/1845 train_time:56209ms step_avg:47.76ms
+step:1178/1845 train_time:56270ms step_avg:47.77ms
+step:1179/1845 train_time:56333ms step_avg:47.78ms
+step:1180/1845 train_time:56394ms step_avg:47.79ms
+step:1181/1845 train_time:56456ms step_avg:47.80ms
+step:1182/1845 train_time:56517ms step_avg:47.81ms
+step:1183/1845 train_time:56579ms step_avg:47.83ms
+step:1184/1845 train_time:56640ms step_avg:47.84ms
+step:1185/1845 train_time:56702ms step_avg:47.85ms
+step:1186/1845 train_time:56763ms step_avg:47.86ms
+step:1187/1845 train_time:56826ms step_avg:47.87ms
+step:1188/1845 train_time:56887ms step_avg:47.88ms
+step:1189/1845 train_time:56949ms step_avg:47.90ms
+step:1190/1845 train_time:57011ms step_avg:47.91ms
+step:1191/1845 train_time:57073ms step_avg:47.92ms
+step:1192/1845 train_time:57134ms step_avg:47.93ms
+step:1193/1845 train_time:57196ms step_avg:47.94ms
+step:1194/1845 train_time:57257ms step_avg:47.95ms
+step:1195/1845 train_time:57319ms step_avg:47.97ms
+step:1196/1845 train_time:57380ms step_avg:47.98ms
+step:1197/1845 train_time:57443ms step_avg:47.99ms
+step:1198/1845 train_time:57504ms step_avg:48.00ms
+step:1199/1845 train_time:57566ms step_avg:48.01ms
+step:1200/1845 train_time:57626ms step_avg:48.02ms
+step:1201/1845 train_time:57689ms step_avg:48.03ms
+step:1202/1845 train_time:57750ms step_avg:48.04ms
+step:1203/1845 train_time:57813ms step_avg:48.06ms
+step:1204/1845 train_time:57874ms step_avg:48.07ms
+step:1205/1845 train_time:57937ms step_avg:48.08ms
+step:1206/1845 train_time:58025ms step_avg:48.11ms
+step:1207/1845 train_time:58114ms step_avg:48.15ms
+step:1208/1845 train_time:58200ms step_avg:48.18ms
+step:1209/1845 train_time:58290ms step_avg:48.21ms
+step:1210/1845 train_time:58378ms step_avg:48.25ms
+step:1211/1845 train_time:58468ms step_avg:48.28ms
+step:1212/1845 train_time:58556ms step_avg:48.31ms
+step:1213/1845 train_time:58644ms step_avg:48.35ms
+step:1214/1845 train_time:58732ms step_avg:48.38ms
+step:1215/1845 train_time:58821ms step_avg:48.41ms
+step:1216/1845 train_time:58908ms step_avg:48.44ms
+step:1217/1845 train_time:58996ms step_avg:48.48ms
+step:1218/1845 train_time:59084ms step_avg:48.51ms
+step:1219/1845 train_time:59172ms step_avg:48.54ms
+step:1220/1845 train_time:59260ms step_avg:48.57ms
+step:1221/1845 train_time:59349ms step_avg:48.61ms
+step:1222/1845 train_time:59436ms step_avg:48.64ms
+step:1223/1845 train_time:59525ms step_avg:48.67ms
+step:1224/1845 train_time:59612ms step_avg:48.70ms
+step:1225/1845 train_time:59701ms step_avg:48.74ms
+step:1226/1845 train_time:59788ms step_avg:48.77ms
+step:1227/1845 train_time:59876ms step_avg:48.80ms
+step:1228/1845 train_time:59963ms step_avg:48.83ms
+step:1229/1845 train_time:60051ms step_avg:48.86ms
+step:1230/1845 train_time:60138ms step_avg:48.89ms
+step:1231/1845 train_time:60227ms step_avg:48.93ms
+step:1232/1845 train_time:60315ms step_avg:48.96ms
+step:1233/1845 train_time:60403ms step_avg:48.99ms
+step:1234/1845 train_time:60491ms step_avg:49.02ms
+step:1235/1845 train_time:60579ms step_avg:49.05ms
+step:1236/1845 train_time:60667ms step_avg:49.08ms
+step:1237/1845 train_time:60756ms step_avg:49.12ms
+step:1238/1845 train_time:60843ms step_avg:49.15ms
+step:1239/1845 train_time:60932ms step_avg:49.18ms
+step:1240/1845 train_time:61020ms step_avg:49.21ms
+step:1241/1845 train_time:61109ms step_avg:49.24ms
+step:1242/1845 train_time:61196ms step_avg:49.27ms
+step:1243/1845 train_time:61285ms step_avg:49.30ms
+step:1244/1845 train_time:61373ms step_avg:49.34ms
+step:1245/1845 train_time:61462ms step_avg:49.37ms
+step:1246/1845 train_time:61549ms step_avg:49.40ms
+step:1247/1845 train_time:61639ms step_avg:49.43ms
+step:1248/1845 train_time:61726ms step_avg:49.46ms
+step:1249/1845 train_time:61815ms step_avg:49.49ms
+step:1250/1845 train_time:61901ms step_avg:49.52ms
+step:1250/1845 val_loss:3.5407 train_time:61991ms step_avg:49.59ms
+step:1251/1845 train_time:62011ms step_avg:49.57ms
+step:1252/1845 train_time:62077ms step_avg:49.58ms
+step:1253/1845 train_time:62166ms step_avg:49.61ms
+step:1254/1845 train_time:62261ms step_avg:49.65ms
+step:1255/1845 train_time:62354ms step_avg:49.68ms
+step:1256/1845 train_time:62440ms step_avg:49.71ms
+step:1257/1845 train_time:62528ms step_avg:49.74ms
+step:1258/1845 train_time:62614ms step_avg:49.77ms
+step:1259/1845 train_time:62702ms step_avg:49.80ms
+step:1260/1845 train_time:62788ms step_avg:49.83ms
+step:1261/1845 train_time:62876ms step_avg:49.86ms
+step:1262/1845 train_time:62968ms step_avg:49.90ms
+step:1263/1845 train_time:63058ms step_avg:49.93ms
+step:1264/1845 train_time:63145ms step_avg:49.96ms
+step:1265/1845 train_time:63237ms step_avg:49.99ms
+step:1266/1845 train_time:63324ms step_avg:50.02ms
+step:1267/1845 train_time:63414ms step_avg:50.05ms
+step:1268/1845 train_time:63500ms step_avg:50.08ms
+step:1269/1845 train_time:63587ms step_avg:50.11ms
+step:1270/1845 train_time:63673ms step_avg:50.14ms
+step:1271/1845 train_time:63760ms step_avg:50.17ms
+step:1272/1845 train_time:63848ms step_avg:50.20ms
+step:1273/1845 train_time:63937ms step_avg:50.23ms
+step:1274/1845 train_time:64025ms step_avg:50.25ms
+step:1275/1845 train_time:64113ms step_avg:50.28ms
+step:1276/1845 train_time:64202ms step_avg:50.32ms
+step:1277/1845 train_time:64290ms step_avg:50.34ms
+step:1278/1845 train_time:64379ms step_avg:50.37ms
+step:1279/1845 train_time:64468ms step_avg:50.40ms
+step:1280/1845 train_time:64555ms step_avg:50.43ms
+step:1281/1845 train_time:64643ms step_avg:50.46ms
+step:1282/1845 train_time:64729ms step_avg:50.49ms
+step:1283/1845 train_time:64816ms step_avg:50.52ms
+step:1284/1845 train_time:64904ms step_avg:50.55ms
+step:1285/1845 train_time:64993ms step_avg:50.58ms
+step:1286/1845 train_time:65081ms step_avg:50.61ms
+step:1287/1845 train_time:65169ms step_avg:50.64ms
+step:1288/1845 train_time:65258ms step_avg:50.67ms
+step:1289/1845 train_time:65346ms step_avg:50.70ms
+step:1290/1845 train_time:65434ms step_avg:50.72ms
+step:1291/1845 train_time:65523ms step_avg:50.75ms
+step:1292/1845 train_time:65610ms step_avg:50.78ms
+step:1293/1845 train_time:65699ms step_avg:50.81ms
+step:1294/1845 train_time:65786ms step_avg:50.84ms
+step:1295/1845 train_time:65874ms step_avg:50.87ms
+step:1296/1845 train_time:65962ms step_avg:50.90ms
+step:1297/1845 train_time:66050ms step_avg:50.93ms
+step:1298/1845 train_time:66138ms step_avg:50.95ms
+step:1299/1845 train_time:66227ms step_avg:50.98ms
+step:1300/1845 train_time:66314ms step_avg:51.01ms
+step:1301/1845 train_time:66403ms step_avg:51.04ms
+step:1302/1845 train_time:66490ms step_avg:51.07ms
+step:1303/1845 train_time:66579ms step_avg:51.10ms
+step:1304/1845 train_time:66666ms step_avg:51.12ms
+step:1305/1845 train_time:66754ms step_avg:51.15ms
+step:1306/1845 train_time:66840ms step_avg:51.18ms
+step:1307/1845 train_time:66929ms step_avg:51.21ms
+step:1308/1845 train_time:67017ms step_avg:51.24ms
+step:1309/1845 train_time:67106ms step_avg:51.27ms
+step:1310/1845 train_time:67195ms step_avg:51.29ms
+step:1311/1845 train_time:67284ms step_avg:51.32ms
+step:1312/1845 train_time:67373ms step_avg:51.35ms
+step:1313/1845 train_time:67461ms step_avg:51.38ms
+step:1314/1845 train_time:67548ms step_avg:51.41ms
+step:1315/1845 train_time:67637ms step_avg:51.44ms
+step:1316/1845 train_time:67724ms step_avg:51.46ms
+step:1317/1845 train_time:67812ms step_avg:51.49ms
+step:1318/1845 train_time:67899ms step_avg:51.52ms
+step:1319/1845 train_time:67987ms step_avg:51.54ms
+step:1320/1845 train_time:68075ms step_avg:51.57ms
+step:1321/1845 train_time:68163ms step_avg:51.60ms
+step:1322/1845 train_time:68250ms step_avg:51.63ms
+step:1323/1845 train_time:68339ms step_avg:51.65ms
+step:1324/1845 train_time:68427ms step_avg:51.68ms
+step:1325/1845 train_time:68515ms step_avg:51.71ms
+step:1326/1845 train_time:68602ms step_avg:51.74ms
+step:1327/1845 train_time:68691ms step_avg:51.76ms
+step:1328/1845 train_time:68779ms step_avg:51.79ms
+step:1329/1845 train_time:68867ms step_avg:51.82ms
+step:1330/1845 train_time:68955ms step_avg:51.85ms
+step:1331/1845 train_time:69044ms step_avg:51.87ms
+step:1332/1845 train_time:69132ms step_avg:51.90ms
+step:1333/1845 train_time:69221ms step_avg:51.93ms
+step:1334/1845 train_time:69309ms step_avg:51.96ms
+step:1335/1845 train_time:69397ms step_avg:51.98ms
+step:1336/1845 train_time:69485ms step_avg:52.01ms
+step:1337/1845 train_time:69573ms step_avg:52.04ms
+step:1338/1845 train_time:69660ms step_avg:52.06ms
+step:1339/1845 train_time:69749ms step_avg:52.09ms
+step:1340/1845 train_time:69837ms step_avg:52.12ms
+step:1341/1845 train_time:69924ms step_avg:52.14ms
+step:1342/1845 train_time:70012ms step_avg:52.17ms
+step:1343/1845 train_time:70101ms step_avg:52.20ms
+step:1344/1845 train_time:70189ms step_avg:52.22ms
+step:1345/1845 train_time:70278ms step_avg:52.25ms
+step:1346/1845 train_time:70365ms step_avg:52.28ms
+step:1347/1845 train_time:70455ms step_avg:52.30ms
+step:1348/1845 train_time:70542ms step_avg:52.33ms
+step:1349/1845 train_time:70629ms step_avg:52.36ms
+step:1350/1845 train_time:70716ms step_avg:52.38ms
+step:1351/1845 train_time:70805ms step_avg:52.41ms
+step:1352/1845 train_time:70892ms step_avg:52.44ms
+step:1353/1845 train_time:70980ms step_avg:52.46ms
+step:1354/1845 train_time:71068ms step_avg:52.49ms
+step:1355/1845 train_time:71157ms step_avg:52.51ms
+step:1356/1845 train_time:71244ms step_avg:52.54ms
+step:1357/1845 train_time:71333ms step_avg:52.57ms
+step:1358/1845 train_time:71421ms step_avg:52.59ms
+step:1359/1845 train_time:71510ms step_avg:52.62ms
+step:1360/1845 train_time:71598ms step_avg:52.65ms
+step:1361/1845 train_time:71685ms step_avg:52.67ms
+step:1362/1845 train_time:71773ms step_avg:52.70ms
+step:1363/1845 train_time:71862ms step_avg:52.72ms
+step:1364/1845 train_time:71949ms step_avg:52.75ms
+step:1365/1845 train_time:72037ms step_avg:52.77ms
+step:1366/1845 train_time:72125ms step_avg:52.80ms
+step:1367/1845 train_time:72212ms step_avg:52.83ms
+step:1368/1845 train_time:72301ms step_avg:52.85ms
+step:1369/1845 train_time:72389ms step_avg:52.88ms
+step:1370/1845 train_time:72477ms step_avg:52.90ms
+step:1371/1845 train_time:72565ms step_avg:52.93ms
+step:1372/1845 train_time:72653ms step_avg:52.95ms
+step:1373/1845 train_time:72741ms step_avg:52.98ms
+step:1374/1845 train_time:72828ms step_avg:53.00ms
+step:1375/1845 train_time:72917ms step_avg:53.03ms
+step:1376/1845 train_time:73004ms step_avg:53.06ms
+step:1377/1845 train_time:73092ms step_avg:53.08ms
+step:1378/1845 train_time:73180ms step_avg:53.11ms
+step:1379/1845 train_time:73269ms step_avg:53.13ms
+step:1380/1845 train_time:73356ms step_avg:53.16ms
+step:1381/1845 train_time:73445ms step_avg:53.18ms
+step:1382/1845 train_time:73533ms step_avg:53.21ms
+step:1383/1845 train_time:73620ms step_avg:53.23ms
+step:1384/1845 train_time:73707ms step_avg:53.26ms
+step:1385/1845 train_time:73795ms step_avg:53.28ms
+step:1386/1845 train_time:73882ms step_avg:53.31ms
+step:1387/1845 train_time:73971ms step_avg:53.33ms
+step:1388/1845 train_time:74059ms step_avg:53.36ms
+step:1389/1845 train_time:74147ms step_avg:53.38ms
+step:1390/1845 train_time:74236ms step_avg:53.41ms
+step:1391/1845 train_time:74325ms step_avg:53.43ms
+step:1392/1845 train_time:74412ms step_avg:53.46ms
+step:1393/1845 train_time:74501ms step_avg:53.48ms
+step:1394/1845 train_time:74589ms step_avg:53.51ms
+step:1395/1845 train_time:74677ms step_avg:53.53ms
+step:1396/1845 train_time:74764ms step_avg:53.56ms
+step:1397/1845 train_time:74853ms step_avg:53.58ms
+step:1398/1845 train_time:74940ms step_avg:53.61ms
+step:1399/1845 train_time:75028ms step_avg:53.63ms
+step:1400/1845 train_time:75115ms step_avg:53.65ms
+step:1401/1845 train_time:75204ms step_avg:53.68ms
+step:1402/1845 train_time:75292ms step_avg:53.70ms
+step:1403/1845 train_time:75380ms step_avg:53.73ms
+step:1404/1845 train_time:75467ms step_avg:53.75ms
+step:1405/1845 train_time:75556ms step_avg:53.78ms
+step:1406/1845 train_time:75643ms step_avg:53.80ms
+step:1407/1845 train_time:75732ms step_avg:53.82ms
+step:1408/1845 train_time:75819ms step_avg:53.85ms
+step:1409/1845 train_time:75907ms step_avg:53.87ms
+step:1410/1845 train_time:75995ms step_avg:53.90ms
+step:1411/1845 train_time:76084ms step_avg:53.92ms
+step:1412/1845 train_time:76171ms step_avg:53.95ms
+step:1413/1845 train_time:76260ms step_avg:53.97ms
+step:1414/1845 train_time:76347ms step_avg:53.99ms
+step:1415/1845 train_time:76436ms step_avg:54.02ms
+step:1416/1845 train_time:76523ms step_avg:54.04ms
+step:1417/1845 train_time:76611ms step_avg:54.07ms
+step:1418/1845 train_time:76699ms step_avg:54.09ms
+step:1419/1845 train_time:76787ms step_avg:54.11ms
+step:1420/1845 train_time:76874ms step_avg:54.14ms
+step:1421/1845 train_time:76963ms step_avg:54.16ms
+step:1422/1845 train_time:77050ms step_avg:54.18ms
+step:1423/1845 train_time:77139ms step_avg:54.21ms
+step:1424/1845 train_time:77226ms step_avg:54.23ms
+step:1425/1845 train_time:77314ms step_avg:54.26ms
+step:1426/1845 train_time:77402ms step_avg:54.28ms
+step:1427/1845 train_time:77491ms step_avg:54.30ms
+step:1428/1845 train_time:77578ms step_avg:54.33ms
+step:1429/1845 train_time:77666ms step_avg:54.35ms
+step:1430/1845 train_time:77755ms step_avg:54.37ms
+step:1431/1845 train_time:77843ms step_avg:54.40ms
+step:1432/1845 train_time:77930ms step_avg:54.42ms
+step:1433/1845 train_time:78018ms step_avg:54.44ms
+step:1434/1845 train_time:78105ms step_avg:54.47ms
+step:1435/1845 train_time:78193ms step_avg:54.49ms
+step:1436/1845 train_time:78281ms step_avg:54.51ms
+step:1437/1845 train_time:78369ms step_avg:54.54ms
+step:1438/1845 train_time:78458ms step_avg:54.56ms
+step:1439/1845 train_time:78546ms step_avg:54.58ms
+step:1440/1845 train_time:78633ms step_avg:54.61ms
+step:1441/1845 train_time:78722ms step_avg:54.63ms
+step:1442/1845 train_time:78809ms step_avg:54.65ms
+step:1443/1845 train_time:78897ms step_avg:54.68ms
+step:1444/1845 train_time:78984ms step_avg:54.70ms
+step:1445/1845 train_time:79072ms step_avg:54.72ms
+step:1446/1845 train_time:79161ms step_avg:54.74ms
+step:1447/1845 train_time:79249ms step_avg:54.77ms
+step:1448/1845 train_time:79336ms step_avg:54.79ms
+step:1449/1845 train_time:79424ms step_avg:54.81ms
+step:1450/1845 train_time:79512ms step_avg:54.84ms
+step:1451/1845 train_time:79601ms step_avg:54.86ms
+step:1452/1845 train_time:79688ms step_avg:54.88ms
+step:1453/1845 train_time:79777ms step_avg:54.90ms
+step:1454/1845 train_time:79864ms step_avg:54.93ms
+step:1455/1845 train_time:79952ms step_avg:54.95ms
+step:1456/1845 train_time:80039ms step_avg:54.97ms
+step:1457/1845 train_time:80127ms step_avg:54.99ms
+step:1458/1845 train_time:80215ms step_avg:55.02ms
+step:1459/1845 train_time:80303ms step_avg:55.04ms
+step:1460/1845 train_time:80390ms step_avg:55.06ms
+step:1461/1845 train_time:80479ms step_avg:55.08ms
+step:1462/1845 train_time:80567ms step_avg:55.11ms
+step:1463/1845 train_time:80657ms step_avg:55.13ms
+step:1464/1845 train_time:80744ms step_avg:55.15ms
+step:1465/1845 train_time:80832ms step_avg:55.18ms
+step:1466/1845 train_time:80919ms step_avg:55.20ms
+step:1467/1845 train_time:81008ms step_avg:55.22ms
+step:1468/1845 train_time:81096ms step_avg:55.24ms
+step:1469/1845 train_time:81184ms step_avg:55.27ms
+step:1470/1845 train_time:81272ms step_avg:55.29ms
+step:1471/1845 train_time:81360ms step_avg:55.31ms
+step:1472/1845 train_time:81448ms step_avg:55.33ms
+step:1473/1845 train_time:81537ms step_avg:55.35ms
+step:1474/1845 train_time:81624ms step_avg:55.38ms
+step:1475/1845 train_time:81713ms step_avg:55.40ms
+step:1476/1845 train_time:81800ms step_avg:55.42ms
+step:1477/1845 train_time:81889ms step_avg:55.44ms
+step:1478/1845 train_time:81977ms step_avg:55.46ms
+step:1479/1845 train_time:82065ms step_avg:55.49ms
+step:1480/1845 train_time:82152ms step_avg:55.51ms
+step:1481/1845 train_time:82241ms step_avg:55.53ms
+step:1482/1845 train_time:82328ms step_avg:55.55ms
+step:1483/1845 train_time:82417ms step_avg:55.57ms
+step:1484/1845 train_time:82504ms step_avg:55.60ms
+step:1485/1845 train_time:82593ms step_avg:55.62ms
+step:1486/1845 train_time:82680ms step_avg:55.64ms
+step:1487/1845 train_time:82769ms step_avg:55.66ms
+step:1488/1845 train_time:82857ms step_avg:55.68ms
+step:1489/1845 train_time:82945ms step_avg:55.70ms
+step:1490/1845 train_time:83032ms step_avg:55.73ms
+step:1491/1845 train_time:83120ms step_avg:55.75ms
+step:1492/1845 train_time:83207ms step_avg:55.77ms
+step:1493/1845 train_time:83295ms step_avg:55.79ms
+step:1494/1845 train_time:83384ms step_avg:55.81ms
+step:1495/1845 train_time:83471ms step_avg:55.83ms
+step:1496/1845 train_time:83559ms step_avg:55.86ms
+step:1497/1845 train_time:83648ms step_avg:55.88ms
+step:1498/1845 train_time:83736ms step_avg:55.90ms
+step:1499/1845 train_time:83824ms step_avg:55.92ms
+step:1500/1845 train_time:83911ms step_avg:55.94ms
+step:1500/1845 val_loss:3.4071 train_time:84002ms step_avg:56.00ms
+step:1501/1845 train_time:84022ms step_avg:55.98ms
+step:1502/1845 train_time:84090ms step_avg:55.99ms
+step:1503/1845 train_time:84179ms step_avg:56.01ms
+step:1504/1845 train_time:84272ms step_avg:56.03ms
+step:1505/1845 train_time:84362ms step_avg:56.05ms
+step:1506/1845 train_time:84447ms step_avg:56.07ms
+step:1507/1845 train_time:84534ms step_avg:56.09ms
+step:1508/1845 train_time:84620ms step_avg:56.11ms
+step:1509/1845 train_time:84707ms step_avg:56.13ms
+step:1510/1845 train_time:84794ms step_avg:56.16ms
+step:1511/1845 train_time:84881ms step_avg:56.18ms
+step:1512/1845 train_time:84969ms step_avg:56.20ms
+step:1513/1845 train_time:85064ms step_avg:56.22ms
+step:1514/1845 train_time:85154ms step_avg:56.24ms
+step:1515/1845 train_time:85243ms step_avg:56.27ms
+step:1516/1845 train_time:85330ms step_avg:56.29ms
+step:1517/1845 train_time:85419ms step_avg:56.31ms
+step:1518/1845 train_time:85505ms step_avg:56.33ms
+step:1519/1845 train_time:85592ms step_avg:56.35ms
+step:1520/1845 train_time:85679ms step_avg:56.37ms
+step:1521/1845 train_time:85765ms step_avg:56.39ms
+step:1522/1845 train_time:85852ms step_avg:56.41ms
+step:1523/1845 train_time:85941ms step_avg:56.43ms
+step:1524/1845 train_time:86030ms step_avg:56.45ms
+step:1525/1845 train_time:86122ms step_avg:56.47ms
+step:1526/1845 train_time:86210ms step_avg:56.49ms
+step:1527/1845 train_time:86300ms step_avg:56.52ms
+step:1528/1845 train_time:86386ms step_avg:56.54ms
+step:1529/1845 train_time:86475ms step_avg:56.56ms
+step:1530/1845 train_time:86562ms step_avg:56.58ms
+step:1531/1845 train_time:86649ms step_avg:56.60ms
+step:1532/1845 train_time:86736ms step_avg:56.62ms
+step:1533/1845 train_time:86823ms step_avg:56.64ms
+step:1534/1845 train_time:86910ms step_avg:56.66ms
+step:1535/1845 train_time:87001ms step_avg:56.68ms
+step:1536/1845 train_time:87090ms step_avg:56.70ms
+step:1537/1845 train_time:87181ms step_avg:56.72ms
+step:1538/1845 train_time:87268ms step_avg:56.74ms
+step:1539/1845 train_time:87357ms step_avg:56.76ms
+step:1540/1845 train_time:87443ms step_avg:56.78ms
+step:1541/1845 train_time:87532ms step_avg:56.80ms
+step:1542/1845 train_time:87619ms step_avg:56.82ms
+step:1543/1845 train_time:87706ms step_avg:56.84ms
+step:1544/1845 train_time:87793ms step_avg:56.86ms
+step:1545/1845 train_time:87882ms step_avg:56.88ms
+step:1546/1845 train_time:87969ms step_avg:56.90ms
+step:1547/1845 train_time:88059ms step_avg:56.92ms
+step:1548/1845 train_time:88147ms step_avg:56.94ms
+step:1549/1845 train_time:88235ms step_avg:56.96ms
+step:1550/1845 train_time:88323ms step_avg:56.98ms
+step:1551/1845 train_time:88410ms step_avg:57.00ms
+step:1552/1845 train_time:88498ms step_avg:57.02ms
+step:1553/1845 train_time:88585ms step_avg:57.04ms
+step:1554/1845 train_time:88672ms step_avg:57.06ms
+step:1555/1845 train_time:88760ms step_avg:57.08ms
+step:1556/1845 train_time:88846ms step_avg:57.10ms
+step:1557/1845 train_time:88935ms step_avg:57.12ms
+step:1558/1845 train_time:89022ms step_avg:57.14ms
+step:1559/1845 train_time:89111ms step_avg:57.16ms
+step:1560/1845 train_time:89199ms step_avg:57.18ms
+step:1561/1845 train_time:89288ms step_avg:57.20ms
+step:1562/1845 train_time:89376ms step_avg:57.22ms
+step:1563/1845 train_time:89464ms step_avg:57.24ms
+step:1564/1845 train_time:89552ms step_avg:57.26ms
+step:1565/1845 train_time:89640ms step_avg:57.28ms
+step:1566/1845 train_time:89727ms step_avg:57.30ms
+step:1567/1845 train_time:89816ms step_avg:57.32ms
+step:1568/1845 train_time:89903ms step_avg:57.34ms
+step:1569/1845 train_time:89992ms step_avg:57.36ms
+step:1570/1845 train_time:90080ms step_avg:57.38ms
+step:1571/1845 train_time:90169ms step_avg:57.40ms
+step:1572/1845 train_time:90256ms step_avg:57.41ms
+step:1573/1845 train_time:90345ms step_avg:57.43ms
+step:1574/1845 train_time:90432ms step_avg:57.45ms
+step:1575/1845 train_time:90520ms step_avg:57.47ms
+step:1576/1845 train_time:90607ms step_avg:57.49ms
+step:1577/1845 train_time:90695ms step_avg:57.51ms
+step:1578/1845 train_time:90782ms step_avg:57.53ms
+step:1579/1845 train_time:90870ms step_avg:57.55ms
+step:1580/1845 train_time:90958ms step_avg:57.57ms
+step:1581/1845 train_time:91046ms step_avg:57.59ms
+step:1582/1845 train_time:91134ms step_avg:57.61ms
+step:1583/1845 train_time:91223ms step_avg:57.63ms
+step:1584/1845 train_time:91310ms step_avg:57.64ms
+step:1585/1845 train_time:91399ms step_avg:57.66ms
+step:1586/1845 train_time:91486ms step_avg:57.68ms
+step:1587/1845 train_time:91574ms step_avg:57.70ms
+step:1588/1845 train_time:91662ms step_avg:57.72ms
+step:1589/1845 train_time:91751ms step_avg:57.74ms
+step:1590/1845 train_time:91838ms step_avg:57.76ms
+step:1591/1845 train_time:91926ms step_avg:57.78ms
+step:1592/1845 train_time:92014ms step_avg:57.80ms
+step:1593/1845 train_time:92102ms step_avg:57.82ms
+step:1594/1845 train_time:92189ms step_avg:57.83ms
+step:1595/1845 train_time:92278ms step_avg:57.85ms
+step:1596/1845 train_time:92366ms step_avg:57.87ms
+step:1597/1845 train_time:92455ms step_avg:57.89ms
+step:1598/1845 train_time:92541ms step_avg:57.91ms
+step:1599/1845 train_time:92631ms step_avg:57.93ms
+step:1600/1845 train_time:92717ms step_avg:57.95ms
+step:1601/1845 train_time:92806ms step_avg:57.97ms
+step:1602/1845 train_time:92893ms step_avg:57.99ms
+step:1603/1845 train_time:92980ms step_avg:58.00ms
+step:1604/1845 train_time:93068ms step_avg:58.02ms
+step:1605/1845 train_time:93157ms step_avg:58.04ms
+step:1606/1845 train_time:93245ms step_avg:58.06ms
+step:1607/1845 train_time:93334ms step_avg:58.08ms
+step:1608/1845 train_time:93421ms step_avg:58.10ms
+step:1609/1845 train_time:93510ms step_avg:58.12ms
+step:1610/1845 train_time:93597ms step_avg:58.13ms
+step:1611/1845 train_time:93685ms step_avg:58.15ms
+step:1612/1845 train_time:93772ms step_avg:58.17ms
+step:1613/1845 train_time:93860ms step_avg:58.19ms
+step:1614/1845 train_time:93948ms step_avg:58.21ms
+step:1615/1845 train_time:94035ms step_avg:58.23ms
+step:1616/1845 train_time:94122ms step_avg:58.24ms
+step:1617/1845 train_time:94211ms step_avg:58.26ms
+step:1618/1845 train_time:94298ms step_avg:58.28ms
+step:1619/1845 train_time:94387ms step_avg:58.30ms
+step:1620/1845 train_time:94475ms step_avg:58.32ms
+step:1621/1845 train_time:94564ms step_avg:58.34ms
+step:1622/1845 train_time:94651ms step_avg:58.35ms
+step:1623/1845 train_time:94739ms step_avg:58.37ms
+step:1624/1845 train_time:94826ms step_avg:58.39ms
+step:1625/1845 train_time:94914ms step_avg:58.41ms
+step:1626/1845 train_time:95002ms step_avg:58.43ms
+step:1627/1845 train_time:95091ms step_avg:58.45ms
+step:1628/1845 train_time:95179ms step_avg:58.46ms
+step:1629/1845 train_time:95267ms step_avg:58.48ms
+step:1630/1845 train_time:95355ms step_avg:58.50ms
+step:1631/1845 train_time:95444ms step_avg:58.52ms
+step:1632/1845 train_time:95532ms step_avg:58.54ms
+step:1633/1845 train_time:95620ms step_avg:58.55ms
+step:1634/1845 train_time:95707ms step_avg:58.57ms
+step:1635/1845 train_time:95795ms step_avg:58.59ms
+step:1636/1845 train_time:95882ms step_avg:58.61ms
+step:1637/1845 train_time:95971ms step_avg:58.63ms
+step:1638/1845 train_time:96059ms step_avg:58.64ms
+step:1639/1845 train_time:96147ms step_avg:58.66ms
+step:1640/1845 train_time:96235ms step_avg:58.68ms
+step:1641/1845 train_time:96323ms step_avg:58.70ms
+step:1642/1845 train_time:96411ms step_avg:58.72ms
+step:1643/1845 train_time:96500ms step_avg:58.73ms
+step:1644/1845 train_time:96587ms step_avg:58.75ms
+step:1645/1845 train_time:96676ms step_avg:58.77ms
+step:1646/1845 train_time:96763ms step_avg:58.79ms
+step:1647/1845 train_time:96852ms step_avg:58.80ms
+step:1648/1845 train_time:96939ms step_avg:58.82ms
+step:1649/1845 train_time:97028ms step_avg:58.84ms
+step:1650/1845 train_time:97116ms step_avg:58.86ms
+step:1651/1845 train_time:97204ms step_avg:58.88ms
+step:1652/1845 train_time:97292ms step_avg:58.89ms
+step:1653/1845 train_time:97381ms step_avg:58.91ms
+step:1654/1845 train_time:97469ms step_avg:58.93ms
+step:1655/1845 train_time:97556ms step_avg:58.95ms
+step:1656/1845 train_time:97643ms step_avg:58.96ms
+step:1657/1845 train_time:97732ms step_avg:58.98ms
+step:1658/1845 train_time:97820ms step_avg:59.00ms
+step:1659/1845 train_time:97907ms step_avg:59.02ms
+step:1660/1845 train_time:97994ms step_avg:59.03ms
+step:1661/1845 train_time:98082ms step_avg:59.05ms
+step:1662/1845 train_time:98170ms step_avg:59.07ms
+step:1663/1845 train_time:98259ms step_avg:59.09ms
+step:1664/1845 train_time:98347ms step_avg:59.10ms
+step:1665/1845 train_time:98435ms step_avg:59.12ms
+step:1666/1845 train_time:98521ms step_avg:59.14ms
+step:1667/1845 train_time:98610ms step_avg:59.15ms
+step:1668/1845 train_time:98698ms step_avg:59.17ms
+step:1669/1845 train_time:98785ms step_avg:59.19ms
+step:1670/1845 train_time:98872ms step_avg:59.20ms
+step:1671/1845 train_time:98961ms step_avg:59.22ms
+step:1672/1845 train_time:99047ms step_avg:59.24ms
+step:1673/1845 train_time:99136ms step_avg:59.26ms
+step:1674/1845 train_time:99223ms step_avg:59.27ms
+step:1675/1845 train_time:99311ms step_avg:59.29ms
+step:1676/1845 train_time:99398ms step_avg:59.31ms
+step:1677/1845 train_time:99487ms step_avg:59.32ms
+step:1678/1845 train_time:99574ms step_avg:59.34ms
+step:1679/1845 train_time:99663ms step_avg:59.36ms
+step:1680/1845 train_time:99750ms step_avg:59.38ms
+step:1681/1845 train_time:99838ms step_avg:59.39ms
+step:1682/1845 train_time:99925ms step_avg:59.41ms
+step:1683/1845 train_time:100013ms step_avg:59.43ms
+step:1684/1845 train_time:100101ms step_avg:59.44ms
+step:1685/1845 train_time:100189ms step_avg:59.46ms
+step:1686/1845 train_time:100277ms step_avg:59.48ms
+step:1687/1845 train_time:100366ms step_avg:59.49ms
+step:1688/1845 train_time:100453ms step_avg:59.51ms
+step:1689/1845 train_time:100541ms step_avg:59.53ms
+step:1690/1845 train_time:100628ms step_avg:59.54ms
+step:1691/1845 train_time:100716ms step_avg:59.56ms
+step:1692/1845 train_time:100803ms step_avg:59.58ms
+step:1693/1845 train_time:100892ms step_avg:59.59ms
+step:1694/1845 train_time:100980ms step_avg:59.61ms
+step:1695/1845 train_time:101068ms step_avg:59.63ms
+step:1696/1845 train_time:101156ms step_avg:59.64ms
+step:1697/1845 train_time:101245ms step_avg:59.66ms
+step:1698/1845 train_time:101332ms step_avg:59.68ms
+step:1699/1845 train_time:101421ms step_avg:59.69ms
+step:1700/1845 train_time:101508ms step_avg:59.71ms
+step:1701/1845 train_time:101597ms step_avg:59.73ms
+step:1702/1845 train_time:101685ms step_avg:59.74ms
+step:1703/1845 train_time:101773ms step_avg:59.76ms
+step:1704/1845 train_time:101861ms step_avg:59.78ms
+step:1705/1845 train_time:101949ms step_avg:59.79ms
+step:1706/1845 train_time:102037ms step_avg:59.81ms
+step:1707/1845 train_time:102125ms step_avg:59.83ms
+step:1708/1845 train_time:102212ms step_avg:59.84ms
+step:1709/1845 train_time:102301ms step_avg:59.86ms
+step:1710/1845 train_time:102388ms step_avg:59.88ms
+step:1711/1845 train_time:102477ms step_avg:59.89ms
+step:1712/1845 train_time:102564ms step_avg:59.91ms
+step:1713/1845 train_time:102652ms step_avg:59.93ms
+step:1714/1845 train_time:102740ms step_avg:59.94ms
+step:1715/1845 train_time:102829ms step_avg:59.96ms
+step:1716/1845 train_time:102915ms step_avg:59.97ms
+step:1717/1845 train_time:103004ms step_avg:59.99ms
+step:1718/1845 train_time:103092ms step_avg:60.01ms
+step:1719/1845 train_time:103180ms step_avg:60.02ms
+step:1720/1845 train_time:103267ms step_avg:60.04ms
+step:1721/1845 train_time:103356ms step_avg:60.06ms
+step:1722/1845 train_time:103443ms step_avg:60.07ms
+step:1723/1845 train_time:103532ms step_avg:60.09ms
+step:1724/1845 train_time:103619ms step_avg:60.10ms
+step:1725/1845 train_time:103708ms step_avg:60.12ms
+step:1726/1845 train_time:103795ms step_avg:60.14ms
+step:1727/1845 train_time:103883ms step_avg:60.15ms
+step:1728/1845 train_time:103972ms step_avg:60.17ms
+step:1729/1845 train_time:104061ms step_avg:60.19ms
+step:1730/1845 train_time:104149ms step_avg:60.20ms
+step:1731/1845 train_time:104238ms step_avg:60.22ms
+step:1732/1845 train_time:104326ms step_avg:60.23ms
+step:1733/1845 train_time:104414ms step_avg:60.25ms
+step:1734/1845 train_time:104501ms step_avg:60.27ms
+step:1735/1845 train_time:104589ms step_avg:60.28ms
+step:1736/1845 train_time:104676ms step_avg:60.30ms
+step:1737/1845 train_time:104765ms step_avg:60.31ms
+step:1738/1845 train_time:104852ms step_avg:60.33ms
+step:1739/1845 train_time:104940ms step_avg:60.35ms
+step:1740/1845 train_time:105028ms step_avg:60.36ms
+step:1741/1845 train_time:105117ms step_avg:60.38ms
+step:1742/1845 train_time:105204ms step_avg:60.39ms
+step:1743/1845 train_time:105293ms step_avg:60.41ms
+step:1744/1845 train_time:105380ms step_avg:60.42ms
+step:1745/1845 train_time:105469ms step_avg:60.44ms
+step:1746/1845 train_time:105556ms step_avg:60.46ms
+step:1747/1845 train_time:105644ms step_avg:60.47ms
+step:1748/1845 train_time:105731ms step_avg:60.49ms
+step:1749/1845 train_time:105820ms step_avg:60.50ms
+step:1750/1845 train_time:105907ms step_avg:60.52ms
+step:1750/1845 val_loss:3.3067 train_time:105997ms step_avg:60.57ms
+step:1751/1845 train_time:106016ms step_avg:60.55ms
+step:1752/1845 train_time:106086ms step_avg:60.55ms
+step:1753/1845 train_time:106180ms step_avg:60.57ms
+step:1754/1845 train_time:106268ms step_avg:60.59ms
+step:1755/1845 train_time:106355ms step_avg:60.60ms
+step:1756/1845 train_time:106442ms step_avg:60.62ms
+step:1757/1845 train_time:106531ms step_avg:60.63ms
+step:1758/1845 train_time:106618ms step_avg:60.65ms
+step:1759/1845 train_time:106705ms step_avg:60.66ms
+step:1760/1845 train_time:106792ms step_avg:60.68ms
+step:1761/1845 train_time:106879ms step_avg:60.69ms
+step:1762/1845 train_time:106966ms step_avg:60.71ms
+step:1763/1845 train_time:107056ms step_avg:60.72ms
+step:1764/1845 train_time:107146ms step_avg:60.74ms
+step:1765/1845 train_time:107235ms step_avg:60.76ms
+step:1766/1845 train_time:107322ms step_avg:60.77ms
+step:1767/1845 train_time:107411ms step_avg:60.79ms
+step:1768/1845 train_time:107498ms step_avg:60.80ms
+step:1769/1845 train_time:107586ms step_avg:60.82ms
+step:1770/1845 train_time:107672ms step_avg:60.83ms
+step:1771/1845 train_time:107759ms step_avg:60.85ms
+step:1772/1845 train_time:107845ms step_avg:60.86ms
+step:1773/1845 train_time:107934ms step_avg:60.88ms
+step:1774/1845 train_time:108022ms step_avg:60.89ms
+step:1775/1845 train_time:108113ms step_avg:60.91ms
+step:1776/1845 train_time:108201ms step_avg:60.92ms
+step:1777/1845 train_time:108292ms step_avg:60.94ms
+step:1778/1845 train_time:108379ms step_avg:60.96ms
+step:1779/1845 train_time:108468ms step_avg:60.97ms
+step:1780/1845 train_time:108554ms step_avg:60.99ms
+step:1781/1845 train_time:108642ms step_avg:61.00ms
+step:1782/1845 train_time:108729ms step_avg:61.02ms
+step:1783/1845 train_time:108816ms step_avg:61.03ms
+step:1784/1845 train_time:108903ms step_avg:61.04ms
+step:1785/1845 train_time:108993ms step_avg:61.06ms
+step:1786/1845 train_time:109081ms step_avg:61.08ms
+step:1787/1845 train_time:109170ms step_avg:61.09ms
+step:1788/1845 train_time:109258ms step_avg:61.11ms
+step:1789/1845 train_time:109347ms step_avg:61.12ms
+step:1790/1845 train_time:109434ms step_avg:61.14ms
+step:1791/1845 train_time:109523ms step_avg:61.15ms
+step:1792/1845 train_time:109610ms step_avg:61.17ms
+step:1793/1845 train_time:109698ms step_avg:61.18ms
+step:1794/1845 train_time:109784ms step_avg:61.20ms
+step:1795/1845 train_time:109872ms step_avg:61.21ms
+step:1796/1845 train_time:109960ms step_avg:61.22ms
+step:1797/1845 train_time:110048ms step_avg:61.24ms
+step:1798/1845 train_time:110136ms step_avg:61.25ms
+step:1799/1845 train_time:110226ms step_avg:61.27ms
+step:1800/1845 train_time:110313ms step_avg:61.28ms
+step:1801/1845 train_time:110401ms step_avg:61.30ms
+step:1802/1845 train_time:110489ms step_avg:61.31ms
+step:1803/1845 train_time:110578ms step_avg:61.33ms
+step:1804/1845 train_time:110665ms step_avg:61.34ms
+step:1805/1845 train_time:110753ms step_avg:61.36ms
+step:1806/1845 train_time:110841ms step_avg:61.37ms
+step:1807/1845 train_time:110930ms step_avg:61.39ms
+step:1808/1845 train_time:111018ms step_avg:61.40ms
+step:1809/1845 train_time:111107ms step_avg:61.42ms
+step:1810/1845 train_time:111195ms step_avg:61.43ms
+step:1811/1845 train_time:111283ms step_avg:61.45ms
+step:1812/1845 train_time:111371ms step_avg:61.46ms
+step:1813/1845 train_time:111461ms step_avg:61.48ms
+step:1814/1845 train_time:111548ms step_avg:61.49ms
+step:1815/1845 train_time:111637ms step_avg:61.51ms
+step:1816/1845 train_time:111724ms step_avg:61.52ms
+step:1817/1845 train_time:111811ms step_avg:61.54ms
+step:1818/1845 train_time:111899ms step_avg:61.55ms
+step:1819/1845 train_time:111988ms step_avg:61.57ms
+step:1820/1845 train_time:112076ms step_avg:61.58ms
+step:1821/1845 train_time:112165ms step_avg:61.60ms
+step:1822/1845 train_time:112252ms step_avg:61.61ms
+step:1823/1845 train_time:112340ms step_avg:61.62ms
+step:1824/1845 train_time:112429ms step_avg:61.64ms
+step:1825/1845 train_time:112518ms step_avg:61.65ms
+step:1826/1845 train_time:112606ms step_avg:61.67ms
+step:1827/1845 train_time:112694ms step_avg:61.68ms
+step:1828/1845 train_time:112781ms step_avg:61.70ms
+step:1829/1845 train_time:112870ms step_avg:61.71ms
+step:1830/1845 train_time:112957ms step_avg:61.73ms
+step:1831/1845 train_time:113047ms step_avg:61.74ms
+step:1832/1845 train_time:113134ms step_avg:61.75ms
+step:1833/1845 train_time:113223ms step_avg:61.77ms
+step:1834/1845 train_time:113311ms step_avg:61.78ms
+step:1835/1845 train_time:113400ms step_avg:61.80ms
+step:1836/1845 train_time:113487ms step_avg:61.81ms
+step:1837/1845 train_time:113576ms step_avg:61.83ms
+step:1838/1845 train_time:113663ms step_avg:61.84ms
+step:1839/1845 train_time:113752ms step_avg:61.86ms
+step:1840/1845 train_time:113838ms step_avg:61.87ms
+step:1841/1845 train_time:113928ms step_avg:61.88ms
+step:1842/1845 train_time:114016ms step_avg:61.90ms
+step:1843/1845 train_time:114105ms step_avg:61.91ms
+step:1844/1845 train_time:114193ms step_avg:61.93ms
+step:1845/1845 train_time:114281ms step_avg:61.94ms
+step:1845/1845 val_loss:3.2800 train_time:114369ms step_avg:61.99ms
+peak memory allocated: 29405 MiB reserved: 44318 MiB

--- a/records/track_1_short/2025-12-29_VeSkipGates/3e55ba7b-e7ff-479c-b736-3532905af2df.txt
+++ b/records/track_1_short/2025-12-29_VeSkipGates/3e55ba7b-e7ff-479c-b736-3532905af2df.txt
@@ -1,0 +1,3725 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, v, wd_tensor, lr_tensor):
+    """Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors."""
+    mask = (v * p) >= 0
+    wd_factor = wd_tensor.to(p.dtype)
+    lr_factor = lr_tensor.to(p.dtype)
+    p.copy_(p - (p * mask * wd_factor * lr_factor) - (v * lr_factor))
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn_gate (10 params 6 padding params)
+        2. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        3. reduce scatter attn/mlp round 2 (16 mlp params)
+        4. wait on step 1, then compute update of 1 and schedule all gather
+        5. wait on step 2, then compute update of 2 and schedule all gather
+        6. wait on step 3, then compute update of 3 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        7. wait on 4, then compute update of 4 and schedule all gather
+        8. wait for each all gather to complete and update params
+    Empirically, leading with small params provides an additional 0.2s improvement.
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        group_sizes = [15, 16, 16]
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+
+        all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"]
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params])
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            # The below shape-based heuristic assumes that matrices have their input along the
+            # row dimension and their output along the columns. Gates are an exception.
+            is_gate = 'gate' in ref_param.label
+
+            if "second_momentum_buffer" not in group:
+                if is_gate:
+                    group["second_momentum_buffer"] = torch.zeros_like(updated_grads[..., :, :1])
+                else:
+                    group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1])
+                        if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                    )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if (is_gate or param_shape[-2] >= param_shape[-1]) else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx],
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete and copy results back into original parameter tensors.
+        for info in all_gather_infos:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str],lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for label in label_order:
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.bfloat16, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-1]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+
+                exp_avg = state["exp_avg"]
+                exp_avg_sq = state["exp_avg_sq"]
+                state["step"] += 1
+                t = state["step"]
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (bias2 ** 0.5 / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                # cautious weight decay
+                mask = (update * p_slice) > 0
+                # lr as weight decay schedule
+                eff_weight_decay = lr * wd * getattr(param, "wd_mul", 1.0)
+                update.addcmul_(p_slice, mask, value=eff_weight_decay * lr)
+
+                p_slice.add_(other=update, alpha=-1.0)
+
+                if not is_small:
+                    all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+
+        self._reduce_scatter_futures.clear()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        self.attn_gate = CastedLinear(12, num_heads)
+        self.attn_gate.weight.label = 'attn_gate'
+
+        # only include gates on layers with value embeds used on forward pass
+        if layer_idx in [0,1,8,9,10]:
+            self.value_embed_gate = CastedLinear(12, num_heads)
+            self.value_embed_gate.weight.label = 'value_embed_gate'
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(self.value_embed_gate(x[..., :self.value_embed_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(self.attn_gate(x[..., :self.attn_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        #self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.5/448, grad_s=0.75/448)
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig, skew = None):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset = key_offset[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if skew is None:
+            logits = 23 * torch.sigmoid((logits+5) / 7.5)
+        else:
+            logits = 23 * torch.sigmoid((logits+skew) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        adam_labels = ['lm_head', 'value_embed', 'smear_gate', 'skip_gate', 'x0_lambdas', 'embed']
+        scalar_labels = ['scalars']
+        muon_labels = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        scalar_params = [p for p in model.parameters() if getattr(p, 'label', None) in scalar_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + scalar_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, lr=0.008, betas=(0.65, 0.95), eps=1e-8, weight_decay=0.005)
+        self.scalar_opt = DistAdam(scalar_params, scalar_labels, lr=0.008, betas=(0.9, 0.99), eps=1e-8, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.scalar_opt, self.muon_opt]
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.freeze_timer = 0
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+        self.scalar_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            if opt.freeze_timer > 0:
+                opt.freeze_timer -= 1
+                opt.zero_grad(set_to_none=True)
+            else:
+                if self._is_active_step(opt, step):
+                    for group in opt.param_groups:
+                        group["lr"] = group["initial_lr"] * step_lr
+                    opt.step()
+                    opt.zero_grad(set_to_none=True)
+                    if opt.odd_step_only:
+                        opt.should_sync = False
+        
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+
+    def start_transition(self, freeze_count=40):
+        # freeze scalar weights during transition
+        self.scalar_opt.freeze_timer = freeze_count
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1805  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+def log_parameter_norms(model):
+    norms = {}
+    for name, param in model.named_parameters():
+        if param.requires_grad:
+            norms[f"param_norm/{name}"] = param.norm().item()
+            norms[f"param_max/{name}"] = param.max().item()
+            norms[f"param_min/{name}"] = param.min().item()
+            if param.grad is not None:
+                norms[f"grad_norm/{name}"] = param.grad.norm().item()
+                norms[f"grad_max/{name}"] = param.grad.max().item()
+    
+    # Total norms
+    total_param_norm = sum(p.norm().item() ** 2 for p in model.parameters()) ** 0.5
+    total_grad_norm = sum(p.grad.norm().item() ** 2 for p in model.parameters() if p.grad is not None) ** 0.5
+    
+    norms["param_norm/total"] = total_param_norm
+    norms["grad_norm/total"] = total_grad_norm
+    
+    return norms
+
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+# import wandb
+# if master_process:
+#     wandb.init(
+#         project="nano4",
+#         name="baseline"
+#     )
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    # if master_process and step%2==1:
+    #     wandb.log({
+    #         "loss": loss.item(),
+    #         **log_parameter_norms(model)  # Add all norms
+    #     })
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Dec 29 05:59:36 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.90.07              Driver Version: 550.90.07      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   26C    P0            110W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            107W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   39C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   27C    P0            113W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   29C    P0            111W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   29C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 601, 602, 603, 1203, 1204, 1205, 1804, 1805, 1806] for warmup
+Resetting Model
+step:0/1845 val_loss:10.8309 train_time:0ms step_avg:0.03ms
+step:1/1845 train_time:86ms step_avg:86.15ms
+step:2/1845 train_time:110ms step_avg:55.04ms
+step:3/1845 train_time:131ms step_avg:43.65ms
+step:4/1845 train_time:164ms step_avg:41.07ms
+step:5/1845 train_time:199ms step_avg:39.83ms
+step:6/1845 train_time:286ms step_avg:47.73ms
+step:7/1845 train_time:429ms step_avg:61.25ms
+step:8/1845 train_time:463ms step_avg:57.84ms
+step:9/1845 train_time:497ms step_avg:55.23ms
+step:10/1845 train_time:531ms step_avg:53.10ms
+step:11/1845 train_time:566ms step_avg:51.41ms
+step:12/1845 train_time:600ms step_avg:49.97ms
+step:13/1845 train_time:634ms step_avg:48.80ms
+step:14/1845 train_time:669ms step_avg:47.80ms
+step:15/1845 train_time:703ms step_avg:46.88ms
+step:16/1845 train_time:737ms step_avg:46.08ms
+step:17/1845 train_time:772ms step_avg:45.42ms
+step:18/1845 train_time:806ms step_avg:44.79ms
+step:19/1845 train_time:841ms step_avg:44.26ms
+step:20/1845 train_time:875ms step_avg:43.75ms
+step:21/1845 train_time:910ms step_avg:43.32ms
+step:22/1845 train_time:944ms step_avg:42.90ms
+step:23/1845 train_time:979ms step_avg:42.54ms
+step:24/1845 train_time:1013ms step_avg:42.20ms
+step:25/1845 train_time:1047ms step_avg:41.88ms
+step:26/1845 train_time:1081ms step_avg:41.58ms
+step:27/1845 train_time:1116ms step_avg:41.33ms
+step:28/1845 train_time:1150ms step_avg:41.07ms
+step:29/1845 train_time:1185ms step_avg:40.85ms
+step:30/1845 train_time:1219ms step_avg:40.62ms
+step:31/1845 train_time:1253ms step_avg:40.43ms
+step:32/1845 train_time:1288ms step_avg:40.24ms
+step:33/1845 train_time:1323ms step_avg:40.09ms
+step:34/1845 train_time:1357ms step_avg:39.92ms
+step:35/1845 train_time:1393ms step_avg:39.79ms
+step:36/1845 train_time:1427ms step_avg:39.63ms
+step:37/1845 train_time:1462ms step_avg:39.51ms
+step:38/1845 train_time:1496ms step_avg:39.38ms
+step:39/1845 train_time:1531ms step_avg:39.27ms
+step:40/1845 train_time:1565ms step_avg:39.14ms
+step:41/1845 train_time:1601ms step_avg:39.04ms
+step:42/1845 train_time:1635ms step_avg:38.93ms
+step:43/1845 train_time:1670ms step_avg:38.83ms
+step:44/1845 train_time:1704ms step_avg:38.73ms
+step:45/1845 train_time:1739ms step_avg:38.64ms
+step:46/1845 train_time:1773ms step_avg:38.54ms
+step:47/1845 train_time:1808ms step_avg:38.46ms
+step:48/1845 train_time:1842ms step_avg:38.37ms
+step:49/1845 train_time:1877ms step_avg:38.30ms
+step:50/1845 train_time:1911ms step_avg:38.21ms
+step:51/1845 train_time:1945ms step_avg:38.14ms
+step:52/1845 train_time:1979ms step_avg:38.06ms
+step:53/1845 train_time:2014ms step_avg:38.00ms
+step:54/1845 train_time:2048ms step_avg:37.93ms
+step:55/1845 train_time:2083ms step_avg:37.87ms
+step:56/1845 train_time:2117ms step_avg:37.80ms
+step:57/1845 train_time:2151ms step_avg:37.74ms
+step:58/1845 train_time:2186ms step_avg:37.68ms
+step:59/1845 train_time:2220ms step_avg:37.63ms
+step:60/1845 train_time:2255ms step_avg:37.58ms
+step:61/1845 train_time:2289ms step_avg:37.53ms
+step:62/1845 train_time:2324ms step_avg:37.48ms
+step:63/1845 train_time:2359ms step_avg:37.44ms
+step:64/1845 train_time:2393ms step_avg:37.39ms
+step:65/1845 train_time:2427ms step_avg:37.34ms
+step:66/1845 train_time:2462ms step_avg:37.30ms
+step:67/1845 train_time:2497ms step_avg:37.26ms
+step:68/1845 train_time:2531ms step_avg:37.21ms
+step:69/1845 train_time:2565ms step_avg:37.18ms
+step:70/1845 train_time:2600ms step_avg:37.14ms
+step:71/1845 train_time:2635ms step_avg:37.11ms
+step:72/1845 train_time:2669ms step_avg:37.07ms
+step:73/1845 train_time:2704ms step_avg:37.04ms
+step:74/1845 train_time:2738ms step_avg:37.00ms
+step:75/1845 train_time:2773ms step_avg:36.98ms
+step:76/1845 train_time:2807ms step_avg:36.94ms
+step:77/1845 train_time:2842ms step_avg:36.91ms
+step:78/1845 train_time:2876ms step_avg:36.87ms
+step:79/1845 train_time:2911ms step_avg:36.85ms
+step:80/1845 train_time:2945ms step_avg:36.81ms
+step:81/1845 train_time:2980ms step_avg:36.79ms
+step:82/1845 train_time:3014ms step_avg:36.75ms
+step:83/1845 train_time:3049ms step_avg:36.73ms
+step:84/1845 train_time:3083ms step_avg:36.70ms
+step:85/1845 train_time:3118ms step_avg:36.68ms
+step:86/1845 train_time:3152ms step_avg:36.65ms
+step:87/1845 train_time:3186ms step_avg:36.62ms
+step:88/1845 train_time:3220ms step_avg:36.60ms
+step:89/1845 train_time:3255ms step_avg:36.58ms
+step:90/1845 train_time:3290ms step_avg:36.55ms
+step:91/1845 train_time:3324ms step_avg:36.53ms
+step:92/1845 train_time:3358ms step_avg:36.50ms
+step:93/1845 train_time:3393ms step_avg:36.49ms
+step:94/1845 train_time:3427ms step_avg:36.46ms
+step:95/1845 train_time:3462ms step_avg:36.45ms
+step:96/1845 train_time:3496ms step_avg:36.42ms
+step:97/1845 train_time:3531ms step_avg:36.41ms
+step:98/1845 train_time:3565ms step_avg:36.38ms
+step:99/1845 train_time:3600ms step_avg:36.36ms
+step:100/1845 train_time:3634ms step_avg:36.34ms
+step:101/1845 train_time:3669ms step_avg:36.32ms
+step:102/1845 train_time:3703ms step_avg:36.30ms
+step:103/1845 train_time:3737ms step_avg:36.28ms
+step:104/1845 train_time:3771ms step_avg:36.26ms
+step:105/1845 train_time:3806ms step_avg:36.25ms
+step:106/1845 train_time:3840ms step_avg:36.23ms
+step:107/1845 train_time:3875ms step_avg:36.21ms
+step:108/1845 train_time:3909ms step_avg:36.19ms
+step:109/1845 train_time:3944ms step_avg:36.18ms
+step:110/1845 train_time:3978ms step_avg:36.16ms
+step:111/1845 train_time:4012ms step_avg:36.15ms
+step:112/1845 train_time:4046ms step_avg:36.13ms
+step:113/1845 train_time:4081ms step_avg:36.11ms
+step:114/1845 train_time:4115ms step_avg:36.10ms
+step:115/1845 train_time:4150ms step_avg:36.08ms
+step:116/1845 train_time:4184ms step_avg:36.07ms
+step:117/1845 train_time:4219ms step_avg:36.06ms
+step:118/1845 train_time:4253ms step_avg:36.04ms
+step:119/1845 train_time:4288ms step_avg:36.03ms
+step:120/1845 train_time:4322ms step_avg:36.01ms
+step:121/1845 train_time:4357ms step_avg:36.01ms
+step:122/1845 train_time:4391ms step_avg:35.99ms
+step:123/1845 train_time:4426ms step_avg:35.98ms
+step:124/1845 train_time:4460ms step_avg:35.96ms
+step:125/1845 train_time:4495ms step_avg:35.96ms
+step:126/1845 train_time:4529ms step_avg:35.94ms
+step:127/1845 train_time:4564ms step_avg:35.93ms
+step:128/1845 train_time:4598ms step_avg:35.92ms
+step:129/1845 train_time:4632ms step_avg:35.91ms
+step:130/1845 train_time:4666ms step_avg:35.90ms
+step:131/1845 train_time:4701ms step_avg:35.89ms
+step:132/1845 train_time:4735ms step_avg:35.87ms
+step:133/1845 train_time:4770ms step_avg:35.86ms
+step:134/1845 train_time:4804ms step_avg:35.85ms
+step:135/1845 train_time:4839ms step_avg:35.84ms
+step:136/1845 train_time:4873ms step_avg:35.83ms
+step:137/1845 train_time:4907ms step_avg:35.82ms
+step:138/1845 train_time:4941ms step_avg:35.81ms
+step:139/1845 train_time:4976ms step_avg:35.80ms
+step:140/1845 train_time:5010ms step_avg:35.79ms
+step:141/1845 train_time:5045ms step_avg:35.78ms
+step:142/1845 train_time:5079ms step_avg:35.77ms
+step:143/1845 train_time:5114ms step_avg:35.76ms
+step:144/1845 train_time:5148ms step_avg:35.75ms
+step:145/1845 train_time:5183ms step_avg:35.74ms
+step:146/1845 train_time:5217ms step_avg:35.73ms
+step:147/1845 train_time:5251ms step_avg:35.72ms
+step:148/1845 train_time:5286ms step_avg:35.71ms
+step:149/1845 train_time:5320ms step_avg:35.71ms
+step:150/1845 train_time:5354ms step_avg:35.70ms
+step:151/1845 train_time:5389ms step_avg:35.69ms
+step:152/1845 train_time:5423ms step_avg:35.68ms
+step:153/1845 train_time:5458ms step_avg:35.67ms
+step:154/1845 train_time:5492ms step_avg:35.66ms
+step:155/1845 train_time:5526ms step_avg:35.65ms
+step:156/1845 train_time:5561ms step_avg:35.65ms
+step:157/1845 train_time:5596ms step_avg:35.64ms
+step:158/1845 train_time:5630ms step_avg:35.63ms
+step:159/1845 train_time:5665ms step_avg:35.63ms
+step:160/1845 train_time:5698ms step_avg:35.62ms
+step:161/1845 train_time:5733ms step_avg:35.61ms
+step:162/1845 train_time:5767ms step_avg:35.60ms
+step:163/1845 train_time:5802ms step_avg:35.59ms
+step:164/1845 train_time:5836ms step_avg:35.59ms
+step:165/1845 train_time:5871ms step_avg:35.58ms
+step:166/1845 train_time:5905ms step_avg:35.57ms
+step:167/1845 train_time:5939ms step_avg:35.56ms
+step:168/1845 train_time:5973ms step_avg:35.56ms
+step:169/1845 train_time:6008ms step_avg:35.55ms
+step:170/1845 train_time:6042ms step_avg:35.54ms
+step:171/1845 train_time:6076ms step_avg:35.53ms
+step:172/1845 train_time:6110ms step_avg:35.52ms
+step:173/1845 train_time:6145ms step_avg:35.52ms
+step:174/1845 train_time:6179ms step_avg:35.51ms
+step:175/1845 train_time:6214ms step_avg:35.51ms
+step:176/1845 train_time:6248ms step_avg:35.50ms
+step:177/1845 train_time:6282ms step_avg:35.49ms
+step:178/1845 train_time:6316ms step_avg:35.48ms
+step:179/1845 train_time:6351ms step_avg:35.48ms
+step:180/1845 train_time:6385ms step_avg:35.47ms
+step:181/1845 train_time:6420ms step_avg:35.47ms
+step:182/1845 train_time:6454ms step_avg:35.46ms
+step:183/1845 train_time:6488ms step_avg:35.45ms
+step:184/1845 train_time:6522ms step_avg:35.45ms
+step:185/1845 train_time:6557ms step_avg:35.44ms
+step:186/1845 train_time:6591ms step_avg:35.44ms
+step:187/1845 train_time:6626ms step_avg:35.43ms
+step:188/1845 train_time:6660ms step_avg:35.42ms
+step:189/1845 train_time:6694ms step_avg:35.42ms
+step:190/1845 train_time:6729ms step_avg:35.41ms
+step:191/1845 train_time:6763ms step_avg:35.41ms
+step:192/1845 train_time:6797ms step_avg:35.40ms
+step:193/1845 train_time:6832ms step_avg:35.40ms
+step:194/1845 train_time:6866ms step_avg:35.39ms
+step:195/1845 train_time:6901ms step_avg:35.39ms
+step:196/1845 train_time:6935ms step_avg:35.38ms
+step:197/1845 train_time:6970ms step_avg:35.38ms
+step:198/1845 train_time:7003ms step_avg:35.37ms
+step:199/1845 train_time:7038ms step_avg:35.37ms
+step:200/1845 train_time:7072ms step_avg:35.36ms
+step:201/1845 train_time:7106ms step_avg:35.35ms
+step:202/1845 train_time:7140ms step_avg:35.35ms
+step:203/1845 train_time:7175ms step_avg:35.34ms
+step:204/1845 train_time:7209ms step_avg:35.34ms
+step:205/1845 train_time:7243ms step_avg:35.33ms
+step:206/1845 train_time:7277ms step_avg:35.33ms
+step:207/1845 train_time:7312ms step_avg:35.32ms
+step:208/1845 train_time:7346ms step_avg:35.32ms
+step:209/1845 train_time:7381ms step_avg:35.31ms
+step:210/1845 train_time:7415ms step_avg:35.31ms
+step:211/1845 train_time:7450ms step_avg:35.31ms
+step:212/1845 train_time:7484ms step_avg:35.30ms
+step:213/1845 train_time:7518ms step_avg:35.30ms
+step:214/1845 train_time:7552ms step_avg:35.29ms
+step:215/1845 train_time:7587ms step_avg:35.29ms
+step:216/1845 train_time:7621ms step_avg:35.28ms
+step:217/1845 train_time:7656ms step_avg:35.28ms
+step:218/1845 train_time:7690ms step_avg:35.28ms
+step:219/1845 train_time:7724ms step_avg:35.27ms
+step:220/1845 train_time:7759ms step_avg:35.27ms
+step:221/1845 train_time:7793ms step_avg:35.26ms
+step:222/1845 train_time:7828ms step_avg:35.26ms
+step:223/1845 train_time:7862ms step_avg:35.26ms
+step:224/1845 train_time:7896ms step_avg:35.25ms
+step:225/1845 train_time:7931ms step_avg:35.25ms
+step:226/1845 train_time:7965ms step_avg:35.24ms
+step:227/1845 train_time:7999ms step_avg:35.24ms
+step:228/1845 train_time:8033ms step_avg:35.23ms
+step:229/1845 train_time:8068ms step_avg:35.23ms
+step:230/1845 train_time:8102ms step_avg:35.22ms
+step:231/1845 train_time:8136ms step_avg:35.22ms
+step:232/1845 train_time:8170ms step_avg:35.22ms
+step:233/1845 train_time:8204ms step_avg:35.21ms
+step:234/1845 train_time:8238ms step_avg:35.21ms
+step:235/1845 train_time:8273ms step_avg:35.20ms
+step:236/1845 train_time:8307ms step_avg:35.20ms
+step:237/1845 train_time:8341ms step_avg:35.20ms
+step:238/1845 train_time:8375ms step_avg:35.19ms
+step:239/1845 train_time:8410ms step_avg:35.19ms
+step:240/1845 train_time:8444ms step_avg:35.18ms
+step:241/1845 train_time:8478ms step_avg:35.18ms
+step:242/1845 train_time:8512ms step_avg:35.18ms
+step:243/1845 train_time:8547ms step_avg:35.17ms
+step:244/1845 train_time:8581ms step_avg:35.17ms
+step:245/1845 train_time:8616ms step_avg:35.17ms
+step:246/1845 train_time:8650ms step_avg:35.16ms
+step:247/1845 train_time:8684ms step_avg:35.16ms
+step:248/1845 train_time:8718ms step_avg:35.15ms
+step:249/1845 train_time:8753ms step_avg:35.15ms
+step:250/1845 train_time:8787ms step_avg:35.15ms
+step:250/1845 val_loss:4.6200 train_time:8824ms step_avg:35.29ms
+step:251/1845 train_time:8843ms step_avg:35.23ms
+step:252/1845 train_time:8864ms step_avg:35.17ms
+step:253/1845 train_time:8894ms step_avg:35.15ms
+step:254/1845 train_time:8928ms step_avg:35.15ms
+step:255/1845 train_time:8963ms step_avg:35.15ms
+step:256/1845 train_time:8998ms step_avg:35.15ms
+step:257/1845 train_time:9032ms step_avg:35.15ms
+step:258/1845 train_time:9066ms step_avg:35.14ms
+step:259/1845 train_time:9101ms step_avg:35.14ms
+step:260/1845 train_time:9135ms step_avg:35.14ms
+step:261/1845 train_time:9170ms step_avg:35.13ms
+step:262/1845 train_time:9204ms step_avg:35.13ms
+step:263/1845 train_time:9238ms step_avg:35.13ms
+step:264/1845 train_time:9272ms step_avg:35.12ms
+step:265/1845 train_time:9306ms step_avg:35.12ms
+step:266/1845 train_time:9340ms step_avg:35.11ms
+step:267/1845 train_time:9375ms step_avg:35.11ms
+step:268/1845 train_time:9408ms step_avg:35.11ms
+step:269/1845 train_time:9443ms step_avg:35.10ms
+step:270/1845 train_time:9477ms step_avg:35.10ms
+step:271/1845 train_time:9511ms step_avg:35.10ms
+step:272/1845 train_time:9545ms step_avg:35.09ms
+step:273/1845 train_time:9579ms step_avg:35.09ms
+step:274/1845 train_time:9613ms step_avg:35.08ms
+step:275/1845 train_time:9647ms step_avg:35.08ms
+step:276/1845 train_time:9681ms step_avg:35.08ms
+step:277/1845 train_time:9716ms step_avg:35.07ms
+step:278/1845 train_time:9750ms step_avg:35.07ms
+step:279/1845 train_time:9784ms step_avg:35.07ms
+step:280/1845 train_time:9818ms step_avg:35.06ms
+step:281/1845 train_time:9852ms step_avg:35.06ms
+step:282/1845 train_time:9886ms step_avg:35.06ms
+step:283/1845 train_time:9921ms step_avg:35.06ms
+step:284/1845 train_time:9955ms step_avg:35.05ms
+step:285/1845 train_time:9989ms step_avg:35.05ms
+step:286/1845 train_time:10023ms step_avg:35.05ms
+step:287/1845 train_time:10058ms step_avg:35.05ms
+step:288/1845 train_time:10092ms step_avg:35.04ms
+step:289/1845 train_time:10127ms step_avg:35.04ms
+step:290/1845 train_time:10161ms step_avg:35.04ms
+step:291/1845 train_time:10195ms step_avg:35.03ms
+step:292/1845 train_time:10229ms step_avg:35.03ms
+step:293/1845 train_time:10263ms step_avg:35.03ms
+step:294/1845 train_time:10297ms step_avg:35.03ms
+step:295/1845 train_time:10332ms step_avg:35.02ms
+step:296/1845 train_time:10366ms step_avg:35.02ms
+step:297/1845 train_time:10400ms step_avg:35.02ms
+step:298/1845 train_time:10434ms step_avg:35.01ms
+step:299/1845 train_time:10468ms step_avg:35.01ms
+step:300/1845 train_time:10502ms step_avg:35.01ms
+step:301/1845 train_time:10537ms step_avg:35.01ms
+step:302/1845 train_time:10571ms step_avg:35.00ms
+step:303/1845 train_time:10605ms step_avg:35.00ms
+step:304/1845 train_time:10639ms step_avg:35.00ms
+step:305/1845 train_time:10674ms step_avg:35.00ms
+step:306/1845 train_time:10708ms step_avg:34.99ms
+step:307/1845 train_time:10742ms step_avg:34.99ms
+step:308/1845 train_time:10776ms step_avg:34.99ms
+step:309/1845 train_time:10811ms step_avg:34.99ms
+step:310/1845 train_time:10845ms step_avg:34.98ms
+step:311/1845 train_time:10879ms step_avg:34.98ms
+step:312/1845 train_time:10913ms step_avg:34.98ms
+step:313/1845 train_time:10947ms step_avg:34.98ms
+step:314/1845 train_time:10981ms step_avg:34.97ms
+step:315/1845 train_time:11016ms step_avg:34.97ms
+step:316/1845 train_time:11050ms step_avg:34.97ms
+step:317/1845 train_time:11085ms step_avg:34.97ms
+step:318/1845 train_time:11119ms step_avg:34.96ms
+step:319/1845 train_time:11153ms step_avg:34.96ms
+step:320/1845 train_time:11187ms step_avg:34.96ms
+step:321/1845 train_time:11221ms step_avg:34.96ms
+step:322/1845 train_time:11256ms step_avg:34.96ms
+step:323/1845 train_time:11289ms step_avg:34.95ms
+step:324/1845 train_time:11324ms step_avg:34.95ms
+step:325/1845 train_time:11358ms step_avg:34.95ms
+step:326/1845 train_time:11392ms step_avg:34.94ms
+step:327/1845 train_time:11426ms step_avg:34.94ms
+step:328/1845 train_time:11460ms step_avg:34.94ms
+step:329/1845 train_time:11495ms step_avg:34.94ms
+step:330/1845 train_time:11529ms step_avg:34.94ms
+step:331/1845 train_time:11563ms step_avg:34.93ms
+step:332/1845 train_time:11597ms step_avg:34.93ms
+step:333/1845 train_time:11631ms step_avg:34.93ms
+step:334/1845 train_time:11665ms step_avg:34.93ms
+step:335/1845 train_time:11700ms step_avg:34.92ms
+step:336/1845 train_time:11734ms step_avg:34.92ms
+step:337/1845 train_time:11768ms step_avg:34.92ms
+step:338/1845 train_time:11802ms step_avg:34.92ms
+step:339/1845 train_time:11837ms step_avg:34.92ms
+step:340/1845 train_time:11871ms step_avg:34.91ms
+step:341/1845 train_time:11905ms step_avg:34.91ms
+step:342/1845 train_time:11939ms step_avg:34.91ms
+step:343/1845 train_time:11974ms step_avg:34.91ms
+step:344/1845 train_time:12008ms step_avg:34.91ms
+step:345/1845 train_time:12042ms step_avg:34.90ms
+step:346/1845 train_time:12076ms step_avg:34.90ms
+step:347/1845 train_time:12110ms step_avg:34.90ms
+step:348/1845 train_time:12144ms step_avg:34.90ms
+step:349/1845 train_time:12179ms step_avg:34.90ms
+step:350/1845 train_time:12213ms step_avg:34.89ms
+step:351/1845 train_time:12248ms step_avg:34.89ms
+step:352/1845 train_time:12281ms step_avg:34.89ms
+step:353/1845 train_time:12316ms step_avg:34.89ms
+step:354/1845 train_time:12350ms step_avg:34.89ms
+step:355/1845 train_time:12385ms step_avg:34.89ms
+step:356/1845 train_time:12419ms step_avg:34.88ms
+step:357/1845 train_time:12453ms step_avg:34.88ms
+step:358/1845 train_time:12487ms step_avg:34.88ms
+step:359/1845 train_time:12521ms step_avg:34.88ms
+step:360/1845 train_time:12555ms step_avg:34.88ms
+step:361/1845 train_time:12590ms step_avg:34.88ms
+step:362/1845 train_time:12624ms step_avg:34.87ms
+step:363/1845 train_time:12659ms step_avg:34.87ms
+step:364/1845 train_time:12692ms step_avg:34.87ms
+step:365/1845 train_time:12727ms step_avg:34.87ms
+step:366/1845 train_time:12761ms step_avg:34.87ms
+step:367/1845 train_time:12795ms step_avg:34.86ms
+step:368/1845 train_time:12829ms step_avg:34.86ms
+step:369/1845 train_time:12863ms step_avg:34.86ms
+step:370/1845 train_time:12897ms step_avg:34.86ms
+step:371/1845 train_time:12932ms step_avg:34.86ms
+step:372/1845 train_time:12966ms step_avg:34.85ms
+step:373/1845 train_time:13000ms step_avg:34.85ms
+step:374/1845 train_time:13034ms step_avg:34.85ms
+step:375/1845 train_time:13069ms step_avg:34.85ms
+step:376/1845 train_time:13103ms step_avg:34.85ms
+step:377/1845 train_time:13137ms step_avg:34.85ms
+step:378/1845 train_time:13171ms step_avg:34.84ms
+step:379/1845 train_time:13206ms step_avg:34.84ms
+step:380/1845 train_time:13239ms step_avg:34.84ms
+step:381/1845 train_time:13274ms step_avg:34.84ms
+step:382/1845 train_time:13308ms step_avg:34.84ms
+step:383/1845 train_time:13342ms step_avg:34.84ms
+step:384/1845 train_time:13376ms step_avg:34.83ms
+step:385/1845 train_time:13410ms step_avg:34.83ms
+step:386/1845 train_time:13444ms step_avg:34.83ms
+step:387/1845 train_time:13479ms step_avg:34.83ms
+step:388/1845 train_time:13513ms step_avg:34.83ms
+step:389/1845 train_time:13547ms step_avg:34.83ms
+step:390/1845 train_time:13581ms step_avg:34.82ms
+step:391/1845 train_time:13616ms step_avg:34.82ms
+step:392/1845 train_time:13650ms step_avg:34.82ms
+step:393/1845 train_time:13684ms step_avg:34.82ms
+step:394/1845 train_time:13718ms step_avg:34.82ms
+step:395/1845 train_time:13753ms step_avg:34.82ms
+step:396/1845 train_time:13787ms step_avg:34.82ms
+step:397/1845 train_time:13821ms step_avg:34.81ms
+step:398/1845 train_time:13855ms step_avg:34.81ms
+step:399/1845 train_time:13890ms step_avg:34.81ms
+step:400/1845 train_time:13924ms step_avg:34.81ms
+step:401/1845 train_time:13958ms step_avg:34.81ms
+step:402/1845 train_time:13992ms step_avg:34.81ms
+step:403/1845 train_time:14026ms step_avg:34.81ms
+step:404/1845 train_time:14060ms step_avg:34.80ms
+step:405/1845 train_time:14095ms step_avg:34.80ms
+step:406/1845 train_time:14129ms step_avg:34.80ms
+step:407/1845 train_time:14163ms step_avg:34.80ms
+step:408/1845 train_time:14197ms step_avg:34.80ms
+step:409/1845 train_time:14231ms step_avg:34.80ms
+step:410/1845 train_time:14265ms step_avg:34.79ms
+step:411/1845 train_time:14299ms step_avg:34.79ms
+step:412/1845 train_time:14333ms step_avg:34.79ms
+step:413/1845 train_time:14368ms step_avg:34.79ms
+step:414/1845 train_time:14402ms step_avg:34.79ms
+step:415/1845 train_time:14436ms step_avg:34.79ms
+step:416/1845 train_time:14470ms step_avg:34.78ms
+step:417/1845 train_time:14504ms step_avg:34.78ms
+step:418/1845 train_time:14538ms step_avg:34.78ms
+step:419/1845 train_time:14573ms step_avg:34.78ms
+step:420/1845 train_time:14607ms step_avg:34.78ms
+step:421/1845 train_time:14641ms step_avg:34.78ms
+step:422/1845 train_time:14675ms step_avg:34.77ms
+step:423/1845 train_time:14709ms step_avg:34.77ms
+step:424/1845 train_time:14743ms step_avg:34.77ms
+step:425/1845 train_time:14777ms step_avg:34.77ms
+step:426/1845 train_time:14811ms step_avg:34.77ms
+step:427/1845 train_time:14846ms step_avg:34.77ms
+step:428/1845 train_time:14880ms step_avg:34.77ms
+step:429/1845 train_time:14914ms step_avg:34.77ms
+step:430/1845 train_time:14948ms step_avg:34.76ms
+step:431/1845 train_time:14983ms step_avg:34.76ms
+step:432/1845 train_time:15016ms step_avg:34.76ms
+step:433/1845 train_time:15051ms step_avg:34.76ms
+step:434/1845 train_time:15085ms step_avg:34.76ms
+step:435/1845 train_time:15119ms step_avg:34.76ms
+step:436/1845 train_time:15153ms step_avg:34.76ms
+step:437/1845 train_time:15188ms step_avg:34.75ms
+step:438/1845 train_time:15222ms step_avg:34.75ms
+step:439/1845 train_time:15256ms step_avg:34.75ms
+step:440/1845 train_time:15290ms step_avg:34.75ms
+step:441/1845 train_time:15325ms step_avg:34.75ms
+step:442/1845 train_time:15359ms step_avg:34.75ms
+step:443/1845 train_time:15393ms step_avg:34.75ms
+step:444/1845 train_time:15427ms step_avg:34.75ms
+step:445/1845 train_time:15462ms step_avg:34.75ms
+step:446/1845 train_time:15496ms step_avg:34.74ms
+step:447/1845 train_time:15530ms step_avg:34.74ms
+step:448/1845 train_time:15564ms step_avg:34.74ms
+step:449/1845 train_time:15599ms step_avg:34.74ms
+step:450/1845 train_time:15632ms step_avg:34.74ms
+step:451/1845 train_time:15667ms step_avg:34.74ms
+step:452/1845 train_time:15701ms step_avg:34.74ms
+step:453/1845 train_time:15735ms step_avg:34.74ms
+step:454/1845 train_time:15769ms step_avg:34.73ms
+step:455/1845 train_time:15804ms step_avg:34.73ms
+step:456/1845 train_time:15838ms step_avg:34.73ms
+step:457/1845 train_time:15872ms step_avg:34.73ms
+step:458/1845 train_time:15906ms step_avg:34.73ms
+step:459/1845 train_time:15940ms step_avg:34.73ms
+step:460/1845 train_time:15974ms step_avg:34.73ms
+step:461/1845 train_time:16008ms step_avg:34.72ms
+step:462/1845 train_time:16042ms step_avg:34.72ms
+step:463/1845 train_time:16076ms step_avg:34.72ms
+step:464/1845 train_time:16110ms step_avg:34.72ms
+step:465/1845 train_time:16145ms step_avg:34.72ms
+step:466/1845 train_time:16179ms step_avg:34.72ms
+step:467/1845 train_time:16213ms step_avg:34.72ms
+step:468/1845 train_time:16247ms step_avg:34.72ms
+step:469/1845 train_time:16282ms step_avg:34.72ms
+step:470/1845 train_time:16316ms step_avg:34.71ms
+step:471/1845 train_time:16350ms step_avg:34.71ms
+step:472/1845 train_time:16384ms step_avg:34.71ms
+step:473/1845 train_time:16419ms step_avg:34.71ms
+step:474/1845 train_time:16453ms step_avg:34.71ms
+step:475/1845 train_time:16487ms step_avg:34.71ms
+step:476/1845 train_time:16521ms step_avg:34.71ms
+step:477/1845 train_time:16555ms step_avg:34.71ms
+step:478/1845 train_time:16589ms step_avg:34.71ms
+step:479/1845 train_time:16624ms step_avg:34.70ms
+step:480/1845 train_time:16658ms step_avg:34.70ms
+step:481/1845 train_time:16692ms step_avg:34.70ms
+step:482/1845 train_time:16726ms step_avg:34.70ms
+step:483/1845 train_time:16760ms step_avg:34.70ms
+step:484/1845 train_time:16794ms step_avg:34.70ms
+step:485/1845 train_time:16829ms step_avg:34.70ms
+step:486/1845 train_time:16863ms step_avg:34.70ms
+step:487/1845 train_time:16897ms step_avg:34.70ms
+step:488/1845 train_time:16931ms step_avg:34.69ms
+step:489/1845 train_time:16965ms step_avg:34.69ms
+step:490/1845 train_time:16999ms step_avg:34.69ms
+step:491/1845 train_time:17034ms step_avg:34.69ms
+step:492/1845 train_time:17068ms step_avg:34.69ms
+step:493/1845 train_time:17102ms step_avg:34.69ms
+step:494/1845 train_time:17136ms step_avg:34.69ms
+step:495/1845 train_time:17170ms step_avg:34.69ms
+step:496/1845 train_time:17204ms step_avg:34.69ms
+step:497/1845 train_time:17238ms step_avg:34.69ms
+step:498/1845 train_time:17273ms step_avg:34.68ms
+step:499/1845 train_time:17307ms step_avg:34.68ms
+step:500/1845 train_time:17341ms step_avg:34.68ms
+step:500/1845 val_loss:4.2807 train_time:17377ms step_avg:34.75ms
+step:501/1845 train_time:17401ms step_avg:34.73ms
+step:502/1845 train_time:17421ms step_avg:34.70ms
+step:503/1845 train_time:17448ms step_avg:34.69ms
+step:504/1845 train_time:17482ms step_avg:34.69ms
+step:505/1845 train_time:17519ms step_avg:34.69ms
+step:506/1845 train_time:17553ms step_avg:34.69ms
+step:507/1845 train_time:17588ms step_avg:34.69ms
+step:508/1845 train_time:17622ms step_avg:34.69ms
+step:509/1845 train_time:17657ms step_avg:34.69ms
+step:510/1845 train_time:17691ms step_avg:34.69ms
+step:511/1845 train_time:17725ms step_avg:34.69ms
+step:512/1845 train_time:17759ms step_avg:34.69ms
+step:513/1845 train_time:17793ms step_avg:34.68ms
+step:514/1845 train_time:17827ms step_avg:34.68ms
+step:515/1845 train_time:17861ms step_avg:34.68ms
+step:516/1845 train_time:17895ms step_avg:34.68ms
+step:517/1845 train_time:17930ms step_avg:34.68ms
+step:518/1845 train_time:17964ms step_avg:34.68ms
+step:519/1845 train_time:17999ms step_avg:34.68ms
+step:520/1845 train_time:18032ms step_avg:34.68ms
+step:521/1845 train_time:18067ms step_avg:34.68ms
+step:522/1845 train_time:18101ms step_avg:34.68ms
+step:523/1845 train_time:18135ms step_avg:34.67ms
+step:524/1845 train_time:18169ms step_avg:34.67ms
+step:525/1845 train_time:18203ms step_avg:34.67ms
+step:526/1845 train_time:18237ms step_avg:34.67ms
+step:527/1845 train_time:18272ms step_avg:34.67ms
+step:528/1845 train_time:18306ms step_avg:34.67ms
+step:529/1845 train_time:18340ms step_avg:34.67ms
+step:530/1845 train_time:18374ms step_avg:34.67ms
+step:531/1845 train_time:18409ms step_avg:34.67ms
+step:532/1845 train_time:18443ms step_avg:34.67ms
+step:533/1845 train_time:18478ms step_avg:34.67ms
+step:534/1845 train_time:18512ms step_avg:34.67ms
+step:535/1845 train_time:18547ms step_avg:34.67ms
+step:536/1845 train_time:18581ms step_avg:34.67ms
+step:537/1845 train_time:18616ms step_avg:34.67ms
+step:538/1845 train_time:18650ms step_avg:34.67ms
+step:539/1845 train_time:18685ms step_avg:34.67ms
+step:540/1845 train_time:18719ms step_avg:34.67ms
+step:541/1845 train_time:18754ms step_avg:34.67ms
+step:542/1845 train_time:18788ms step_avg:34.66ms
+step:543/1845 train_time:18822ms step_avg:34.66ms
+step:544/1845 train_time:18856ms step_avg:34.66ms
+step:545/1845 train_time:18891ms step_avg:34.66ms
+step:546/1845 train_time:18925ms step_avg:34.66ms
+step:547/1845 train_time:18959ms step_avg:34.66ms
+step:548/1845 train_time:18993ms step_avg:34.66ms
+step:549/1845 train_time:19028ms step_avg:34.66ms
+step:550/1845 train_time:19062ms step_avg:34.66ms
+step:551/1845 train_time:19096ms step_avg:34.66ms
+step:552/1845 train_time:19130ms step_avg:34.66ms
+step:553/1845 train_time:19164ms step_avg:34.66ms
+step:554/1845 train_time:19198ms step_avg:34.65ms
+step:555/1845 train_time:19233ms step_avg:34.65ms
+step:556/1845 train_time:19267ms step_avg:34.65ms
+step:557/1845 train_time:19301ms step_avg:34.65ms
+step:558/1845 train_time:19335ms step_avg:34.65ms
+step:559/1845 train_time:19370ms step_avg:34.65ms
+step:560/1845 train_time:19404ms step_avg:34.65ms
+step:561/1845 train_time:19438ms step_avg:34.65ms
+step:562/1845 train_time:19472ms step_avg:34.65ms
+step:563/1845 train_time:19507ms step_avg:34.65ms
+step:564/1845 train_time:19541ms step_avg:34.65ms
+step:565/1845 train_time:19576ms step_avg:34.65ms
+step:566/1845 train_time:19610ms step_avg:34.65ms
+step:567/1845 train_time:19644ms step_avg:34.65ms
+step:568/1845 train_time:19678ms step_avg:34.65ms
+step:569/1845 train_time:19713ms step_avg:34.65ms
+step:570/1845 train_time:19747ms step_avg:34.64ms
+step:571/1845 train_time:19782ms step_avg:34.64ms
+step:572/1845 train_time:19816ms step_avg:34.64ms
+step:573/1845 train_time:19850ms step_avg:34.64ms
+step:574/1845 train_time:19884ms step_avg:34.64ms
+step:575/1845 train_time:19919ms step_avg:34.64ms
+step:576/1845 train_time:19953ms step_avg:34.64ms
+step:577/1845 train_time:19987ms step_avg:34.64ms
+step:578/1845 train_time:20021ms step_avg:34.64ms
+step:579/1845 train_time:20056ms step_avg:34.64ms
+step:580/1845 train_time:20090ms step_avg:34.64ms
+step:581/1845 train_time:20124ms step_avg:34.64ms
+step:582/1845 train_time:20158ms step_avg:34.64ms
+step:583/1845 train_time:20193ms step_avg:34.64ms
+step:584/1845 train_time:20227ms step_avg:34.63ms
+step:585/1845 train_time:20262ms step_avg:34.64ms
+step:586/1845 train_time:20295ms step_avg:34.63ms
+step:587/1845 train_time:20330ms step_avg:34.63ms
+step:588/1845 train_time:20364ms step_avg:34.63ms
+step:589/1845 train_time:20398ms step_avg:34.63ms
+step:590/1845 train_time:20432ms step_avg:34.63ms
+step:591/1845 train_time:20467ms step_avg:34.63ms
+step:592/1845 train_time:20501ms step_avg:34.63ms
+step:593/1845 train_time:20535ms step_avg:34.63ms
+step:594/1845 train_time:20569ms step_avg:34.63ms
+step:595/1845 train_time:20604ms step_avg:34.63ms
+step:596/1845 train_time:20638ms step_avg:34.63ms
+step:597/1845 train_time:20673ms step_avg:34.63ms
+step:598/1845 train_time:20707ms step_avg:34.63ms
+step:599/1845 train_time:20741ms step_avg:34.63ms
+step:600/1845 train_time:20775ms step_avg:34.63ms
+step:601/1845 train_time:20810ms step_avg:34.63ms
+step:602/1845 train_time:20844ms step_avg:34.62ms
+step:603/1845 train_time:20880ms step_avg:34.63ms
+step:604/1845 train_time:20940ms step_avg:34.67ms
+step:605/1845 train_time:21002ms step_avg:34.71ms
+step:606/1845 train_time:21063ms step_avg:34.76ms
+step:607/1845 train_time:21125ms step_avg:34.80ms
+step:608/1845 train_time:21186ms step_avg:34.85ms
+step:609/1845 train_time:21250ms step_avg:34.89ms
+step:610/1845 train_time:21311ms step_avg:34.94ms
+step:611/1845 train_time:21373ms step_avg:34.98ms
+step:612/1845 train_time:21434ms step_avg:35.02ms
+step:613/1845 train_time:21498ms step_avg:35.07ms
+step:614/1845 train_time:21559ms step_avg:35.11ms
+step:615/1845 train_time:21622ms step_avg:35.16ms
+step:616/1845 train_time:21683ms step_avg:35.20ms
+step:617/1845 train_time:21746ms step_avg:35.24ms
+step:618/1845 train_time:21807ms step_avg:35.29ms
+step:619/1845 train_time:21869ms step_avg:35.33ms
+step:620/1845 train_time:21930ms step_avg:35.37ms
+step:621/1845 train_time:21992ms step_avg:35.41ms
+step:622/1845 train_time:22053ms step_avg:35.45ms
+step:623/1845 train_time:22115ms step_avg:35.50ms
+step:624/1845 train_time:22177ms step_avg:35.54ms
+step:625/1845 train_time:22240ms step_avg:35.58ms
+step:626/1845 train_time:22301ms step_avg:35.62ms
+step:627/1845 train_time:22364ms step_avg:35.67ms
+step:628/1845 train_time:22425ms step_avg:35.71ms
+step:629/1845 train_time:22488ms step_avg:35.75ms
+step:630/1845 train_time:22548ms step_avg:35.79ms
+step:631/1845 train_time:22612ms step_avg:35.83ms
+step:632/1845 train_time:22671ms step_avg:35.87ms
+step:633/1845 train_time:22734ms step_avg:35.92ms
+step:634/1845 train_time:22796ms step_avg:35.96ms
+step:635/1845 train_time:22859ms step_avg:36.00ms
+step:636/1845 train_time:22920ms step_avg:36.04ms
+step:637/1845 train_time:22982ms step_avg:36.08ms
+step:638/1845 train_time:23043ms step_avg:36.12ms
+step:639/1845 train_time:23105ms step_avg:36.16ms
+step:640/1845 train_time:23166ms step_avg:36.20ms
+step:641/1845 train_time:23228ms step_avg:36.24ms
+step:642/1845 train_time:23289ms step_avg:36.28ms
+step:643/1845 train_time:23352ms step_avg:36.32ms
+step:644/1845 train_time:23413ms step_avg:36.36ms
+step:645/1845 train_time:23476ms step_avg:36.40ms
+step:646/1845 train_time:23538ms step_avg:36.44ms
+step:647/1845 train_time:23601ms step_avg:36.48ms
+step:648/1845 train_time:23662ms step_avg:36.51ms
+step:649/1845 train_time:23724ms step_avg:36.55ms
+step:650/1845 train_time:23785ms step_avg:36.59ms
+step:651/1845 train_time:23848ms step_avg:36.63ms
+step:652/1845 train_time:23909ms step_avg:36.67ms
+step:653/1845 train_time:23971ms step_avg:36.71ms
+step:654/1845 train_time:24031ms step_avg:36.75ms
+step:655/1845 train_time:24094ms step_avg:36.79ms
+step:656/1845 train_time:24156ms step_avg:36.82ms
+step:657/1845 train_time:24218ms step_avg:36.86ms
+step:658/1845 train_time:24279ms step_avg:36.90ms
+step:659/1845 train_time:24343ms step_avg:36.94ms
+step:660/1845 train_time:24404ms step_avg:36.98ms
+step:661/1845 train_time:24466ms step_avg:37.01ms
+step:662/1845 train_time:24527ms step_avg:37.05ms
+step:663/1845 train_time:24590ms step_avg:37.09ms
+step:664/1845 train_time:24650ms step_avg:37.12ms
+step:665/1845 train_time:24713ms step_avg:37.16ms
+step:666/1845 train_time:24774ms step_avg:37.20ms
+step:667/1845 train_time:24838ms step_avg:37.24ms
+step:668/1845 train_time:24899ms step_avg:37.27ms
+step:669/1845 train_time:24961ms step_avg:37.31ms
+step:670/1845 train_time:25022ms step_avg:37.35ms
+step:671/1845 train_time:25084ms step_avg:37.38ms
+step:672/1845 train_time:25145ms step_avg:37.42ms
+step:673/1845 train_time:25207ms step_avg:37.46ms
+step:674/1845 train_time:25268ms step_avg:37.49ms
+step:675/1845 train_time:25330ms step_avg:37.53ms
+step:676/1845 train_time:25391ms step_avg:37.56ms
+step:677/1845 train_time:25455ms step_avg:37.60ms
+step:678/1845 train_time:25517ms step_avg:37.64ms
+step:679/1845 train_time:25580ms step_avg:37.67ms
+step:680/1845 train_time:25641ms step_avg:37.71ms
+step:681/1845 train_time:25704ms step_avg:37.74ms
+step:682/1845 train_time:25764ms step_avg:37.78ms
+step:683/1845 train_time:25827ms step_avg:37.81ms
+step:684/1845 train_time:25888ms step_avg:37.85ms
+step:685/1845 train_time:25951ms step_avg:37.89ms
+step:686/1845 train_time:26012ms step_avg:37.92ms
+step:687/1845 train_time:26075ms step_avg:37.96ms
+step:688/1845 train_time:26136ms step_avg:37.99ms
+step:689/1845 train_time:26199ms step_avg:38.03ms
+step:690/1845 train_time:26260ms step_avg:38.06ms
+step:691/1845 train_time:26322ms step_avg:38.09ms
+step:692/1845 train_time:26383ms step_avg:38.13ms
+step:693/1845 train_time:26446ms step_avg:38.16ms
+step:694/1845 train_time:26507ms step_avg:38.19ms
+step:695/1845 train_time:26570ms step_avg:38.23ms
+step:696/1845 train_time:26631ms step_avg:38.26ms
+step:697/1845 train_time:26694ms step_avg:38.30ms
+step:698/1845 train_time:26755ms step_avg:38.33ms
+step:699/1845 train_time:26818ms step_avg:38.37ms
+step:700/1845 train_time:26879ms step_avg:38.40ms
+step:701/1845 train_time:26942ms step_avg:38.43ms
+step:702/1845 train_time:27003ms step_avg:38.47ms
+step:703/1845 train_time:27065ms step_avg:38.50ms
+step:704/1845 train_time:27126ms step_avg:38.53ms
+step:705/1845 train_time:27189ms step_avg:38.57ms
+step:706/1845 train_time:27249ms step_avg:38.60ms
+step:707/1845 train_time:27312ms step_avg:38.63ms
+step:708/1845 train_time:27373ms step_avg:38.66ms
+step:709/1845 train_time:27436ms step_avg:38.70ms
+step:710/1845 train_time:27497ms step_avg:38.73ms
+step:711/1845 train_time:27560ms step_avg:38.76ms
+step:712/1845 train_time:27621ms step_avg:38.79ms
+step:713/1845 train_time:27684ms step_avg:38.83ms
+step:714/1845 train_time:27743ms step_avg:38.86ms
+step:715/1845 train_time:27806ms step_avg:38.89ms
+step:716/1845 train_time:27867ms step_avg:38.92ms
+step:717/1845 train_time:27929ms step_avg:38.95ms
+step:718/1845 train_time:27990ms step_avg:38.98ms
+step:719/1845 train_time:28053ms step_avg:39.02ms
+step:720/1845 train_time:28114ms step_avg:39.05ms
+step:721/1845 train_time:28178ms step_avg:39.08ms
+step:722/1845 train_time:28239ms step_avg:39.11ms
+step:723/1845 train_time:28302ms step_avg:39.15ms
+step:724/1845 train_time:28363ms step_avg:39.18ms
+step:725/1845 train_time:28425ms step_avg:39.21ms
+step:726/1845 train_time:28486ms step_avg:39.24ms
+step:727/1845 train_time:28549ms step_avg:39.27ms
+step:728/1845 train_time:28610ms step_avg:39.30ms
+step:729/1845 train_time:28673ms step_avg:39.33ms
+step:730/1845 train_time:28734ms step_avg:39.36ms
+step:731/1845 train_time:28797ms step_avg:39.39ms
+step:732/1845 train_time:28858ms step_avg:39.42ms
+step:733/1845 train_time:28921ms step_avg:39.46ms
+step:734/1845 train_time:28982ms step_avg:39.48ms
+step:735/1845 train_time:29044ms step_avg:39.52ms
+step:736/1845 train_time:29105ms step_avg:39.54ms
+step:737/1845 train_time:29167ms step_avg:39.58ms
+step:738/1845 train_time:29228ms step_avg:39.60ms
+step:739/1845 train_time:29291ms step_avg:39.64ms
+step:740/1845 train_time:29352ms step_avg:39.66ms
+step:741/1845 train_time:29415ms step_avg:39.70ms
+step:742/1845 train_time:29476ms step_avg:39.72ms
+step:743/1845 train_time:29539ms step_avg:39.76ms
+step:744/1845 train_time:29599ms step_avg:39.78ms
+step:745/1845 train_time:29662ms step_avg:39.81ms
+step:746/1845 train_time:29723ms step_avg:39.84ms
+step:747/1845 train_time:29786ms step_avg:39.87ms
+step:748/1845 train_time:29846ms step_avg:39.90ms
+step:749/1845 train_time:29909ms step_avg:39.93ms
+step:750/1845 train_time:29970ms step_avg:39.96ms
+step:750/1845 val_loss:4.0266 train_time:30034ms step_avg:40.05ms
+step:751/1845 train_time:30059ms step_avg:40.02ms
+step:752/1845 train_time:30096ms step_avg:40.02ms
+step:753/1845 train_time:30160ms step_avg:40.05ms
+step:754/1845 train_time:30223ms step_avg:40.08ms
+step:755/1845 train_time:30285ms step_avg:40.11ms
+step:756/1845 train_time:30347ms step_avg:40.14ms
+step:757/1845 train_time:30408ms step_avg:40.17ms
+step:758/1845 train_time:30468ms step_avg:40.20ms
+step:759/1845 train_time:30530ms step_avg:40.22ms
+step:760/1845 train_time:30591ms step_avg:40.25ms
+step:761/1845 train_time:30653ms step_avg:40.28ms
+step:762/1845 train_time:30713ms step_avg:40.31ms
+step:763/1845 train_time:30776ms step_avg:40.34ms
+step:764/1845 train_time:30836ms step_avg:40.36ms
+step:765/1845 train_time:30898ms step_avg:40.39ms
+step:766/1845 train_time:30960ms step_avg:40.42ms
+step:767/1845 train_time:31024ms step_avg:40.45ms
+step:768/1845 train_time:31086ms step_avg:40.48ms
+step:769/1845 train_time:31150ms step_avg:40.51ms
+step:770/1845 train_time:31212ms step_avg:40.53ms
+step:771/1845 train_time:31275ms step_avg:40.56ms
+step:772/1845 train_time:31337ms step_avg:40.59ms
+step:773/1845 train_time:31400ms step_avg:40.62ms
+step:774/1845 train_time:31461ms step_avg:40.65ms
+step:775/1845 train_time:31524ms step_avg:40.68ms
+step:776/1845 train_time:31584ms step_avg:40.70ms
+step:777/1845 train_time:31647ms step_avg:40.73ms
+step:778/1845 train_time:31707ms step_avg:40.75ms
+step:779/1845 train_time:31770ms step_avg:40.78ms
+step:780/1845 train_time:31830ms step_avg:40.81ms
+step:781/1845 train_time:31893ms step_avg:40.84ms
+step:782/1845 train_time:31955ms step_avg:40.86ms
+step:783/1845 train_time:32017ms step_avg:40.89ms
+step:784/1845 train_time:32078ms step_avg:40.92ms
+step:785/1845 train_time:32142ms step_avg:40.94ms
+step:786/1845 train_time:32203ms step_avg:40.97ms
+step:787/1845 train_time:32266ms step_avg:41.00ms
+step:788/1845 train_time:32327ms step_avg:41.02ms
+step:789/1845 train_time:32390ms step_avg:41.05ms
+step:790/1845 train_time:32451ms step_avg:41.08ms
+step:791/1845 train_time:32514ms step_avg:41.10ms
+step:792/1845 train_time:32574ms step_avg:41.13ms
+step:793/1845 train_time:32637ms step_avg:41.16ms
+step:794/1845 train_time:32698ms step_avg:41.18ms
+step:795/1845 train_time:32762ms step_avg:41.21ms
+step:796/1845 train_time:32823ms step_avg:41.23ms
+step:797/1845 train_time:32885ms step_avg:41.26ms
+step:798/1845 train_time:32946ms step_avg:41.29ms
+step:799/1845 train_time:33008ms step_avg:41.31ms
+step:800/1845 train_time:33069ms step_avg:41.34ms
+step:801/1845 train_time:33131ms step_avg:41.36ms
+step:802/1845 train_time:33192ms step_avg:41.39ms
+step:803/1845 train_time:33255ms step_avg:41.41ms
+step:804/1845 train_time:33316ms step_avg:41.44ms
+step:805/1845 train_time:33379ms step_avg:41.46ms
+step:806/1845 train_time:33441ms step_avg:41.49ms
+step:807/1845 train_time:33504ms step_avg:41.52ms
+step:808/1845 train_time:33565ms step_avg:41.54ms
+step:809/1845 train_time:33627ms step_avg:41.57ms
+step:810/1845 train_time:33688ms step_avg:41.59ms
+step:811/1845 train_time:33750ms step_avg:41.62ms
+step:812/1845 train_time:33811ms step_avg:41.64ms
+step:813/1845 train_time:33873ms step_avg:41.66ms
+step:814/1845 train_time:33934ms step_avg:41.69ms
+step:815/1845 train_time:33997ms step_avg:41.71ms
+step:816/1845 train_time:34058ms step_avg:41.74ms
+step:817/1845 train_time:34120ms step_avg:41.76ms
+step:818/1845 train_time:34182ms step_avg:41.79ms
+step:819/1845 train_time:34245ms step_avg:41.81ms
+step:820/1845 train_time:34306ms step_avg:41.84ms
+step:821/1845 train_time:34368ms step_avg:41.86ms
+step:822/1845 train_time:34429ms step_avg:41.88ms
+step:823/1845 train_time:34492ms step_avg:41.91ms
+step:824/1845 train_time:34553ms step_avg:41.93ms
+step:825/1845 train_time:34616ms step_avg:41.96ms
+step:826/1845 train_time:34677ms step_avg:41.98ms
+step:827/1845 train_time:34740ms step_avg:42.01ms
+step:828/1845 train_time:34801ms step_avg:42.03ms
+step:829/1845 train_time:34864ms step_avg:42.06ms
+step:830/1845 train_time:34925ms step_avg:42.08ms
+step:831/1845 train_time:34986ms step_avg:42.10ms
+step:832/1845 train_time:35047ms step_avg:42.12ms
+step:833/1845 train_time:35110ms step_avg:42.15ms
+step:834/1845 train_time:35171ms step_avg:42.17ms
+step:835/1845 train_time:35233ms step_avg:42.20ms
+step:836/1845 train_time:35294ms step_avg:42.22ms
+step:837/1845 train_time:35356ms step_avg:42.24ms
+step:838/1845 train_time:35418ms step_avg:42.26ms
+step:839/1845 train_time:35481ms step_avg:42.29ms
+step:840/1845 train_time:35542ms step_avg:42.31ms
+step:841/1845 train_time:35606ms step_avg:42.34ms
+step:842/1845 train_time:35666ms step_avg:42.36ms
+step:843/1845 train_time:35729ms step_avg:42.38ms
+step:844/1845 train_time:35791ms step_avg:42.41ms
+step:845/1845 train_time:35853ms step_avg:42.43ms
+step:846/1845 train_time:35914ms step_avg:42.45ms
+step:847/1845 train_time:35976ms step_avg:42.48ms
+step:848/1845 train_time:36038ms step_avg:42.50ms
+step:849/1845 train_time:36101ms step_avg:42.52ms
+step:850/1845 train_time:36162ms step_avg:42.54ms
+step:851/1845 train_time:36225ms step_avg:42.57ms
+step:852/1845 train_time:36286ms step_avg:42.59ms
+step:853/1845 train_time:36348ms step_avg:42.61ms
+step:854/1845 train_time:36409ms step_avg:42.63ms
+step:855/1845 train_time:36472ms step_avg:42.66ms
+step:856/1845 train_time:36532ms step_avg:42.68ms
+step:857/1845 train_time:36595ms step_avg:42.70ms
+step:858/1845 train_time:36656ms step_avg:42.72ms
+step:859/1845 train_time:36719ms step_avg:42.75ms
+step:860/1845 train_time:36781ms step_avg:42.77ms
+step:861/1845 train_time:36844ms step_avg:42.79ms
+step:862/1845 train_time:36905ms step_avg:42.81ms
+step:863/1845 train_time:36967ms step_avg:42.84ms
+step:864/1845 train_time:37028ms step_avg:42.86ms
+step:865/1845 train_time:37090ms step_avg:42.88ms
+step:866/1845 train_time:37151ms step_avg:42.90ms
+step:867/1845 train_time:37213ms step_avg:42.92ms
+step:868/1845 train_time:37274ms step_avg:42.94ms
+step:869/1845 train_time:37336ms step_avg:42.96ms
+step:870/1845 train_time:37398ms step_avg:42.99ms
+step:871/1845 train_time:37460ms step_avg:43.01ms
+step:872/1845 train_time:37521ms step_avg:43.03ms
+step:873/1845 train_time:37584ms step_avg:43.05ms
+step:874/1845 train_time:37645ms step_avg:43.07ms
+step:875/1845 train_time:37707ms step_avg:43.09ms
+step:876/1845 train_time:37768ms step_avg:43.11ms
+step:877/1845 train_time:37831ms step_avg:43.14ms
+step:878/1845 train_time:37892ms step_avg:43.16ms
+step:879/1845 train_time:37955ms step_avg:43.18ms
+step:880/1845 train_time:38016ms step_avg:43.20ms
+step:881/1845 train_time:38080ms step_avg:43.22ms
+step:882/1845 train_time:38142ms step_avg:43.24ms
+step:883/1845 train_time:38205ms step_avg:43.27ms
+step:884/1845 train_time:38266ms step_avg:43.29ms
+step:885/1845 train_time:38328ms step_avg:43.31ms
+step:886/1845 train_time:38389ms step_avg:43.33ms
+step:887/1845 train_time:38452ms step_avg:43.35ms
+step:888/1845 train_time:38513ms step_avg:43.37ms
+step:889/1845 train_time:38575ms step_avg:43.39ms
+step:890/1845 train_time:38636ms step_avg:43.41ms
+step:891/1845 train_time:38698ms step_avg:43.43ms
+step:892/1845 train_time:38760ms step_avg:43.45ms
+step:893/1845 train_time:38822ms step_avg:43.47ms
+step:894/1845 train_time:38883ms step_avg:43.49ms
+step:895/1845 train_time:38946ms step_avg:43.52ms
+step:896/1845 train_time:39006ms step_avg:43.53ms
+step:897/1845 train_time:39069ms step_avg:43.55ms
+step:898/1845 train_time:39129ms step_avg:43.57ms
+step:899/1845 train_time:39192ms step_avg:43.60ms
+step:900/1845 train_time:39253ms step_avg:43.61ms
+step:901/1845 train_time:39316ms step_avg:43.64ms
+step:902/1845 train_time:39377ms step_avg:43.66ms
+step:903/1845 train_time:39440ms step_avg:43.68ms
+step:904/1845 train_time:39501ms step_avg:43.70ms
+step:905/1845 train_time:39563ms step_avg:43.72ms
+step:906/1845 train_time:39624ms step_avg:43.74ms
+step:907/1845 train_time:39686ms step_avg:43.76ms
+step:908/1845 train_time:39747ms step_avg:43.77ms
+step:909/1845 train_time:39810ms step_avg:43.80ms
+step:910/1845 train_time:39871ms step_avg:43.81ms
+step:911/1845 train_time:39933ms step_avg:43.83ms
+step:912/1845 train_time:39994ms step_avg:43.85ms
+step:913/1845 train_time:40057ms step_avg:43.87ms
+step:914/1845 train_time:40118ms step_avg:43.89ms
+step:915/1845 train_time:40181ms step_avg:43.91ms
+step:916/1845 train_time:40242ms step_avg:43.93ms
+step:917/1845 train_time:40305ms step_avg:43.95ms
+step:918/1845 train_time:40365ms step_avg:43.97ms
+step:919/1845 train_time:40428ms step_avg:43.99ms
+step:920/1845 train_time:40489ms step_avg:44.01ms
+step:921/1845 train_time:40551ms step_avg:44.03ms
+step:922/1845 train_time:40611ms step_avg:44.05ms
+step:923/1845 train_time:40674ms step_avg:44.07ms
+step:924/1845 train_time:40735ms step_avg:44.09ms
+step:925/1845 train_time:40798ms step_avg:44.11ms
+step:926/1845 train_time:40859ms step_avg:44.12ms
+step:927/1845 train_time:40923ms step_avg:44.15ms
+step:928/1845 train_time:40984ms step_avg:44.16ms
+step:929/1845 train_time:41046ms step_avg:44.18ms
+step:930/1845 train_time:41107ms step_avg:44.20ms
+step:931/1845 train_time:41170ms step_avg:44.22ms
+step:932/1845 train_time:41230ms step_avg:44.24ms
+step:933/1845 train_time:41293ms step_avg:44.26ms
+step:934/1845 train_time:41353ms step_avg:44.28ms
+step:935/1845 train_time:41416ms step_avg:44.30ms
+step:936/1845 train_time:41478ms step_avg:44.31ms
+step:937/1845 train_time:41542ms step_avg:44.34ms
+step:938/1845 train_time:41603ms step_avg:44.35ms
+step:939/1845 train_time:41665ms step_avg:44.37ms
+step:940/1845 train_time:41726ms step_avg:44.39ms
+step:941/1845 train_time:41789ms step_avg:44.41ms
+step:942/1845 train_time:41849ms step_avg:44.43ms
+step:943/1845 train_time:41912ms step_avg:44.45ms
+step:944/1845 train_time:41972ms step_avg:44.46ms
+step:945/1845 train_time:42035ms step_avg:44.48ms
+step:946/1845 train_time:42096ms step_avg:44.50ms
+step:947/1845 train_time:42158ms step_avg:44.52ms
+step:948/1845 train_time:42220ms step_avg:44.54ms
+step:949/1845 train_time:42283ms step_avg:44.55ms
+step:950/1845 train_time:42344ms step_avg:44.57ms
+step:951/1845 train_time:42407ms step_avg:44.59ms
+step:952/1845 train_time:42467ms step_avg:44.61ms
+step:953/1845 train_time:42530ms step_avg:44.63ms
+step:954/1845 train_time:42591ms step_avg:44.64ms
+step:955/1845 train_time:42654ms step_avg:44.66ms
+step:956/1845 train_time:42715ms step_avg:44.68ms
+step:957/1845 train_time:42779ms step_avg:44.70ms
+step:958/1845 train_time:42840ms step_avg:44.72ms
+step:959/1845 train_time:42903ms step_avg:44.74ms
+step:960/1845 train_time:42964ms step_avg:44.75ms
+step:961/1845 train_time:43026ms step_avg:44.77ms
+step:962/1845 train_time:43087ms step_avg:44.79ms
+step:963/1845 train_time:43150ms step_avg:44.81ms
+step:964/1845 train_time:43211ms step_avg:44.82ms
+step:965/1845 train_time:43273ms step_avg:44.84ms
+step:966/1845 train_time:43333ms step_avg:44.86ms
+step:967/1845 train_time:43396ms step_avg:44.88ms
+step:968/1845 train_time:43458ms step_avg:44.89ms
+step:969/1845 train_time:43520ms step_avg:44.91ms
+step:970/1845 train_time:43582ms step_avg:44.93ms
+step:971/1845 train_time:43645ms step_avg:44.95ms
+step:972/1845 train_time:43706ms step_avg:44.96ms
+step:973/1845 train_time:43768ms step_avg:44.98ms
+step:974/1845 train_time:43829ms step_avg:45.00ms
+step:975/1845 train_time:43891ms step_avg:45.02ms
+step:976/1845 train_time:43951ms step_avg:45.03ms
+step:977/1845 train_time:44014ms step_avg:45.05ms
+step:978/1845 train_time:44075ms step_avg:45.07ms
+step:979/1845 train_time:44138ms step_avg:45.08ms
+step:980/1845 train_time:44199ms step_avg:45.10ms
+step:981/1845 train_time:44262ms step_avg:45.12ms
+step:982/1845 train_time:44323ms step_avg:45.14ms
+step:983/1845 train_time:44385ms step_avg:45.15ms
+step:984/1845 train_time:44446ms step_avg:45.17ms
+step:985/1845 train_time:44509ms step_avg:45.19ms
+step:986/1845 train_time:44570ms step_avg:45.20ms
+step:987/1845 train_time:44633ms step_avg:45.22ms
+step:988/1845 train_time:44693ms step_avg:45.24ms
+step:989/1845 train_time:44756ms step_avg:45.25ms
+step:990/1845 train_time:44817ms step_avg:45.27ms
+step:991/1845 train_time:44880ms step_avg:45.29ms
+step:992/1845 train_time:44941ms step_avg:45.30ms
+step:993/1845 train_time:45005ms step_avg:45.32ms
+step:994/1845 train_time:45065ms step_avg:45.34ms
+step:995/1845 train_time:45128ms step_avg:45.35ms
+step:996/1845 train_time:45188ms step_avg:45.37ms
+step:997/1845 train_time:45251ms step_avg:45.39ms
+step:998/1845 train_time:45311ms step_avg:45.40ms
+step:999/1845 train_time:45374ms step_avg:45.42ms
+step:1000/1845 train_time:45435ms step_avg:45.43ms
+step:1000/1845 val_loss:3.7712 train_time:45500ms step_avg:45.50ms
+step:1001/1845 train_time:45521ms step_avg:45.48ms
+step:1002/1845 train_time:45561ms step_avg:45.47ms
+step:1003/1845 train_time:45625ms step_avg:45.49ms
+step:1004/1845 train_time:45690ms step_avg:45.51ms
+step:1005/1845 train_time:45751ms step_avg:45.52ms
+step:1006/1845 train_time:45812ms step_avg:45.54ms
+step:1007/1845 train_time:45874ms step_avg:45.56ms
+step:1008/1845 train_time:45935ms step_avg:45.57ms
+step:1009/1845 train_time:45997ms step_avg:45.59ms
+step:1010/1845 train_time:46057ms step_avg:45.60ms
+step:1011/1845 train_time:46119ms step_avg:45.62ms
+step:1012/1845 train_time:46179ms step_avg:45.63ms
+step:1013/1845 train_time:46242ms step_avg:45.65ms
+step:1014/1845 train_time:46304ms step_avg:45.66ms
+step:1015/1845 train_time:46366ms step_avg:45.68ms
+step:1016/1845 train_time:46427ms step_avg:45.70ms
+step:1017/1845 train_time:46490ms step_avg:45.71ms
+step:1018/1845 train_time:46551ms step_avg:45.73ms
+step:1019/1845 train_time:46614ms step_avg:45.74ms
+step:1020/1845 train_time:46675ms step_avg:45.76ms
+step:1021/1845 train_time:46738ms step_avg:45.78ms
+step:1022/1845 train_time:46800ms step_avg:45.79ms
+step:1023/1845 train_time:46862ms step_avg:45.81ms
+step:1024/1845 train_time:46924ms step_avg:45.82ms
+step:1025/1845 train_time:46986ms step_avg:45.84ms
+step:1026/1845 train_time:47047ms step_avg:45.85ms
+step:1027/1845 train_time:47109ms step_avg:45.87ms
+step:1028/1845 train_time:47169ms step_avg:45.88ms
+step:1029/1845 train_time:47231ms step_avg:45.90ms
+step:1030/1845 train_time:47292ms step_avg:45.92ms
+step:1031/1845 train_time:47355ms step_avg:45.93ms
+step:1032/1845 train_time:47416ms step_avg:45.95ms
+step:1033/1845 train_time:47478ms step_avg:45.96ms
+step:1034/1845 train_time:47539ms step_avg:45.98ms
+step:1035/1845 train_time:47603ms step_avg:45.99ms
+step:1036/1845 train_time:47664ms step_avg:46.01ms
+step:1037/1845 train_time:47727ms step_avg:46.02ms
+step:1038/1845 train_time:47789ms step_avg:46.04ms
+step:1039/1845 train_time:47852ms step_avg:46.06ms
+step:1040/1845 train_time:47913ms step_avg:46.07ms
+step:1041/1845 train_time:47975ms step_avg:46.09ms
+step:1042/1845 train_time:48035ms step_avg:46.10ms
+step:1043/1845 train_time:48098ms step_avg:46.11ms
+step:1044/1845 train_time:48158ms step_avg:46.13ms
+step:1045/1845 train_time:48221ms step_avg:46.14ms
+step:1046/1845 train_time:48282ms step_avg:46.16ms
+step:1047/1845 train_time:48345ms step_avg:46.17ms
+step:1048/1845 train_time:48406ms step_avg:46.19ms
+step:1049/1845 train_time:48469ms step_avg:46.20ms
+step:1050/1845 train_time:48529ms step_avg:46.22ms
+step:1051/1845 train_time:48592ms step_avg:46.23ms
+step:1052/1845 train_time:48653ms step_avg:46.25ms
+step:1053/1845 train_time:48715ms step_avg:46.26ms
+step:1054/1845 train_time:48776ms step_avg:46.28ms
+step:1055/1845 train_time:48839ms step_avg:46.29ms
+step:1056/1845 train_time:48901ms step_avg:46.31ms
+step:1057/1845 train_time:48963ms step_avg:46.32ms
+step:1058/1845 train_time:49024ms step_avg:46.34ms
+step:1059/1845 train_time:49086ms step_avg:46.35ms
+step:1060/1845 train_time:49147ms step_avg:46.36ms
+step:1061/1845 train_time:49209ms step_avg:46.38ms
+step:1062/1845 train_time:49269ms step_avg:46.39ms
+step:1063/1845 train_time:49332ms step_avg:46.41ms
+step:1064/1845 train_time:49393ms step_avg:46.42ms
+step:1065/1845 train_time:49456ms step_avg:46.44ms
+step:1066/1845 train_time:49516ms step_avg:46.45ms
+step:1067/1845 train_time:49579ms step_avg:46.47ms
+step:1068/1845 train_time:49640ms step_avg:46.48ms
+step:1069/1845 train_time:49702ms step_avg:46.49ms
+step:1070/1845 train_time:49763ms step_avg:46.51ms
+step:1071/1845 train_time:49826ms step_avg:46.52ms
+step:1072/1845 train_time:49887ms step_avg:46.54ms
+step:1073/1845 train_time:49950ms step_avg:46.55ms
+step:1074/1845 train_time:50011ms step_avg:46.57ms
+step:1075/1845 train_time:50074ms step_avg:46.58ms
+step:1076/1845 train_time:50135ms step_avg:46.59ms
+step:1077/1845 train_time:50196ms step_avg:46.61ms
+step:1078/1845 train_time:50257ms step_avg:46.62ms
+step:1079/1845 train_time:50319ms step_avg:46.63ms
+step:1080/1845 train_time:50380ms step_avg:46.65ms
+step:1081/1845 train_time:50442ms step_avg:46.66ms
+step:1082/1845 train_time:50503ms step_avg:46.68ms
+step:1083/1845 train_time:50565ms step_avg:46.69ms
+step:1084/1845 train_time:50626ms step_avg:46.70ms
+step:1085/1845 train_time:50688ms step_avg:46.72ms
+step:1086/1845 train_time:50749ms step_avg:46.73ms
+step:1087/1845 train_time:50811ms step_avg:46.74ms
+step:1088/1845 train_time:50872ms step_avg:46.76ms
+step:1089/1845 train_time:50935ms step_avg:46.77ms
+step:1090/1845 train_time:50996ms step_avg:46.78ms
+step:1091/1845 train_time:51058ms step_avg:46.80ms
+step:1092/1845 train_time:51119ms step_avg:46.81ms
+step:1093/1845 train_time:51182ms step_avg:46.83ms
+step:1094/1845 train_time:51242ms step_avg:46.84ms
+step:1095/1845 train_time:51305ms step_avg:46.85ms
+step:1096/1845 train_time:51367ms step_avg:46.87ms
+step:1097/1845 train_time:51429ms step_avg:46.88ms
+step:1098/1845 train_time:51490ms step_avg:46.89ms
+step:1099/1845 train_time:51553ms step_avg:46.91ms
+step:1100/1845 train_time:51613ms step_avg:46.92ms
+step:1101/1845 train_time:51675ms step_avg:46.93ms
+step:1102/1845 train_time:51736ms step_avg:46.95ms
+step:1103/1845 train_time:51799ms step_avg:46.96ms
+step:1104/1845 train_time:51860ms step_avg:46.97ms
+step:1105/1845 train_time:51922ms step_avg:46.99ms
+step:1106/1845 train_time:51984ms step_avg:47.00ms
+step:1107/1845 train_time:52046ms step_avg:47.02ms
+step:1108/1845 train_time:52107ms step_avg:47.03ms
+step:1109/1845 train_time:52170ms step_avg:47.04ms
+step:1110/1845 train_time:52230ms step_avg:47.05ms
+step:1111/1845 train_time:52293ms step_avg:47.07ms
+step:1112/1845 train_time:52354ms step_avg:47.08ms
+step:1113/1845 train_time:52416ms step_avg:47.09ms
+step:1114/1845 train_time:52477ms step_avg:47.11ms
+step:1115/1845 train_time:52539ms step_avg:47.12ms
+step:1116/1845 train_time:52601ms step_avg:47.13ms
+step:1117/1845 train_time:52663ms step_avg:47.15ms
+step:1118/1845 train_time:52724ms step_avg:47.16ms
+step:1119/1845 train_time:52787ms step_avg:47.17ms
+step:1120/1845 train_time:52848ms step_avg:47.19ms
+step:1121/1845 train_time:52910ms step_avg:47.20ms
+step:1122/1845 train_time:52971ms step_avg:47.21ms
+step:1123/1845 train_time:53033ms step_avg:47.22ms
+step:1124/1845 train_time:53094ms step_avg:47.24ms
+step:1125/1845 train_time:53156ms step_avg:47.25ms
+step:1126/1845 train_time:53217ms step_avg:47.26ms
+step:1127/1845 train_time:53279ms step_avg:47.28ms
+step:1128/1845 train_time:53341ms step_avg:47.29ms
+step:1129/1845 train_time:53403ms step_avg:47.30ms
+step:1130/1845 train_time:53464ms step_avg:47.31ms
+step:1131/1845 train_time:53527ms step_avg:47.33ms
+step:1132/1845 train_time:53587ms step_avg:47.34ms
+step:1133/1845 train_time:53649ms step_avg:47.35ms
+step:1134/1845 train_time:53710ms step_avg:47.36ms
+step:1135/1845 train_time:53772ms step_avg:47.38ms
+step:1136/1845 train_time:53833ms step_avg:47.39ms
+step:1137/1845 train_time:53895ms step_avg:47.40ms
+step:1138/1845 train_time:53956ms step_avg:47.41ms
+step:1139/1845 train_time:54018ms step_avg:47.43ms
+step:1140/1845 train_time:54079ms step_avg:47.44ms
+step:1141/1845 train_time:54142ms step_avg:47.45ms
+step:1142/1845 train_time:54203ms step_avg:47.46ms
+step:1143/1845 train_time:54265ms step_avg:47.48ms
+step:1144/1845 train_time:54326ms step_avg:47.49ms
+step:1145/1845 train_time:54389ms step_avg:47.50ms
+step:1146/1845 train_time:54449ms step_avg:47.51ms
+step:1147/1845 train_time:54512ms step_avg:47.53ms
+step:1148/1845 train_time:54573ms step_avg:47.54ms
+step:1149/1845 train_time:54636ms step_avg:47.55ms
+step:1150/1845 train_time:54696ms step_avg:47.56ms
+step:1151/1845 train_time:54759ms step_avg:47.57ms
+step:1152/1845 train_time:54820ms step_avg:47.59ms
+step:1153/1845 train_time:54882ms step_avg:47.60ms
+step:1154/1845 train_time:54944ms step_avg:47.61ms
+step:1155/1845 train_time:55007ms step_avg:47.62ms
+step:1156/1845 train_time:55068ms step_avg:47.64ms
+step:1157/1845 train_time:55130ms step_avg:47.65ms
+step:1158/1845 train_time:55190ms step_avg:47.66ms
+step:1159/1845 train_time:55253ms step_avg:47.67ms
+step:1160/1845 train_time:55314ms step_avg:47.68ms
+step:1161/1845 train_time:55376ms step_avg:47.70ms
+step:1162/1845 train_time:55437ms step_avg:47.71ms
+step:1163/1845 train_time:55499ms step_avg:47.72ms
+step:1164/1845 train_time:55560ms step_avg:47.73ms
+step:1165/1845 train_time:55623ms step_avg:47.75ms
+step:1166/1845 train_time:55684ms step_avg:47.76ms
+step:1167/1845 train_time:55747ms step_avg:47.77ms
+step:1168/1845 train_time:55808ms step_avg:47.78ms
+step:1169/1845 train_time:55870ms step_avg:47.79ms
+step:1170/1845 train_time:55931ms step_avg:47.80ms
+step:1171/1845 train_time:55994ms step_avg:47.82ms
+step:1172/1845 train_time:56054ms step_avg:47.83ms
+step:1173/1845 train_time:56116ms step_avg:47.84ms
+step:1174/1845 train_time:56177ms step_avg:47.85ms
+step:1175/1845 train_time:56239ms step_avg:47.86ms
+step:1176/1845 train_time:56300ms step_avg:47.87ms
+step:1177/1845 train_time:56363ms step_avg:47.89ms
+step:1178/1845 train_time:56424ms step_avg:47.90ms
+step:1179/1845 train_time:56487ms step_avg:47.91ms
+step:1180/1845 train_time:56547ms step_avg:47.92ms
+step:1181/1845 train_time:56610ms step_avg:47.93ms
+step:1182/1845 train_time:56670ms step_avg:47.94ms
+step:1183/1845 train_time:56733ms step_avg:47.96ms
+step:1184/1845 train_time:56794ms step_avg:47.97ms
+step:1185/1845 train_time:56856ms step_avg:47.98ms
+step:1186/1845 train_time:56917ms step_avg:47.99ms
+step:1187/1845 train_time:56979ms step_avg:48.00ms
+step:1188/1845 train_time:57041ms step_avg:48.01ms
+step:1189/1845 train_time:57103ms step_avg:48.03ms
+step:1190/1845 train_time:57164ms step_avg:48.04ms
+step:1191/1845 train_time:57226ms step_avg:48.05ms
+step:1192/1845 train_time:57287ms step_avg:48.06ms
+step:1193/1845 train_time:57350ms step_avg:48.07ms
+step:1194/1845 train_time:57410ms step_avg:48.08ms
+step:1195/1845 train_time:57473ms step_avg:48.09ms
+step:1196/1845 train_time:57533ms step_avg:48.10ms
+step:1197/1845 train_time:57596ms step_avg:48.12ms
+step:1198/1845 train_time:57656ms step_avg:48.13ms
+step:1199/1845 train_time:57718ms step_avg:48.14ms
+step:1200/1845 train_time:57780ms step_avg:48.15ms
+step:1201/1845 train_time:57842ms step_avg:48.16ms
+step:1202/1845 train_time:57903ms step_avg:48.17ms
+step:1203/1845 train_time:57966ms step_avg:48.18ms
+step:1204/1845 train_time:58027ms step_avg:48.20ms
+step:1205/1845 train_time:58090ms step_avg:48.21ms
+step:1206/1845 train_time:58177ms step_avg:48.24ms
+step:1207/1845 train_time:58265ms step_avg:48.27ms
+step:1208/1845 train_time:58354ms step_avg:48.31ms
+step:1209/1845 train_time:58443ms step_avg:48.34ms
+step:1210/1845 train_time:58531ms step_avg:48.37ms
+step:1211/1845 train_time:58620ms step_avg:48.41ms
+step:1212/1845 train_time:58707ms step_avg:48.44ms
+step:1213/1845 train_time:58796ms step_avg:48.47ms
+step:1214/1845 train_time:58883ms step_avg:48.50ms
+step:1215/1845 train_time:58973ms step_avg:48.54ms
+step:1216/1845 train_time:59060ms step_avg:48.57ms
+step:1217/1845 train_time:59147ms step_avg:48.60ms
+step:1218/1845 train_time:59235ms step_avg:48.63ms
+step:1219/1845 train_time:59323ms step_avg:48.67ms
+step:1220/1845 train_time:59410ms step_avg:48.70ms
+step:1221/1845 train_time:59500ms step_avg:48.73ms
+step:1222/1845 train_time:59588ms step_avg:48.76ms
+step:1223/1845 train_time:59677ms step_avg:48.80ms
+step:1224/1845 train_time:59764ms step_avg:48.83ms
+step:1225/1845 train_time:59853ms step_avg:48.86ms
+step:1226/1845 train_time:59940ms step_avg:48.89ms
+step:1227/1845 train_time:60029ms step_avg:48.92ms
+step:1228/1845 train_time:60115ms step_avg:48.95ms
+step:1229/1845 train_time:60203ms step_avg:48.99ms
+step:1230/1845 train_time:60290ms step_avg:49.02ms
+step:1231/1845 train_time:60379ms step_avg:49.05ms
+step:1232/1845 train_time:60466ms step_avg:49.08ms
+step:1233/1845 train_time:60556ms step_avg:49.11ms
+step:1234/1845 train_time:60643ms step_avg:49.14ms
+step:1235/1845 train_time:60732ms step_avg:49.18ms
+step:1236/1845 train_time:60819ms step_avg:49.21ms
+step:1237/1845 train_time:60908ms step_avg:49.24ms
+step:1238/1845 train_time:60997ms step_avg:49.27ms
+step:1239/1845 train_time:61085ms step_avg:49.30ms
+step:1240/1845 train_time:61172ms step_avg:49.33ms
+step:1241/1845 train_time:61262ms step_avg:49.36ms
+step:1242/1845 train_time:61349ms step_avg:49.40ms
+step:1243/1845 train_time:61439ms step_avg:49.43ms
+step:1244/1845 train_time:61527ms step_avg:49.46ms
+step:1245/1845 train_time:61616ms step_avg:49.49ms
+step:1246/1845 train_time:61702ms step_avg:49.52ms
+step:1247/1845 train_time:61791ms step_avg:49.55ms
+step:1248/1845 train_time:61879ms step_avg:49.58ms
+step:1249/1845 train_time:61968ms step_avg:49.61ms
+step:1250/1845 train_time:62055ms step_avg:49.64ms
+step:1250/1845 val_loss:3.5330 train_time:62145ms step_avg:49.72ms
+step:1251/1845 train_time:62166ms step_avg:49.69ms
+step:1252/1845 train_time:62235ms step_avg:49.71ms
+step:1253/1845 train_time:62325ms step_avg:49.74ms
+step:1254/1845 train_time:62413ms step_avg:49.77ms
+step:1255/1845 train_time:62501ms step_avg:49.80ms
+step:1256/1845 train_time:62587ms step_avg:49.83ms
+step:1257/1845 train_time:62675ms step_avg:49.86ms
+step:1258/1845 train_time:62762ms step_avg:49.89ms
+step:1259/1845 train_time:62850ms step_avg:49.92ms
+step:1260/1845 train_time:62936ms step_avg:49.95ms
+step:1261/1845 train_time:63024ms step_avg:49.98ms
+step:1262/1845 train_time:63113ms step_avg:50.01ms
+step:1263/1845 train_time:63204ms step_avg:50.04ms
+step:1264/1845 train_time:63293ms step_avg:50.07ms
+step:1265/1845 train_time:63383ms step_avg:50.11ms
+step:1266/1845 train_time:63471ms step_avg:50.13ms
+step:1267/1845 train_time:63559ms step_avg:50.16ms
+step:1268/1845 train_time:63646ms step_avg:50.19ms
+step:1269/1845 train_time:63734ms step_avg:50.22ms
+step:1270/1845 train_time:63819ms step_avg:50.25ms
+step:1271/1845 train_time:63907ms step_avg:50.28ms
+step:1272/1845 train_time:63993ms step_avg:50.31ms
+step:1273/1845 train_time:64083ms step_avg:50.34ms
+step:1274/1845 train_time:64171ms step_avg:50.37ms
+step:1275/1845 train_time:64261ms step_avg:50.40ms
+step:1276/1845 train_time:64349ms step_avg:50.43ms
+step:1277/1845 train_time:64438ms step_avg:50.46ms
+step:1278/1845 train_time:64525ms step_avg:50.49ms
+step:1279/1845 train_time:64613ms step_avg:50.52ms
+step:1280/1845 train_time:64699ms step_avg:50.55ms
+step:1281/1845 train_time:64788ms step_avg:50.58ms
+step:1282/1845 train_time:64875ms step_avg:50.60ms
+step:1283/1845 train_time:64963ms step_avg:50.63ms
+step:1284/1845 train_time:65051ms step_avg:50.66ms
+step:1285/1845 train_time:65140ms step_avg:50.69ms
+step:1286/1845 train_time:65228ms step_avg:50.72ms
+step:1287/1845 train_time:65318ms step_avg:50.75ms
+step:1288/1845 train_time:65405ms step_avg:50.78ms
+step:1289/1845 train_time:65494ms step_avg:50.81ms
+step:1290/1845 train_time:65581ms step_avg:50.84ms
+step:1291/1845 train_time:65669ms step_avg:50.87ms
+step:1292/1845 train_time:65755ms step_avg:50.89ms
+step:1293/1845 train_time:65843ms step_avg:50.92ms
+step:1294/1845 train_time:65930ms step_avg:50.95ms
+step:1295/1845 train_time:66019ms step_avg:50.98ms
+step:1296/1845 train_time:66107ms step_avg:51.01ms
+step:1297/1845 train_time:66196ms step_avg:51.04ms
+step:1298/1845 train_time:66283ms step_avg:51.07ms
+step:1299/1845 train_time:66372ms step_avg:51.09ms
+step:1300/1845 train_time:66459ms step_avg:51.12ms
+step:1301/1845 train_time:66548ms step_avg:51.15ms
+step:1302/1845 train_time:66636ms step_avg:51.18ms
+step:1303/1845 train_time:66725ms step_avg:51.21ms
+step:1304/1845 train_time:66812ms step_avg:51.24ms
+step:1305/1845 train_time:66900ms step_avg:51.26ms
+step:1306/1845 train_time:66987ms step_avg:51.29ms
+step:1307/1845 train_time:67076ms step_avg:51.32ms
+step:1308/1845 train_time:67164ms step_avg:51.35ms
+step:1309/1845 train_time:67252ms step_avg:51.38ms
+step:1310/1845 train_time:67339ms step_avg:51.40ms
+step:1311/1845 train_time:67428ms step_avg:51.43ms
+step:1312/1845 train_time:67516ms step_avg:51.46ms
+step:1313/1845 train_time:67604ms step_avg:51.49ms
+step:1314/1845 train_time:67692ms step_avg:51.52ms
+step:1315/1845 train_time:67780ms step_avg:51.54ms
+step:1316/1845 train_time:67867ms step_avg:51.57ms
+step:1317/1845 train_time:67955ms step_avg:51.60ms
+step:1318/1845 train_time:68044ms step_avg:51.63ms
+step:1319/1845 train_time:68133ms step_avg:51.66ms
+step:1320/1845 train_time:68219ms step_avg:51.68ms
+step:1321/1845 train_time:68308ms step_avg:51.71ms
+step:1322/1845 train_time:68396ms step_avg:51.74ms
+step:1323/1845 train_time:68485ms step_avg:51.77ms
+step:1324/1845 train_time:68572ms step_avg:51.79ms
+step:1325/1845 train_time:68660ms step_avg:51.82ms
+step:1326/1845 train_time:68747ms step_avg:51.85ms
+step:1327/1845 train_time:68836ms step_avg:51.87ms
+step:1328/1845 train_time:68924ms step_avg:51.90ms
+step:1329/1845 train_time:69012ms step_avg:51.93ms
+step:1330/1845 train_time:69098ms step_avg:51.95ms
+step:1331/1845 train_time:69188ms step_avg:51.98ms
+step:1332/1845 train_time:69275ms step_avg:52.01ms
+step:1333/1845 train_time:69363ms step_avg:52.04ms
+step:1334/1845 train_time:69452ms step_avg:52.06ms
+step:1335/1845 train_time:69539ms step_avg:52.09ms
+step:1336/1845 train_time:69627ms step_avg:52.12ms
+step:1337/1845 train_time:69716ms step_avg:52.14ms
+step:1338/1845 train_time:69803ms step_avg:52.17ms
+step:1339/1845 train_time:69893ms step_avg:52.20ms
+step:1340/1845 train_time:69981ms step_avg:52.22ms
+step:1341/1845 train_time:70068ms step_avg:52.25ms
+step:1342/1845 train_time:70156ms step_avg:52.28ms
+step:1343/1845 train_time:70244ms step_avg:52.30ms
+step:1344/1845 train_time:70332ms step_avg:52.33ms
+step:1345/1845 train_time:70420ms step_avg:52.36ms
+step:1346/1845 train_time:70507ms step_avg:52.38ms
+step:1347/1845 train_time:70596ms step_avg:52.41ms
+step:1348/1845 train_time:70683ms step_avg:52.44ms
+step:1349/1845 train_time:70771ms step_avg:52.46ms
+step:1350/1845 train_time:70858ms step_avg:52.49ms
+step:1351/1845 train_time:70946ms step_avg:52.51ms
+step:1352/1845 train_time:71034ms step_avg:52.54ms
+step:1353/1845 train_time:71122ms step_avg:52.57ms
+step:1354/1845 train_time:71209ms step_avg:52.59ms
+step:1355/1845 train_time:71298ms step_avg:52.62ms
+step:1356/1845 train_time:71385ms step_avg:52.64ms
+step:1357/1845 train_time:71474ms step_avg:52.67ms
+step:1358/1845 train_time:71561ms step_avg:52.70ms
+step:1359/1845 train_time:71650ms step_avg:52.72ms
+step:1360/1845 train_time:71737ms step_avg:52.75ms
+step:1361/1845 train_time:71826ms step_avg:52.77ms
+step:1362/1845 train_time:71913ms step_avg:52.80ms
+step:1363/1845 train_time:72001ms step_avg:52.83ms
+step:1364/1845 train_time:72089ms step_avg:52.85ms
+step:1365/1845 train_time:72177ms step_avg:52.88ms
+step:1366/1845 train_time:72266ms step_avg:52.90ms
+step:1367/1845 train_time:72357ms step_avg:52.93ms
+step:1368/1845 train_time:72445ms step_avg:52.96ms
+step:1369/1845 train_time:72533ms step_avg:52.98ms
+step:1370/1845 train_time:72620ms step_avg:53.01ms
+step:1371/1845 train_time:72708ms step_avg:53.03ms
+step:1372/1845 train_time:72795ms step_avg:53.06ms
+step:1373/1845 train_time:72883ms step_avg:53.08ms
+step:1374/1845 train_time:72970ms step_avg:53.11ms
+step:1375/1845 train_time:73059ms step_avg:53.13ms
+step:1376/1845 train_time:73146ms step_avg:53.16ms
+step:1377/1845 train_time:73235ms step_avg:53.18ms
+step:1378/1845 train_time:73322ms step_avg:53.21ms
+step:1379/1845 train_time:73411ms step_avg:53.23ms
+step:1380/1845 train_time:73497ms step_avg:53.26ms
+step:1381/1845 train_time:73586ms step_avg:53.28ms
+step:1382/1845 train_time:73674ms step_avg:53.31ms
+step:1383/1845 train_time:73763ms step_avg:53.34ms
+step:1384/1845 train_time:73851ms step_avg:53.36ms
+step:1385/1845 train_time:73938ms step_avg:53.39ms
+step:1386/1845 train_time:74026ms step_avg:53.41ms
+step:1387/1845 train_time:74114ms step_avg:53.43ms
+step:1388/1845 train_time:74200ms step_avg:53.46ms
+step:1389/1845 train_time:74289ms step_avg:53.48ms
+step:1390/1845 train_time:74377ms step_avg:53.51ms
+step:1391/1845 train_time:74466ms step_avg:53.53ms
+step:1392/1845 train_time:74553ms step_avg:53.56ms
+step:1393/1845 train_time:74642ms step_avg:53.58ms
+step:1394/1845 train_time:74730ms step_avg:53.61ms
+step:1395/1845 train_time:74818ms step_avg:53.63ms
+step:1396/1845 train_time:74906ms step_avg:53.66ms
+step:1397/1845 train_time:74996ms step_avg:53.68ms
+step:1398/1845 train_time:75083ms step_avg:53.71ms
+step:1399/1845 train_time:75171ms step_avg:53.73ms
+step:1400/1845 train_time:75258ms step_avg:53.76ms
+step:1401/1845 train_time:75347ms step_avg:53.78ms
+step:1402/1845 train_time:75434ms step_avg:53.80ms
+step:1403/1845 train_time:75523ms step_avg:53.83ms
+step:1404/1845 train_time:75611ms step_avg:53.85ms
+step:1405/1845 train_time:75700ms step_avg:53.88ms
+step:1406/1845 train_time:75786ms step_avg:53.90ms
+step:1407/1845 train_time:75875ms step_avg:53.93ms
+step:1408/1845 train_time:75962ms step_avg:53.95ms
+step:1409/1845 train_time:76052ms step_avg:53.98ms
+step:1410/1845 train_time:76138ms step_avg:54.00ms
+step:1411/1845 train_time:76227ms step_avg:54.02ms
+step:1412/1845 train_time:76314ms step_avg:54.05ms
+step:1413/1845 train_time:76402ms step_avg:54.07ms
+step:1414/1845 train_time:76489ms step_avg:54.09ms
+step:1415/1845 train_time:76579ms step_avg:54.12ms
+step:1416/1845 train_time:76667ms step_avg:54.14ms
+step:1417/1845 train_time:76755ms step_avg:54.17ms
+step:1418/1845 train_time:76843ms step_avg:54.19ms
+step:1419/1845 train_time:76931ms step_avg:54.21ms
+step:1420/1845 train_time:77018ms step_avg:54.24ms
+step:1421/1845 train_time:77106ms step_avg:54.26ms
+step:1422/1845 train_time:77194ms step_avg:54.29ms
+step:1423/1845 train_time:77282ms step_avg:54.31ms
+step:1424/1845 train_time:77370ms step_avg:54.33ms
+step:1425/1845 train_time:77459ms step_avg:54.36ms
+step:1426/1845 train_time:77546ms step_avg:54.38ms
+step:1427/1845 train_time:77635ms step_avg:54.40ms
+step:1428/1845 train_time:77722ms step_avg:54.43ms
+step:1429/1845 train_time:77811ms step_avg:54.45ms
+step:1430/1845 train_time:77897ms step_avg:54.47ms
+step:1431/1845 train_time:77986ms step_avg:54.50ms
+step:1432/1845 train_time:78074ms step_avg:54.52ms
+step:1433/1845 train_time:78162ms step_avg:54.54ms
+step:1434/1845 train_time:78250ms step_avg:54.57ms
+step:1435/1845 train_time:78338ms step_avg:54.59ms
+step:1436/1845 train_time:78425ms step_avg:54.61ms
+step:1437/1845 train_time:78513ms step_avg:54.64ms
+step:1438/1845 train_time:78600ms step_avg:54.66ms
+step:1439/1845 train_time:78690ms step_avg:54.68ms
+step:1440/1845 train_time:78777ms step_avg:54.71ms
+step:1441/1845 train_time:78865ms step_avg:54.73ms
+step:1442/1845 train_time:78954ms step_avg:54.75ms
+step:1443/1845 train_time:79041ms step_avg:54.78ms
+step:1444/1845 train_time:79128ms step_avg:54.80ms
+step:1445/1845 train_time:79217ms step_avg:54.82ms
+step:1446/1845 train_time:79306ms step_avg:54.84ms
+step:1447/1845 train_time:79395ms step_avg:54.87ms
+step:1448/1845 train_time:79482ms step_avg:54.89ms
+step:1449/1845 train_time:79569ms step_avg:54.91ms
+step:1450/1845 train_time:79657ms step_avg:54.94ms
+step:1451/1845 train_time:79745ms step_avg:54.96ms
+step:1452/1845 train_time:79832ms step_avg:54.98ms
+step:1453/1845 train_time:79921ms step_avg:55.00ms
+step:1454/1845 train_time:80008ms step_avg:55.03ms
+step:1455/1845 train_time:80098ms step_avg:55.05ms
+step:1456/1845 train_time:80185ms step_avg:55.07ms
+step:1457/1845 train_time:80274ms step_avg:55.10ms
+step:1458/1845 train_time:80361ms step_avg:55.12ms
+step:1459/1845 train_time:80449ms step_avg:55.14ms
+step:1460/1845 train_time:80536ms step_avg:55.16ms
+step:1461/1845 train_time:80624ms step_avg:55.18ms
+step:1462/1845 train_time:80711ms step_avg:55.21ms
+step:1463/1845 train_time:80799ms step_avg:55.23ms
+step:1464/1845 train_time:80886ms step_avg:55.25ms
+step:1465/1845 train_time:80975ms step_avg:55.27ms
+step:1466/1845 train_time:81063ms step_avg:55.30ms
+step:1467/1845 train_time:81151ms step_avg:55.32ms
+step:1468/1845 train_time:81239ms step_avg:55.34ms
+step:1469/1845 train_time:81328ms step_avg:55.36ms
+step:1470/1845 train_time:81415ms step_avg:55.38ms
+step:1471/1845 train_time:81504ms step_avg:55.41ms
+step:1472/1845 train_time:81591ms step_avg:55.43ms
+step:1473/1845 train_time:81680ms step_avg:55.45ms
+step:1474/1845 train_time:81768ms step_avg:55.47ms
+step:1475/1845 train_time:81856ms step_avg:55.50ms
+step:1476/1845 train_time:81943ms step_avg:55.52ms
+step:1477/1845 train_time:82031ms step_avg:55.54ms
+step:1478/1845 train_time:82119ms step_avg:55.56ms
+step:1479/1845 train_time:82207ms step_avg:55.58ms
+step:1480/1845 train_time:82295ms step_avg:55.60ms
+step:1481/1845 train_time:82383ms step_avg:55.63ms
+step:1482/1845 train_time:82470ms step_avg:55.65ms
+step:1483/1845 train_time:82559ms step_avg:55.67ms
+step:1484/1845 train_time:82648ms step_avg:55.69ms
+step:1485/1845 train_time:82736ms step_avg:55.71ms
+step:1486/1845 train_time:82824ms step_avg:55.74ms
+step:1487/1845 train_time:82912ms step_avg:55.76ms
+step:1488/1845 train_time:82998ms step_avg:55.78ms
+step:1489/1845 train_time:83087ms step_avg:55.80ms
+step:1490/1845 train_time:83174ms step_avg:55.82ms
+step:1491/1845 train_time:83263ms step_avg:55.84ms
+step:1492/1845 train_time:83351ms step_avg:55.87ms
+step:1493/1845 train_time:83439ms step_avg:55.89ms
+step:1494/1845 train_time:83526ms step_avg:55.91ms
+step:1495/1845 train_time:83614ms step_avg:55.93ms
+step:1496/1845 train_time:83702ms step_avg:55.95ms
+step:1497/1845 train_time:83790ms step_avg:55.97ms
+step:1498/1845 train_time:83876ms step_avg:55.99ms
+step:1499/1845 train_time:83965ms step_avg:56.01ms
+step:1500/1845 train_time:84053ms step_avg:56.04ms
+step:1500/1845 val_loss:3.4024 train_time:84142ms step_avg:56.09ms
+step:1501/1845 train_time:84164ms step_avg:56.07ms
+step:1502/1845 train_time:84234ms step_avg:56.08ms
+step:1503/1845 train_time:84325ms step_avg:56.10ms
+step:1504/1845 train_time:84414ms step_avg:56.13ms
+step:1505/1845 train_time:84501ms step_avg:56.15ms
+step:1506/1845 train_time:84588ms step_avg:56.17ms
+step:1507/1845 train_time:84675ms step_avg:56.19ms
+step:1508/1845 train_time:84761ms step_avg:56.21ms
+step:1509/1845 train_time:84849ms step_avg:56.23ms
+step:1510/1845 train_time:84936ms step_avg:56.25ms
+step:1511/1845 train_time:85023ms step_avg:56.27ms
+step:1512/1845 train_time:85113ms step_avg:56.29ms
+step:1513/1845 train_time:85202ms step_avg:56.31ms
+step:1514/1845 train_time:85292ms step_avg:56.34ms
+step:1515/1845 train_time:85382ms step_avg:56.36ms
+step:1516/1845 train_time:85470ms step_avg:56.38ms
+step:1517/1845 train_time:85558ms step_avg:56.40ms
+step:1518/1845 train_time:85644ms step_avg:56.42ms
+step:1519/1845 train_time:85732ms step_avg:56.44ms
+step:1520/1845 train_time:85818ms step_avg:56.46ms
+step:1521/1845 train_time:85906ms step_avg:56.48ms
+step:1522/1845 train_time:85993ms step_avg:56.50ms
+step:1523/1845 train_time:86082ms step_avg:56.52ms
+step:1524/1845 train_time:86171ms step_avg:56.54ms
+step:1525/1845 train_time:86261ms step_avg:56.56ms
+step:1526/1845 train_time:86350ms step_avg:56.59ms
+step:1527/1845 train_time:86439ms step_avg:56.61ms
+step:1528/1845 train_time:86528ms step_avg:56.63ms
+step:1529/1845 train_time:86616ms step_avg:56.65ms
+step:1530/1845 train_time:86702ms step_avg:56.67ms
+step:1531/1845 train_time:86790ms step_avg:56.69ms
+step:1532/1845 train_time:86876ms step_avg:56.71ms
+step:1533/1845 train_time:86964ms step_avg:56.73ms
+step:1534/1845 train_time:87051ms step_avg:56.75ms
+step:1535/1845 train_time:87139ms step_avg:56.77ms
+step:1536/1845 train_time:87228ms step_avg:56.79ms
+step:1537/1845 train_time:87318ms step_avg:56.81ms
+step:1538/1845 train_time:87406ms step_avg:56.83ms
+step:1539/1845 train_time:87494ms step_avg:56.85ms
+step:1540/1845 train_time:87581ms step_avg:56.87ms
+step:1541/1845 train_time:87670ms step_avg:56.89ms
+step:1542/1845 train_time:87757ms step_avg:56.91ms
+step:1543/1845 train_time:87844ms step_avg:56.93ms
+step:1544/1845 train_time:87932ms step_avg:56.95ms
+step:1545/1845 train_time:88019ms step_avg:56.97ms
+step:1546/1845 train_time:88107ms step_avg:56.99ms
+step:1547/1845 train_time:88196ms step_avg:57.01ms
+step:1548/1845 train_time:88284ms step_avg:57.03ms
+step:1549/1845 train_time:88373ms step_avg:57.05ms
+step:1550/1845 train_time:88461ms step_avg:57.07ms
+step:1551/1845 train_time:88549ms step_avg:57.09ms
+step:1552/1845 train_time:88637ms step_avg:57.11ms
+step:1553/1845 train_time:88725ms step_avg:57.13ms
+step:1554/1845 train_time:88812ms step_avg:57.15ms
+step:1555/1845 train_time:88900ms step_avg:57.17ms
+step:1556/1845 train_time:88987ms step_avg:57.19ms
+step:1557/1845 train_time:89077ms step_avg:57.21ms
+step:1558/1845 train_time:89164ms step_avg:57.23ms
+step:1559/1845 train_time:89252ms step_avg:57.25ms
+step:1560/1845 train_time:89341ms step_avg:57.27ms
+step:1561/1845 train_time:89430ms step_avg:57.29ms
+step:1562/1845 train_time:89517ms step_avg:57.31ms
+step:1563/1845 train_time:89606ms step_avg:57.33ms
+step:1564/1845 train_time:89695ms step_avg:57.35ms
+step:1565/1845 train_time:89782ms step_avg:57.37ms
+step:1566/1845 train_time:89869ms step_avg:57.39ms
+step:1567/1845 train_time:89957ms step_avg:57.41ms
+step:1568/1845 train_time:90044ms step_avg:57.43ms
+step:1569/1845 train_time:90133ms step_avg:57.45ms
+step:1570/1845 train_time:90219ms step_avg:57.46ms
+step:1571/1845 train_time:90308ms step_avg:57.48ms
+step:1572/1845 train_time:90396ms step_avg:57.50ms
+step:1573/1845 train_time:90485ms step_avg:57.52ms
+step:1574/1845 train_time:90573ms step_avg:57.54ms
+step:1575/1845 train_time:90661ms step_avg:57.56ms
+step:1576/1845 train_time:90749ms step_avg:57.58ms
+step:1577/1845 train_time:90838ms step_avg:57.60ms
+step:1578/1845 train_time:90925ms step_avg:57.62ms
+step:1579/1845 train_time:91014ms step_avg:57.64ms
+step:1580/1845 train_time:91101ms step_avg:57.66ms
+step:1581/1845 train_time:91189ms step_avg:57.68ms
+step:1582/1845 train_time:91277ms step_avg:57.70ms
+step:1583/1845 train_time:91366ms step_avg:57.72ms
+step:1584/1845 train_time:91453ms step_avg:57.74ms
+step:1585/1845 train_time:91542ms step_avg:57.76ms
+step:1586/1845 train_time:91629ms step_avg:57.77ms
+step:1587/1845 train_time:91718ms step_avg:57.79ms
+step:1588/1845 train_time:91806ms step_avg:57.81ms
+step:1589/1845 train_time:91896ms step_avg:57.83ms
+step:1590/1845 train_time:91983ms step_avg:57.85ms
+step:1591/1845 train_time:92072ms step_avg:57.87ms
+step:1592/1845 train_time:92158ms step_avg:57.89ms
+step:1593/1845 train_time:92248ms step_avg:57.91ms
+step:1594/1845 train_time:92336ms step_avg:57.93ms
+step:1595/1845 train_time:92425ms step_avg:57.95ms
+step:1596/1845 train_time:92513ms step_avg:57.97ms
+step:1597/1845 train_time:92600ms step_avg:57.98ms
+step:1598/1845 train_time:92687ms step_avg:58.00ms
+step:1599/1845 train_time:92775ms step_avg:58.02ms
+step:1600/1845 train_time:92862ms step_avg:58.04ms
+step:1601/1845 train_time:92950ms step_avg:58.06ms
+step:1602/1845 train_time:93037ms step_avg:58.08ms
+step:1603/1845 train_time:93125ms step_avg:58.09ms
+step:1604/1845 train_time:93212ms step_avg:58.11ms
+step:1605/1845 train_time:93301ms step_avg:58.13ms
+step:1606/1845 train_time:93388ms step_avg:58.15ms
+step:1607/1845 train_time:93477ms step_avg:58.17ms
+step:1608/1845 train_time:93564ms step_avg:58.19ms
+step:1609/1845 train_time:93654ms step_avg:58.21ms
+step:1610/1845 train_time:93741ms step_avg:58.22ms
+step:1611/1845 train_time:93830ms step_avg:58.24ms
+step:1612/1845 train_time:93917ms step_avg:58.26ms
+step:1613/1845 train_time:94005ms step_avg:58.28ms
+step:1614/1845 train_time:94094ms step_avg:58.30ms
+step:1615/1845 train_time:94182ms step_avg:58.32ms
+step:1616/1845 train_time:94269ms step_avg:58.33ms
+step:1617/1845 train_time:94358ms step_avg:58.35ms
+step:1618/1845 train_time:94446ms step_avg:58.37ms
+step:1619/1845 train_time:94535ms step_avg:58.39ms
+step:1620/1845 train_time:94623ms step_avg:58.41ms
+step:1621/1845 train_time:94710ms step_avg:58.43ms
+step:1622/1845 train_time:94797ms step_avg:58.44ms
+step:1623/1845 train_time:94886ms step_avg:58.46ms
+step:1624/1845 train_time:94972ms step_avg:58.48ms
+step:1625/1845 train_time:95060ms step_avg:58.50ms
+step:1626/1845 train_time:95147ms step_avg:58.52ms
+step:1627/1845 train_time:95236ms step_avg:58.53ms
+step:1628/1845 train_time:95323ms step_avg:58.55ms
+step:1629/1845 train_time:95412ms step_avg:58.57ms
+step:1630/1845 train_time:95499ms step_avg:58.59ms
+step:1631/1845 train_time:95588ms step_avg:58.61ms
+step:1632/1845 train_time:95675ms step_avg:58.62ms
+step:1633/1845 train_time:95763ms step_avg:58.64ms
+step:1634/1845 train_time:95851ms step_avg:58.66ms
+step:1635/1845 train_time:95939ms step_avg:58.68ms
+step:1636/1845 train_time:96026ms step_avg:58.70ms
+step:1637/1845 train_time:96116ms step_avg:58.71ms
+step:1638/1845 train_time:96203ms step_avg:58.73ms
+step:1639/1845 train_time:96291ms step_avg:58.75ms
+step:1640/1845 train_time:96378ms step_avg:58.77ms
+step:1641/1845 train_time:96467ms step_avg:58.79ms
+step:1642/1845 train_time:96555ms step_avg:58.80ms
+step:1643/1845 train_time:96642ms step_avg:58.82ms
+step:1644/1845 train_time:96730ms step_avg:58.84ms
+step:1645/1845 train_time:96820ms step_avg:58.86ms
+step:1646/1845 train_time:96906ms step_avg:58.87ms
+step:1647/1845 train_time:96995ms step_avg:58.89ms
+step:1648/1845 train_time:97081ms step_avg:58.91ms
+step:1649/1845 train_time:97170ms step_avg:58.93ms
+step:1650/1845 train_time:97257ms step_avg:58.94ms
+step:1651/1845 train_time:97347ms step_avg:58.96ms
+step:1652/1845 train_time:97434ms step_avg:58.98ms
+step:1653/1845 train_time:97522ms step_avg:59.00ms
+step:1654/1845 train_time:97610ms step_avg:59.01ms
+step:1655/1845 train_time:97698ms step_avg:59.03ms
+step:1656/1845 train_time:97785ms step_avg:59.05ms
+step:1657/1845 train_time:97873ms step_avg:59.07ms
+step:1658/1845 train_time:97960ms step_avg:59.08ms
+step:1659/1845 train_time:98048ms step_avg:59.10ms
+step:1660/1845 train_time:98136ms step_avg:59.12ms
+step:1661/1845 train_time:98224ms step_avg:59.14ms
+step:1662/1845 train_time:98311ms step_avg:59.15ms
+step:1663/1845 train_time:98400ms step_avg:59.17ms
+step:1664/1845 train_time:98487ms step_avg:59.19ms
+step:1665/1845 train_time:98575ms step_avg:59.20ms
+step:1666/1845 train_time:98662ms step_avg:59.22ms
+step:1667/1845 train_time:98751ms step_avg:59.24ms
+step:1668/1845 train_time:98838ms step_avg:59.26ms
+step:1669/1845 train_time:98926ms step_avg:59.27ms
+step:1670/1845 train_time:99014ms step_avg:59.29ms
+step:1671/1845 train_time:99102ms step_avg:59.31ms
+step:1672/1845 train_time:99190ms step_avg:59.32ms
+step:1673/1845 train_time:99278ms step_avg:59.34ms
+step:1674/1845 train_time:99365ms step_avg:59.36ms
+step:1675/1845 train_time:99453ms step_avg:59.38ms
+step:1676/1845 train_time:99540ms step_avg:59.39ms
+step:1677/1845 train_time:99629ms step_avg:59.41ms
+step:1678/1845 train_time:99716ms step_avg:59.43ms
+step:1679/1845 train_time:99804ms step_avg:59.44ms
+step:1680/1845 train_time:99891ms step_avg:59.46ms
+step:1681/1845 train_time:99979ms step_avg:59.48ms
+step:1682/1845 train_time:100067ms step_avg:59.49ms
+step:1683/1845 train_time:100156ms step_avg:59.51ms
+step:1684/1845 train_time:100243ms step_avg:59.53ms
+step:1685/1845 train_time:100332ms step_avg:59.54ms
+step:1686/1845 train_time:100419ms step_avg:59.56ms
+step:1687/1845 train_time:100507ms step_avg:59.58ms
+step:1688/1845 train_time:100595ms step_avg:59.59ms
+step:1689/1845 train_time:100683ms step_avg:59.61ms
+step:1690/1845 train_time:100770ms step_avg:59.63ms
+step:1691/1845 train_time:100858ms step_avg:59.64ms
+step:1692/1845 train_time:100945ms step_avg:59.66ms
+step:1693/1845 train_time:101034ms step_avg:59.68ms
+step:1694/1845 train_time:101121ms step_avg:59.69ms
+step:1695/1845 train_time:101210ms step_avg:59.71ms
+step:1696/1845 train_time:101298ms step_avg:59.73ms
+step:1697/1845 train_time:101387ms step_avg:59.74ms
+step:1698/1845 train_time:101474ms step_avg:59.76ms
+step:1699/1845 train_time:101562ms step_avg:59.78ms
+step:1700/1845 train_time:101650ms step_avg:59.79ms
+step:1701/1845 train_time:101739ms step_avg:59.81ms
+step:1702/1845 train_time:101826ms step_avg:59.83ms
+step:1703/1845 train_time:101914ms step_avg:59.84ms
+step:1704/1845 train_time:102001ms step_avg:59.86ms
+step:1705/1845 train_time:102089ms step_avg:59.88ms
+step:1706/1845 train_time:102177ms step_avg:59.89ms
+step:1707/1845 train_time:102266ms step_avg:59.91ms
+step:1708/1845 train_time:102353ms step_avg:59.93ms
+step:1709/1845 train_time:102441ms step_avg:59.94ms
+step:1710/1845 train_time:102529ms step_avg:59.96ms
+step:1711/1845 train_time:102618ms step_avg:59.98ms
+step:1712/1845 train_time:102705ms step_avg:59.99ms
+step:1713/1845 train_time:102793ms step_avg:60.01ms
+step:1714/1845 train_time:102880ms step_avg:60.02ms
+step:1715/1845 train_time:102969ms step_avg:60.04ms
+step:1716/1845 train_time:103056ms step_avg:60.06ms
+step:1717/1845 train_time:103145ms step_avg:60.07ms
+step:1718/1845 train_time:103232ms step_avg:60.09ms
+step:1719/1845 train_time:103320ms step_avg:60.10ms
+step:1720/1845 train_time:103408ms step_avg:60.12ms
+step:1721/1845 train_time:103496ms step_avg:60.14ms
+step:1722/1845 train_time:103583ms step_avg:60.15ms
+step:1723/1845 train_time:103673ms step_avg:60.17ms
+step:1724/1845 train_time:103759ms step_avg:60.19ms
+step:1725/1845 train_time:103848ms step_avg:60.20ms
+step:1726/1845 train_time:103935ms step_avg:60.22ms
+step:1727/1845 train_time:104024ms step_avg:60.23ms
+step:1728/1845 train_time:104112ms step_avg:60.25ms
+step:1729/1845 train_time:104199ms step_avg:60.27ms
+step:1730/1845 train_time:104287ms step_avg:60.28ms
+step:1731/1845 train_time:104375ms step_avg:60.30ms
+step:1732/1845 train_time:104462ms step_avg:60.31ms
+step:1733/1845 train_time:104550ms step_avg:60.33ms
+step:1734/1845 train_time:104637ms step_avg:60.34ms
+step:1735/1845 train_time:104726ms step_avg:60.36ms
+step:1736/1845 train_time:104813ms step_avg:60.38ms
+step:1737/1845 train_time:104901ms step_avg:60.39ms
+step:1738/1845 train_time:104989ms step_avg:60.41ms
+step:1739/1845 train_time:105079ms step_avg:60.42ms
+step:1740/1845 train_time:105166ms step_avg:60.44ms
+step:1741/1845 train_time:105254ms step_avg:60.46ms
+step:1742/1845 train_time:105341ms step_avg:60.47ms
+step:1743/1845 train_time:105429ms step_avg:60.49ms
+step:1744/1845 train_time:105517ms step_avg:60.50ms
+step:1745/1845 train_time:105606ms step_avg:60.52ms
+step:1746/1845 train_time:105693ms step_avg:60.53ms
+step:1747/1845 train_time:105780ms step_avg:60.55ms
+step:1748/1845 train_time:105867ms step_avg:60.56ms
+step:1749/1845 train_time:105957ms step_avg:60.58ms
+step:1750/1845 train_time:106044ms step_avg:60.60ms
+step:1750/1845 val_loss:3.3037 train_time:106135ms step_avg:60.65ms
+step:1751/1845 train_time:106155ms step_avg:60.63ms
+step:1752/1845 train_time:106226ms step_avg:60.63ms
+step:1753/1845 train_time:106316ms step_avg:60.65ms
+step:1754/1845 train_time:106405ms step_avg:60.66ms
+step:1755/1845 train_time:106494ms step_avg:60.68ms
+step:1756/1845 train_time:106580ms step_avg:60.69ms
+step:1757/1845 train_time:106667ms step_avg:60.71ms
+step:1758/1845 train_time:106753ms step_avg:60.72ms
+step:1759/1845 train_time:106840ms step_avg:60.74ms
+step:1760/1845 train_time:106928ms step_avg:60.75ms
+step:1761/1845 train_time:107015ms step_avg:60.77ms
+step:1762/1845 train_time:107103ms step_avg:60.78ms
+step:1763/1845 train_time:107194ms step_avg:60.80ms
+step:1764/1845 train_time:107284ms step_avg:60.82ms
+step:1765/1845 train_time:107373ms step_avg:60.83ms
+step:1766/1845 train_time:107460ms step_avg:60.85ms
+step:1767/1845 train_time:107549ms step_avg:60.87ms
+step:1768/1845 train_time:107635ms step_avg:60.88ms
+step:1769/1845 train_time:107723ms step_avg:60.89ms
+step:1770/1845 train_time:107809ms step_avg:60.91ms
+step:1771/1845 train_time:107897ms step_avg:60.92ms
+step:1772/1845 train_time:107984ms step_avg:60.94ms
+step:1773/1845 train_time:108072ms step_avg:60.95ms
+step:1774/1845 train_time:108161ms step_avg:60.97ms
+step:1775/1845 train_time:108250ms step_avg:60.99ms
+step:1776/1845 train_time:108339ms step_avg:61.00ms
+step:1777/1845 train_time:108428ms step_avg:61.02ms
+step:1778/1845 train_time:108515ms step_avg:61.03ms
+step:1779/1845 train_time:108603ms step_avg:61.05ms
+step:1780/1845 train_time:108690ms step_avg:61.06ms
+step:1781/1845 train_time:108777ms step_avg:61.08ms
+step:1782/1845 train_time:108864ms step_avg:61.09ms
+step:1783/1845 train_time:108952ms step_avg:61.11ms
+step:1784/1845 train_time:109039ms step_avg:61.12ms
+step:1785/1845 train_time:109129ms step_avg:61.14ms
+step:1786/1845 train_time:109217ms step_avg:61.15ms
+step:1787/1845 train_time:109306ms step_avg:61.17ms
+step:1788/1845 train_time:109395ms step_avg:61.18ms
+step:1789/1845 train_time:109483ms step_avg:61.20ms
+step:1790/1845 train_time:109571ms step_avg:61.21ms
+step:1791/1845 train_time:109658ms step_avg:61.23ms
+step:1792/1845 train_time:109746ms step_avg:61.24ms
+step:1793/1845 train_time:109833ms step_avg:61.26ms
+step:1794/1845 train_time:109920ms step_avg:61.27ms
+step:1795/1845 train_time:110008ms step_avg:61.29ms
+step:1796/1845 train_time:110095ms step_avg:61.30ms
+step:1797/1845 train_time:110184ms step_avg:61.32ms
+step:1798/1845 train_time:110272ms step_avg:61.33ms
+step:1799/1845 train_time:110361ms step_avg:61.35ms
+step:1800/1845 train_time:110448ms step_avg:61.36ms
+step:1801/1845 train_time:110536ms step_avg:61.37ms
+step:1802/1845 train_time:110623ms step_avg:61.39ms
+step:1803/1845 train_time:110712ms step_avg:61.40ms
+step:1804/1845 train_time:110799ms step_avg:61.42ms
+step:1805/1845 train_time:110887ms step_avg:61.43ms
+step:1806/1845 train_time:110974ms step_avg:61.45ms
+step:1807/1845 train_time:111063ms step_avg:61.46ms
+step:1808/1845 train_time:111152ms step_avg:61.48ms
+step:1809/1845 train_time:111242ms step_avg:61.49ms
+step:1810/1845 train_time:111330ms step_avg:61.51ms
+step:1811/1845 train_time:111419ms step_avg:61.52ms
+step:1812/1845 train_time:111506ms step_avg:61.54ms
+step:1813/1845 train_time:111595ms step_avg:61.55ms
+step:1814/1845 train_time:111682ms step_avg:61.57ms
+step:1815/1845 train_time:111772ms step_avg:61.58ms
+step:1816/1845 train_time:111859ms step_avg:61.60ms
+step:1817/1845 train_time:111947ms step_avg:61.61ms
+step:1818/1845 train_time:112035ms step_avg:61.63ms
+step:1819/1845 train_time:112123ms step_avg:61.64ms
+step:1820/1845 train_time:112211ms step_avg:61.65ms
+step:1821/1845 train_time:112300ms step_avg:61.67ms
+step:1822/1845 train_time:112387ms step_avg:61.68ms
+step:1823/1845 train_time:112476ms step_avg:61.70ms
+step:1824/1845 train_time:112563ms step_avg:61.71ms
+step:1825/1845 train_time:112653ms step_avg:61.73ms
+step:1826/1845 train_time:112740ms step_avg:61.74ms
+step:1827/1845 train_time:112829ms step_avg:61.76ms
+step:1828/1845 train_time:112915ms step_avg:61.77ms
+step:1829/1845 train_time:113005ms step_avg:61.78ms
+step:1830/1845 train_time:113092ms step_avg:61.80ms
+step:1831/1845 train_time:113182ms step_avg:61.81ms
+step:1832/1845 train_time:113270ms step_avg:61.83ms
+step:1833/1845 train_time:113358ms step_avg:61.84ms
+step:1834/1845 train_time:113446ms step_avg:61.86ms
+step:1835/1845 train_time:113535ms step_avg:61.87ms
+step:1836/1845 train_time:113625ms step_avg:61.89ms
+step:1837/1845 train_time:113714ms step_avg:61.90ms
+step:1838/1845 train_time:113801ms step_avg:61.92ms
+step:1839/1845 train_time:113890ms step_avg:61.93ms
+step:1840/1845 train_time:113977ms step_avg:61.94ms
+step:1841/1845 train_time:114068ms step_avg:61.96ms
+step:1842/1845 train_time:114154ms step_avg:61.97ms
+step:1843/1845 train_time:114243ms step_avg:61.99ms
+step:1844/1845 train_time:114331ms step_avg:62.00ms
+step:1845/1845 train_time:114420ms step_avg:62.02ms
+step:1845/1845 val_loss:3.2790 train_time:114508ms step_avg:62.06ms
+peak memory allocated: 29405 MiB reserved: 45118 MiB

--- a/records/track_1_short/2025-12-29_VeSkipGates/6ce339bb-580e-4a27-9ac0-d5bda9783033.txt
+++ b/records/track_1_short/2025-12-29_VeSkipGates/6ce339bb-580e-4a27-9ac0-d5bda9783033.txt
@@ -1,0 +1,3725 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, v, wd_tensor, lr_tensor):
+    """Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors."""
+    mask = (v * p) >= 0
+    wd_factor = wd_tensor.to(p.dtype)
+    lr_factor = lr_tensor.to(p.dtype)
+    p.copy_(p - (p * mask * wd_factor * lr_factor) - (v * lr_factor))
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn_gate (10 params 6 padding params)
+        2. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        3. reduce scatter attn/mlp round 2 (16 mlp params)
+        4. wait on step 1, then compute update of 1 and schedule all gather
+        5. wait on step 2, then compute update of 2 and schedule all gather
+        6. wait on step 3, then compute update of 3 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        7. wait on 4, then compute update of 4 and schedule all gather
+        8. wait for each all gather to complete and update params
+    Empirically, leading with small params provides an additional 0.2s improvement.
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        group_sizes = [15, 16, 16]
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+
+        all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"]
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params])
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            # The below shape-based heuristic assumes that matrices have their input along the
+            # row dimension and their output along the columns. Gates are an exception.
+            is_gate = 'gate' in ref_param.label
+
+            if "second_momentum_buffer" not in group:
+                if is_gate:
+                    group["second_momentum_buffer"] = torch.zeros_like(updated_grads[..., :, :1])
+                else:
+                    group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1])
+                        if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                    )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if (is_gate or param_shape[-2] >= param_shape[-1]) else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx],
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete and copy results back into original parameter tensors.
+        for info in all_gather_infos:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str],lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for label in label_order:
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.bfloat16, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-1]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+
+                exp_avg = state["exp_avg"]
+                exp_avg_sq = state["exp_avg_sq"]
+                state["step"] += 1
+                t = state["step"]
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (bias2 ** 0.5 / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                # cautious weight decay
+                mask = (update * p_slice) > 0
+                # lr as weight decay schedule
+                eff_weight_decay = lr * wd * getattr(param, "wd_mul", 1.0)
+                update.addcmul_(p_slice, mask, value=eff_weight_decay * lr)
+
+                p_slice.add_(other=update, alpha=-1.0)
+
+                if not is_small:
+                    all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+
+        self._reduce_scatter_futures.clear()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        self.attn_gate = CastedLinear(12, num_heads)
+        self.attn_gate.weight.label = 'attn_gate'
+
+        # only include gates on layers with value embeds used on forward pass
+        if layer_idx in [0,1,8,9,10]:
+            self.value_embed_gate = CastedLinear(12, num_heads)
+            self.value_embed_gate.weight.label = 'value_embed_gate'
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(self.value_embed_gate(x[..., :self.value_embed_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(self.attn_gate(x[..., :self.attn_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        #self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.5/448, grad_s=0.75/448)
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig, skew = None):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset = key_offset[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if skew is None:
+            logits = 23 * torch.sigmoid((logits+5) / 7.5)
+        else:
+            logits = 23 * torch.sigmoid((logits+skew) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        adam_labels = ['lm_head', 'value_embed', 'smear_gate', 'skip_gate', 'x0_lambdas', 'embed']
+        scalar_labels = ['scalars']
+        muon_labels = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        scalar_params = [p for p in model.parameters() if getattr(p, 'label', None) in scalar_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + scalar_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, lr=0.008, betas=(0.65, 0.95), eps=1e-8, weight_decay=0.005)
+        self.scalar_opt = DistAdam(scalar_params, scalar_labels, lr=0.008, betas=(0.9, 0.99), eps=1e-8, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.scalar_opt, self.muon_opt]
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.freeze_timer = 0
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+        self.scalar_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            if opt.freeze_timer > 0:
+                opt.freeze_timer -= 1
+                opt.zero_grad(set_to_none=True)
+            else:
+                if self._is_active_step(opt, step):
+                    for group in opt.param_groups:
+                        group["lr"] = group["initial_lr"] * step_lr
+                    opt.step()
+                    opt.zero_grad(set_to_none=True)
+                    if opt.odd_step_only:
+                        opt.should_sync = False
+        
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+
+    def start_transition(self, freeze_count=40):
+        # freeze scalar weights during transition
+        self.scalar_opt.freeze_timer = freeze_count
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1805  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+def log_parameter_norms(model):
+    norms = {}
+    for name, param in model.named_parameters():
+        if param.requires_grad:
+            norms[f"param_norm/{name}"] = param.norm().item()
+            norms[f"param_max/{name}"] = param.max().item()
+            norms[f"param_min/{name}"] = param.min().item()
+            if param.grad is not None:
+                norms[f"grad_norm/{name}"] = param.grad.norm().item()
+                norms[f"grad_max/{name}"] = param.grad.max().item()
+    
+    # Total norms
+    total_param_norm = sum(p.norm().item() ** 2 for p in model.parameters()) ** 0.5
+    total_grad_norm = sum(p.grad.norm().item() ** 2 for p in model.parameters() if p.grad is not None) ** 0.5
+    
+    norms["param_norm/total"] = total_param_norm
+    norms["grad_norm/total"] = total_grad_norm
+    
+    return norms
+
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+# import wandb
+# if master_process:
+#     wandb.init(
+#         project="nano4",
+#         name="baseline"
+#     )
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    # if master_process and step%2==1:
+    #     wandb.log({
+    #         "loss": loss.item(),
+    #         **log_parameter_norms(model)  # Add all norms
+    #     })
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Dec 29 05:47:54 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.90.07              Driver Version: 550.90.07      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   25C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   24C    P0            109W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   23C    P0            107W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   26C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   37C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   25C    P0            111W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   25C    P0            110W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   27C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 601, 602, 603, 1203, 1204, 1205, 1804, 1805, 1806] for warmup
+Resetting Model
+step:0/1845 val_loss:10.8309 train_time:0ms step_avg:0.03ms
+step:1/1845 train_time:81ms step_avg:80.51ms
+step:2/1845 train_time:104ms step_avg:52.23ms
+step:3/1845 train_time:125ms step_avg:41.81ms
+step:4/1845 train_time:159ms step_avg:39.82ms
+step:5/1845 train_time:194ms step_avg:38.70ms
+step:6/1845 train_time:274ms step_avg:45.61ms
+step:7/1845 train_time:398ms step_avg:56.79ms
+step:8/1845 train_time:431ms step_avg:53.93ms
+step:9/1845 train_time:466ms step_avg:51.74ms
+step:10/1845 train_time:500ms step_avg:49.97ms
+step:11/1845 train_time:534ms step_avg:48.58ms
+step:12/1845 train_time:568ms step_avg:47.37ms
+step:13/1845 train_time:603ms step_avg:46.37ms
+step:14/1845 train_time:637ms step_avg:45.49ms
+step:15/1845 train_time:671ms step_avg:44.75ms
+step:16/1845 train_time:705ms step_avg:44.09ms
+step:17/1845 train_time:740ms step_avg:43.54ms
+step:18/1845 train_time:774ms step_avg:43.01ms
+step:19/1845 train_time:809ms step_avg:42.56ms
+step:20/1845 train_time:843ms step_avg:42.15ms
+step:21/1845 train_time:877ms step_avg:41.78ms
+step:22/1845 train_time:911ms step_avg:41.42ms
+step:23/1845 train_time:946ms step_avg:41.12ms
+step:24/1845 train_time:980ms step_avg:40.83ms
+step:25/1845 train_time:1014ms step_avg:40.57ms
+step:26/1845 train_time:1048ms step_avg:40.31ms
+step:27/1845 train_time:1083ms step_avg:40.10ms
+step:28/1845 train_time:1117ms step_avg:39.89ms
+step:29/1845 train_time:1151ms step_avg:39.70ms
+step:30/1845 train_time:1185ms step_avg:39.51ms
+step:31/1845 train_time:1220ms step_avg:39.34ms
+step:32/1845 train_time:1254ms step_avg:39.18ms
+step:33/1845 train_time:1288ms step_avg:39.03ms
+step:34/1845 train_time:1322ms step_avg:38.88ms
+step:35/1845 train_time:1357ms step_avg:38.77ms
+step:36/1845 train_time:1391ms step_avg:38.64ms
+step:37/1845 train_time:1426ms step_avg:38.53ms
+step:38/1845 train_time:1460ms step_avg:38.42ms
+step:39/1845 train_time:1495ms step_avg:38.32ms
+step:40/1845 train_time:1529ms step_avg:38.22ms
+step:41/1845 train_time:1563ms step_avg:38.13ms
+step:42/1845 train_time:1598ms step_avg:38.05ms
+step:43/1845 train_time:1633ms step_avg:37.97ms
+step:44/1845 train_time:1667ms step_avg:37.88ms
+step:45/1845 train_time:1701ms step_avg:37.81ms
+step:46/1845 train_time:1735ms step_avg:37.73ms
+step:47/1845 train_time:1770ms step_avg:37.66ms
+step:48/1845 train_time:1804ms step_avg:37.59ms
+step:49/1845 train_time:1839ms step_avg:37.53ms
+step:50/1845 train_time:1873ms step_avg:37.46ms
+step:51/1845 train_time:1907ms step_avg:37.40ms
+step:52/1845 train_time:1941ms step_avg:37.33ms
+step:53/1845 train_time:1976ms step_avg:37.28ms
+step:54/1845 train_time:2010ms step_avg:37.22ms
+step:55/1845 train_time:2044ms step_avg:37.17ms
+step:56/1845 train_time:2079ms step_avg:37.12ms
+step:57/1845 train_time:2113ms step_avg:37.07ms
+step:58/1845 train_time:2147ms step_avg:37.02ms
+step:59/1845 train_time:2181ms step_avg:36.97ms
+step:60/1845 train_time:2216ms step_avg:36.93ms
+step:61/1845 train_time:2250ms step_avg:36.89ms
+step:62/1845 train_time:2284ms step_avg:36.85ms
+step:63/1845 train_time:2319ms step_avg:36.81ms
+step:64/1845 train_time:2353ms step_avg:36.77ms
+step:65/1845 train_time:2388ms step_avg:36.73ms
+step:66/1845 train_time:2422ms step_avg:36.69ms
+step:67/1845 train_time:2456ms step_avg:36.66ms
+step:68/1845 train_time:2491ms step_avg:36.63ms
+step:69/1845 train_time:2525ms step_avg:36.60ms
+step:70/1845 train_time:2559ms step_avg:36.56ms
+step:71/1845 train_time:2594ms step_avg:36.53ms
+step:72/1845 train_time:2628ms step_avg:36.50ms
+step:73/1845 train_time:2663ms step_avg:36.48ms
+step:74/1845 train_time:2697ms step_avg:36.45ms
+step:75/1845 train_time:2732ms step_avg:36.42ms
+step:76/1845 train_time:2766ms step_avg:36.39ms
+step:77/1845 train_time:2801ms step_avg:36.37ms
+step:78/1845 train_time:2835ms step_avg:36.34ms
+step:79/1845 train_time:2869ms step_avg:36.32ms
+step:80/1845 train_time:2903ms step_avg:36.29ms
+step:81/1845 train_time:2938ms step_avg:36.27ms
+step:82/1845 train_time:2972ms step_avg:36.24ms
+step:83/1845 train_time:3006ms step_avg:36.22ms
+step:84/1845 train_time:3040ms step_avg:36.19ms
+step:85/1845 train_time:3075ms step_avg:36.17ms
+step:86/1845 train_time:3109ms step_avg:36.15ms
+step:87/1845 train_time:3143ms step_avg:36.13ms
+step:88/1845 train_time:3177ms step_avg:36.11ms
+step:89/1845 train_time:3212ms step_avg:36.09ms
+step:90/1845 train_time:3246ms step_avg:36.07ms
+step:91/1845 train_time:3281ms step_avg:36.05ms
+step:92/1845 train_time:3315ms step_avg:36.03ms
+step:93/1845 train_time:3349ms step_avg:36.01ms
+step:94/1845 train_time:3383ms step_avg:35.99ms
+step:95/1845 train_time:3418ms step_avg:35.97ms
+step:96/1845 train_time:3452ms step_avg:35.95ms
+step:97/1845 train_time:3486ms step_avg:35.94ms
+step:98/1845 train_time:3520ms step_avg:35.92ms
+step:99/1845 train_time:3555ms step_avg:35.91ms
+step:100/1845 train_time:3589ms step_avg:35.89ms
+step:101/1845 train_time:3623ms step_avg:35.87ms
+step:102/1845 train_time:3657ms step_avg:35.86ms
+step:103/1845 train_time:3692ms step_avg:35.84ms
+step:104/1845 train_time:3726ms step_avg:35.83ms
+step:105/1845 train_time:3761ms step_avg:35.82ms
+step:106/1845 train_time:3795ms step_avg:35.80ms
+step:107/1845 train_time:3829ms step_avg:35.79ms
+step:108/1845 train_time:3864ms step_avg:35.77ms
+step:109/1845 train_time:3898ms step_avg:35.77ms
+step:110/1845 train_time:3932ms step_avg:35.75ms
+step:111/1845 train_time:3967ms step_avg:35.74ms
+step:112/1845 train_time:4001ms step_avg:35.72ms
+step:113/1845 train_time:4036ms step_avg:35.72ms
+step:114/1845 train_time:4070ms step_avg:35.70ms
+step:115/1845 train_time:4104ms step_avg:35.69ms
+step:116/1845 train_time:4138ms step_avg:35.67ms
+step:117/1845 train_time:4173ms step_avg:35.66ms
+step:118/1845 train_time:4207ms step_avg:35.65ms
+step:119/1845 train_time:4241ms step_avg:35.64ms
+step:120/1845 train_time:4275ms step_avg:35.63ms
+step:121/1845 train_time:4310ms step_avg:35.62ms
+step:122/1845 train_time:4344ms step_avg:35.61ms
+step:123/1845 train_time:4379ms step_avg:35.60ms
+step:124/1845 train_time:4413ms step_avg:35.59ms
+step:125/1845 train_time:4447ms step_avg:35.58ms
+step:126/1845 train_time:4481ms step_avg:35.57ms
+step:127/1845 train_time:4516ms step_avg:35.56ms
+step:128/1845 train_time:4550ms step_avg:35.55ms
+step:129/1845 train_time:4585ms step_avg:35.54ms
+step:130/1845 train_time:4619ms step_avg:35.53ms
+step:131/1845 train_time:4653ms step_avg:35.52ms
+step:132/1845 train_time:4687ms step_avg:35.51ms
+step:133/1845 train_time:4722ms step_avg:35.50ms
+step:134/1845 train_time:4756ms step_avg:35.49ms
+step:135/1845 train_time:4790ms step_avg:35.48ms
+step:136/1845 train_time:4824ms step_avg:35.47ms
+step:137/1845 train_time:4860ms step_avg:35.47ms
+step:138/1845 train_time:4893ms step_avg:35.46ms
+step:139/1845 train_time:4928ms step_avg:35.46ms
+step:140/1845 train_time:4962ms step_avg:35.44ms
+step:141/1845 train_time:4997ms step_avg:35.44ms
+step:142/1845 train_time:5031ms step_avg:35.43ms
+step:143/1845 train_time:5066ms step_avg:35.43ms
+step:144/1845 train_time:5100ms step_avg:35.42ms
+step:145/1845 train_time:5135ms step_avg:35.41ms
+step:146/1845 train_time:5169ms step_avg:35.40ms
+step:147/1845 train_time:5203ms step_avg:35.40ms
+step:148/1845 train_time:5237ms step_avg:35.39ms
+step:149/1845 train_time:5272ms step_avg:35.38ms
+step:150/1845 train_time:5306ms step_avg:35.37ms
+step:151/1845 train_time:5340ms step_avg:35.37ms
+step:152/1845 train_time:5374ms step_avg:35.36ms
+step:153/1845 train_time:5409ms step_avg:35.35ms
+step:154/1845 train_time:5443ms step_avg:35.34ms
+step:155/1845 train_time:5477ms step_avg:35.34ms
+step:156/1845 train_time:5511ms step_avg:35.33ms
+step:157/1845 train_time:5546ms step_avg:35.32ms
+step:158/1845 train_time:5580ms step_avg:35.31ms
+step:159/1845 train_time:5614ms step_avg:35.31ms
+step:160/1845 train_time:5648ms step_avg:35.30ms
+step:161/1845 train_time:5683ms step_avg:35.30ms
+step:162/1845 train_time:5717ms step_avg:35.29ms
+step:163/1845 train_time:5751ms step_avg:35.28ms
+step:164/1845 train_time:5785ms step_avg:35.27ms
+step:165/1845 train_time:5820ms step_avg:35.27ms
+step:166/1845 train_time:5853ms step_avg:35.26ms
+step:167/1845 train_time:5888ms step_avg:35.26ms
+step:168/1845 train_time:5922ms step_avg:35.25ms
+step:169/1845 train_time:5957ms step_avg:35.25ms
+step:170/1845 train_time:5991ms step_avg:35.24ms
+step:171/1845 train_time:6026ms step_avg:35.24ms
+step:172/1845 train_time:6060ms step_avg:35.23ms
+step:173/1845 train_time:6094ms step_avg:35.23ms
+step:174/1845 train_time:6128ms step_avg:35.22ms
+step:175/1845 train_time:6163ms step_avg:35.22ms
+step:176/1845 train_time:6197ms step_avg:35.21ms
+step:177/1845 train_time:6231ms step_avg:35.20ms
+step:178/1845 train_time:6265ms step_avg:35.20ms
+step:179/1845 train_time:6300ms step_avg:35.19ms
+step:180/1845 train_time:6334ms step_avg:35.19ms
+step:181/1845 train_time:6368ms step_avg:35.18ms
+step:182/1845 train_time:6402ms step_avg:35.18ms
+step:183/1845 train_time:6437ms step_avg:35.17ms
+step:184/1845 train_time:6471ms step_avg:35.17ms
+step:185/1845 train_time:6506ms step_avg:35.16ms
+step:186/1845 train_time:6540ms step_avg:35.16ms
+step:187/1845 train_time:6574ms step_avg:35.16ms
+step:188/1845 train_time:6608ms step_avg:35.15ms
+step:189/1845 train_time:6643ms step_avg:35.15ms
+step:190/1845 train_time:6677ms step_avg:35.14ms
+step:191/1845 train_time:6711ms step_avg:35.14ms
+step:192/1845 train_time:6745ms step_avg:35.13ms
+step:193/1845 train_time:6780ms step_avg:35.13ms
+step:194/1845 train_time:6814ms step_avg:35.12ms
+step:195/1845 train_time:6848ms step_avg:35.12ms
+step:196/1845 train_time:6882ms step_avg:35.11ms
+step:197/1845 train_time:6917ms step_avg:35.11ms
+step:198/1845 train_time:6951ms step_avg:35.11ms
+step:199/1845 train_time:6985ms step_avg:35.10ms
+step:200/1845 train_time:7019ms step_avg:35.10ms
+step:201/1845 train_time:7054ms step_avg:35.09ms
+step:202/1845 train_time:7088ms step_avg:35.09ms
+step:203/1845 train_time:7122ms step_avg:35.09ms
+step:204/1845 train_time:7156ms step_avg:35.08ms
+step:205/1845 train_time:7191ms step_avg:35.08ms
+step:206/1845 train_time:7225ms step_avg:35.07ms
+step:207/1845 train_time:7259ms step_avg:35.07ms
+step:208/1845 train_time:7293ms step_avg:35.06ms
+step:209/1845 train_time:7328ms step_avg:35.06ms
+step:210/1845 train_time:7362ms step_avg:35.06ms
+step:211/1845 train_time:7397ms step_avg:35.06ms
+step:212/1845 train_time:7431ms step_avg:35.05ms
+step:213/1845 train_time:7465ms step_avg:35.05ms
+step:214/1845 train_time:7499ms step_avg:35.04ms
+step:215/1845 train_time:7533ms step_avg:35.04ms
+step:216/1845 train_time:7567ms step_avg:35.03ms
+step:217/1845 train_time:7602ms step_avg:35.03ms
+step:218/1845 train_time:7636ms step_avg:35.03ms
+step:219/1845 train_time:7670ms step_avg:35.02ms
+step:220/1845 train_time:7704ms step_avg:35.02ms
+step:221/1845 train_time:7739ms step_avg:35.02ms
+step:222/1845 train_time:7773ms step_avg:35.01ms
+step:223/1845 train_time:7807ms step_avg:35.01ms
+step:224/1845 train_time:7841ms step_avg:35.00ms
+step:225/1845 train_time:7875ms step_avg:35.00ms
+step:226/1845 train_time:7909ms step_avg:35.00ms
+step:227/1845 train_time:7944ms step_avg:34.99ms
+step:228/1845 train_time:7978ms step_avg:34.99ms
+step:229/1845 train_time:8012ms step_avg:34.99ms
+step:230/1845 train_time:8046ms step_avg:34.98ms
+step:231/1845 train_time:8080ms step_avg:34.98ms
+step:232/1845 train_time:8114ms step_avg:34.98ms
+step:233/1845 train_time:8149ms step_avg:34.97ms
+step:234/1845 train_time:8183ms step_avg:34.97ms
+step:235/1845 train_time:8217ms step_avg:34.97ms
+step:236/1845 train_time:8251ms step_avg:34.96ms
+step:237/1845 train_time:8285ms step_avg:34.96ms
+step:238/1845 train_time:8319ms step_avg:34.95ms
+step:239/1845 train_time:8354ms step_avg:34.95ms
+step:240/1845 train_time:8388ms step_avg:34.95ms
+step:241/1845 train_time:8422ms step_avg:34.95ms
+step:242/1845 train_time:8456ms step_avg:34.94ms
+step:243/1845 train_time:8491ms step_avg:34.94ms
+step:244/1845 train_time:8525ms step_avg:34.94ms
+step:245/1845 train_time:8560ms step_avg:34.94ms
+step:246/1845 train_time:8594ms step_avg:34.93ms
+step:247/1845 train_time:8628ms step_avg:34.93ms
+step:248/1845 train_time:8662ms step_avg:34.93ms
+step:249/1845 train_time:8697ms step_avg:34.93ms
+step:250/1845 train_time:8731ms step_avg:34.92ms
+step:250/1845 val_loss:4.6199 train_time:8767ms step_avg:35.07ms
+step:251/1845 train_time:8786ms step_avg:35.01ms
+step:252/1845 train_time:8807ms step_avg:34.95ms
+step:253/1845 train_time:8837ms step_avg:34.93ms
+step:254/1845 train_time:8872ms step_avg:34.93ms
+step:255/1845 train_time:8907ms step_avg:34.93ms
+step:256/1845 train_time:8942ms step_avg:34.93ms
+step:257/1845 train_time:8977ms step_avg:34.93ms
+step:258/1845 train_time:9011ms step_avg:34.93ms
+step:259/1845 train_time:9046ms step_avg:34.92ms
+step:260/1845 train_time:9080ms step_avg:34.92ms
+step:261/1845 train_time:9114ms step_avg:34.92ms
+step:262/1845 train_time:9148ms step_avg:34.92ms
+step:263/1845 train_time:9182ms step_avg:34.91ms
+step:264/1845 train_time:9216ms step_avg:34.91ms
+step:265/1845 train_time:9250ms step_avg:34.91ms
+step:266/1845 train_time:9284ms step_avg:34.90ms
+step:267/1845 train_time:9318ms step_avg:34.90ms
+step:268/1845 train_time:9352ms step_avg:34.90ms
+step:269/1845 train_time:9386ms step_avg:34.89ms
+step:270/1845 train_time:9420ms step_avg:34.89ms
+step:271/1845 train_time:9455ms step_avg:34.89ms
+step:272/1845 train_time:9488ms step_avg:34.88ms
+step:273/1845 train_time:9523ms step_avg:34.88ms
+step:274/1845 train_time:9557ms step_avg:34.88ms
+step:275/1845 train_time:9591ms step_avg:34.88ms
+step:276/1845 train_time:9625ms step_avg:34.87ms
+step:277/1845 train_time:9659ms step_avg:34.87ms
+step:278/1845 train_time:9693ms step_avg:34.87ms
+step:279/1845 train_time:9727ms step_avg:34.86ms
+step:280/1845 train_time:9761ms step_avg:34.86ms
+step:281/1845 train_time:9796ms step_avg:34.86ms
+step:282/1845 train_time:9830ms step_avg:34.86ms
+step:283/1845 train_time:9864ms step_avg:34.86ms
+step:284/1845 train_time:9898ms step_avg:34.85ms
+step:285/1845 train_time:9933ms step_avg:34.85ms
+step:286/1845 train_time:9967ms step_avg:34.85ms
+step:287/1845 train_time:10001ms step_avg:34.85ms
+step:288/1845 train_time:10035ms step_avg:34.84ms
+step:289/1845 train_time:10069ms step_avg:34.84ms
+step:290/1845 train_time:10103ms step_avg:34.84ms
+step:291/1845 train_time:10138ms step_avg:34.84ms
+step:292/1845 train_time:10172ms step_avg:34.83ms
+step:293/1845 train_time:10206ms step_avg:34.83ms
+step:294/1845 train_time:10240ms step_avg:34.83ms
+step:295/1845 train_time:10274ms step_avg:34.83ms
+step:296/1845 train_time:10308ms step_avg:34.83ms
+step:297/1845 train_time:10343ms step_avg:34.82ms
+step:298/1845 train_time:10377ms step_avg:34.82ms
+step:299/1845 train_time:10411ms step_avg:34.82ms
+step:300/1845 train_time:10445ms step_avg:34.82ms
+step:301/1845 train_time:10479ms step_avg:34.82ms
+step:302/1845 train_time:10514ms step_avg:34.81ms
+step:303/1845 train_time:10547ms step_avg:34.81ms
+step:304/1845 train_time:10581ms step_avg:34.81ms
+step:305/1845 train_time:10616ms step_avg:34.81ms
+step:306/1845 train_time:10650ms step_avg:34.80ms
+step:307/1845 train_time:10684ms step_avg:34.80ms
+step:308/1845 train_time:10718ms step_avg:34.80ms
+step:309/1845 train_time:10752ms step_avg:34.80ms
+step:310/1845 train_time:10786ms step_avg:34.79ms
+step:311/1845 train_time:10821ms step_avg:34.79ms
+step:312/1845 train_time:10855ms step_avg:34.79ms
+step:313/1845 train_time:10889ms step_avg:34.79ms
+step:314/1845 train_time:10923ms step_avg:34.79ms
+step:315/1845 train_time:10957ms step_avg:34.79ms
+step:316/1845 train_time:10991ms step_avg:34.78ms
+step:317/1845 train_time:11025ms step_avg:34.78ms
+step:318/1845 train_time:11060ms step_avg:34.78ms
+step:319/1845 train_time:11094ms step_avg:34.78ms
+step:320/1845 train_time:11128ms step_avg:34.78ms
+step:321/1845 train_time:11163ms step_avg:34.77ms
+step:322/1845 train_time:11196ms step_avg:34.77ms
+step:323/1845 train_time:11231ms step_avg:34.77ms
+step:324/1845 train_time:11265ms step_avg:34.77ms
+step:325/1845 train_time:11299ms step_avg:34.77ms
+step:326/1845 train_time:11333ms step_avg:34.76ms
+step:327/1845 train_time:11367ms step_avg:34.76ms
+step:328/1845 train_time:11401ms step_avg:34.76ms
+step:329/1845 train_time:11435ms step_avg:34.76ms
+step:330/1845 train_time:11470ms step_avg:34.76ms
+step:331/1845 train_time:11504ms step_avg:34.76ms
+step:332/1845 train_time:11538ms step_avg:34.75ms
+step:333/1845 train_time:11573ms step_avg:34.75ms
+step:334/1845 train_time:11607ms step_avg:34.75ms
+step:335/1845 train_time:11641ms step_avg:34.75ms
+step:336/1845 train_time:11675ms step_avg:34.75ms
+step:337/1845 train_time:11709ms step_avg:34.75ms
+step:338/1845 train_time:11743ms step_avg:34.74ms
+step:339/1845 train_time:11778ms step_avg:34.74ms
+step:340/1845 train_time:11812ms step_avg:34.74ms
+step:341/1845 train_time:11846ms step_avg:34.74ms
+step:342/1845 train_time:11880ms step_avg:34.74ms
+step:343/1845 train_time:11914ms step_avg:34.73ms
+step:344/1845 train_time:11948ms step_avg:34.73ms
+step:345/1845 train_time:11982ms step_avg:34.73ms
+step:346/1845 train_time:12016ms step_avg:34.73ms
+step:347/1845 train_time:12050ms step_avg:34.73ms
+step:348/1845 train_time:12084ms step_avg:34.73ms
+step:349/1845 train_time:12119ms step_avg:34.72ms
+step:350/1845 train_time:12153ms step_avg:34.72ms
+step:351/1845 train_time:12187ms step_avg:34.72ms
+step:352/1845 train_time:12221ms step_avg:34.72ms
+step:353/1845 train_time:12255ms step_avg:34.72ms
+step:354/1845 train_time:12289ms step_avg:34.72ms
+step:355/1845 train_time:12324ms step_avg:34.71ms
+step:356/1845 train_time:12358ms step_avg:34.71ms
+step:357/1845 train_time:12392ms step_avg:34.71ms
+step:358/1845 train_time:12426ms step_avg:34.71ms
+step:359/1845 train_time:12460ms step_avg:34.71ms
+step:360/1845 train_time:12494ms step_avg:34.71ms
+step:361/1845 train_time:12528ms step_avg:34.70ms
+step:362/1845 train_time:12564ms step_avg:34.71ms
+step:363/1845 train_time:12597ms step_avg:34.70ms
+step:364/1845 train_time:12631ms step_avg:34.70ms
+step:365/1845 train_time:12665ms step_avg:34.70ms
+step:366/1845 train_time:12699ms step_avg:34.70ms
+step:367/1845 train_time:12733ms step_avg:34.70ms
+step:368/1845 train_time:12767ms step_avg:34.69ms
+step:369/1845 train_time:12801ms step_avg:34.69ms
+step:370/1845 train_time:12835ms step_avg:34.69ms
+step:371/1845 train_time:12869ms step_avg:34.69ms
+step:372/1845 train_time:12903ms step_avg:34.69ms
+step:373/1845 train_time:12938ms step_avg:34.69ms
+step:374/1845 train_time:12972ms step_avg:34.68ms
+step:375/1845 train_time:13006ms step_avg:34.68ms
+step:376/1845 train_time:13040ms step_avg:34.68ms
+step:377/1845 train_time:13074ms step_avg:34.68ms
+step:378/1845 train_time:13108ms step_avg:34.68ms
+step:379/1845 train_time:13142ms step_avg:34.68ms
+step:380/1845 train_time:13176ms step_avg:34.67ms
+step:381/1845 train_time:13211ms step_avg:34.67ms
+step:382/1845 train_time:13245ms step_avg:34.67ms
+step:383/1845 train_time:13279ms step_avg:34.67ms
+step:384/1845 train_time:13313ms step_avg:34.67ms
+step:385/1845 train_time:13347ms step_avg:34.67ms
+step:386/1845 train_time:13381ms step_avg:34.67ms
+step:387/1845 train_time:13416ms step_avg:34.67ms
+step:388/1845 train_time:13450ms step_avg:34.66ms
+step:389/1845 train_time:13484ms step_avg:34.66ms
+step:390/1845 train_time:13518ms step_avg:34.66ms
+step:391/1845 train_time:13552ms step_avg:34.66ms
+step:392/1845 train_time:13586ms step_avg:34.66ms
+step:393/1845 train_time:13620ms step_avg:34.66ms
+step:394/1845 train_time:13654ms step_avg:34.66ms
+step:395/1845 train_time:13689ms step_avg:34.66ms
+step:396/1845 train_time:13723ms step_avg:34.65ms
+step:397/1845 train_time:13757ms step_avg:34.65ms
+step:398/1845 train_time:13791ms step_avg:34.65ms
+step:399/1845 train_time:13825ms step_avg:34.65ms
+step:400/1845 train_time:13859ms step_avg:34.65ms
+step:401/1845 train_time:13893ms step_avg:34.65ms
+step:402/1845 train_time:13927ms step_avg:34.65ms
+step:403/1845 train_time:13961ms step_avg:34.64ms
+step:404/1845 train_time:13995ms step_avg:34.64ms
+step:405/1845 train_time:14030ms step_avg:34.64ms
+step:406/1845 train_time:14064ms step_avg:34.64ms
+step:407/1845 train_time:14098ms step_avg:34.64ms
+step:408/1845 train_time:14132ms step_avg:34.64ms
+step:409/1845 train_time:14166ms step_avg:34.64ms
+step:410/1845 train_time:14200ms step_avg:34.63ms
+step:411/1845 train_time:14234ms step_avg:34.63ms
+step:412/1845 train_time:14268ms step_avg:34.63ms
+step:413/1845 train_time:14303ms step_avg:34.63ms
+step:414/1845 train_time:14337ms step_avg:34.63ms
+step:415/1845 train_time:14371ms step_avg:34.63ms
+step:416/1845 train_time:14405ms step_avg:34.63ms
+step:417/1845 train_time:14440ms step_avg:34.63ms
+step:418/1845 train_time:14474ms step_avg:34.63ms
+step:419/1845 train_time:14508ms step_avg:34.63ms
+step:420/1845 train_time:14542ms step_avg:34.62ms
+step:421/1845 train_time:14576ms step_avg:34.62ms
+step:422/1845 train_time:14610ms step_avg:34.62ms
+step:423/1845 train_time:14644ms step_avg:34.62ms
+step:424/1845 train_time:14678ms step_avg:34.62ms
+step:425/1845 train_time:14713ms step_avg:34.62ms
+step:426/1845 train_time:14747ms step_avg:34.62ms
+step:427/1845 train_time:14781ms step_avg:34.62ms
+step:428/1845 train_time:14815ms step_avg:34.61ms
+step:429/1845 train_time:14850ms step_avg:34.61ms
+step:430/1845 train_time:14883ms step_avg:34.61ms
+step:431/1845 train_time:14918ms step_avg:34.61ms
+step:432/1845 train_time:14952ms step_avg:34.61ms
+step:433/1845 train_time:14986ms step_avg:34.61ms
+step:434/1845 train_time:15020ms step_avg:34.61ms
+step:435/1845 train_time:15054ms step_avg:34.61ms
+step:436/1845 train_time:15088ms step_avg:34.61ms
+step:437/1845 train_time:15123ms step_avg:34.61ms
+step:438/1845 train_time:15157ms step_avg:34.60ms
+step:439/1845 train_time:15191ms step_avg:34.60ms
+step:440/1845 train_time:15225ms step_avg:34.60ms
+step:441/1845 train_time:15259ms step_avg:34.60ms
+step:442/1845 train_time:15293ms step_avg:34.60ms
+step:443/1845 train_time:15328ms step_avg:34.60ms
+step:444/1845 train_time:15362ms step_avg:34.60ms
+step:445/1845 train_time:15396ms step_avg:34.60ms
+step:446/1845 train_time:15430ms step_avg:34.60ms
+step:447/1845 train_time:15464ms step_avg:34.60ms
+step:448/1845 train_time:15498ms step_avg:34.59ms
+step:449/1845 train_time:15533ms step_avg:34.59ms
+step:450/1845 train_time:15567ms step_avg:34.59ms
+step:451/1845 train_time:15601ms step_avg:34.59ms
+step:452/1845 train_time:15635ms step_avg:34.59ms
+step:453/1845 train_time:15669ms step_avg:34.59ms
+step:454/1845 train_time:15703ms step_avg:34.59ms
+step:455/1845 train_time:15737ms step_avg:34.59ms
+step:456/1845 train_time:15771ms step_avg:34.59ms
+step:457/1845 train_time:15806ms step_avg:34.59ms
+step:458/1845 train_time:15840ms step_avg:34.58ms
+step:459/1845 train_time:15874ms step_avg:34.58ms
+step:460/1845 train_time:15908ms step_avg:34.58ms
+step:461/1845 train_time:15942ms step_avg:34.58ms
+step:462/1845 train_time:15976ms step_avg:34.58ms
+step:463/1845 train_time:16011ms step_avg:34.58ms
+step:464/1845 train_time:16045ms step_avg:34.58ms
+step:465/1845 train_time:16079ms step_avg:34.58ms
+step:466/1845 train_time:16113ms step_avg:34.58ms
+step:467/1845 train_time:16147ms step_avg:34.58ms
+step:468/1845 train_time:16181ms step_avg:34.58ms
+step:469/1845 train_time:16216ms step_avg:34.57ms
+step:470/1845 train_time:16250ms step_avg:34.57ms
+step:471/1845 train_time:16284ms step_avg:34.57ms
+step:472/1845 train_time:16318ms step_avg:34.57ms
+step:473/1845 train_time:16352ms step_avg:34.57ms
+step:474/1845 train_time:16386ms step_avg:34.57ms
+step:475/1845 train_time:16420ms step_avg:34.57ms
+step:476/1845 train_time:16454ms step_avg:34.57ms
+step:477/1845 train_time:16489ms step_avg:34.57ms
+step:478/1845 train_time:16523ms step_avg:34.57ms
+step:479/1845 train_time:16557ms step_avg:34.57ms
+step:480/1845 train_time:16591ms step_avg:34.56ms
+step:481/1845 train_time:16625ms step_avg:34.56ms
+step:482/1845 train_time:16659ms step_avg:34.56ms
+step:483/1845 train_time:16693ms step_avg:34.56ms
+step:484/1845 train_time:16727ms step_avg:34.56ms
+step:485/1845 train_time:16761ms step_avg:34.56ms
+step:486/1845 train_time:16795ms step_avg:34.56ms
+step:487/1845 train_time:16829ms step_avg:34.56ms
+step:488/1845 train_time:16863ms step_avg:34.56ms
+step:489/1845 train_time:16898ms step_avg:34.56ms
+step:490/1845 train_time:16931ms step_avg:34.55ms
+step:491/1845 train_time:16966ms step_avg:34.55ms
+step:492/1845 train_time:17000ms step_avg:34.55ms
+step:493/1845 train_time:17034ms step_avg:34.55ms
+step:494/1845 train_time:17068ms step_avg:34.55ms
+step:495/1845 train_time:17102ms step_avg:34.55ms
+step:496/1845 train_time:17136ms step_avg:34.55ms
+step:497/1845 train_time:17171ms step_avg:34.55ms
+step:498/1845 train_time:17205ms step_avg:34.55ms
+step:499/1845 train_time:17239ms step_avg:34.55ms
+step:500/1845 train_time:17273ms step_avg:34.55ms
+step:500/1845 val_loss:4.3018 train_time:17310ms step_avg:34.62ms
+step:501/1845 train_time:17329ms step_avg:34.59ms
+step:502/1845 train_time:17349ms step_avg:34.56ms
+step:503/1845 train_time:17380ms step_avg:34.55ms
+step:504/1845 train_time:17416ms step_avg:34.56ms
+step:505/1845 train_time:17452ms step_avg:34.56ms
+step:506/1845 train_time:17486ms step_avg:34.56ms
+step:507/1845 train_time:17521ms step_avg:34.56ms
+step:508/1845 train_time:17555ms step_avg:34.56ms
+step:509/1845 train_time:17589ms step_avg:34.56ms
+step:510/1845 train_time:17623ms step_avg:34.56ms
+step:511/1845 train_time:17658ms step_avg:34.55ms
+step:512/1845 train_time:17691ms step_avg:34.55ms
+step:513/1845 train_time:17726ms step_avg:34.55ms
+step:514/1845 train_time:17759ms step_avg:34.55ms
+step:515/1845 train_time:17794ms step_avg:34.55ms
+step:516/1845 train_time:17828ms step_avg:34.55ms
+step:517/1845 train_time:17862ms step_avg:34.55ms
+step:518/1845 train_time:17896ms step_avg:34.55ms
+step:519/1845 train_time:17930ms step_avg:34.55ms
+step:520/1845 train_time:17964ms step_avg:34.55ms
+step:521/1845 train_time:17998ms step_avg:34.55ms
+step:522/1845 train_time:18032ms step_avg:34.54ms
+step:523/1845 train_time:18066ms step_avg:34.54ms
+step:524/1845 train_time:18100ms step_avg:34.54ms
+step:525/1845 train_time:18135ms step_avg:34.54ms
+step:526/1845 train_time:18169ms step_avg:34.54ms
+step:527/1845 train_time:18203ms step_avg:34.54ms
+step:528/1845 train_time:18237ms step_avg:34.54ms
+step:529/1845 train_time:18271ms step_avg:34.54ms
+step:530/1845 train_time:18305ms step_avg:34.54ms
+step:531/1845 train_time:18339ms step_avg:34.54ms
+step:532/1845 train_time:18373ms step_avg:34.54ms
+step:533/1845 train_time:18408ms step_avg:34.54ms
+step:534/1845 train_time:18442ms step_avg:34.54ms
+step:535/1845 train_time:18476ms step_avg:34.54ms
+step:536/1845 train_time:18510ms step_avg:34.53ms
+step:537/1845 train_time:18545ms step_avg:34.53ms
+step:538/1845 train_time:18579ms step_avg:34.53ms
+step:539/1845 train_time:18613ms step_avg:34.53ms
+step:540/1845 train_time:18647ms step_avg:34.53ms
+step:541/1845 train_time:18682ms step_avg:34.53ms
+step:542/1845 train_time:18715ms step_avg:34.53ms
+step:543/1845 train_time:18750ms step_avg:34.53ms
+step:544/1845 train_time:18784ms step_avg:34.53ms
+step:545/1845 train_time:18818ms step_avg:34.53ms
+step:546/1845 train_time:18852ms step_avg:34.53ms
+step:547/1845 train_time:18887ms step_avg:34.53ms
+step:548/1845 train_time:18921ms step_avg:34.53ms
+step:549/1845 train_time:18955ms step_avg:34.53ms
+step:550/1845 train_time:18989ms step_avg:34.53ms
+step:551/1845 train_time:19023ms step_avg:34.53ms
+step:552/1845 train_time:19057ms step_avg:34.52ms
+step:553/1845 train_time:19092ms step_avg:34.52ms
+step:554/1845 train_time:19126ms step_avg:34.52ms
+step:555/1845 train_time:19160ms step_avg:34.52ms
+step:556/1845 train_time:19194ms step_avg:34.52ms
+step:557/1845 train_time:19228ms step_avg:34.52ms
+step:558/1845 train_time:19262ms step_avg:34.52ms
+step:559/1845 train_time:19296ms step_avg:34.52ms
+step:560/1845 train_time:19330ms step_avg:34.52ms
+step:561/1845 train_time:19364ms step_avg:34.52ms
+step:562/1845 train_time:19398ms step_avg:34.52ms
+step:563/1845 train_time:19433ms step_avg:34.52ms
+step:564/1845 train_time:19467ms step_avg:34.52ms
+step:565/1845 train_time:19501ms step_avg:34.52ms
+step:566/1845 train_time:19535ms step_avg:34.51ms
+step:567/1845 train_time:19570ms step_avg:34.51ms
+step:568/1845 train_time:19603ms step_avg:34.51ms
+step:569/1845 train_time:19638ms step_avg:34.51ms
+step:570/1845 train_time:19672ms step_avg:34.51ms
+step:571/1845 train_time:19706ms step_avg:34.51ms
+step:572/1845 train_time:19740ms step_avg:34.51ms
+step:573/1845 train_time:19774ms step_avg:34.51ms
+step:574/1845 train_time:19808ms step_avg:34.51ms
+step:575/1845 train_time:19842ms step_avg:34.51ms
+step:576/1845 train_time:19876ms step_avg:34.51ms
+step:577/1845 train_time:19910ms step_avg:34.51ms
+step:578/1845 train_time:19944ms step_avg:34.51ms
+step:579/1845 train_time:19979ms step_avg:34.51ms
+step:580/1845 train_time:20013ms step_avg:34.51ms
+step:581/1845 train_time:20047ms step_avg:34.50ms
+step:582/1845 train_time:20081ms step_avg:34.50ms
+step:583/1845 train_time:20116ms step_avg:34.50ms
+step:584/1845 train_time:20150ms step_avg:34.50ms
+step:585/1845 train_time:20184ms step_avg:34.50ms
+step:586/1845 train_time:20218ms step_avg:34.50ms
+step:587/1845 train_time:20252ms step_avg:34.50ms
+step:588/1845 train_time:20286ms step_avg:34.50ms
+step:589/1845 train_time:20321ms step_avg:34.50ms
+step:590/1845 train_time:20355ms step_avg:34.50ms
+step:591/1845 train_time:20389ms step_avg:34.50ms
+step:592/1845 train_time:20423ms step_avg:34.50ms
+step:593/1845 train_time:20457ms step_avg:34.50ms
+step:594/1845 train_time:20491ms step_avg:34.50ms
+step:595/1845 train_time:20525ms step_avg:34.50ms
+step:596/1845 train_time:20559ms step_avg:34.49ms
+step:597/1845 train_time:20593ms step_avg:34.49ms
+step:598/1845 train_time:20627ms step_avg:34.49ms
+step:599/1845 train_time:20662ms step_avg:34.49ms
+step:600/1845 train_time:20696ms step_avg:34.49ms
+step:601/1845 train_time:20730ms step_avg:34.49ms
+step:602/1845 train_time:20764ms step_avg:34.49ms
+step:603/1845 train_time:20799ms step_avg:34.49ms
+step:604/1845 train_time:20859ms step_avg:34.54ms
+step:605/1845 train_time:20922ms step_avg:34.58ms
+step:606/1845 train_time:20983ms step_avg:34.63ms
+step:607/1845 train_time:21046ms step_avg:34.67ms
+step:608/1845 train_time:21107ms step_avg:34.72ms
+step:609/1845 train_time:21169ms step_avg:34.76ms
+step:610/1845 train_time:21231ms step_avg:34.80ms
+step:611/1845 train_time:21293ms step_avg:34.85ms
+step:612/1845 train_time:21354ms step_avg:34.89ms
+step:613/1845 train_time:21417ms step_avg:34.94ms
+step:614/1845 train_time:21478ms step_avg:34.98ms
+step:615/1845 train_time:21540ms step_avg:35.02ms
+step:616/1845 train_time:21601ms step_avg:35.07ms
+step:617/1845 train_time:21664ms step_avg:35.11ms
+step:618/1845 train_time:21725ms step_avg:35.15ms
+step:619/1845 train_time:21787ms step_avg:35.20ms
+step:620/1845 train_time:21847ms step_avg:35.24ms
+step:621/1845 train_time:21909ms step_avg:35.28ms
+step:622/1845 train_time:21969ms step_avg:35.32ms
+step:623/1845 train_time:22031ms step_avg:35.36ms
+step:624/1845 train_time:22092ms step_avg:35.40ms
+step:625/1845 train_time:22154ms step_avg:35.45ms
+step:626/1845 train_time:22215ms step_avg:35.49ms
+step:627/1845 train_time:22278ms step_avg:35.53ms
+step:628/1845 train_time:22338ms step_avg:35.57ms
+step:629/1845 train_time:22401ms step_avg:35.61ms
+step:630/1845 train_time:22462ms step_avg:35.65ms
+step:631/1845 train_time:22525ms step_avg:35.70ms
+step:632/1845 train_time:22586ms step_avg:35.74ms
+step:633/1845 train_time:22648ms step_avg:35.78ms
+step:634/1845 train_time:22708ms step_avg:35.82ms
+step:635/1845 train_time:22771ms step_avg:35.86ms
+step:636/1845 train_time:22831ms step_avg:35.90ms
+step:637/1845 train_time:22894ms step_avg:35.94ms
+step:638/1845 train_time:22956ms step_avg:35.98ms
+step:639/1845 train_time:23018ms step_avg:36.02ms
+step:640/1845 train_time:23079ms step_avg:36.06ms
+step:641/1845 train_time:23141ms step_avg:36.10ms
+step:642/1845 train_time:23202ms step_avg:36.14ms
+step:643/1845 train_time:23265ms step_avg:36.18ms
+step:644/1845 train_time:23326ms step_avg:36.22ms
+step:645/1845 train_time:23389ms step_avg:36.26ms
+step:646/1845 train_time:23449ms step_avg:36.30ms
+step:647/1845 train_time:23511ms step_avg:36.34ms
+step:648/1845 train_time:23572ms step_avg:36.38ms
+step:649/1845 train_time:23634ms step_avg:36.42ms
+step:650/1845 train_time:23695ms step_avg:36.45ms
+step:651/1845 train_time:23757ms step_avg:36.49ms
+step:652/1845 train_time:23819ms step_avg:36.53ms
+step:653/1845 train_time:23881ms step_avg:36.57ms
+step:654/1845 train_time:23942ms step_avg:36.61ms
+step:655/1845 train_time:24004ms step_avg:36.65ms
+step:656/1845 train_time:24065ms step_avg:36.68ms
+step:657/1845 train_time:24128ms step_avg:36.72ms
+step:658/1845 train_time:24188ms step_avg:36.76ms
+step:659/1845 train_time:24251ms step_avg:36.80ms
+step:660/1845 train_time:24311ms step_avg:36.84ms
+step:661/1845 train_time:24374ms step_avg:36.87ms
+step:662/1845 train_time:24434ms step_avg:36.91ms
+step:663/1845 train_time:24496ms step_avg:36.95ms
+step:664/1845 train_time:24557ms step_avg:36.98ms
+step:665/1845 train_time:24620ms step_avg:37.02ms
+step:666/1845 train_time:24680ms step_avg:37.06ms
+step:667/1845 train_time:24743ms step_avg:37.10ms
+step:668/1845 train_time:24804ms step_avg:37.13ms
+step:669/1845 train_time:24866ms step_avg:37.17ms
+step:670/1845 train_time:24927ms step_avg:37.20ms
+step:671/1845 train_time:24989ms step_avg:37.24ms
+step:672/1845 train_time:25050ms step_avg:37.28ms
+step:673/1845 train_time:25112ms step_avg:37.31ms
+step:674/1845 train_time:25173ms step_avg:37.35ms
+step:675/1845 train_time:25235ms step_avg:37.39ms
+step:676/1845 train_time:25296ms step_avg:37.42ms
+step:677/1845 train_time:25359ms step_avg:37.46ms
+step:678/1845 train_time:25420ms step_avg:37.49ms
+step:679/1845 train_time:25482ms step_avg:37.53ms
+step:680/1845 train_time:25543ms step_avg:37.56ms
+step:681/1845 train_time:25605ms step_avg:37.60ms
+step:682/1845 train_time:25666ms step_avg:37.63ms
+step:683/1845 train_time:25728ms step_avg:37.67ms
+step:684/1845 train_time:25788ms step_avg:37.70ms
+step:685/1845 train_time:25851ms step_avg:37.74ms
+step:686/1845 train_time:25911ms step_avg:37.77ms
+step:687/1845 train_time:25974ms step_avg:37.81ms
+step:688/1845 train_time:26035ms step_avg:37.84ms
+step:689/1845 train_time:26098ms step_avg:37.88ms
+step:690/1845 train_time:26158ms step_avg:37.91ms
+step:691/1845 train_time:26220ms step_avg:37.95ms
+step:692/1845 train_time:26281ms step_avg:37.98ms
+step:693/1845 train_time:26344ms step_avg:38.01ms
+step:694/1845 train_time:26404ms step_avg:38.05ms
+step:695/1845 train_time:26466ms step_avg:38.08ms
+step:696/1845 train_time:26527ms step_avg:38.11ms
+step:697/1845 train_time:26589ms step_avg:38.15ms
+step:698/1845 train_time:26649ms step_avg:38.18ms
+step:699/1845 train_time:26711ms step_avg:38.21ms
+step:700/1845 train_time:26772ms step_avg:38.25ms
+step:701/1845 train_time:26835ms step_avg:38.28ms
+step:702/1845 train_time:26896ms step_avg:38.31ms
+step:703/1845 train_time:26959ms step_avg:38.35ms
+step:704/1845 train_time:27019ms step_avg:38.38ms
+step:705/1845 train_time:27082ms step_avg:38.41ms
+step:706/1845 train_time:27143ms step_avg:38.45ms
+step:707/1845 train_time:27206ms step_avg:38.48ms
+step:708/1845 train_time:27266ms step_avg:38.51ms
+step:709/1845 train_time:27329ms step_avg:38.55ms
+step:710/1845 train_time:27389ms step_avg:38.58ms
+step:711/1845 train_time:27451ms step_avg:38.61ms
+step:712/1845 train_time:27512ms step_avg:38.64ms
+step:713/1845 train_time:27574ms step_avg:38.67ms
+step:714/1845 train_time:27635ms step_avg:38.70ms
+step:715/1845 train_time:27697ms step_avg:38.74ms
+step:716/1845 train_time:27758ms step_avg:38.77ms
+step:717/1845 train_time:27821ms step_avg:38.80ms
+step:718/1845 train_time:27882ms step_avg:38.83ms
+step:719/1845 train_time:27945ms step_avg:38.87ms
+step:720/1845 train_time:28006ms step_avg:38.90ms
+step:721/1845 train_time:28068ms step_avg:38.93ms
+step:722/1845 train_time:28129ms step_avg:38.96ms
+step:723/1845 train_time:28191ms step_avg:38.99ms
+step:724/1845 train_time:28251ms step_avg:39.02ms
+step:725/1845 train_time:28313ms step_avg:39.05ms
+step:726/1845 train_time:28374ms step_avg:39.08ms
+step:727/1845 train_time:28437ms step_avg:39.11ms
+step:728/1845 train_time:28498ms step_avg:39.15ms
+step:729/1845 train_time:28560ms step_avg:39.18ms
+step:730/1845 train_time:28621ms step_avg:39.21ms
+step:731/1845 train_time:28683ms step_avg:39.24ms
+step:732/1845 train_time:28744ms step_avg:39.27ms
+step:733/1845 train_time:28807ms step_avg:39.30ms
+step:734/1845 train_time:28868ms step_avg:39.33ms
+step:735/1845 train_time:28930ms step_avg:39.36ms
+step:736/1845 train_time:28990ms step_avg:39.39ms
+step:737/1845 train_time:29053ms step_avg:39.42ms
+step:738/1845 train_time:29113ms step_avg:39.45ms
+step:739/1845 train_time:29177ms step_avg:39.48ms
+step:740/1845 train_time:29238ms step_avg:39.51ms
+step:741/1845 train_time:29300ms step_avg:39.54ms
+step:742/1845 train_time:29361ms step_avg:39.57ms
+step:743/1845 train_time:29424ms step_avg:39.60ms
+step:744/1845 train_time:29485ms step_avg:39.63ms
+step:745/1845 train_time:29547ms step_avg:39.66ms
+step:746/1845 train_time:29608ms step_avg:39.69ms
+step:747/1845 train_time:29670ms step_avg:39.72ms
+step:748/1845 train_time:29731ms step_avg:39.75ms
+step:749/1845 train_time:29793ms step_avg:39.78ms
+step:750/1845 train_time:29854ms step_avg:39.81ms
+step:750/1845 val_loss:4.0156 train_time:29917ms step_avg:39.89ms
+step:751/1845 train_time:29937ms step_avg:39.86ms
+step:752/1845 train_time:29980ms step_avg:39.87ms
+step:753/1845 train_time:30045ms step_avg:39.90ms
+step:754/1845 train_time:30108ms step_avg:39.93ms
+step:755/1845 train_time:30170ms step_avg:39.96ms
+step:756/1845 train_time:30231ms step_avg:39.99ms
+step:757/1845 train_time:30293ms step_avg:40.02ms
+step:758/1845 train_time:30353ms step_avg:40.04ms
+step:759/1845 train_time:30415ms step_avg:40.07ms
+step:760/1845 train_time:30475ms step_avg:40.10ms
+step:761/1845 train_time:30537ms step_avg:40.13ms
+step:762/1845 train_time:30597ms step_avg:40.15ms
+step:763/1845 train_time:30658ms step_avg:40.18ms
+step:764/1845 train_time:30719ms step_avg:40.21ms
+step:765/1845 train_time:30780ms step_avg:40.24ms
+step:766/1845 train_time:30841ms step_avg:40.26ms
+step:767/1845 train_time:30905ms step_avg:40.29ms
+step:768/1845 train_time:30966ms step_avg:40.32ms
+step:769/1845 train_time:31029ms step_avg:40.35ms
+step:770/1845 train_time:31090ms step_avg:40.38ms
+step:771/1845 train_time:31153ms step_avg:40.41ms
+step:772/1845 train_time:31214ms step_avg:40.43ms
+step:773/1845 train_time:31277ms step_avg:40.46ms
+step:774/1845 train_time:31337ms step_avg:40.49ms
+step:775/1845 train_time:31399ms step_avg:40.52ms
+step:776/1845 train_time:31460ms step_avg:40.54ms
+step:777/1845 train_time:31522ms step_avg:40.57ms
+step:778/1845 train_time:31583ms step_avg:40.59ms
+step:779/1845 train_time:31645ms step_avg:40.62ms
+step:780/1845 train_time:31706ms step_avg:40.65ms
+step:781/1845 train_time:31769ms step_avg:40.68ms
+step:782/1845 train_time:31829ms step_avg:40.70ms
+step:783/1845 train_time:31892ms step_avg:40.73ms
+step:784/1845 train_time:31952ms step_avg:40.76ms
+step:785/1845 train_time:32015ms step_avg:40.78ms
+step:786/1845 train_time:32076ms step_avg:40.81ms
+step:787/1845 train_time:32139ms step_avg:40.84ms
+step:788/1845 train_time:32201ms step_avg:40.86ms
+step:789/1845 train_time:32263ms step_avg:40.89ms
+step:790/1845 train_time:32324ms step_avg:40.92ms
+step:791/1845 train_time:32387ms step_avg:40.94ms
+step:792/1845 train_time:32448ms step_avg:40.97ms
+step:793/1845 train_time:32511ms step_avg:41.00ms
+step:794/1845 train_time:32571ms step_avg:41.02ms
+step:795/1845 train_time:32633ms step_avg:41.05ms
+step:796/1845 train_time:32693ms step_avg:41.07ms
+step:797/1845 train_time:32756ms step_avg:41.10ms
+step:798/1845 train_time:32816ms step_avg:41.12ms
+step:799/1845 train_time:32879ms step_avg:41.15ms
+step:800/1845 train_time:32939ms step_avg:41.17ms
+step:801/1845 train_time:33002ms step_avg:41.20ms
+step:802/1845 train_time:33063ms step_avg:41.23ms
+step:803/1845 train_time:33126ms step_avg:41.25ms
+step:804/1845 train_time:33188ms step_avg:41.28ms
+step:805/1845 train_time:33250ms step_avg:41.30ms
+step:806/1845 train_time:33311ms step_avg:41.33ms
+step:807/1845 train_time:33373ms step_avg:41.35ms
+step:808/1845 train_time:33434ms step_avg:41.38ms
+step:809/1845 train_time:33495ms step_avg:41.40ms
+step:810/1845 train_time:33556ms step_avg:41.43ms
+step:811/1845 train_time:33619ms step_avg:41.45ms
+step:812/1845 train_time:33680ms step_avg:41.48ms
+step:813/1845 train_time:33742ms step_avg:41.50ms
+step:814/1845 train_time:33802ms step_avg:41.53ms
+step:815/1845 train_time:33865ms step_avg:41.55ms
+step:816/1845 train_time:33926ms step_avg:41.58ms
+step:817/1845 train_time:33989ms step_avg:41.60ms
+step:818/1845 train_time:34049ms step_avg:41.63ms
+step:819/1845 train_time:34112ms step_avg:41.65ms
+step:820/1845 train_time:34173ms step_avg:41.67ms
+step:821/1845 train_time:34236ms step_avg:41.70ms
+step:822/1845 train_time:34296ms step_avg:41.72ms
+step:823/1845 train_time:34359ms step_avg:41.75ms
+step:824/1845 train_time:34420ms step_avg:41.77ms
+step:825/1845 train_time:34482ms step_avg:41.80ms
+step:826/1845 train_time:34543ms step_avg:41.82ms
+step:827/1845 train_time:34606ms step_avg:41.84ms
+step:828/1845 train_time:34667ms step_avg:41.87ms
+step:829/1845 train_time:34729ms step_avg:41.89ms
+step:830/1845 train_time:34790ms step_avg:41.92ms
+step:831/1845 train_time:34853ms step_avg:41.94ms
+step:832/1845 train_time:34913ms step_avg:41.96ms
+step:833/1845 train_time:34975ms step_avg:41.99ms
+step:834/1845 train_time:35036ms step_avg:42.01ms
+step:835/1845 train_time:35099ms step_avg:42.03ms
+step:836/1845 train_time:35160ms step_avg:42.06ms
+step:837/1845 train_time:35224ms step_avg:42.08ms
+step:838/1845 train_time:35285ms step_avg:42.11ms
+step:839/1845 train_time:35348ms step_avg:42.13ms
+step:840/1845 train_time:35408ms step_avg:42.15ms
+step:841/1845 train_time:35471ms step_avg:42.18ms
+step:842/1845 train_time:35532ms step_avg:42.20ms
+step:843/1845 train_time:35594ms step_avg:42.22ms
+step:844/1845 train_time:35654ms step_avg:42.24ms
+step:845/1845 train_time:35716ms step_avg:42.27ms
+step:846/1845 train_time:35777ms step_avg:42.29ms
+step:847/1845 train_time:35840ms step_avg:42.31ms
+step:848/1845 train_time:35902ms step_avg:42.34ms
+step:849/1845 train_time:35964ms step_avg:42.36ms
+step:850/1845 train_time:36024ms step_avg:42.38ms
+step:851/1845 train_time:36087ms step_avg:42.41ms
+step:852/1845 train_time:36148ms step_avg:42.43ms
+step:853/1845 train_time:36211ms step_avg:42.45ms
+step:854/1845 train_time:36272ms step_avg:42.47ms
+step:855/1845 train_time:36334ms step_avg:42.50ms
+step:856/1845 train_time:36395ms step_avg:42.52ms
+step:857/1845 train_time:36457ms step_avg:42.54ms
+step:858/1845 train_time:36518ms step_avg:42.56ms
+step:859/1845 train_time:36581ms step_avg:42.59ms
+step:860/1845 train_time:36642ms step_avg:42.61ms
+step:861/1845 train_time:36704ms step_avg:42.63ms
+step:862/1845 train_time:36765ms step_avg:42.65ms
+step:863/1845 train_time:36828ms step_avg:42.67ms
+step:864/1845 train_time:36889ms step_avg:42.70ms
+step:865/1845 train_time:36951ms step_avg:42.72ms
+step:866/1845 train_time:37012ms step_avg:42.74ms
+step:867/1845 train_time:37074ms step_avg:42.76ms
+step:868/1845 train_time:37135ms step_avg:42.78ms
+step:869/1845 train_time:37197ms step_avg:42.80ms
+step:870/1845 train_time:37257ms step_avg:42.82ms
+step:871/1845 train_time:37320ms step_avg:42.85ms
+step:872/1845 train_time:37381ms step_avg:42.87ms
+step:873/1845 train_time:37443ms step_avg:42.89ms
+step:874/1845 train_time:37504ms step_avg:42.91ms
+step:875/1845 train_time:37567ms step_avg:42.93ms
+step:876/1845 train_time:37628ms step_avg:42.95ms
+step:877/1845 train_time:37690ms step_avg:42.98ms
+step:878/1845 train_time:37750ms step_avg:43.00ms
+step:879/1845 train_time:37813ms step_avg:43.02ms
+step:880/1845 train_time:37874ms step_avg:43.04ms
+step:881/1845 train_time:37935ms step_avg:43.06ms
+step:882/1845 train_time:37996ms step_avg:43.08ms
+step:883/1845 train_time:38058ms step_avg:43.10ms
+step:884/1845 train_time:38118ms step_avg:43.12ms
+step:885/1845 train_time:38181ms step_avg:43.14ms
+step:886/1845 train_time:38242ms step_avg:43.16ms
+step:887/1845 train_time:38305ms step_avg:43.18ms
+step:888/1845 train_time:38365ms step_avg:43.20ms
+step:889/1845 train_time:38427ms step_avg:43.23ms
+step:890/1845 train_time:38488ms step_avg:43.25ms
+step:891/1845 train_time:38551ms step_avg:43.27ms
+step:892/1845 train_time:38612ms step_avg:43.29ms
+step:893/1845 train_time:38674ms step_avg:43.31ms
+step:894/1845 train_time:38734ms step_avg:43.33ms
+step:895/1845 train_time:38796ms step_avg:43.35ms
+step:896/1845 train_time:38857ms step_avg:43.37ms
+step:897/1845 train_time:38919ms step_avg:43.39ms
+step:898/1845 train_time:38980ms step_avg:43.41ms
+step:899/1845 train_time:39042ms step_avg:43.43ms
+step:900/1845 train_time:39103ms step_avg:43.45ms
+step:901/1845 train_time:39165ms step_avg:43.47ms
+step:902/1845 train_time:39226ms step_avg:43.49ms
+step:903/1845 train_time:39289ms step_avg:43.51ms
+step:904/1845 train_time:39350ms step_avg:43.53ms
+step:905/1845 train_time:39413ms step_avg:43.55ms
+step:906/1845 train_time:39473ms step_avg:43.57ms
+step:907/1845 train_time:39535ms step_avg:43.59ms
+step:908/1845 train_time:39596ms step_avg:43.61ms
+step:909/1845 train_time:39658ms step_avg:43.63ms
+step:910/1845 train_time:39719ms step_avg:43.65ms
+step:911/1845 train_time:39781ms step_avg:43.67ms
+step:912/1845 train_time:39842ms step_avg:43.69ms
+step:913/1845 train_time:39904ms step_avg:43.71ms
+step:914/1845 train_time:39965ms step_avg:43.73ms
+step:915/1845 train_time:40028ms step_avg:43.75ms
+step:916/1845 train_time:40089ms step_avg:43.77ms
+step:917/1845 train_time:40152ms step_avg:43.79ms
+step:918/1845 train_time:40212ms step_avg:43.80ms
+step:919/1845 train_time:40275ms step_avg:43.82ms
+step:920/1845 train_time:40335ms step_avg:43.84ms
+step:921/1845 train_time:40398ms step_avg:43.86ms
+step:922/1845 train_time:40458ms step_avg:43.88ms
+step:923/1845 train_time:40521ms step_avg:43.90ms
+step:924/1845 train_time:40582ms step_avg:43.92ms
+step:925/1845 train_time:40645ms step_avg:43.94ms
+step:926/1845 train_time:40706ms step_avg:43.96ms
+step:927/1845 train_time:40768ms step_avg:43.98ms
+step:928/1845 train_time:40829ms step_avg:44.00ms
+step:929/1845 train_time:40892ms step_avg:44.02ms
+step:930/1845 train_time:40952ms step_avg:44.03ms
+step:931/1845 train_time:41015ms step_avg:44.05ms
+step:932/1845 train_time:41075ms step_avg:44.07ms
+step:933/1845 train_time:41137ms step_avg:44.09ms
+step:934/1845 train_time:41198ms step_avg:44.11ms
+step:935/1845 train_time:41260ms step_avg:44.13ms
+step:936/1845 train_time:41321ms step_avg:44.15ms
+step:937/1845 train_time:41383ms step_avg:44.17ms
+step:938/1845 train_time:41444ms step_avg:44.18ms
+step:939/1845 train_time:41506ms step_avg:44.20ms
+step:940/1845 train_time:41566ms step_avg:44.22ms
+step:941/1845 train_time:41629ms step_avg:44.24ms
+step:942/1845 train_time:41690ms step_avg:44.26ms
+step:943/1845 train_time:41753ms step_avg:44.28ms
+step:944/1845 train_time:41813ms step_avg:44.29ms
+step:945/1845 train_time:41876ms step_avg:44.31ms
+step:946/1845 train_time:41936ms step_avg:44.33ms
+step:947/1845 train_time:41998ms step_avg:44.35ms
+step:948/1845 train_time:42059ms step_avg:44.37ms
+step:949/1845 train_time:42121ms step_avg:44.38ms
+step:950/1845 train_time:42182ms step_avg:44.40ms
+step:951/1845 train_time:42245ms step_avg:44.42ms
+step:952/1845 train_time:42306ms step_avg:44.44ms
+step:953/1845 train_time:42368ms step_avg:44.46ms
+step:954/1845 train_time:42429ms step_avg:44.47ms
+step:955/1845 train_time:42491ms step_avg:44.49ms
+step:956/1845 train_time:42552ms step_avg:44.51ms
+step:957/1845 train_time:42614ms step_avg:44.53ms
+step:958/1845 train_time:42675ms step_avg:44.55ms
+step:959/1845 train_time:42737ms step_avg:44.56ms
+step:960/1845 train_time:42798ms step_avg:44.58ms
+step:961/1845 train_time:42860ms step_avg:44.60ms
+step:962/1845 train_time:42921ms step_avg:44.62ms
+step:963/1845 train_time:42983ms step_avg:44.63ms
+step:964/1845 train_time:43044ms step_avg:44.65ms
+step:965/1845 train_time:43106ms step_avg:44.67ms
+step:966/1845 train_time:43167ms step_avg:44.69ms
+step:967/1845 train_time:43230ms step_avg:44.71ms
+step:968/1845 train_time:43291ms step_avg:44.72ms
+step:969/1845 train_time:43353ms step_avg:44.74ms
+step:970/1845 train_time:43414ms step_avg:44.76ms
+step:971/1845 train_time:43476ms step_avg:44.77ms
+step:972/1845 train_time:43536ms step_avg:44.79ms
+step:973/1845 train_time:43599ms step_avg:44.81ms
+step:974/1845 train_time:43661ms step_avg:44.83ms
+step:975/1845 train_time:43723ms step_avg:44.84ms
+step:976/1845 train_time:43784ms step_avg:44.86ms
+step:977/1845 train_time:43846ms step_avg:44.88ms
+step:978/1845 train_time:43907ms step_avg:44.90ms
+step:979/1845 train_time:43970ms step_avg:44.91ms
+step:980/1845 train_time:44031ms step_avg:44.93ms
+step:981/1845 train_time:44092ms step_avg:44.95ms
+step:982/1845 train_time:44153ms step_avg:44.96ms
+step:983/1845 train_time:44215ms step_avg:44.98ms
+step:984/1845 train_time:44276ms step_avg:45.00ms
+step:985/1845 train_time:44338ms step_avg:45.01ms
+step:986/1845 train_time:44399ms step_avg:45.03ms
+step:987/1845 train_time:44463ms step_avg:45.05ms
+step:988/1845 train_time:44522ms step_avg:45.06ms
+step:989/1845 train_time:44585ms step_avg:45.08ms
+step:990/1845 train_time:44646ms step_avg:45.10ms
+step:991/1845 train_time:44708ms step_avg:45.11ms
+step:992/1845 train_time:44768ms step_avg:45.13ms
+step:993/1845 train_time:44831ms step_avg:45.15ms
+step:994/1845 train_time:44892ms step_avg:45.16ms
+step:995/1845 train_time:44954ms step_avg:45.18ms
+step:996/1845 train_time:45015ms step_avg:45.20ms
+step:997/1845 train_time:45077ms step_avg:45.21ms
+step:998/1845 train_time:45138ms step_avg:45.23ms
+step:999/1845 train_time:45200ms step_avg:45.24ms
+step:1000/1845 train_time:45261ms step_avg:45.26ms
+step:1000/1845 val_loss:3.7869 train_time:45325ms step_avg:45.32ms
+step:1001/1845 train_time:45344ms step_avg:45.30ms
+step:1002/1845 train_time:45386ms step_avg:45.30ms
+step:1003/1845 train_time:45451ms step_avg:45.32ms
+step:1004/1845 train_time:45515ms step_avg:45.33ms
+step:1005/1845 train_time:45577ms step_avg:45.35ms
+step:1006/1845 train_time:45638ms step_avg:45.37ms
+step:1007/1845 train_time:45700ms step_avg:45.38ms
+step:1008/1845 train_time:45760ms step_avg:45.40ms
+step:1009/1845 train_time:45822ms step_avg:45.41ms
+step:1010/1845 train_time:45883ms step_avg:45.43ms
+step:1011/1845 train_time:45945ms step_avg:45.44ms
+step:1012/1845 train_time:46005ms step_avg:45.46ms
+step:1013/1845 train_time:46067ms step_avg:45.48ms
+step:1014/1845 train_time:46129ms step_avg:45.49ms
+step:1015/1845 train_time:46191ms step_avg:45.51ms
+step:1016/1845 train_time:46252ms step_avg:45.52ms
+step:1017/1845 train_time:46316ms step_avg:45.54ms
+step:1018/1845 train_time:46377ms step_avg:45.56ms
+step:1019/1845 train_time:46440ms step_avg:45.57ms
+step:1020/1845 train_time:46502ms step_avg:45.59ms
+step:1021/1845 train_time:46564ms step_avg:45.61ms
+step:1022/1845 train_time:46626ms step_avg:45.62ms
+step:1023/1845 train_time:46688ms step_avg:45.64ms
+step:1024/1845 train_time:46749ms step_avg:45.65ms
+step:1025/1845 train_time:46812ms step_avg:45.67ms
+step:1026/1845 train_time:46873ms step_avg:45.69ms
+step:1027/1845 train_time:46936ms step_avg:45.70ms
+step:1028/1845 train_time:46997ms step_avg:45.72ms
+step:1029/1845 train_time:47058ms step_avg:45.73ms
+step:1030/1845 train_time:47118ms step_avg:45.75ms
+step:1031/1845 train_time:47180ms step_avg:45.76ms
+step:1032/1845 train_time:47240ms step_avg:45.78ms
+step:1033/1845 train_time:47304ms step_avg:45.79ms
+step:1034/1845 train_time:47365ms step_avg:45.81ms
+step:1035/1845 train_time:47428ms step_avg:45.82ms
+step:1036/1845 train_time:47489ms step_avg:45.84ms
+step:1037/1845 train_time:47552ms step_avg:45.86ms
+step:1038/1845 train_time:47613ms step_avg:45.87ms
+step:1039/1845 train_time:47676ms step_avg:45.89ms
+step:1040/1845 train_time:47736ms step_avg:45.90ms
+step:1041/1845 train_time:47798ms step_avg:45.92ms
+step:1042/1845 train_time:47859ms step_avg:45.93ms
+step:1043/1845 train_time:47921ms step_avg:45.95ms
+step:1044/1845 train_time:47982ms step_avg:45.96ms
+step:1045/1845 train_time:48044ms step_avg:45.97ms
+step:1046/1845 train_time:48104ms step_avg:45.99ms
+step:1047/1845 train_time:48166ms step_avg:46.00ms
+step:1048/1845 train_time:48227ms step_avg:46.02ms
+step:1049/1845 train_time:48290ms step_avg:46.03ms
+step:1050/1845 train_time:48350ms step_avg:46.05ms
+step:1051/1845 train_time:48413ms step_avg:46.06ms
+step:1052/1845 train_time:48475ms step_avg:46.08ms
+step:1053/1845 train_time:48537ms step_avg:46.09ms
+step:1054/1845 train_time:48598ms step_avg:46.11ms
+step:1055/1845 train_time:48661ms step_avg:46.12ms
+step:1056/1845 train_time:48722ms step_avg:46.14ms
+step:1057/1845 train_time:48784ms step_avg:46.15ms
+step:1058/1845 train_time:48845ms step_avg:46.17ms
+step:1059/1845 train_time:48908ms step_avg:46.18ms
+step:1060/1845 train_time:48968ms step_avg:46.20ms
+step:1061/1845 train_time:49031ms step_avg:46.21ms
+step:1062/1845 train_time:49091ms step_avg:46.23ms
+step:1063/1845 train_time:49153ms step_avg:46.24ms
+step:1064/1845 train_time:49214ms step_avg:46.25ms
+step:1065/1845 train_time:49276ms step_avg:46.27ms
+step:1066/1845 train_time:49337ms step_avg:46.28ms
+step:1067/1845 train_time:49399ms step_avg:46.30ms
+step:1068/1845 train_time:49460ms step_avg:46.31ms
+step:1069/1845 train_time:49522ms step_avg:46.33ms
+step:1070/1845 train_time:49584ms step_avg:46.34ms
+step:1071/1845 train_time:49646ms step_avg:46.36ms
+step:1072/1845 train_time:49708ms step_avg:46.37ms
+step:1073/1845 train_time:49770ms step_avg:46.38ms
+step:1074/1845 train_time:49831ms step_avg:46.40ms
+step:1075/1845 train_time:49894ms step_avg:46.41ms
+step:1076/1845 train_time:49955ms step_avg:46.43ms
+step:1077/1845 train_time:50017ms step_avg:46.44ms
+step:1078/1845 train_time:50077ms step_avg:46.45ms
+step:1079/1845 train_time:50140ms step_avg:46.47ms
+step:1080/1845 train_time:50200ms step_avg:46.48ms
+step:1081/1845 train_time:50262ms step_avg:46.50ms
+step:1082/1845 train_time:50322ms step_avg:46.51ms
+step:1083/1845 train_time:50385ms step_avg:46.52ms
+step:1084/1845 train_time:50446ms step_avg:46.54ms
+step:1085/1845 train_time:50509ms step_avg:46.55ms
+step:1086/1845 train_time:50570ms step_avg:46.57ms
+step:1087/1845 train_time:50632ms step_avg:46.58ms
+step:1088/1845 train_time:50693ms step_avg:46.59ms
+step:1089/1845 train_time:50756ms step_avg:46.61ms
+step:1090/1845 train_time:50817ms step_avg:46.62ms
+step:1091/1845 train_time:50880ms step_avg:46.64ms
+step:1092/1845 train_time:50941ms step_avg:46.65ms
+step:1093/1845 train_time:51003ms step_avg:46.66ms
+step:1094/1845 train_time:51063ms step_avg:46.68ms
+step:1095/1845 train_time:51126ms step_avg:46.69ms
+step:1096/1845 train_time:51187ms step_avg:46.70ms
+step:1097/1845 train_time:51249ms step_avg:46.72ms
+step:1098/1845 train_time:51309ms step_avg:46.73ms
+step:1099/1845 train_time:51372ms step_avg:46.74ms
+step:1100/1845 train_time:51433ms step_avg:46.76ms
+step:1101/1845 train_time:51496ms step_avg:46.77ms
+step:1102/1845 train_time:51556ms step_avg:46.78ms
+step:1103/1845 train_time:51619ms step_avg:46.80ms
+step:1104/1845 train_time:51679ms step_avg:46.81ms
+step:1105/1845 train_time:51741ms step_avg:46.82ms
+step:1106/1845 train_time:51802ms step_avg:46.84ms
+step:1107/1845 train_time:51864ms step_avg:46.85ms
+step:1108/1845 train_time:51926ms step_avg:46.86ms
+step:1109/1845 train_time:51988ms step_avg:46.88ms
+step:1110/1845 train_time:52049ms step_avg:46.89ms
+step:1111/1845 train_time:52112ms step_avg:46.91ms
+step:1112/1845 train_time:52173ms step_avg:46.92ms
+step:1113/1845 train_time:52235ms step_avg:46.93ms
+step:1114/1845 train_time:52295ms step_avg:46.94ms
+step:1115/1845 train_time:52358ms step_avg:46.96ms
+step:1116/1845 train_time:52418ms step_avg:46.97ms
+step:1117/1845 train_time:52480ms step_avg:46.98ms
+step:1118/1845 train_time:52541ms step_avg:47.00ms
+step:1119/1845 train_time:52603ms step_avg:47.01ms
+step:1120/1845 train_time:52663ms step_avg:47.02ms
+step:1121/1845 train_time:52726ms step_avg:47.03ms
+step:1122/1845 train_time:52787ms step_avg:47.05ms
+step:1123/1845 train_time:52849ms step_avg:47.06ms
+step:1124/1845 train_time:52910ms step_avg:47.07ms
+step:1125/1845 train_time:52972ms step_avg:47.09ms
+step:1126/1845 train_time:53033ms step_avg:47.10ms
+step:1127/1845 train_time:53095ms step_avg:47.11ms
+step:1128/1845 train_time:53156ms step_avg:47.12ms
+step:1129/1845 train_time:53218ms step_avg:47.14ms
+step:1130/1845 train_time:53278ms step_avg:47.15ms
+step:1131/1845 train_time:53340ms step_avg:47.16ms
+step:1132/1845 train_time:53401ms step_avg:47.17ms
+step:1133/1845 train_time:53463ms step_avg:47.19ms
+step:1134/1845 train_time:53524ms step_avg:47.20ms
+step:1135/1845 train_time:53586ms step_avg:47.21ms
+step:1136/1845 train_time:53647ms step_avg:47.22ms
+step:1137/1845 train_time:53710ms step_avg:47.24ms
+step:1138/1845 train_time:53771ms step_avg:47.25ms
+step:1139/1845 train_time:53833ms step_avg:47.26ms
+step:1140/1845 train_time:53894ms step_avg:47.28ms
+step:1141/1845 train_time:53957ms step_avg:47.29ms
+step:1142/1845 train_time:54018ms step_avg:47.30ms
+step:1143/1845 train_time:54080ms step_avg:47.31ms
+step:1144/1845 train_time:54140ms step_avg:47.33ms
+step:1145/1845 train_time:54202ms step_avg:47.34ms
+step:1146/1845 train_time:54263ms step_avg:47.35ms
+step:1147/1845 train_time:54326ms step_avg:47.36ms
+step:1148/1845 train_time:54387ms step_avg:47.38ms
+step:1149/1845 train_time:54450ms step_avg:47.39ms
+step:1150/1845 train_time:54510ms step_avg:47.40ms
+step:1151/1845 train_time:54573ms step_avg:47.41ms
+step:1152/1845 train_time:54634ms step_avg:47.43ms
+step:1153/1845 train_time:54697ms step_avg:47.44ms
+step:1154/1845 train_time:54757ms step_avg:47.45ms
+step:1155/1845 train_time:54819ms step_avg:47.46ms
+step:1156/1845 train_time:54880ms step_avg:47.47ms
+step:1157/1845 train_time:54942ms step_avg:47.49ms
+step:1158/1845 train_time:55003ms step_avg:47.50ms
+step:1159/1845 train_time:55065ms step_avg:47.51ms
+step:1160/1845 train_time:55126ms step_avg:47.52ms
+step:1161/1845 train_time:55188ms step_avg:47.54ms
+step:1162/1845 train_time:55249ms step_avg:47.55ms
+step:1163/1845 train_time:55312ms step_avg:47.56ms
+step:1164/1845 train_time:55374ms step_avg:47.57ms
+step:1165/1845 train_time:55436ms step_avg:47.58ms
+step:1166/1845 train_time:55497ms step_avg:47.60ms
+step:1167/1845 train_time:55559ms step_avg:47.61ms
+step:1168/1845 train_time:55620ms step_avg:47.62ms
+step:1169/1845 train_time:55682ms step_avg:47.63ms
+step:1170/1845 train_time:55742ms step_avg:47.64ms
+step:1171/1845 train_time:55805ms step_avg:47.66ms
+step:1172/1845 train_time:55866ms step_avg:47.67ms
+step:1173/1845 train_time:55928ms step_avg:47.68ms
+step:1174/1845 train_time:55989ms step_avg:47.69ms
+step:1175/1845 train_time:56052ms step_avg:47.70ms
+step:1176/1845 train_time:56113ms step_avg:47.71ms
+step:1177/1845 train_time:56176ms step_avg:47.73ms
+step:1178/1845 train_time:56236ms step_avg:47.74ms
+step:1179/1845 train_time:56298ms step_avg:47.75ms
+step:1180/1845 train_time:56359ms step_avg:47.76ms
+step:1181/1845 train_time:56421ms step_avg:47.77ms
+step:1182/1845 train_time:56482ms step_avg:47.78ms
+step:1183/1845 train_time:56544ms step_avg:47.80ms
+step:1184/1845 train_time:56605ms step_avg:47.81ms
+step:1185/1845 train_time:56668ms step_avg:47.82ms
+step:1186/1845 train_time:56728ms step_avg:47.83ms
+step:1187/1845 train_time:56791ms step_avg:47.84ms
+step:1188/1845 train_time:56852ms step_avg:47.86ms
+step:1189/1845 train_time:56915ms step_avg:47.87ms
+step:1190/1845 train_time:56975ms step_avg:47.88ms
+step:1191/1845 train_time:57038ms step_avg:47.89ms
+step:1192/1845 train_time:57098ms step_avg:47.90ms
+step:1193/1845 train_time:57160ms step_avg:47.91ms
+step:1194/1845 train_time:57220ms step_avg:47.92ms
+step:1195/1845 train_time:57283ms step_avg:47.94ms
+step:1196/1845 train_time:57344ms step_avg:47.95ms
+step:1197/1845 train_time:57407ms step_avg:47.96ms
+step:1198/1845 train_time:57467ms step_avg:47.97ms
+step:1199/1845 train_time:57530ms step_avg:47.98ms
+step:1200/1845 train_time:57591ms step_avg:47.99ms
+step:1201/1845 train_time:57654ms step_avg:48.00ms
+step:1202/1845 train_time:57714ms step_avg:48.02ms
+step:1203/1845 train_time:57777ms step_avg:48.03ms
+step:1204/1845 train_time:57838ms step_avg:48.04ms
+step:1205/1845 train_time:57900ms step_avg:48.05ms
+step:1206/1845 train_time:57987ms step_avg:48.08ms
+step:1207/1845 train_time:58076ms step_avg:48.12ms
+step:1208/1845 train_time:58163ms step_avg:48.15ms
+step:1209/1845 train_time:58253ms step_avg:48.18ms
+step:1210/1845 train_time:58340ms step_avg:48.22ms
+step:1211/1845 train_time:58429ms step_avg:48.25ms
+step:1212/1845 train_time:58516ms step_avg:48.28ms
+step:1213/1845 train_time:58605ms step_avg:48.31ms
+step:1214/1845 train_time:58692ms step_avg:48.35ms
+step:1215/1845 train_time:58782ms step_avg:48.38ms
+step:1216/1845 train_time:58868ms step_avg:48.41ms
+step:1217/1845 train_time:58957ms step_avg:48.44ms
+step:1218/1845 train_time:59044ms step_avg:48.48ms
+step:1219/1845 train_time:59132ms step_avg:48.51ms
+step:1220/1845 train_time:59219ms step_avg:48.54ms
+step:1221/1845 train_time:59308ms step_avg:48.57ms
+step:1222/1845 train_time:59395ms step_avg:48.60ms
+step:1223/1845 train_time:59484ms step_avg:48.64ms
+step:1224/1845 train_time:59571ms step_avg:48.67ms
+step:1225/1845 train_time:59660ms step_avg:48.70ms
+step:1226/1845 train_time:59747ms step_avg:48.73ms
+step:1227/1845 train_time:59835ms step_avg:48.77ms
+step:1228/1845 train_time:59922ms step_avg:48.80ms
+step:1229/1845 train_time:60010ms step_avg:48.83ms
+step:1230/1845 train_time:60098ms step_avg:48.86ms
+step:1231/1845 train_time:60187ms step_avg:48.89ms
+step:1232/1845 train_time:60274ms step_avg:48.92ms
+step:1233/1845 train_time:60362ms step_avg:48.96ms
+step:1234/1845 train_time:60450ms step_avg:48.99ms
+step:1235/1845 train_time:60538ms step_avg:49.02ms
+step:1236/1845 train_time:60625ms step_avg:49.05ms
+step:1237/1845 train_time:60714ms step_avg:49.08ms
+step:1238/1845 train_time:60802ms step_avg:49.11ms
+step:1239/1845 train_time:60890ms step_avg:49.14ms
+step:1240/1845 train_time:60978ms step_avg:49.18ms
+step:1241/1845 train_time:61068ms step_avg:49.21ms
+step:1242/1845 train_time:61155ms step_avg:49.24ms
+step:1243/1845 train_time:61244ms step_avg:49.27ms
+step:1244/1845 train_time:61331ms step_avg:49.30ms
+step:1245/1845 train_time:61420ms step_avg:49.33ms
+step:1246/1845 train_time:61509ms step_avg:49.36ms
+step:1247/1845 train_time:61598ms step_avg:49.40ms
+step:1248/1845 train_time:61685ms step_avg:49.43ms
+step:1249/1845 train_time:61773ms step_avg:49.46ms
+step:1250/1845 train_time:61861ms step_avg:49.49ms
+step:1250/1845 val_loss:3.5345 train_time:61950ms step_avg:49.56ms
+step:1251/1845 train_time:61971ms step_avg:49.54ms
+step:1252/1845 train_time:62039ms step_avg:49.55ms
+step:1253/1845 train_time:62135ms step_avg:49.59ms
+step:1254/1845 train_time:62224ms step_avg:49.62ms
+step:1255/1845 train_time:62312ms step_avg:49.65ms
+step:1256/1845 train_time:62399ms step_avg:49.68ms
+step:1257/1845 train_time:62487ms step_avg:49.71ms
+step:1258/1845 train_time:62572ms step_avg:49.74ms
+step:1259/1845 train_time:62660ms step_avg:49.77ms
+step:1260/1845 train_time:62746ms step_avg:49.80ms
+step:1261/1845 train_time:62834ms step_avg:49.83ms
+step:1262/1845 train_time:62922ms step_avg:49.86ms
+step:1263/1845 train_time:63013ms step_avg:49.89ms
+step:1264/1845 train_time:63103ms step_avg:49.92ms
+step:1265/1845 train_time:63193ms step_avg:49.95ms
+step:1266/1845 train_time:63281ms step_avg:49.98ms
+step:1267/1845 train_time:63369ms step_avg:50.02ms
+step:1268/1845 train_time:63455ms step_avg:50.04ms
+step:1269/1845 train_time:63543ms step_avg:50.07ms
+step:1270/1845 train_time:63629ms step_avg:50.10ms
+step:1271/1845 train_time:63717ms step_avg:50.13ms
+step:1272/1845 train_time:63805ms step_avg:50.16ms
+step:1273/1845 train_time:63893ms step_avg:50.19ms
+step:1274/1845 train_time:63981ms step_avg:50.22ms
+step:1275/1845 train_time:64071ms step_avg:50.25ms
+step:1276/1845 train_time:64160ms step_avg:50.28ms
+step:1277/1845 train_time:64250ms step_avg:50.31ms
+step:1278/1845 train_time:64337ms step_avg:50.34ms
+step:1279/1845 train_time:64426ms step_avg:50.37ms
+step:1280/1845 train_time:64512ms step_avg:50.40ms
+step:1281/1845 train_time:64600ms step_avg:50.43ms
+step:1282/1845 train_time:64687ms step_avg:50.46ms
+step:1283/1845 train_time:64776ms step_avg:50.49ms
+step:1284/1845 train_time:64863ms step_avg:50.52ms
+step:1285/1845 train_time:64952ms step_avg:50.55ms
+step:1286/1845 train_time:65041ms step_avg:50.58ms
+step:1287/1845 train_time:65130ms step_avg:50.61ms
+step:1288/1845 train_time:65219ms step_avg:50.64ms
+step:1289/1845 train_time:65308ms step_avg:50.67ms
+step:1290/1845 train_time:65395ms step_avg:50.69ms
+step:1291/1845 train_time:65484ms step_avg:50.72ms
+step:1292/1845 train_time:65570ms step_avg:50.75ms
+step:1293/1845 train_time:65658ms step_avg:50.78ms
+step:1294/1845 train_time:65745ms step_avg:50.81ms
+step:1295/1845 train_time:65833ms step_avg:50.84ms
+step:1296/1845 train_time:65921ms step_avg:50.86ms
+step:1297/1845 train_time:66010ms step_avg:50.89ms
+step:1298/1845 train_time:66099ms step_avg:50.92ms
+step:1299/1845 train_time:66187ms step_avg:50.95ms
+step:1300/1845 train_time:66274ms step_avg:50.98ms
+step:1301/1845 train_time:66362ms step_avg:51.01ms
+step:1302/1845 train_time:66450ms step_avg:51.04ms
+step:1303/1845 train_time:66539ms step_avg:51.07ms
+step:1304/1845 train_time:66627ms step_avg:51.09ms
+step:1305/1845 train_time:66714ms step_avg:51.12ms
+step:1306/1845 train_time:66802ms step_avg:51.15ms
+step:1307/1845 train_time:66892ms step_avg:51.18ms
+step:1308/1845 train_time:66981ms step_avg:51.21ms
+step:1309/1845 train_time:67071ms step_avg:51.24ms
+step:1310/1845 train_time:67159ms step_avg:51.27ms
+step:1311/1845 train_time:67249ms step_avg:51.30ms
+step:1312/1845 train_time:67336ms step_avg:51.32ms
+step:1313/1845 train_time:67425ms step_avg:51.35ms
+step:1314/1845 train_time:67512ms step_avg:51.38ms
+step:1315/1845 train_time:67599ms step_avg:51.41ms
+step:1316/1845 train_time:67686ms step_avg:51.43ms
+step:1317/1845 train_time:67774ms step_avg:51.46ms
+step:1318/1845 train_time:67862ms step_avg:51.49ms
+step:1319/1845 train_time:67951ms step_avg:51.52ms
+step:1320/1845 train_time:68039ms step_avg:51.54ms
+step:1321/1845 train_time:68127ms step_avg:51.57ms
+step:1322/1845 train_time:68215ms step_avg:51.60ms
+step:1323/1845 train_time:68303ms step_avg:51.63ms
+step:1324/1845 train_time:68391ms step_avg:51.65ms
+step:1325/1845 train_time:68479ms step_avg:51.68ms
+step:1326/1845 train_time:68566ms step_avg:51.71ms
+step:1327/1845 train_time:68654ms step_avg:51.74ms
+step:1328/1845 train_time:68742ms step_avg:51.76ms
+step:1329/1845 train_time:68831ms step_avg:51.79ms
+step:1330/1845 train_time:68919ms step_avg:51.82ms
+step:1331/1845 train_time:69008ms step_avg:51.85ms
+step:1332/1845 train_time:69095ms step_avg:51.87ms
+step:1333/1845 train_time:69185ms step_avg:51.90ms
+step:1334/1845 train_time:69273ms step_avg:51.93ms
+step:1335/1845 train_time:69361ms step_avg:51.96ms
+step:1336/1845 train_time:69448ms step_avg:51.98ms
+step:1337/1845 train_time:69537ms step_avg:52.01ms
+step:1338/1845 train_time:69625ms step_avg:52.04ms
+step:1339/1845 train_time:69713ms step_avg:52.06ms
+step:1340/1845 train_time:69800ms step_avg:52.09ms
+step:1341/1845 train_time:69890ms step_avg:52.12ms
+step:1342/1845 train_time:69977ms step_avg:52.14ms
+step:1343/1845 train_time:70066ms step_avg:52.17ms
+step:1344/1845 train_time:70153ms step_avg:52.20ms
+step:1345/1845 train_time:70242ms step_avg:52.22ms
+step:1346/1845 train_time:70330ms step_avg:52.25ms
+step:1347/1845 train_time:70418ms step_avg:52.28ms
+step:1348/1845 train_time:70505ms step_avg:52.30ms
+step:1349/1845 train_time:70592ms step_avg:52.33ms
+step:1350/1845 train_time:70679ms step_avg:52.35ms
+step:1351/1845 train_time:70768ms step_avg:52.38ms
+step:1352/1845 train_time:70855ms step_avg:52.41ms
+step:1353/1845 train_time:70944ms step_avg:52.43ms
+step:1354/1845 train_time:71031ms step_avg:52.46ms
+step:1355/1845 train_time:71120ms step_avg:52.49ms
+step:1356/1845 train_time:71207ms step_avg:52.51ms
+step:1357/1845 train_time:71295ms step_avg:52.54ms
+step:1358/1845 train_time:71383ms step_avg:52.56ms
+step:1359/1845 train_time:71471ms step_avg:52.59ms
+step:1360/1845 train_time:71559ms step_avg:52.62ms
+step:1361/1845 train_time:71648ms step_avg:52.64ms
+step:1362/1845 train_time:71735ms step_avg:52.67ms
+step:1363/1845 train_time:71823ms step_avg:52.69ms
+step:1364/1845 train_time:71911ms step_avg:52.72ms
+step:1365/1845 train_time:71999ms step_avg:52.75ms
+step:1366/1845 train_time:72087ms step_avg:52.77ms
+step:1367/1845 train_time:72177ms step_avg:52.80ms
+step:1368/1845 train_time:72264ms step_avg:52.82ms
+step:1369/1845 train_time:72352ms step_avg:52.85ms
+step:1370/1845 train_time:72440ms step_avg:52.88ms
+step:1371/1845 train_time:72529ms step_avg:52.90ms
+step:1372/1845 train_time:72616ms step_avg:52.93ms
+step:1373/1845 train_time:72705ms step_avg:52.95ms
+step:1374/1845 train_time:72791ms step_avg:52.98ms
+step:1375/1845 train_time:72879ms step_avg:53.00ms
+step:1376/1845 train_time:72966ms step_avg:53.03ms
+step:1377/1845 train_time:73054ms step_avg:53.05ms
+step:1378/1845 train_time:73142ms step_avg:53.08ms
+step:1379/1845 train_time:73232ms step_avg:53.10ms
+step:1380/1845 train_time:73319ms step_avg:53.13ms
+step:1381/1845 train_time:73407ms step_avg:53.15ms
+step:1382/1845 train_time:73494ms step_avg:53.18ms
+step:1383/1845 train_time:73583ms step_avg:53.21ms
+step:1384/1845 train_time:73669ms step_avg:53.23ms
+step:1385/1845 train_time:73757ms step_avg:53.25ms
+step:1386/1845 train_time:73845ms step_avg:53.28ms
+step:1387/1845 train_time:73933ms step_avg:53.30ms
+step:1388/1845 train_time:74020ms step_avg:53.33ms
+step:1389/1845 train_time:74108ms step_avg:53.35ms
+step:1390/1845 train_time:74196ms step_avg:53.38ms
+step:1391/1845 train_time:74284ms step_avg:53.40ms
+step:1392/1845 train_time:74371ms step_avg:53.43ms
+step:1393/1845 train_time:74459ms step_avg:53.45ms
+step:1394/1845 train_time:74546ms step_avg:53.48ms
+step:1395/1845 train_time:74635ms step_avg:53.50ms
+step:1396/1845 train_time:74722ms step_avg:53.53ms
+step:1397/1845 train_time:74811ms step_avg:53.55ms
+step:1398/1845 train_time:74899ms step_avg:53.58ms
+step:1399/1845 train_time:74987ms step_avg:53.60ms
+step:1400/1845 train_time:75074ms step_avg:53.62ms
+step:1401/1845 train_time:75163ms step_avg:53.65ms
+step:1402/1845 train_time:75250ms step_avg:53.67ms
+step:1403/1845 train_time:75339ms step_avg:53.70ms
+step:1404/1845 train_time:75427ms step_avg:53.72ms
+step:1405/1845 train_time:75516ms step_avg:53.75ms
+step:1406/1845 train_time:75603ms step_avg:53.77ms
+step:1407/1845 train_time:75692ms step_avg:53.80ms
+step:1408/1845 train_time:75779ms step_avg:53.82ms
+step:1409/1845 train_time:75868ms step_avg:53.85ms
+step:1410/1845 train_time:75954ms step_avg:53.87ms
+step:1411/1845 train_time:76043ms step_avg:53.89ms
+step:1412/1845 train_time:76130ms step_avg:53.92ms
+step:1413/1845 train_time:76218ms step_avg:53.94ms
+step:1414/1845 train_time:76306ms step_avg:53.96ms
+step:1415/1845 train_time:76394ms step_avg:53.99ms
+step:1416/1845 train_time:76482ms step_avg:54.01ms
+step:1417/1845 train_time:76571ms step_avg:54.04ms
+step:1418/1845 train_time:76658ms step_avg:54.06ms
+step:1419/1845 train_time:76747ms step_avg:54.09ms
+step:1420/1845 train_time:76834ms step_avg:54.11ms
+step:1421/1845 train_time:76923ms step_avg:54.13ms
+step:1422/1845 train_time:77010ms step_avg:54.16ms
+step:1423/1845 train_time:77098ms step_avg:54.18ms
+step:1424/1845 train_time:77185ms step_avg:54.20ms
+step:1425/1845 train_time:77273ms step_avg:54.23ms
+step:1426/1845 train_time:77360ms step_avg:54.25ms
+step:1427/1845 train_time:77449ms step_avg:54.27ms
+step:1428/1845 train_time:77536ms step_avg:54.30ms
+step:1429/1845 train_time:77625ms step_avg:54.32ms
+step:1430/1845 train_time:77712ms step_avg:54.34ms
+step:1431/1845 train_time:77800ms step_avg:54.37ms
+step:1432/1845 train_time:77888ms step_avg:54.39ms
+step:1433/1845 train_time:77976ms step_avg:54.41ms
+step:1434/1845 train_time:78064ms step_avg:54.44ms
+step:1435/1845 train_time:78153ms step_avg:54.46ms
+step:1436/1845 train_time:78241ms step_avg:54.49ms
+step:1437/1845 train_time:78328ms step_avg:54.51ms
+step:1438/1845 train_time:78416ms step_avg:54.53ms
+step:1439/1845 train_time:78504ms step_avg:54.55ms
+step:1440/1845 train_time:78591ms step_avg:54.58ms
+step:1441/1845 train_time:78680ms step_avg:54.60ms
+step:1442/1845 train_time:78767ms step_avg:54.62ms
+step:1443/1845 train_time:78855ms step_avg:54.65ms
+step:1444/1845 train_time:78942ms step_avg:54.67ms
+step:1445/1845 train_time:79031ms step_avg:54.69ms
+step:1446/1845 train_time:79119ms step_avg:54.72ms
+step:1447/1845 train_time:79208ms step_avg:54.74ms
+step:1448/1845 train_time:79295ms step_avg:54.76ms
+step:1449/1845 train_time:79383ms step_avg:54.78ms
+step:1450/1845 train_time:79470ms step_avg:54.81ms
+step:1451/1845 train_time:79558ms step_avg:54.83ms
+step:1452/1845 train_time:79646ms step_avg:54.85ms
+step:1453/1845 train_time:79734ms step_avg:54.88ms
+step:1454/1845 train_time:79821ms step_avg:54.90ms
+step:1455/1845 train_time:79910ms step_avg:54.92ms
+step:1456/1845 train_time:79997ms step_avg:54.94ms
+step:1457/1845 train_time:80085ms step_avg:54.97ms
+step:1458/1845 train_time:80173ms step_avg:54.99ms
+step:1459/1845 train_time:80261ms step_avg:55.01ms
+step:1460/1845 train_time:80349ms step_avg:55.03ms
+step:1461/1845 train_time:80438ms step_avg:55.06ms
+step:1462/1845 train_time:80525ms step_avg:55.08ms
+step:1463/1845 train_time:80614ms step_avg:55.10ms
+step:1464/1845 train_time:80701ms step_avg:55.12ms
+step:1465/1845 train_time:80790ms step_avg:55.15ms
+step:1466/1845 train_time:80877ms step_avg:55.17ms
+step:1467/1845 train_time:80966ms step_avg:55.19ms
+step:1468/1845 train_time:81054ms step_avg:55.21ms
+step:1469/1845 train_time:81143ms step_avg:55.24ms
+step:1470/1845 train_time:81230ms step_avg:55.26ms
+step:1471/1845 train_time:81318ms step_avg:55.28ms
+step:1472/1845 train_time:81406ms step_avg:55.30ms
+step:1473/1845 train_time:81494ms step_avg:55.33ms
+step:1474/1845 train_time:81582ms step_avg:55.35ms
+step:1475/1845 train_time:81671ms step_avg:55.37ms
+step:1476/1845 train_time:81758ms step_avg:55.39ms
+step:1477/1845 train_time:81847ms step_avg:55.41ms
+step:1478/1845 train_time:81934ms step_avg:55.44ms
+step:1479/1845 train_time:82022ms step_avg:55.46ms
+step:1480/1845 train_time:82110ms step_avg:55.48ms
+step:1481/1845 train_time:82198ms step_avg:55.50ms
+step:1482/1845 train_time:82286ms step_avg:55.52ms
+step:1483/1845 train_time:82375ms step_avg:55.55ms
+step:1484/1845 train_time:82463ms step_avg:55.57ms
+step:1485/1845 train_time:82552ms step_avg:55.59ms
+step:1486/1845 train_time:82639ms step_avg:55.61ms
+step:1487/1845 train_time:82729ms step_avg:55.63ms
+step:1488/1845 train_time:82817ms step_avg:55.66ms
+step:1489/1845 train_time:82906ms step_avg:55.68ms
+step:1490/1845 train_time:82993ms step_avg:55.70ms
+step:1491/1845 train_time:83081ms step_avg:55.72ms
+step:1492/1845 train_time:83168ms step_avg:55.74ms
+step:1493/1845 train_time:83256ms step_avg:55.76ms
+step:1494/1845 train_time:83344ms step_avg:55.79ms
+step:1495/1845 train_time:83432ms step_avg:55.81ms
+step:1496/1845 train_time:83519ms step_avg:55.83ms
+step:1497/1845 train_time:83609ms step_avg:55.85ms
+step:1498/1845 train_time:83696ms step_avg:55.87ms
+step:1499/1845 train_time:83784ms step_avg:55.89ms
+step:1500/1845 train_time:83872ms step_avg:55.91ms
+step:1500/1845 val_loss:3.4032 train_time:83961ms step_avg:55.97ms
+step:1501/1845 train_time:83980ms step_avg:55.95ms
+step:1502/1845 train_time:84051ms step_avg:55.96ms
+step:1503/1845 train_time:84142ms step_avg:55.98ms
+step:1504/1845 train_time:84230ms step_avg:56.00ms
+step:1505/1845 train_time:84318ms step_avg:56.03ms
+step:1506/1845 train_time:84404ms step_avg:56.05ms
+step:1507/1845 train_time:84492ms step_avg:56.07ms
+step:1508/1845 train_time:84580ms step_avg:56.09ms
+step:1509/1845 train_time:84668ms step_avg:56.11ms
+step:1510/1845 train_time:84756ms step_avg:56.13ms
+step:1511/1845 train_time:84844ms step_avg:56.15ms
+step:1512/1845 train_time:84932ms step_avg:56.17ms
+step:1513/1845 train_time:85023ms step_avg:56.20ms
+step:1514/1845 train_time:85113ms step_avg:56.22ms
+step:1515/1845 train_time:85203ms step_avg:56.24ms
+step:1516/1845 train_time:85289ms step_avg:56.26ms
+step:1517/1845 train_time:85377ms step_avg:56.28ms
+step:1518/1845 train_time:85465ms step_avg:56.30ms
+step:1519/1845 train_time:85552ms step_avg:56.32ms
+step:1520/1845 train_time:85639ms step_avg:56.34ms
+step:1521/1845 train_time:85726ms step_avg:56.36ms
+step:1522/1845 train_time:85812ms step_avg:56.38ms
+step:1523/1845 train_time:85902ms step_avg:56.40ms
+step:1524/1845 train_time:85990ms step_avg:56.42ms
+step:1525/1845 train_time:86080ms step_avg:56.45ms
+step:1526/1845 train_time:86169ms step_avg:56.47ms
+step:1527/1845 train_time:86258ms step_avg:56.49ms
+step:1528/1845 train_time:86344ms step_avg:56.51ms
+step:1529/1845 train_time:86432ms step_avg:56.53ms
+step:1530/1845 train_time:86519ms step_avg:56.55ms
+step:1531/1845 train_time:86607ms step_avg:56.57ms
+step:1532/1845 train_time:86693ms step_avg:56.59ms
+step:1533/1845 train_time:86782ms step_avg:56.61ms
+step:1534/1845 train_time:86870ms step_avg:56.63ms
+step:1535/1845 train_time:86959ms step_avg:56.65ms
+step:1536/1845 train_time:87047ms step_avg:56.67ms
+step:1537/1845 train_time:87136ms step_avg:56.69ms
+step:1538/1845 train_time:87224ms step_avg:56.71ms
+step:1539/1845 train_time:87313ms step_avg:56.73ms
+step:1540/1845 train_time:87401ms step_avg:56.75ms
+step:1541/1845 train_time:87489ms step_avg:56.77ms
+step:1542/1845 train_time:87576ms step_avg:56.79ms
+step:1543/1845 train_time:87664ms step_avg:56.81ms
+step:1544/1845 train_time:87750ms step_avg:56.83ms
+step:1545/1845 train_time:87838ms step_avg:56.85ms
+step:1546/1845 train_time:87926ms step_avg:56.87ms
+step:1547/1845 train_time:88014ms step_avg:56.89ms
+step:1548/1845 train_time:88103ms step_avg:56.91ms
+step:1549/1845 train_time:88191ms step_avg:56.93ms
+step:1550/1845 train_time:88279ms step_avg:56.95ms
+step:1551/1845 train_time:88368ms step_avg:56.97ms
+step:1552/1845 train_time:88455ms step_avg:56.99ms
+step:1553/1845 train_time:88544ms step_avg:57.01ms
+step:1554/1845 train_time:88631ms step_avg:57.03ms
+step:1555/1845 train_time:88719ms step_avg:57.05ms
+step:1556/1845 train_time:88806ms step_avg:57.07ms
+step:1557/1845 train_time:88895ms step_avg:57.09ms
+step:1558/1845 train_time:88984ms step_avg:57.11ms
+step:1559/1845 train_time:89074ms step_avg:57.14ms
+step:1560/1845 train_time:89161ms step_avg:57.15ms
+step:1561/1845 train_time:89249ms step_avg:57.17ms
+step:1562/1845 train_time:89337ms step_avg:57.19ms
+step:1563/1845 train_time:89426ms step_avg:57.21ms
+step:1564/1845 train_time:89514ms step_avg:57.23ms
+step:1565/1845 train_time:89602ms step_avg:57.25ms
+step:1566/1845 train_time:89689ms step_avg:57.27ms
+step:1567/1845 train_time:89778ms step_avg:57.29ms
+step:1568/1845 train_time:89865ms step_avg:57.31ms
+step:1569/1845 train_time:89954ms step_avg:57.33ms
+step:1570/1845 train_time:90041ms step_avg:57.35ms
+step:1571/1845 train_time:90130ms step_avg:57.37ms
+step:1572/1845 train_time:90218ms step_avg:57.39ms
+step:1573/1845 train_time:90306ms step_avg:57.41ms
+step:1574/1845 train_time:90394ms step_avg:57.43ms
+step:1575/1845 train_time:90484ms step_avg:57.45ms
+step:1576/1845 train_time:90570ms step_avg:57.47ms
+step:1577/1845 train_time:90660ms step_avg:57.49ms
+step:1578/1845 train_time:90747ms step_avg:57.51ms
+step:1579/1845 train_time:90836ms step_avg:57.53ms
+step:1580/1845 train_time:90922ms step_avg:57.55ms
+step:1581/1845 train_time:91012ms step_avg:57.57ms
+step:1582/1845 train_time:91100ms step_avg:57.59ms
+step:1583/1845 train_time:91187ms step_avg:57.60ms
+step:1584/1845 train_time:91274ms step_avg:57.62ms
+step:1585/1845 train_time:91363ms step_avg:57.64ms
+step:1586/1845 train_time:91450ms step_avg:57.66ms
+step:1587/1845 train_time:91538ms step_avg:57.68ms
+step:1588/1845 train_time:91625ms step_avg:57.70ms
+step:1589/1845 train_time:91714ms step_avg:57.72ms
+step:1590/1845 train_time:91801ms step_avg:57.74ms
+step:1591/1845 train_time:91890ms step_avg:57.76ms
+step:1592/1845 train_time:91978ms step_avg:57.77ms
+step:1593/1845 train_time:92067ms step_avg:57.79ms
+step:1594/1845 train_time:92154ms step_avg:57.81ms
+step:1595/1845 train_time:92243ms step_avg:57.83ms
+step:1596/1845 train_time:92330ms step_avg:57.85ms
+step:1597/1845 train_time:92418ms step_avg:57.87ms
+step:1598/1845 train_time:92505ms step_avg:57.89ms
+step:1599/1845 train_time:92593ms step_avg:57.91ms
+step:1600/1845 train_time:92680ms step_avg:57.93ms
+step:1601/1845 train_time:92768ms step_avg:57.94ms
+step:1602/1845 train_time:92856ms step_avg:57.96ms
+step:1603/1845 train_time:92944ms step_avg:57.98ms
+step:1604/1845 train_time:93032ms step_avg:58.00ms
+step:1605/1845 train_time:93122ms step_avg:58.02ms
+step:1606/1845 train_time:93208ms step_avg:58.04ms
+step:1607/1845 train_time:93297ms step_avg:58.06ms
+step:1608/1845 train_time:93384ms step_avg:58.07ms
+step:1609/1845 train_time:93473ms step_avg:58.09ms
+step:1610/1845 train_time:93561ms step_avg:58.11ms
+step:1611/1845 train_time:93650ms step_avg:58.13ms
+step:1612/1845 train_time:93738ms step_avg:58.15ms
+step:1613/1845 train_time:93825ms step_avg:58.17ms
+step:1614/1845 train_time:93912ms step_avg:58.19ms
+step:1615/1845 train_time:94001ms step_avg:58.20ms
+step:1616/1845 train_time:94088ms step_avg:58.22ms
+step:1617/1845 train_time:94176ms step_avg:58.24ms
+step:1618/1845 train_time:94264ms step_avg:58.26ms
+step:1619/1845 train_time:94353ms step_avg:58.28ms
+step:1620/1845 train_time:94440ms step_avg:58.30ms
+step:1621/1845 train_time:94528ms step_avg:58.31ms
+step:1622/1845 train_time:94616ms step_avg:58.33ms
+step:1623/1845 train_time:94704ms step_avg:58.35ms
+step:1624/1845 train_time:94792ms step_avg:58.37ms
+step:1625/1845 train_time:94881ms step_avg:58.39ms
+step:1626/1845 train_time:94968ms step_avg:58.41ms
+step:1627/1845 train_time:95057ms step_avg:58.42ms
+step:1628/1845 train_time:95144ms step_avg:58.44ms
+step:1629/1845 train_time:95233ms step_avg:58.46ms
+step:1630/1845 train_time:95321ms step_avg:58.48ms
+step:1631/1845 train_time:95409ms step_avg:58.50ms
+step:1632/1845 train_time:95496ms step_avg:58.51ms
+step:1633/1845 train_time:95585ms step_avg:58.53ms
+step:1634/1845 train_time:95674ms step_avg:58.55ms
+step:1635/1845 train_time:95763ms step_avg:58.57ms
+step:1636/1845 train_time:95850ms step_avg:58.59ms
+step:1637/1845 train_time:95938ms step_avg:58.61ms
+step:1638/1845 train_time:96025ms step_avg:58.62ms
+step:1639/1845 train_time:96114ms step_avg:58.64ms
+step:1640/1845 train_time:96201ms step_avg:58.66ms
+step:1641/1845 train_time:96290ms step_avg:58.68ms
+step:1642/1845 train_time:96377ms step_avg:58.69ms
+step:1643/1845 train_time:96466ms step_avg:58.71ms
+step:1644/1845 train_time:96554ms step_avg:58.73ms
+step:1645/1845 train_time:96642ms step_avg:58.75ms
+step:1646/1845 train_time:96729ms step_avg:58.77ms
+step:1647/1845 train_time:96819ms step_avg:58.79ms
+step:1648/1845 train_time:96907ms step_avg:58.80ms
+step:1649/1845 train_time:96996ms step_avg:58.82ms
+step:1650/1845 train_time:97083ms step_avg:58.84ms
+step:1651/1845 train_time:97173ms step_avg:58.86ms
+step:1652/1845 train_time:97260ms step_avg:58.87ms
+step:1653/1845 train_time:97349ms step_avg:58.89ms
+step:1654/1845 train_time:97437ms step_avg:58.91ms
+step:1655/1845 train_time:97526ms step_avg:58.93ms
+step:1656/1845 train_time:97613ms step_avg:58.95ms
+step:1657/1845 train_time:97702ms step_avg:58.96ms
+step:1658/1845 train_time:97789ms step_avg:58.98ms
+step:1659/1845 train_time:97879ms step_avg:59.00ms
+step:1660/1845 train_time:97965ms step_avg:59.02ms
+step:1661/1845 train_time:98054ms step_avg:59.03ms
+step:1662/1845 train_time:98141ms step_avg:59.05ms
+step:1663/1845 train_time:98230ms step_avg:59.07ms
+step:1664/1845 train_time:98317ms step_avg:59.08ms
+step:1665/1845 train_time:98405ms step_avg:59.10ms
+step:1666/1845 train_time:98492ms step_avg:59.12ms
+step:1667/1845 train_time:98581ms step_avg:59.14ms
+step:1668/1845 train_time:98668ms step_avg:59.15ms
+step:1669/1845 train_time:98757ms step_avg:59.17ms
+step:1670/1845 train_time:98844ms step_avg:59.19ms
+step:1671/1845 train_time:98933ms step_avg:59.21ms
+step:1672/1845 train_time:99020ms step_avg:59.22ms
+step:1673/1845 train_time:99109ms step_avg:59.24ms
+step:1674/1845 train_time:99196ms step_avg:59.26ms
+step:1675/1845 train_time:99284ms step_avg:59.27ms
+step:1676/1845 train_time:99371ms step_avg:59.29ms
+step:1677/1845 train_time:99461ms step_avg:59.31ms
+step:1678/1845 train_time:99548ms step_avg:59.33ms
+step:1679/1845 train_time:99638ms step_avg:59.34ms
+step:1680/1845 train_time:99726ms step_avg:59.36ms
+step:1681/1845 train_time:99813ms step_avg:59.38ms
+step:1682/1845 train_time:99901ms step_avg:59.39ms
+step:1683/1845 train_time:99989ms step_avg:59.41ms
+step:1684/1845 train_time:100077ms step_avg:59.43ms
+step:1685/1845 train_time:100165ms step_avg:59.44ms
+step:1686/1845 train_time:100252ms step_avg:59.46ms
+step:1687/1845 train_time:100341ms step_avg:59.48ms
+step:1688/1845 train_time:100428ms step_avg:59.50ms
+step:1689/1845 train_time:100518ms step_avg:59.51ms
+step:1690/1845 train_time:100605ms step_avg:59.53ms
+step:1691/1845 train_time:100693ms step_avg:59.55ms
+step:1692/1845 train_time:100781ms step_avg:59.56ms
+step:1693/1845 train_time:100869ms step_avg:59.58ms
+step:1694/1845 train_time:100956ms step_avg:59.60ms
+step:1695/1845 train_time:101045ms step_avg:59.61ms
+step:1696/1845 train_time:101133ms step_avg:59.63ms
+step:1697/1845 train_time:101220ms step_avg:59.65ms
+step:1698/1845 train_time:101307ms step_avg:59.66ms
+step:1699/1845 train_time:101396ms step_avg:59.68ms
+step:1700/1845 train_time:101483ms step_avg:59.70ms
+step:1701/1845 train_time:101572ms step_avg:59.71ms
+step:1702/1845 train_time:101660ms step_avg:59.73ms
+step:1703/1845 train_time:101747ms step_avg:59.75ms
+step:1704/1845 train_time:101835ms step_avg:59.76ms
+step:1705/1845 train_time:101923ms step_avg:59.78ms
+step:1706/1845 train_time:102011ms step_avg:59.80ms
+step:1707/1845 train_time:102101ms step_avg:59.81ms
+step:1708/1845 train_time:102187ms step_avg:59.83ms
+step:1709/1845 train_time:102276ms step_avg:59.85ms
+step:1710/1845 train_time:102363ms step_avg:59.86ms
+step:1711/1845 train_time:102451ms step_avg:59.88ms
+step:1712/1845 train_time:102539ms step_avg:59.89ms
+step:1713/1845 train_time:102628ms step_avg:59.91ms
+step:1714/1845 train_time:102715ms step_avg:59.93ms
+step:1715/1845 train_time:102804ms step_avg:59.94ms
+step:1716/1845 train_time:102892ms step_avg:59.96ms
+step:1717/1845 train_time:102981ms step_avg:59.98ms
+step:1718/1845 train_time:103069ms step_avg:59.99ms
+step:1719/1845 train_time:103157ms step_avg:60.01ms
+step:1720/1845 train_time:103244ms step_avg:60.03ms
+step:1721/1845 train_time:103332ms step_avg:60.04ms
+step:1722/1845 train_time:103420ms step_avg:60.06ms
+step:1723/1845 train_time:103509ms step_avg:60.07ms
+step:1724/1845 train_time:103596ms step_avg:60.09ms
+step:1725/1845 train_time:103685ms step_avg:60.11ms
+step:1726/1845 train_time:103773ms step_avg:60.12ms
+step:1727/1845 train_time:103861ms step_avg:60.14ms
+step:1728/1845 train_time:103948ms step_avg:60.16ms
+step:1729/1845 train_time:104037ms step_avg:60.17ms
+step:1730/1845 train_time:104124ms step_avg:60.19ms
+step:1731/1845 train_time:104212ms step_avg:60.20ms
+step:1732/1845 train_time:104299ms step_avg:60.22ms
+step:1733/1845 train_time:104387ms step_avg:60.23ms
+step:1734/1845 train_time:104475ms step_avg:60.25ms
+step:1735/1845 train_time:104564ms step_avg:60.27ms
+step:1736/1845 train_time:104651ms step_avg:60.28ms
+step:1737/1845 train_time:104740ms step_avg:60.30ms
+step:1738/1845 train_time:104828ms step_avg:60.32ms
+step:1739/1845 train_time:104915ms step_avg:60.33ms
+step:1740/1845 train_time:105004ms step_avg:60.35ms
+step:1741/1845 train_time:105092ms step_avg:60.36ms
+step:1742/1845 train_time:105180ms step_avg:60.38ms
+step:1743/1845 train_time:105267ms step_avg:60.39ms
+step:1744/1845 train_time:105355ms step_avg:60.41ms
+step:1745/1845 train_time:105444ms step_avg:60.43ms
+step:1746/1845 train_time:105531ms step_avg:60.44ms
+step:1747/1845 train_time:105619ms step_avg:60.46ms
+step:1748/1845 train_time:105706ms step_avg:60.47ms
+step:1749/1845 train_time:105794ms step_avg:60.49ms
+step:1750/1845 train_time:105882ms step_avg:60.50ms
+step:1750/1845 val_loss:3.3040 train_time:105972ms step_avg:60.56ms
+step:1751/1845 train_time:105991ms step_avg:60.53ms
+step:1752/1845 train_time:106063ms step_avg:60.54ms
+step:1753/1845 train_time:106155ms step_avg:60.56ms
+step:1754/1845 train_time:106244ms step_avg:60.57ms
+step:1755/1845 train_time:106332ms step_avg:60.59ms
+step:1756/1845 train_time:106420ms step_avg:60.60ms
+step:1757/1845 train_time:106507ms step_avg:60.62ms
+step:1758/1845 train_time:106594ms step_avg:60.63ms
+step:1759/1845 train_time:106681ms step_avg:60.65ms
+step:1760/1845 train_time:106767ms step_avg:60.66ms
+step:1761/1845 train_time:106855ms step_avg:60.68ms
+step:1762/1845 train_time:106942ms step_avg:60.69ms
+step:1763/1845 train_time:107034ms step_avg:60.71ms
+step:1764/1845 train_time:107125ms step_avg:60.73ms
+step:1765/1845 train_time:107215ms step_avg:60.75ms
+step:1766/1845 train_time:107304ms step_avg:60.76ms
+step:1767/1845 train_time:107392ms step_avg:60.78ms
+step:1768/1845 train_time:107478ms step_avg:60.79ms
+step:1769/1845 train_time:107566ms step_avg:60.81ms
+step:1770/1845 train_time:107652ms step_avg:60.82ms
+step:1771/1845 train_time:107740ms step_avg:60.84ms
+step:1772/1845 train_time:107826ms step_avg:60.85ms
+step:1773/1845 train_time:107915ms step_avg:60.87ms
+step:1774/1845 train_time:108004ms step_avg:60.88ms
+step:1775/1845 train_time:108093ms step_avg:60.90ms
+step:1776/1845 train_time:108181ms step_avg:60.91ms
+step:1777/1845 train_time:108271ms step_avg:60.93ms
+step:1778/1845 train_time:108359ms step_avg:60.94ms
+step:1779/1845 train_time:108446ms step_avg:60.96ms
+step:1780/1845 train_time:108534ms step_avg:60.97ms
+step:1781/1845 train_time:108623ms step_avg:60.99ms
+step:1782/1845 train_time:108710ms step_avg:61.00ms
+step:1783/1845 train_time:108798ms step_avg:61.02ms
+step:1784/1845 train_time:108885ms step_avg:61.03ms
+step:1785/1845 train_time:108975ms step_avg:61.05ms
+step:1786/1845 train_time:109063ms step_avg:61.07ms
+step:1787/1845 train_time:109153ms step_avg:61.08ms
+step:1788/1845 train_time:109241ms step_avg:61.10ms
+step:1789/1845 train_time:109330ms step_avg:61.11ms
+step:1790/1845 train_time:109417ms step_avg:61.13ms
+step:1791/1845 train_time:109505ms step_avg:61.14ms
+step:1792/1845 train_time:109593ms step_avg:61.16ms
+step:1793/1845 train_time:109682ms step_avg:61.17ms
+step:1794/1845 train_time:109770ms step_avg:61.19ms
+step:1795/1845 train_time:109859ms step_avg:61.20ms
+step:1796/1845 train_time:109947ms step_avg:61.22ms
+step:1797/1845 train_time:110036ms step_avg:61.23ms
+step:1798/1845 train_time:110124ms step_avg:61.25ms
+step:1799/1845 train_time:110213ms step_avg:61.26ms
+step:1800/1845 train_time:110301ms step_avg:61.28ms
+step:1801/1845 train_time:110389ms step_avg:61.29ms
+step:1802/1845 train_time:110477ms step_avg:61.31ms
+step:1803/1845 train_time:110564ms step_avg:61.32ms
+step:1804/1845 train_time:110652ms step_avg:61.34ms
+step:1805/1845 train_time:110740ms step_avg:61.35ms
+step:1806/1845 train_time:110827ms step_avg:61.37ms
+step:1807/1845 train_time:110916ms step_avg:61.38ms
+step:1808/1845 train_time:111004ms step_avg:61.40ms
+step:1809/1845 train_time:111095ms step_avg:61.41ms
+step:1810/1845 train_time:111183ms step_avg:61.43ms
+step:1811/1845 train_time:111272ms step_avg:61.44ms
+step:1812/1845 train_time:111359ms step_avg:61.46ms
+step:1813/1845 train_time:111449ms step_avg:61.47ms
+step:1814/1845 train_time:111535ms step_avg:61.49ms
+step:1815/1845 train_time:111624ms step_avg:61.50ms
+step:1816/1845 train_time:111712ms step_avg:61.52ms
+step:1817/1845 train_time:111802ms step_avg:61.53ms
+step:1818/1845 train_time:111890ms step_avg:61.55ms
+step:1819/1845 train_time:111980ms step_avg:61.56ms
+step:1820/1845 train_time:112068ms step_avg:61.58ms
+step:1821/1845 train_time:112159ms step_avg:61.59ms
+step:1822/1845 train_time:112246ms step_avg:61.61ms
+step:1823/1845 train_time:112335ms step_avg:61.62ms
+step:1824/1845 train_time:112423ms step_avg:61.64ms
+step:1825/1845 train_time:112512ms step_avg:61.65ms
+step:1826/1845 train_time:112599ms step_avg:61.66ms
+step:1827/1845 train_time:112687ms step_avg:61.68ms
+step:1828/1845 train_time:112775ms step_avg:61.69ms
+step:1829/1845 train_time:112863ms step_avg:61.71ms
+step:1830/1845 train_time:112951ms step_avg:61.72ms
+step:1831/1845 train_time:113041ms step_avg:61.74ms
+step:1832/1845 train_time:113129ms step_avg:61.75ms
+step:1833/1845 train_time:113219ms step_avg:61.77ms
+step:1834/1845 train_time:113307ms step_avg:61.78ms
+step:1835/1845 train_time:113397ms step_avg:61.80ms
+step:1836/1845 train_time:113484ms step_avg:61.81ms
+step:1837/1845 train_time:113574ms step_avg:61.83ms
+step:1838/1845 train_time:113661ms step_avg:61.84ms
+step:1839/1845 train_time:113749ms step_avg:61.85ms
+step:1840/1845 train_time:113836ms step_avg:61.87ms
+step:1841/1845 train_time:113925ms step_avg:61.88ms
+step:1842/1845 train_time:114014ms step_avg:61.90ms
+step:1843/1845 train_time:114104ms step_avg:61.91ms
+step:1844/1845 train_time:114193ms step_avg:61.93ms
+step:1845/1845 train_time:114283ms step_avg:61.94ms
+step:1845/1845 val_loss:3.2774 train_time:114373ms step_avg:61.99ms
+peak memory allocated: 29405 MiB reserved: 44678 MiB

--- a/records/track_1_short/2025-12-29_VeSkipGates/6df58830-05f6-4dd5-9136-2b3828f70859.txt
+++ b/records/track_1_short/2025-12-29_VeSkipGates/6df58830-05f6-4dd5-9136-2b3828f70859.txt
@@ -1,0 +1,3693 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, v, wd_tensor, lr_tensor):
+    """Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors."""
+    mask = (v * p) >= 0
+    wd_factor = wd_tensor.to(p.dtype)
+    lr_factor = lr_tensor.to(p.dtype)
+    p.copy_(p - (p * mask * wd_factor * lr_factor) - (v * lr_factor))
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn_gate (10 params 6 padding params)
+        2. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        3. reduce scatter attn/mlp round 2 (16 mlp params)
+        4. wait on step 1, then compute update of 1 and schedule all gather
+        5. wait on step 2, then compute update of 2 and schedule all gather
+        6. wait on step 3, then compute update of 3 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        7. wait on 4, then compute update of 4 and schedule all gather
+        8. wait for each all gather to complete and update params
+    Empirically, leading with small params provides an additional 0.2s improvement.
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        group_sizes = [15, 16, 16]
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+
+        all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"]
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params])
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            # The below shape-based heuristic assumes that matrices have their input along the
+            # row dimension and their output along the columns. Gates are an exception.
+            is_gate = 'gate' in ref_param.label
+
+            if "second_momentum_buffer" not in group:
+                if is_gate:
+                    group["second_momentum_buffer"] = torch.zeros_like(updated_grads[..., :, :1])
+                else:
+                    group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1])
+                        if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                    )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if (is_gate or param_shape[-2] >= param_shape[-1]) else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx],
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete and copy results back into original parameter tensors.
+        for info in all_gather_infos:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str],lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for label in label_order:
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.bfloat16, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-1]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+
+                exp_avg = state["exp_avg"]
+                exp_avg_sq = state["exp_avg_sq"]
+                state["step"] += 1
+                t = state["step"]
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (bias2 ** 0.5 / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                # cautious weight decay
+                mask = (update * p_slice) > 0
+                # lr as weight decay schedule
+                eff_weight_decay = lr * wd * getattr(param, "wd_mul", 1.0)
+                update.addcmul_(p_slice, mask, value=eff_weight_decay * lr)
+
+                p_slice.add_(other=update, alpha=-1.0)
+
+                if not is_small:
+                    all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+
+        self._reduce_scatter_futures.clear()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        self.attn_gate = CastedLinear(12, num_heads)
+        self.attn_gate.weight.label = 'attn_gate'
+
+        # only include gates on layers with value embeds used on forward pass
+        if layer_idx in [0,1,8,9,10]:
+            self.value_embed_gate = CastedLinear(12, num_heads)
+            self.value_embed_gate.weight.label = 'value_embed_gate'
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(self.value_embed_gate(x[..., :self.value_embed_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(self.attn_gate(x[..., :self.attn_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        #self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.5/448, grad_s=0.75/448)
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig, skew = None):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset = key_offset[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if skew is None:
+            logits = 23 * torch.sigmoid((logits+5) / 7.5)
+        else:
+            logits = 23 * torch.sigmoid((logits+skew) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        adam_labels = ['lm_head', 'value_embed', 'smear_gate', 'skip_gate', 'x0_lambdas', 'embed']
+        scalar_labels = ['scalars']
+        muon_labels = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        scalar_params = [p for p in model.parameters() if getattr(p, 'label', None) in scalar_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + scalar_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, lr=0.008, betas=(0.65, 0.95), eps=1e-8, weight_decay=0.005)
+        self.scalar_opt = DistAdam(scalar_params, scalar_labels, lr=0.008, betas=(0.9, 0.99), eps=1e-8, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.scalar_opt, self.muon_opt]
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.freeze_timer = 0
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+        self.scalar_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            if opt.freeze_timer > 0:
+                opt.freeze_timer -= 1
+                opt.zero_grad(set_to_none=True)
+            else:
+                if self._is_active_step(opt, step):
+                    for group in opt.param_groups:
+                        group["lr"] = group["initial_lr"] * step_lr
+                    opt.step()
+                    opt.zero_grad(set_to_none=True)
+                    if opt.odd_step_only:
+                        opt.should_sync = False
+        
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+
+    def start_transition(self, freeze_count=40):
+        # freeze scalar weights during transition
+        self.scalar_opt.freeze_timer = freeze_count
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1805  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Dec 29 06:03:30 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.90.07              Driver Version: 550.90.07      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   30C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   26C    P0            110W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            107W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   39C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   27C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   29C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   29C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 601, 602, 603, 1203, 1204, 1205, 1804, 1805, 1806] for warmup
+Resetting Model
+step:0/1845 val_loss:10.8300 train_time:0ms step_avg:0.04ms
+step:1/1845 train_time:89ms step_avg:89.27ms
+step:2/1845 train_time:112ms step_avg:56.20ms
+step:3/1845 train_time:135ms step_avg:45.11ms
+step:4/1845 train_time:169ms step_avg:42.34ms
+step:5/1845 train_time:204ms step_avg:40.72ms
+step:6/1845 train_time:286ms step_avg:47.65ms
+step:7/1845 train_time:431ms step_avg:61.55ms
+step:8/1845 train_time:465ms step_avg:58.10ms
+step:9/1845 train_time:499ms step_avg:55.45ms
+step:10/1845 train_time:533ms step_avg:53.29ms
+step:11/1845 train_time:568ms step_avg:51.60ms
+step:12/1845 train_time:601ms step_avg:50.12ms
+step:13/1845 train_time:636ms step_avg:48.93ms
+step:14/1845 train_time:670ms step_avg:47.89ms
+step:15/1845 train_time:705ms step_avg:46.98ms
+step:16/1845 train_time:739ms step_avg:46.17ms
+step:17/1845 train_time:773ms step_avg:45.49ms
+step:18/1845 train_time:808ms step_avg:44.86ms
+step:19/1845 train_time:842ms step_avg:44.34ms
+step:20/1845 train_time:876ms step_avg:43.82ms
+step:21/1845 train_time:911ms step_avg:43.39ms
+step:22/1845 train_time:945ms step_avg:42.96ms
+step:23/1845 train_time:980ms step_avg:42.61ms
+step:24/1845 train_time:1014ms step_avg:42.26ms
+step:25/1845 train_time:1049ms step_avg:41.95ms
+step:26/1845 train_time:1083ms step_avg:41.65ms
+step:27/1845 train_time:1117ms step_avg:41.39ms
+step:28/1845 train_time:1152ms step_avg:41.13ms
+step:29/1845 train_time:1186ms step_avg:40.90ms
+step:30/1845 train_time:1220ms step_avg:40.67ms
+step:31/1845 train_time:1255ms step_avg:40.48ms
+step:32/1845 train_time:1289ms step_avg:40.28ms
+step:33/1845 train_time:1324ms step_avg:40.11ms
+step:34/1845 train_time:1358ms step_avg:39.93ms
+step:35/1845 train_time:1393ms step_avg:39.79ms
+step:36/1845 train_time:1427ms step_avg:39.64ms
+step:37/1845 train_time:1462ms step_avg:39.51ms
+step:38/1845 train_time:1496ms step_avg:39.37ms
+step:39/1845 train_time:1531ms step_avg:39.25ms
+step:40/1845 train_time:1565ms step_avg:39.13ms
+step:41/1845 train_time:1601ms step_avg:39.04ms
+step:42/1845 train_time:1635ms step_avg:38.92ms
+step:43/1845 train_time:1670ms step_avg:38.84ms
+step:44/1845 train_time:1704ms step_avg:38.73ms
+step:45/1845 train_time:1739ms step_avg:38.64ms
+step:46/1845 train_time:1773ms step_avg:38.55ms
+step:47/1845 train_time:1808ms step_avg:38.47ms
+step:48/1845 train_time:1842ms step_avg:38.38ms
+step:49/1845 train_time:1877ms step_avg:38.30ms
+step:50/1845 train_time:1911ms step_avg:38.22ms
+step:51/1845 train_time:1946ms step_avg:38.15ms
+step:52/1845 train_time:1980ms step_avg:38.07ms
+step:53/1845 train_time:2015ms step_avg:38.01ms
+step:54/1845 train_time:2049ms step_avg:37.94ms
+step:55/1845 train_time:2083ms step_avg:37.87ms
+step:56/1845 train_time:2117ms step_avg:37.81ms
+step:57/1845 train_time:2152ms step_avg:37.75ms
+step:58/1845 train_time:2186ms step_avg:37.69ms
+step:59/1845 train_time:2220ms step_avg:37.63ms
+step:60/1845 train_time:2254ms step_avg:37.57ms
+step:61/1845 train_time:2289ms step_avg:37.52ms
+step:62/1845 train_time:2323ms step_avg:37.47ms
+step:63/1845 train_time:2358ms step_avg:37.43ms
+step:64/1845 train_time:2392ms step_avg:37.38ms
+step:65/1845 train_time:2427ms step_avg:37.34ms
+step:66/1845 train_time:2461ms step_avg:37.29ms
+step:67/1845 train_time:2496ms step_avg:37.25ms
+step:68/1845 train_time:2530ms step_avg:37.20ms
+step:69/1845 train_time:2564ms step_avg:37.16ms
+step:70/1845 train_time:2598ms step_avg:37.12ms
+step:71/1845 train_time:2633ms step_avg:37.08ms
+step:72/1845 train_time:2667ms step_avg:37.04ms
+step:73/1845 train_time:2702ms step_avg:37.01ms
+step:74/1845 train_time:2736ms step_avg:36.97ms
+step:75/1845 train_time:2771ms step_avg:36.94ms
+step:76/1845 train_time:2805ms step_avg:36.90ms
+step:77/1845 train_time:2839ms step_avg:36.88ms
+step:78/1845 train_time:2873ms step_avg:36.84ms
+step:79/1845 train_time:2908ms step_avg:36.81ms
+step:80/1845 train_time:2942ms step_avg:36.78ms
+step:81/1845 train_time:2977ms step_avg:36.75ms
+step:82/1845 train_time:3011ms step_avg:36.72ms
+step:83/1845 train_time:3046ms step_avg:36.69ms
+step:84/1845 train_time:3080ms step_avg:36.66ms
+step:85/1845 train_time:3114ms step_avg:36.64ms
+step:86/1845 train_time:3149ms step_avg:36.61ms
+step:87/1845 train_time:3184ms step_avg:36.59ms
+step:88/1845 train_time:3218ms step_avg:36.56ms
+step:89/1845 train_time:3252ms step_avg:36.54ms
+step:90/1845 train_time:3286ms step_avg:36.51ms
+step:91/1845 train_time:3321ms step_avg:36.50ms
+step:92/1845 train_time:3355ms step_avg:36.47ms
+step:93/1845 train_time:3390ms step_avg:36.45ms
+step:94/1845 train_time:3424ms step_avg:36.43ms
+step:95/1845 train_time:3459ms step_avg:36.41ms
+step:96/1845 train_time:3493ms step_avg:36.39ms
+step:97/1845 train_time:3528ms step_avg:36.37ms
+step:98/1845 train_time:3562ms step_avg:36.35ms
+step:99/1845 train_time:3597ms step_avg:36.33ms
+step:100/1845 train_time:3631ms step_avg:36.31ms
+step:101/1845 train_time:3666ms step_avg:36.29ms
+step:102/1845 train_time:3700ms step_avg:36.27ms
+step:103/1845 train_time:3734ms step_avg:36.25ms
+step:104/1845 train_time:3769ms step_avg:36.24ms
+step:105/1845 train_time:3803ms step_avg:36.22ms
+step:106/1845 train_time:3838ms step_avg:36.20ms
+step:107/1845 train_time:3872ms step_avg:36.19ms
+step:108/1845 train_time:3906ms step_avg:36.17ms
+step:109/1845 train_time:3941ms step_avg:36.16ms
+step:110/1845 train_time:3975ms step_avg:36.14ms
+step:111/1845 train_time:4010ms step_avg:36.12ms
+step:112/1845 train_time:4044ms step_avg:36.11ms
+step:113/1845 train_time:4079ms step_avg:36.10ms
+step:114/1845 train_time:4113ms step_avg:36.08ms
+step:115/1845 train_time:4148ms step_avg:36.07ms
+step:116/1845 train_time:4182ms step_avg:36.05ms
+step:117/1845 train_time:4217ms step_avg:36.04ms
+step:118/1845 train_time:4251ms step_avg:36.02ms
+step:119/1845 train_time:4286ms step_avg:36.01ms
+step:120/1845 train_time:4320ms step_avg:36.00ms
+step:121/1845 train_time:4354ms step_avg:35.99ms
+step:122/1845 train_time:4389ms step_avg:35.97ms
+step:123/1845 train_time:4423ms step_avg:35.96ms
+step:124/1845 train_time:4457ms step_avg:35.95ms
+step:125/1845 train_time:4492ms step_avg:35.94ms
+step:126/1845 train_time:4527ms step_avg:35.92ms
+step:127/1845 train_time:4562ms step_avg:35.92ms
+step:128/1845 train_time:4596ms step_avg:35.91ms
+step:129/1845 train_time:4631ms step_avg:35.90ms
+step:130/1845 train_time:4665ms step_avg:35.88ms
+step:131/1845 train_time:4700ms step_avg:35.88ms
+step:132/1845 train_time:4734ms step_avg:35.86ms
+step:133/1845 train_time:4769ms step_avg:35.85ms
+step:134/1845 train_time:4803ms step_avg:35.84ms
+step:135/1845 train_time:4838ms step_avg:35.83ms
+step:136/1845 train_time:4872ms step_avg:35.82ms
+step:137/1845 train_time:4906ms step_avg:35.81ms
+step:138/1845 train_time:4940ms step_avg:35.80ms
+step:139/1845 train_time:4975ms step_avg:35.79ms
+step:140/1845 train_time:5009ms step_avg:35.78ms
+step:141/1845 train_time:5044ms step_avg:35.77ms
+step:142/1845 train_time:5078ms step_avg:35.76ms
+step:143/1845 train_time:5112ms step_avg:35.75ms
+step:144/1845 train_time:5146ms step_avg:35.74ms
+step:145/1845 train_time:5181ms step_avg:35.73ms
+step:146/1845 train_time:5215ms step_avg:35.72ms
+step:147/1845 train_time:5250ms step_avg:35.71ms
+step:148/1845 train_time:5284ms step_avg:35.70ms
+step:149/1845 train_time:5318ms step_avg:35.69ms
+step:150/1845 train_time:5352ms step_avg:35.68ms
+step:151/1845 train_time:5387ms step_avg:35.68ms
+step:152/1845 train_time:5421ms step_avg:35.66ms
+step:153/1845 train_time:5456ms step_avg:35.66ms
+step:154/1845 train_time:5490ms step_avg:35.65ms
+step:155/1845 train_time:5524ms step_avg:35.64ms
+step:156/1845 train_time:5558ms step_avg:35.63ms
+step:157/1845 train_time:5593ms step_avg:35.62ms
+step:158/1845 train_time:5627ms step_avg:35.61ms
+step:159/1845 train_time:5662ms step_avg:35.61ms
+step:160/1845 train_time:5696ms step_avg:35.60ms
+step:161/1845 train_time:5730ms step_avg:35.59ms
+step:162/1845 train_time:5764ms step_avg:35.58ms
+step:163/1845 train_time:5799ms step_avg:35.58ms
+step:164/1845 train_time:5833ms step_avg:35.57ms
+step:165/1845 train_time:5868ms step_avg:35.56ms
+step:166/1845 train_time:5902ms step_avg:35.55ms
+step:167/1845 train_time:5937ms step_avg:35.55ms
+step:168/1845 train_time:5971ms step_avg:35.54ms
+step:169/1845 train_time:6006ms step_avg:35.54ms
+step:170/1845 train_time:6040ms step_avg:35.53ms
+step:171/1845 train_time:6075ms step_avg:35.52ms
+step:172/1845 train_time:6109ms step_avg:35.52ms
+step:173/1845 train_time:6144ms step_avg:35.51ms
+step:174/1845 train_time:6177ms step_avg:35.50ms
+step:175/1845 train_time:6212ms step_avg:35.50ms
+step:176/1845 train_time:6246ms step_avg:35.49ms
+step:177/1845 train_time:6281ms step_avg:35.49ms
+step:178/1845 train_time:6315ms step_avg:35.48ms
+step:179/1845 train_time:6350ms step_avg:35.47ms
+step:180/1845 train_time:6384ms step_avg:35.47ms
+step:181/1845 train_time:6419ms step_avg:35.46ms
+step:182/1845 train_time:6453ms step_avg:35.46ms
+step:183/1845 train_time:6488ms step_avg:35.45ms
+step:184/1845 train_time:6522ms step_avg:35.44ms
+step:185/1845 train_time:6556ms step_avg:35.44ms
+step:186/1845 train_time:6590ms step_avg:35.43ms
+step:187/1845 train_time:6625ms step_avg:35.43ms
+step:188/1845 train_time:6659ms step_avg:35.42ms
+step:189/1845 train_time:6694ms step_avg:35.42ms
+step:190/1845 train_time:6728ms step_avg:35.41ms
+step:191/1845 train_time:6763ms step_avg:35.41ms
+step:192/1845 train_time:6797ms step_avg:35.40ms
+step:193/1845 train_time:6831ms step_avg:35.39ms
+step:194/1845 train_time:6865ms step_avg:35.39ms
+step:195/1845 train_time:6900ms step_avg:35.38ms
+step:196/1845 train_time:6934ms step_avg:35.38ms
+step:197/1845 train_time:6969ms step_avg:35.37ms
+step:198/1845 train_time:7003ms step_avg:35.37ms
+step:199/1845 train_time:7037ms step_avg:35.36ms
+step:200/1845 train_time:7071ms step_avg:35.36ms
+step:201/1845 train_time:7106ms step_avg:35.35ms
+step:202/1845 train_time:7140ms step_avg:35.35ms
+step:203/1845 train_time:7175ms step_avg:35.34ms
+step:204/1845 train_time:7210ms step_avg:35.34ms
+step:205/1845 train_time:7243ms step_avg:35.33ms
+step:206/1845 train_time:7277ms step_avg:35.33ms
+step:207/1845 train_time:7312ms step_avg:35.32ms
+step:208/1845 train_time:7346ms step_avg:35.32ms
+step:209/1845 train_time:7381ms step_avg:35.32ms
+step:210/1845 train_time:7415ms step_avg:35.31ms
+step:211/1845 train_time:7450ms step_avg:35.31ms
+step:212/1845 train_time:7484ms step_avg:35.30ms
+step:213/1845 train_time:7518ms step_avg:35.30ms
+step:214/1845 train_time:7552ms step_avg:35.29ms
+step:215/1845 train_time:7587ms step_avg:35.29ms
+step:216/1845 train_time:7621ms step_avg:35.28ms
+step:217/1845 train_time:7656ms step_avg:35.28ms
+step:218/1845 train_time:7690ms step_avg:35.27ms
+step:219/1845 train_time:7724ms step_avg:35.27ms
+step:220/1845 train_time:7758ms step_avg:35.27ms
+step:221/1845 train_time:7793ms step_avg:35.26ms
+step:222/1845 train_time:7827ms step_avg:35.26ms
+step:223/1845 train_time:7861ms step_avg:35.25ms
+step:224/1845 train_time:7895ms step_avg:35.25ms
+step:225/1845 train_time:7930ms step_avg:35.24ms
+step:226/1845 train_time:7964ms step_avg:35.24ms
+step:227/1845 train_time:7998ms step_avg:35.23ms
+step:228/1845 train_time:8032ms step_avg:35.23ms
+step:229/1845 train_time:8067ms step_avg:35.23ms
+step:230/1845 train_time:8101ms step_avg:35.22ms
+step:231/1845 train_time:8136ms step_avg:35.22ms
+step:232/1845 train_time:8169ms step_avg:35.21ms
+step:233/1845 train_time:8204ms step_avg:35.21ms
+step:234/1845 train_time:8238ms step_avg:35.21ms
+step:235/1845 train_time:8273ms step_avg:35.20ms
+step:236/1845 train_time:8307ms step_avg:35.20ms
+step:237/1845 train_time:8341ms step_avg:35.20ms
+step:238/1845 train_time:8376ms step_avg:35.19ms
+step:239/1845 train_time:8410ms step_avg:35.19ms
+step:240/1845 train_time:8444ms step_avg:35.18ms
+step:241/1845 train_time:8479ms step_avg:35.18ms
+step:242/1845 train_time:8513ms step_avg:35.18ms
+step:243/1845 train_time:8547ms step_avg:35.17ms
+step:244/1845 train_time:8581ms step_avg:35.17ms
+step:245/1845 train_time:8616ms step_avg:35.17ms
+step:246/1845 train_time:8650ms step_avg:35.16ms
+step:247/1845 train_time:8685ms step_avg:35.16ms
+step:248/1845 train_time:8718ms step_avg:35.16ms
+step:249/1845 train_time:8753ms step_avg:35.15ms
+step:250/1845 train_time:8787ms step_avg:35.15ms
+step:250/1845 val_loss:4.6095 train_time:8823ms step_avg:35.29ms
+step:251/1845 train_time:8844ms step_avg:35.24ms
+step:252/1845 train_time:8864ms step_avg:35.17ms
+step:253/1845 train_time:8893ms step_avg:35.15ms
+step:254/1845 train_time:8927ms step_avg:35.15ms
+step:255/1845 train_time:8963ms step_avg:35.15ms
+step:256/1845 train_time:8998ms step_avg:35.15ms
+step:257/1845 train_time:9032ms step_avg:35.15ms
+step:258/1845 train_time:9067ms step_avg:35.14ms
+step:259/1845 train_time:9101ms step_avg:35.14ms
+step:260/1845 train_time:9135ms step_avg:35.13ms
+step:261/1845 train_time:9170ms step_avg:35.13ms
+step:262/1845 train_time:9204ms step_avg:35.13ms
+step:263/1845 train_time:9238ms step_avg:35.13ms
+step:264/1845 train_time:9272ms step_avg:35.12ms
+step:265/1845 train_time:9306ms step_avg:35.12ms
+step:266/1845 train_time:9340ms step_avg:35.11ms
+step:267/1845 train_time:9374ms step_avg:35.11ms
+step:268/1845 train_time:9408ms step_avg:35.11ms
+step:269/1845 train_time:9442ms step_avg:35.10ms
+step:270/1845 train_time:9476ms step_avg:35.10ms
+step:271/1845 train_time:9511ms step_avg:35.10ms
+step:272/1845 train_time:9545ms step_avg:35.09ms
+step:273/1845 train_time:9579ms step_avg:35.09ms
+step:274/1845 train_time:9613ms step_avg:35.08ms
+step:275/1845 train_time:9647ms step_avg:35.08ms
+step:276/1845 train_time:9681ms step_avg:35.08ms
+step:277/1845 train_time:9716ms step_avg:35.07ms
+step:278/1845 train_time:9750ms step_avg:35.07ms
+step:279/1845 train_time:9784ms step_avg:35.07ms
+step:280/1845 train_time:9818ms step_avg:35.06ms
+step:281/1845 train_time:9853ms step_avg:35.06ms
+step:282/1845 train_time:9887ms step_avg:35.06ms
+step:283/1845 train_time:9922ms step_avg:35.06ms
+step:284/1845 train_time:9956ms step_avg:35.06ms
+step:285/1845 train_time:9991ms step_avg:35.06ms
+step:286/1845 train_time:10025ms step_avg:35.05ms
+step:287/1845 train_time:10060ms step_avg:35.05ms
+step:288/1845 train_time:10094ms step_avg:35.05ms
+step:289/1845 train_time:10129ms step_avg:35.05ms
+step:290/1845 train_time:10163ms step_avg:35.04ms
+step:291/1845 train_time:10197ms step_avg:35.04ms
+step:292/1845 train_time:10231ms step_avg:35.04ms
+step:293/1845 train_time:10266ms step_avg:35.04ms
+step:294/1845 train_time:10300ms step_avg:35.03ms
+step:295/1845 train_time:10334ms step_avg:35.03ms
+step:296/1845 train_time:10368ms step_avg:35.03ms
+step:297/1845 train_time:10402ms step_avg:35.03ms
+step:298/1845 train_time:10436ms step_avg:35.02ms
+step:299/1845 train_time:10471ms step_avg:35.02ms
+step:300/1845 train_time:10505ms step_avg:35.02ms
+step:301/1845 train_time:10539ms step_avg:35.01ms
+step:302/1845 train_time:10573ms step_avg:35.01ms
+step:303/1845 train_time:10608ms step_avg:35.01ms
+step:304/1845 train_time:10642ms step_avg:35.01ms
+step:305/1845 train_time:10676ms step_avg:35.00ms
+step:306/1845 train_time:10710ms step_avg:35.00ms
+step:307/1845 train_time:10744ms step_avg:35.00ms
+step:308/1845 train_time:10778ms step_avg:34.99ms
+step:309/1845 train_time:10813ms step_avg:34.99ms
+step:310/1845 train_time:10847ms step_avg:34.99ms
+step:311/1845 train_time:10881ms step_avg:34.99ms
+step:312/1845 train_time:10915ms step_avg:34.98ms
+step:313/1845 train_time:10950ms step_avg:34.98ms
+step:314/1845 train_time:10984ms step_avg:34.98ms
+step:315/1845 train_time:11018ms step_avg:34.98ms
+step:316/1845 train_time:11052ms step_avg:34.97ms
+step:317/1845 train_time:11087ms step_avg:34.97ms
+step:318/1845 train_time:11121ms step_avg:34.97ms
+step:319/1845 train_time:11155ms step_avg:34.97ms
+step:320/1845 train_time:11189ms step_avg:34.97ms
+step:321/1845 train_time:11224ms step_avg:34.97ms
+step:322/1845 train_time:11258ms step_avg:34.96ms
+step:323/1845 train_time:11292ms step_avg:34.96ms
+step:324/1845 train_time:11326ms step_avg:34.96ms
+step:325/1845 train_time:11361ms step_avg:34.96ms
+step:326/1845 train_time:11395ms step_avg:34.95ms
+step:327/1845 train_time:11430ms step_avg:34.95ms
+step:328/1845 train_time:11464ms step_avg:34.95ms
+step:329/1845 train_time:11498ms step_avg:34.95ms
+step:330/1845 train_time:11532ms step_avg:34.94ms
+step:331/1845 train_time:11566ms step_avg:34.94ms
+step:332/1845 train_time:11600ms step_avg:34.94ms
+step:333/1845 train_time:11635ms step_avg:34.94ms
+step:334/1845 train_time:11669ms step_avg:34.94ms
+step:335/1845 train_time:11703ms step_avg:34.94ms
+step:336/1845 train_time:11737ms step_avg:34.93ms
+step:337/1845 train_time:11772ms step_avg:34.93ms
+step:338/1845 train_time:11805ms step_avg:34.93ms
+step:339/1845 train_time:11840ms step_avg:34.93ms
+step:340/1845 train_time:11874ms step_avg:34.92ms
+step:341/1845 train_time:11908ms step_avg:34.92ms
+step:342/1845 train_time:11942ms step_avg:34.92ms
+step:343/1845 train_time:11976ms step_avg:34.92ms
+step:344/1845 train_time:12010ms step_avg:34.91ms
+step:345/1845 train_time:12045ms step_avg:34.91ms
+step:346/1845 train_time:12079ms step_avg:34.91ms
+step:347/1845 train_time:12114ms step_avg:34.91ms
+step:348/1845 train_time:12148ms step_avg:34.91ms
+step:349/1845 train_time:12182ms step_avg:34.91ms
+step:350/1845 train_time:12216ms step_avg:34.90ms
+step:351/1845 train_time:12250ms step_avg:34.90ms
+step:352/1845 train_time:12284ms step_avg:34.90ms
+step:353/1845 train_time:12319ms step_avg:34.90ms
+step:354/1845 train_time:12353ms step_avg:34.89ms
+step:355/1845 train_time:12388ms step_avg:34.89ms
+step:356/1845 train_time:12421ms step_avg:34.89ms
+step:357/1845 train_time:12456ms step_avg:34.89ms
+step:358/1845 train_time:12490ms step_avg:34.89ms
+step:359/1845 train_time:12524ms step_avg:34.89ms
+step:360/1845 train_time:12558ms step_avg:34.88ms
+step:361/1845 train_time:12593ms step_avg:34.88ms
+step:362/1845 train_time:12627ms step_avg:34.88ms
+step:363/1845 train_time:12661ms step_avg:34.88ms
+step:364/1845 train_time:12695ms step_avg:34.88ms
+step:365/1845 train_time:12730ms step_avg:34.88ms
+step:366/1845 train_time:12764ms step_avg:34.87ms
+step:367/1845 train_time:12798ms step_avg:34.87ms
+step:368/1845 train_time:12832ms step_avg:34.87ms
+step:369/1845 train_time:12866ms step_avg:34.87ms
+step:370/1845 train_time:12900ms step_avg:34.87ms
+step:371/1845 train_time:12935ms step_avg:34.86ms
+step:372/1845 train_time:12969ms step_avg:34.86ms
+step:373/1845 train_time:13003ms step_avg:34.86ms
+step:374/1845 train_time:13037ms step_avg:34.86ms
+step:375/1845 train_time:13071ms step_avg:34.86ms
+step:376/1845 train_time:13105ms step_avg:34.85ms
+step:377/1845 train_time:13139ms step_avg:34.85ms
+step:378/1845 train_time:13173ms step_avg:34.85ms
+step:379/1845 train_time:13208ms step_avg:34.85ms
+step:380/1845 train_time:13242ms step_avg:34.85ms
+step:381/1845 train_time:13276ms step_avg:34.85ms
+step:382/1845 train_time:13310ms step_avg:34.84ms
+step:383/1845 train_time:13345ms step_avg:34.84ms
+step:384/1845 train_time:13379ms step_avg:34.84ms
+step:385/1845 train_time:13413ms step_avg:34.84ms
+step:386/1845 train_time:13447ms step_avg:34.84ms
+step:387/1845 train_time:13482ms step_avg:34.84ms
+step:388/1845 train_time:13515ms step_avg:34.83ms
+step:389/1845 train_time:13550ms step_avg:34.83ms
+step:390/1845 train_time:13584ms step_avg:34.83ms
+step:391/1845 train_time:13618ms step_avg:34.83ms
+step:392/1845 train_time:13652ms step_avg:34.83ms
+step:393/1845 train_time:13687ms step_avg:34.83ms
+step:394/1845 train_time:13721ms step_avg:34.82ms
+step:395/1845 train_time:13755ms step_avg:34.82ms
+step:396/1845 train_time:13789ms step_avg:34.82ms
+step:397/1845 train_time:13824ms step_avg:34.82ms
+step:398/1845 train_time:13858ms step_avg:34.82ms
+step:399/1845 train_time:13892ms step_avg:34.82ms
+step:400/1845 train_time:13926ms step_avg:34.82ms
+step:401/1845 train_time:13961ms step_avg:34.82ms
+step:402/1845 train_time:13995ms step_avg:34.81ms
+step:403/1845 train_time:14029ms step_avg:34.81ms
+step:404/1845 train_time:14063ms step_avg:34.81ms
+step:405/1845 train_time:14097ms step_avg:34.81ms
+step:406/1845 train_time:14132ms step_avg:34.81ms
+step:407/1845 train_time:14166ms step_avg:34.81ms
+step:408/1845 train_time:14200ms step_avg:34.80ms
+step:409/1845 train_time:14234ms step_avg:34.80ms
+step:410/1845 train_time:14268ms step_avg:34.80ms
+step:411/1845 train_time:14302ms step_avg:34.80ms
+step:412/1845 train_time:14337ms step_avg:34.80ms
+step:413/1845 train_time:14371ms step_avg:34.80ms
+step:414/1845 train_time:14405ms step_avg:34.80ms
+step:415/1845 train_time:14440ms step_avg:34.80ms
+step:416/1845 train_time:14474ms step_avg:34.79ms
+step:417/1845 train_time:14509ms step_avg:34.79ms
+step:418/1845 train_time:14543ms step_avg:34.79ms
+step:419/1845 train_time:14577ms step_avg:34.79ms
+step:420/1845 train_time:14611ms step_avg:34.79ms
+step:421/1845 train_time:14646ms step_avg:34.79ms
+step:422/1845 train_time:14680ms step_avg:34.79ms
+step:423/1845 train_time:14714ms step_avg:34.79ms
+step:424/1845 train_time:14748ms step_avg:34.78ms
+step:425/1845 train_time:14782ms step_avg:34.78ms
+step:426/1845 train_time:14816ms step_avg:34.78ms
+step:427/1845 train_time:14851ms step_avg:34.78ms
+step:428/1845 train_time:14885ms step_avg:34.78ms
+step:429/1845 train_time:14919ms step_avg:34.78ms
+step:430/1845 train_time:14953ms step_avg:34.77ms
+step:431/1845 train_time:14987ms step_avg:34.77ms
+step:432/1845 train_time:15021ms step_avg:34.77ms
+step:433/1845 train_time:15056ms step_avg:34.77ms
+step:434/1845 train_time:15090ms step_avg:34.77ms
+step:435/1845 train_time:15124ms step_avg:34.77ms
+step:436/1845 train_time:15158ms step_avg:34.77ms
+step:437/1845 train_time:15193ms step_avg:34.77ms
+step:438/1845 train_time:15227ms step_avg:34.76ms
+step:439/1845 train_time:15261ms step_avg:34.76ms
+step:440/1845 train_time:15295ms step_avg:34.76ms
+step:441/1845 train_time:15330ms step_avg:34.76ms
+step:442/1845 train_time:15364ms step_avg:34.76ms
+step:443/1845 train_time:15398ms step_avg:34.76ms
+step:444/1845 train_time:15432ms step_avg:34.76ms
+step:445/1845 train_time:15466ms step_avg:34.76ms
+step:446/1845 train_time:15500ms step_avg:34.75ms
+step:447/1845 train_time:15535ms step_avg:34.75ms
+step:448/1845 train_time:15569ms step_avg:34.75ms
+step:449/1845 train_time:15603ms step_avg:34.75ms
+step:450/1845 train_time:15637ms step_avg:34.75ms
+step:451/1845 train_time:15672ms step_avg:34.75ms
+step:452/1845 train_time:15706ms step_avg:34.75ms
+step:453/1845 train_time:15740ms step_avg:34.75ms
+step:454/1845 train_time:15774ms step_avg:34.75ms
+step:455/1845 train_time:15809ms step_avg:34.74ms
+step:456/1845 train_time:15843ms step_avg:34.74ms
+step:457/1845 train_time:15877ms step_avg:34.74ms
+step:458/1845 train_time:15911ms step_avg:34.74ms
+step:459/1845 train_time:15945ms step_avg:34.74ms
+step:460/1845 train_time:15979ms step_avg:34.74ms
+step:461/1845 train_time:16014ms step_avg:34.74ms
+step:462/1845 train_time:16048ms step_avg:34.73ms
+step:463/1845 train_time:16082ms step_avg:34.73ms
+step:464/1845 train_time:16116ms step_avg:34.73ms
+step:465/1845 train_time:16150ms step_avg:34.73ms
+step:466/1845 train_time:16184ms step_avg:34.73ms
+step:467/1845 train_time:16218ms step_avg:34.73ms
+step:468/1845 train_time:16252ms step_avg:34.73ms
+step:469/1845 train_time:16287ms step_avg:34.73ms
+step:470/1845 train_time:16321ms step_avg:34.72ms
+step:471/1845 train_time:16355ms step_avg:34.72ms
+step:472/1845 train_time:16389ms step_avg:34.72ms
+step:473/1845 train_time:16424ms step_avg:34.72ms
+step:474/1845 train_time:16458ms step_avg:34.72ms
+step:475/1845 train_time:16492ms step_avg:34.72ms
+step:476/1845 train_time:16526ms step_avg:34.72ms
+step:477/1845 train_time:16560ms step_avg:34.72ms
+step:478/1845 train_time:16595ms step_avg:34.72ms
+step:479/1845 train_time:16629ms step_avg:34.72ms
+step:480/1845 train_time:16663ms step_avg:34.71ms
+step:481/1845 train_time:16698ms step_avg:34.71ms
+step:482/1845 train_time:16732ms step_avg:34.71ms
+step:483/1845 train_time:16766ms step_avg:34.71ms
+step:484/1845 train_time:16800ms step_avg:34.71ms
+step:485/1845 train_time:16835ms step_avg:34.71ms
+step:486/1845 train_time:16869ms step_avg:34.71ms
+step:487/1845 train_time:16903ms step_avg:34.71ms
+step:488/1845 train_time:16937ms step_avg:34.71ms
+step:489/1845 train_time:16972ms step_avg:34.71ms
+step:490/1845 train_time:17006ms step_avg:34.71ms
+step:491/1845 train_time:17040ms step_avg:34.70ms
+step:492/1845 train_time:17074ms step_avg:34.70ms
+step:493/1845 train_time:17108ms step_avg:34.70ms
+step:494/1845 train_time:17142ms step_avg:34.70ms
+step:495/1845 train_time:17177ms step_avg:34.70ms
+step:496/1845 train_time:17211ms step_avg:34.70ms
+step:497/1845 train_time:17245ms step_avg:34.70ms
+step:498/1845 train_time:17279ms step_avg:34.70ms
+step:499/1845 train_time:17313ms step_avg:34.70ms
+step:500/1845 train_time:17347ms step_avg:34.69ms
+step:500/1845 val_loss:4.2937 train_time:17384ms step_avg:34.77ms
+step:501/1845 train_time:17403ms step_avg:34.74ms
+step:502/1845 train_time:17422ms step_avg:34.71ms
+step:503/1845 train_time:17453ms step_avg:34.70ms
+step:504/1845 train_time:17487ms step_avg:34.70ms
+step:505/1845 train_time:17522ms step_avg:34.70ms
+step:506/1845 train_time:17556ms step_avg:34.70ms
+step:507/1845 train_time:17591ms step_avg:34.70ms
+step:508/1845 train_time:17625ms step_avg:34.69ms
+step:509/1845 train_time:17659ms step_avg:34.69ms
+step:510/1845 train_time:17693ms step_avg:34.69ms
+step:511/1845 train_time:17727ms step_avg:34.69ms
+step:512/1845 train_time:17761ms step_avg:34.69ms
+step:513/1845 train_time:17796ms step_avg:34.69ms
+step:514/1845 train_time:17830ms step_avg:34.69ms
+step:515/1845 train_time:17864ms step_avg:34.69ms
+step:516/1845 train_time:17898ms step_avg:34.69ms
+step:517/1845 train_time:17932ms step_avg:34.69ms
+step:518/1845 train_time:17966ms step_avg:34.68ms
+step:519/1845 train_time:18000ms step_avg:34.68ms
+step:520/1845 train_time:18034ms step_avg:34.68ms
+step:521/1845 train_time:18069ms step_avg:34.68ms
+step:522/1845 train_time:18103ms step_avg:34.68ms
+step:523/1845 train_time:18137ms step_avg:34.68ms
+step:524/1845 train_time:18171ms step_avg:34.68ms
+step:525/1845 train_time:18206ms step_avg:34.68ms
+step:526/1845 train_time:18239ms step_avg:34.68ms
+step:527/1845 train_time:18274ms step_avg:34.68ms
+step:528/1845 train_time:18308ms step_avg:34.67ms
+step:529/1845 train_time:18342ms step_avg:34.67ms
+step:530/1845 train_time:18376ms step_avg:34.67ms
+step:531/1845 train_time:18411ms step_avg:34.67ms
+step:532/1845 train_time:18445ms step_avg:34.67ms
+step:533/1845 train_time:18480ms step_avg:34.67ms
+step:534/1845 train_time:18514ms step_avg:34.67ms
+step:535/1845 train_time:18548ms step_avg:34.67ms
+step:536/1845 train_time:18582ms step_avg:34.67ms
+step:537/1845 train_time:18616ms step_avg:34.67ms
+step:538/1845 train_time:18650ms step_avg:34.67ms
+step:539/1845 train_time:18685ms step_avg:34.67ms
+step:540/1845 train_time:18719ms step_avg:34.66ms
+step:541/1845 train_time:18753ms step_avg:34.66ms
+step:542/1845 train_time:18787ms step_avg:34.66ms
+step:543/1845 train_time:18822ms step_avg:34.66ms
+step:544/1845 train_time:18856ms step_avg:34.66ms
+step:545/1845 train_time:18890ms step_avg:34.66ms
+step:546/1845 train_time:18924ms step_avg:34.66ms
+step:547/1845 train_time:18958ms step_avg:34.66ms
+step:548/1845 train_time:18992ms step_avg:34.66ms
+step:549/1845 train_time:19027ms step_avg:34.66ms
+step:550/1845 train_time:19061ms step_avg:34.66ms
+step:551/1845 train_time:19095ms step_avg:34.66ms
+step:552/1845 train_time:19129ms step_avg:34.65ms
+step:553/1845 train_time:19163ms step_avg:34.65ms
+step:554/1845 train_time:19197ms step_avg:34.65ms
+step:555/1845 train_time:19232ms step_avg:34.65ms
+step:556/1845 train_time:19266ms step_avg:34.65ms
+step:557/1845 train_time:19300ms step_avg:34.65ms
+step:558/1845 train_time:19334ms step_avg:34.65ms
+step:559/1845 train_time:19368ms step_avg:34.65ms
+step:560/1845 train_time:19402ms step_avg:34.65ms
+step:561/1845 train_time:19437ms step_avg:34.65ms
+step:562/1845 train_time:19471ms step_avg:34.65ms
+step:563/1845 train_time:19506ms step_avg:34.65ms
+step:564/1845 train_time:19540ms step_avg:34.65ms
+step:565/1845 train_time:19574ms step_avg:34.64ms
+step:566/1845 train_time:19608ms step_avg:34.64ms
+step:567/1845 train_time:19642ms step_avg:34.64ms
+step:568/1845 train_time:19676ms step_avg:34.64ms
+step:569/1845 train_time:19711ms step_avg:34.64ms
+step:570/1845 train_time:19745ms step_avg:34.64ms
+step:571/1845 train_time:19779ms step_avg:34.64ms
+step:572/1845 train_time:19813ms step_avg:34.64ms
+step:573/1845 train_time:19848ms step_avg:34.64ms
+step:574/1845 train_time:19882ms step_avg:34.64ms
+step:575/1845 train_time:19916ms step_avg:34.64ms
+step:576/1845 train_time:19950ms step_avg:34.64ms
+step:577/1845 train_time:19984ms step_avg:34.64ms
+step:578/1845 train_time:20018ms step_avg:34.63ms
+step:579/1845 train_time:20053ms step_avg:34.63ms
+step:580/1845 train_time:20087ms step_avg:34.63ms
+step:581/1845 train_time:20121ms step_avg:34.63ms
+step:582/1845 train_time:20155ms step_avg:34.63ms
+step:583/1845 train_time:20190ms step_avg:34.63ms
+step:584/1845 train_time:20224ms step_avg:34.63ms
+step:585/1845 train_time:20258ms step_avg:34.63ms
+step:586/1845 train_time:20292ms step_avg:34.63ms
+step:587/1845 train_time:20327ms step_avg:34.63ms
+step:588/1845 train_time:20361ms step_avg:34.63ms
+step:589/1845 train_time:20395ms step_avg:34.63ms
+step:590/1845 train_time:20429ms step_avg:34.63ms
+step:591/1845 train_time:20463ms step_avg:34.62ms
+step:592/1845 train_time:20497ms step_avg:34.62ms
+step:593/1845 train_time:20532ms step_avg:34.62ms
+step:594/1845 train_time:20566ms step_avg:34.62ms
+step:595/1845 train_time:20600ms step_avg:34.62ms
+step:596/1845 train_time:20634ms step_avg:34.62ms
+step:597/1845 train_time:20668ms step_avg:34.62ms
+step:598/1845 train_time:20702ms step_avg:34.62ms
+step:599/1845 train_time:20737ms step_avg:34.62ms
+step:600/1845 train_time:20771ms step_avg:34.62ms
+step:601/1845 train_time:20805ms step_avg:34.62ms
+step:602/1845 train_time:20839ms step_avg:34.62ms
+step:603/1845 train_time:20874ms step_avg:34.62ms
+step:604/1845 train_time:20935ms step_avg:34.66ms
+step:605/1845 train_time:20997ms step_avg:34.71ms
+step:606/1845 train_time:21058ms step_avg:34.75ms
+step:607/1845 train_time:21120ms step_avg:34.79ms
+step:608/1845 train_time:21181ms step_avg:34.84ms
+step:609/1845 train_time:21244ms step_avg:34.88ms
+step:610/1845 train_time:21305ms step_avg:34.93ms
+step:611/1845 train_time:21368ms step_avg:34.97ms
+step:612/1845 train_time:21429ms step_avg:35.01ms
+step:613/1845 train_time:21491ms step_avg:35.06ms
+step:614/1845 train_time:21552ms step_avg:35.10ms
+step:615/1845 train_time:21615ms step_avg:35.15ms
+step:616/1845 train_time:21677ms step_avg:35.19ms
+step:617/1845 train_time:21739ms step_avg:35.23ms
+step:618/1845 train_time:21799ms step_avg:35.27ms
+step:619/1845 train_time:21862ms step_avg:35.32ms
+step:620/1845 train_time:21923ms step_avg:35.36ms
+step:621/1845 train_time:21985ms step_avg:35.40ms
+step:622/1845 train_time:22046ms step_avg:35.44ms
+step:623/1845 train_time:22108ms step_avg:35.49ms
+step:624/1845 train_time:22169ms step_avg:35.53ms
+step:625/1845 train_time:22232ms step_avg:35.57ms
+step:626/1845 train_time:22293ms step_avg:35.61ms
+step:627/1845 train_time:22356ms step_avg:35.66ms
+step:628/1845 train_time:22418ms step_avg:35.70ms
+step:629/1845 train_time:22480ms step_avg:35.74ms
+step:630/1845 train_time:22541ms step_avg:35.78ms
+step:631/1845 train_time:22605ms step_avg:35.82ms
+step:632/1845 train_time:22666ms step_avg:35.86ms
+step:633/1845 train_time:22728ms step_avg:35.91ms
+step:634/1845 train_time:22789ms step_avg:35.94ms
+step:635/1845 train_time:22851ms step_avg:35.99ms
+step:636/1845 train_time:22912ms step_avg:36.03ms
+step:637/1845 train_time:22975ms step_avg:36.07ms
+step:638/1845 train_time:23036ms step_avg:36.11ms
+step:639/1845 train_time:23099ms step_avg:36.15ms
+step:640/1845 train_time:23160ms step_avg:36.19ms
+step:641/1845 train_time:23222ms step_avg:36.23ms
+step:642/1845 train_time:23283ms step_avg:36.27ms
+step:643/1845 train_time:23346ms step_avg:36.31ms
+step:644/1845 train_time:23406ms step_avg:36.35ms
+step:645/1845 train_time:23469ms step_avg:36.39ms
+step:646/1845 train_time:23529ms step_avg:36.42ms
+step:647/1845 train_time:23593ms step_avg:36.47ms
+step:648/1845 train_time:23654ms step_avg:36.50ms
+step:649/1845 train_time:23717ms step_avg:36.54ms
+step:650/1845 train_time:23778ms step_avg:36.58ms
+step:651/1845 train_time:23840ms step_avg:36.62ms
+step:652/1845 train_time:23901ms step_avg:36.66ms
+step:653/1845 train_time:23964ms step_avg:36.70ms
+step:654/1845 train_time:24025ms step_avg:36.74ms
+step:655/1845 train_time:24087ms step_avg:36.77ms
+step:656/1845 train_time:24147ms step_avg:36.81ms
+step:657/1845 train_time:24209ms step_avg:36.85ms
+step:658/1845 train_time:24270ms step_avg:36.88ms
+step:659/1845 train_time:24333ms step_avg:36.92ms
+step:660/1845 train_time:24394ms step_avg:36.96ms
+step:661/1845 train_time:24456ms step_avg:37.00ms
+step:662/1845 train_time:24517ms step_avg:37.04ms
+step:663/1845 train_time:24580ms step_avg:37.07ms
+step:664/1845 train_time:24641ms step_avg:37.11ms
+step:665/1845 train_time:24704ms step_avg:37.15ms
+step:666/1845 train_time:24764ms step_avg:37.18ms
+step:667/1845 train_time:24827ms step_avg:37.22ms
+step:668/1845 train_time:24888ms step_avg:37.26ms
+step:669/1845 train_time:24950ms step_avg:37.29ms
+step:670/1845 train_time:25011ms step_avg:37.33ms
+step:671/1845 train_time:25073ms step_avg:37.37ms
+step:672/1845 train_time:25134ms step_avg:37.40ms
+step:673/1845 train_time:25196ms step_avg:37.44ms
+step:674/1845 train_time:25257ms step_avg:37.47ms
+step:675/1845 train_time:25320ms step_avg:37.51ms
+step:676/1845 train_time:25380ms step_avg:37.54ms
+step:677/1845 train_time:25443ms step_avg:37.58ms
+step:678/1845 train_time:25504ms step_avg:37.62ms
+step:679/1845 train_time:25566ms step_avg:37.65ms
+step:680/1845 train_time:25626ms step_avg:37.69ms
+step:681/1845 train_time:25689ms step_avg:37.72ms
+step:682/1845 train_time:25749ms step_avg:37.76ms
+step:683/1845 train_time:25812ms step_avg:37.79ms
+step:684/1845 train_time:25873ms step_avg:37.83ms
+step:685/1845 train_time:25935ms step_avg:37.86ms
+step:686/1845 train_time:25996ms step_avg:37.90ms
+step:687/1845 train_time:26059ms step_avg:37.93ms
+step:688/1845 train_time:26120ms step_avg:37.96ms
+step:689/1845 train_time:26183ms step_avg:38.00ms
+step:690/1845 train_time:26244ms step_avg:38.03ms
+step:691/1845 train_time:26306ms step_avg:38.07ms
+step:692/1845 train_time:26366ms step_avg:38.10ms
+step:693/1845 train_time:26429ms step_avg:38.14ms
+step:694/1845 train_time:26490ms step_avg:38.17ms
+step:695/1845 train_time:26553ms step_avg:38.21ms
+step:696/1845 train_time:26614ms step_avg:38.24ms
+step:697/1845 train_time:26676ms step_avg:38.27ms
+step:698/1845 train_time:26737ms step_avg:38.31ms
+step:699/1845 train_time:26800ms step_avg:38.34ms
+step:700/1845 train_time:26861ms step_avg:38.37ms
+step:701/1845 train_time:26923ms step_avg:38.41ms
+step:702/1845 train_time:26984ms step_avg:38.44ms
+step:703/1845 train_time:27047ms step_avg:38.47ms
+step:704/1845 train_time:27108ms step_avg:38.51ms
+step:705/1845 train_time:27170ms step_avg:38.54ms
+step:706/1845 train_time:27230ms step_avg:38.57ms
+step:707/1845 train_time:27293ms step_avg:38.60ms
+step:708/1845 train_time:27355ms step_avg:38.64ms
+step:709/1845 train_time:27417ms step_avg:38.67ms
+step:710/1845 train_time:27479ms step_avg:38.70ms
+step:711/1845 train_time:27541ms step_avg:38.74ms
+step:712/1845 train_time:27602ms step_avg:38.77ms
+step:713/1845 train_time:27665ms step_avg:38.80ms
+step:714/1845 train_time:27726ms step_avg:38.83ms
+step:715/1845 train_time:27789ms step_avg:38.87ms
+step:716/1845 train_time:27849ms step_avg:38.90ms
+step:717/1845 train_time:27912ms step_avg:38.93ms
+step:718/1845 train_time:27974ms step_avg:38.96ms
+step:719/1845 train_time:28036ms step_avg:38.99ms
+step:720/1845 train_time:28097ms step_avg:39.02ms
+step:721/1845 train_time:28159ms step_avg:39.06ms
+step:722/1845 train_time:28220ms step_avg:39.09ms
+step:723/1845 train_time:28283ms step_avg:39.12ms
+step:724/1845 train_time:28344ms step_avg:39.15ms
+step:725/1845 train_time:28406ms step_avg:39.18ms
+step:726/1845 train_time:28467ms step_avg:39.21ms
+step:727/1845 train_time:28529ms step_avg:39.24ms
+step:728/1845 train_time:28591ms step_avg:39.27ms
+step:729/1845 train_time:28653ms step_avg:39.31ms
+step:730/1845 train_time:28715ms step_avg:39.34ms
+step:731/1845 train_time:28777ms step_avg:39.37ms
+step:732/1845 train_time:28838ms step_avg:39.40ms
+step:733/1845 train_time:28901ms step_avg:39.43ms
+step:734/1845 train_time:28962ms step_avg:39.46ms
+step:735/1845 train_time:29025ms step_avg:39.49ms
+step:736/1845 train_time:29085ms step_avg:39.52ms
+step:737/1845 train_time:29147ms step_avg:39.55ms
+step:738/1845 train_time:29208ms step_avg:39.58ms
+step:739/1845 train_time:29270ms step_avg:39.61ms
+step:740/1845 train_time:29331ms step_avg:39.64ms
+step:741/1845 train_time:29394ms step_avg:39.67ms
+step:742/1845 train_time:29455ms step_avg:39.70ms
+step:743/1845 train_time:29517ms step_avg:39.73ms
+step:744/1845 train_time:29578ms step_avg:39.76ms
+step:745/1845 train_time:29641ms step_avg:39.79ms
+step:746/1845 train_time:29702ms step_avg:39.81ms
+step:747/1845 train_time:29764ms step_avg:39.85ms
+step:748/1845 train_time:29825ms step_avg:39.87ms
+step:749/1845 train_time:29888ms step_avg:39.90ms
+step:750/1845 train_time:29948ms step_avg:39.93ms
+step:750/1845 val_loss:4.0267 train_time:30012ms step_avg:40.02ms
+step:751/1845 train_time:30039ms step_avg:40.00ms
+step:752/1845 train_time:30074ms step_avg:39.99ms
+step:753/1845 train_time:30138ms step_avg:40.02ms
+step:754/1845 train_time:30200ms step_avg:40.05ms
+step:755/1845 train_time:30262ms step_avg:40.08ms
+step:756/1845 train_time:30323ms step_avg:40.11ms
+step:757/1845 train_time:30385ms step_avg:40.14ms
+step:758/1845 train_time:30445ms step_avg:40.16ms
+step:759/1845 train_time:30507ms step_avg:40.19ms
+step:760/1845 train_time:30567ms step_avg:40.22ms
+step:761/1845 train_time:30630ms step_avg:40.25ms
+step:762/1845 train_time:30689ms step_avg:40.27ms
+step:763/1845 train_time:30751ms step_avg:40.30ms
+step:764/1845 train_time:30812ms step_avg:40.33ms
+step:765/1845 train_time:30873ms step_avg:40.36ms
+step:766/1845 train_time:30934ms step_avg:40.38ms
+step:767/1845 train_time:30998ms step_avg:40.41ms
+step:768/1845 train_time:31060ms step_avg:40.44ms
+step:769/1845 train_time:31123ms step_avg:40.47ms
+step:770/1845 train_time:31184ms step_avg:40.50ms
+step:771/1845 train_time:31247ms step_avg:40.53ms
+step:772/1845 train_time:31308ms step_avg:40.55ms
+step:773/1845 train_time:31370ms step_avg:40.58ms
+step:774/1845 train_time:31430ms step_avg:40.61ms
+step:775/1845 train_time:31492ms step_avg:40.63ms
+step:776/1845 train_time:31552ms step_avg:40.66ms
+step:777/1845 train_time:31614ms step_avg:40.69ms
+step:778/1845 train_time:31675ms step_avg:40.71ms
+step:779/1845 train_time:31738ms step_avg:40.74ms
+step:780/1845 train_time:31799ms step_avg:40.77ms
+step:781/1845 train_time:31861ms step_avg:40.80ms
+step:782/1845 train_time:31923ms step_avg:40.82ms
+step:783/1845 train_time:31985ms step_avg:40.85ms
+step:784/1845 train_time:32046ms step_avg:40.88ms
+step:785/1845 train_time:32109ms step_avg:40.90ms
+step:786/1845 train_time:32170ms step_avg:40.93ms
+step:787/1845 train_time:32234ms step_avg:40.96ms
+step:788/1845 train_time:32294ms step_avg:40.98ms
+step:789/1845 train_time:32357ms step_avg:41.01ms
+step:790/1845 train_time:32417ms step_avg:41.03ms
+step:791/1845 train_time:32480ms step_avg:41.06ms
+step:792/1845 train_time:32541ms step_avg:41.09ms
+step:793/1845 train_time:32603ms step_avg:41.11ms
+step:794/1845 train_time:32663ms step_avg:41.14ms
+step:795/1845 train_time:32726ms step_avg:41.16ms
+step:796/1845 train_time:32786ms step_avg:41.19ms
+step:797/1845 train_time:32848ms step_avg:41.21ms
+step:798/1845 train_time:32909ms step_avg:41.24ms
+step:799/1845 train_time:32972ms step_avg:41.27ms
+step:800/1845 train_time:33032ms step_avg:41.29ms
+step:801/1845 train_time:33095ms step_avg:41.32ms
+step:802/1845 train_time:33156ms step_avg:41.34ms
+step:803/1845 train_time:33219ms step_avg:41.37ms
+step:804/1845 train_time:33280ms step_avg:41.39ms
+step:805/1845 train_time:33343ms step_avg:41.42ms
+step:806/1845 train_time:33404ms step_avg:41.44ms
+step:807/1845 train_time:33466ms step_avg:41.47ms
+step:808/1845 train_time:33527ms step_avg:41.49ms
+step:809/1845 train_time:33589ms step_avg:41.52ms
+step:810/1845 train_time:33650ms step_avg:41.54ms
+step:811/1845 train_time:33712ms step_avg:41.57ms
+step:812/1845 train_time:33772ms step_avg:41.59ms
+step:813/1845 train_time:33835ms step_avg:41.62ms
+step:814/1845 train_time:33895ms step_avg:41.64ms
+step:815/1845 train_time:33957ms step_avg:41.67ms
+step:816/1845 train_time:34019ms step_avg:41.69ms
+step:817/1845 train_time:34081ms step_avg:41.71ms
+step:818/1845 train_time:34143ms step_avg:41.74ms
+step:819/1845 train_time:34205ms step_avg:41.76ms
+step:820/1845 train_time:34266ms step_avg:41.79ms
+step:821/1845 train_time:34329ms step_avg:41.81ms
+step:822/1845 train_time:34390ms step_avg:41.84ms
+step:823/1845 train_time:34452ms step_avg:41.86ms
+step:824/1845 train_time:34513ms step_avg:41.89ms
+step:825/1845 train_time:34576ms step_avg:41.91ms
+step:826/1845 train_time:34637ms step_avg:41.93ms
+step:827/1845 train_time:34699ms step_avg:41.96ms
+step:828/1845 train_time:34761ms step_avg:41.98ms
+step:829/1845 train_time:34824ms step_avg:42.01ms
+step:830/1845 train_time:34884ms step_avg:42.03ms
+step:831/1845 train_time:34947ms step_avg:42.05ms
+step:832/1845 train_time:35007ms step_avg:42.08ms
+step:833/1845 train_time:35070ms step_avg:42.10ms
+step:834/1845 train_time:35132ms step_avg:42.12ms
+step:835/1845 train_time:35194ms step_avg:42.15ms
+step:836/1845 train_time:35255ms step_avg:42.17ms
+step:837/1845 train_time:35317ms step_avg:42.19ms
+step:838/1845 train_time:35377ms step_avg:42.22ms
+step:839/1845 train_time:35440ms step_avg:42.24ms
+step:840/1845 train_time:35501ms step_avg:42.26ms
+step:841/1845 train_time:35563ms step_avg:42.29ms
+step:842/1845 train_time:35624ms step_avg:42.31ms
+step:843/1845 train_time:35687ms step_avg:42.33ms
+step:844/1845 train_time:35747ms step_avg:42.35ms
+step:845/1845 train_time:35810ms step_avg:42.38ms
+step:846/1845 train_time:35870ms step_avg:42.40ms
+step:847/1845 train_time:35933ms step_avg:42.42ms
+step:848/1845 train_time:35993ms step_avg:42.44ms
+step:849/1845 train_time:36056ms step_avg:42.47ms
+step:850/1845 train_time:36116ms step_avg:42.49ms
+step:851/1845 train_time:36179ms step_avg:42.51ms
+step:852/1845 train_time:36240ms step_avg:42.54ms
+step:853/1845 train_time:36303ms step_avg:42.56ms
+step:854/1845 train_time:36364ms step_avg:42.58ms
+step:855/1845 train_time:36426ms step_avg:42.60ms
+step:856/1845 train_time:36487ms step_avg:42.63ms
+step:857/1845 train_time:36549ms step_avg:42.65ms
+step:858/1845 train_time:36610ms step_avg:42.67ms
+step:859/1845 train_time:36672ms step_avg:42.69ms
+step:860/1845 train_time:36733ms step_avg:42.71ms
+step:861/1845 train_time:36796ms step_avg:42.74ms
+step:862/1845 train_time:36857ms step_avg:42.76ms
+step:863/1845 train_time:36920ms step_avg:42.78ms
+step:864/1845 train_time:36981ms step_avg:42.80ms
+step:865/1845 train_time:37044ms step_avg:42.83ms
+step:866/1845 train_time:37105ms step_avg:42.85ms
+step:867/1845 train_time:37167ms step_avg:42.87ms
+step:868/1845 train_time:37229ms step_avg:42.89ms
+step:869/1845 train_time:37292ms step_avg:42.91ms
+step:870/1845 train_time:37352ms step_avg:42.93ms
+step:871/1845 train_time:37415ms step_avg:42.96ms
+step:872/1845 train_time:37475ms step_avg:42.98ms
+step:873/1845 train_time:37538ms step_avg:43.00ms
+step:874/1845 train_time:37600ms step_avg:43.02ms
+step:875/1845 train_time:37663ms step_avg:43.04ms
+step:876/1845 train_time:37724ms step_avg:43.06ms
+step:877/1845 train_time:37786ms step_avg:43.09ms
+step:878/1845 train_time:37846ms step_avg:43.11ms
+step:879/1845 train_time:37909ms step_avg:43.13ms
+step:880/1845 train_time:37970ms step_avg:43.15ms
+step:881/1845 train_time:38033ms step_avg:43.17ms
+step:882/1845 train_time:38093ms step_avg:43.19ms
+step:883/1845 train_time:38156ms step_avg:43.21ms
+step:884/1845 train_time:38217ms step_avg:43.23ms
+step:885/1845 train_time:38280ms step_avg:43.25ms
+step:886/1845 train_time:38341ms step_avg:43.27ms
+step:887/1845 train_time:38404ms step_avg:43.30ms
+step:888/1845 train_time:38464ms step_avg:43.32ms
+step:889/1845 train_time:38527ms step_avg:43.34ms
+step:890/1845 train_time:38588ms step_avg:43.36ms
+step:891/1845 train_time:38650ms step_avg:43.38ms
+step:892/1845 train_time:38711ms step_avg:43.40ms
+step:893/1845 train_time:38773ms step_avg:43.42ms
+step:894/1845 train_time:38833ms step_avg:43.44ms
+step:895/1845 train_time:38895ms step_avg:43.46ms
+step:896/1845 train_time:38956ms step_avg:43.48ms
+step:897/1845 train_time:39018ms step_avg:43.50ms
+step:898/1845 train_time:39080ms step_avg:43.52ms
+step:899/1845 train_time:39142ms step_avg:43.54ms
+step:900/1845 train_time:39203ms step_avg:43.56ms
+step:901/1845 train_time:39266ms step_avg:43.58ms
+step:902/1845 train_time:39326ms step_avg:43.60ms
+step:903/1845 train_time:39389ms step_avg:43.62ms
+step:904/1845 train_time:39450ms step_avg:43.64ms
+step:905/1845 train_time:39512ms step_avg:43.66ms
+step:906/1845 train_time:39573ms step_avg:43.68ms
+step:907/1845 train_time:39636ms step_avg:43.70ms
+step:908/1845 train_time:39696ms step_avg:43.72ms
+step:909/1845 train_time:39759ms step_avg:43.74ms
+step:910/1845 train_time:39820ms step_avg:43.76ms
+step:911/1845 train_time:39883ms step_avg:43.78ms
+step:912/1845 train_time:39944ms step_avg:43.80ms
+step:913/1845 train_time:40006ms step_avg:43.82ms
+step:914/1845 train_time:40067ms step_avg:43.84ms
+step:915/1845 train_time:40129ms step_avg:43.86ms
+step:916/1845 train_time:40190ms step_avg:43.88ms
+step:917/1845 train_time:40252ms step_avg:43.90ms
+step:918/1845 train_time:40313ms step_avg:43.91ms
+step:919/1845 train_time:40375ms step_avg:43.93ms
+step:920/1845 train_time:40436ms step_avg:43.95ms
+step:921/1845 train_time:40499ms step_avg:43.97ms
+step:922/1845 train_time:40560ms step_avg:43.99ms
+step:923/1845 train_time:40622ms step_avg:44.01ms
+step:924/1845 train_time:40684ms step_avg:44.03ms
+step:925/1845 train_time:40746ms step_avg:44.05ms
+step:926/1845 train_time:40807ms step_avg:44.07ms
+step:927/1845 train_time:40869ms step_avg:44.09ms
+step:928/1845 train_time:40930ms step_avg:44.11ms
+step:929/1845 train_time:40992ms step_avg:44.13ms
+step:930/1845 train_time:41053ms step_avg:44.14ms
+step:931/1845 train_time:41116ms step_avg:44.16ms
+step:932/1845 train_time:41176ms step_avg:44.18ms
+step:933/1845 train_time:41239ms step_avg:44.20ms
+step:934/1845 train_time:41300ms step_avg:44.22ms
+step:935/1845 train_time:41363ms step_avg:44.24ms
+step:936/1845 train_time:41423ms step_avg:44.26ms
+step:937/1845 train_time:41486ms step_avg:44.28ms
+step:938/1845 train_time:41547ms step_avg:44.29ms
+step:939/1845 train_time:41609ms step_avg:44.31ms
+step:940/1845 train_time:41670ms step_avg:44.33ms
+step:941/1845 train_time:41732ms step_avg:44.35ms
+step:942/1845 train_time:41793ms step_avg:44.37ms
+step:943/1845 train_time:41855ms step_avg:44.39ms
+step:944/1845 train_time:41916ms step_avg:44.40ms
+step:945/1845 train_time:41979ms step_avg:44.42ms
+step:946/1845 train_time:42040ms step_avg:44.44ms
+step:947/1845 train_time:42103ms step_avg:44.46ms
+step:948/1845 train_time:42164ms step_avg:44.48ms
+step:949/1845 train_time:42227ms step_avg:44.50ms
+step:950/1845 train_time:42287ms step_avg:44.51ms
+step:951/1845 train_time:42351ms step_avg:44.53ms
+step:952/1845 train_time:42411ms step_avg:44.55ms
+step:953/1845 train_time:42474ms step_avg:44.57ms
+step:954/1845 train_time:42534ms step_avg:44.58ms
+step:955/1845 train_time:42596ms step_avg:44.60ms
+step:956/1845 train_time:42657ms step_avg:44.62ms
+step:957/1845 train_time:42719ms step_avg:44.64ms
+step:958/1845 train_time:42781ms step_avg:44.66ms
+step:959/1845 train_time:42843ms step_avg:44.67ms
+step:960/1845 train_time:42904ms step_avg:44.69ms
+step:961/1845 train_time:42966ms step_avg:44.71ms
+step:962/1845 train_time:43027ms step_avg:44.73ms
+step:963/1845 train_time:43090ms step_avg:44.75ms
+step:964/1845 train_time:43150ms step_avg:44.76ms
+step:965/1845 train_time:43212ms step_avg:44.78ms
+step:966/1845 train_time:43273ms step_avg:44.80ms
+step:967/1845 train_time:43335ms step_avg:44.81ms
+step:968/1845 train_time:43396ms step_avg:44.83ms
+step:969/1845 train_time:43458ms step_avg:44.85ms
+step:970/1845 train_time:43519ms step_avg:44.87ms
+step:971/1845 train_time:43582ms step_avg:44.88ms
+step:972/1845 train_time:43643ms step_avg:44.90ms
+step:973/1845 train_time:43705ms step_avg:44.92ms
+step:974/1845 train_time:43766ms step_avg:44.93ms
+step:975/1845 train_time:43828ms step_avg:44.95ms
+step:976/1845 train_time:43889ms step_avg:44.97ms
+step:977/1845 train_time:43951ms step_avg:44.99ms
+step:978/1845 train_time:44012ms step_avg:45.00ms
+step:979/1845 train_time:44075ms step_avg:45.02ms
+step:980/1845 train_time:44136ms step_avg:45.04ms
+step:981/1845 train_time:44198ms step_avg:45.05ms
+step:982/1845 train_time:44259ms step_avg:45.07ms
+step:983/1845 train_time:44321ms step_avg:45.09ms
+step:984/1845 train_time:44382ms step_avg:45.10ms
+step:985/1845 train_time:44445ms step_avg:45.12ms
+step:986/1845 train_time:44506ms step_avg:45.14ms
+step:987/1845 train_time:44568ms step_avg:45.15ms
+step:988/1845 train_time:44628ms step_avg:45.17ms
+step:989/1845 train_time:44691ms step_avg:45.19ms
+step:990/1845 train_time:44752ms step_avg:45.20ms
+step:991/1845 train_time:44814ms step_avg:45.22ms
+step:992/1845 train_time:44875ms step_avg:45.24ms
+step:993/1845 train_time:44938ms step_avg:45.25ms
+step:994/1845 train_time:44999ms step_avg:45.27ms
+step:995/1845 train_time:45062ms step_avg:45.29ms
+step:996/1845 train_time:45123ms step_avg:45.30ms
+step:997/1845 train_time:45186ms step_avg:45.32ms
+step:998/1845 train_time:45246ms step_avg:45.34ms
+step:999/1845 train_time:45309ms step_avg:45.35ms
+step:1000/1845 train_time:45370ms step_avg:45.37ms
+step:1000/1845 val_loss:3.7850 train_time:45434ms step_avg:45.43ms
+step:1001/1845 train_time:45457ms step_avg:45.41ms
+step:1002/1845 train_time:45496ms step_avg:45.40ms
+step:1003/1845 train_time:45558ms step_avg:45.42ms
+step:1004/1845 train_time:45621ms step_avg:45.44ms
+step:1005/1845 train_time:45684ms step_avg:45.46ms
+step:1006/1845 train_time:45744ms step_avg:45.47ms
+step:1007/1845 train_time:45806ms step_avg:45.49ms
+step:1008/1845 train_time:45866ms step_avg:45.50ms
+step:1009/1845 train_time:45928ms step_avg:45.52ms
+step:1010/1845 train_time:45988ms step_avg:45.53ms
+step:1011/1845 train_time:46050ms step_avg:45.55ms
+step:1012/1845 train_time:46111ms step_avg:45.56ms
+step:1013/1845 train_time:46173ms step_avg:45.58ms
+step:1014/1845 train_time:46234ms step_avg:45.60ms
+step:1015/1845 train_time:46296ms step_avg:45.61ms
+step:1016/1845 train_time:46357ms step_avg:45.63ms
+step:1017/1845 train_time:46420ms step_avg:45.64ms
+step:1018/1845 train_time:46482ms step_avg:45.66ms
+step:1019/1845 train_time:46545ms step_avg:45.68ms
+step:1020/1845 train_time:46607ms step_avg:45.69ms
+step:1021/1845 train_time:46671ms step_avg:45.71ms
+step:1022/1845 train_time:46732ms step_avg:45.73ms
+step:1023/1845 train_time:46795ms step_avg:45.74ms
+step:1024/1845 train_time:46855ms step_avg:45.76ms
+step:1025/1845 train_time:46918ms step_avg:45.77ms
+step:1026/1845 train_time:46978ms step_avg:45.79ms
+step:1027/1845 train_time:47041ms step_avg:45.80ms
+step:1028/1845 train_time:47101ms step_avg:45.82ms
+step:1029/1845 train_time:47164ms step_avg:45.84ms
+step:1030/1845 train_time:47224ms step_avg:45.85ms
+step:1031/1845 train_time:47286ms step_avg:45.86ms
+step:1032/1845 train_time:47346ms step_avg:45.88ms
+step:1033/1845 train_time:47409ms step_avg:45.89ms
+step:1034/1845 train_time:47471ms step_avg:45.91ms
+step:1035/1845 train_time:47534ms step_avg:45.93ms
+step:1036/1845 train_time:47596ms step_avg:45.94ms
+step:1037/1845 train_time:47658ms step_avg:45.96ms
+step:1038/1845 train_time:47719ms step_avg:45.97ms
+step:1039/1845 train_time:47782ms step_avg:45.99ms
+step:1040/1845 train_time:47842ms step_avg:46.00ms
+step:1041/1845 train_time:47904ms step_avg:46.02ms
+step:1042/1845 train_time:47965ms step_avg:46.03ms
+step:1043/1845 train_time:48027ms step_avg:46.05ms
+step:1044/1845 train_time:48088ms step_avg:46.06ms
+step:1045/1845 train_time:48151ms step_avg:46.08ms
+step:1046/1845 train_time:48212ms step_avg:46.09ms
+step:1047/1845 train_time:48274ms step_avg:46.11ms
+step:1048/1845 train_time:48335ms step_avg:46.12ms
+step:1049/1845 train_time:48397ms step_avg:46.14ms
+step:1050/1845 train_time:48458ms step_avg:46.15ms
+step:1051/1845 train_time:48520ms step_avg:46.17ms
+step:1052/1845 train_time:48582ms step_avg:46.18ms
+step:1053/1845 train_time:48644ms step_avg:46.20ms
+step:1054/1845 train_time:48705ms step_avg:46.21ms
+step:1055/1845 train_time:48767ms step_avg:46.22ms
+step:1056/1845 train_time:48829ms step_avg:46.24ms
+step:1057/1845 train_time:48891ms step_avg:46.25ms
+step:1058/1845 train_time:48952ms step_avg:46.27ms
+step:1059/1845 train_time:49015ms step_avg:46.28ms
+step:1060/1845 train_time:49075ms step_avg:46.30ms
+step:1061/1845 train_time:49137ms step_avg:46.31ms
+step:1062/1845 train_time:49198ms step_avg:46.33ms
+step:1063/1845 train_time:49261ms step_avg:46.34ms
+step:1064/1845 train_time:49322ms step_avg:46.35ms
+step:1065/1845 train_time:49384ms step_avg:46.37ms
+step:1066/1845 train_time:49444ms step_avg:46.38ms
+step:1067/1845 train_time:49507ms step_avg:46.40ms
+step:1068/1845 train_time:49567ms step_avg:46.41ms
+step:1069/1845 train_time:49630ms step_avg:46.43ms
+step:1070/1845 train_time:49692ms step_avg:46.44ms
+step:1071/1845 train_time:49754ms step_avg:46.46ms
+step:1072/1845 train_time:49815ms step_avg:46.47ms
+step:1073/1845 train_time:49877ms step_avg:46.48ms
+step:1074/1845 train_time:49938ms step_avg:46.50ms
+step:1075/1845 train_time:50001ms step_avg:46.51ms
+step:1076/1845 train_time:50061ms step_avg:46.53ms
+step:1077/1845 train_time:50124ms step_avg:46.54ms
+step:1078/1845 train_time:50185ms step_avg:46.55ms
+step:1079/1845 train_time:50247ms step_avg:46.57ms
+step:1080/1845 train_time:50308ms step_avg:46.58ms
+step:1081/1845 train_time:50370ms step_avg:46.60ms
+step:1082/1845 train_time:50431ms step_avg:46.61ms
+step:1083/1845 train_time:50494ms step_avg:46.62ms
+step:1084/1845 train_time:50555ms step_avg:46.64ms
+step:1085/1845 train_time:50617ms step_avg:46.65ms
+step:1086/1845 train_time:50678ms step_avg:46.66ms
+step:1087/1845 train_time:50740ms step_avg:46.68ms
+step:1088/1845 train_time:50801ms step_avg:46.69ms
+step:1089/1845 train_time:50864ms step_avg:46.71ms
+step:1090/1845 train_time:50924ms step_avg:46.72ms
+step:1091/1845 train_time:50987ms step_avg:46.73ms
+step:1092/1845 train_time:51048ms step_avg:46.75ms
+step:1093/1845 train_time:51110ms step_avg:46.76ms
+step:1094/1845 train_time:51171ms step_avg:46.77ms
+step:1095/1845 train_time:51234ms step_avg:46.79ms
+step:1096/1845 train_time:51295ms step_avg:46.80ms
+step:1097/1845 train_time:51357ms step_avg:46.82ms
+step:1098/1845 train_time:51418ms step_avg:46.83ms
+step:1099/1845 train_time:51481ms step_avg:46.84ms
+step:1100/1845 train_time:51542ms step_avg:46.86ms
+step:1101/1845 train_time:51604ms step_avg:46.87ms
+step:1102/1845 train_time:51665ms step_avg:46.88ms
+step:1103/1845 train_time:51728ms step_avg:46.90ms
+step:1104/1845 train_time:51789ms step_avg:46.91ms
+step:1105/1845 train_time:51851ms step_avg:46.92ms
+step:1106/1845 train_time:51913ms step_avg:46.94ms
+step:1107/1845 train_time:51975ms step_avg:46.95ms
+step:1108/1845 train_time:52036ms step_avg:46.96ms
+step:1109/1845 train_time:52099ms step_avg:46.98ms
+step:1110/1845 train_time:52160ms step_avg:46.99ms
+step:1111/1845 train_time:52222ms step_avg:47.00ms
+step:1112/1845 train_time:52283ms step_avg:47.02ms
+step:1113/1845 train_time:52345ms step_avg:47.03ms
+step:1114/1845 train_time:52406ms step_avg:47.04ms
+step:1115/1845 train_time:52469ms step_avg:47.06ms
+step:1116/1845 train_time:52530ms step_avg:47.07ms
+step:1117/1845 train_time:52592ms step_avg:47.08ms
+step:1118/1845 train_time:52653ms step_avg:47.10ms
+step:1119/1845 train_time:52716ms step_avg:47.11ms
+step:1120/1845 train_time:52777ms step_avg:47.12ms
+step:1121/1845 train_time:52840ms step_avg:47.14ms
+step:1122/1845 train_time:52901ms step_avg:47.15ms
+step:1123/1845 train_time:52963ms step_avg:47.16ms
+step:1124/1845 train_time:53024ms step_avg:47.17ms
+step:1125/1845 train_time:53086ms step_avg:47.19ms
+step:1126/1845 train_time:53147ms step_avg:47.20ms
+step:1127/1845 train_time:53210ms step_avg:47.21ms
+step:1128/1845 train_time:53272ms step_avg:47.23ms
+step:1129/1845 train_time:53334ms step_avg:47.24ms
+step:1130/1845 train_time:53394ms step_avg:47.25ms
+step:1131/1845 train_time:53457ms step_avg:47.27ms
+step:1132/1845 train_time:53517ms step_avg:47.28ms
+step:1133/1845 train_time:53580ms step_avg:47.29ms
+step:1134/1845 train_time:53641ms step_avg:47.30ms
+step:1135/1845 train_time:53703ms step_avg:47.32ms
+step:1136/1845 train_time:53764ms step_avg:47.33ms
+step:1137/1845 train_time:53826ms step_avg:47.34ms
+step:1138/1845 train_time:53887ms step_avg:47.35ms
+step:1139/1845 train_time:53949ms step_avg:47.37ms
+step:1140/1845 train_time:54010ms step_avg:47.38ms
+step:1141/1845 train_time:54073ms step_avg:47.39ms
+step:1142/1845 train_time:54134ms step_avg:47.40ms
+step:1143/1845 train_time:54196ms step_avg:47.42ms
+step:1144/1845 train_time:54258ms step_avg:47.43ms
+step:1145/1845 train_time:54320ms step_avg:47.44ms
+step:1146/1845 train_time:54380ms step_avg:47.45ms
+step:1147/1845 train_time:54443ms step_avg:47.47ms
+step:1148/1845 train_time:54504ms step_avg:47.48ms
+step:1149/1845 train_time:54566ms step_avg:47.49ms
+step:1150/1845 train_time:54627ms step_avg:47.50ms
+step:1151/1845 train_time:54690ms step_avg:47.51ms
+step:1152/1845 train_time:54751ms step_avg:47.53ms
+step:1153/1845 train_time:54813ms step_avg:47.54ms
+step:1154/1845 train_time:54874ms step_avg:47.55ms
+step:1155/1845 train_time:54937ms step_avg:47.56ms
+step:1156/1845 train_time:54998ms step_avg:47.58ms
+step:1157/1845 train_time:55060ms step_avg:47.59ms
+step:1158/1845 train_time:55120ms step_avg:47.60ms
+step:1159/1845 train_time:55184ms step_avg:47.61ms
+step:1160/1845 train_time:55244ms step_avg:47.62ms
+step:1161/1845 train_time:55306ms step_avg:47.64ms
+step:1162/1845 train_time:55367ms step_avg:47.65ms
+step:1163/1845 train_time:55429ms step_avg:47.66ms
+step:1164/1845 train_time:55490ms step_avg:47.67ms
+step:1165/1845 train_time:55553ms step_avg:47.69ms
+step:1166/1845 train_time:55614ms step_avg:47.70ms
+step:1167/1845 train_time:55677ms step_avg:47.71ms
+step:1168/1845 train_time:55738ms step_avg:47.72ms
+step:1169/1845 train_time:55800ms step_avg:47.73ms
+step:1170/1845 train_time:55861ms step_avg:47.74ms
+step:1171/1845 train_time:55924ms step_avg:47.76ms
+step:1172/1845 train_time:55984ms step_avg:47.77ms
+step:1173/1845 train_time:56047ms step_avg:47.78ms
+step:1174/1845 train_time:56108ms step_avg:47.79ms
+step:1175/1845 train_time:56170ms step_avg:47.80ms
+step:1176/1845 train_time:56232ms step_avg:47.82ms
+step:1177/1845 train_time:56294ms step_avg:47.83ms
+step:1178/1845 train_time:56355ms step_avg:47.84ms
+step:1179/1845 train_time:56417ms step_avg:47.85ms
+step:1180/1845 train_time:56478ms step_avg:47.86ms
+step:1181/1845 train_time:56540ms step_avg:47.88ms
+step:1182/1845 train_time:56601ms step_avg:47.89ms
+step:1183/1845 train_time:56664ms step_avg:47.90ms
+step:1184/1845 train_time:56725ms step_avg:47.91ms
+step:1185/1845 train_time:56787ms step_avg:47.92ms
+step:1186/1845 train_time:56848ms step_avg:47.93ms
+step:1187/1845 train_time:56911ms step_avg:47.94ms
+step:1188/1845 train_time:56972ms step_avg:47.96ms
+step:1189/1845 train_time:57034ms step_avg:47.97ms
+step:1190/1845 train_time:57095ms step_avg:47.98ms
+step:1191/1845 train_time:57157ms step_avg:47.99ms
+step:1192/1845 train_time:57218ms step_avg:48.00ms
+step:1193/1845 train_time:57280ms step_avg:48.01ms
+step:1194/1845 train_time:57341ms step_avg:48.02ms
+step:1195/1845 train_time:57404ms step_avg:48.04ms
+step:1196/1845 train_time:57464ms step_avg:48.05ms
+step:1197/1845 train_time:57526ms step_avg:48.06ms
+step:1198/1845 train_time:57587ms step_avg:48.07ms
+step:1199/1845 train_time:57650ms step_avg:48.08ms
+step:1200/1845 train_time:57711ms step_avg:48.09ms
+step:1201/1845 train_time:57773ms step_avg:48.10ms
+step:1202/1845 train_time:57834ms step_avg:48.11ms
+step:1203/1845 train_time:57896ms step_avg:48.13ms
+step:1204/1845 train_time:57956ms step_avg:48.14ms
+step:1205/1845 train_time:58019ms step_avg:48.15ms
+step:1206/1845 train_time:58107ms step_avg:48.18ms
+step:1207/1845 train_time:58196ms step_avg:48.22ms
+step:1208/1845 train_time:58283ms step_avg:48.25ms
+step:1209/1845 train_time:58372ms step_avg:48.28ms
+step:1210/1845 train_time:58458ms step_avg:48.31ms
+step:1211/1845 train_time:58547ms step_avg:48.35ms
+step:1212/1845 train_time:58634ms step_avg:48.38ms
+step:1213/1845 train_time:58723ms step_avg:48.41ms
+step:1214/1845 train_time:58810ms step_avg:48.44ms
+step:1215/1845 train_time:58898ms step_avg:48.48ms
+step:1216/1845 train_time:58985ms step_avg:48.51ms
+step:1217/1845 train_time:59074ms step_avg:48.54ms
+step:1218/1845 train_time:59161ms step_avg:48.57ms
+step:1219/1845 train_time:59251ms step_avg:48.61ms
+step:1220/1845 train_time:59339ms step_avg:48.64ms
+step:1221/1845 train_time:59428ms step_avg:48.67ms
+step:1222/1845 train_time:59515ms step_avg:48.70ms
+step:1223/1845 train_time:59604ms step_avg:48.74ms
+step:1224/1845 train_time:59690ms step_avg:48.77ms
+step:1225/1845 train_time:59779ms step_avg:48.80ms
+step:1226/1845 train_time:59866ms step_avg:48.83ms
+step:1227/1845 train_time:59955ms step_avg:48.86ms
+step:1228/1845 train_time:60042ms step_avg:48.89ms
+step:1229/1845 train_time:60130ms step_avg:48.93ms
+step:1230/1845 train_time:60217ms step_avg:48.96ms
+step:1231/1845 train_time:60306ms step_avg:48.99ms
+step:1232/1845 train_time:60393ms step_avg:49.02ms
+step:1233/1845 train_time:60481ms step_avg:49.05ms
+step:1234/1845 train_time:60569ms step_avg:49.08ms
+step:1235/1845 train_time:60658ms step_avg:49.12ms
+step:1236/1845 train_time:60746ms step_avg:49.15ms
+step:1237/1845 train_time:60833ms step_avg:49.18ms
+step:1238/1845 train_time:60920ms step_avg:49.21ms
+step:1239/1845 train_time:61009ms step_avg:49.24ms
+step:1240/1845 train_time:61098ms step_avg:49.27ms
+step:1241/1845 train_time:61187ms step_avg:49.30ms
+step:1242/1845 train_time:61274ms step_avg:49.34ms
+step:1243/1845 train_time:61363ms step_avg:49.37ms
+step:1244/1845 train_time:61451ms step_avg:49.40ms
+step:1245/1845 train_time:61538ms step_avg:49.43ms
+step:1246/1845 train_time:61626ms step_avg:49.46ms
+step:1247/1845 train_time:61715ms step_avg:49.49ms
+step:1248/1845 train_time:61803ms step_avg:49.52ms
+step:1249/1845 train_time:61892ms step_avg:49.55ms
+step:1250/1845 train_time:61979ms step_avg:49.58ms
+step:1250/1845 val_loss:3.5358 train_time:62069ms step_avg:49.66ms
+step:1251/1845 train_time:62093ms step_avg:49.63ms
+step:1252/1845 train_time:62155ms step_avg:49.64ms
+step:1253/1845 train_time:62242ms step_avg:49.67ms
+step:1254/1845 train_time:62333ms step_avg:49.71ms
+step:1255/1845 train_time:62424ms step_avg:49.74ms
+step:1256/1845 train_time:62510ms step_avg:49.77ms
+step:1257/1845 train_time:62598ms step_avg:49.80ms
+step:1258/1845 train_time:62684ms step_avg:49.83ms
+step:1259/1845 train_time:62772ms step_avg:49.86ms
+step:1260/1845 train_time:62858ms step_avg:49.89ms
+step:1261/1845 train_time:62947ms step_avg:49.92ms
+step:1262/1845 train_time:63040ms step_avg:49.95ms
+step:1263/1845 train_time:63131ms step_avg:49.98ms
+step:1264/1845 train_time:63219ms step_avg:50.01ms
+step:1265/1845 train_time:63308ms step_avg:50.05ms
+step:1266/1845 train_time:63395ms step_avg:50.07ms
+step:1267/1845 train_time:63483ms step_avg:50.11ms
+step:1268/1845 train_time:63570ms step_avg:50.13ms
+step:1269/1845 train_time:63657ms step_avg:50.16ms
+step:1270/1845 train_time:63744ms step_avg:50.19ms
+step:1271/1845 train_time:63831ms step_avg:50.22ms
+step:1272/1845 train_time:63919ms step_avg:50.25ms
+step:1273/1845 train_time:64010ms step_avg:50.28ms
+step:1274/1845 train_time:64099ms step_avg:50.31ms
+step:1275/1845 train_time:64187ms step_avg:50.34ms
+step:1276/1845 train_time:64275ms step_avg:50.37ms
+step:1277/1845 train_time:64364ms step_avg:50.40ms
+step:1278/1845 train_time:64451ms step_avg:50.43ms
+step:1279/1845 train_time:64538ms step_avg:50.46ms
+step:1280/1845 train_time:64625ms step_avg:50.49ms
+step:1281/1845 train_time:64713ms step_avg:50.52ms
+step:1282/1845 train_time:64800ms step_avg:50.55ms
+step:1283/1845 train_time:64889ms step_avg:50.58ms
+step:1284/1845 train_time:64977ms step_avg:50.60ms
+step:1285/1845 train_time:65067ms step_avg:50.64ms
+step:1286/1845 train_time:65154ms step_avg:50.66ms
+step:1287/1845 train_time:65244ms step_avg:50.69ms
+step:1288/1845 train_time:65331ms step_avg:50.72ms
+step:1289/1845 train_time:65420ms step_avg:50.75ms
+step:1290/1845 train_time:65507ms step_avg:50.78ms
+step:1291/1845 train_time:65595ms step_avg:50.81ms
+step:1292/1845 train_time:65682ms step_avg:50.84ms
+step:1293/1845 train_time:65770ms step_avg:50.87ms
+step:1294/1845 train_time:65857ms step_avg:50.89ms
+step:1295/1845 train_time:65947ms step_avg:50.92ms
+step:1296/1845 train_time:66034ms step_avg:50.95ms
+step:1297/1845 train_time:66123ms step_avg:50.98ms
+step:1298/1845 train_time:66212ms step_avg:51.01ms
+step:1299/1845 train_time:66302ms step_avg:51.04ms
+step:1300/1845 train_time:66389ms step_avg:51.07ms
+step:1301/1845 train_time:66476ms step_avg:51.10ms
+step:1302/1845 train_time:66564ms step_avg:51.12ms
+step:1303/1845 train_time:66652ms step_avg:51.15ms
+step:1304/1845 train_time:66740ms step_avg:51.18ms
+step:1305/1845 train_time:66828ms step_avg:51.21ms
+step:1306/1845 train_time:66914ms step_avg:51.24ms
+step:1307/1845 train_time:67003ms step_avg:51.27ms
+step:1308/1845 train_time:67091ms step_avg:51.29ms
+step:1309/1845 train_time:67180ms step_avg:51.32ms
+step:1310/1845 train_time:67268ms step_avg:51.35ms
+step:1311/1845 train_time:67357ms step_avg:51.38ms
+step:1312/1845 train_time:67446ms step_avg:51.41ms
+step:1313/1845 train_time:67533ms step_avg:51.43ms
+step:1314/1845 train_time:67619ms step_avg:51.46ms
+step:1315/1845 train_time:67708ms step_avg:51.49ms
+step:1316/1845 train_time:67795ms step_avg:51.52ms
+step:1317/1845 train_time:67883ms step_avg:51.54ms
+step:1318/1845 train_time:67970ms step_avg:51.57ms
+step:1319/1845 train_time:68059ms step_avg:51.60ms
+step:1320/1845 train_time:68148ms step_avg:51.63ms
+step:1321/1845 train_time:68237ms step_avg:51.66ms
+step:1322/1845 train_time:68325ms step_avg:51.68ms
+step:1323/1845 train_time:68414ms step_avg:51.71ms
+step:1324/1845 train_time:68500ms step_avg:51.74ms
+step:1325/1845 train_time:68588ms step_avg:51.76ms
+step:1326/1845 train_time:68675ms step_avg:51.79ms
+step:1327/1845 train_time:68764ms step_avg:51.82ms
+step:1328/1845 train_time:68851ms step_avg:51.85ms
+step:1329/1845 train_time:68939ms step_avg:51.87ms
+step:1330/1845 train_time:69027ms step_avg:51.90ms
+step:1331/1845 train_time:69116ms step_avg:51.93ms
+step:1332/1845 train_time:69205ms step_avg:51.96ms
+step:1333/1845 train_time:69293ms step_avg:51.98ms
+step:1334/1845 train_time:69381ms step_avg:52.01ms
+step:1335/1845 train_time:69470ms step_avg:52.04ms
+step:1336/1845 train_time:69557ms step_avg:52.06ms
+step:1337/1845 train_time:69645ms step_avg:52.09ms
+step:1338/1845 train_time:69732ms step_avg:52.12ms
+step:1339/1845 train_time:69822ms step_avg:52.14ms
+step:1340/1845 train_time:69909ms step_avg:52.17ms
+step:1341/1845 train_time:69997ms step_avg:52.20ms
+step:1342/1845 train_time:70086ms step_avg:52.23ms
+step:1343/1845 train_time:70176ms step_avg:52.25ms
+step:1344/1845 train_time:70262ms step_avg:52.28ms
+step:1345/1845 train_time:70352ms step_avg:52.31ms
+step:1346/1845 train_time:70439ms step_avg:52.33ms
+step:1347/1845 train_time:70529ms step_avg:52.36ms
+step:1348/1845 train_time:70617ms step_avg:52.39ms
+step:1349/1845 train_time:70704ms step_avg:52.41ms
+step:1350/1845 train_time:70791ms step_avg:52.44ms
+step:1351/1845 train_time:70880ms step_avg:52.46ms
+step:1352/1845 train_time:70968ms step_avg:52.49ms
+step:1353/1845 train_time:71055ms step_avg:52.52ms
+step:1354/1845 train_time:71143ms step_avg:52.54ms
+step:1355/1845 train_time:71231ms step_avg:52.57ms
+step:1356/1845 train_time:71319ms step_avg:52.59ms
+step:1357/1845 train_time:71408ms step_avg:52.62ms
+step:1358/1845 train_time:71495ms step_avg:52.65ms
+step:1359/1845 train_time:71584ms step_avg:52.67ms
+step:1360/1845 train_time:71670ms step_avg:52.70ms
+step:1361/1845 train_time:71759ms step_avg:52.73ms
+step:1362/1845 train_time:71846ms step_avg:52.75ms
+step:1363/1845 train_time:71934ms step_avg:52.78ms
+step:1364/1845 train_time:72022ms step_avg:52.80ms
+step:1365/1845 train_time:72111ms step_avg:52.83ms
+step:1366/1845 train_time:72198ms step_avg:52.85ms
+step:1367/1845 train_time:72287ms step_avg:52.88ms
+step:1368/1845 train_time:72374ms step_avg:52.90ms
+step:1369/1845 train_time:72462ms step_avg:52.93ms
+step:1370/1845 train_time:72550ms step_avg:52.96ms
+step:1371/1845 train_time:72639ms step_avg:52.98ms
+step:1372/1845 train_time:72727ms step_avg:53.01ms
+step:1373/1845 train_time:72815ms step_avg:53.03ms
+step:1374/1845 train_time:72902ms step_avg:53.06ms
+step:1375/1845 train_time:72990ms step_avg:53.08ms
+step:1376/1845 train_time:73078ms step_avg:53.11ms
+step:1377/1845 train_time:73166ms step_avg:53.13ms
+step:1378/1845 train_time:73254ms step_avg:53.16ms
+step:1379/1845 train_time:73342ms step_avg:53.19ms
+step:1380/1845 train_time:73429ms step_avg:53.21ms
+step:1381/1845 train_time:73518ms step_avg:53.24ms
+step:1382/1845 train_time:73606ms step_avg:53.26ms
+step:1383/1845 train_time:73695ms step_avg:53.29ms
+step:1384/1845 train_time:73782ms step_avg:53.31ms
+step:1385/1845 train_time:73870ms step_avg:53.34ms
+step:1386/1845 train_time:73957ms step_avg:53.36ms
+step:1387/1845 train_time:74046ms step_avg:53.39ms
+step:1388/1845 train_time:74133ms step_avg:53.41ms
+step:1389/1845 train_time:74222ms step_avg:53.44ms
+step:1390/1845 train_time:74309ms step_avg:53.46ms
+step:1391/1845 train_time:74398ms step_avg:53.49ms
+step:1392/1845 train_time:74485ms step_avg:53.51ms
+step:1393/1845 train_time:74575ms step_avg:53.54ms
+step:1394/1845 train_time:74661ms step_avg:53.56ms
+step:1395/1845 train_time:74750ms step_avg:53.58ms
+step:1396/1845 train_time:74838ms step_avg:53.61ms
+step:1397/1845 train_time:74926ms step_avg:53.63ms
+step:1398/1845 train_time:75013ms step_avg:53.66ms
+step:1399/1845 train_time:75102ms step_avg:53.68ms
+step:1400/1845 train_time:75189ms step_avg:53.71ms
+step:1401/1845 train_time:75278ms step_avg:53.73ms
+step:1402/1845 train_time:75365ms step_avg:53.76ms
+step:1403/1845 train_time:75453ms step_avg:53.78ms
+step:1404/1845 train_time:75541ms step_avg:53.80ms
+step:1405/1845 train_time:75629ms step_avg:53.83ms
+step:1406/1845 train_time:75717ms step_avg:53.85ms
+step:1407/1845 train_time:75806ms step_avg:53.88ms
+step:1408/1845 train_time:75893ms step_avg:53.90ms
+step:1409/1845 train_time:75982ms step_avg:53.93ms
+step:1410/1845 train_time:76069ms step_avg:53.95ms
+step:1411/1845 train_time:76157ms step_avg:53.97ms
+step:1412/1845 train_time:76245ms step_avg:54.00ms
+step:1413/1845 train_time:76334ms step_avg:54.02ms
+step:1414/1845 train_time:76421ms step_avg:54.05ms
+step:1415/1845 train_time:76511ms step_avg:54.07ms
+step:1416/1845 train_time:76598ms step_avg:54.09ms
+step:1417/1845 train_time:76685ms step_avg:54.12ms
+step:1418/1845 train_time:76772ms step_avg:54.14ms
+step:1419/1845 train_time:76860ms step_avg:54.17ms
+step:1420/1845 train_time:76948ms step_avg:54.19ms
+step:1421/1845 train_time:77036ms step_avg:54.21ms
+step:1422/1845 train_time:77124ms step_avg:54.24ms
+step:1423/1845 train_time:77211ms step_avg:54.26ms
+step:1424/1845 train_time:77299ms step_avg:54.28ms
+step:1425/1845 train_time:77387ms step_avg:54.31ms
+step:1426/1845 train_time:77474ms step_avg:54.33ms
+step:1427/1845 train_time:77562ms step_avg:54.35ms
+step:1428/1845 train_time:77650ms step_avg:54.38ms
+step:1429/1845 train_time:77738ms step_avg:54.40ms
+step:1430/1845 train_time:77825ms step_avg:54.42ms
+step:1431/1845 train_time:77914ms step_avg:54.45ms
+step:1432/1845 train_time:78001ms step_avg:54.47ms
+step:1433/1845 train_time:78089ms step_avg:54.49ms
+step:1434/1845 train_time:78177ms step_avg:54.52ms
+step:1435/1845 train_time:78266ms step_avg:54.54ms
+step:1436/1845 train_time:78353ms step_avg:54.56ms
+step:1437/1845 train_time:78441ms step_avg:54.59ms
+step:1438/1845 train_time:78529ms step_avg:54.61ms
+step:1439/1845 train_time:78617ms step_avg:54.63ms
+step:1440/1845 train_time:78705ms step_avg:54.66ms
+step:1441/1845 train_time:78793ms step_avg:54.68ms
+step:1442/1845 train_time:78880ms step_avg:54.70ms
+step:1443/1845 train_time:78969ms step_avg:54.73ms
+step:1444/1845 train_time:79056ms step_avg:54.75ms
+step:1445/1845 train_time:79144ms step_avg:54.77ms
+step:1446/1845 train_time:79232ms step_avg:54.79ms
+step:1447/1845 train_time:79321ms step_avg:54.82ms
+step:1448/1845 train_time:79409ms step_avg:54.84ms
+step:1449/1845 train_time:79496ms step_avg:54.86ms
+step:1450/1845 train_time:79583ms step_avg:54.88ms
+step:1451/1845 train_time:79672ms step_avg:54.91ms
+step:1452/1845 train_time:79760ms step_avg:54.93ms
+step:1453/1845 train_time:79848ms step_avg:54.95ms
+step:1454/1845 train_time:79936ms step_avg:54.98ms
+step:1455/1845 train_time:80024ms step_avg:55.00ms
+step:1456/1845 train_time:80111ms step_avg:55.02ms
+step:1457/1845 train_time:80199ms step_avg:55.04ms
+step:1458/1845 train_time:80287ms step_avg:55.07ms
+step:1459/1845 train_time:80375ms step_avg:55.09ms
+step:1460/1845 train_time:80463ms step_avg:55.11ms
+step:1461/1845 train_time:80552ms step_avg:55.13ms
+step:1462/1845 train_time:80639ms step_avg:55.16ms
+step:1463/1845 train_time:80728ms step_avg:55.18ms
+step:1464/1845 train_time:80814ms step_avg:55.20ms
+step:1465/1845 train_time:80902ms step_avg:55.22ms
+step:1466/1845 train_time:80989ms step_avg:55.24ms
+step:1467/1845 train_time:81078ms step_avg:55.27ms
+step:1468/1845 train_time:81165ms step_avg:55.29ms
+step:1469/1845 train_time:81253ms step_avg:55.31ms
+step:1470/1845 train_time:81340ms step_avg:55.33ms
+step:1471/1845 train_time:81429ms step_avg:55.36ms
+step:1472/1845 train_time:81517ms step_avg:55.38ms
+step:1473/1845 train_time:81605ms step_avg:55.40ms
+step:1474/1845 train_time:81693ms step_avg:55.42ms
+step:1475/1845 train_time:81782ms step_avg:55.45ms
+step:1476/1845 train_time:81868ms step_avg:55.47ms
+step:1477/1845 train_time:81957ms step_avg:55.49ms
+step:1478/1845 train_time:82045ms step_avg:55.51ms
+step:1479/1845 train_time:82132ms step_avg:55.53ms
+step:1480/1845 train_time:82219ms step_avg:55.55ms
+step:1481/1845 train_time:82308ms step_avg:55.58ms
+step:1482/1845 train_time:82395ms step_avg:55.60ms
+step:1483/1845 train_time:82484ms step_avg:55.62ms
+step:1484/1845 train_time:82571ms step_avg:55.64ms
+step:1485/1845 train_time:82660ms step_avg:55.66ms
+step:1486/1845 train_time:82747ms step_avg:55.68ms
+step:1487/1845 train_time:82836ms step_avg:55.71ms
+step:1488/1845 train_time:82923ms step_avg:55.73ms
+step:1489/1845 train_time:83012ms step_avg:55.75ms
+step:1490/1845 train_time:83099ms step_avg:55.77ms
+step:1491/1845 train_time:83188ms step_avg:55.79ms
+step:1492/1845 train_time:83275ms step_avg:55.81ms
+step:1493/1845 train_time:83363ms step_avg:55.84ms
+step:1494/1845 train_time:83450ms step_avg:55.86ms
+step:1495/1845 train_time:83538ms step_avg:55.88ms
+step:1496/1845 train_time:83625ms step_avg:55.90ms
+step:1497/1845 train_time:83714ms step_avg:55.92ms
+step:1498/1845 train_time:83801ms step_avg:55.94ms
+step:1499/1845 train_time:83889ms step_avg:55.96ms
+step:1500/1845 train_time:83977ms step_avg:55.98ms
+step:1500/1845 val_loss:3.4051 train_time:84066ms step_avg:56.04ms
+step:1501/1845 train_time:84090ms step_avg:56.02ms
+step:1502/1845 train_time:84155ms step_avg:56.03ms
+step:1503/1845 train_time:84247ms step_avg:56.05ms
+step:1504/1845 train_time:84335ms step_avg:56.07ms
+step:1505/1845 train_time:84423ms step_avg:56.09ms
+step:1506/1845 train_time:84510ms step_avg:56.12ms
+step:1507/1845 train_time:84598ms step_avg:56.14ms
+step:1508/1845 train_time:84684ms step_avg:56.16ms
+step:1509/1845 train_time:84772ms step_avg:56.18ms
+step:1510/1845 train_time:84859ms step_avg:56.20ms
+step:1511/1845 train_time:84947ms step_avg:56.22ms
+step:1512/1845 train_time:85035ms step_avg:56.24ms
+step:1513/1845 train_time:85125ms step_avg:56.26ms
+step:1514/1845 train_time:85214ms step_avg:56.28ms
+step:1515/1845 train_time:85303ms step_avg:56.31ms
+step:1516/1845 train_time:85392ms step_avg:56.33ms
+step:1517/1845 train_time:85480ms step_avg:56.35ms
+step:1518/1845 train_time:85568ms step_avg:56.37ms
+step:1519/1845 train_time:85655ms step_avg:56.39ms
+step:1520/1845 train_time:85742ms step_avg:56.41ms
+step:1521/1845 train_time:85830ms step_avg:56.43ms
+step:1522/1845 train_time:85916ms step_avg:56.45ms
+step:1523/1845 train_time:86004ms step_avg:56.47ms
+step:1524/1845 train_time:86092ms step_avg:56.49ms
+step:1525/1845 train_time:86182ms step_avg:56.51ms
+step:1526/1845 train_time:86269ms step_avg:56.53ms
+step:1527/1845 train_time:86358ms step_avg:56.55ms
+step:1528/1845 train_time:86446ms step_avg:56.57ms
+step:1529/1845 train_time:86535ms step_avg:56.60ms
+step:1530/1845 train_time:86621ms step_avg:56.62ms
+step:1531/1845 train_time:86710ms step_avg:56.64ms
+step:1532/1845 train_time:86796ms step_avg:56.66ms
+step:1533/1845 train_time:86884ms step_avg:56.68ms
+step:1534/1845 train_time:86972ms step_avg:56.70ms
+step:1535/1845 train_time:87060ms step_avg:56.72ms
+step:1536/1845 train_time:87150ms step_avg:56.74ms
+step:1537/1845 train_time:87238ms step_avg:56.76ms
+step:1538/1845 train_time:87326ms step_avg:56.78ms
+step:1539/1845 train_time:87415ms step_avg:56.80ms
+step:1540/1845 train_time:87502ms step_avg:56.82ms
+step:1541/1845 train_time:87591ms step_avg:56.84ms
+step:1542/1845 train_time:87679ms step_avg:56.86ms
+step:1543/1845 train_time:87767ms step_avg:56.88ms
+step:1544/1845 train_time:87853ms step_avg:56.90ms
+step:1545/1845 train_time:87940ms step_avg:56.92ms
+step:1546/1845 train_time:88029ms step_avg:56.94ms
+step:1547/1845 train_time:88117ms step_avg:56.96ms
+step:1548/1845 train_time:88205ms step_avg:56.98ms
+step:1549/1845 train_time:88295ms step_avg:57.00ms
+step:1550/1845 train_time:88383ms step_avg:57.02ms
+step:1551/1845 train_time:88472ms step_avg:57.04ms
+step:1552/1845 train_time:88559ms step_avg:57.06ms
+step:1553/1845 train_time:88648ms step_avg:57.08ms
+step:1554/1845 train_time:88735ms step_avg:57.10ms
+step:1555/1845 train_time:88823ms step_avg:57.12ms
+step:1556/1845 train_time:88910ms step_avg:57.14ms
+step:1557/1845 train_time:89000ms step_avg:57.16ms
+step:1558/1845 train_time:89088ms step_avg:57.18ms
+step:1559/1845 train_time:89177ms step_avg:57.20ms
+step:1560/1845 train_time:89265ms step_avg:57.22ms
+step:1561/1845 train_time:89355ms step_avg:57.24ms
+step:1562/1845 train_time:89443ms step_avg:57.26ms
+step:1563/1845 train_time:89532ms step_avg:57.28ms
+step:1564/1845 train_time:89620ms step_avg:57.30ms
+step:1565/1845 train_time:89709ms step_avg:57.32ms
+step:1566/1845 train_time:89796ms step_avg:57.34ms
+step:1567/1845 train_time:89886ms step_avg:57.36ms
+step:1568/1845 train_time:89973ms step_avg:57.38ms
+step:1569/1845 train_time:90063ms step_avg:57.40ms
+step:1570/1845 train_time:90150ms step_avg:57.42ms
+step:1571/1845 train_time:90239ms step_avg:57.44ms
+step:1572/1845 train_time:90327ms step_avg:57.46ms
+step:1573/1845 train_time:90416ms step_avg:57.48ms
+step:1574/1845 train_time:90504ms step_avg:57.50ms
+step:1575/1845 train_time:90593ms step_avg:57.52ms
+step:1576/1845 train_time:90680ms step_avg:57.54ms
+step:1577/1845 train_time:90769ms step_avg:57.56ms
+step:1578/1845 train_time:90856ms step_avg:57.58ms
+step:1579/1845 train_time:90944ms step_avg:57.60ms
+step:1580/1845 train_time:91031ms step_avg:57.61ms
+step:1581/1845 train_time:91119ms step_avg:57.63ms
+step:1582/1845 train_time:91207ms step_avg:57.65ms
+step:1583/1845 train_time:91296ms step_avg:57.67ms
+step:1584/1845 train_time:91383ms step_avg:57.69ms
+step:1585/1845 train_time:91472ms step_avg:57.71ms
+step:1586/1845 train_time:91559ms step_avg:57.73ms
+step:1587/1845 train_time:91647ms step_avg:57.75ms
+step:1588/1845 train_time:91734ms step_avg:57.77ms
+step:1589/1845 train_time:91823ms step_avg:57.79ms
+step:1590/1845 train_time:91911ms step_avg:57.81ms
+step:1591/1845 train_time:91999ms step_avg:57.82ms
+step:1592/1845 train_time:92087ms step_avg:57.84ms
+step:1593/1845 train_time:92176ms step_avg:57.86ms
+step:1594/1845 train_time:92263ms step_avg:57.88ms
+step:1595/1845 train_time:92352ms step_avg:57.90ms
+step:1596/1845 train_time:92440ms step_avg:57.92ms
+step:1597/1845 train_time:92529ms step_avg:57.94ms
+step:1598/1845 train_time:92616ms step_avg:57.96ms
+step:1599/1845 train_time:92705ms step_avg:57.98ms
+step:1600/1845 train_time:92792ms step_avg:57.99ms
+step:1601/1845 train_time:92880ms step_avg:58.01ms
+step:1602/1845 train_time:92967ms step_avg:58.03ms
+step:1603/1845 train_time:93055ms step_avg:58.05ms
+step:1604/1845 train_time:93143ms step_avg:58.07ms
+step:1605/1845 train_time:93232ms step_avg:58.09ms
+step:1606/1845 train_time:93320ms step_avg:58.11ms
+step:1607/1845 train_time:93409ms step_avg:58.13ms
+step:1608/1845 train_time:93496ms step_avg:58.14ms
+step:1609/1845 train_time:93587ms step_avg:58.16ms
+step:1610/1845 train_time:93674ms step_avg:58.18ms
+step:1611/1845 train_time:93762ms step_avg:58.20ms
+step:1612/1845 train_time:93850ms step_avg:58.22ms
+step:1613/1845 train_time:93938ms step_avg:58.24ms
+step:1614/1845 train_time:94025ms step_avg:58.26ms
+step:1615/1845 train_time:94114ms step_avg:58.27ms
+step:1616/1845 train_time:94201ms step_avg:58.29ms
+step:1617/1845 train_time:94291ms step_avg:58.31ms
+step:1618/1845 train_time:94378ms step_avg:58.33ms
+step:1619/1845 train_time:94468ms step_avg:58.35ms
+step:1620/1845 train_time:94554ms step_avg:58.37ms
+step:1621/1845 train_time:94644ms step_avg:58.39ms
+step:1622/1845 train_time:94731ms step_avg:58.40ms
+step:1623/1845 train_time:94819ms step_avg:58.42ms
+step:1624/1845 train_time:94906ms step_avg:58.44ms
+step:1625/1845 train_time:94994ms step_avg:58.46ms
+step:1626/1845 train_time:95081ms step_avg:58.48ms
+step:1627/1845 train_time:95170ms step_avg:58.49ms
+step:1628/1845 train_time:95257ms step_avg:58.51ms
+step:1629/1845 train_time:95345ms step_avg:58.53ms
+step:1630/1845 train_time:95432ms step_avg:58.55ms
+step:1631/1845 train_time:95521ms step_avg:58.57ms
+step:1632/1845 train_time:95609ms step_avg:58.58ms
+step:1633/1845 train_time:95697ms step_avg:58.60ms
+step:1634/1845 train_time:95785ms step_avg:58.62ms
+step:1635/1845 train_time:95873ms step_avg:58.64ms
+step:1636/1845 train_time:95961ms step_avg:58.66ms
+step:1637/1845 train_time:96049ms step_avg:58.67ms
+step:1638/1845 train_time:96135ms step_avg:58.69ms
+step:1639/1845 train_time:96223ms step_avg:58.71ms
+step:1640/1845 train_time:96311ms step_avg:58.73ms
+step:1641/1845 train_time:96401ms step_avg:58.75ms
+step:1642/1845 train_time:96489ms step_avg:58.76ms
+step:1643/1845 train_time:96578ms step_avg:58.78ms
+step:1644/1845 train_time:96665ms step_avg:58.80ms
+step:1645/1845 train_time:96754ms step_avg:58.82ms
+step:1646/1845 train_time:96842ms step_avg:58.83ms
+step:1647/1845 train_time:96930ms step_avg:58.85ms
+step:1648/1845 train_time:97017ms step_avg:58.87ms
+step:1649/1845 train_time:97105ms step_avg:58.89ms
+step:1650/1845 train_time:97193ms step_avg:58.90ms
+step:1651/1845 train_time:97282ms step_avg:58.92ms
+step:1652/1845 train_time:97369ms step_avg:58.94ms
+step:1653/1845 train_time:97458ms step_avg:58.96ms
+step:1654/1845 train_time:97547ms step_avg:58.98ms
+step:1655/1845 train_time:97634ms step_avg:58.99ms
+step:1656/1845 train_time:97722ms step_avg:59.01ms
+step:1657/1845 train_time:97811ms step_avg:59.03ms
+step:1658/1845 train_time:97898ms step_avg:59.05ms
+step:1659/1845 train_time:97987ms step_avg:59.06ms
+step:1660/1845 train_time:98075ms step_avg:59.08ms
+step:1661/1845 train_time:98163ms step_avg:59.10ms
+step:1662/1845 train_time:98252ms step_avg:59.12ms
+step:1663/1845 train_time:98339ms step_avg:59.13ms
+step:1664/1845 train_time:98427ms step_avg:59.15ms
+step:1665/1845 train_time:98514ms step_avg:59.17ms
+step:1666/1845 train_time:98601ms step_avg:59.18ms
+step:1667/1845 train_time:98690ms step_avg:59.20ms
+step:1668/1845 train_time:98778ms step_avg:59.22ms
+step:1669/1845 train_time:98866ms step_avg:59.24ms
+step:1670/1845 train_time:98953ms step_avg:59.25ms
+step:1671/1845 train_time:99042ms step_avg:59.27ms
+step:1672/1845 train_time:99129ms step_avg:59.29ms
+step:1673/1845 train_time:99218ms step_avg:59.31ms
+step:1674/1845 train_time:99305ms step_avg:59.32ms
+step:1675/1845 train_time:99393ms step_avg:59.34ms
+step:1676/1845 train_time:99480ms step_avg:59.36ms
+step:1677/1845 train_time:99570ms step_avg:59.37ms
+step:1678/1845 train_time:99656ms step_avg:59.39ms
+step:1679/1845 train_time:99745ms step_avg:59.41ms
+step:1680/1845 train_time:99833ms step_avg:59.42ms
+step:1681/1845 train_time:99921ms step_avg:59.44ms
+step:1682/1845 train_time:100008ms step_avg:59.46ms
+step:1683/1845 train_time:100097ms step_avg:59.48ms
+step:1684/1845 train_time:100184ms step_avg:59.49ms
+step:1685/1845 train_time:100272ms step_avg:59.51ms
+step:1686/1845 train_time:100360ms step_avg:59.53ms
+step:1687/1845 train_time:100450ms step_avg:59.54ms
+step:1688/1845 train_time:100536ms step_avg:59.56ms
+step:1689/1845 train_time:100626ms step_avg:59.58ms
+step:1690/1845 train_time:100713ms step_avg:59.59ms
+step:1691/1845 train_time:100802ms step_avg:59.61ms
+step:1692/1845 train_time:100889ms step_avg:59.63ms
+step:1693/1845 train_time:100977ms step_avg:59.64ms
+step:1694/1845 train_time:101064ms step_avg:59.66ms
+step:1695/1845 train_time:101153ms step_avg:59.68ms
+step:1696/1845 train_time:101240ms step_avg:59.69ms
+step:1697/1845 train_time:101329ms step_avg:59.71ms
+step:1698/1845 train_time:101417ms step_avg:59.73ms
+step:1699/1845 train_time:101505ms step_avg:59.74ms
+step:1700/1845 train_time:101593ms step_avg:59.76ms
+step:1701/1845 train_time:101681ms step_avg:59.78ms
+step:1702/1845 train_time:101768ms step_avg:59.79ms
+step:1703/1845 train_time:101857ms step_avg:59.81ms
+step:1704/1845 train_time:101944ms step_avg:59.83ms
+step:1705/1845 train_time:102033ms step_avg:59.84ms
+step:1706/1845 train_time:102120ms step_avg:59.86ms
+step:1707/1845 train_time:102210ms step_avg:59.88ms
+step:1708/1845 train_time:102298ms step_avg:59.89ms
+step:1709/1845 train_time:102387ms step_avg:59.91ms
+step:1710/1845 train_time:102475ms step_avg:59.93ms
+step:1711/1845 train_time:102563ms step_avg:59.94ms
+step:1712/1845 train_time:102650ms step_avg:59.96ms
+step:1713/1845 train_time:102738ms step_avg:59.98ms
+step:1714/1845 train_time:102825ms step_avg:59.99ms
+step:1715/1845 train_time:102915ms step_avg:60.01ms
+step:1716/1845 train_time:103002ms step_avg:60.02ms
+step:1717/1845 train_time:103091ms step_avg:60.04ms
+step:1718/1845 train_time:103178ms step_avg:60.06ms
+step:1719/1845 train_time:103267ms step_avg:60.07ms
+step:1720/1845 train_time:103354ms step_avg:60.09ms
+step:1721/1845 train_time:103443ms step_avg:60.11ms
+step:1722/1845 train_time:103530ms step_avg:60.12ms
+step:1723/1845 train_time:103620ms step_avg:60.14ms
+step:1724/1845 train_time:103708ms step_avg:60.16ms
+step:1725/1845 train_time:103797ms step_avg:60.17ms
+step:1726/1845 train_time:103885ms step_avg:60.19ms
+step:1727/1845 train_time:103973ms step_avg:60.20ms
+step:1728/1845 train_time:104060ms step_avg:60.22ms
+step:1729/1845 train_time:104148ms step_avg:60.24ms
+step:1730/1845 train_time:104235ms step_avg:60.25ms
+step:1731/1845 train_time:104325ms step_avg:60.27ms
+step:1732/1845 train_time:104412ms step_avg:60.28ms
+step:1733/1845 train_time:104500ms step_avg:60.30ms
+step:1734/1845 train_time:104588ms step_avg:60.32ms
+step:1735/1845 train_time:104676ms step_avg:60.33ms
+step:1736/1845 train_time:104764ms step_avg:60.35ms
+step:1737/1845 train_time:104853ms step_avg:60.36ms
+step:1738/1845 train_time:104940ms step_avg:60.38ms
+step:1739/1845 train_time:105029ms step_avg:60.40ms
+step:1740/1845 train_time:105115ms step_avg:60.41ms
+step:1741/1845 train_time:105204ms step_avg:60.43ms
+step:1742/1845 train_time:105291ms step_avg:60.44ms
+step:1743/1845 train_time:105379ms step_avg:60.46ms
+step:1744/1845 train_time:105468ms step_avg:60.47ms
+step:1745/1845 train_time:105555ms step_avg:60.49ms
+step:1746/1845 train_time:105643ms step_avg:60.51ms
+step:1747/1845 train_time:105731ms step_avg:60.52ms
+step:1748/1845 train_time:105818ms step_avg:60.54ms
+step:1749/1845 train_time:105907ms step_avg:60.55ms
+step:1750/1845 train_time:105994ms step_avg:60.57ms
+step:1750/1845 val_loss:3.3063 train_time:106084ms step_avg:60.62ms
+step:1751/1845 train_time:106104ms step_avg:60.60ms
+step:1752/1845 train_time:106175ms step_avg:60.60ms
+step:1753/1845 train_time:106265ms step_avg:60.62ms
+step:1754/1845 train_time:106352ms step_avg:60.63ms
+step:1755/1845 train_time:106441ms step_avg:60.65ms
+step:1756/1845 train_time:106528ms step_avg:60.66ms
+step:1757/1845 train_time:106615ms step_avg:60.68ms
+step:1758/1845 train_time:106701ms step_avg:60.69ms
+step:1759/1845 train_time:106789ms step_avg:60.71ms
+step:1760/1845 train_time:106875ms step_avg:60.72ms
+step:1761/1845 train_time:106963ms step_avg:60.74ms
+step:1762/1845 train_time:107051ms step_avg:60.76ms
+step:1763/1845 train_time:107143ms step_avg:60.77ms
+step:1764/1845 train_time:107232ms step_avg:60.79ms
+step:1765/1845 train_time:107321ms step_avg:60.81ms
+step:1766/1845 train_time:107408ms step_avg:60.82ms
+step:1767/1845 train_time:107497ms step_avg:60.84ms
+step:1768/1845 train_time:107583ms step_avg:60.85ms
+step:1769/1845 train_time:107671ms step_avg:60.87ms
+step:1770/1845 train_time:107756ms step_avg:60.88ms
+step:1771/1845 train_time:107845ms step_avg:60.89ms
+step:1772/1845 train_time:107932ms step_avg:60.91ms
+step:1773/1845 train_time:108020ms step_avg:60.93ms
+step:1774/1845 train_time:108108ms step_avg:60.94ms
+step:1775/1845 train_time:108199ms step_avg:60.96ms
+step:1776/1845 train_time:108287ms step_avg:60.97ms
+step:1777/1845 train_time:108376ms step_avg:60.99ms
+step:1778/1845 train_time:108463ms step_avg:61.00ms
+step:1779/1845 train_time:108551ms step_avg:61.02ms
+step:1780/1845 train_time:108637ms step_avg:61.03ms
+step:1781/1845 train_time:108726ms step_avg:61.05ms
+step:1782/1845 train_time:108814ms step_avg:61.06ms
+step:1783/1845 train_time:108902ms step_avg:61.08ms
+step:1784/1845 train_time:108989ms step_avg:61.09ms
+step:1785/1845 train_time:109078ms step_avg:61.11ms
+step:1786/1845 train_time:109167ms step_avg:61.12ms
+step:1787/1845 train_time:109257ms step_avg:61.14ms
+step:1788/1845 train_time:109344ms step_avg:61.15ms
+step:1789/1845 train_time:109433ms step_avg:61.17ms
+step:1790/1845 train_time:109520ms step_avg:61.18ms
+step:1791/1845 train_time:109608ms step_avg:61.20ms
+step:1792/1845 train_time:109695ms step_avg:61.21ms
+step:1793/1845 train_time:109783ms step_avg:61.23ms
+step:1794/1845 train_time:109870ms step_avg:61.24ms
+step:1795/1845 train_time:109959ms step_avg:61.26ms
+step:1796/1845 train_time:110046ms step_avg:61.27ms
+step:1797/1845 train_time:110136ms step_avg:61.29ms
+step:1798/1845 train_time:110224ms step_avg:61.30ms
+step:1799/1845 train_time:110314ms step_avg:61.32ms
+step:1800/1845 train_time:110401ms step_avg:61.33ms
+step:1801/1845 train_time:110491ms step_avg:61.35ms
+step:1802/1845 train_time:110578ms step_avg:61.36ms
+step:1803/1845 train_time:110666ms step_avg:61.38ms
+step:1804/1845 train_time:110753ms step_avg:61.39ms
+step:1805/1845 train_time:110841ms step_avg:61.41ms
+step:1806/1845 train_time:110928ms step_avg:61.42ms
+step:1807/1845 train_time:111017ms step_avg:61.44ms
+step:1808/1845 train_time:111105ms step_avg:61.45ms
+step:1809/1845 train_time:111196ms step_avg:61.47ms
+step:1810/1845 train_time:111283ms step_avg:61.48ms
+step:1811/1845 train_time:111372ms step_avg:61.50ms
+step:1812/1845 train_time:111459ms step_avg:61.51ms
+step:1813/1845 train_time:111548ms step_avg:61.53ms
+step:1814/1845 train_time:111635ms step_avg:61.54ms
+step:1815/1845 train_time:111724ms step_avg:61.56ms
+step:1816/1845 train_time:111812ms step_avg:61.57ms
+step:1817/1845 train_time:111900ms step_avg:61.59ms
+step:1818/1845 train_time:111987ms step_avg:61.60ms
+step:1819/1845 train_time:112076ms step_avg:61.61ms
+step:1820/1845 train_time:112165ms step_avg:61.63ms
+step:1821/1845 train_time:112255ms step_avg:61.64ms
+step:1822/1845 train_time:112343ms step_avg:61.66ms
+step:1823/1845 train_time:112432ms step_avg:61.67ms
+step:1824/1845 train_time:112518ms step_avg:61.69ms
+step:1825/1845 train_time:112608ms step_avg:61.70ms
+step:1826/1845 train_time:112696ms step_avg:61.72ms
+step:1827/1845 train_time:112784ms step_avg:61.73ms
+step:1828/1845 train_time:112871ms step_avg:61.75ms
+step:1829/1845 train_time:112959ms step_avg:61.76ms
+step:1830/1845 train_time:113047ms step_avg:61.77ms
+step:1831/1845 train_time:113136ms step_avg:61.79ms
+step:1832/1845 train_time:113224ms step_avg:61.80ms
+step:1833/1845 train_time:113314ms step_avg:61.82ms
+step:1834/1845 train_time:113402ms step_avg:61.83ms
+step:1835/1845 train_time:113492ms step_avg:61.85ms
+step:1836/1845 train_time:113579ms step_avg:61.86ms
+step:1837/1845 train_time:113668ms step_avg:61.88ms
+step:1838/1845 train_time:113755ms step_avg:61.89ms
+step:1839/1845 train_time:113845ms step_avg:61.91ms
+step:1840/1845 train_time:113933ms step_avg:61.92ms
+step:1841/1845 train_time:114022ms step_avg:61.93ms
+step:1842/1845 train_time:114109ms step_avg:61.95ms
+step:1843/1845 train_time:114198ms step_avg:61.96ms
+step:1844/1845 train_time:114287ms step_avg:61.98ms
+step:1845/1845 train_time:114376ms step_avg:61.99ms
+step:1845/1845 val_loss:3.2795 train_time:114464ms step_avg:62.04ms
+peak memory allocated: 29709 MiB reserved: 44758 MiB

--- a/records/track_1_short/2025-12-29_VeSkipGates/7f9448a2-e58d-4bb2-a868-996d41287fd5.txt
+++ b/records/track_1_short/2025-12-29_VeSkipGates/7f9448a2-e58d-4bb2-a868-996d41287fd5.txt
@@ -1,0 +1,3691 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, v, wd_tensor, lr_tensor):
+    """Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors."""
+    mask = (v * p) >= 0
+    wd_factor = wd_tensor.to(p.dtype)
+    lr_factor = lr_tensor.to(p.dtype)
+    p.copy_(p - (p * mask * wd_factor * lr_factor) - (v * lr_factor))
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn_gate (10 params 6 padding params)
+        2. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        3. reduce scatter attn/mlp round 2 (16 mlp params)
+        4. wait on step 1, then compute update of 1 and schedule all gather
+        5. wait on step 2, then compute update of 2 and schedule all gather
+        6. wait on step 3, then compute update of 3 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        7. wait on 4, then compute update of 4 and schedule all gather
+        8. wait for each all gather to complete and update params
+    Empirically, leading with small params provides an additional 0.2s improvement.
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        group_sizes = [15, 16, 16]
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+
+        all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"]
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params])
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            # The below shape-based heuristic assumes that matrices have their input along the
+            # row dimension and their output along the columns. Gates are an exception.
+            is_gate = 'gate' in ref_param.label
+
+            if "second_momentum_buffer" not in group:
+                if is_gate:
+                    group["second_momentum_buffer"] = torch.zeros_like(updated_grads[..., :, :1])
+                else:
+                    group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1])
+                        if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                    )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if (is_gate or param_shape[-2] >= param_shape[-1]) else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx],
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete and copy results back into original parameter tensors.
+        for info in all_gather_infos:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str],lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for label in label_order:
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.bfloat16, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-1]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+
+                exp_avg = state["exp_avg"]
+                exp_avg_sq = state["exp_avg_sq"]
+                state["step"] += 1
+                t = state["step"]
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (bias2 ** 0.5 / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                # cautious weight decay
+                mask = (update * p_slice) > 0
+                # lr as weight decay schedule
+                eff_weight_decay = lr * wd * getattr(param, "wd_mul", 1.0)
+                update.addcmul_(p_slice, mask, value=eff_weight_decay * lr)
+
+                p_slice.add_(other=update, alpha=-1.0)
+
+                if not is_small:
+                    all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+
+        self._reduce_scatter_futures.clear()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        self.attn_gate = CastedLinear(12, num_heads)
+        self.attn_gate.weight.label = 'attn_gate'
+
+        # only include gates on layers with value embeds used on forward pass
+        if layer_idx in [0,1,8,9,10]:
+            self.value_embed_gate = CastedLinear(12, num_heads)
+            self.value_embed_gate.weight.label = 'value_embed_gate'
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(self.value_embed_gate(x[..., :self.value_embed_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(self.attn_gate(x[..., :self.attn_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset = key_offset[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        adam_labels = ['lm_head', 'value_embed', 'smear_gate', 'skip_gate', 'x0_lambdas', 'embed']
+        scalar_labels = ['scalars']
+        muon_labels = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        scalar_params = [p for p in model.parameters() if getattr(p, 'label', None) in scalar_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + scalar_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, lr=0.008, betas=(0.65, 0.95), eps=1e-8, weight_decay=0.005)
+        self.scalar_opt = DistAdam(scalar_params, scalar_labels, lr=0.008, betas=(0.9, 0.99), eps=1e-8, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.scalar_opt, self.muon_opt]
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.freeze_timer = 0
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+        self.scalar_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            if opt.freeze_timer > 0:
+                opt.freeze_timer -= 1
+                opt.zero_grad(set_to_none=True)
+            else:
+                if self._is_active_step(opt, step):
+                    for group in opt.param_groups:
+                        group["lr"] = group["initial_lr"] * step_lr
+                    opt.step()
+                    opt.zero_grad(set_to_none=True)
+                    if opt.odd_step_only:
+                        opt.should_sync = False
+        
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+
+    def start_transition(self, freeze_count=40):
+        # freeze scalar weights during transition
+        self.scalar_opt.freeze_timer = freeze_count
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1805  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Dec 29 06:11:18 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.90.07              Driver Version: 550.90.07      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   26C    P0            110W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            109W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   39C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   27C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   29C    P0            111W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   29C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 601, 602, 603, 1203, 1204, 1205, 1804, 1805, 1806] for warmup
+Resetting Model
+step:0/1845 val_loss:10.8273 train_time:0ms step_avg:0.04ms
+step:1/1845 train_time:77ms step_avg:77.04ms
+step:2/1845 train_time:101ms step_avg:50.33ms
+step:3/1845 train_time:122ms step_avg:40.77ms
+step:4/1845 train_time:156ms step_avg:39.06ms
+step:5/1845 train_time:191ms step_avg:38.12ms
+step:6/1845 train_time:293ms step_avg:48.76ms
+step:7/1845 train_time:311ms step_avg:44.44ms
+step:8/1845 train_time:340ms step_avg:42.46ms
+step:9/1845 train_time:374ms step_avg:41.55ms
+step:10/1845 train_time:408ms step_avg:40.80ms
+step:11/1845 train_time:442ms step_avg:40.22ms
+step:12/1845 train_time:476ms step_avg:39.71ms
+step:13/1845 train_time:511ms step_avg:39.31ms
+step:14/1845 train_time:545ms step_avg:38.93ms
+step:15/1845 train_time:580ms step_avg:38.64ms
+step:16/1845 train_time:614ms step_avg:38.35ms
+step:17/1845 train_time:648ms step_avg:38.14ms
+step:18/1845 train_time:682ms step_avg:37.91ms
+step:19/1845 train_time:717ms step_avg:37.73ms
+step:20/1845 train_time:751ms step_avg:37.54ms
+step:21/1845 train_time:786ms step_avg:37.41ms
+step:22/1845 train_time:820ms step_avg:37.25ms
+step:23/1845 train_time:854ms step_avg:37.14ms
+step:24/1845 train_time:888ms step_avg:37.01ms
+step:25/1845 train_time:923ms step_avg:36.92ms
+step:26/1845 train_time:957ms step_avg:36.81ms
+step:27/1845 train_time:992ms step_avg:36.73ms
+step:28/1845 train_time:1026ms step_avg:36.64ms
+step:29/1845 train_time:1061ms step_avg:36.57ms
+step:30/1845 train_time:1095ms step_avg:36.49ms
+step:31/1845 train_time:1129ms step_avg:36.43ms
+step:32/1845 train_time:1163ms step_avg:36.35ms
+step:33/1845 train_time:1198ms step_avg:36.30ms
+step:34/1845 train_time:1232ms step_avg:36.24ms
+step:35/1845 train_time:1267ms step_avg:36.20ms
+step:36/1845 train_time:1301ms step_avg:36.15ms
+step:37/1845 train_time:1336ms step_avg:36.10ms
+step:38/1845 train_time:1370ms step_avg:36.05ms
+step:39/1845 train_time:1404ms step_avg:36.01ms
+step:40/1845 train_time:1439ms step_avg:35.96ms
+step:41/1845 train_time:1473ms step_avg:35.94ms
+step:42/1845 train_time:1508ms step_avg:35.89ms
+step:43/1845 train_time:1542ms step_avg:35.87ms
+step:44/1845 train_time:1576ms step_avg:35.83ms
+step:45/1845 train_time:1611ms step_avg:35.80ms
+step:46/1845 train_time:1646ms step_avg:35.78ms
+step:47/1845 train_time:1680ms step_avg:35.74ms
+step:48/1845 train_time:1714ms step_avg:35.71ms
+step:49/1845 train_time:1749ms step_avg:35.69ms
+step:50/1845 train_time:1783ms step_avg:35.65ms
+step:51/1845 train_time:1817ms step_avg:35.63ms
+step:52/1845 train_time:1851ms step_avg:35.60ms
+step:53/1845 train_time:1886ms step_avg:35.58ms
+step:54/1845 train_time:1920ms step_avg:35.56ms
+step:55/1845 train_time:1954ms step_avg:35.53ms
+step:56/1845 train_time:1988ms step_avg:35.51ms
+step:57/1845 train_time:2023ms step_avg:35.50ms
+step:58/1845 train_time:2057ms step_avg:35.47ms
+step:59/1845 train_time:2092ms step_avg:35.46ms
+step:60/1845 train_time:2126ms step_avg:35.44ms
+step:61/1845 train_time:2161ms step_avg:35.43ms
+step:62/1845 train_time:2195ms step_avg:35.41ms
+step:63/1845 train_time:2231ms step_avg:35.40ms
+step:64/1845 train_time:2265ms step_avg:35.39ms
+step:65/1845 train_time:2300ms step_avg:35.38ms
+step:66/1845 train_time:2334ms step_avg:35.36ms
+step:67/1845 train_time:2368ms step_avg:35.35ms
+step:68/1845 train_time:2402ms step_avg:35.33ms
+step:69/1845 train_time:2437ms step_avg:35.32ms
+step:70/1845 train_time:2471ms step_avg:35.30ms
+step:71/1845 train_time:2506ms step_avg:35.29ms
+step:72/1845 train_time:2540ms step_avg:35.28ms
+step:73/1845 train_time:2574ms step_avg:35.27ms
+step:74/1845 train_time:2609ms step_avg:35.25ms
+step:75/1845 train_time:2643ms step_avg:35.24ms
+step:76/1845 train_time:2677ms step_avg:35.23ms
+step:77/1845 train_time:2712ms step_avg:35.22ms
+step:78/1845 train_time:2746ms step_avg:35.21ms
+step:79/1845 train_time:2781ms step_avg:35.20ms
+step:80/1845 train_time:2815ms step_avg:35.19ms
+step:81/1845 train_time:2850ms step_avg:35.18ms
+step:82/1845 train_time:2884ms step_avg:35.17ms
+step:83/1845 train_time:2918ms step_avg:35.16ms
+step:84/1845 train_time:2952ms step_avg:35.14ms
+step:85/1845 train_time:2987ms step_avg:35.14ms
+step:86/1845 train_time:3021ms step_avg:35.13ms
+step:87/1845 train_time:3056ms step_avg:35.12ms
+step:88/1845 train_time:3090ms step_avg:35.11ms
+step:89/1845 train_time:3125ms step_avg:35.11ms
+step:90/1845 train_time:3159ms step_avg:35.10ms
+step:91/1845 train_time:3194ms step_avg:35.10ms
+step:92/1845 train_time:3228ms step_avg:35.08ms
+step:93/1845 train_time:3262ms step_avg:35.08ms
+step:94/1845 train_time:3296ms step_avg:35.07ms
+step:95/1845 train_time:3331ms step_avg:35.07ms
+step:96/1845 train_time:3366ms step_avg:35.06ms
+step:97/1845 train_time:3401ms step_avg:35.06ms
+step:98/1845 train_time:3435ms step_avg:35.05ms
+step:99/1845 train_time:3469ms step_avg:35.04ms
+step:100/1845 train_time:3503ms step_avg:35.03ms
+step:101/1845 train_time:3538ms step_avg:35.03ms
+step:102/1845 train_time:3572ms step_avg:35.02ms
+step:103/1845 train_time:3606ms step_avg:35.01ms
+step:104/1845 train_time:3640ms step_avg:35.00ms
+step:105/1845 train_time:3675ms step_avg:35.00ms
+step:106/1845 train_time:3709ms step_avg:34.99ms
+step:107/1845 train_time:3744ms step_avg:34.99ms
+step:108/1845 train_time:3778ms step_avg:34.98ms
+step:109/1845 train_time:3812ms step_avg:34.98ms
+step:110/1845 train_time:3846ms step_avg:34.97ms
+step:111/1845 train_time:3881ms step_avg:34.96ms
+step:112/1845 train_time:3915ms step_avg:34.95ms
+step:113/1845 train_time:3950ms step_avg:34.95ms
+step:114/1845 train_time:3984ms step_avg:34.94ms
+step:115/1845 train_time:4018ms step_avg:34.94ms
+step:116/1845 train_time:4052ms step_avg:34.93ms
+step:117/1845 train_time:4087ms step_avg:34.93ms
+step:118/1845 train_time:4121ms step_avg:34.93ms
+step:119/1845 train_time:4156ms step_avg:34.92ms
+step:120/1845 train_time:4190ms step_avg:34.92ms
+step:121/1845 train_time:4225ms step_avg:34.92ms
+step:122/1845 train_time:4259ms step_avg:34.91ms
+step:123/1845 train_time:4293ms step_avg:34.90ms
+step:124/1845 train_time:4327ms step_avg:34.90ms
+step:125/1845 train_time:4362ms step_avg:34.90ms
+step:126/1845 train_time:4396ms step_avg:34.89ms
+step:127/1845 train_time:4431ms step_avg:34.89ms
+step:128/1845 train_time:4465ms step_avg:34.88ms
+step:129/1845 train_time:4500ms step_avg:34.88ms
+step:130/1845 train_time:4534ms step_avg:34.88ms
+step:131/1845 train_time:4569ms step_avg:34.88ms
+step:132/1845 train_time:4603ms step_avg:34.87ms
+step:133/1845 train_time:4637ms step_avg:34.86ms
+step:134/1845 train_time:4671ms step_avg:34.86ms
+step:135/1845 train_time:4706ms step_avg:34.86ms
+step:136/1845 train_time:4740ms step_avg:34.85ms
+step:137/1845 train_time:4774ms step_avg:34.85ms
+step:138/1845 train_time:4808ms step_avg:34.84ms
+step:139/1845 train_time:4843ms step_avg:34.84ms
+step:140/1845 train_time:4877ms step_avg:34.83ms
+step:141/1845 train_time:4911ms step_avg:34.83ms
+step:142/1845 train_time:4945ms step_avg:34.83ms
+step:143/1845 train_time:4980ms step_avg:34.82ms
+step:144/1845 train_time:5014ms step_avg:34.82ms
+step:145/1845 train_time:5048ms step_avg:34.82ms
+step:146/1845 train_time:5082ms step_avg:34.81ms
+step:147/1845 train_time:5117ms step_avg:34.81ms
+step:148/1845 train_time:5151ms step_avg:34.80ms
+step:149/1845 train_time:5185ms step_avg:34.80ms
+step:150/1845 train_time:5219ms step_avg:34.80ms
+step:151/1845 train_time:5254ms step_avg:34.79ms
+step:152/1845 train_time:5288ms step_avg:34.79ms
+step:153/1845 train_time:5322ms step_avg:34.79ms
+step:154/1845 train_time:5356ms step_avg:34.78ms
+step:155/1845 train_time:5391ms step_avg:34.78ms
+step:156/1845 train_time:5425ms step_avg:34.78ms
+step:157/1845 train_time:5460ms step_avg:34.78ms
+step:158/1845 train_time:5494ms step_avg:34.77ms
+step:159/1845 train_time:5529ms step_avg:34.77ms
+step:160/1845 train_time:5563ms step_avg:34.77ms
+step:161/1845 train_time:5598ms step_avg:34.77ms
+step:162/1845 train_time:5632ms step_avg:34.76ms
+step:163/1845 train_time:5666ms step_avg:34.76ms
+step:164/1845 train_time:5700ms step_avg:34.76ms
+step:165/1845 train_time:5735ms step_avg:34.76ms
+step:166/1845 train_time:5769ms step_avg:34.75ms
+step:167/1845 train_time:5803ms step_avg:34.75ms
+step:168/1845 train_time:5837ms step_avg:34.74ms
+step:169/1845 train_time:5871ms step_avg:34.74ms
+step:170/1845 train_time:5905ms step_avg:34.74ms
+step:171/1845 train_time:5940ms step_avg:34.74ms
+step:172/1845 train_time:5974ms step_avg:34.73ms
+step:173/1845 train_time:6008ms step_avg:34.73ms
+step:174/1845 train_time:6042ms step_avg:34.73ms
+step:175/1845 train_time:6076ms step_avg:34.72ms
+step:176/1845 train_time:6110ms step_avg:34.72ms
+step:177/1845 train_time:6145ms step_avg:34.72ms
+step:178/1845 train_time:6179ms step_avg:34.71ms
+step:179/1845 train_time:6214ms step_avg:34.71ms
+step:180/1845 train_time:6248ms step_avg:34.71ms
+step:181/1845 train_time:6282ms step_avg:34.71ms
+step:182/1845 train_time:6316ms step_avg:34.71ms
+step:183/1845 train_time:6351ms step_avg:34.70ms
+step:184/1845 train_time:6385ms step_avg:34.70ms
+step:185/1845 train_time:6419ms step_avg:34.70ms
+step:186/1845 train_time:6453ms step_avg:34.70ms
+step:187/1845 train_time:6488ms step_avg:34.70ms
+step:188/1845 train_time:6522ms step_avg:34.69ms
+step:189/1845 train_time:6556ms step_avg:34.69ms
+step:190/1845 train_time:6590ms step_avg:34.69ms
+step:191/1845 train_time:6625ms step_avg:34.69ms
+step:192/1845 train_time:6659ms step_avg:34.68ms
+step:193/1845 train_time:6694ms step_avg:34.68ms
+step:194/1845 train_time:6728ms step_avg:34.68ms
+step:195/1845 train_time:6762ms step_avg:34.68ms
+step:196/1845 train_time:6796ms step_avg:34.67ms
+step:197/1845 train_time:6830ms step_avg:34.67ms
+step:198/1845 train_time:6864ms step_avg:34.67ms
+step:199/1845 train_time:6899ms step_avg:34.67ms
+step:200/1845 train_time:6933ms step_avg:34.66ms
+step:201/1845 train_time:6967ms step_avg:34.66ms
+step:202/1845 train_time:7001ms step_avg:34.66ms
+step:203/1845 train_time:7036ms step_avg:34.66ms
+step:204/1845 train_time:7070ms step_avg:34.66ms
+step:205/1845 train_time:7105ms step_avg:34.66ms
+step:206/1845 train_time:7139ms step_avg:34.66ms
+step:207/1845 train_time:7174ms step_avg:34.65ms
+step:208/1845 train_time:7207ms step_avg:34.65ms
+step:209/1845 train_time:7242ms step_avg:34.65ms
+step:210/1845 train_time:7276ms step_avg:34.65ms
+step:211/1845 train_time:7311ms step_avg:34.65ms
+step:212/1845 train_time:7344ms step_avg:34.64ms
+step:213/1845 train_time:7379ms step_avg:34.64ms
+step:214/1845 train_time:7413ms step_avg:34.64ms
+step:215/1845 train_time:7448ms step_avg:34.64ms
+step:216/1845 train_time:7482ms step_avg:34.64ms
+step:217/1845 train_time:7516ms step_avg:34.64ms
+step:218/1845 train_time:7550ms step_avg:34.63ms
+step:219/1845 train_time:7585ms step_avg:34.63ms
+step:220/1845 train_time:7619ms step_avg:34.63ms
+step:221/1845 train_time:7653ms step_avg:34.63ms
+step:222/1845 train_time:7688ms step_avg:34.63ms
+step:223/1845 train_time:7722ms step_avg:34.63ms
+step:224/1845 train_time:7756ms step_avg:34.63ms
+step:225/1845 train_time:7791ms step_avg:34.63ms
+step:226/1845 train_time:7825ms step_avg:34.62ms
+step:227/1845 train_time:7859ms step_avg:34.62ms
+step:228/1845 train_time:7893ms step_avg:34.62ms
+step:229/1845 train_time:7928ms step_avg:34.62ms
+step:230/1845 train_time:7961ms step_avg:34.62ms
+step:231/1845 train_time:7996ms step_avg:34.61ms
+step:232/1845 train_time:8030ms step_avg:34.61ms
+step:233/1845 train_time:8065ms step_avg:34.61ms
+step:234/1845 train_time:8099ms step_avg:34.61ms
+step:235/1845 train_time:8133ms step_avg:34.61ms
+step:236/1845 train_time:8167ms step_avg:34.61ms
+step:237/1845 train_time:8202ms step_avg:34.61ms
+step:238/1845 train_time:8235ms step_avg:34.60ms
+step:239/1845 train_time:8270ms step_avg:34.60ms
+step:240/1845 train_time:8304ms step_avg:34.60ms
+step:241/1845 train_time:8338ms step_avg:34.60ms
+step:242/1845 train_time:8372ms step_avg:34.60ms
+step:243/1845 train_time:8407ms step_avg:34.60ms
+step:244/1845 train_time:8441ms step_avg:34.59ms
+step:245/1845 train_time:8475ms step_avg:34.59ms
+step:246/1845 train_time:8509ms step_avg:34.59ms
+step:247/1845 train_time:8544ms step_avg:34.59ms
+step:248/1845 train_time:8578ms step_avg:34.59ms
+step:249/1845 train_time:8613ms step_avg:34.59ms
+step:250/1845 train_time:8647ms step_avg:34.59ms
+step:250/1845 val_loss:4.5990 train_time:8683ms step_avg:34.73ms
+step:251/1845 train_time:8703ms step_avg:34.67ms
+step:252/1845 train_time:8722ms step_avg:34.61ms
+step:253/1845 train_time:8752ms step_avg:34.59ms
+step:254/1845 train_time:8787ms step_avg:34.59ms
+step:255/1845 train_time:8822ms step_avg:34.60ms
+step:256/1845 train_time:8857ms step_avg:34.60ms
+step:257/1845 train_time:8893ms step_avg:34.60ms
+step:258/1845 train_time:8927ms step_avg:34.60ms
+step:259/1845 train_time:8962ms step_avg:34.60ms
+step:260/1845 train_time:8996ms step_avg:34.60ms
+step:261/1845 train_time:9030ms step_avg:34.60ms
+step:262/1845 train_time:9065ms step_avg:34.60ms
+step:263/1845 train_time:9099ms step_avg:34.60ms
+step:264/1845 train_time:9133ms step_avg:34.59ms
+step:265/1845 train_time:9167ms step_avg:34.59ms
+step:266/1845 train_time:9201ms step_avg:34.59ms
+step:267/1845 train_time:9235ms step_avg:34.59ms
+step:268/1845 train_time:9269ms step_avg:34.59ms
+step:269/1845 train_time:9304ms step_avg:34.59ms
+step:270/1845 train_time:9338ms step_avg:34.58ms
+step:271/1845 train_time:9372ms step_avg:34.58ms
+step:272/1845 train_time:9406ms step_avg:34.58ms
+step:273/1845 train_time:9440ms step_avg:34.58ms
+step:274/1845 train_time:9474ms step_avg:34.58ms
+step:275/1845 train_time:9508ms step_avg:34.58ms
+step:276/1845 train_time:9542ms step_avg:34.57ms
+step:277/1845 train_time:9577ms step_avg:34.57ms
+step:278/1845 train_time:9611ms step_avg:34.57ms
+step:279/1845 train_time:9645ms step_avg:34.57ms
+step:280/1845 train_time:9679ms step_avg:34.57ms
+step:281/1845 train_time:9713ms step_avg:34.57ms
+step:282/1845 train_time:9747ms step_avg:34.57ms
+step:283/1845 train_time:9782ms step_avg:34.57ms
+step:284/1845 train_time:9816ms step_avg:34.56ms
+step:285/1845 train_time:9851ms step_avg:34.57ms
+step:286/1845 train_time:9885ms step_avg:34.56ms
+step:287/1845 train_time:9920ms step_avg:34.56ms
+step:288/1845 train_time:9954ms step_avg:34.56ms
+step:289/1845 train_time:9988ms step_avg:34.56ms
+step:290/1845 train_time:10022ms step_avg:34.56ms
+step:291/1845 train_time:10057ms step_avg:34.56ms
+step:292/1845 train_time:10091ms step_avg:34.56ms
+step:293/1845 train_time:10126ms step_avg:34.56ms
+step:294/1845 train_time:10160ms step_avg:34.56ms
+step:295/1845 train_time:10194ms step_avg:34.56ms
+step:296/1845 train_time:10228ms step_avg:34.55ms
+step:297/1845 train_time:10263ms step_avg:34.55ms
+step:298/1845 train_time:10297ms step_avg:34.55ms
+step:299/1845 train_time:10331ms step_avg:34.55ms
+step:300/1845 train_time:10365ms step_avg:34.55ms
+step:301/1845 train_time:10400ms step_avg:34.55ms
+step:302/1845 train_time:10434ms step_avg:34.55ms
+step:303/1845 train_time:10468ms step_avg:34.55ms
+step:304/1845 train_time:10502ms step_avg:34.55ms
+step:305/1845 train_time:10536ms step_avg:34.54ms
+step:306/1845 train_time:10570ms step_avg:34.54ms
+step:307/1845 train_time:10605ms step_avg:34.54ms
+step:308/1845 train_time:10638ms step_avg:34.54ms
+step:309/1845 train_time:10673ms step_avg:34.54ms
+step:310/1845 train_time:10707ms step_avg:34.54ms
+step:311/1845 train_time:10741ms step_avg:34.54ms
+step:312/1845 train_time:10775ms step_avg:34.54ms
+step:313/1845 train_time:10810ms step_avg:34.54ms
+step:314/1845 train_time:10844ms step_avg:34.53ms
+step:315/1845 train_time:10879ms step_avg:34.54ms
+step:316/1845 train_time:10913ms step_avg:34.53ms
+step:317/1845 train_time:10947ms step_avg:34.53ms
+step:318/1845 train_time:10981ms step_avg:34.53ms
+step:319/1845 train_time:11015ms step_avg:34.53ms
+step:320/1845 train_time:11049ms step_avg:34.53ms
+step:321/1845 train_time:11084ms step_avg:34.53ms
+step:322/1845 train_time:11118ms step_avg:34.53ms
+step:323/1845 train_time:11153ms step_avg:34.53ms
+step:324/1845 train_time:11187ms step_avg:34.53ms
+step:325/1845 train_time:11221ms step_avg:34.53ms
+step:326/1845 train_time:11255ms step_avg:34.53ms
+step:327/1845 train_time:11290ms step_avg:34.53ms
+step:328/1845 train_time:11324ms step_avg:34.52ms
+step:329/1845 train_time:11358ms step_avg:34.52ms
+step:330/1845 train_time:11392ms step_avg:34.52ms
+step:331/1845 train_time:11427ms step_avg:34.52ms
+step:332/1845 train_time:11461ms step_avg:34.52ms
+step:333/1845 train_time:11495ms step_avg:34.52ms
+step:334/1845 train_time:11529ms step_avg:34.52ms
+step:335/1845 train_time:11564ms step_avg:34.52ms
+step:336/1845 train_time:11598ms step_avg:34.52ms
+step:337/1845 train_time:11632ms step_avg:34.52ms
+step:338/1845 train_time:11666ms step_avg:34.52ms
+step:339/1845 train_time:11701ms step_avg:34.52ms
+step:340/1845 train_time:11735ms step_avg:34.51ms
+step:341/1845 train_time:11769ms step_avg:34.51ms
+step:342/1845 train_time:11803ms step_avg:34.51ms
+step:343/1845 train_time:11838ms step_avg:34.51ms
+step:344/1845 train_time:11872ms step_avg:34.51ms
+step:345/1845 train_time:11907ms step_avg:34.51ms
+step:346/1845 train_time:11941ms step_avg:34.51ms
+step:347/1845 train_time:11975ms step_avg:34.51ms
+step:348/1845 train_time:12009ms step_avg:34.51ms
+step:349/1845 train_time:12044ms step_avg:34.51ms
+step:350/1845 train_time:12078ms step_avg:34.51ms
+step:351/1845 train_time:12112ms step_avg:34.51ms
+step:352/1845 train_time:12146ms step_avg:34.51ms
+step:353/1845 train_time:12181ms step_avg:34.51ms
+step:354/1845 train_time:12215ms step_avg:34.50ms
+step:355/1845 train_time:12249ms step_avg:34.50ms
+step:356/1845 train_time:12283ms step_avg:34.50ms
+step:357/1845 train_time:12318ms step_avg:34.50ms
+step:358/1845 train_time:12352ms step_avg:34.50ms
+step:359/1845 train_time:12386ms step_avg:34.50ms
+step:360/1845 train_time:12420ms step_avg:34.50ms
+step:361/1845 train_time:12455ms step_avg:34.50ms
+step:362/1845 train_time:12489ms step_avg:34.50ms
+step:363/1845 train_time:12523ms step_avg:34.50ms
+step:364/1845 train_time:12557ms step_avg:34.50ms
+step:365/1845 train_time:12592ms step_avg:34.50ms
+step:366/1845 train_time:12625ms step_avg:34.50ms
+step:367/1845 train_time:12660ms step_avg:34.50ms
+step:368/1845 train_time:12694ms step_avg:34.49ms
+step:369/1845 train_time:12728ms step_avg:34.49ms
+step:370/1845 train_time:12762ms step_avg:34.49ms
+step:371/1845 train_time:12796ms step_avg:34.49ms
+step:372/1845 train_time:12830ms step_avg:34.49ms
+step:373/1845 train_time:12865ms step_avg:34.49ms
+step:374/1845 train_time:12899ms step_avg:34.49ms
+step:375/1845 train_time:12933ms step_avg:34.49ms
+step:376/1845 train_time:12967ms step_avg:34.49ms
+step:377/1845 train_time:13001ms step_avg:34.49ms
+step:378/1845 train_time:13035ms step_avg:34.49ms
+step:379/1845 train_time:13070ms step_avg:34.48ms
+step:380/1845 train_time:13104ms step_avg:34.48ms
+step:381/1845 train_time:13138ms step_avg:34.48ms
+step:382/1845 train_time:13172ms step_avg:34.48ms
+step:383/1845 train_time:13207ms step_avg:34.48ms
+step:384/1845 train_time:13241ms step_avg:34.48ms
+step:385/1845 train_time:13275ms step_avg:34.48ms
+step:386/1845 train_time:13309ms step_avg:34.48ms
+step:387/1845 train_time:13344ms step_avg:34.48ms
+step:388/1845 train_time:13378ms step_avg:34.48ms
+step:389/1845 train_time:13412ms step_avg:34.48ms
+step:390/1845 train_time:13446ms step_avg:34.48ms
+step:391/1845 train_time:13481ms step_avg:34.48ms
+step:392/1845 train_time:13515ms step_avg:34.48ms
+step:393/1845 train_time:13550ms step_avg:34.48ms
+step:394/1845 train_time:13584ms step_avg:34.48ms
+step:395/1845 train_time:13618ms step_avg:34.48ms
+step:396/1845 train_time:13652ms step_avg:34.48ms
+step:397/1845 train_time:13687ms step_avg:34.48ms
+step:398/1845 train_time:13721ms step_avg:34.47ms
+step:399/1845 train_time:13755ms step_avg:34.47ms
+step:400/1845 train_time:13789ms step_avg:34.47ms
+step:401/1845 train_time:13824ms step_avg:34.47ms
+step:402/1845 train_time:13858ms step_avg:34.47ms
+step:403/1845 train_time:13893ms step_avg:34.47ms
+step:404/1845 train_time:13926ms step_avg:34.47ms
+step:405/1845 train_time:13961ms step_avg:34.47ms
+step:406/1845 train_time:13995ms step_avg:34.47ms
+step:407/1845 train_time:14029ms step_avg:34.47ms
+step:408/1845 train_time:14063ms step_avg:34.47ms
+step:409/1845 train_time:14098ms step_avg:34.47ms
+step:410/1845 train_time:14132ms step_avg:34.47ms
+step:411/1845 train_time:14166ms step_avg:34.47ms
+step:412/1845 train_time:14200ms step_avg:34.47ms
+step:413/1845 train_time:14234ms step_avg:34.47ms
+step:414/1845 train_time:14268ms step_avg:34.46ms
+step:415/1845 train_time:14303ms step_avg:34.46ms
+step:416/1845 train_time:14336ms step_avg:34.46ms
+step:417/1845 train_time:14371ms step_avg:34.46ms
+step:418/1845 train_time:14405ms step_avg:34.46ms
+step:419/1845 train_time:14439ms step_avg:34.46ms
+step:420/1845 train_time:14473ms step_avg:34.46ms
+step:421/1845 train_time:14508ms step_avg:34.46ms
+step:422/1845 train_time:14542ms step_avg:34.46ms
+step:423/1845 train_time:14576ms step_avg:34.46ms
+step:424/1845 train_time:14610ms step_avg:34.46ms
+step:425/1845 train_time:14645ms step_avg:34.46ms
+step:426/1845 train_time:14679ms step_avg:34.46ms
+step:427/1845 train_time:14713ms step_avg:34.46ms
+step:428/1845 train_time:14747ms step_avg:34.46ms
+step:429/1845 train_time:14782ms step_avg:34.46ms
+step:430/1845 train_time:14816ms step_avg:34.46ms
+step:431/1845 train_time:14850ms step_avg:34.46ms
+step:432/1845 train_time:14884ms step_avg:34.45ms
+step:433/1845 train_time:14919ms step_avg:34.45ms
+step:434/1845 train_time:14953ms step_avg:34.45ms
+step:435/1845 train_time:14987ms step_avg:34.45ms
+step:436/1845 train_time:15021ms step_avg:34.45ms
+step:437/1845 train_time:15056ms step_avg:34.45ms
+step:438/1845 train_time:15090ms step_avg:34.45ms
+step:439/1845 train_time:15125ms step_avg:34.45ms
+step:440/1845 train_time:15159ms step_avg:34.45ms
+step:441/1845 train_time:15193ms step_avg:34.45ms
+step:442/1845 train_time:15227ms step_avg:34.45ms
+step:443/1845 train_time:15262ms step_avg:34.45ms
+step:444/1845 train_time:15295ms step_avg:34.45ms
+step:445/1845 train_time:15330ms step_avg:34.45ms
+step:446/1845 train_time:15364ms step_avg:34.45ms
+step:447/1845 train_time:15399ms step_avg:34.45ms
+step:448/1845 train_time:15433ms step_avg:34.45ms
+step:449/1845 train_time:15468ms step_avg:34.45ms
+step:450/1845 train_time:15501ms step_avg:34.45ms
+step:451/1845 train_time:15536ms step_avg:34.45ms
+step:452/1845 train_time:15570ms step_avg:34.45ms
+step:453/1845 train_time:15604ms step_avg:34.45ms
+step:454/1845 train_time:15638ms step_avg:34.45ms
+step:455/1845 train_time:15673ms step_avg:34.45ms
+step:456/1845 train_time:15707ms step_avg:34.44ms
+step:457/1845 train_time:15741ms step_avg:34.44ms
+step:458/1845 train_time:15775ms step_avg:34.44ms
+step:459/1845 train_time:15810ms step_avg:34.44ms
+step:460/1845 train_time:15843ms step_avg:34.44ms
+step:461/1845 train_time:15878ms step_avg:34.44ms
+step:462/1845 train_time:15912ms step_avg:34.44ms
+step:463/1845 train_time:15947ms step_avg:34.44ms
+step:464/1845 train_time:15981ms step_avg:34.44ms
+step:465/1845 train_time:16015ms step_avg:34.44ms
+step:466/1845 train_time:16049ms step_avg:34.44ms
+step:467/1845 train_time:16084ms step_avg:34.44ms
+step:468/1845 train_time:16118ms step_avg:34.44ms
+step:469/1845 train_time:16152ms step_avg:34.44ms
+step:470/1845 train_time:16186ms step_avg:34.44ms
+step:471/1845 train_time:16221ms step_avg:34.44ms
+step:472/1845 train_time:16255ms step_avg:34.44ms
+step:473/1845 train_time:16289ms step_avg:34.44ms
+step:474/1845 train_time:16323ms step_avg:34.44ms
+step:475/1845 train_time:16358ms step_avg:34.44ms
+step:476/1845 train_time:16392ms step_avg:34.44ms
+step:477/1845 train_time:16426ms step_avg:34.44ms
+step:478/1845 train_time:16460ms step_avg:34.44ms
+step:479/1845 train_time:16494ms step_avg:34.44ms
+step:480/1845 train_time:16528ms step_avg:34.43ms
+step:481/1845 train_time:16563ms step_avg:34.43ms
+step:482/1845 train_time:16597ms step_avg:34.43ms
+step:483/1845 train_time:16632ms step_avg:34.43ms
+step:484/1845 train_time:16666ms step_avg:34.43ms
+step:485/1845 train_time:16700ms step_avg:34.43ms
+step:486/1845 train_time:16734ms step_avg:34.43ms
+step:487/1845 train_time:16769ms step_avg:34.43ms
+step:488/1845 train_time:16803ms step_avg:34.43ms
+step:489/1845 train_time:16837ms step_avg:34.43ms
+step:490/1845 train_time:16871ms step_avg:34.43ms
+step:491/1845 train_time:16906ms step_avg:34.43ms
+step:492/1845 train_time:16940ms step_avg:34.43ms
+step:493/1845 train_time:16974ms step_avg:34.43ms
+step:494/1845 train_time:17008ms step_avg:34.43ms
+step:495/1845 train_time:17042ms step_avg:34.43ms
+step:496/1845 train_time:17076ms step_avg:34.43ms
+step:497/1845 train_time:17111ms step_avg:34.43ms
+step:498/1845 train_time:17145ms step_avg:34.43ms
+step:499/1845 train_time:17179ms step_avg:34.43ms
+step:500/1845 train_time:17213ms step_avg:34.43ms
+step:500/1845 val_loss:4.2887 train_time:17250ms step_avg:34.50ms
+step:501/1845 train_time:17270ms step_avg:34.47ms
+step:502/1845 train_time:17290ms step_avg:34.44ms
+step:503/1845 train_time:17319ms step_avg:34.43ms
+step:504/1845 train_time:17354ms step_avg:34.43ms
+step:505/1845 train_time:17390ms step_avg:34.44ms
+step:506/1845 train_time:17425ms step_avg:34.44ms
+step:507/1845 train_time:17459ms step_avg:34.44ms
+step:508/1845 train_time:17493ms step_avg:34.44ms
+step:509/1845 train_time:17528ms step_avg:34.44ms
+step:510/1845 train_time:17562ms step_avg:34.44ms
+step:511/1845 train_time:17596ms step_avg:34.43ms
+step:512/1845 train_time:17630ms step_avg:34.43ms
+step:513/1845 train_time:17664ms step_avg:34.43ms
+step:514/1845 train_time:17698ms step_avg:34.43ms
+step:515/1845 train_time:17733ms step_avg:34.43ms
+step:516/1845 train_time:17767ms step_avg:34.43ms
+step:517/1845 train_time:17801ms step_avg:34.43ms
+step:518/1845 train_time:17835ms step_avg:34.43ms
+step:519/1845 train_time:17869ms step_avg:34.43ms
+step:520/1845 train_time:17903ms step_avg:34.43ms
+step:521/1845 train_time:17938ms step_avg:34.43ms
+step:522/1845 train_time:17972ms step_avg:34.43ms
+step:523/1845 train_time:18006ms step_avg:34.43ms
+step:524/1845 train_time:18040ms step_avg:34.43ms
+step:525/1845 train_time:18074ms step_avg:34.43ms
+step:526/1845 train_time:18108ms step_avg:34.43ms
+step:527/1845 train_time:18142ms step_avg:34.43ms
+step:528/1845 train_time:18177ms step_avg:34.43ms
+step:529/1845 train_time:18211ms step_avg:34.43ms
+step:530/1845 train_time:18245ms step_avg:34.42ms
+step:531/1845 train_time:18280ms step_avg:34.42ms
+step:532/1845 train_time:18314ms step_avg:34.42ms
+step:533/1845 train_time:18349ms step_avg:34.43ms
+step:534/1845 train_time:18383ms step_avg:34.42ms
+step:535/1845 train_time:18417ms step_avg:34.42ms
+step:536/1845 train_time:18451ms step_avg:34.42ms
+step:537/1845 train_time:18486ms step_avg:34.42ms
+step:538/1845 train_time:18520ms step_avg:34.42ms
+step:539/1845 train_time:18554ms step_avg:34.42ms
+step:540/1845 train_time:18588ms step_avg:34.42ms
+step:541/1845 train_time:18623ms step_avg:34.42ms
+step:542/1845 train_time:18657ms step_avg:34.42ms
+step:543/1845 train_time:18691ms step_avg:34.42ms
+step:544/1845 train_time:18726ms step_avg:34.42ms
+step:545/1845 train_time:18760ms step_avg:34.42ms
+step:546/1845 train_time:18794ms step_avg:34.42ms
+step:547/1845 train_time:18829ms step_avg:34.42ms
+step:548/1845 train_time:18863ms step_avg:34.42ms
+step:549/1845 train_time:18897ms step_avg:34.42ms
+step:550/1845 train_time:18931ms step_avg:34.42ms
+step:551/1845 train_time:18965ms step_avg:34.42ms
+step:552/1845 train_time:18999ms step_avg:34.42ms
+step:553/1845 train_time:19034ms step_avg:34.42ms
+step:554/1845 train_time:19068ms step_avg:34.42ms
+step:555/1845 train_time:19102ms step_avg:34.42ms
+step:556/1845 train_time:19136ms step_avg:34.42ms
+step:557/1845 train_time:19171ms step_avg:34.42ms
+step:558/1845 train_time:19205ms step_avg:34.42ms
+step:559/1845 train_time:19239ms step_avg:34.42ms
+step:560/1845 train_time:19273ms step_avg:34.42ms
+step:561/1845 train_time:19308ms step_avg:34.42ms
+step:562/1845 train_time:19342ms step_avg:34.42ms
+step:563/1845 train_time:19376ms step_avg:34.42ms
+step:564/1845 train_time:19410ms step_avg:34.42ms
+step:565/1845 train_time:19445ms step_avg:34.42ms
+step:566/1845 train_time:19478ms step_avg:34.41ms
+step:567/1845 train_time:19513ms step_avg:34.41ms
+step:568/1845 train_time:19547ms step_avg:34.41ms
+step:569/1845 train_time:19582ms step_avg:34.41ms
+step:570/1845 train_time:19616ms step_avg:34.41ms
+step:571/1845 train_time:19650ms step_avg:34.41ms
+step:572/1845 train_time:19684ms step_avg:34.41ms
+step:573/1845 train_time:19719ms step_avg:34.41ms
+step:574/1845 train_time:19753ms step_avg:34.41ms
+step:575/1845 train_time:19787ms step_avg:34.41ms
+step:576/1845 train_time:19821ms step_avg:34.41ms
+step:577/1845 train_time:19856ms step_avg:34.41ms
+step:578/1845 train_time:19889ms step_avg:34.41ms
+step:579/1845 train_time:19924ms step_avg:34.41ms
+step:580/1845 train_time:19958ms step_avg:34.41ms
+step:581/1845 train_time:19993ms step_avg:34.41ms
+step:582/1845 train_time:20027ms step_avg:34.41ms
+step:583/1845 train_time:20061ms step_avg:34.41ms
+step:584/1845 train_time:20095ms step_avg:34.41ms
+step:585/1845 train_time:20130ms step_avg:34.41ms
+step:586/1845 train_time:20164ms step_avg:34.41ms
+step:587/1845 train_time:20199ms step_avg:34.41ms
+step:588/1845 train_time:20233ms step_avg:34.41ms
+step:589/1845 train_time:20267ms step_avg:34.41ms
+step:590/1845 train_time:20302ms step_avg:34.41ms
+step:591/1845 train_time:20336ms step_avg:34.41ms
+step:592/1845 train_time:20370ms step_avg:34.41ms
+step:593/1845 train_time:20405ms step_avg:34.41ms
+step:594/1845 train_time:20439ms step_avg:34.41ms
+step:595/1845 train_time:20473ms step_avg:34.41ms
+step:596/1845 train_time:20507ms step_avg:34.41ms
+step:597/1845 train_time:20541ms step_avg:34.41ms
+step:598/1845 train_time:20575ms step_avg:34.41ms
+step:599/1845 train_time:20610ms step_avg:34.41ms
+step:600/1845 train_time:20644ms step_avg:34.41ms
+step:601/1845 train_time:20678ms step_avg:34.41ms
+step:602/1845 train_time:20712ms step_avg:34.41ms
+step:603/1845 train_time:20748ms step_avg:34.41ms
+step:604/1845 train_time:20808ms step_avg:34.45ms
+step:605/1845 train_time:20870ms step_avg:34.50ms
+step:606/1845 train_time:20931ms step_avg:34.54ms
+step:607/1845 train_time:20993ms step_avg:34.58ms
+step:608/1845 train_time:21054ms step_avg:34.63ms
+step:609/1845 train_time:21117ms step_avg:34.67ms
+step:610/1845 train_time:21177ms step_avg:34.72ms
+step:611/1845 train_time:21239ms step_avg:34.76ms
+step:612/1845 train_time:21300ms step_avg:34.80ms
+step:613/1845 train_time:21364ms step_avg:34.85ms
+step:614/1845 train_time:21425ms step_avg:34.89ms
+step:615/1845 train_time:21488ms step_avg:34.94ms
+step:616/1845 train_time:21549ms step_avg:34.98ms
+step:617/1845 train_time:21611ms step_avg:35.03ms
+step:618/1845 train_time:21673ms step_avg:35.07ms
+step:619/1845 train_time:21735ms step_avg:35.11ms
+step:620/1845 train_time:21795ms step_avg:35.15ms
+step:621/1845 train_time:21858ms step_avg:35.20ms
+step:622/1845 train_time:21919ms step_avg:35.24ms
+step:623/1845 train_time:21982ms step_avg:35.28ms
+step:624/1845 train_time:22043ms step_avg:35.33ms
+step:625/1845 train_time:22107ms step_avg:35.37ms
+step:626/1845 train_time:22168ms step_avg:35.41ms
+step:627/1845 train_time:22230ms step_avg:35.45ms
+step:628/1845 train_time:22291ms step_avg:35.50ms
+step:629/1845 train_time:22354ms step_avg:35.54ms
+step:630/1845 train_time:22415ms step_avg:35.58ms
+step:631/1845 train_time:22478ms step_avg:35.62ms
+step:632/1845 train_time:22540ms step_avg:35.66ms
+step:633/1845 train_time:22603ms step_avg:35.71ms
+step:634/1845 train_time:22664ms step_avg:35.75ms
+step:635/1845 train_time:22726ms step_avg:35.79ms
+step:636/1845 train_time:22787ms step_avg:35.83ms
+step:637/1845 train_time:22850ms step_avg:35.87ms
+step:638/1845 train_time:22911ms step_avg:35.91ms
+step:639/1845 train_time:22974ms step_avg:35.95ms
+step:640/1845 train_time:23035ms step_avg:35.99ms
+step:641/1845 train_time:23097ms step_avg:36.03ms
+step:642/1845 train_time:23157ms step_avg:36.07ms
+step:643/1845 train_time:23219ms step_avg:36.11ms
+step:644/1845 train_time:23280ms step_avg:36.15ms
+step:645/1845 train_time:23343ms step_avg:36.19ms
+step:646/1845 train_time:23404ms step_avg:36.23ms
+step:647/1845 train_time:23467ms step_avg:36.27ms
+step:648/1845 train_time:23528ms step_avg:36.31ms
+step:649/1845 train_time:23590ms step_avg:36.35ms
+step:650/1845 train_time:23651ms step_avg:36.39ms
+step:651/1845 train_time:23714ms step_avg:36.43ms
+step:652/1845 train_time:23775ms step_avg:36.46ms
+step:653/1845 train_time:23837ms step_avg:36.50ms
+step:654/1845 train_time:23898ms step_avg:36.54ms
+step:655/1845 train_time:23961ms step_avg:36.58ms
+step:656/1845 train_time:24023ms step_avg:36.62ms
+step:657/1845 train_time:24085ms step_avg:36.66ms
+step:658/1845 train_time:24147ms step_avg:36.70ms
+step:659/1845 train_time:24209ms step_avg:36.74ms
+step:660/1845 train_time:24270ms step_avg:36.77ms
+step:661/1845 train_time:24333ms step_avg:36.81ms
+step:662/1845 train_time:24393ms step_avg:36.85ms
+step:663/1845 train_time:24456ms step_avg:36.89ms
+step:664/1845 train_time:24516ms step_avg:36.92ms
+step:665/1845 train_time:24579ms step_avg:36.96ms
+step:666/1845 train_time:24639ms step_avg:37.00ms
+step:667/1845 train_time:24702ms step_avg:37.04ms
+step:668/1845 train_time:24764ms step_avg:37.07ms
+step:669/1845 train_time:24827ms step_avg:37.11ms
+step:670/1845 train_time:24888ms step_avg:37.15ms
+step:671/1845 train_time:24950ms step_avg:37.18ms
+step:672/1845 train_time:25011ms step_avg:37.22ms
+step:673/1845 train_time:25073ms step_avg:37.26ms
+step:674/1845 train_time:25134ms step_avg:37.29ms
+step:675/1845 train_time:25197ms step_avg:37.33ms
+step:676/1845 train_time:25257ms step_avg:37.36ms
+step:677/1845 train_time:25320ms step_avg:37.40ms
+step:678/1845 train_time:25380ms step_avg:37.43ms
+step:679/1845 train_time:25443ms step_avg:37.47ms
+step:680/1845 train_time:25504ms step_avg:37.51ms
+step:681/1845 train_time:25567ms step_avg:37.54ms
+step:682/1845 train_time:25628ms step_avg:37.58ms
+step:683/1845 train_time:25690ms step_avg:37.61ms
+step:684/1845 train_time:25751ms step_avg:37.65ms
+step:685/1845 train_time:25814ms step_avg:37.68ms
+step:686/1845 train_time:25875ms step_avg:37.72ms
+step:687/1845 train_time:25937ms step_avg:37.75ms
+step:688/1845 train_time:25998ms step_avg:37.79ms
+step:689/1845 train_time:26060ms step_avg:37.82ms
+step:690/1845 train_time:26121ms step_avg:37.86ms
+step:691/1845 train_time:26184ms step_avg:37.89ms
+step:692/1845 train_time:26246ms step_avg:37.93ms
+step:693/1845 train_time:26308ms step_avg:37.96ms
+step:694/1845 train_time:26369ms step_avg:38.00ms
+step:695/1845 train_time:26432ms step_avg:38.03ms
+step:696/1845 train_time:26492ms step_avg:38.06ms
+step:697/1845 train_time:26555ms step_avg:38.10ms
+step:698/1845 train_time:26616ms step_avg:38.13ms
+step:699/1845 train_time:26678ms step_avg:38.17ms
+step:700/1845 train_time:26739ms step_avg:38.20ms
+step:701/1845 train_time:26802ms step_avg:38.23ms
+step:702/1845 train_time:26863ms step_avg:38.27ms
+step:703/1845 train_time:26926ms step_avg:38.30ms
+step:704/1845 train_time:26987ms step_avg:38.33ms
+step:705/1845 train_time:27050ms step_avg:38.37ms
+step:706/1845 train_time:27111ms step_avg:38.40ms
+step:707/1845 train_time:27173ms step_avg:38.43ms
+step:708/1845 train_time:27234ms step_avg:38.47ms
+step:709/1845 train_time:27296ms step_avg:38.50ms
+step:710/1845 train_time:27357ms step_avg:38.53ms
+step:711/1845 train_time:27419ms step_avg:38.56ms
+step:712/1845 train_time:27480ms step_avg:38.60ms
+step:713/1845 train_time:27543ms step_avg:38.63ms
+step:714/1845 train_time:27604ms step_avg:38.66ms
+step:715/1845 train_time:27667ms step_avg:38.69ms
+step:716/1845 train_time:27728ms step_avg:38.73ms
+step:717/1845 train_time:27791ms step_avg:38.76ms
+step:718/1845 train_time:27852ms step_avg:38.79ms
+step:719/1845 train_time:27915ms step_avg:38.83ms
+step:720/1845 train_time:27976ms step_avg:38.86ms
+step:721/1845 train_time:28039ms step_avg:38.89ms
+step:722/1845 train_time:28099ms step_avg:38.92ms
+step:723/1845 train_time:28163ms step_avg:38.95ms
+step:724/1845 train_time:28224ms step_avg:38.98ms
+step:725/1845 train_time:28287ms step_avg:39.02ms
+step:726/1845 train_time:28348ms step_avg:39.05ms
+step:727/1845 train_time:28411ms step_avg:39.08ms
+step:728/1845 train_time:28472ms step_avg:39.11ms
+step:729/1845 train_time:28534ms step_avg:39.14ms
+step:730/1845 train_time:28594ms step_avg:39.17ms
+step:731/1845 train_time:28657ms step_avg:39.20ms
+step:732/1845 train_time:28718ms step_avg:39.23ms
+step:733/1845 train_time:28781ms step_avg:39.26ms
+step:734/1845 train_time:28842ms step_avg:39.29ms
+step:735/1845 train_time:28905ms step_avg:39.33ms
+step:736/1845 train_time:28966ms step_avg:39.36ms
+step:737/1845 train_time:29029ms step_avg:39.39ms
+step:738/1845 train_time:29090ms step_avg:39.42ms
+step:739/1845 train_time:29152ms step_avg:39.45ms
+step:740/1845 train_time:29212ms step_avg:39.48ms
+step:741/1845 train_time:29275ms step_avg:39.51ms
+step:742/1845 train_time:29336ms step_avg:39.54ms
+step:743/1845 train_time:29397ms step_avg:39.57ms
+step:744/1845 train_time:29458ms step_avg:39.59ms
+step:745/1845 train_time:29521ms step_avg:39.63ms
+step:746/1845 train_time:29582ms step_avg:39.65ms
+step:747/1845 train_time:29645ms step_avg:39.69ms
+step:748/1845 train_time:29706ms step_avg:39.71ms
+step:749/1845 train_time:29769ms step_avg:39.74ms
+step:750/1845 train_time:29829ms step_avg:39.77ms
+step:750/1845 val_loss:4.0129 train_time:29893ms step_avg:39.86ms
+step:751/1845 train_time:29913ms step_avg:39.83ms
+step:752/1845 train_time:29954ms step_avg:39.83ms
+step:753/1845 train_time:30019ms step_avg:39.87ms
+step:754/1845 train_time:30082ms step_avg:39.90ms
+step:755/1845 train_time:30145ms step_avg:39.93ms
+step:756/1845 train_time:30206ms step_avg:39.95ms
+step:757/1845 train_time:30268ms step_avg:39.98ms
+step:758/1845 train_time:30328ms step_avg:40.01ms
+step:759/1845 train_time:30390ms step_avg:40.04ms
+step:760/1845 train_time:30451ms step_avg:40.07ms
+step:761/1845 train_time:30513ms step_avg:40.10ms
+step:762/1845 train_time:30573ms step_avg:40.12ms
+step:763/1845 train_time:30635ms step_avg:40.15ms
+step:764/1845 train_time:30695ms step_avg:40.18ms
+step:765/1845 train_time:30757ms step_avg:40.21ms
+step:766/1845 train_time:30817ms step_avg:40.23ms
+step:767/1845 train_time:30880ms step_avg:40.26ms
+step:768/1845 train_time:30942ms step_avg:40.29ms
+step:769/1845 train_time:31005ms step_avg:40.32ms
+step:770/1845 train_time:31067ms step_avg:40.35ms
+step:771/1845 train_time:31131ms step_avg:40.38ms
+step:772/1845 train_time:31192ms step_avg:40.40ms
+step:773/1845 train_time:31254ms step_avg:40.43ms
+step:774/1845 train_time:31315ms step_avg:40.46ms
+step:775/1845 train_time:31377ms step_avg:40.49ms
+step:776/1845 train_time:31437ms step_avg:40.51ms
+step:777/1845 train_time:31499ms step_avg:40.54ms
+step:778/1845 train_time:31559ms step_avg:40.56ms
+step:779/1845 train_time:31622ms step_avg:40.59ms
+step:780/1845 train_time:31682ms step_avg:40.62ms
+step:781/1845 train_time:31744ms step_avg:40.64ms
+step:782/1845 train_time:31804ms step_avg:40.67ms
+step:783/1845 train_time:31867ms step_avg:40.70ms
+step:784/1845 train_time:31929ms step_avg:40.73ms
+step:785/1845 train_time:31991ms step_avg:40.75ms
+step:786/1845 train_time:32052ms step_avg:40.78ms
+step:787/1845 train_time:32116ms step_avg:40.81ms
+step:788/1845 train_time:32177ms step_avg:40.83ms
+step:789/1845 train_time:32239ms step_avg:40.86ms
+step:790/1845 train_time:32300ms step_avg:40.89ms
+step:791/1845 train_time:32363ms step_avg:40.91ms
+step:792/1845 train_time:32425ms step_avg:40.94ms
+step:793/1845 train_time:32487ms step_avg:40.97ms
+step:794/1845 train_time:32548ms step_avg:40.99ms
+step:795/1845 train_time:32611ms step_avg:41.02ms
+step:796/1845 train_time:32671ms step_avg:41.04ms
+step:797/1845 train_time:32734ms step_avg:41.07ms
+step:798/1845 train_time:32794ms step_avg:41.10ms
+step:799/1845 train_time:32857ms step_avg:41.12ms
+step:800/1845 train_time:32917ms step_avg:41.15ms
+step:801/1845 train_time:32979ms step_avg:41.17ms
+step:802/1845 train_time:33040ms step_avg:41.20ms
+step:803/1845 train_time:33103ms step_avg:41.22ms
+step:804/1845 train_time:33164ms step_avg:41.25ms
+step:805/1845 train_time:33227ms step_avg:41.28ms
+step:806/1845 train_time:33288ms step_avg:41.30ms
+step:807/1845 train_time:33351ms step_avg:41.33ms
+step:808/1845 train_time:33412ms step_avg:41.35ms
+step:809/1845 train_time:33474ms step_avg:41.38ms
+step:810/1845 train_time:33535ms step_avg:41.40ms
+step:811/1845 train_time:33597ms step_avg:41.43ms
+step:812/1845 train_time:33658ms step_avg:41.45ms
+step:813/1845 train_time:33720ms step_avg:41.48ms
+step:814/1845 train_time:33781ms step_avg:41.50ms
+step:815/1845 train_time:33844ms step_avg:41.53ms
+step:816/1845 train_time:33905ms step_avg:41.55ms
+step:817/1845 train_time:33967ms step_avg:41.58ms
+step:818/1845 train_time:34028ms step_avg:41.60ms
+step:819/1845 train_time:34091ms step_avg:41.62ms
+step:820/1845 train_time:34152ms step_avg:41.65ms
+step:821/1845 train_time:34214ms step_avg:41.67ms
+step:822/1845 train_time:34275ms step_avg:41.70ms
+step:823/1845 train_time:34337ms step_avg:41.72ms
+step:824/1845 train_time:34398ms step_avg:41.75ms
+step:825/1845 train_time:34461ms step_avg:41.77ms
+step:826/1845 train_time:34521ms step_avg:41.79ms
+step:827/1845 train_time:34584ms step_avg:41.82ms
+step:828/1845 train_time:34645ms step_avg:41.84ms
+step:829/1845 train_time:34708ms step_avg:41.87ms
+step:830/1845 train_time:34769ms step_avg:41.89ms
+step:831/1845 train_time:34831ms step_avg:41.91ms
+step:832/1845 train_time:34892ms step_avg:41.94ms
+step:833/1845 train_time:34954ms step_avg:41.96ms
+step:834/1845 train_time:35015ms step_avg:41.98ms
+step:835/1845 train_time:35078ms step_avg:42.01ms
+step:836/1845 train_time:35138ms step_avg:42.03ms
+step:837/1845 train_time:35200ms step_avg:42.06ms
+step:838/1845 train_time:35261ms step_avg:42.08ms
+step:839/1845 train_time:35324ms step_avg:42.10ms
+step:840/1845 train_time:35385ms step_avg:42.13ms
+step:841/1845 train_time:35448ms step_avg:42.15ms
+step:842/1845 train_time:35509ms step_avg:42.17ms
+step:843/1845 train_time:35572ms step_avg:42.20ms
+step:844/1845 train_time:35633ms step_avg:42.22ms
+step:845/1845 train_time:35696ms step_avg:42.24ms
+step:846/1845 train_time:35756ms step_avg:42.26ms
+step:847/1845 train_time:35818ms step_avg:42.29ms
+step:848/1845 train_time:35879ms step_avg:42.31ms
+step:849/1845 train_time:35942ms step_avg:42.33ms
+step:850/1845 train_time:36002ms step_avg:42.36ms
+step:851/1845 train_time:36065ms step_avg:42.38ms
+step:852/1845 train_time:36126ms step_avg:42.40ms
+step:853/1845 train_time:36189ms step_avg:42.43ms
+step:854/1845 train_time:36250ms step_avg:42.45ms
+step:855/1845 train_time:36312ms step_avg:42.47ms
+step:856/1845 train_time:36373ms step_avg:42.49ms
+step:857/1845 train_time:36435ms step_avg:42.52ms
+step:858/1845 train_time:36496ms step_avg:42.54ms
+step:859/1845 train_time:36558ms step_avg:42.56ms
+step:860/1845 train_time:36619ms step_avg:42.58ms
+step:861/1845 train_time:36682ms step_avg:42.60ms
+step:862/1845 train_time:36742ms step_avg:42.62ms
+step:863/1845 train_time:36805ms step_avg:42.65ms
+step:864/1845 train_time:36867ms step_avg:42.67ms
+step:865/1845 train_time:36930ms step_avg:42.69ms
+step:866/1845 train_time:36990ms step_avg:42.71ms
+step:867/1845 train_time:37053ms step_avg:42.74ms
+step:868/1845 train_time:37114ms step_avg:42.76ms
+step:869/1845 train_time:37176ms step_avg:42.78ms
+step:870/1845 train_time:37236ms step_avg:42.80ms
+step:871/1845 train_time:37299ms step_avg:42.82ms
+step:872/1845 train_time:37360ms step_avg:42.84ms
+step:873/1845 train_time:37422ms step_avg:42.87ms
+step:874/1845 train_time:37483ms step_avg:42.89ms
+step:875/1845 train_time:37547ms step_avg:42.91ms
+step:876/1845 train_time:37608ms step_avg:42.93ms
+step:877/1845 train_time:37670ms step_avg:42.95ms
+step:878/1845 train_time:37731ms step_avg:42.97ms
+step:879/1845 train_time:37794ms step_avg:43.00ms
+step:880/1845 train_time:37854ms step_avg:43.02ms
+step:881/1845 train_time:37917ms step_avg:43.04ms
+step:882/1845 train_time:37978ms step_avg:43.06ms
+step:883/1845 train_time:38040ms step_avg:43.08ms
+step:884/1845 train_time:38101ms step_avg:43.10ms
+step:885/1845 train_time:38164ms step_avg:43.12ms
+step:886/1845 train_time:38225ms step_avg:43.14ms
+step:887/1845 train_time:38288ms step_avg:43.17ms
+step:888/1845 train_time:38349ms step_avg:43.19ms
+step:889/1845 train_time:38411ms step_avg:43.21ms
+step:890/1845 train_time:38472ms step_avg:43.23ms
+step:891/1845 train_time:38535ms step_avg:43.25ms
+step:892/1845 train_time:38596ms step_avg:43.27ms
+step:893/1845 train_time:38658ms step_avg:43.29ms
+step:894/1845 train_time:38719ms step_avg:43.31ms
+step:895/1845 train_time:38781ms step_avg:43.33ms
+step:896/1845 train_time:38842ms step_avg:43.35ms
+step:897/1845 train_time:38906ms step_avg:43.37ms
+step:898/1845 train_time:38967ms step_avg:43.39ms
+step:899/1845 train_time:39030ms step_avg:43.41ms
+step:900/1845 train_time:39090ms step_avg:43.43ms
+step:901/1845 train_time:39152ms step_avg:43.45ms
+step:902/1845 train_time:39213ms step_avg:43.47ms
+step:903/1845 train_time:39276ms step_avg:43.49ms
+step:904/1845 train_time:39337ms step_avg:43.51ms
+step:905/1845 train_time:39399ms step_avg:43.53ms
+step:906/1845 train_time:39459ms step_avg:43.55ms
+step:907/1845 train_time:39522ms step_avg:43.57ms
+step:908/1845 train_time:39583ms step_avg:43.59ms
+step:909/1845 train_time:39646ms step_avg:43.61ms
+step:910/1845 train_time:39707ms step_avg:43.63ms
+step:911/1845 train_time:39769ms step_avg:43.65ms
+step:912/1845 train_time:39830ms step_avg:43.67ms
+step:913/1845 train_time:39893ms step_avg:43.69ms
+step:914/1845 train_time:39954ms step_avg:43.71ms
+step:915/1845 train_time:40016ms step_avg:43.73ms
+step:916/1845 train_time:40077ms step_avg:43.75ms
+step:917/1845 train_time:40140ms step_avg:43.77ms
+step:918/1845 train_time:40200ms step_avg:43.79ms
+step:919/1845 train_time:40263ms step_avg:43.81ms
+step:920/1845 train_time:40325ms step_avg:43.83ms
+step:921/1845 train_time:40388ms step_avg:43.85ms
+step:922/1845 train_time:40449ms step_avg:43.87ms
+step:923/1845 train_time:40511ms step_avg:43.89ms
+step:924/1845 train_time:40572ms step_avg:43.91ms
+step:925/1845 train_time:40635ms step_avg:43.93ms
+step:926/1845 train_time:40696ms step_avg:43.95ms
+step:927/1845 train_time:40758ms step_avg:43.97ms
+step:928/1845 train_time:40818ms step_avg:43.99ms
+step:929/1845 train_time:40881ms step_avg:44.01ms
+step:930/1845 train_time:40942ms step_avg:44.02ms
+step:931/1845 train_time:41005ms step_avg:44.04ms
+step:932/1845 train_time:41066ms step_avg:44.06ms
+step:933/1845 train_time:41128ms step_avg:44.08ms
+step:934/1845 train_time:41189ms step_avg:44.10ms
+step:935/1845 train_time:41252ms step_avg:44.12ms
+step:936/1845 train_time:41313ms step_avg:44.14ms
+step:937/1845 train_time:41375ms step_avg:44.16ms
+step:938/1845 train_time:41436ms step_avg:44.17ms
+step:939/1845 train_time:41498ms step_avg:44.19ms
+step:940/1845 train_time:41559ms step_avg:44.21ms
+step:941/1845 train_time:41621ms step_avg:44.23ms
+step:942/1845 train_time:41683ms step_avg:44.25ms
+step:943/1845 train_time:41746ms step_avg:44.27ms
+step:944/1845 train_time:41807ms step_avg:44.29ms
+step:945/1845 train_time:41869ms step_avg:44.31ms
+step:946/1845 train_time:41930ms step_avg:44.32ms
+step:947/1845 train_time:41993ms step_avg:44.34ms
+step:948/1845 train_time:42053ms step_avg:44.36ms
+step:949/1845 train_time:42115ms step_avg:44.38ms
+step:950/1845 train_time:42176ms step_avg:44.40ms
+step:951/1845 train_time:42239ms step_avg:44.41ms
+step:952/1845 train_time:42299ms step_avg:44.43ms
+step:953/1845 train_time:42361ms step_avg:44.45ms
+step:954/1845 train_time:42422ms step_avg:44.47ms
+step:955/1845 train_time:42485ms step_avg:44.49ms
+step:956/1845 train_time:42547ms step_avg:44.50ms
+step:957/1845 train_time:42609ms step_avg:44.52ms
+step:958/1845 train_time:42670ms step_avg:44.54ms
+step:959/1845 train_time:42732ms step_avg:44.56ms
+step:960/1845 train_time:42793ms step_avg:44.58ms
+step:961/1845 train_time:42855ms step_avg:44.59ms
+step:962/1845 train_time:42916ms step_avg:44.61ms
+step:963/1845 train_time:42978ms step_avg:44.63ms
+step:964/1845 train_time:43038ms step_avg:44.65ms
+step:965/1845 train_time:43100ms step_avg:44.66ms
+step:966/1845 train_time:43161ms step_avg:44.68ms
+step:967/1845 train_time:43224ms step_avg:44.70ms
+step:968/1845 train_time:43285ms step_avg:44.72ms
+step:969/1845 train_time:43348ms step_avg:44.73ms
+step:970/1845 train_time:43409ms step_avg:44.75ms
+step:971/1845 train_time:43471ms step_avg:44.77ms
+step:972/1845 train_time:43532ms step_avg:44.79ms
+step:973/1845 train_time:43594ms step_avg:44.80ms
+step:974/1845 train_time:43655ms step_avg:44.82ms
+step:975/1845 train_time:43717ms step_avg:44.84ms
+step:976/1845 train_time:43777ms step_avg:44.85ms
+step:977/1845 train_time:43839ms step_avg:44.87ms
+step:978/1845 train_time:43900ms step_avg:44.89ms
+step:979/1845 train_time:43962ms step_avg:44.91ms
+step:980/1845 train_time:44023ms step_avg:44.92ms
+step:981/1845 train_time:44085ms step_avg:44.94ms
+step:982/1845 train_time:44146ms step_avg:44.96ms
+step:983/1845 train_time:44209ms step_avg:44.97ms
+step:984/1845 train_time:44270ms step_avg:44.99ms
+step:985/1845 train_time:44332ms step_avg:45.01ms
+step:986/1845 train_time:44393ms step_avg:45.02ms
+step:987/1845 train_time:44456ms step_avg:45.04ms
+step:988/1845 train_time:44516ms step_avg:45.06ms
+step:989/1845 train_time:44578ms step_avg:45.07ms
+step:990/1845 train_time:44639ms step_avg:45.09ms
+step:991/1845 train_time:44702ms step_avg:45.11ms
+step:992/1845 train_time:44763ms step_avg:45.12ms
+step:993/1845 train_time:44826ms step_avg:45.14ms
+step:994/1845 train_time:44887ms step_avg:45.16ms
+step:995/1845 train_time:44949ms step_avg:45.18ms
+step:996/1845 train_time:45010ms step_avg:45.19ms
+step:997/1845 train_time:45072ms step_avg:45.21ms
+step:998/1845 train_time:45133ms step_avg:45.22ms
+step:999/1845 train_time:45195ms step_avg:45.24ms
+step:1000/1845 train_time:45256ms step_avg:45.26ms
+step:1000/1845 val_loss:3.7737 train_time:45319ms step_avg:45.32ms
+step:1001/1845 train_time:45340ms step_avg:45.29ms
+step:1002/1845 train_time:45381ms step_avg:45.29ms
+step:1003/1845 train_time:45445ms step_avg:45.31ms
+step:1004/1845 train_time:45509ms step_avg:45.33ms
+step:1005/1845 train_time:45573ms step_avg:45.35ms
+step:1006/1845 train_time:45634ms step_avg:45.36ms
+step:1007/1845 train_time:45696ms step_avg:45.38ms
+step:1008/1845 train_time:45757ms step_avg:45.39ms
+step:1009/1845 train_time:45819ms step_avg:45.41ms
+step:1010/1845 train_time:45879ms step_avg:45.42ms
+step:1011/1845 train_time:45941ms step_avg:45.44ms
+step:1012/1845 train_time:46001ms step_avg:45.46ms
+step:1013/1845 train_time:46062ms step_avg:45.47ms
+step:1014/1845 train_time:46123ms step_avg:45.49ms
+step:1015/1845 train_time:46185ms step_avg:45.50ms
+step:1016/1845 train_time:46245ms step_avg:45.52ms
+step:1017/1845 train_time:46308ms step_avg:45.53ms
+step:1018/1845 train_time:46370ms step_avg:45.55ms
+step:1019/1845 train_time:46433ms step_avg:45.57ms
+step:1020/1845 train_time:46495ms step_avg:45.58ms
+step:1021/1845 train_time:46557ms step_avg:45.60ms
+step:1022/1845 train_time:46618ms step_avg:45.61ms
+step:1023/1845 train_time:46681ms step_avg:45.63ms
+step:1024/1845 train_time:46741ms step_avg:45.65ms
+step:1025/1845 train_time:46803ms step_avg:45.66ms
+step:1026/1845 train_time:46864ms step_avg:45.68ms
+step:1027/1845 train_time:46927ms step_avg:45.69ms
+step:1028/1845 train_time:46987ms step_avg:45.71ms
+step:1029/1845 train_time:47049ms step_avg:45.72ms
+step:1030/1845 train_time:47110ms step_avg:45.74ms
+step:1031/1845 train_time:47172ms step_avg:45.75ms
+step:1032/1845 train_time:47232ms step_avg:45.77ms
+step:1033/1845 train_time:47295ms step_avg:45.78ms
+step:1034/1845 train_time:47356ms step_avg:45.80ms
+step:1035/1845 train_time:47419ms step_avg:45.82ms
+step:1036/1845 train_time:47480ms step_avg:45.83ms
+step:1037/1845 train_time:47542ms step_avg:45.85ms
+step:1038/1845 train_time:47603ms step_avg:45.86ms
+step:1039/1845 train_time:47666ms step_avg:45.88ms
+step:1040/1845 train_time:47727ms step_avg:45.89ms
+step:1041/1845 train_time:47789ms step_avg:45.91ms
+step:1042/1845 train_time:47850ms step_avg:45.92ms
+step:1043/1845 train_time:47912ms step_avg:45.94ms
+step:1044/1845 train_time:47973ms step_avg:45.95ms
+step:1045/1845 train_time:48036ms step_avg:45.97ms
+step:1046/1845 train_time:48097ms step_avg:45.98ms
+step:1047/1845 train_time:48159ms step_avg:46.00ms
+step:1048/1845 train_time:48219ms step_avg:46.01ms
+step:1049/1845 train_time:48282ms step_avg:46.03ms
+step:1050/1845 train_time:48342ms step_avg:46.04ms
+step:1051/1845 train_time:48405ms step_avg:46.06ms
+step:1052/1845 train_time:48466ms step_avg:46.07ms
+step:1053/1845 train_time:48529ms step_avg:46.09ms
+step:1054/1845 train_time:48591ms step_avg:46.10ms
+step:1055/1845 train_time:48654ms step_avg:46.12ms
+step:1056/1845 train_time:48715ms step_avg:46.13ms
+step:1057/1845 train_time:48778ms step_avg:46.15ms
+step:1058/1845 train_time:48838ms step_avg:46.16ms
+step:1059/1845 train_time:48900ms step_avg:46.18ms
+step:1060/1845 train_time:48961ms step_avg:46.19ms
+step:1061/1845 train_time:49023ms step_avg:46.20ms
+step:1062/1845 train_time:49083ms step_avg:46.22ms
+step:1063/1845 train_time:49146ms step_avg:46.23ms
+step:1064/1845 train_time:49207ms step_avg:46.25ms
+step:1065/1845 train_time:49270ms step_avg:46.26ms
+step:1066/1845 train_time:49331ms step_avg:46.28ms
+step:1067/1845 train_time:49392ms step_avg:46.29ms
+step:1068/1845 train_time:49453ms step_avg:46.30ms
+step:1069/1845 train_time:49516ms step_avg:46.32ms
+step:1070/1845 train_time:49577ms step_avg:46.33ms
+step:1071/1845 train_time:49641ms step_avg:46.35ms
+step:1072/1845 train_time:49701ms step_avg:46.36ms
+step:1073/1845 train_time:49763ms step_avg:46.38ms
+step:1074/1845 train_time:49824ms step_avg:46.39ms
+step:1075/1845 train_time:49887ms step_avg:46.41ms
+step:1076/1845 train_time:49948ms step_avg:46.42ms
+step:1077/1845 train_time:50011ms step_avg:46.44ms
+step:1078/1845 train_time:50072ms step_avg:46.45ms
+step:1079/1845 train_time:50134ms step_avg:46.46ms
+step:1080/1845 train_time:50195ms step_avg:46.48ms
+step:1081/1845 train_time:50258ms step_avg:46.49ms
+step:1082/1845 train_time:50319ms step_avg:46.51ms
+step:1083/1845 train_time:50381ms step_avg:46.52ms
+step:1084/1845 train_time:50441ms step_avg:46.53ms
+step:1085/1845 train_time:50503ms step_avg:46.55ms
+step:1086/1845 train_time:50564ms step_avg:46.56ms
+step:1087/1845 train_time:50627ms step_avg:46.58ms
+step:1088/1845 train_time:50688ms step_avg:46.59ms
+step:1089/1845 train_time:50751ms step_avg:46.60ms
+step:1090/1845 train_time:50812ms step_avg:46.62ms
+step:1091/1845 train_time:50874ms step_avg:46.63ms
+step:1092/1845 train_time:50935ms step_avg:46.64ms
+step:1093/1845 train_time:50997ms step_avg:46.66ms
+step:1094/1845 train_time:51058ms step_avg:46.67ms
+step:1095/1845 train_time:51121ms step_avg:46.69ms
+step:1096/1845 train_time:51181ms step_avg:46.70ms
+step:1097/1845 train_time:51243ms step_avg:46.71ms
+step:1098/1845 train_time:51304ms step_avg:46.72ms
+step:1099/1845 train_time:51366ms step_avg:46.74ms
+step:1100/1845 train_time:51427ms step_avg:46.75ms
+step:1101/1845 train_time:51490ms step_avg:46.77ms
+step:1102/1845 train_time:51551ms step_avg:46.78ms
+step:1103/1845 train_time:51613ms step_avg:46.79ms
+step:1104/1845 train_time:51674ms step_avg:46.81ms
+step:1105/1845 train_time:51736ms step_avg:46.82ms
+step:1106/1845 train_time:51797ms step_avg:46.83ms
+step:1107/1845 train_time:51859ms step_avg:46.85ms
+step:1108/1845 train_time:51920ms step_avg:46.86ms
+step:1109/1845 train_time:51982ms step_avg:46.87ms
+step:1110/1845 train_time:52043ms step_avg:46.89ms
+step:1111/1845 train_time:52106ms step_avg:46.90ms
+step:1112/1845 train_time:52166ms step_avg:46.91ms
+step:1113/1845 train_time:52229ms step_avg:46.93ms
+step:1114/1845 train_time:52290ms step_avg:46.94ms
+step:1115/1845 train_time:52353ms step_avg:46.95ms
+step:1116/1845 train_time:52414ms step_avg:46.97ms
+step:1117/1845 train_time:52476ms step_avg:46.98ms
+step:1118/1845 train_time:52537ms step_avg:46.99ms
+step:1119/1845 train_time:52599ms step_avg:47.01ms
+step:1120/1845 train_time:52660ms step_avg:47.02ms
+step:1121/1845 train_time:52722ms step_avg:47.03ms
+step:1122/1845 train_time:52782ms step_avg:47.04ms
+step:1123/1845 train_time:52844ms step_avg:47.06ms
+step:1124/1845 train_time:52905ms step_avg:47.07ms
+step:1125/1845 train_time:52968ms step_avg:47.08ms
+step:1126/1845 train_time:53029ms step_avg:47.09ms
+step:1127/1845 train_time:53092ms step_avg:47.11ms
+step:1128/1845 train_time:53152ms step_avg:47.12ms
+step:1129/1845 train_time:53214ms step_avg:47.13ms
+step:1130/1845 train_time:53275ms step_avg:47.15ms
+step:1131/1845 train_time:53337ms step_avg:47.16ms
+step:1132/1845 train_time:53398ms step_avg:47.17ms
+step:1133/1845 train_time:53460ms step_avg:47.18ms
+step:1134/1845 train_time:53521ms step_avg:47.20ms
+step:1135/1845 train_time:53583ms step_avg:47.21ms
+step:1136/1845 train_time:53644ms step_avg:47.22ms
+step:1137/1845 train_time:53707ms step_avg:47.24ms
+step:1138/1845 train_time:53768ms step_avg:47.25ms
+step:1139/1845 train_time:53831ms step_avg:47.26ms
+step:1140/1845 train_time:53892ms step_avg:47.27ms
+step:1141/1845 train_time:53955ms step_avg:47.29ms
+step:1142/1845 train_time:54016ms step_avg:47.30ms
+step:1143/1845 train_time:54079ms step_avg:47.31ms
+step:1144/1845 train_time:54139ms step_avg:47.32ms
+step:1145/1845 train_time:54202ms step_avg:47.34ms
+step:1146/1845 train_time:54262ms step_avg:47.35ms
+step:1147/1845 train_time:54325ms step_avg:47.36ms
+step:1148/1845 train_time:54385ms step_avg:47.37ms
+step:1149/1845 train_time:54448ms step_avg:47.39ms
+step:1150/1845 train_time:54509ms step_avg:47.40ms
+step:1151/1845 train_time:54572ms step_avg:47.41ms
+step:1152/1845 train_time:54633ms step_avg:47.42ms
+step:1153/1845 train_time:54695ms step_avg:47.44ms
+step:1154/1845 train_time:54756ms step_avg:47.45ms
+step:1155/1845 train_time:54819ms step_avg:47.46ms
+step:1156/1845 train_time:54879ms step_avg:47.47ms
+step:1157/1845 train_time:54941ms step_avg:47.49ms
+step:1158/1845 train_time:55002ms step_avg:47.50ms
+step:1159/1845 train_time:55065ms step_avg:47.51ms
+step:1160/1845 train_time:55126ms step_avg:47.52ms
+step:1161/1845 train_time:55189ms step_avg:47.54ms
+step:1162/1845 train_time:55250ms step_avg:47.55ms
+step:1163/1845 train_time:55312ms step_avg:47.56ms
+step:1164/1845 train_time:55373ms step_avg:47.57ms
+step:1165/1845 train_time:55435ms step_avg:47.58ms
+step:1166/1845 train_time:55496ms step_avg:47.59ms
+step:1167/1845 train_time:55558ms step_avg:47.61ms
+step:1168/1845 train_time:55619ms step_avg:47.62ms
+step:1169/1845 train_time:55681ms step_avg:47.63ms
+step:1170/1845 train_time:55742ms step_avg:47.64ms
+step:1171/1845 train_time:55804ms step_avg:47.65ms
+step:1172/1845 train_time:55864ms step_avg:47.67ms
+step:1173/1845 train_time:55927ms step_avg:47.68ms
+step:1174/1845 train_time:55988ms step_avg:47.69ms
+step:1175/1845 train_time:56051ms step_avg:47.70ms
+step:1176/1845 train_time:56112ms step_avg:47.71ms
+step:1177/1845 train_time:56174ms step_avg:47.73ms
+step:1178/1845 train_time:56235ms step_avg:47.74ms
+step:1179/1845 train_time:56297ms step_avg:47.75ms
+step:1180/1845 train_time:56357ms step_avg:47.76ms
+step:1181/1845 train_time:56419ms step_avg:47.77ms
+step:1182/1845 train_time:56480ms step_avg:47.78ms
+step:1183/1845 train_time:56542ms step_avg:47.80ms
+step:1184/1845 train_time:56603ms step_avg:47.81ms
+step:1185/1845 train_time:56665ms step_avg:47.82ms
+step:1186/1845 train_time:56726ms step_avg:47.83ms
+step:1187/1845 train_time:56789ms step_avg:47.84ms
+step:1188/1845 train_time:56850ms step_avg:47.85ms
+step:1189/1845 train_time:56912ms step_avg:47.87ms
+step:1190/1845 train_time:56973ms step_avg:47.88ms
+step:1191/1845 train_time:57036ms step_avg:47.89ms
+step:1192/1845 train_time:57097ms step_avg:47.90ms
+step:1193/1845 train_time:57159ms step_avg:47.91ms
+step:1194/1845 train_time:57220ms step_avg:47.92ms
+step:1195/1845 train_time:57282ms step_avg:47.93ms
+step:1196/1845 train_time:57342ms step_avg:47.95ms
+step:1197/1845 train_time:57404ms step_avg:47.96ms
+step:1198/1845 train_time:57465ms step_avg:47.97ms
+step:1199/1845 train_time:57529ms step_avg:47.98ms
+step:1200/1845 train_time:57589ms step_avg:47.99ms
+step:1201/1845 train_time:57652ms step_avg:48.00ms
+step:1202/1845 train_time:57714ms step_avg:48.01ms
+step:1203/1845 train_time:57776ms step_avg:48.03ms
+step:1204/1845 train_time:57836ms step_avg:48.04ms
+step:1205/1845 train_time:57899ms step_avg:48.05ms
+step:1206/1845 train_time:57987ms step_avg:48.08ms
+step:1207/1845 train_time:58075ms step_avg:48.12ms
+step:1208/1845 train_time:58164ms step_avg:48.15ms
+step:1209/1845 train_time:58253ms step_avg:48.18ms
+step:1210/1845 train_time:58341ms step_avg:48.22ms
+step:1211/1845 train_time:58430ms step_avg:48.25ms
+step:1212/1845 train_time:58517ms step_avg:48.28ms
+step:1213/1845 train_time:58606ms step_avg:48.32ms
+step:1214/1845 train_time:58695ms step_avg:48.35ms
+step:1215/1845 train_time:58784ms step_avg:48.38ms
+step:1216/1845 train_time:58870ms step_avg:48.41ms
+step:1217/1845 train_time:58959ms step_avg:48.45ms
+step:1218/1845 train_time:59045ms step_avg:48.48ms
+step:1219/1845 train_time:59134ms step_avg:48.51ms
+step:1220/1845 train_time:59221ms step_avg:48.54ms
+step:1221/1845 train_time:59310ms step_avg:48.57ms
+step:1222/1845 train_time:59397ms step_avg:48.61ms
+step:1223/1845 train_time:59486ms step_avg:48.64ms
+step:1224/1845 train_time:59573ms step_avg:48.67ms
+step:1225/1845 train_time:59663ms step_avg:48.70ms
+step:1226/1845 train_time:59750ms step_avg:48.74ms
+step:1227/1845 train_time:59839ms step_avg:48.77ms
+step:1228/1845 train_time:59926ms step_avg:48.80ms
+step:1229/1845 train_time:60014ms step_avg:48.83ms
+step:1230/1845 train_time:60102ms step_avg:48.86ms
+step:1231/1845 train_time:60190ms step_avg:48.90ms
+step:1232/1845 train_time:60277ms step_avg:48.93ms
+step:1233/1845 train_time:60366ms step_avg:48.96ms
+step:1234/1845 train_time:60454ms step_avg:48.99ms
+step:1235/1845 train_time:60542ms step_avg:49.02ms
+step:1236/1845 train_time:60630ms step_avg:49.05ms
+step:1237/1845 train_time:60719ms step_avg:49.09ms
+step:1238/1845 train_time:60808ms step_avg:49.12ms
+step:1239/1845 train_time:60896ms step_avg:49.15ms
+step:1240/1845 train_time:60984ms step_avg:49.18ms
+step:1241/1845 train_time:61074ms step_avg:49.21ms
+step:1242/1845 train_time:61160ms step_avg:49.24ms
+step:1243/1845 train_time:61248ms step_avg:49.27ms
+step:1244/1845 train_time:61336ms step_avg:49.31ms
+step:1245/1845 train_time:61425ms step_avg:49.34ms
+step:1246/1845 train_time:61512ms step_avg:49.37ms
+step:1247/1845 train_time:61600ms step_avg:49.40ms
+step:1248/1845 train_time:61688ms step_avg:49.43ms
+step:1249/1845 train_time:61777ms step_avg:49.46ms
+step:1250/1845 train_time:61864ms step_avg:49.49ms
+step:1250/1845 val_loss:3.5335 train_time:61954ms step_avg:49.56ms
+step:1251/1845 train_time:61974ms step_avg:49.54ms
+step:1252/1845 train_time:62044ms step_avg:49.56ms
+step:1253/1845 train_time:62138ms step_avg:49.59ms
+step:1254/1845 train_time:62226ms step_avg:49.62ms
+step:1255/1845 train_time:62314ms step_avg:49.65ms
+step:1256/1845 train_time:62401ms step_avg:49.68ms
+step:1257/1845 train_time:62488ms step_avg:49.71ms
+step:1258/1845 train_time:62575ms step_avg:49.74ms
+step:1259/1845 train_time:62663ms step_avg:49.77ms
+step:1260/1845 train_time:62749ms step_avg:49.80ms
+step:1261/1845 train_time:62837ms step_avg:49.83ms
+step:1262/1845 train_time:62925ms step_avg:49.86ms
+step:1263/1845 train_time:63015ms step_avg:49.89ms
+step:1264/1845 train_time:63105ms step_avg:49.93ms
+step:1265/1845 train_time:63195ms step_avg:49.96ms
+step:1266/1845 train_time:63283ms step_avg:49.99ms
+step:1267/1845 train_time:63372ms step_avg:50.02ms
+step:1268/1845 train_time:63459ms step_avg:50.05ms
+step:1269/1845 train_time:63547ms step_avg:50.08ms
+step:1270/1845 train_time:63633ms step_avg:50.10ms
+step:1271/1845 train_time:63720ms step_avg:50.13ms
+step:1272/1845 train_time:63807ms step_avg:50.16ms
+step:1273/1845 train_time:63897ms step_avg:50.19ms
+step:1274/1845 train_time:63985ms step_avg:50.22ms
+step:1275/1845 train_time:64075ms step_avg:50.25ms
+step:1276/1845 train_time:64163ms step_avg:50.28ms
+step:1277/1845 train_time:64252ms step_avg:50.31ms
+step:1278/1845 train_time:64340ms step_avg:50.34ms
+step:1279/1845 train_time:64428ms step_avg:50.37ms
+step:1280/1845 train_time:64516ms step_avg:50.40ms
+step:1281/1845 train_time:64604ms step_avg:50.43ms
+step:1282/1845 train_time:64690ms step_avg:50.46ms
+step:1283/1845 train_time:64778ms step_avg:50.49ms
+step:1284/1845 train_time:64865ms step_avg:50.52ms
+step:1285/1845 train_time:64954ms step_avg:50.55ms
+step:1286/1845 train_time:65042ms step_avg:50.58ms
+step:1287/1845 train_time:65131ms step_avg:50.61ms
+step:1288/1845 train_time:65221ms step_avg:50.64ms
+step:1289/1845 train_time:65310ms step_avg:50.67ms
+step:1290/1845 train_time:65397ms step_avg:50.70ms
+step:1291/1845 train_time:65485ms step_avg:50.72ms
+step:1292/1845 train_time:65572ms step_avg:50.75ms
+step:1293/1845 train_time:65660ms step_avg:50.78ms
+step:1294/1845 train_time:65746ms step_avg:50.81ms
+step:1295/1845 train_time:65834ms step_avg:50.84ms
+step:1296/1845 train_time:65922ms step_avg:50.87ms
+step:1297/1845 train_time:66010ms step_avg:50.89ms
+step:1298/1845 train_time:66099ms step_avg:50.92ms
+step:1299/1845 train_time:66188ms step_avg:50.95ms
+step:1300/1845 train_time:66275ms step_avg:50.98ms
+step:1301/1845 train_time:66364ms step_avg:51.01ms
+step:1302/1845 train_time:66453ms step_avg:51.04ms
+step:1303/1845 train_time:66541ms step_avg:51.07ms
+step:1304/1845 train_time:66629ms step_avg:51.10ms
+step:1305/1845 train_time:66718ms step_avg:51.12ms
+step:1306/1845 train_time:66804ms step_avg:51.15ms
+step:1307/1845 train_time:66893ms step_avg:51.18ms
+step:1308/1845 train_time:66982ms step_avg:51.21ms
+step:1309/1845 train_time:67070ms step_avg:51.24ms
+step:1310/1845 train_time:67158ms step_avg:51.27ms
+step:1311/1845 train_time:67248ms step_avg:51.30ms
+step:1312/1845 train_time:67337ms step_avg:51.32ms
+step:1313/1845 train_time:67425ms step_avg:51.35ms
+step:1314/1845 train_time:67512ms step_avg:51.38ms
+step:1315/1845 train_time:67601ms step_avg:51.41ms
+step:1316/1845 train_time:67688ms step_avg:51.43ms
+step:1317/1845 train_time:67777ms step_avg:51.46ms
+step:1318/1845 train_time:67864ms step_avg:51.49ms
+step:1319/1845 train_time:67953ms step_avg:51.52ms
+step:1320/1845 train_time:68040ms step_avg:51.55ms
+step:1321/1845 train_time:68128ms step_avg:51.57ms
+step:1322/1845 train_time:68217ms step_avg:51.60ms
+step:1323/1845 train_time:68306ms step_avg:51.63ms
+step:1324/1845 train_time:68393ms step_avg:51.66ms
+step:1325/1845 train_time:68481ms step_avg:51.68ms
+step:1326/1845 train_time:68568ms step_avg:51.71ms
+step:1327/1845 train_time:68657ms step_avg:51.74ms
+step:1328/1845 train_time:68745ms step_avg:51.77ms
+step:1329/1845 train_time:68833ms step_avg:51.79ms
+step:1330/1845 train_time:68922ms step_avg:51.82ms
+step:1331/1845 train_time:69010ms step_avg:51.85ms
+step:1332/1845 train_time:69098ms step_avg:51.88ms
+step:1333/1845 train_time:69187ms step_avg:51.90ms
+step:1334/1845 train_time:69275ms step_avg:51.93ms
+step:1335/1845 train_time:69363ms step_avg:51.96ms
+step:1336/1845 train_time:69451ms step_avg:51.98ms
+step:1337/1845 train_time:69540ms step_avg:52.01ms
+step:1338/1845 train_time:69626ms step_avg:52.04ms
+step:1339/1845 train_time:69716ms step_avg:52.07ms
+step:1340/1845 train_time:69803ms step_avg:52.09ms
+step:1341/1845 train_time:69891ms step_avg:52.12ms
+step:1342/1845 train_time:69979ms step_avg:52.15ms
+step:1343/1845 train_time:70067ms step_avg:52.17ms
+step:1344/1845 train_time:70155ms step_avg:52.20ms
+step:1345/1845 train_time:70244ms step_avg:52.23ms
+step:1346/1845 train_time:70332ms step_avg:52.25ms
+step:1347/1845 train_time:70421ms step_avg:52.28ms
+step:1348/1845 train_time:70509ms step_avg:52.31ms
+step:1349/1845 train_time:70597ms step_avg:52.33ms
+step:1350/1845 train_time:70684ms step_avg:52.36ms
+step:1351/1845 train_time:70773ms step_avg:52.39ms
+step:1352/1845 train_time:70860ms step_avg:52.41ms
+step:1353/1845 train_time:70948ms step_avg:52.44ms
+step:1354/1845 train_time:71036ms step_avg:52.46ms
+step:1355/1845 train_time:71124ms step_avg:52.49ms
+step:1356/1845 train_time:71212ms step_avg:52.52ms
+step:1357/1845 train_time:71300ms step_avg:52.54ms
+step:1358/1845 train_time:71388ms step_avg:52.57ms
+step:1359/1845 train_time:71477ms step_avg:52.60ms
+step:1360/1845 train_time:71563ms step_avg:52.62ms
+step:1361/1845 train_time:71653ms step_avg:52.65ms
+step:1362/1845 train_time:71740ms step_avg:52.67ms
+step:1363/1845 train_time:71829ms step_avg:52.70ms
+step:1364/1845 train_time:71918ms step_avg:52.73ms
+step:1365/1845 train_time:72006ms step_avg:52.75ms
+step:1366/1845 train_time:72094ms step_avg:52.78ms
+step:1367/1845 train_time:72183ms step_avg:52.80ms
+step:1368/1845 train_time:72271ms step_avg:52.83ms
+step:1369/1845 train_time:72360ms step_avg:52.86ms
+step:1370/1845 train_time:72447ms step_avg:52.88ms
+step:1371/1845 train_time:72536ms step_avg:52.91ms
+step:1372/1845 train_time:72623ms step_avg:52.93ms
+step:1373/1845 train_time:72712ms step_avg:52.96ms
+step:1374/1845 train_time:72799ms step_avg:52.98ms
+step:1375/1845 train_time:72888ms step_avg:53.01ms
+step:1376/1845 train_time:72975ms step_avg:53.03ms
+step:1377/1845 train_time:73064ms step_avg:53.06ms
+step:1378/1845 train_time:73151ms step_avg:53.09ms
+step:1379/1845 train_time:73239ms step_avg:53.11ms
+step:1380/1845 train_time:73326ms step_avg:53.13ms
+step:1381/1845 train_time:73414ms step_avg:53.16ms
+step:1382/1845 train_time:73503ms step_avg:53.19ms
+step:1383/1845 train_time:73590ms step_avg:53.21ms
+step:1384/1845 train_time:73678ms step_avg:53.24ms
+step:1385/1845 train_time:73765ms step_avg:53.26ms
+step:1386/1845 train_time:73852ms step_avg:53.28ms
+step:1387/1845 train_time:73941ms step_avg:53.31ms
+step:1388/1845 train_time:74028ms step_avg:53.33ms
+step:1389/1845 train_time:74117ms step_avg:53.36ms
+step:1390/1845 train_time:74204ms step_avg:53.38ms
+step:1391/1845 train_time:74292ms step_avg:53.41ms
+step:1392/1845 train_time:74380ms step_avg:53.43ms
+step:1393/1845 train_time:74468ms step_avg:53.46ms
+step:1394/1845 train_time:74556ms step_avg:53.48ms
+step:1395/1845 train_time:74644ms step_avg:53.51ms
+step:1396/1845 train_time:74731ms step_avg:53.53ms
+step:1397/1845 train_time:74820ms step_avg:53.56ms
+step:1398/1845 train_time:74909ms step_avg:53.58ms
+step:1399/1845 train_time:74997ms step_avg:53.61ms
+step:1400/1845 train_time:75084ms step_avg:53.63ms
+step:1401/1845 train_time:75172ms step_avg:53.66ms
+step:1402/1845 train_time:75260ms step_avg:53.68ms
+step:1403/1845 train_time:75348ms step_avg:53.70ms
+step:1404/1845 train_time:75435ms step_avg:53.73ms
+step:1405/1845 train_time:75523ms step_avg:53.75ms
+step:1406/1845 train_time:75611ms step_avg:53.78ms
+step:1407/1845 train_time:75699ms step_avg:53.80ms
+step:1408/1845 train_time:75787ms step_avg:53.83ms
+step:1409/1845 train_time:75876ms step_avg:53.85ms
+step:1410/1845 train_time:75963ms step_avg:53.87ms
+step:1411/1845 train_time:76051ms step_avg:53.90ms
+step:1412/1845 train_time:76138ms step_avg:53.92ms
+step:1413/1845 train_time:76227ms step_avg:53.95ms
+step:1414/1845 train_time:76314ms step_avg:53.97ms
+step:1415/1845 train_time:76402ms step_avg:53.99ms
+step:1416/1845 train_time:76490ms step_avg:54.02ms
+step:1417/1845 train_time:76580ms step_avg:54.04ms
+step:1418/1845 train_time:76668ms step_avg:54.07ms
+step:1419/1845 train_time:76757ms step_avg:54.09ms
+step:1420/1845 train_time:76845ms step_avg:54.12ms
+step:1421/1845 train_time:76933ms step_avg:54.14ms
+step:1422/1845 train_time:77021ms step_avg:54.16ms
+step:1423/1845 train_time:77108ms step_avg:54.19ms
+step:1424/1845 train_time:77196ms step_avg:54.21ms
+step:1425/1845 train_time:77284ms step_avg:54.23ms
+step:1426/1845 train_time:77371ms step_avg:54.26ms
+step:1427/1845 train_time:77459ms step_avg:54.28ms
+step:1428/1845 train_time:77547ms step_avg:54.30ms
+step:1429/1845 train_time:77636ms step_avg:54.33ms
+step:1430/1845 train_time:77724ms step_avg:54.35ms
+step:1431/1845 train_time:77811ms step_avg:54.38ms
+step:1432/1845 train_time:77899ms step_avg:54.40ms
+step:1433/1845 train_time:77987ms step_avg:54.42ms
+step:1434/1845 train_time:78075ms step_avg:54.45ms
+step:1435/1845 train_time:78163ms step_avg:54.47ms
+step:1436/1845 train_time:78250ms step_avg:54.49ms
+step:1437/1845 train_time:78338ms step_avg:54.51ms
+step:1438/1845 train_time:78424ms step_avg:54.54ms
+step:1439/1845 train_time:78513ms step_avg:54.56ms
+step:1440/1845 train_time:78601ms step_avg:54.58ms
+step:1441/1845 train_time:78690ms step_avg:54.61ms
+step:1442/1845 train_time:78778ms step_avg:54.63ms
+step:1443/1845 train_time:78866ms step_avg:54.65ms
+step:1444/1845 train_time:78953ms step_avg:54.68ms
+step:1445/1845 train_time:79041ms step_avg:54.70ms
+step:1446/1845 train_time:79129ms step_avg:54.72ms
+step:1447/1845 train_time:79218ms step_avg:54.75ms
+step:1448/1845 train_time:79306ms step_avg:54.77ms
+step:1449/1845 train_time:79394ms step_avg:54.79ms
+step:1450/1845 train_time:79481ms step_avg:54.81ms
+step:1451/1845 train_time:79569ms step_avg:54.84ms
+step:1452/1845 train_time:79657ms step_avg:54.86ms
+step:1453/1845 train_time:79745ms step_avg:54.88ms
+step:1454/1845 train_time:79834ms step_avg:54.91ms
+step:1455/1845 train_time:79922ms step_avg:54.93ms
+step:1456/1845 train_time:80010ms step_avg:54.95ms
+step:1457/1845 train_time:80099ms step_avg:54.98ms
+step:1458/1845 train_time:80187ms step_avg:55.00ms
+step:1459/1845 train_time:80276ms step_avg:55.02ms
+step:1460/1845 train_time:80363ms step_avg:55.04ms
+step:1461/1845 train_time:80452ms step_avg:55.07ms
+step:1462/1845 train_time:80539ms step_avg:55.09ms
+step:1463/1845 train_time:80628ms step_avg:55.11ms
+step:1464/1845 train_time:80715ms step_avg:55.13ms
+step:1465/1845 train_time:80804ms step_avg:55.16ms
+step:1466/1845 train_time:80891ms step_avg:55.18ms
+step:1467/1845 train_time:80980ms step_avg:55.20ms
+step:1468/1845 train_time:81067ms step_avg:55.22ms
+step:1469/1845 train_time:81156ms step_avg:55.25ms
+step:1470/1845 train_time:81243ms step_avg:55.27ms
+step:1471/1845 train_time:81332ms step_avg:55.29ms
+step:1472/1845 train_time:81420ms step_avg:55.31ms
+step:1473/1845 train_time:81508ms step_avg:55.33ms
+step:1474/1845 train_time:81596ms step_avg:55.36ms
+step:1475/1845 train_time:81685ms step_avg:55.38ms
+step:1476/1845 train_time:81773ms step_avg:55.40ms
+step:1477/1845 train_time:81862ms step_avg:55.42ms
+step:1478/1845 train_time:81950ms step_avg:55.45ms
+step:1479/1845 train_time:82038ms step_avg:55.47ms
+step:1480/1845 train_time:82126ms step_avg:55.49ms
+step:1481/1845 train_time:82215ms step_avg:55.51ms
+step:1482/1845 train_time:82302ms step_avg:55.53ms
+step:1483/1845 train_time:82390ms step_avg:55.56ms
+step:1484/1845 train_time:82478ms step_avg:55.58ms
+step:1485/1845 train_time:82566ms step_avg:55.60ms
+step:1486/1845 train_time:82653ms step_avg:55.62ms
+step:1487/1845 train_time:82741ms step_avg:55.64ms
+step:1488/1845 train_time:82828ms step_avg:55.66ms
+step:1489/1845 train_time:82917ms step_avg:55.69ms
+step:1490/1845 train_time:83004ms step_avg:55.71ms
+step:1491/1845 train_time:83093ms step_avg:55.73ms
+step:1492/1845 train_time:83180ms step_avg:55.75ms
+step:1493/1845 train_time:83268ms step_avg:55.77ms
+step:1494/1845 train_time:83356ms step_avg:55.79ms
+step:1495/1845 train_time:83445ms step_avg:55.82ms
+step:1496/1845 train_time:83532ms step_avg:55.84ms
+step:1497/1845 train_time:83620ms step_avg:55.86ms
+step:1498/1845 train_time:83708ms step_avg:55.88ms
+step:1499/1845 train_time:83796ms step_avg:55.90ms
+step:1500/1845 train_time:83884ms step_avg:55.92ms
+step:1500/1845 val_loss:3.4029 train_time:83973ms step_avg:55.98ms
+step:1501/1845 train_time:83994ms step_avg:55.96ms
+step:1502/1845 train_time:84064ms step_avg:55.97ms
+step:1503/1845 train_time:84158ms step_avg:55.99ms
+step:1504/1845 train_time:84245ms step_avg:56.01ms
+step:1505/1845 train_time:84333ms step_avg:56.04ms
+step:1506/1845 train_time:84419ms step_avg:56.06ms
+step:1507/1845 train_time:84506ms step_avg:56.08ms
+step:1508/1845 train_time:84593ms step_avg:56.10ms
+step:1509/1845 train_time:84681ms step_avg:56.12ms
+step:1510/1845 train_time:84768ms step_avg:56.14ms
+step:1511/1845 train_time:84856ms step_avg:56.16ms
+step:1512/1845 train_time:84944ms step_avg:56.18ms
+step:1513/1845 train_time:85036ms step_avg:56.20ms
+step:1514/1845 train_time:85125ms step_avg:56.23ms
+step:1515/1845 train_time:85214ms step_avg:56.25ms
+step:1516/1845 train_time:85302ms step_avg:56.27ms
+step:1517/1845 train_time:85390ms step_avg:56.29ms
+step:1518/1845 train_time:85476ms step_avg:56.31ms
+step:1519/1845 train_time:85564ms step_avg:56.33ms
+step:1520/1845 train_time:85650ms step_avg:56.35ms
+step:1521/1845 train_time:85737ms step_avg:56.37ms
+step:1522/1845 train_time:85824ms step_avg:56.39ms
+step:1523/1845 train_time:85914ms step_avg:56.41ms
+step:1524/1845 train_time:86002ms step_avg:56.43ms
+step:1525/1845 train_time:86092ms step_avg:56.45ms
+step:1526/1845 train_time:86181ms step_avg:56.47ms
+step:1527/1845 train_time:86269ms step_avg:56.50ms
+step:1528/1845 train_time:86357ms step_avg:56.52ms
+step:1529/1845 train_time:86445ms step_avg:56.54ms
+step:1530/1845 train_time:86532ms step_avg:56.56ms
+step:1531/1845 train_time:86620ms step_avg:56.58ms
+step:1532/1845 train_time:86706ms step_avg:56.60ms
+step:1533/1845 train_time:86795ms step_avg:56.62ms
+step:1534/1845 train_time:86882ms step_avg:56.64ms
+step:1535/1845 train_time:86972ms step_avg:56.66ms
+step:1536/1845 train_time:87060ms step_avg:56.68ms
+step:1537/1845 train_time:87149ms step_avg:56.70ms
+step:1538/1845 train_time:87237ms step_avg:56.72ms
+step:1539/1845 train_time:87325ms step_avg:56.74ms
+step:1540/1845 train_time:87413ms step_avg:56.76ms
+step:1541/1845 train_time:87501ms step_avg:56.78ms
+step:1542/1845 train_time:87588ms step_avg:56.80ms
+step:1543/1845 train_time:87676ms step_avg:56.82ms
+step:1544/1845 train_time:87762ms step_avg:56.84ms
+step:1545/1845 train_time:87851ms step_avg:56.86ms
+step:1546/1845 train_time:87938ms step_avg:56.88ms
+step:1547/1845 train_time:88027ms step_avg:56.90ms
+step:1548/1845 train_time:88116ms step_avg:56.92ms
+step:1549/1845 train_time:88205ms step_avg:56.94ms
+step:1550/1845 train_time:88292ms step_avg:56.96ms
+step:1551/1845 train_time:88380ms step_avg:56.98ms
+step:1552/1845 train_time:88468ms step_avg:57.00ms
+step:1553/1845 train_time:88556ms step_avg:57.02ms
+step:1554/1845 train_time:88643ms step_avg:57.04ms
+step:1555/1845 train_time:88731ms step_avg:57.06ms
+step:1556/1845 train_time:88818ms step_avg:57.08ms
+step:1557/1845 train_time:88907ms step_avg:57.10ms
+step:1558/1845 train_time:88994ms step_avg:57.12ms
+step:1559/1845 train_time:89083ms step_avg:57.14ms
+step:1560/1845 train_time:89170ms step_avg:57.16ms
+step:1561/1845 train_time:89260ms step_avg:57.18ms
+step:1562/1845 train_time:89347ms step_avg:57.20ms
+step:1563/1845 train_time:89436ms step_avg:57.22ms
+step:1564/1845 train_time:89523ms step_avg:57.24ms
+step:1565/1845 train_time:89612ms step_avg:57.26ms
+step:1566/1845 train_time:89699ms step_avg:57.28ms
+step:1567/1845 train_time:89787ms step_avg:57.30ms
+step:1568/1845 train_time:89874ms step_avg:57.32ms
+step:1569/1845 train_time:89962ms step_avg:57.34ms
+step:1570/1845 train_time:90050ms step_avg:57.36ms
+step:1571/1845 train_time:90138ms step_avg:57.38ms
+step:1572/1845 train_time:90226ms step_avg:57.40ms
+step:1573/1845 train_time:90315ms step_avg:57.42ms
+step:1574/1845 train_time:90403ms step_avg:57.44ms
+step:1575/1845 train_time:90492ms step_avg:57.46ms
+step:1576/1845 train_time:90578ms step_avg:57.47ms
+step:1577/1845 train_time:90667ms step_avg:57.49ms
+step:1578/1845 train_time:90754ms step_avg:57.51ms
+step:1579/1845 train_time:90842ms step_avg:57.53ms
+step:1580/1845 train_time:90930ms step_avg:57.55ms
+step:1581/1845 train_time:91018ms step_avg:57.57ms
+step:1582/1845 train_time:91106ms step_avg:57.59ms
+step:1583/1845 train_time:91196ms step_avg:57.61ms
+step:1584/1845 train_time:91283ms step_avg:57.63ms
+step:1585/1845 train_time:91372ms step_avg:57.65ms
+step:1586/1845 train_time:91459ms step_avg:57.67ms
+step:1587/1845 train_time:91548ms step_avg:57.69ms
+step:1588/1845 train_time:91635ms step_avg:57.70ms
+step:1589/1845 train_time:91723ms step_avg:57.72ms
+step:1590/1845 train_time:91810ms step_avg:57.74ms
+step:1591/1845 train_time:91900ms step_avg:57.76ms
+step:1592/1845 train_time:91987ms step_avg:57.78ms
+step:1593/1845 train_time:92075ms step_avg:57.80ms
+step:1594/1845 train_time:92162ms step_avg:57.82ms
+step:1595/1845 train_time:92251ms step_avg:57.84ms
+step:1596/1845 train_time:92338ms step_avg:57.86ms
+step:1597/1845 train_time:92426ms step_avg:57.88ms
+step:1598/1845 train_time:92513ms step_avg:57.89ms
+step:1599/1845 train_time:92602ms step_avg:57.91ms
+step:1600/1845 train_time:92689ms step_avg:57.93ms
+step:1601/1845 train_time:92777ms step_avg:57.95ms
+step:1602/1845 train_time:92864ms step_avg:57.97ms
+step:1603/1845 train_time:92953ms step_avg:57.99ms
+step:1604/1845 train_time:93040ms step_avg:58.01ms
+step:1605/1845 train_time:93129ms step_avg:58.02ms
+step:1606/1845 train_time:93216ms step_avg:58.04ms
+step:1607/1845 train_time:93304ms step_avg:58.06ms
+step:1608/1845 train_time:93392ms step_avg:58.08ms
+step:1609/1845 train_time:93480ms step_avg:58.10ms
+step:1610/1845 train_time:93567ms step_avg:58.12ms
+step:1611/1845 train_time:93656ms step_avg:58.14ms
+step:1612/1845 train_time:93744ms step_avg:58.15ms
+step:1613/1845 train_time:93832ms step_avg:58.17ms
+step:1614/1845 train_time:93920ms step_avg:58.19ms
+step:1615/1845 train_time:94008ms step_avg:58.21ms
+step:1616/1845 train_time:94095ms step_avg:58.23ms
+step:1617/1845 train_time:94184ms step_avg:58.25ms
+step:1618/1845 train_time:94271ms step_avg:58.26ms
+step:1619/1845 train_time:94360ms step_avg:58.28ms
+step:1620/1845 train_time:94448ms step_avg:58.30ms
+step:1621/1845 train_time:94536ms step_avg:58.32ms
+step:1622/1845 train_time:94624ms step_avg:58.34ms
+step:1623/1845 train_time:94712ms step_avg:58.36ms
+step:1624/1845 train_time:94798ms step_avg:58.37ms
+step:1625/1845 train_time:94886ms step_avg:58.39ms
+step:1626/1845 train_time:94973ms step_avg:58.41ms
+step:1627/1845 train_time:95062ms step_avg:58.43ms
+step:1628/1845 train_time:95150ms step_avg:58.45ms
+step:1629/1845 train_time:95239ms step_avg:58.46ms
+step:1630/1845 train_time:95327ms step_avg:58.48ms
+step:1631/1845 train_time:95416ms step_avg:58.50ms
+step:1632/1845 train_time:95504ms step_avg:58.52ms
+step:1633/1845 train_time:95593ms step_avg:58.54ms
+step:1634/1845 train_time:95680ms step_avg:58.56ms
+step:1635/1845 train_time:95768ms step_avg:58.57ms
+step:1636/1845 train_time:95855ms step_avg:58.59ms
+step:1637/1845 train_time:95944ms step_avg:58.61ms
+step:1638/1845 train_time:96031ms step_avg:58.63ms
+step:1639/1845 train_time:96120ms step_avg:58.65ms
+step:1640/1845 train_time:96207ms step_avg:58.66ms
+step:1641/1845 train_time:96296ms step_avg:58.68ms
+step:1642/1845 train_time:96384ms step_avg:58.70ms
+step:1643/1845 train_time:96473ms step_avg:58.72ms
+step:1644/1845 train_time:96561ms step_avg:58.74ms
+step:1645/1845 train_time:96649ms step_avg:58.75ms
+step:1646/1845 train_time:96736ms step_avg:58.77ms
+step:1647/1845 train_time:96824ms step_avg:58.79ms
+step:1648/1845 train_time:96912ms step_avg:58.81ms
+step:1649/1845 train_time:96999ms step_avg:58.82ms
+step:1650/1845 train_time:97087ms step_avg:58.84ms
+step:1651/1845 train_time:97176ms step_avg:58.86ms
+step:1652/1845 train_time:97263ms step_avg:58.88ms
+step:1653/1845 train_time:97352ms step_avg:58.89ms
+step:1654/1845 train_time:97439ms step_avg:58.91ms
+step:1655/1845 train_time:97528ms step_avg:58.93ms
+step:1656/1845 train_time:97616ms step_avg:58.95ms
+step:1657/1845 train_time:97704ms step_avg:58.96ms
+step:1658/1845 train_time:97791ms step_avg:58.98ms
+step:1659/1845 train_time:97879ms step_avg:59.00ms
+step:1660/1845 train_time:97966ms step_avg:59.02ms
+step:1661/1845 train_time:98055ms step_avg:59.03ms
+step:1662/1845 train_time:98142ms step_avg:59.05ms
+step:1663/1845 train_time:98231ms step_avg:59.07ms
+step:1664/1845 train_time:98319ms step_avg:59.09ms
+step:1665/1845 train_time:98407ms step_avg:59.10ms
+step:1666/1845 train_time:98494ms step_avg:59.12ms
+step:1667/1845 train_time:98583ms step_avg:59.14ms
+step:1668/1845 train_time:98670ms step_avg:59.15ms
+step:1669/1845 train_time:98758ms step_avg:59.17ms
+step:1670/1845 train_time:98845ms step_avg:59.19ms
+step:1671/1845 train_time:98934ms step_avg:59.21ms
+step:1672/1845 train_time:99021ms step_avg:59.22ms
+step:1673/1845 train_time:99109ms step_avg:59.24ms
+step:1674/1845 train_time:99196ms step_avg:59.26ms
+step:1675/1845 train_time:99285ms step_avg:59.27ms
+step:1676/1845 train_time:99372ms step_avg:59.29ms
+step:1677/1845 train_time:99460ms step_avg:59.31ms
+step:1678/1845 train_time:99550ms step_avg:59.33ms
+step:1679/1845 train_time:99638ms step_avg:59.34ms
+step:1680/1845 train_time:99725ms step_avg:59.36ms
+step:1681/1845 train_time:99813ms step_avg:59.38ms
+step:1682/1845 train_time:99900ms step_avg:59.39ms
+step:1683/1845 train_time:99989ms step_avg:59.41ms
+step:1684/1845 train_time:100076ms step_avg:59.43ms
+step:1685/1845 train_time:100164ms step_avg:59.44ms
+step:1686/1845 train_time:100252ms step_avg:59.46ms
+step:1687/1845 train_time:100340ms step_avg:59.48ms
+step:1688/1845 train_time:100428ms step_avg:59.50ms
+step:1689/1845 train_time:100518ms step_avg:59.51ms
+step:1690/1845 train_time:100607ms step_avg:59.53ms
+step:1691/1845 train_time:100696ms step_avg:59.55ms
+step:1692/1845 train_time:100783ms step_avg:59.56ms
+step:1693/1845 train_time:100871ms step_avg:59.58ms
+step:1694/1845 train_time:100959ms step_avg:59.60ms
+step:1695/1845 train_time:101048ms step_avg:59.62ms
+step:1696/1845 train_time:101135ms step_avg:59.63ms
+step:1697/1845 train_time:101223ms step_avg:59.65ms
+step:1698/1845 train_time:101311ms step_avg:59.66ms
+step:1699/1845 train_time:101398ms step_avg:59.68ms
+step:1700/1845 train_time:101486ms step_avg:59.70ms
+step:1701/1845 train_time:101575ms step_avg:59.71ms
+step:1702/1845 train_time:101662ms step_avg:59.73ms
+step:1703/1845 train_time:101750ms step_avg:59.75ms
+step:1704/1845 train_time:101837ms step_avg:59.76ms
+step:1705/1845 train_time:101926ms step_avg:59.78ms
+step:1706/1845 train_time:102014ms step_avg:59.80ms
+step:1707/1845 train_time:102103ms step_avg:59.81ms
+step:1708/1845 train_time:102190ms step_avg:59.83ms
+step:1709/1845 train_time:102278ms step_avg:59.85ms
+step:1710/1845 train_time:102364ms step_avg:59.86ms
+step:1711/1845 train_time:102453ms step_avg:59.88ms
+step:1712/1845 train_time:102540ms step_avg:59.90ms
+step:1713/1845 train_time:102629ms step_avg:59.91ms
+step:1714/1845 train_time:102716ms step_avg:59.93ms
+step:1715/1845 train_time:102805ms step_avg:59.94ms
+step:1716/1845 train_time:102893ms step_avg:59.96ms
+step:1717/1845 train_time:102982ms step_avg:59.98ms
+step:1718/1845 train_time:103069ms step_avg:59.99ms
+step:1719/1845 train_time:103158ms step_avg:60.01ms
+step:1720/1845 train_time:103246ms step_avg:60.03ms
+step:1721/1845 train_time:103334ms step_avg:60.04ms
+step:1722/1845 train_time:103421ms step_avg:60.06ms
+step:1723/1845 train_time:103510ms step_avg:60.08ms
+step:1724/1845 train_time:103597ms step_avg:60.09ms
+step:1725/1845 train_time:103685ms step_avg:60.11ms
+step:1726/1845 train_time:103772ms step_avg:60.12ms
+step:1727/1845 train_time:103861ms step_avg:60.14ms
+step:1728/1845 train_time:103949ms step_avg:60.16ms
+step:1729/1845 train_time:104037ms step_avg:60.17ms
+step:1730/1845 train_time:104126ms step_avg:60.19ms
+step:1731/1845 train_time:104216ms step_avg:60.21ms
+step:1732/1845 train_time:104304ms step_avg:60.22ms
+step:1733/1845 train_time:104393ms step_avg:60.24ms
+step:1734/1845 train_time:104480ms step_avg:60.25ms
+step:1735/1845 train_time:104569ms step_avg:60.27ms
+step:1736/1845 train_time:104655ms step_avg:60.29ms
+step:1737/1845 train_time:104743ms step_avg:60.30ms
+step:1738/1845 train_time:104830ms step_avg:60.32ms
+step:1739/1845 train_time:104919ms step_avg:60.33ms
+step:1740/1845 train_time:105007ms step_avg:60.35ms
+step:1741/1845 train_time:105094ms step_avg:60.36ms
+step:1742/1845 train_time:105182ms step_avg:60.38ms
+step:1743/1845 train_time:105271ms step_avg:60.40ms
+step:1744/1845 train_time:105359ms step_avg:60.41ms
+step:1745/1845 train_time:105447ms step_avg:60.43ms
+step:1746/1845 train_time:105535ms step_avg:60.44ms
+step:1747/1845 train_time:105623ms step_avg:60.46ms
+step:1748/1845 train_time:105712ms step_avg:60.48ms
+step:1749/1845 train_time:105799ms step_avg:60.49ms
+step:1750/1845 train_time:105886ms step_avg:60.51ms
+step:1750/1845 val_loss:3.3044 train_time:105975ms step_avg:60.56ms
+step:1751/1845 train_time:105996ms step_avg:60.53ms
+step:1752/1845 train_time:106066ms step_avg:60.54ms
+step:1753/1845 train_time:106159ms step_avg:60.56ms
+step:1754/1845 train_time:106248ms step_avg:60.57ms
+step:1755/1845 train_time:106335ms step_avg:60.59ms
+step:1756/1845 train_time:106422ms step_avg:60.60ms
+step:1757/1845 train_time:106509ms step_avg:60.62ms
+step:1758/1845 train_time:106596ms step_avg:60.63ms
+step:1759/1845 train_time:106683ms step_avg:60.65ms
+step:1760/1845 train_time:106770ms step_avg:60.66ms
+step:1761/1845 train_time:106857ms step_avg:60.68ms
+step:1762/1845 train_time:106946ms step_avg:60.70ms
+step:1763/1845 train_time:107036ms step_avg:60.71ms
+step:1764/1845 train_time:107127ms step_avg:60.73ms
+step:1765/1845 train_time:107216ms step_avg:60.75ms
+step:1766/1845 train_time:107304ms step_avg:60.76ms
+step:1767/1845 train_time:107392ms step_avg:60.78ms
+step:1768/1845 train_time:107478ms step_avg:60.79ms
+step:1769/1845 train_time:107565ms step_avg:60.81ms
+step:1770/1845 train_time:107652ms step_avg:60.82ms
+step:1771/1845 train_time:107739ms step_avg:60.84ms
+step:1772/1845 train_time:107826ms step_avg:60.85ms
+step:1773/1845 train_time:107914ms step_avg:60.87ms
+step:1774/1845 train_time:108002ms step_avg:60.88ms
+step:1775/1845 train_time:108093ms step_avg:60.90ms
+step:1776/1845 train_time:108183ms step_avg:60.91ms
+step:1777/1845 train_time:108272ms step_avg:60.93ms
+step:1778/1845 train_time:108358ms step_avg:60.94ms
+step:1779/1845 train_time:108447ms step_avg:60.96ms
+step:1780/1845 train_time:108533ms step_avg:60.97ms
+step:1781/1845 train_time:108621ms step_avg:60.99ms
+step:1782/1845 train_time:108707ms step_avg:61.00ms
+step:1783/1845 train_time:108795ms step_avg:61.02ms
+step:1784/1845 train_time:108882ms step_avg:61.03ms
+step:1785/1845 train_time:108972ms step_avg:61.05ms
+step:1786/1845 train_time:109059ms step_avg:61.06ms
+step:1787/1845 train_time:109151ms step_avg:61.08ms
+step:1788/1845 train_time:109240ms step_avg:61.10ms
+step:1789/1845 train_time:109329ms step_avg:61.11ms
+step:1790/1845 train_time:109415ms step_avg:61.13ms
+step:1791/1845 train_time:109504ms step_avg:61.14ms
+step:1792/1845 train_time:109591ms step_avg:61.16ms
+step:1793/1845 train_time:109680ms step_avg:61.17ms
+step:1794/1845 train_time:109766ms step_avg:61.19ms
+step:1795/1845 train_time:109854ms step_avg:61.20ms
+step:1796/1845 train_time:109941ms step_avg:61.21ms
+step:1797/1845 train_time:110030ms step_avg:61.23ms
+step:1798/1845 train_time:110118ms step_avg:61.24ms
+step:1799/1845 train_time:110207ms step_avg:61.26ms
+step:1800/1845 train_time:110294ms step_avg:61.27ms
+step:1801/1845 train_time:110382ms step_avg:61.29ms
+step:1802/1845 train_time:110470ms step_avg:61.30ms
+step:1803/1845 train_time:110558ms step_avg:61.32ms
+step:1804/1845 train_time:110646ms step_avg:61.33ms
+step:1805/1845 train_time:110733ms step_avg:61.35ms
+step:1806/1845 train_time:110821ms step_avg:61.36ms
+step:1807/1845 train_time:110909ms step_avg:61.38ms
+step:1808/1845 train_time:110996ms step_avg:61.39ms
+step:1809/1845 train_time:111086ms step_avg:61.41ms
+step:1810/1845 train_time:111174ms step_avg:61.42ms
+step:1811/1845 train_time:111262ms step_avg:61.44ms
+step:1812/1845 train_time:111351ms step_avg:61.45ms
+step:1813/1845 train_time:111439ms step_avg:61.47ms
+step:1814/1845 train_time:111526ms step_avg:61.48ms
+step:1815/1845 train_time:111614ms step_avg:61.50ms
+step:1816/1845 train_time:111702ms step_avg:61.51ms
+step:1817/1845 train_time:111791ms step_avg:61.53ms
+step:1818/1845 train_time:111878ms step_avg:61.54ms
+step:1819/1845 train_time:111967ms step_avg:61.55ms
+step:1820/1845 train_time:112055ms step_avg:61.57ms
+step:1821/1845 train_time:112143ms step_avg:61.58ms
+step:1822/1845 train_time:112231ms step_avg:61.60ms
+step:1823/1845 train_time:112319ms step_avg:61.61ms
+step:1824/1845 train_time:112406ms step_avg:61.63ms
+step:1825/1845 train_time:112495ms step_avg:61.64ms
+step:1826/1845 train_time:112582ms step_avg:61.65ms
+step:1827/1845 train_time:112670ms step_avg:61.67ms
+step:1828/1845 train_time:112757ms step_avg:61.68ms
+step:1829/1845 train_time:112847ms step_avg:61.70ms
+step:1830/1845 train_time:112934ms step_avg:61.71ms
+step:1831/1845 train_time:113023ms step_avg:61.73ms
+step:1832/1845 train_time:113110ms step_avg:61.74ms
+step:1833/1845 train_time:113199ms step_avg:61.76ms
+step:1834/1845 train_time:113287ms step_avg:61.77ms
+step:1835/1845 train_time:113376ms step_avg:61.79ms
+step:1836/1845 train_time:113463ms step_avg:61.80ms
+step:1837/1845 train_time:113552ms step_avg:61.81ms
+step:1838/1845 train_time:113640ms step_avg:61.83ms
+step:1839/1845 train_time:113728ms step_avg:61.84ms
+step:1840/1845 train_time:113815ms step_avg:61.86ms
+step:1841/1845 train_time:113904ms step_avg:61.87ms
+step:1842/1845 train_time:113991ms step_avg:61.88ms
+step:1843/1845 train_time:114079ms step_avg:61.90ms
+step:1844/1845 train_time:114167ms step_avg:61.91ms
+step:1845/1845 train_time:114256ms step_avg:61.93ms
+step:1845/1845 val_loss:3.2779 train_time:114343ms step_avg:61.97ms
+peak memory allocated: 29709 MiB reserved: 44458 MiB

--- a/records/track_1_short/2025-12-29_VeSkipGates/README.md
+++ b/records/track_1_short/2025-12-29_VeSkipGates/README.md
@@ -1,0 +1,34 @@
+## New Record: Value Embed and Skip Gates (-35 steps, -1.3s)
+
+Updates in PR:
+* Add gates to value embeds, using same structure as attention gates (first 12 dims of residual stream)
+* Add gate to skip connection, using same structure as smear gate
+* Update w_s from 1.5/448 to 1.6/448
+* Add wd_mul 5 to value embeds, wd_mul 150x to embed and lm_head.
+* Drop 35 steps
+
+When I tested re-adding the frozen scalars for 40 steps (that got removed last PR) I got worse loss, so I kept it off for now. May be worthwhile to re-add for just the first window transition, not sure. The biggest change here is the value_embed gates. Loss is around 3.2830 without them. The skip_gate is pretty marginal, but it only costs ~300ms to add and seems to slightly pay for itself. I haven't heavily ablated the weight decay parameters, nonzero chance one of those is actually detrimental. At some point we should update the notation of how weight decay is calculated to be lr/init_lr * lr instead of lr^2. lr^2 is making the wd_mul rather unintuitive. The w_s update is surprisingly important for controlling variance.
+
+I also tested adding gates for the x0 contributions but saw no improvement and higher runtime.
+
+## Timing and Validation
+```
+import scipy.stats
+import torch
+
+losses = [3.279, 3.2795, 3.2774, 3.2779, 3.2784, 3.2792, 3.28]
+times = [114.508, 114.464, 114.373, 114.343, 114.22, 114.401, 114.369]
+
+print("p=%.4f" % scipy.stats.ttest_1samp(losses, 3.28, alternative="less").pvalue)
+# p=0.0061
+
+print("losses:", torch.std_mean(torch.tensor(losses)))
+# losses: (tensor(0.0009), tensor(3.2788))
+
+print("time:", torch.std_mean(torch.tensor(times)))
+# time: (tensor(0.0922), tensor(114.3826))
+```
+
+retiming prior record (faster machine this time): 115.686 [115.669, 115.717, 115.674]
+
+If no changes, will merge at 115.1s to be consistent with 1.3s improvement.

--- a/records/track_1_short/2025-12-29_VeSkipGates/ac4f65ee-0334-49dd-b23b-579871f81718.txt
+++ b/records/track_1_short/2025-12-29_VeSkipGates/ac4f65ee-0334-49dd-b23b-579871f81718.txt
@@ -1,0 +1,3725 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, v, wd_tensor, lr_tensor):
+    """Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors."""
+    mask = (v * p) >= 0
+    wd_factor = wd_tensor.to(p.dtype)
+    lr_factor = lr_tensor.to(p.dtype)
+    p.copy_(p - (p * mask * wd_factor * lr_factor) - (v * lr_factor))
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn_gate (10 params 6 padding params)
+        2. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        3. reduce scatter attn/mlp round 2 (16 mlp params)
+        4. wait on step 1, then compute update of 1 and schedule all gather
+        5. wait on step 2, then compute update of 2 and schedule all gather
+        6. wait on step 3, then compute update of 3 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        7. wait on 4, then compute update of 4 and schedule all gather
+        8. wait for each all gather to complete and update params
+    Empirically, leading with small params provides an additional 0.2s improvement.
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        group_sizes = [15, 16, 16]
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+
+        all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"]
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params])
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            # The below shape-based heuristic assumes that matrices have their input along the
+            # row dimension and their output along the columns. Gates are an exception.
+            is_gate = 'gate' in ref_param.label
+
+            if "second_momentum_buffer" not in group:
+                if is_gate:
+                    group["second_momentum_buffer"] = torch.zeros_like(updated_grads[..., :, :1])
+                else:
+                    group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1])
+                        if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                    )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if (is_gate or param_shape[-2] >= param_shape[-1]) else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx],
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete and copy results back into original parameter tensors.
+        for info in all_gather_infos:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str],lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for label in label_order:
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.bfloat16, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-1]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+
+                exp_avg = state["exp_avg"]
+                exp_avg_sq = state["exp_avg_sq"]
+                state["step"] += 1
+                t = state["step"]
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (bias2 ** 0.5 / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                # cautious weight decay
+                mask = (update * p_slice) > 0
+                # lr as weight decay schedule
+                eff_weight_decay = lr * wd * getattr(param, "wd_mul", 1.0)
+                update.addcmul_(p_slice, mask, value=eff_weight_decay * lr)
+
+                p_slice.add_(other=update, alpha=-1.0)
+
+                if not is_small:
+                    all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+
+        self._reduce_scatter_futures.clear()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        self.attn_gate = CastedLinear(12, num_heads)
+        self.attn_gate.weight.label = 'attn_gate'
+
+        # only include gates on layers with value embeds used on forward pass
+        if layer_idx in [0,1,8,9,10]:
+            self.value_embed_gate = CastedLinear(12, num_heads)
+            self.value_embed_gate.weight.label = 'value_embed_gate'
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(self.value_embed_gate(x[..., :self.value_embed_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(self.attn_gate(x[..., :self.attn_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        #self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.5/448, grad_s=0.75/448)
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig, skew = None):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset = key_offset[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if skew is None:
+            logits = 23 * torch.sigmoid((logits+5) / 7.5)
+        else:
+            logits = 23 * torch.sigmoid((logits+skew) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        adam_labels = ['lm_head', 'value_embed', 'smear_gate', 'skip_gate', 'x0_lambdas', 'embed']
+        scalar_labels = ['scalars']
+        muon_labels = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        scalar_params = [p for p in model.parameters() if getattr(p, 'label', None) in scalar_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + scalar_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, lr=0.008, betas=(0.65, 0.95), eps=1e-8, weight_decay=0.005)
+        self.scalar_opt = DistAdam(scalar_params, scalar_labels, lr=0.008, betas=(0.9, 0.99), eps=1e-8, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.scalar_opt, self.muon_opt]
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.freeze_timer = 0
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+        self.scalar_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            if opt.freeze_timer > 0:
+                opt.freeze_timer -= 1
+                opt.zero_grad(set_to_none=True)
+            else:
+                if self._is_active_step(opt, step):
+                    for group in opt.param_groups:
+                        group["lr"] = group["initial_lr"] * step_lr
+                    opt.step()
+                    opt.zero_grad(set_to_none=True)
+                    if opt.odd_step_only:
+                        opt.should_sync = False
+        
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+
+    def start_transition(self, freeze_count=40):
+        # freeze scalar weights during transition
+        self.scalar_opt.freeze_timer = freeze_count
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1805  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+def log_parameter_norms(model):
+    norms = {}
+    for name, param in model.named_parameters():
+        if param.requires_grad:
+            norms[f"param_norm/{name}"] = param.norm().item()
+            norms[f"param_max/{name}"] = param.max().item()
+            norms[f"param_min/{name}"] = param.min().item()
+            if param.grad is not None:
+                norms[f"grad_norm/{name}"] = param.grad.norm().item()
+                norms[f"grad_max/{name}"] = param.grad.max().item()
+    
+    # Total norms
+    total_param_norm = sum(p.norm().item() ** 2 for p in model.parameters()) ** 0.5
+    total_grad_norm = sum(p.grad.norm().item() ** 2 for p in model.parameters() if p.grad is not None) ** 0.5
+    
+    norms["param_norm/total"] = total_param_norm
+    norms["grad_norm/total"] = total_grad_norm
+    
+    return norms
+
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+# import wandb
+# if master_process:
+#     wandb.init(
+#         project="nano4",
+#         name="baseline"
+#     )
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    # if master_process and step%2==1:
+    #     wandb.log({
+    #         "loss": loss.item(),
+    #         **log_parameter_norms(model)  # Add all norms
+    #     })
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Dec 29 05:55:42 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.90.07              Driver Version: 550.90.07      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   26C    P0            109W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            107W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   39C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   27C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   29C    P0            111W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   29C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 601, 602, 603, 1203, 1204, 1205, 1804, 1805, 1806] for warmup
+Resetting Model
+step:0/1845 val_loss:10.8307 train_time:0ms step_avg:0.03ms
+step:1/1845 train_time:77ms step_avg:76.84ms
+step:2/1845 train_time:100ms step_avg:50.24ms
+step:3/1845 train_time:124ms step_avg:41.41ms
+step:4/1845 train_time:158ms step_avg:39.53ms
+step:5/1845 train_time:193ms step_avg:38.56ms
+step:6/1845 train_time:279ms step_avg:46.55ms
+step:7/1845 train_time:298ms step_avg:42.57ms
+step:8/1845 train_time:331ms step_avg:41.42ms
+step:9/1845 train_time:366ms step_avg:40.63ms
+step:10/1845 train_time:400ms step_avg:39.96ms
+step:11/1845 train_time:434ms step_avg:39.47ms
+step:12/1845 train_time:468ms step_avg:39.02ms
+step:13/1845 train_time:503ms step_avg:38.69ms
+step:14/1845 train_time:537ms step_avg:38.36ms
+step:15/1845 train_time:572ms step_avg:38.11ms
+step:16/1845 train_time:606ms step_avg:37.87ms
+step:17/1845 train_time:640ms step_avg:37.68ms
+step:18/1845 train_time:675ms step_avg:37.48ms
+step:19/1845 train_time:709ms step_avg:37.33ms
+step:20/1845 train_time:744ms step_avg:37.18ms
+step:21/1845 train_time:778ms step_avg:37.04ms
+step:22/1845 train_time:812ms step_avg:36.91ms
+step:23/1845 train_time:847ms step_avg:36.82ms
+step:24/1845 train_time:881ms step_avg:36.71ms
+step:25/1845 train_time:915ms step_avg:36.62ms
+step:26/1845 train_time:949ms step_avg:36.52ms
+step:27/1845 train_time:984ms step_avg:36.45ms
+step:28/1845 train_time:1018ms step_avg:36.37ms
+step:29/1845 train_time:1053ms step_avg:36.31ms
+step:30/1845 train_time:1087ms step_avg:36.24ms
+step:31/1845 train_time:1122ms step_avg:36.18ms
+step:32/1845 train_time:1156ms step_avg:36.11ms
+step:33/1845 train_time:1191ms step_avg:36.08ms
+step:34/1845 train_time:1225ms step_avg:36.03ms
+step:35/1845 train_time:1260ms step_avg:36.00ms
+step:36/1845 train_time:1294ms step_avg:35.95ms
+step:37/1845 train_time:1329ms step_avg:35.92ms
+step:38/1845 train_time:1363ms step_avg:35.87ms
+step:39/1845 train_time:1398ms step_avg:35.84ms
+step:40/1845 train_time:1432ms step_avg:35.80ms
+step:41/1845 train_time:1467ms step_avg:35.77ms
+step:42/1845 train_time:1501ms step_avg:35.74ms
+step:43/1845 train_time:1536ms step_avg:35.71ms
+step:44/1845 train_time:1570ms step_avg:35.68ms
+step:45/1845 train_time:1605ms step_avg:35.66ms
+step:46/1845 train_time:1639ms step_avg:35.62ms
+step:47/1845 train_time:1673ms step_avg:35.60ms
+step:48/1845 train_time:1708ms step_avg:35.58ms
+step:49/1845 train_time:1742ms step_avg:35.55ms
+step:50/1845 train_time:1776ms step_avg:35.52ms
+step:51/1845 train_time:1811ms step_avg:35.51ms
+step:52/1845 train_time:1845ms step_avg:35.48ms
+step:53/1845 train_time:1879ms step_avg:35.46ms
+step:54/1845 train_time:1914ms step_avg:35.44ms
+step:55/1845 train_time:1948ms step_avg:35.43ms
+step:56/1845 train_time:1982ms step_avg:35.40ms
+step:57/1845 train_time:2017ms step_avg:35.39ms
+step:58/1845 train_time:2051ms step_avg:35.37ms
+step:59/1845 train_time:2086ms step_avg:35.35ms
+step:60/1845 train_time:2120ms step_avg:35.33ms
+step:61/1845 train_time:2154ms step_avg:35.32ms
+step:62/1845 train_time:2189ms step_avg:35.31ms
+step:63/1845 train_time:2224ms step_avg:35.30ms
+step:64/1845 train_time:2258ms step_avg:35.28ms
+step:65/1845 train_time:2293ms step_avg:35.28ms
+step:66/1845 train_time:2327ms step_avg:35.26ms
+step:67/1845 train_time:2363ms step_avg:35.26ms
+step:68/1845 train_time:2396ms step_avg:35.24ms
+step:69/1845 train_time:2431ms step_avg:35.23ms
+step:70/1845 train_time:2465ms step_avg:35.22ms
+step:71/1845 train_time:2500ms step_avg:35.21ms
+step:72/1845 train_time:2534ms step_avg:35.20ms
+step:73/1845 train_time:2569ms step_avg:35.19ms
+step:74/1845 train_time:2603ms step_avg:35.17ms
+step:75/1845 train_time:2638ms step_avg:35.17ms
+step:76/1845 train_time:2672ms step_avg:35.15ms
+step:77/1845 train_time:2707ms step_avg:35.15ms
+step:78/1845 train_time:2741ms step_avg:35.14ms
+step:79/1845 train_time:2775ms step_avg:35.13ms
+step:80/1845 train_time:2809ms step_avg:35.12ms
+step:81/1845 train_time:2845ms step_avg:35.12ms
+step:82/1845 train_time:2879ms step_avg:35.11ms
+step:83/1845 train_time:2914ms step_avg:35.11ms
+step:84/1845 train_time:2948ms step_avg:35.09ms
+step:85/1845 train_time:2983ms step_avg:35.09ms
+step:86/1845 train_time:3017ms step_avg:35.08ms
+step:87/1845 train_time:3051ms step_avg:35.07ms
+step:88/1845 train_time:3086ms step_avg:35.06ms
+step:89/1845 train_time:3120ms step_avg:35.06ms
+step:90/1845 train_time:3154ms step_avg:35.05ms
+step:91/1845 train_time:3189ms step_avg:35.04ms
+step:92/1845 train_time:3223ms step_avg:35.03ms
+step:93/1845 train_time:3257ms step_avg:35.03ms
+step:94/1845 train_time:3292ms step_avg:35.02ms
+step:95/1845 train_time:3327ms step_avg:35.02ms
+step:96/1845 train_time:3361ms step_avg:35.01ms
+step:97/1845 train_time:3396ms step_avg:35.01ms
+step:98/1845 train_time:3430ms step_avg:35.00ms
+step:99/1845 train_time:3465ms step_avg:35.00ms
+step:100/1845 train_time:3500ms step_avg:35.00ms
+step:101/1845 train_time:3534ms step_avg:34.99ms
+step:102/1845 train_time:3568ms step_avg:34.98ms
+step:103/1845 train_time:3603ms step_avg:34.98ms
+step:104/1845 train_time:3637ms step_avg:34.97ms
+step:105/1845 train_time:3672ms step_avg:34.97ms
+step:106/1845 train_time:3706ms step_avg:34.96ms
+step:107/1845 train_time:3740ms step_avg:34.96ms
+step:108/1845 train_time:3774ms step_avg:34.95ms
+step:109/1845 train_time:3809ms step_avg:34.95ms
+step:110/1845 train_time:3843ms step_avg:34.94ms
+step:111/1845 train_time:3878ms step_avg:34.93ms
+step:112/1845 train_time:3912ms step_avg:34.93ms
+step:113/1845 train_time:3947ms step_avg:34.93ms
+step:114/1845 train_time:3981ms step_avg:34.92ms
+step:115/1845 train_time:4016ms step_avg:34.92ms
+step:116/1845 train_time:4050ms step_avg:34.91ms
+step:117/1845 train_time:4085ms step_avg:34.92ms
+step:118/1845 train_time:4119ms step_avg:34.91ms
+step:119/1845 train_time:4154ms step_avg:34.91ms
+step:120/1845 train_time:4188ms step_avg:34.90ms
+step:121/1845 train_time:4223ms step_avg:34.90ms
+step:122/1845 train_time:4257ms step_avg:34.89ms
+step:123/1845 train_time:4291ms step_avg:34.89ms
+step:124/1845 train_time:4326ms step_avg:34.88ms
+step:125/1845 train_time:4360ms step_avg:34.88ms
+step:126/1845 train_time:4394ms step_avg:34.87ms
+step:127/1845 train_time:4429ms step_avg:34.87ms
+step:128/1845 train_time:4463ms step_avg:34.87ms
+step:129/1845 train_time:4497ms step_avg:34.86ms
+step:130/1845 train_time:4531ms step_avg:34.86ms
+step:131/1845 train_time:4566ms step_avg:34.85ms
+step:132/1845 train_time:4600ms step_avg:34.85ms
+step:133/1845 train_time:4635ms step_avg:34.85ms
+step:134/1845 train_time:4669ms step_avg:34.84ms
+step:135/1845 train_time:4703ms step_avg:34.84ms
+step:136/1845 train_time:4737ms step_avg:34.83ms
+step:137/1845 train_time:4772ms step_avg:34.83ms
+step:138/1845 train_time:4806ms step_avg:34.83ms
+step:139/1845 train_time:4841ms step_avg:34.83ms
+step:140/1845 train_time:4875ms step_avg:34.82ms
+step:141/1845 train_time:4909ms step_avg:34.82ms
+step:142/1845 train_time:4944ms step_avg:34.81ms
+step:143/1845 train_time:4978ms step_avg:34.81ms
+step:144/1845 train_time:5013ms step_avg:34.81ms
+step:145/1845 train_time:5048ms step_avg:34.81ms
+step:146/1845 train_time:5082ms step_avg:34.81ms
+step:147/1845 train_time:5116ms step_avg:34.81ms
+step:148/1845 train_time:5150ms step_avg:34.80ms
+step:149/1845 train_time:5185ms step_avg:34.80ms
+step:150/1845 train_time:5219ms step_avg:34.79ms
+step:151/1845 train_time:5254ms step_avg:34.79ms
+step:152/1845 train_time:5288ms step_avg:34.79ms
+step:153/1845 train_time:5323ms step_avg:34.79ms
+step:154/1845 train_time:5357ms step_avg:34.78ms
+step:155/1845 train_time:5392ms step_avg:34.79ms
+step:156/1845 train_time:5426ms step_avg:34.78ms
+step:157/1845 train_time:5460ms step_avg:34.78ms
+step:158/1845 train_time:5495ms step_avg:34.78ms
+step:159/1845 train_time:5530ms step_avg:34.78ms
+step:160/1845 train_time:5564ms step_avg:34.77ms
+step:161/1845 train_time:5598ms step_avg:34.77ms
+step:162/1845 train_time:5632ms step_avg:34.77ms
+step:163/1845 train_time:5667ms step_avg:34.77ms
+step:164/1845 train_time:5701ms step_avg:34.76ms
+step:165/1845 train_time:5735ms step_avg:34.76ms
+step:166/1845 train_time:5769ms step_avg:34.76ms
+step:167/1845 train_time:5804ms step_avg:34.75ms
+step:168/1845 train_time:5838ms step_avg:34.75ms
+step:169/1845 train_time:5872ms step_avg:34.75ms
+step:170/1845 train_time:5907ms step_avg:34.74ms
+step:171/1845 train_time:5941ms step_avg:34.74ms
+step:172/1845 train_time:5975ms step_avg:34.74ms
+step:173/1845 train_time:6010ms step_avg:34.74ms
+step:174/1845 train_time:6044ms step_avg:34.74ms
+step:175/1845 train_time:6079ms step_avg:34.74ms
+step:176/1845 train_time:6113ms step_avg:34.73ms
+step:177/1845 train_time:6148ms step_avg:34.73ms
+step:178/1845 train_time:6182ms step_avg:34.73ms
+step:179/1845 train_time:6216ms step_avg:34.73ms
+step:180/1845 train_time:6251ms step_avg:34.73ms
+step:181/1845 train_time:6286ms step_avg:34.73ms
+step:182/1845 train_time:6320ms step_avg:34.72ms
+step:183/1845 train_time:6354ms step_avg:34.72ms
+step:184/1845 train_time:6388ms step_avg:34.72ms
+step:185/1845 train_time:6423ms step_avg:34.72ms
+step:186/1845 train_time:6457ms step_avg:34.72ms
+step:187/1845 train_time:6492ms step_avg:34.72ms
+step:188/1845 train_time:6526ms step_avg:34.71ms
+step:189/1845 train_time:6561ms step_avg:34.72ms
+step:190/1845 train_time:6595ms step_avg:34.71ms
+step:191/1845 train_time:6630ms step_avg:34.71ms
+step:192/1845 train_time:6664ms step_avg:34.71ms
+step:193/1845 train_time:6699ms step_avg:34.71ms
+step:194/1845 train_time:6733ms step_avg:34.70ms
+step:195/1845 train_time:6767ms step_avg:34.70ms
+step:196/1845 train_time:6801ms step_avg:34.70ms
+step:197/1845 train_time:6835ms step_avg:34.70ms
+step:198/1845 train_time:6869ms step_avg:34.69ms
+step:199/1845 train_time:6904ms step_avg:34.69ms
+step:200/1845 train_time:6938ms step_avg:34.69ms
+step:201/1845 train_time:6973ms step_avg:34.69ms
+step:202/1845 train_time:7007ms step_avg:34.69ms
+step:203/1845 train_time:7041ms step_avg:34.69ms
+step:204/1845 train_time:7075ms step_avg:34.68ms
+step:205/1845 train_time:7110ms step_avg:34.68ms
+step:206/1845 train_time:7144ms step_avg:34.68ms
+step:207/1845 train_time:7178ms step_avg:34.68ms
+step:208/1845 train_time:7212ms step_avg:34.68ms
+step:209/1845 train_time:7247ms step_avg:34.68ms
+step:210/1845 train_time:7281ms step_avg:34.67ms
+step:211/1845 train_time:7316ms step_avg:34.67ms
+step:212/1845 train_time:7350ms step_avg:34.67ms
+step:213/1845 train_time:7385ms step_avg:34.67ms
+step:214/1845 train_time:7419ms step_avg:34.67ms
+step:215/1845 train_time:7454ms step_avg:34.67ms
+step:216/1845 train_time:7488ms step_avg:34.67ms
+step:217/1845 train_time:7522ms step_avg:34.67ms
+step:218/1845 train_time:7557ms step_avg:34.66ms
+step:219/1845 train_time:7591ms step_avg:34.66ms
+step:220/1845 train_time:7625ms step_avg:34.66ms
+step:221/1845 train_time:7659ms step_avg:34.66ms
+step:222/1845 train_time:7694ms step_avg:34.66ms
+step:223/1845 train_time:7728ms step_avg:34.65ms
+step:224/1845 train_time:7762ms step_avg:34.65ms
+step:225/1845 train_time:7796ms step_avg:34.65ms
+step:226/1845 train_time:7830ms step_avg:34.65ms
+step:227/1845 train_time:7865ms step_avg:34.65ms
+step:228/1845 train_time:7899ms step_avg:34.64ms
+step:229/1845 train_time:7934ms step_avg:34.64ms
+step:230/1845 train_time:7968ms step_avg:34.64ms
+step:231/1845 train_time:8002ms step_avg:34.64ms
+step:232/1845 train_time:8036ms step_avg:34.64ms
+step:233/1845 train_time:8070ms step_avg:34.64ms
+step:234/1845 train_time:8104ms step_avg:34.63ms
+step:235/1845 train_time:8139ms step_avg:34.63ms
+step:236/1845 train_time:8173ms step_avg:34.63ms
+step:237/1845 train_time:8208ms step_avg:34.63ms
+step:238/1845 train_time:8242ms step_avg:34.63ms
+step:239/1845 train_time:8276ms step_avg:34.63ms
+step:240/1845 train_time:8310ms step_avg:34.63ms
+step:241/1845 train_time:8345ms step_avg:34.63ms
+step:242/1845 train_time:8379ms step_avg:34.62ms
+step:243/1845 train_time:8414ms step_avg:34.62ms
+step:244/1845 train_time:8448ms step_avg:34.62ms
+step:245/1845 train_time:8482ms step_avg:34.62ms
+step:246/1845 train_time:8516ms step_avg:34.62ms
+step:247/1845 train_time:8551ms step_avg:34.62ms
+step:248/1845 train_time:8585ms step_avg:34.62ms
+step:249/1845 train_time:8619ms step_avg:34.62ms
+step:250/1845 train_time:8654ms step_avg:34.61ms
+step:250/1845 val_loss:4.6164 train_time:8690ms step_avg:34.76ms
+step:251/1845 train_time:8710ms step_avg:34.70ms
+step:252/1845 train_time:8729ms step_avg:34.64ms
+step:253/1845 train_time:8760ms step_avg:34.62ms
+step:254/1845 train_time:8794ms step_avg:34.62ms
+step:255/1845 train_time:8830ms step_avg:34.63ms
+step:256/1845 train_time:8865ms step_avg:34.63ms
+step:257/1845 train_time:8899ms step_avg:34.63ms
+step:258/1845 train_time:8934ms step_avg:34.63ms
+step:259/1845 train_time:8968ms step_avg:34.63ms
+step:260/1845 train_time:9002ms step_avg:34.62ms
+step:261/1845 train_time:9037ms step_avg:34.62ms
+step:262/1845 train_time:9071ms step_avg:34.62ms
+step:263/1845 train_time:9105ms step_avg:34.62ms
+step:264/1845 train_time:9139ms step_avg:34.62ms
+step:265/1845 train_time:9173ms step_avg:34.62ms
+step:266/1845 train_time:9208ms step_avg:34.62ms
+step:267/1845 train_time:9242ms step_avg:34.61ms
+step:268/1845 train_time:9276ms step_avg:34.61ms
+step:269/1845 train_time:9310ms step_avg:34.61ms
+step:270/1845 train_time:9344ms step_avg:34.61ms
+step:271/1845 train_time:9379ms step_avg:34.61ms
+step:272/1845 train_time:9413ms step_avg:34.61ms
+step:273/1845 train_time:9447ms step_avg:34.61ms
+step:274/1845 train_time:9482ms step_avg:34.60ms
+step:275/1845 train_time:9516ms step_avg:34.60ms
+step:276/1845 train_time:9550ms step_avg:34.60ms
+step:277/1845 train_time:9584ms step_avg:34.60ms
+step:278/1845 train_time:9618ms step_avg:34.60ms
+step:279/1845 train_time:9652ms step_avg:34.60ms
+step:280/1845 train_time:9687ms step_avg:34.59ms
+step:281/1845 train_time:9721ms step_avg:34.59ms
+step:282/1845 train_time:9755ms step_avg:34.59ms
+step:283/1845 train_time:9790ms step_avg:34.59ms
+step:284/1845 train_time:9824ms step_avg:34.59ms
+step:285/1845 train_time:9858ms step_avg:34.59ms
+step:286/1845 train_time:9892ms step_avg:34.59ms
+step:287/1845 train_time:9927ms step_avg:34.59ms
+step:288/1845 train_time:9962ms step_avg:34.59ms
+step:289/1845 train_time:9996ms step_avg:34.59ms
+step:290/1845 train_time:10030ms step_avg:34.59ms
+step:291/1845 train_time:10065ms step_avg:34.59ms
+step:292/1845 train_time:10099ms step_avg:34.58ms
+step:293/1845 train_time:10133ms step_avg:34.59ms
+step:294/1845 train_time:10168ms step_avg:34.58ms
+step:295/1845 train_time:10202ms step_avg:34.58ms
+step:296/1845 train_time:10236ms step_avg:34.58ms
+step:297/1845 train_time:10271ms step_avg:34.58ms
+step:298/1845 train_time:10305ms step_avg:34.58ms
+step:299/1845 train_time:10340ms step_avg:34.58ms
+step:300/1845 train_time:10374ms step_avg:34.58ms
+step:301/1845 train_time:10408ms step_avg:34.58ms
+step:302/1845 train_time:10442ms step_avg:34.58ms
+step:303/1845 train_time:10477ms step_avg:34.58ms
+step:304/1845 train_time:10511ms step_avg:34.57ms
+step:305/1845 train_time:10545ms step_avg:34.57ms
+step:306/1845 train_time:10579ms step_avg:34.57ms
+step:307/1845 train_time:10613ms step_avg:34.57ms
+step:308/1845 train_time:10647ms step_avg:34.57ms
+step:309/1845 train_time:10682ms step_avg:34.57ms
+step:310/1845 train_time:10716ms step_avg:34.57ms
+step:311/1845 train_time:10750ms step_avg:34.57ms
+step:312/1845 train_time:10784ms step_avg:34.57ms
+step:313/1845 train_time:10819ms step_avg:34.57ms
+step:314/1845 train_time:10853ms step_avg:34.56ms
+step:315/1845 train_time:10887ms step_avg:34.56ms
+step:316/1845 train_time:10921ms step_avg:34.56ms
+step:317/1845 train_time:10956ms step_avg:34.56ms
+step:318/1845 train_time:10990ms step_avg:34.56ms
+step:319/1845 train_time:11024ms step_avg:34.56ms
+step:320/1845 train_time:11058ms step_avg:34.56ms
+step:321/1845 train_time:11093ms step_avg:34.56ms
+step:322/1845 train_time:11127ms step_avg:34.56ms
+step:323/1845 train_time:11161ms step_avg:34.56ms
+step:324/1845 train_time:11196ms step_avg:34.55ms
+step:325/1845 train_time:11230ms step_avg:34.55ms
+step:326/1845 train_time:11264ms step_avg:34.55ms
+step:327/1845 train_time:11299ms step_avg:34.55ms
+step:328/1845 train_time:11333ms step_avg:34.55ms
+step:329/1845 train_time:11368ms step_avg:34.55ms
+step:330/1845 train_time:11402ms step_avg:34.55ms
+step:331/1845 train_time:11436ms step_avg:34.55ms
+step:332/1845 train_time:11470ms step_avg:34.55ms
+step:333/1845 train_time:11505ms step_avg:34.55ms
+step:334/1845 train_time:11539ms step_avg:34.55ms
+step:335/1845 train_time:11573ms step_avg:34.55ms
+step:336/1845 train_time:11607ms step_avg:34.54ms
+step:337/1845 train_time:11642ms step_avg:34.55ms
+step:338/1845 train_time:11676ms step_avg:34.54ms
+step:339/1845 train_time:11710ms step_avg:34.54ms
+step:340/1845 train_time:11744ms step_avg:34.54ms
+step:341/1845 train_time:11779ms step_avg:34.54ms
+step:342/1845 train_time:11813ms step_avg:34.54ms
+step:343/1845 train_time:11847ms step_avg:34.54ms
+step:344/1845 train_time:11882ms step_avg:34.54ms
+step:345/1845 train_time:11916ms step_avg:34.54ms
+step:346/1845 train_time:11950ms step_avg:34.54ms
+step:347/1845 train_time:11985ms step_avg:34.54ms
+step:348/1845 train_time:12019ms step_avg:34.54ms
+step:349/1845 train_time:12053ms step_avg:34.54ms
+step:350/1845 train_time:12087ms step_avg:34.53ms
+step:351/1845 train_time:12122ms step_avg:34.54ms
+step:352/1845 train_time:12156ms step_avg:34.53ms
+step:353/1845 train_time:12190ms step_avg:34.53ms
+step:354/1845 train_time:12224ms step_avg:34.53ms
+step:355/1845 train_time:12259ms step_avg:34.53ms
+step:356/1845 train_time:12293ms step_avg:34.53ms
+step:357/1845 train_time:12328ms step_avg:34.53ms
+step:358/1845 train_time:12362ms step_avg:34.53ms
+step:359/1845 train_time:12396ms step_avg:34.53ms
+step:360/1845 train_time:12430ms step_avg:34.53ms
+step:361/1845 train_time:12465ms step_avg:34.53ms
+step:362/1845 train_time:12499ms step_avg:34.53ms
+step:363/1845 train_time:12533ms step_avg:34.53ms
+step:364/1845 train_time:12567ms step_avg:34.53ms
+step:365/1845 train_time:12602ms step_avg:34.53ms
+step:366/1845 train_time:12636ms step_avg:34.52ms
+step:367/1845 train_time:12671ms step_avg:34.52ms
+step:368/1845 train_time:12705ms step_avg:34.52ms
+step:369/1845 train_time:12740ms step_avg:34.53ms
+step:370/1845 train_time:12774ms step_avg:34.52ms
+step:371/1845 train_time:12808ms step_avg:34.52ms
+step:372/1845 train_time:12842ms step_avg:34.52ms
+step:373/1845 train_time:12877ms step_avg:34.52ms
+step:374/1845 train_time:12911ms step_avg:34.52ms
+step:375/1845 train_time:12945ms step_avg:34.52ms
+step:376/1845 train_time:12980ms step_avg:34.52ms
+step:377/1845 train_time:13014ms step_avg:34.52ms
+step:378/1845 train_time:13048ms step_avg:34.52ms
+step:379/1845 train_time:13083ms step_avg:34.52ms
+step:380/1845 train_time:13117ms step_avg:34.52ms
+step:381/1845 train_time:13151ms step_avg:34.52ms
+step:382/1845 train_time:13185ms step_avg:34.52ms
+step:383/1845 train_time:13219ms step_avg:34.52ms
+step:384/1845 train_time:13253ms step_avg:34.51ms
+step:385/1845 train_time:13288ms step_avg:34.51ms
+step:386/1845 train_time:13322ms step_avg:34.51ms
+step:387/1845 train_time:13357ms step_avg:34.51ms
+step:388/1845 train_time:13391ms step_avg:34.51ms
+step:389/1845 train_time:13425ms step_avg:34.51ms
+step:390/1845 train_time:13459ms step_avg:34.51ms
+step:391/1845 train_time:13494ms step_avg:34.51ms
+step:392/1845 train_time:13528ms step_avg:34.51ms
+step:393/1845 train_time:13562ms step_avg:34.51ms
+step:394/1845 train_time:13596ms step_avg:34.51ms
+step:395/1845 train_time:13631ms step_avg:34.51ms
+step:396/1845 train_time:13665ms step_avg:34.51ms
+step:397/1845 train_time:13699ms step_avg:34.51ms
+step:398/1845 train_time:13734ms step_avg:34.51ms
+step:399/1845 train_time:13768ms step_avg:34.51ms
+step:400/1845 train_time:13802ms step_avg:34.51ms
+step:401/1845 train_time:13837ms step_avg:34.51ms
+step:402/1845 train_time:13871ms step_avg:34.51ms
+step:403/1845 train_time:13906ms step_avg:34.51ms
+step:404/1845 train_time:13940ms step_avg:34.50ms
+step:405/1845 train_time:13975ms step_avg:34.51ms
+step:406/1845 train_time:14009ms step_avg:34.50ms
+step:407/1845 train_time:14043ms step_avg:34.50ms
+step:408/1845 train_time:14078ms step_avg:34.50ms
+step:409/1845 train_time:14112ms step_avg:34.50ms
+step:410/1845 train_time:14146ms step_avg:34.50ms
+step:411/1845 train_time:14180ms step_avg:34.50ms
+step:412/1845 train_time:14215ms step_avg:34.50ms
+step:413/1845 train_time:14249ms step_avg:34.50ms
+step:414/1845 train_time:14283ms step_avg:34.50ms
+step:415/1845 train_time:14318ms step_avg:34.50ms
+step:416/1845 train_time:14352ms step_avg:34.50ms
+step:417/1845 train_time:14386ms step_avg:34.50ms
+step:418/1845 train_time:14421ms step_avg:34.50ms
+step:419/1845 train_time:14455ms step_avg:34.50ms
+step:420/1845 train_time:14489ms step_avg:34.50ms
+step:421/1845 train_time:14523ms step_avg:34.50ms
+step:422/1845 train_time:14557ms step_avg:34.50ms
+step:423/1845 train_time:14592ms step_avg:34.50ms
+step:424/1845 train_time:14626ms step_avg:34.49ms
+step:425/1845 train_time:14660ms step_avg:34.49ms
+step:426/1845 train_time:14694ms step_avg:34.49ms
+step:427/1845 train_time:14729ms step_avg:34.49ms
+step:428/1845 train_time:14763ms step_avg:34.49ms
+step:429/1845 train_time:14798ms step_avg:34.49ms
+step:430/1845 train_time:14832ms step_avg:34.49ms
+step:431/1845 train_time:14866ms step_avg:34.49ms
+step:432/1845 train_time:14900ms step_avg:34.49ms
+step:433/1845 train_time:14934ms step_avg:34.49ms
+step:434/1845 train_time:14968ms step_avg:34.49ms
+step:435/1845 train_time:15003ms step_avg:34.49ms
+step:436/1845 train_time:15037ms step_avg:34.49ms
+step:437/1845 train_time:15071ms step_avg:34.49ms
+step:438/1845 train_time:15105ms step_avg:34.49ms
+step:439/1845 train_time:15140ms step_avg:34.49ms
+step:440/1845 train_time:15174ms step_avg:34.49ms
+step:441/1845 train_time:15208ms step_avg:34.49ms
+step:442/1845 train_time:15242ms step_avg:34.49ms
+step:443/1845 train_time:15277ms step_avg:34.49ms
+step:444/1845 train_time:15311ms step_avg:34.48ms
+step:445/1845 train_time:15346ms step_avg:34.49ms
+step:446/1845 train_time:15380ms step_avg:34.48ms
+step:447/1845 train_time:15415ms step_avg:34.48ms
+step:448/1845 train_time:15449ms step_avg:34.48ms
+step:449/1845 train_time:15483ms step_avg:34.48ms
+step:450/1845 train_time:15517ms step_avg:34.48ms
+step:451/1845 train_time:15552ms step_avg:34.48ms
+step:452/1845 train_time:15586ms step_avg:34.48ms
+step:453/1845 train_time:15620ms step_avg:34.48ms
+step:454/1845 train_time:15654ms step_avg:34.48ms
+step:455/1845 train_time:15689ms step_avg:34.48ms
+step:456/1845 train_time:15723ms step_avg:34.48ms
+step:457/1845 train_time:15757ms step_avg:34.48ms
+step:458/1845 train_time:15791ms step_avg:34.48ms
+step:459/1845 train_time:15826ms step_avg:34.48ms
+step:460/1845 train_time:15860ms step_avg:34.48ms
+step:461/1845 train_time:15894ms step_avg:34.48ms
+step:462/1845 train_time:15928ms step_avg:34.48ms
+step:463/1845 train_time:15963ms step_avg:34.48ms
+step:464/1845 train_time:15997ms step_avg:34.48ms
+step:465/1845 train_time:16031ms step_avg:34.48ms
+step:466/1845 train_time:16066ms step_avg:34.48ms
+step:467/1845 train_time:16100ms step_avg:34.48ms
+step:468/1845 train_time:16134ms step_avg:34.48ms
+step:469/1845 train_time:16169ms step_avg:34.48ms
+step:470/1845 train_time:16203ms step_avg:34.47ms
+step:471/1845 train_time:16238ms step_avg:34.47ms
+step:472/1845 train_time:16272ms step_avg:34.47ms
+step:473/1845 train_time:16306ms step_avg:34.47ms
+step:474/1845 train_time:16340ms step_avg:34.47ms
+step:475/1845 train_time:16375ms step_avg:34.47ms
+step:476/1845 train_time:16409ms step_avg:34.47ms
+step:477/1845 train_time:16444ms step_avg:34.47ms
+step:478/1845 train_time:16478ms step_avg:34.47ms
+step:479/1845 train_time:16512ms step_avg:34.47ms
+step:480/1845 train_time:16546ms step_avg:34.47ms
+step:481/1845 train_time:16581ms step_avg:34.47ms
+step:482/1845 train_time:16615ms step_avg:34.47ms
+step:483/1845 train_time:16649ms step_avg:34.47ms
+step:484/1845 train_time:16683ms step_avg:34.47ms
+step:485/1845 train_time:16717ms step_avg:34.47ms
+step:486/1845 train_time:16751ms step_avg:34.47ms
+step:487/1845 train_time:16786ms step_avg:34.47ms
+step:488/1845 train_time:16820ms step_avg:34.47ms
+step:489/1845 train_time:16855ms step_avg:34.47ms
+step:490/1845 train_time:16889ms step_avg:34.47ms
+step:491/1845 train_time:16923ms step_avg:34.47ms
+step:492/1845 train_time:16957ms step_avg:34.47ms
+step:493/1845 train_time:16992ms step_avg:34.47ms
+step:494/1845 train_time:17026ms step_avg:34.46ms
+step:495/1845 train_time:17060ms step_avg:34.47ms
+step:496/1845 train_time:17094ms step_avg:34.46ms
+step:497/1845 train_time:17129ms step_avg:34.46ms
+step:498/1845 train_time:17163ms step_avg:34.46ms
+step:499/1845 train_time:17197ms step_avg:34.46ms
+step:500/1845 train_time:17231ms step_avg:34.46ms
+step:500/1845 val_loss:4.2912 train_time:17268ms step_avg:34.54ms
+step:501/1845 train_time:17287ms step_avg:34.50ms
+step:502/1845 train_time:17306ms step_avg:34.47ms
+step:503/1845 train_time:17336ms step_avg:34.47ms
+step:504/1845 train_time:17371ms step_avg:34.47ms
+step:505/1845 train_time:17406ms step_avg:34.47ms
+step:506/1845 train_time:17440ms step_avg:34.47ms
+step:507/1845 train_time:17475ms step_avg:34.47ms
+step:508/1845 train_time:17509ms step_avg:34.47ms
+step:509/1845 train_time:17543ms step_avg:34.47ms
+step:510/1845 train_time:17578ms step_avg:34.47ms
+step:511/1845 train_time:17612ms step_avg:34.46ms
+step:512/1845 train_time:17646ms step_avg:34.46ms
+step:513/1845 train_time:17680ms step_avg:34.46ms
+step:514/1845 train_time:17714ms step_avg:34.46ms
+step:515/1845 train_time:17748ms step_avg:34.46ms
+step:516/1845 train_time:17782ms step_avg:34.46ms
+step:517/1845 train_time:17816ms step_avg:34.46ms
+step:518/1845 train_time:17850ms step_avg:34.46ms
+step:519/1845 train_time:17885ms step_avg:34.46ms
+step:520/1845 train_time:17918ms step_avg:34.46ms
+step:521/1845 train_time:17953ms step_avg:34.46ms
+step:522/1845 train_time:17987ms step_avg:34.46ms
+step:523/1845 train_time:18021ms step_avg:34.46ms
+step:524/1845 train_time:18055ms step_avg:34.46ms
+step:525/1845 train_time:18089ms step_avg:34.46ms
+step:526/1845 train_time:18123ms step_avg:34.45ms
+step:527/1845 train_time:18157ms step_avg:34.45ms
+step:528/1845 train_time:18191ms step_avg:34.45ms
+step:529/1845 train_time:18226ms step_avg:34.45ms
+step:530/1845 train_time:18260ms step_avg:34.45ms
+step:531/1845 train_time:18295ms step_avg:34.45ms
+step:532/1845 train_time:18329ms step_avg:34.45ms
+step:533/1845 train_time:18363ms step_avg:34.45ms
+step:534/1845 train_time:18397ms step_avg:34.45ms
+step:535/1845 train_time:18432ms step_avg:34.45ms
+step:536/1845 train_time:18466ms step_avg:34.45ms
+step:537/1845 train_time:18500ms step_avg:34.45ms
+step:538/1845 train_time:18535ms step_avg:34.45ms
+step:539/1845 train_time:18569ms step_avg:34.45ms
+step:540/1845 train_time:18603ms step_avg:34.45ms
+step:541/1845 train_time:18637ms step_avg:34.45ms
+step:542/1845 train_time:18671ms step_avg:34.45ms
+step:543/1845 train_time:18706ms step_avg:34.45ms
+step:544/1845 train_time:18740ms step_avg:34.45ms
+step:545/1845 train_time:18774ms step_avg:34.45ms
+step:546/1845 train_time:18808ms step_avg:34.45ms
+step:547/1845 train_time:18842ms step_avg:34.45ms
+step:548/1845 train_time:18876ms step_avg:34.45ms
+step:549/1845 train_time:18911ms step_avg:34.45ms
+step:550/1845 train_time:18945ms step_avg:34.45ms
+step:551/1845 train_time:18979ms step_avg:34.45ms
+step:552/1845 train_time:19013ms step_avg:34.44ms
+step:553/1845 train_time:19048ms step_avg:34.44ms
+step:554/1845 train_time:19082ms step_avg:34.44ms
+step:555/1845 train_time:19116ms step_avg:34.44ms
+step:556/1845 train_time:19150ms step_avg:34.44ms
+step:557/1845 train_time:19184ms step_avg:34.44ms
+step:558/1845 train_time:19218ms step_avg:34.44ms
+step:559/1845 train_time:19253ms step_avg:34.44ms
+step:560/1845 train_time:19286ms step_avg:34.44ms
+step:561/1845 train_time:19320ms step_avg:34.44ms
+step:562/1845 train_time:19355ms step_avg:34.44ms
+step:563/1845 train_time:19389ms step_avg:34.44ms
+step:564/1845 train_time:19423ms step_avg:34.44ms
+step:565/1845 train_time:19457ms step_avg:34.44ms
+step:566/1845 train_time:19492ms step_avg:34.44ms
+step:567/1845 train_time:19526ms step_avg:34.44ms
+step:568/1845 train_time:19560ms step_avg:34.44ms
+step:569/1845 train_time:19594ms step_avg:34.44ms
+step:570/1845 train_time:19628ms step_avg:34.43ms
+step:571/1845 train_time:19662ms step_avg:34.44ms
+step:572/1845 train_time:19696ms step_avg:34.43ms
+step:573/1845 train_time:19731ms step_avg:34.43ms
+step:574/1845 train_time:19765ms step_avg:34.43ms
+step:575/1845 train_time:19799ms step_avg:34.43ms
+step:576/1845 train_time:19833ms step_avg:34.43ms
+step:577/1845 train_time:19868ms step_avg:34.43ms
+step:578/1845 train_time:19902ms step_avg:34.43ms
+step:579/1845 train_time:19937ms step_avg:34.43ms
+step:580/1845 train_time:19971ms step_avg:34.43ms
+step:581/1845 train_time:20005ms step_avg:34.43ms
+step:582/1845 train_time:20039ms step_avg:34.43ms
+step:583/1845 train_time:20074ms step_avg:34.43ms
+step:584/1845 train_time:20108ms step_avg:34.43ms
+step:585/1845 train_time:20142ms step_avg:34.43ms
+step:586/1845 train_time:20176ms step_avg:34.43ms
+step:587/1845 train_time:20211ms step_avg:34.43ms
+step:588/1845 train_time:20245ms step_avg:34.43ms
+step:589/1845 train_time:20279ms step_avg:34.43ms
+step:590/1845 train_time:20313ms step_avg:34.43ms
+step:591/1845 train_time:20347ms step_avg:34.43ms
+step:592/1845 train_time:20381ms step_avg:34.43ms
+step:593/1845 train_time:20416ms step_avg:34.43ms
+step:594/1845 train_time:20450ms step_avg:34.43ms
+step:595/1845 train_time:20484ms step_avg:34.43ms
+step:596/1845 train_time:20518ms step_avg:34.43ms
+step:597/1845 train_time:20552ms step_avg:34.43ms
+step:598/1845 train_time:20586ms step_avg:34.43ms
+step:599/1845 train_time:20621ms step_avg:34.42ms
+step:600/1845 train_time:20655ms step_avg:34.42ms
+step:601/1845 train_time:20689ms step_avg:34.42ms
+step:602/1845 train_time:20723ms step_avg:34.42ms
+step:603/1845 train_time:20758ms step_avg:34.42ms
+step:604/1845 train_time:20818ms step_avg:34.47ms
+step:605/1845 train_time:20880ms step_avg:34.51ms
+step:606/1845 train_time:20941ms step_avg:34.56ms
+step:607/1845 train_time:21004ms step_avg:34.60ms
+step:608/1845 train_time:21065ms step_avg:34.65ms
+step:609/1845 train_time:21127ms step_avg:34.69ms
+step:610/1845 train_time:21188ms step_avg:34.73ms
+step:611/1845 train_time:21250ms step_avg:34.78ms
+step:612/1845 train_time:21312ms step_avg:34.82ms
+step:613/1845 train_time:21374ms step_avg:34.87ms
+step:614/1845 train_time:21435ms step_avg:34.91ms
+step:615/1845 train_time:21498ms step_avg:34.96ms
+step:616/1845 train_time:21559ms step_avg:35.00ms
+step:617/1845 train_time:21621ms step_avg:35.04ms
+step:618/1845 train_time:21683ms step_avg:35.09ms
+step:619/1845 train_time:21745ms step_avg:35.13ms
+step:620/1845 train_time:21805ms step_avg:35.17ms
+step:621/1845 train_time:21868ms step_avg:35.21ms
+step:622/1845 train_time:21929ms step_avg:35.26ms
+step:623/1845 train_time:21992ms step_avg:35.30ms
+step:624/1845 train_time:22053ms step_avg:35.34ms
+step:625/1845 train_time:22115ms step_avg:35.38ms
+step:626/1845 train_time:22176ms step_avg:35.43ms
+step:627/1845 train_time:22239ms step_avg:35.47ms
+step:628/1845 train_time:22300ms step_avg:35.51ms
+step:629/1845 train_time:22363ms step_avg:35.55ms
+step:630/1845 train_time:22424ms step_avg:35.59ms
+step:631/1845 train_time:22486ms step_avg:35.64ms
+step:632/1845 train_time:22547ms step_avg:35.68ms
+step:633/1845 train_time:22609ms step_avg:35.72ms
+step:634/1845 train_time:22671ms step_avg:35.76ms
+step:635/1845 train_time:22734ms step_avg:35.80ms
+step:636/1845 train_time:22795ms step_avg:35.84ms
+step:637/1845 train_time:22857ms step_avg:35.88ms
+step:638/1845 train_time:22918ms step_avg:35.92ms
+step:639/1845 train_time:22982ms step_avg:35.97ms
+step:640/1845 train_time:23043ms step_avg:36.00ms
+step:641/1845 train_time:23105ms step_avg:36.05ms
+step:642/1845 train_time:23166ms step_avg:36.08ms
+step:643/1845 train_time:23228ms step_avg:36.12ms
+step:644/1845 train_time:23289ms step_avg:36.16ms
+step:645/1845 train_time:23352ms step_avg:36.20ms
+step:646/1845 train_time:23413ms step_avg:36.24ms
+step:647/1845 train_time:23475ms step_avg:36.28ms
+step:648/1845 train_time:23536ms step_avg:36.32ms
+step:649/1845 train_time:23598ms step_avg:36.36ms
+step:650/1845 train_time:23659ms step_avg:36.40ms
+step:651/1845 train_time:23723ms step_avg:36.44ms
+step:652/1845 train_time:23784ms step_avg:36.48ms
+step:653/1845 train_time:23846ms step_avg:36.52ms
+step:654/1845 train_time:23907ms step_avg:36.55ms
+step:655/1845 train_time:23969ms step_avg:36.59ms
+step:656/1845 train_time:24030ms step_avg:36.63ms
+step:657/1845 train_time:24093ms step_avg:36.67ms
+step:658/1845 train_time:24153ms step_avg:36.71ms
+step:659/1845 train_time:24216ms step_avg:36.75ms
+step:660/1845 train_time:24278ms step_avg:36.78ms
+step:661/1845 train_time:24340ms step_avg:36.82ms
+step:662/1845 train_time:24401ms step_avg:36.86ms
+step:663/1845 train_time:24464ms step_avg:36.90ms
+step:664/1845 train_time:24525ms step_avg:36.93ms
+step:665/1845 train_time:24587ms step_avg:36.97ms
+step:666/1845 train_time:24647ms step_avg:37.01ms
+step:667/1845 train_time:24710ms step_avg:37.05ms
+step:668/1845 train_time:24770ms step_avg:37.08ms
+step:669/1845 train_time:24833ms step_avg:37.12ms
+step:670/1845 train_time:24894ms step_avg:37.15ms
+step:671/1845 train_time:24956ms step_avg:37.19ms
+step:672/1845 train_time:25017ms step_avg:37.23ms
+step:673/1845 train_time:25080ms step_avg:37.27ms
+step:674/1845 train_time:25140ms step_avg:37.30ms
+step:675/1845 train_time:25203ms step_avg:37.34ms
+step:676/1845 train_time:25264ms step_avg:37.37ms
+step:677/1845 train_time:25326ms step_avg:37.41ms
+step:678/1845 train_time:25387ms step_avg:37.44ms
+step:679/1845 train_time:25450ms step_avg:37.48ms
+step:680/1845 train_time:25511ms step_avg:37.52ms
+step:681/1845 train_time:25573ms step_avg:37.55ms
+step:682/1845 train_time:25634ms step_avg:37.59ms
+step:683/1845 train_time:25696ms step_avg:37.62ms
+step:684/1845 train_time:25757ms step_avg:37.66ms
+step:685/1845 train_time:25820ms step_avg:37.69ms
+step:686/1845 train_time:25881ms step_avg:37.73ms
+step:687/1845 train_time:25943ms step_avg:37.76ms
+step:688/1845 train_time:26004ms step_avg:37.80ms
+step:689/1845 train_time:26066ms step_avg:37.83ms
+step:690/1845 train_time:26127ms step_avg:37.86ms
+step:691/1845 train_time:26189ms step_avg:37.90ms
+step:692/1845 train_time:26250ms step_avg:37.93ms
+step:693/1845 train_time:26312ms step_avg:37.97ms
+step:694/1845 train_time:26373ms step_avg:38.00ms
+step:695/1845 train_time:26436ms step_avg:38.04ms
+step:696/1845 train_time:26497ms step_avg:38.07ms
+step:697/1845 train_time:26559ms step_avg:38.11ms
+step:698/1845 train_time:26620ms step_avg:38.14ms
+step:699/1845 train_time:26683ms step_avg:38.17ms
+step:700/1845 train_time:26744ms step_avg:38.21ms
+step:701/1845 train_time:26806ms step_avg:38.24ms
+step:702/1845 train_time:26867ms step_avg:38.27ms
+step:703/1845 train_time:26929ms step_avg:38.31ms
+step:704/1845 train_time:26990ms step_avg:38.34ms
+step:705/1845 train_time:27053ms step_avg:38.37ms
+step:706/1845 train_time:27114ms step_avg:38.40ms
+step:707/1845 train_time:27176ms step_avg:38.44ms
+step:708/1845 train_time:27238ms step_avg:38.47ms
+step:709/1845 train_time:27300ms step_avg:38.51ms
+step:710/1845 train_time:27361ms step_avg:38.54ms
+step:711/1845 train_time:27424ms step_avg:38.57ms
+step:712/1845 train_time:27485ms step_avg:38.60ms
+step:713/1845 train_time:27547ms step_avg:38.64ms
+step:714/1845 train_time:27608ms step_avg:38.67ms
+step:715/1845 train_time:27670ms step_avg:38.70ms
+step:716/1845 train_time:27731ms step_avg:38.73ms
+step:717/1845 train_time:27794ms step_avg:38.76ms
+step:718/1845 train_time:27855ms step_avg:38.79ms
+step:719/1845 train_time:27917ms step_avg:38.83ms
+step:720/1845 train_time:27979ms step_avg:38.86ms
+step:721/1845 train_time:28041ms step_avg:38.89ms
+step:722/1845 train_time:28102ms step_avg:38.92ms
+step:723/1845 train_time:28165ms step_avg:38.96ms
+step:724/1845 train_time:28226ms step_avg:38.99ms
+step:725/1845 train_time:28288ms step_avg:39.02ms
+step:726/1845 train_time:28349ms step_avg:39.05ms
+step:727/1845 train_time:28411ms step_avg:39.08ms
+step:728/1845 train_time:28472ms step_avg:39.11ms
+step:729/1845 train_time:28534ms step_avg:39.14ms
+step:730/1845 train_time:28596ms step_avg:39.17ms
+step:731/1845 train_time:28659ms step_avg:39.20ms
+step:732/1845 train_time:28720ms step_avg:39.24ms
+step:733/1845 train_time:28782ms step_avg:39.27ms
+step:734/1845 train_time:28844ms step_avg:39.30ms
+step:735/1845 train_time:28906ms step_avg:39.33ms
+step:736/1845 train_time:28967ms step_avg:39.36ms
+step:737/1845 train_time:29029ms step_avg:39.39ms
+step:738/1845 train_time:29090ms step_avg:39.42ms
+step:739/1845 train_time:29152ms step_avg:39.45ms
+step:740/1845 train_time:29212ms step_avg:39.48ms
+step:741/1845 train_time:29276ms step_avg:39.51ms
+step:742/1845 train_time:29337ms step_avg:39.54ms
+step:743/1845 train_time:29399ms step_avg:39.57ms
+step:744/1845 train_time:29460ms step_avg:39.60ms
+step:745/1845 train_time:29522ms step_avg:39.63ms
+step:746/1845 train_time:29583ms step_avg:39.66ms
+step:747/1845 train_time:29645ms step_avg:39.69ms
+step:748/1845 train_time:29706ms step_avg:39.71ms
+step:749/1845 train_time:29769ms step_avg:39.75ms
+step:750/1845 train_time:29830ms step_avg:39.77ms
+step:750/1845 val_loss:4.0336 train_time:29893ms step_avg:39.86ms
+step:751/1845 train_time:29913ms step_avg:39.83ms
+step:752/1845 train_time:29956ms step_avg:39.84ms
+step:753/1845 train_time:30020ms step_avg:39.87ms
+step:754/1845 train_time:30082ms step_avg:39.90ms
+step:755/1845 train_time:30144ms step_avg:39.93ms
+step:756/1845 train_time:30206ms step_avg:39.96ms
+step:757/1845 train_time:30268ms step_avg:39.98ms
+step:758/1845 train_time:30328ms step_avg:40.01ms
+step:759/1845 train_time:30390ms step_avg:40.04ms
+step:760/1845 train_time:30450ms step_avg:40.07ms
+step:761/1845 train_time:30512ms step_avg:40.09ms
+step:762/1845 train_time:30572ms step_avg:40.12ms
+step:763/1845 train_time:30634ms step_avg:40.15ms
+step:764/1845 train_time:30694ms step_avg:40.18ms
+step:765/1845 train_time:30756ms step_avg:40.20ms
+step:766/1845 train_time:30817ms step_avg:40.23ms
+step:767/1845 train_time:30880ms step_avg:40.26ms
+step:768/1845 train_time:30941ms step_avg:40.29ms
+step:769/1845 train_time:31004ms step_avg:40.32ms
+step:770/1845 train_time:31066ms step_avg:40.35ms
+step:771/1845 train_time:31129ms step_avg:40.37ms
+step:772/1845 train_time:31190ms step_avg:40.40ms
+step:773/1845 train_time:31252ms step_avg:40.43ms
+step:774/1845 train_time:31313ms step_avg:40.46ms
+step:775/1845 train_time:31375ms step_avg:40.48ms
+step:776/1845 train_time:31436ms step_avg:40.51ms
+step:777/1845 train_time:31498ms step_avg:40.54ms
+step:778/1845 train_time:31558ms step_avg:40.56ms
+step:779/1845 train_time:31620ms step_avg:40.59ms
+step:780/1845 train_time:31681ms step_avg:40.62ms
+step:781/1845 train_time:31744ms step_avg:40.65ms
+step:782/1845 train_time:31805ms step_avg:40.67ms
+step:783/1845 train_time:31868ms step_avg:40.70ms
+step:784/1845 train_time:31929ms step_avg:40.73ms
+step:785/1845 train_time:31992ms step_avg:40.75ms
+step:786/1845 train_time:32053ms step_avg:40.78ms
+step:787/1845 train_time:32116ms step_avg:40.81ms
+step:788/1845 train_time:32178ms step_avg:40.83ms
+step:789/1845 train_time:32240ms step_avg:40.86ms
+step:790/1845 train_time:32301ms step_avg:40.89ms
+step:791/1845 train_time:32364ms step_avg:40.92ms
+step:792/1845 train_time:32425ms step_avg:40.94ms
+step:793/1845 train_time:32487ms step_avg:40.97ms
+step:794/1845 train_time:32548ms step_avg:40.99ms
+step:795/1845 train_time:32610ms step_avg:41.02ms
+step:796/1845 train_time:32671ms step_avg:41.04ms
+step:797/1845 train_time:32733ms step_avg:41.07ms
+step:798/1845 train_time:32793ms step_avg:41.09ms
+step:799/1845 train_time:32856ms step_avg:41.12ms
+step:800/1845 train_time:32917ms step_avg:41.15ms
+step:801/1845 train_time:32980ms step_avg:41.17ms
+step:802/1845 train_time:33041ms step_avg:41.20ms
+step:803/1845 train_time:33104ms step_avg:41.23ms
+step:804/1845 train_time:33165ms step_avg:41.25ms
+step:805/1845 train_time:33228ms step_avg:41.28ms
+step:806/1845 train_time:33288ms step_avg:41.30ms
+step:807/1845 train_time:33351ms step_avg:41.33ms
+step:808/1845 train_time:33412ms step_avg:41.35ms
+step:809/1845 train_time:33475ms step_avg:41.38ms
+step:810/1845 train_time:33535ms step_avg:41.40ms
+step:811/1845 train_time:33597ms step_avg:41.43ms
+step:812/1845 train_time:33658ms step_avg:41.45ms
+step:813/1845 train_time:33720ms step_avg:41.48ms
+step:814/1845 train_time:33781ms step_avg:41.50ms
+step:815/1845 train_time:33843ms step_avg:41.53ms
+step:816/1845 train_time:33904ms step_avg:41.55ms
+step:817/1845 train_time:33967ms step_avg:41.57ms
+step:818/1845 train_time:34028ms step_avg:41.60ms
+step:819/1845 train_time:34090ms step_avg:41.62ms
+step:820/1845 train_time:34151ms step_avg:41.65ms
+step:821/1845 train_time:34215ms step_avg:41.67ms
+step:822/1845 train_time:34276ms step_avg:41.70ms
+step:823/1845 train_time:34338ms step_avg:41.72ms
+step:824/1845 train_time:34399ms step_avg:41.75ms
+step:825/1845 train_time:34462ms step_avg:41.77ms
+step:826/1845 train_time:34523ms step_avg:41.80ms
+step:827/1845 train_time:34586ms step_avg:41.82ms
+step:828/1845 train_time:34647ms step_avg:41.84ms
+step:829/1845 train_time:34710ms step_avg:41.87ms
+step:830/1845 train_time:34770ms step_avg:41.89ms
+step:831/1845 train_time:34832ms step_avg:41.92ms
+step:832/1845 train_time:34892ms step_avg:41.94ms
+step:833/1845 train_time:34954ms step_avg:41.96ms
+step:834/1845 train_time:35015ms step_avg:41.98ms
+step:835/1845 train_time:35077ms step_avg:42.01ms
+step:836/1845 train_time:35138ms step_avg:42.03ms
+step:837/1845 train_time:35201ms step_avg:42.06ms
+step:838/1845 train_time:35262ms step_avg:42.08ms
+step:839/1845 train_time:35324ms step_avg:42.10ms
+step:840/1845 train_time:35385ms step_avg:42.13ms
+step:841/1845 train_time:35448ms step_avg:42.15ms
+step:842/1845 train_time:35509ms step_avg:42.17ms
+step:843/1845 train_time:35571ms step_avg:42.20ms
+step:844/1845 train_time:35632ms step_avg:42.22ms
+step:845/1845 train_time:35695ms step_avg:42.24ms
+step:846/1845 train_time:35756ms step_avg:42.26ms
+step:847/1845 train_time:35818ms step_avg:42.29ms
+step:848/1845 train_time:35879ms step_avg:42.31ms
+step:849/1845 train_time:35942ms step_avg:42.33ms
+step:850/1845 train_time:36002ms step_avg:42.36ms
+step:851/1845 train_time:36065ms step_avg:42.38ms
+step:852/1845 train_time:36127ms step_avg:42.40ms
+step:853/1845 train_time:36189ms step_avg:42.43ms
+step:854/1845 train_time:36250ms step_avg:42.45ms
+step:855/1845 train_time:36312ms step_avg:42.47ms
+step:856/1845 train_time:36373ms step_avg:42.49ms
+step:857/1845 train_time:36435ms step_avg:42.52ms
+step:858/1845 train_time:36497ms step_avg:42.54ms
+step:859/1845 train_time:36558ms step_avg:42.56ms
+step:860/1845 train_time:36620ms step_avg:42.58ms
+step:861/1845 train_time:36682ms step_avg:42.60ms
+step:862/1845 train_time:36744ms step_avg:42.63ms
+step:863/1845 train_time:36807ms step_avg:42.65ms
+step:864/1845 train_time:36868ms step_avg:42.67ms
+step:865/1845 train_time:36930ms step_avg:42.69ms
+step:866/1845 train_time:36990ms step_avg:42.71ms
+step:867/1845 train_time:37053ms step_avg:42.74ms
+step:868/1845 train_time:37114ms step_avg:42.76ms
+step:869/1845 train_time:37177ms step_avg:42.78ms
+step:870/1845 train_time:37237ms step_avg:42.80ms
+step:871/1845 train_time:37300ms step_avg:42.82ms
+step:872/1845 train_time:37361ms step_avg:42.85ms
+step:873/1845 train_time:37423ms step_avg:42.87ms
+step:874/1845 train_time:37484ms step_avg:42.89ms
+step:875/1845 train_time:37547ms step_avg:42.91ms
+step:876/1845 train_time:37608ms step_avg:42.93ms
+step:877/1845 train_time:37670ms step_avg:42.95ms
+step:878/1845 train_time:37731ms step_avg:42.97ms
+step:879/1845 train_time:37794ms step_avg:43.00ms
+step:880/1845 train_time:37855ms step_avg:43.02ms
+step:881/1845 train_time:37917ms step_avg:43.04ms
+step:882/1845 train_time:37978ms step_avg:43.06ms
+step:883/1845 train_time:38041ms step_avg:43.08ms
+step:884/1845 train_time:38102ms step_avg:43.10ms
+step:885/1845 train_time:38164ms step_avg:43.12ms
+step:886/1845 train_time:38225ms step_avg:43.14ms
+step:887/1845 train_time:38287ms step_avg:43.16ms
+step:888/1845 train_time:38348ms step_avg:43.18ms
+step:889/1845 train_time:38410ms step_avg:43.21ms
+step:890/1845 train_time:38471ms step_avg:43.23ms
+step:891/1845 train_time:38534ms step_avg:43.25ms
+step:892/1845 train_time:38595ms step_avg:43.27ms
+step:893/1845 train_time:38657ms step_avg:43.29ms
+step:894/1845 train_time:38717ms step_avg:43.31ms
+step:895/1845 train_time:38780ms step_avg:43.33ms
+step:896/1845 train_time:38840ms step_avg:43.35ms
+step:897/1845 train_time:38903ms step_avg:43.37ms
+step:898/1845 train_time:38964ms step_avg:43.39ms
+step:899/1845 train_time:39027ms step_avg:43.41ms
+step:900/1845 train_time:39088ms step_avg:43.43ms
+step:901/1845 train_time:39150ms step_avg:43.45ms
+step:902/1845 train_time:39211ms step_avg:43.47ms
+step:903/1845 train_time:39273ms step_avg:43.49ms
+step:904/1845 train_time:39334ms step_avg:43.51ms
+step:905/1845 train_time:39396ms step_avg:43.53ms
+step:906/1845 train_time:39458ms step_avg:43.55ms
+step:907/1845 train_time:39520ms step_avg:43.57ms
+step:908/1845 train_time:39581ms step_avg:43.59ms
+step:909/1845 train_time:39644ms step_avg:43.61ms
+step:910/1845 train_time:39705ms step_avg:43.63ms
+step:911/1845 train_time:39767ms step_avg:43.65ms
+step:912/1845 train_time:39828ms step_avg:43.67ms
+step:913/1845 train_time:39890ms step_avg:43.69ms
+step:914/1845 train_time:39951ms step_avg:43.71ms
+step:915/1845 train_time:40014ms step_avg:43.73ms
+step:916/1845 train_time:40075ms step_avg:43.75ms
+step:917/1845 train_time:40138ms step_avg:43.77ms
+step:918/1845 train_time:40198ms step_avg:43.79ms
+step:919/1845 train_time:40261ms step_avg:43.81ms
+step:920/1845 train_time:40323ms step_avg:43.83ms
+step:921/1845 train_time:40385ms step_avg:43.85ms
+step:922/1845 train_time:40446ms step_avg:43.87ms
+step:923/1845 train_time:40509ms step_avg:43.89ms
+step:924/1845 train_time:40570ms step_avg:43.91ms
+step:925/1845 train_time:40632ms step_avg:43.93ms
+step:926/1845 train_time:40693ms step_avg:43.94ms
+step:927/1845 train_time:40756ms step_avg:43.96ms
+step:928/1845 train_time:40817ms step_avg:43.98ms
+step:929/1845 train_time:40879ms step_avg:44.00ms
+step:930/1845 train_time:40940ms step_avg:44.02ms
+step:931/1845 train_time:41003ms step_avg:44.04ms
+step:932/1845 train_time:41064ms step_avg:44.06ms
+step:933/1845 train_time:41127ms step_avg:44.08ms
+step:934/1845 train_time:41187ms step_avg:44.10ms
+step:935/1845 train_time:41249ms step_avg:44.12ms
+step:936/1845 train_time:41310ms step_avg:44.13ms
+step:937/1845 train_time:41372ms step_avg:44.15ms
+step:938/1845 train_time:41432ms step_avg:44.17ms
+step:939/1845 train_time:41495ms step_avg:44.19ms
+step:940/1845 train_time:41555ms step_avg:44.21ms
+step:941/1845 train_time:41618ms step_avg:44.23ms
+step:942/1845 train_time:41679ms step_avg:44.24ms
+step:943/1845 train_time:41741ms step_avg:44.26ms
+step:944/1845 train_time:41802ms step_avg:44.28ms
+step:945/1845 train_time:41864ms step_avg:44.30ms
+step:946/1845 train_time:41925ms step_avg:44.32ms
+step:947/1845 train_time:41987ms step_avg:44.34ms
+step:948/1845 train_time:42048ms step_avg:44.35ms
+step:949/1845 train_time:42111ms step_avg:44.37ms
+step:950/1845 train_time:42172ms step_avg:44.39ms
+step:951/1845 train_time:42235ms step_avg:44.41ms
+step:952/1845 train_time:42296ms step_avg:44.43ms
+step:953/1845 train_time:42358ms step_avg:44.45ms
+step:954/1845 train_time:42419ms step_avg:44.46ms
+step:955/1845 train_time:42482ms step_avg:44.48ms
+step:956/1845 train_time:42543ms step_avg:44.50ms
+step:957/1845 train_time:42606ms step_avg:44.52ms
+step:958/1845 train_time:42667ms step_avg:44.54ms
+step:959/1845 train_time:42730ms step_avg:44.56ms
+step:960/1845 train_time:42790ms step_avg:44.57ms
+step:961/1845 train_time:42852ms step_avg:44.59ms
+step:962/1845 train_time:42913ms step_avg:44.61ms
+step:963/1845 train_time:42976ms step_avg:44.63ms
+step:964/1845 train_time:43036ms step_avg:44.64ms
+step:965/1845 train_time:43099ms step_avg:44.66ms
+step:966/1845 train_time:43160ms step_avg:44.68ms
+step:967/1845 train_time:43222ms step_avg:44.70ms
+step:968/1845 train_time:43284ms step_avg:44.71ms
+step:969/1845 train_time:43346ms step_avg:44.73ms
+step:970/1845 train_time:43407ms step_avg:44.75ms
+step:971/1845 train_time:43469ms step_avg:44.77ms
+step:972/1845 train_time:43530ms step_avg:44.78ms
+step:973/1845 train_time:43592ms step_avg:44.80ms
+step:974/1845 train_time:43653ms step_avg:44.82ms
+step:975/1845 train_time:43716ms step_avg:44.84ms
+step:976/1845 train_time:43777ms step_avg:44.85ms
+step:977/1845 train_time:43839ms step_avg:44.87ms
+step:978/1845 train_time:43901ms step_avg:44.89ms
+step:979/1845 train_time:43963ms step_avg:44.91ms
+step:980/1845 train_time:44024ms step_avg:44.92ms
+step:981/1845 train_time:44087ms step_avg:44.94ms
+step:982/1845 train_time:44148ms step_avg:44.96ms
+step:983/1845 train_time:44210ms step_avg:44.97ms
+step:984/1845 train_time:44271ms step_avg:44.99ms
+step:985/1845 train_time:44333ms step_avg:45.01ms
+step:986/1845 train_time:44394ms step_avg:45.02ms
+step:987/1845 train_time:44457ms step_avg:45.04ms
+step:988/1845 train_time:44517ms step_avg:45.06ms
+step:989/1845 train_time:44580ms step_avg:45.08ms
+step:990/1845 train_time:44641ms step_avg:45.09ms
+step:991/1845 train_time:44703ms step_avg:45.11ms
+step:992/1845 train_time:44764ms step_avg:45.13ms
+step:993/1845 train_time:44827ms step_avg:45.14ms
+step:994/1845 train_time:44888ms step_avg:45.16ms
+step:995/1845 train_time:44951ms step_avg:45.18ms
+step:996/1845 train_time:45011ms step_avg:45.19ms
+step:997/1845 train_time:45073ms step_avg:45.21ms
+step:998/1845 train_time:45135ms step_avg:45.22ms
+step:999/1845 train_time:45197ms step_avg:45.24ms
+step:1000/1845 train_time:45258ms step_avg:45.26ms
+step:1000/1845 val_loss:3.7719 train_time:45322ms step_avg:45.32ms
+step:1001/1845 train_time:45342ms step_avg:45.30ms
+step:1002/1845 train_time:45383ms step_avg:45.29ms
+step:1003/1845 train_time:45448ms step_avg:45.31ms
+step:1004/1845 train_time:45512ms step_avg:45.33ms
+step:1005/1845 train_time:45575ms step_avg:45.35ms
+step:1006/1845 train_time:45635ms step_avg:45.36ms
+step:1007/1845 train_time:45697ms step_avg:45.38ms
+step:1008/1845 train_time:45757ms step_avg:45.39ms
+step:1009/1845 train_time:45819ms step_avg:45.41ms
+step:1010/1845 train_time:45880ms step_avg:45.43ms
+step:1011/1845 train_time:45943ms step_avg:45.44ms
+step:1012/1845 train_time:46003ms step_avg:45.46ms
+step:1013/1845 train_time:46065ms step_avg:45.47ms
+step:1014/1845 train_time:46126ms step_avg:45.49ms
+step:1015/1845 train_time:46188ms step_avg:45.51ms
+step:1016/1845 train_time:46249ms step_avg:45.52ms
+step:1017/1845 train_time:46312ms step_avg:45.54ms
+step:1018/1845 train_time:46373ms step_avg:45.55ms
+step:1019/1845 train_time:46437ms step_avg:45.57ms
+step:1020/1845 train_time:46498ms step_avg:45.59ms
+step:1021/1845 train_time:46561ms step_avg:45.60ms
+step:1022/1845 train_time:46622ms step_avg:45.62ms
+step:1023/1845 train_time:46685ms step_avg:45.64ms
+step:1024/1845 train_time:46746ms step_avg:45.65ms
+step:1025/1845 train_time:46809ms step_avg:45.67ms
+step:1026/1845 train_time:46871ms step_avg:45.68ms
+step:1027/1845 train_time:46933ms step_avg:45.70ms
+step:1028/1845 train_time:46994ms step_avg:45.71ms
+step:1029/1845 train_time:47055ms step_avg:45.73ms
+step:1030/1845 train_time:47115ms step_avg:45.74ms
+step:1031/1845 train_time:47177ms step_avg:45.76ms
+step:1032/1845 train_time:47238ms step_avg:45.77ms
+step:1033/1845 train_time:47300ms step_avg:45.79ms
+step:1034/1845 train_time:47361ms step_avg:45.80ms
+step:1035/1845 train_time:47424ms step_avg:45.82ms
+step:1036/1845 train_time:47485ms step_avg:45.84ms
+step:1037/1845 train_time:47548ms step_avg:45.85ms
+step:1038/1845 train_time:47610ms step_avg:45.87ms
+step:1039/1845 train_time:47672ms step_avg:45.88ms
+step:1040/1845 train_time:47733ms step_avg:45.90ms
+step:1041/1845 train_time:47795ms step_avg:45.91ms
+step:1042/1845 train_time:47856ms step_avg:45.93ms
+step:1043/1845 train_time:47918ms step_avg:45.94ms
+step:1044/1845 train_time:47979ms step_avg:45.96ms
+step:1045/1845 train_time:48042ms step_avg:45.97ms
+step:1046/1845 train_time:48102ms step_avg:45.99ms
+step:1047/1845 train_time:48165ms step_avg:46.00ms
+step:1048/1845 train_time:48226ms step_avg:46.02ms
+step:1049/1845 train_time:48289ms step_avg:46.03ms
+step:1050/1845 train_time:48349ms step_avg:46.05ms
+step:1051/1845 train_time:48411ms step_avg:46.06ms
+step:1052/1845 train_time:48472ms step_avg:46.08ms
+step:1053/1845 train_time:48535ms step_avg:46.09ms
+step:1054/1845 train_time:48596ms step_avg:46.11ms
+step:1055/1845 train_time:48659ms step_avg:46.12ms
+step:1056/1845 train_time:48720ms step_avg:46.14ms
+step:1057/1845 train_time:48782ms step_avg:46.15ms
+step:1058/1845 train_time:48843ms step_avg:46.17ms
+step:1059/1845 train_time:48906ms step_avg:46.18ms
+step:1060/1845 train_time:48968ms step_avg:46.20ms
+step:1061/1845 train_time:49031ms step_avg:46.21ms
+step:1062/1845 train_time:49091ms step_avg:46.23ms
+step:1063/1845 train_time:49153ms step_avg:46.24ms
+step:1064/1845 train_time:49214ms step_avg:46.25ms
+step:1065/1845 train_time:49276ms step_avg:46.27ms
+step:1066/1845 train_time:49336ms step_avg:46.28ms
+step:1067/1845 train_time:49398ms step_avg:46.30ms
+step:1068/1845 train_time:49459ms step_avg:46.31ms
+step:1069/1845 train_time:49521ms step_avg:46.32ms
+step:1070/1845 train_time:49583ms step_avg:46.34ms
+step:1071/1845 train_time:49645ms step_avg:46.35ms
+step:1072/1845 train_time:49707ms step_avg:46.37ms
+step:1073/1845 train_time:49769ms step_avg:46.38ms
+step:1074/1845 train_time:49831ms step_avg:46.40ms
+step:1075/1845 train_time:49893ms step_avg:46.41ms
+step:1076/1845 train_time:49955ms step_avg:46.43ms
+step:1077/1845 train_time:50017ms step_avg:46.44ms
+step:1078/1845 train_time:50078ms step_avg:46.45ms
+step:1079/1845 train_time:50140ms step_avg:46.47ms
+step:1080/1845 train_time:50201ms step_avg:46.48ms
+step:1081/1845 train_time:50263ms step_avg:46.50ms
+step:1082/1845 train_time:50324ms step_avg:46.51ms
+step:1083/1845 train_time:50386ms step_avg:46.52ms
+step:1084/1845 train_time:50447ms step_avg:46.54ms
+step:1085/1845 train_time:50509ms step_avg:46.55ms
+step:1086/1845 train_time:50570ms step_avg:46.57ms
+step:1087/1845 train_time:50633ms step_avg:46.58ms
+step:1088/1845 train_time:50693ms step_avg:46.59ms
+step:1089/1845 train_time:50756ms step_avg:46.61ms
+step:1090/1845 train_time:50817ms step_avg:46.62ms
+step:1091/1845 train_time:50879ms step_avg:46.64ms
+step:1092/1845 train_time:50940ms step_avg:46.65ms
+step:1093/1845 train_time:51003ms step_avg:46.66ms
+step:1094/1845 train_time:51064ms step_avg:46.68ms
+step:1095/1845 train_time:51127ms step_avg:46.69ms
+step:1096/1845 train_time:51188ms step_avg:46.70ms
+step:1097/1845 train_time:51250ms step_avg:46.72ms
+step:1098/1845 train_time:51311ms step_avg:46.73ms
+step:1099/1845 train_time:51373ms step_avg:46.75ms
+step:1100/1845 train_time:51434ms step_avg:46.76ms
+step:1101/1845 train_time:51497ms step_avg:46.77ms
+step:1102/1845 train_time:51557ms step_avg:46.79ms
+step:1103/1845 train_time:51621ms step_avg:46.80ms
+step:1104/1845 train_time:51682ms step_avg:46.81ms
+step:1105/1845 train_time:51744ms step_avg:46.83ms
+step:1106/1845 train_time:51806ms step_avg:46.84ms
+step:1107/1845 train_time:51868ms step_avg:46.85ms
+step:1108/1845 train_time:51929ms step_avg:46.87ms
+step:1109/1845 train_time:51992ms step_avg:46.88ms
+step:1110/1845 train_time:52052ms step_avg:46.89ms
+step:1111/1845 train_time:52115ms step_avg:46.91ms
+step:1112/1845 train_time:52176ms step_avg:46.92ms
+step:1113/1845 train_time:52239ms step_avg:46.94ms
+step:1114/1845 train_time:52300ms step_avg:46.95ms
+step:1115/1845 train_time:52362ms step_avg:46.96ms
+step:1116/1845 train_time:52423ms step_avg:46.97ms
+step:1117/1845 train_time:52486ms step_avg:46.99ms
+step:1118/1845 train_time:52547ms step_avg:47.00ms
+step:1119/1845 train_time:52609ms step_avg:47.01ms
+step:1120/1845 train_time:52670ms step_avg:47.03ms
+step:1121/1845 train_time:52733ms step_avg:47.04ms
+step:1122/1845 train_time:52793ms step_avg:47.05ms
+step:1123/1845 train_time:52855ms step_avg:47.07ms
+step:1124/1845 train_time:52916ms step_avg:47.08ms
+step:1125/1845 train_time:52978ms step_avg:47.09ms
+step:1126/1845 train_time:53039ms step_avg:47.10ms
+step:1127/1845 train_time:53102ms step_avg:47.12ms
+step:1128/1845 train_time:53162ms step_avg:47.13ms
+step:1129/1845 train_time:53225ms step_avg:47.14ms
+step:1130/1845 train_time:53286ms step_avg:47.16ms
+step:1131/1845 train_time:53349ms step_avg:47.17ms
+step:1132/1845 train_time:53410ms step_avg:47.18ms
+step:1133/1845 train_time:53473ms step_avg:47.20ms
+step:1134/1845 train_time:53533ms step_avg:47.21ms
+step:1135/1845 train_time:53596ms step_avg:47.22ms
+step:1136/1845 train_time:53656ms step_avg:47.23ms
+step:1137/1845 train_time:53719ms step_avg:47.25ms
+step:1138/1845 train_time:53780ms step_avg:47.26ms
+step:1139/1845 train_time:53842ms step_avg:47.27ms
+step:1140/1845 train_time:53903ms step_avg:47.28ms
+step:1141/1845 train_time:53966ms step_avg:47.30ms
+step:1142/1845 train_time:54027ms step_avg:47.31ms
+step:1143/1845 train_time:54090ms step_avg:47.32ms
+step:1144/1845 train_time:54151ms step_avg:47.34ms
+step:1145/1845 train_time:54213ms step_avg:47.35ms
+step:1146/1845 train_time:54274ms step_avg:47.36ms
+step:1147/1845 train_time:54337ms step_avg:47.37ms
+step:1148/1845 train_time:54397ms step_avg:47.38ms
+step:1149/1845 train_time:54459ms step_avg:47.40ms
+step:1150/1845 train_time:54520ms step_avg:47.41ms
+step:1151/1845 train_time:54583ms step_avg:47.42ms
+step:1152/1845 train_time:54644ms step_avg:47.43ms
+step:1153/1845 train_time:54706ms step_avg:47.45ms
+step:1154/1845 train_time:54767ms step_avg:47.46ms
+step:1155/1845 train_time:54830ms step_avg:47.47ms
+step:1156/1845 train_time:54891ms step_avg:47.48ms
+step:1157/1845 train_time:54953ms step_avg:47.50ms
+step:1158/1845 train_time:55014ms step_avg:47.51ms
+step:1159/1845 train_time:55077ms step_avg:47.52ms
+step:1160/1845 train_time:55137ms step_avg:47.53ms
+step:1161/1845 train_time:55199ms step_avg:47.54ms
+step:1162/1845 train_time:55260ms step_avg:47.56ms
+step:1163/1845 train_time:55322ms step_avg:47.57ms
+step:1164/1845 train_time:55383ms step_avg:47.58ms
+step:1165/1845 train_time:55445ms step_avg:47.59ms
+step:1166/1845 train_time:55506ms step_avg:47.60ms
+step:1167/1845 train_time:55569ms step_avg:47.62ms
+step:1168/1845 train_time:55630ms step_avg:47.63ms
+step:1169/1845 train_time:55693ms step_avg:47.64ms
+step:1170/1845 train_time:55753ms step_avg:47.65ms
+step:1171/1845 train_time:55815ms step_avg:47.66ms
+step:1172/1845 train_time:55876ms step_avg:47.68ms
+step:1173/1845 train_time:55938ms step_avg:47.69ms
+step:1174/1845 train_time:55998ms step_avg:47.70ms
+step:1175/1845 train_time:56061ms step_avg:47.71ms
+step:1176/1845 train_time:56122ms step_avg:47.72ms
+step:1177/1845 train_time:56184ms step_avg:47.74ms
+step:1178/1845 train_time:56245ms step_avg:47.75ms
+step:1179/1845 train_time:56307ms step_avg:47.76ms
+step:1180/1845 train_time:56368ms step_avg:47.77ms
+step:1181/1845 train_time:56430ms step_avg:47.78ms
+step:1182/1845 train_time:56491ms step_avg:47.79ms
+step:1183/1845 train_time:56553ms step_avg:47.81ms
+step:1184/1845 train_time:56614ms step_avg:47.82ms
+step:1185/1845 train_time:56676ms step_avg:47.83ms
+step:1186/1845 train_time:56737ms step_avg:47.84ms
+step:1187/1845 train_time:56799ms step_avg:47.85ms
+step:1188/1845 train_time:56860ms step_avg:47.86ms
+step:1189/1845 train_time:56923ms step_avg:47.87ms
+step:1190/1845 train_time:56984ms step_avg:47.89ms
+step:1191/1845 train_time:57047ms step_avg:47.90ms
+step:1192/1845 train_time:57108ms step_avg:47.91ms
+step:1193/1845 train_time:57171ms step_avg:47.92ms
+step:1194/1845 train_time:57232ms step_avg:47.93ms
+step:1195/1845 train_time:57294ms step_avg:47.95ms
+step:1196/1845 train_time:57355ms step_avg:47.96ms
+step:1197/1845 train_time:57418ms step_avg:47.97ms
+step:1198/1845 train_time:57479ms step_avg:47.98ms
+step:1199/1845 train_time:57542ms step_avg:47.99ms
+step:1200/1845 train_time:57602ms step_avg:48.00ms
+step:1201/1845 train_time:57665ms step_avg:48.01ms
+step:1202/1845 train_time:57726ms step_avg:48.03ms
+step:1203/1845 train_time:57788ms step_avg:48.04ms
+step:1204/1845 train_time:57849ms step_avg:48.05ms
+step:1205/1845 train_time:57912ms step_avg:48.06ms
+step:1206/1845 train_time:58000ms step_avg:48.09ms
+step:1207/1845 train_time:58088ms step_avg:48.13ms
+step:1208/1845 train_time:58176ms step_avg:48.16ms
+step:1209/1845 train_time:58265ms step_avg:48.19ms
+step:1210/1845 train_time:58352ms step_avg:48.23ms
+step:1211/1845 train_time:58441ms step_avg:48.26ms
+step:1212/1845 train_time:58527ms step_avg:48.29ms
+step:1213/1845 train_time:58616ms step_avg:48.32ms
+step:1214/1845 train_time:58704ms step_avg:48.36ms
+step:1215/1845 train_time:58792ms step_avg:48.39ms
+step:1216/1845 train_time:58879ms step_avg:48.42ms
+step:1217/1845 train_time:58967ms step_avg:48.45ms
+step:1218/1845 train_time:59055ms step_avg:48.48ms
+step:1219/1845 train_time:59143ms step_avg:48.52ms
+step:1220/1845 train_time:59230ms step_avg:48.55ms
+step:1221/1845 train_time:59319ms step_avg:48.58ms
+step:1222/1845 train_time:59408ms step_avg:48.62ms
+step:1223/1845 train_time:59496ms step_avg:48.65ms
+step:1224/1845 train_time:59583ms step_avg:48.68ms
+step:1225/1845 train_time:59672ms step_avg:48.71ms
+step:1226/1845 train_time:59760ms step_avg:48.74ms
+step:1227/1845 train_time:59848ms step_avg:48.78ms
+step:1228/1845 train_time:59934ms step_avg:48.81ms
+step:1229/1845 train_time:60023ms step_avg:48.84ms
+step:1230/1845 train_time:60110ms step_avg:48.87ms
+step:1231/1845 train_time:60199ms step_avg:48.90ms
+step:1232/1845 train_time:60286ms step_avg:48.93ms
+step:1233/1845 train_time:60374ms step_avg:48.97ms
+step:1234/1845 train_time:60462ms step_avg:49.00ms
+step:1235/1845 train_time:60551ms step_avg:49.03ms
+step:1236/1845 train_time:60638ms step_avg:49.06ms
+step:1237/1845 train_time:60727ms step_avg:49.09ms
+step:1238/1845 train_time:60814ms step_avg:49.12ms
+step:1239/1845 train_time:60903ms step_avg:49.15ms
+step:1240/1845 train_time:60990ms step_avg:49.19ms
+step:1241/1845 train_time:61078ms step_avg:49.22ms
+step:1242/1845 train_time:61166ms step_avg:49.25ms
+step:1243/1845 train_time:61254ms step_avg:49.28ms
+step:1244/1845 train_time:61343ms step_avg:49.31ms
+step:1245/1845 train_time:61431ms step_avg:49.34ms
+step:1246/1845 train_time:61519ms step_avg:49.37ms
+step:1247/1845 train_time:61607ms step_avg:49.40ms
+step:1248/1845 train_time:61694ms step_avg:49.43ms
+step:1249/1845 train_time:61782ms step_avg:49.47ms
+step:1250/1845 train_time:61869ms step_avg:49.49ms
+step:1250/1845 val_loss:3.5390 train_time:61959ms step_avg:49.57ms
+step:1251/1845 train_time:61979ms step_avg:49.54ms
+step:1252/1845 train_time:62049ms step_avg:49.56ms
+step:1253/1845 train_time:62142ms step_avg:49.59ms
+step:1254/1845 train_time:62231ms step_avg:49.63ms
+step:1255/1845 train_time:62320ms step_avg:49.66ms
+step:1256/1845 train_time:62406ms step_avg:49.69ms
+step:1257/1845 train_time:62493ms step_avg:49.72ms
+step:1258/1845 train_time:62579ms step_avg:49.75ms
+step:1259/1845 train_time:62666ms step_avg:49.77ms
+step:1260/1845 train_time:62752ms step_avg:49.80ms
+step:1261/1845 train_time:62840ms step_avg:49.83ms
+step:1262/1845 train_time:62927ms step_avg:49.86ms
+step:1263/1845 train_time:63020ms step_avg:49.90ms
+step:1264/1845 train_time:63110ms step_avg:49.93ms
+step:1265/1845 train_time:63198ms step_avg:49.96ms
+step:1266/1845 train_time:63286ms step_avg:49.99ms
+step:1267/1845 train_time:63375ms step_avg:50.02ms
+step:1268/1845 train_time:63462ms step_avg:50.05ms
+step:1269/1845 train_time:63550ms step_avg:50.08ms
+step:1270/1845 train_time:63636ms step_avg:50.11ms
+step:1271/1845 train_time:63723ms step_avg:50.14ms
+step:1272/1845 train_time:63810ms step_avg:50.17ms
+step:1273/1845 train_time:63899ms step_avg:50.20ms
+step:1274/1845 train_time:63988ms step_avg:50.23ms
+step:1275/1845 train_time:64077ms step_avg:50.26ms
+step:1276/1845 train_time:64167ms step_avg:50.29ms
+step:1277/1845 train_time:64257ms step_avg:50.32ms
+step:1278/1845 train_time:64345ms step_avg:50.35ms
+step:1279/1845 train_time:64433ms step_avg:50.38ms
+step:1280/1845 train_time:64520ms step_avg:50.41ms
+step:1281/1845 train_time:64607ms step_avg:50.44ms
+step:1282/1845 train_time:64694ms step_avg:50.46ms
+step:1283/1845 train_time:64782ms step_avg:50.49ms
+step:1284/1845 train_time:64869ms step_avg:50.52ms
+step:1285/1845 train_time:64958ms step_avg:50.55ms
+step:1286/1845 train_time:65046ms step_avg:50.58ms
+step:1287/1845 train_time:65135ms step_avg:50.61ms
+step:1288/1845 train_time:65223ms step_avg:50.64ms
+step:1289/1845 train_time:65312ms step_avg:50.67ms
+step:1290/1845 train_time:65399ms step_avg:50.70ms
+step:1291/1845 train_time:65487ms step_avg:50.73ms
+step:1292/1845 train_time:65574ms step_avg:50.75ms
+step:1293/1845 train_time:65662ms step_avg:50.78ms
+step:1294/1845 train_time:65749ms step_avg:50.81ms
+step:1295/1845 train_time:65837ms step_avg:50.84ms
+step:1296/1845 train_time:65924ms step_avg:50.87ms
+step:1297/1845 train_time:66013ms step_avg:50.90ms
+step:1298/1845 train_time:66101ms step_avg:50.92ms
+step:1299/1845 train_time:66190ms step_avg:50.95ms
+step:1300/1845 train_time:66279ms step_avg:50.98ms
+step:1301/1845 train_time:66367ms step_avg:51.01ms
+step:1302/1845 train_time:66454ms step_avg:51.04ms
+step:1303/1845 train_time:66542ms step_avg:51.07ms
+step:1304/1845 train_time:66629ms step_avg:51.10ms
+step:1305/1845 train_time:66717ms step_avg:51.12ms
+step:1306/1845 train_time:66803ms step_avg:51.15ms
+step:1307/1845 train_time:66892ms step_avg:51.18ms
+step:1308/1845 train_time:66979ms step_avg:51.21ms
+step:1309/1845 train_time:67067ms step_avg:51.24ms
+step:1310/1845 train_time:67156ms step_avg:51.26ms
+step:1311/1845 train_time:67244ms step_avg:51.29ms
+step:1312/1845 train_time:67332ms step_avg:51.32ms
+step:1313/1845 train_time:67420ms step_avg:51.35ms
+step:1314/1845 train_time:67507ms step_avg:51.37ms
+step:1315/1845 train_time:67595ms step_avg:51.40ms
+step:1316/1845 train_time:67682ms step_avg:51.43ms
+step:1317/1845 train_time:67770ms step_avg:51.46ms
+step:1318/1845 train_time:67858ms step_avg:51.49ms
+step:1319/1845 train_time:67947ms step_avg:51.51ms
+step:1320/1845 train_time:68035ms step_avg:51.54ms
+step:1321/1845 train_time:68124ms step_avg:51.57ms
+step:1322/1845 train_time:68211ms step_avg:51.60ms
+step:1323/1845 train_time:68300ms step_avg:51.62ms
+step:1324/1845 train_time:68387ms step_avg:51.65ms
+step:1325/1845 train_time:68475ms step_avg:51.68ms
+step:1326/1845 train_time:68563ms step_avg:51.71ms
+step:1327/1845 train_time:68651ms step_avg:51.73ms
+step:1328/1845 train_time:68739ms step_avg:51.76ms
+step:1329/1845 train_time:68827ms step_avg:51.79ms
+step:1330/1845 train_time:68914ms step_avg:51.81ms
+step:1331/1845 train_time:69003ms step_avg:51.84ms
+step:1332/1845 train_time:69090ms step_avg:51.87ms
+step:1333/1845 train_time:69181ms step_avg:51.90ms
+step:1334/1845 train_time:69267ms step_avg:51.92ms
+step:1335/1845 train_time:69357ms step_avg:51.95ms
+step:1336/1845 train_time:69443ms step_avg:51.98ms
+step:1337/1845 train_time:69532ms step_avg:52.01ms
+step:1338/1845 train_time:69618ms step_avg:52.03ms
+step:1339/1845 train_time:69707ms step_avg:52.06ms
+step:1340/1845 train_time:69795ms step_avg:52.09ms
+step:1341/1845 train_time:69884ms step_avg:52.11ms
+step:1342/1845 train_time:69972ms step_avg:52.14ms
+step:1343/1845 train_time:70060ms step_avg:52.17ms
+step:1344/1845 train_time:70147ms step_avg:52.19ms
+step:1345/1845 train_time:70237ms step_avg:52.22ms
+step:1346/1845 train_time:70324ms step_avg:52.25ms
+step:1347/1845 train_time:70412ms step_avg:52.27ms
+step:1348/1845 train_time:70499ms step_avg:52.30ms
+step:1349/1845 train_time:70587ms step_avg:52.33ms
+step:1350/1845 train_time:70674ms step_avg:52.35ms
+step:1351/1845 train_time:70762ms step_avg:52.38ms
+step:1352/1845 train_time:70850ms step_avg:52.40ms
+step:1353/1845 train_time:70938ms step_avg:52.43ms
+step:1354/1845 train_time:71025ms step_avg:52.46ms
+step:1355/1845 train_time:71114ms step_avg:52.48ms
+step:1356/1845 train_time:71201ms step_avg:52.51ms
+step:1357/1845 train_time:71290ms step_avg:52.54ms
+step:1358/1845 train_time:71378ms step_avg:52.56ms
+step:1359/1845 train_time:71467ms step_avg:52.59ms
+step:1360/1845 train_time:71554ms step_avg:52.61ms
+step:1361/1845 train_time:71642ms step_avg:52.64ms
+step:1362/1845 train_time:71730ms step_avg:52.67ms
+step:1363/1845 train_time:71819ms step_avg:52.69ms
+step:1364/1845 train_time:71905ms step_avg:52.72ms
+step:1365/1845 train_time:71993ms step_avg:52.74ms
+step:1366/1845 train_time:72081ms step_avg:52.77ms
+step:1367/1845 train_time:72169ms step_avg:52.79ms
+step:1368/1845 train_time:72257ms step_avg:52.82ms
+step:1369/1845 train_time:72346ms step_avg:52.85ms
+step:1370/1845 train_time:72434ms step_avg:52.87ms
+step:1371/1845 train_time:72522ms step_avg:52.90ms
+step:1372/1845 train_time:72609ms step_avg:52.92ms
+step:1373/1845 train_time:72697ms step_avg:52.95ms
+step:1374/1845 train_time:72784ms step_avg:52.97ms
+step:1375/1845 train_time:72873ms step_avg:53.00ms
+step:1376/1845 train_time:72960ms step_avg:53.02ms
+step:1377/1845 train_time:73048ms step_avg:53.05ms
+step:1378/1845 train_time:73137ms step_avg:53.07ms
+step:1379/1845 train_time:73225ms step_avg:53.10ms
+step:1380/1845 train_time:73312ms step_avg:53.12ms
+step:1381/1845 train_time:73401ms step_avg:53.15ms
+step:1382/1845 train_time:73488ms step_avg:53.18ms
+step:1383/1845 train_time:73576ms step_avg:53.20ms
+step:1384/1845 train_time:73664ms step_avg:53.23ms
+step:1385/1845 train_time:73752ms step_avg:53.25ms
+step:1386/1845 train_time:73839ms step_avg:53.27ms
+step:1387/1845 train_time:73928ms step_avg:53.30ms
+step:1388/1845 train_time:74016ms step_avg:53.33ms
+step:1389/1845 train_time:74104ms step_avg:53.35ms
+step:1390/1845 train_time:74192ms step_avg:53.38ms
+step:1391/1845 train_time:74280ms step_avg:53.40ms
+step:1392/1845 train_time:74367ms step_avg:53.42ms
+step:1393/1845 train_time:74455ms step_avg:53.45ms
+step:1394/1845 train_time:74542ms step_avg:53.47ms
+step:1395/1845 train_time:74630ms step_avg:53.50ms
+step:1396/1845 train_time:74717ms step_avg:53.52ms
+step:1397/1845 train_time:74805ms step_avg:53.55ms
+step:1398/1845 train_time:74892ms step_avg:53.57ms
+step:1399/1845 train_time:74981ms step_avg:53.60ms
+step:1400/1845 train_time:75068ms step_avg:53.62ms
+step:1401/1845 train_time:75156ms step_avg:53.64ms
+step:1402/1845 train_time:75243ms step_avg:53.67ms
+step:1403/1845 train_time:75331ms step_avg:53.69ms
+step:1404/1845 train_time:75419ms step_avg:53.72ms
+step:1405/1845 train_time:75507ms step_avg:53.74ms
+step:1406/1845 train_time:75594ms step_avg:53.77ms
+step:1407/1845 train_time:75683ms step_avg:53.79ms
+step:1408/1845 train_time:75770ms step_avg:53.81ms
+step:1409/1845 train_time:75859ms step_avg:53.84ms
+step:1410/1845 train_time:75946ms step_avg:53.86ms
+step:1411/1845 train_time:76034ms step_avg:53.89ms
+step:1412/1845 train_time:76122ms step_avg:53.91ms
+step:1413/1845 train_time:76211ms step_avg:53.94ms
+step:1414/1845 train_time:76298ms step_avg:53.96ms
+step:1415/1845 train_time:76386ms step_avg:53.98ms
+step:1416/1845 train_time:76474ms step_avg:54.01ms
+step:1417/1845 train_time:76562ms step_avg:54.03ms
+step:1418/1845 train_time:76650ms step_avg:54.05ms
+step:1419/1845 train_time:76738ms step_avg:54.08ms
+step:1420/1845 train_time:76825ms step_avg:54.10ms
+step:1421/1845 train_time:76914ms step_avg:54.13ms
+step:1422/1845 train_time:77001ms step_avg:54.15ms
+step:1423/1845 train_time:77089ms step_avg:54.17ms
+step:1424/1845 train_time:77177ms step_avg:54.20ms
+step:1425/1845 train_time:77265ms step_avg:54.22ms
+step:1426/1845 train_time:77352ms step_avg:54.24ms
+step:1427/1845 train_time:77442ms step_avg:54.27ms
+step:1428/1845 train_time:77530ms step_avg:54.29ms
+step:1429/1845 train_time:77619ms step_avg:54.32ms
+step:1430/1845 train_time:77705ms step_avg:54.34ms
+step:1431/1845 train_time:77794ms step_avg:54.36ms
+step:1432/1845 train_time:77881ms step_avg:54.39ms
+step:1433/1845 train_time:77969ms step_avg:54.41ms
+step:1434/1845 train_time:78058ms step_avg:54.43ms
+step:1435/1845 train_time:78145ms step_avg:54.46ms
+step:1436/1845 train_time:78232ms step_avg:54.48ms
+step:1437/1845 train_time:78321ms step_avg:54.50ms
+step:1438/1845 train_time:78409ms step_avg:54.53ms
+step:1439/1845 train_time:78498ms step_avg:54.55ms
+step:1440/1845 train_time:78585ms step_avg:54.57ms
+step:1441/1845 train_time:78674ms step_avg:54.60ms
+step:1442/1845 train_time:78761ms step_avg:54.62ms
+step:1443/1845 train_time:78849ms step_avg:54.64ms
+step:1444/1845 train_time:78937ms step_avg:54.67ms
+step:1445/1845 train_time:79025ms step_avg:54.69ms
+step:1446/1845 train_time:79112ms step_avg:54.71ms
+step:1447/1845 train_time:79201ms step_avg:54.73ms
+step:1448/1845 train_time:79288ms step_avg:54.76ms
+step:1449/1845 train_time:79377ms step_avg:54.78ms
+step:1450/1845 train_time:79464ms step_avg:54.80ms
+step:1451/1845 train_time:79553ms step_avg:54.83ms
+step:1452/1845 train_time:79640ms step_avg:54.85ms
+step:1453/1845 train_time:79729ms step_avg:54.87ms
+step:1454/1845 train_time:79816ms step_avg:54.89ms
+step:1455/1845 train_time:79904ms step_avg:54.92ms
+step:1456/1845 train_time:79991ms step_avg:54.94ms
+step:1457/1845 train_time:80080ms step_avg:54.96ms
+step:1458/1845 train_time:80167ms step_avg:54.98ms
+step:1459/1845 train_time:80255ms step_avg:55.01ms
+step:1460/1845 train_time:80343ms step_avg:55.03ms
+step:1461/1845 train_time:80431ms step_avg:55.05ms
+step:1462/1845 train_time:80519ms step_avg:55.07ms
+step:1463/1845 train_time:80608ms step_avg:55.10ms
+step:1464/1845 train_time:80695ms step_avg:55.12ms
+step:1465/1845 train_time:80784ms step_avg:55.14ms
+step:1466/1845 train_time:80871ms step_avg:55.16ms
+step:1467/1845 train_time:80960ms step_avg:55.19ms
+step:1468/1845 train_time:81047ms step_avg:55.21ms
+step:1469/1845 train_time:81136ms step_avg:55.23ms
+step:1470/1845 train_time:81223ms step_avg:55.25ms
+step:1471/1845 train_time:81312ms step_avg:55.28ms
+step:1472/1845 train_time:81399ms step_avg:55.30ms
+step:1473/1845 train_time:81487ms step_avg:55.32ms
+step:1474/1845 train_time:81575ms step_avg:55.34ms
+step:1475/1845 train_time:81663ms step_avg:55.36ms
+step:1476/1845 train_time:81751ms step_avg:55.39ms
+step:1477/1845 train_time:81838ms step_avg:55.41ms
+step:1478/1845 train_time:81925ms step_avg:55.43ms
+step:1479/1845 train_time:82014ms step_avg:55.45ms
+step:1480/1845 train_time:82102ms step_avg:55.47ms
+step:1481/1845 train_time:82191ms step_avg:55.50ms
+step:1482/1845 train_time:82279ms step_avg:55.52ms
+step:1483/1845 train_time:82367ms step_avg:55.54ms
+step:1484/1845 train_time:82455ms step_avg:55.56ms
+step:1485/1845 train_time:82543ms step_avg:55.58ms
+step:1486/1845 train_time:82630ms step_avg:55.61ms
+step:1487/1845 train_time:82720ms step_avg:55.63ms
+step:1488/1845 train_time:82806ms step_avg:55.65ms
+step:1489/1845 train_time:82895ms step_avg:55.67ms
+step:1490/1845 train_time:82982ms step_avg:55.69ms
+step:1491/1845 train_time:83071ms step_avg:55.72ms
+step:1492/1845 train_time:83159ms step_avg:55.74ms
+step:1493/1845 train_time:83247ms step_avg:55.76ms
+step:1494/1845 train_time:83335ms step_avg:55.78ms
+step:1495/1845 train_time:83423ms step_avg:55.80ms
+step:1496/1845 train_time:83510ms step_avg:55.82ms
+step:1497/1845 train_time:83598ms step_avg:55.84ms
+step:1498/1845 train_time:83684ms step_avg:55.86ms
+step:1499/1845 train_time:83773ms step_avg:55.89ms
+step:1500/1845 train_time:83861ms step_avg:55.91ms
+step:1500/1845 val_loss:3.4054 train_time:83951ms step_avg:55.97ms
+step:1501/1845 train_time:83971ms step_avg:55.94ms
+step:1502/1845 train_time:84042ms step_avg:55.95ms
+step:1503/1845 train_time:84136ms step_avg:55.98ms
+step:1504/1845 train_time:84224ms step_avg:56.00ms
+step:1505/1845 train_time:84312ms step_avg:56.02ms
+step:1506/1845 train_time:84399ms step_avg:56.04ms
+step:1507/1845 train_time:84487ms step_avg:56.06ms
+step:1508/1845 train_time:84574ms step_avg:56.08ms
+step:1509/1845 train_time:84662ms step_avg:56.10ms
+step:1510/1845 train_time:84748ms step_avg:56.12ms
+step:1511/1845 train_time:84836ms step_avg:56.15ms
+step:1512/1845 train_time:84923ms step_avg:56.17ms
+step:1513/1845 train_time:85015ms step_avg:56.19ms
+step:1514/1845 train_time:85105ms step_avg:56.21ms
+step:1515/1845 train_time:85195ms step_avg:56.23ms
+step:1516/1845 train_time:85283ms step_avg:56.26ms
+step:1517/1845 train_time:85371ms step_avg:56.28ms
+step:1518/1845 train_time:85458ms step_avg:56.30ms
+step:1519/1845 train_time:85545ms step_avg:56.32ms
+step:1520/1845 train_time:85632ms step_avg:56.34ms
+step:1521/1845 train_time:85720ms step_avg:56.36ms
+step:1522/1845 train_time:85807ms step_avg:56.38ms
+step:1523/1845 train_time:85896ms step_avg:56.40ms
+step:1524/1845 train_time:85984ms step_avg:56.42ms
+step:1525/1845 train_time:86075ms step_avg:56.44ms
+step:1526/1845 train_time:86164ms step_avg:56.46ms
+step:1527/1845 train_time:86254ms step_avg:56.49ms
+step:1528/1845 train_time:86342ms step_avg:56.51ms
+step:1529/1845 train_time:86430ms step_avg:56.53ms
+step:1530/1845 train_time:86518ms step_avg:56.55ms
+step:1531/1845 train_time:86606ms step_avg:56.57ms
+step:1532/1845 train_time:86693ms step_avg:56.59ms
+step:1533/1845 train_time:86781ms step_avg:56.61ms
+step:1534/1845 train_time:86868ms step_avg:56.63ms
+step:1535/1845 train_time:86958ms step_avg:56.65ms
+step:1536/1845 train_time:87047ms step_avg:56.67ms
+step:1537/1845 train_time:87138ms step_avg:56.69ms
+step:1538/1845 train_time:87226ms step_avg:56.71ms
+step:1539/1845 train_time:87316ms step_avg:56.74ms
+step:1540/1845 train_time:87403ms step_avg:56.76ms
+step:1541/1845 train_time:87491ms step_avg:56.78ms
+step:1542/1845 train_time:87579ms step_avg:56.80ms
+step:1543/1845 train_time:87667ms step_avg:56.82ms
+step:1544/1845 train_time:87754ms step_avg:56.84ms
+step:1545/1845 train_time:87843ms step_avg:56.86ms
+step:1546/1845 train_time:87930ms step_avg:56.88ms
+step:1547/1845 train_time:88019ms step_avg:56.90ms
+step:1548/1845 train_time:88107ms step_avg:56.92ms
+step:1549/1845 train_time:88198ms step_avg:56.94ms
+step:1550/1845 train_time:88286ms step_avg:56.96ms
+step:1551/1845 train_time:88375ms step_avg:56.98ms
+step:1552/1845 train_time:88462ms step_avg:57.00ms
+step:1553/1845 train_time:88551ms step_avg:57.02ms
+step:1554/1845 train_time:88638ms step_avg:57.04ms
+step:1555/1845 train_time:88726ms step_avg:57.06ms
+step:1556/1845 train_time:88813ms step_avg:57.08ms
+step:1557/1845 train_time:88901ms step_avg:57.10ms
+step:1558/1845 train_time:88989ms step_avg:57.12ms
+step:1559/1845 train_time:89078ms step_avg:57.14ms
+step:1560/1845 train_time:89168ms step_avg:57.16ms
+step:1561/1845 train_time:89258ms step_avg:57.18ms
+step:1562/1845 train_time:89346ms step_avg:57.20ms
+step:1563/1845 train_time:89435ms step_avg:57.22ms
+step:1564/1845 train_time:89522ms step_avg:57.24ms
+step:1565/1845 train_time:89611ms step_avg:57.26ms
+step:1566/1845 train_time:89698ms step_avg:57.28ms
+step:1567/1845 train_time:89787ms step_avg:57.30ms
+step:1568/1845 train_time:89874ms step_avg:57.32ms
+step:1569/1845 train_time:89962ms step_avg:57.34ms
+step:1570/1845 train_time:90051ms step_avg:57.36ms
+step:1571/1845 train_time:90140ms step_avg:57.38ms
+step:1572/1845 train_time:90227ms step_avg:57.40ms
+step:1573/1845 train_time:90317ms step_avg:57.42ms
+step:1574/1845 train_time:90405ms step_avg:57.44ms
+step:1575/1845 train_time:90494ms step_avg:57.46ms
+step:1576/1845 train_time:90581ms step_avg:57.48ms
+step:1577/1845 train_time:90670ms step_avg:57.50ms
+step:1578/1845 train_time:90758ms step_avg:57.51ms
+step:1579/1845 train_time:90847ms step_avg:57.53ms
+step:1580/1845 train_time:90933ms step_avg:57.55ms
+step:1581/1845 train_time:91022ms step_avg:57.57ms
+step:1582/1845 train_time:91111ms step_avg:57.59ms
+step:1583/1845 train_time:91201ms step_avg:57.61ms
+step:1584/1845 train_time:91290ms step_avg:57.63ms
+step:1585/1845 train_time:91379ms step_avg:57.65ms
+step:1586/1845 train_time:91467ms step_avg:57.67ms
+step:1587/1845 train_time:91556ms step_avg:57.69ms
+step:1588/1845 train_time:91643ms step_avg:57.71ms
+step:1589/1845 train_time:91731ms step_avg:57.73ms
+step:1590/1845 train_time:91818ms step_avg:57.75ms
+step:1591/1845 train_time:91906ms step_avg:57.77ms
+step:1592/1845 train_time:91994ms step_avg:57.79ms
+step:1593/1845 train_time:92083ms step_avg:57.80ms
+step:1594/1845 train_time:92170ms step_avg:57.82ms
+step:1595/1845 train_time:92259ms step_avg:57.84ms
+step:1596/1845 train_time:92347ms step_avg:57.86ms
+step:1597/1845 train_time:92436ms step_avg:57.88ms
+step:1598/1845 train_time:92523ms step_avg:57.90ms
+step:1599/1845 train_time:92612ms step_avg:57.92ms
+step:1600/1845 train_time:92699ms step_avg:57.94ms
+step:1601/1845 train_time:92788ms step_avg:57.96ms
+step:1602/1845 train_time:92877ms step_avg:57.98ms
+step:1603/1845 train_time:92965ms step_avg:57.99ms
+step:1604/1845 train_time:93052ms step_avg:58.01ms
+step:1605/1845 train_time:93140ms step_avg:58.03ms
+step:1606/1845 train_time:93227ms step_avg:58.05ms
+step:1607/1845 train_time:93318ms step_avg:58.07ms
+step:1608/1845 train_time:93406ms step_avg:58.09ms
+step:1609/1845 train_time:93495ms step_avg:58.11ms
+step:1610/1845 train_time:93582ms step_avg:58.13ms
+step:1611/1845 train_time:93671ms step_avg:58.14ms
+step:1612/1845 train_time:93758ms step_avg:58.16ms
+step:1613/1845 train_time:93847ms step_avg:58.18ms
+step:1614/1845 train_time:93935ms step_avg:58.20ms
+step:1615/1845 train_time:94023ms step_avg:58.22ms
+step:1616/1845 train_time:94110ms step_avg:58.24ms
+step:1617/1845 train_time:94200ms step_avg:58.26ms
+step:1618/1845 train_time:94288ms step_avg:58.27ms
+step:1619/1845 train_time:94377ms step_avg:58.29ms
+step:1620/1845 train_time:94465ms step_avg:58.31ms
+step:1621/1845 train_time:94555ms step_avg:58.33ms
+step:1622/1845 train_time:94643ms step_avg:58.35ms
+step:1623/1845 train_time:94732ms step_avg:58.37ms
+step:1624/1845 train_time:94819ms step_avg:58.39ms
+step:1625/1845 train_time:94908ms step_avg:58.40ms
+step:1626/1845 train_time:94994ms step_avg:58.42ms
+step:1627/1845 train_time:95083ms step_avg:58.44ms
+step:1628/1845 train_time:95171ms step_avg:58.46ms
+step:1629/1845 train_time:95260ms step_avg:58.48ms
+step:1630/1845 train_time:95348ms step_avg:58.50ms
+step:1631/1845 train_time:95437ms step_avg:58.51ms
+step:1632/1845 train_time:95524ms step_avg:58.53ms
+step:1633/1845 train_time:95614ms step_avg:58.55ms
+step:1634/1845 train_time:95701ms step_avg:58.57ms
+step:1635/1845 train_time:95790ms step_avg:58.59ms
+step:1636/1845 train_time:95877ms step_avg:58.60ms
+step:1637/1845 train_time:95966ms step_avg:58.62ms
+step:1638/1845 train_time:96054ms step_avg:58.64ms
+step:1639/1845 train_time:96142ms step_avg:58.66ms
+step:1640/1845 train_time:96229ms step_avg:58.68ms
+step:1641/1845 train_time:96319ms step_avg:58.70ms
+step:1642/1845 train_time:96406ms step_avg:58.71ms
+step:1643/1845 train_time:96495ms step_avg:58.73ms
+step:1644/1845 train_time:96582ms step_avg:58.75ms
+step:1645/1845 train_time:96672ms step_avg:58.77ms
+step:1646/1845 train_time:96759ms step_avg:58.78ms
+step:1647/1845 train_time:96848ms step_avg:58.80ms
+step:1648/1845 train_time:96936ms step_avg:58.82ms
+step:1649/1845 train_time:97024ms step_avg:58.84ms
+step:1650/1845 train_time:97112ms step_avg:58.86ms
+step:1651/1845 train_time:97201ms step_avg:58.87ms
+step:1652/1845 train_time:97288ms step_avg:58.89ms
+step:1653/1845 train_time:97377ms step_avg:58.91ms
+step:1654/1845 train_time:97466ms step_avg:58.93ms
+step:1655/1845 train_time:97554ms step_avg:58.94ms
+step:1656/1845 train_time:97640ms step_avg:58.96ms
+step:1657/1845 train_time:97729ms step_avg:58.98ms
+step:1658/1845 train_time:97818ms step_avg:59.00ms
+step:1659/1845 train_time:97906ms step_avg:59.02ms
+step:1660/1845 train_time:97993ms step_avg:59.03ms
+step:1661/1845 train_time:98082ms step_avg:59.05ms
+step:1662/1845 train_time:98170ms step_avg:59.07ms
+step:1663/1845 train_time:98258ms step_avg:59.08ms
+step:1664/1845 train_time:98347ms step_avg:59.10ms
+step:1665/1845 train_time:98435ms step_avg:59.12ms
+step:1666/1845 train_time:98522ms step_avg:59.14ms
+step:1667/1845 train_time:98612ms step_avg:59.16ms
+step:1668/1845 train_time:98698ms step_avg:59.17ms
+step:1669/1845 train_time:98787ms step_avg:59.19ms
+step:1670/1845 train_time:98875ms step_avg:59.21ms
+step:1671/1845 train_time:98963ms step_avg:59.22ms
+step:1672/1845 train_time:99051ms step_avg:59.24ms
+step:1673/1845 train_time:99139ms step_avg:59.26ms
+step:1674/1845 train_time:99226ms step_avg:59.27ms
+step:1675/1845 train_time:99315ms step_avg:59.29ms
+step:1676/1845 train_time:99402ms step_avg:59.31ms
+step:1677/1845 train_time:99491ms step_avg:59.33ms
+step:1678/1845 train_time:99578ms step_avg:59.34ms
+step:1679/1845 train_time:99668ms step_avg:59.36ms
+step:1680/1845 train_time:99755ms step_avg:59.38ms
+step:1681/1845 train_time:99843ms step_avg:59.40ms
+step:1682/1845 train_time:99931ms step_avg:59.41ms
+step:1683/1845 train_time:100020ms step_avg:59.43ms
+step:1684/1845 train_time:100107ms step_avg:59.45ms
+step:1685/1845 train_time:100197ms step_avg:59.46ms
+step:1686/1845 train_time:100285ms step_avg:59.48ms
+step:1687/1845 train_time:100375ms step_avg:59.50ms
+step:1688/1845 train_time:100462ms step_avg:59.52ms
+step:1689/1845 train_time:100550ms step_avg:59.53ms
+step:1690/1845 train_time:100638ms step_avg:59.55ms
+step:1691/1845 train_time:100727ms step_avg:59.57ms
+step:1692/1845 train_time:100815ms step_avg:59.58ms
+step:1693/1845 train_time:100903ms step_avg:59.60ms
+step:1694/1845 train_time:100992ms step_avg:59.62ms
+step:1695/1845 train_time:101081ms step_avg:59.63ms
+step:1696/1845 train_time:101170ms step_avg:59.65ms
+step:1697/1845 train_time:101260ms step_avg:59.67ms
+step:1698/1845 train_time:101349ms step_avg:59.69ms
+step:1699/1845 train_time:101439ms step_avg:59.70ms
+step:1700/1845 train_time:101526ms step_avg:59.72ms
+step:1701/1845 train_time:101615ms step_avg:59.74ms
+step:1702/1845 train_time:101703ms step_avg:59.75ms
+step:1703/1845 train_time:101791ms step_avg:59.77ms
+step:1704/1845 train_time:101878ms step_avg:59.79ms
+step:1705/1845 train_time:101967ms step_avg:59.80ms
+step:1706/1845 train_time:102054ms step_avg:59.82ms
+step:1707/1845 train_time:102142ms step_avg:59.84ms
+step:1708/1845 train_time:102229ms step_avg:59.85ms
+step:1709/1845 train_time:102319ms step_avg:59.87ms
+step:1710/1845 train_time:102408ms step_avg:59.89ms
+step:1711/1845 train_time:102497ms step_avg:59.90ms
+step:1712/1845 train_time:102584ms step_avg:59.92ms
+step:1713/1845 train_time:102674ms step_avg:59.94ms
+step:1714/1845 train_time:102760ms step_avg:59.95ms
+step:1715/1845 train_time:102849ms step_avg:59.97ms
+step:1716/1845 train_time:102936ms step_avg:59.99ms
+step:1717/1845 train_time:103024ms step_avg:60.00ms
+step:1718/1845 train_time:103112ms step_avg:60.02ms
+step:1719/1845 train_time:103200ms step_avg:60.04ms
+step:1720/1845 train_time:103288ms step_avg:60.05ms
+step:1721/1845 train_time:103377ms step_avg:60.07ms
+step:1722/1845 train_time:103464ms step_avg:60.08ms
+step:1723/1845 train_time:103553ms step_avg:60.10ms
+step:1724/1845 train_time:103640ms step_avg:60.12ms
+step:1725/1845 train_time:103729ms step_avg:60.13ms
+step:1726/1845 train_time:103817ms step_avg:60.15ms
+step:1727/1845 train_time:103905ms step_avg:60.16ms
+step:1728/1845 train_time:103992ms step_avg:60.18ms
+step:1729/1845 train_time:104081ms step_avg:60.20ms
+step:1730/1845 train_time:104168ms step_avg:60.21ms
+step:1731/1845 train_time:104257ms step_avg:60.23ms
+step:1732/1845 train_time:104345ms step_avg:60.25ms
+step:1733/1845 train_time:104434ms step_avg:60.26ms
+step:1734/1845 train_time:104521ms step_avg:60.28ms
+step:1735/1845 train_time:104611ms step_avg:60.29ms
+step:1736/1845 train_time:104698ms step_avg:60.31ms
+step:1737/1845 train_time:104787ms step_avg:60.33ms
+step:1738/1845 train_time:104875ms step_avg:60.34ms
+step:1739/1845 train_time:104963ms step_avg:60.36ms
+step:1740/1845 train_time:105052ms step_avg:60.37ms
+step:1741/1845 train_time:105140ms step_avg:60.39ms
+step:1742/1845 train_time:105227ms step_avg:60.41ms
+step:1743/1845 train_time:105318ms step_avg:60.42ms
+step:1744/1845 train_time:105406ms step_avg:60.44ms
+step:1745/1845 train_time:105496ms step_avg:60.46ms
+step:1746/1845 train_time:105583ms step_avg:60.47ms
+step:1747/1845 train_time:105671ms step_avg:60.49ms
+step:1748/1845 train_time:105758ms step_avg:60.50ms
+step:1749/1845 train_time:105848ms step_avg:60.52ms
+step:1750/1845 train_time:105934ms step_avg:60.53ms
+step:1750/1845 val_loss:3.3053 train_time:106024ms step_avg:60.59ms
+step:1751/1845 train_time:106044ms step_avg:60.56ms
+step:1752/1845 train_time:106116ms step_avg:60.57ms
+step:1753/1845 train_time:106211ms step_avg:60.59ms
+step:1754/1845 train_time:106299ms step_avg:60.60ms
+step:1755/1845 train_time:106386ms step_avg:60.62ms
+step:1756/1845 train_time:106472ms step_avg:60.63ms
+step:1757/1845 train_time:106560ms step_avg:60.65ms
+step:1758/1845 train_time:106646ms step_avg:60.66ms
+step:1759/1845 train_time:106733ms step_avg:60.68ms
+step:1760/1845 train_time:106819ms step_avg:60.69ms
+step:1761/1845 train_time:106908ms step_avg:60.71ms
+step:1762/1845 train_time:106997ms step_avg:60.72ms
+step:1763/1845 train_time:107088ms step_avg:60.74ms
+step:1764/1845 train_time:107178ms step_avg:60.76ms
+step:1765/1845 train_time:107268ms step_avg:60.77ms
+step:1766/1845 train_time:107354ms step_avg:60.79ms
+step:1767/1845 train_time:107442ms step_avg:60.80ms
+step:1768/1845 train_time:107529ms step_avg:60.82ms
+step:1769/1845 train_time:107616ms step_avg:60.83ms
+step:1770/1845 train_time:107702ms step_avg:60.85ms
+step:1771/1845 train_time:107790ms step_avg:60.86ms
+step:1772/1845 train_time:107876ms step_avg:60.88ms
+step:1773/1845 train_time:107964ms step_avg:60.89ms
+step:1774/1845 train_time:108053ms step_avg:60.91ms
+step:1775/1845 train_time:108144ms step_avg:60.93ms
+step:1776/1845 train_time:108232ms step_avg:60.94ms
+step:1777/1845 train_time:108321ms step_avg:60.96ms
+step:1778/1845 train_time:108409ms step_avg:60.97ms
+step:1779/1845 train_time:108497ms step_avg:60.99ms
+step:1780/1845 train_time:108583ms step_avg:61.00ms
+step:1781/1845 train_time:108671ms step_avg:61.02ms
+step:1782/1845 train_time:108757ms step_avg:61.03ms
+step:1783/1845 train_time:108845ms step_avg:61.05ms
+step:1784/1845 train_time:108933ms step_avg:61.06ms
+step:1785/1845 train_time:109023ms step_avg:61.08ms
+step:1786/1845 train_time:109111ms step_avg:61.09ms
+step:1787/1845 train_time:109201ms step_avg:61.11ms
+step:1788/1845 train_time:109289ms step_avg:61.12ms
+step:1789/1845 train_time:109378ms step_avg:61.14ms
+step:1790/1845 train_time:109465ms step_avg:61.15ms
+step:1791/1845 train_time:109553ms step_avg:61.17ms
+step:1792/1845 train_time:109640ms step_avg:61.18ms
+step:1793/1845 train_time:109728ms step_avg:61.20ms
+step:1794/1845 train_time:109814ms step_avg:61.21ms
+step:1795/1845 train_time:109903ms step_avg:61.23ms
+step:1796/1845 train_time:109991ms step_avg:61.24ms
+step:1797/1845 train_time:110080ms step_avg:61.26ms
+step:1798/1845 train_time:110168ms step_avg:61.27ms
+step:1799/1845 train_time:110257ms step_avg:61.29ms
+step:1800/1845 train_time:110346ms step_avg:61.30ms
+step:1801/1845 train_time:110435ms step_avg:61.32ms
+step:1802/1845 train_time:110523ms step_avg:61.33ms
+step:1803/1845 train_time:110611ms step_avg:61.35ms
+step:1804/1845 train_time:110698ms step_avg:61.36ms
+step:1805/1845 train_time:110786ms step_avg:61.38ms
+step:1806/1845 train_time:110873ms step_avg:61.39ms
+step:1807/1845 train_time:110961ms step_avg:61.41ms
+step:1808/1845 train_time:111050ms step_avg:61.42ms
+step:1809/1845 train_time:111138ms step_avg:61.44ms
+step:1810/1845 train_time:111227ms step_avg:61.45ms
+step:1811/1845 train_time:111315ms step_avg:61.47ms
+step:1812/1845 train_time:111404ms step_avg:61.48ms
+step:1813/1845 train_time:111493ms step_avg:61.50ms
+step:1814/1845 train_time:111579ms step_avg:61.51ms
+step:1815/1845 train_time:111668ms step_avg:61.53ms
+step:1816/1845 train_time:111755ms step_avg:61.54ms
+step:1817/1845 train_time:111845ms step_avg:61.55ms
+step:1818/1845 train_time:111932ms step_avg:61.57ms
+step:1819/1845 train_time:112022ms step_avg:61.58ms
+step:1820/1845 train_time:112110ms step_avg:61.60ms
+step:1821/1845 train_time:112198ms step_avg:61.61ms
+step:1822/1845 train_time:112285ms step_avg:61.63ms
+step:1823/1845 train_time:112375ms step_avg:61.64ms
+step:1824/1845 train_time:112462ms step_avg:61.66ms
+step:1825/1845 train_time:112552ms step_avg:61.67ms
+step:1826/1845 train_time:112639ms step_avg:61.69ms
+step:1827/1845 train_time:112728ms step_avg:61.70ms
+step:1828/1845 train_time:112815ms step_avg:61.72ms
+step:1829/1845 train_time:112904ms step_avg:61.73ms
+step:1830/1845 train_time:112992ms step_avg:61.74ms
+step:1831/1845 train_time:113081ms step_avg:61.76ms
+step:1832/1845 train_time:113169ms step_avg:61.77ms
+step:1833/1845 train_time:113257ms step_avg:61.79ms
+step:1834/1845 train_time:113346ms step_avg:61.80ms
+step:1835/1845 train_time:113434ms step_avg:61.82ms
+step:1836/1845 train_time:113522ms step_avg:61.83ms
+step:1837/1845 train_time:113610ms step_avg:61.85ms
+step:1838/1845 train_time:113697ms step_avg:61.86ms
+step:1839/1845 train_time:113786ms step_avg:61.87ms
+step:1840/1845 train_time:113873ms step_avg:61.89ms
+step:1841/1845 train_time:113962ms step_avg:61.90ms
+step:1842/1845 train_time:114049ms step_avg:61.92ms
+step:1843/1845 train_time:114137ms step_avg:61.93ms
+step:1844/1845 train_time:114224ms step_avg:61.94ms
+step:1845/1845 train_time:114313ms step_avg:61.96ms
+step:1845/1845 val_loss:3.2792 train_time:114401ms step_avg:62.01ms
+peak memory allocated: 29405 MiB reserved: 44238 MiB

--- a/records/track_1_short/2025-12-29_VeSkipGates/dbb767ac-4ec7-40de-8398-d09946c839fa.txt
+++ b/records/track_1_short/2025-12-29_VeSkipGates/dbb767ac-4ec7-40de-8398-d09946c839fa.txt
@@ -1,0 +1,3725 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, v, wd_tensor, lr_tensor):
+    """Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors."""
+    mask = (v * p) >= 0
+    wd_factor = wd_tensor.to(p.dtype)
+    lr_factor = lr_tensor.to(p.dtype)
+    p.copy_(p - (p * mask * wd_factor * lr_factor) - (v * lr_factor))
+
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn_gate (10 params 6 padding params)
+        2. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        3. reduce scatter attn/mlp round 2 (16 mlp params)
+        4. wait on step 1, then compute update of 1 and schedule all gather
+        5. wait on step 2, then compute update of 2 and schedule all gather
+        6. wait on step 3, then compute update of 3 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        7. wait on 4, then compute update of 4 and schedule all gather
+        8. wait for each all gather to complete and update params
+    Empirically, leading with small params provides an additional 0.2s improvement.
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        group_sizes = [15, 16, 16]
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    @torch.no_grad()
+    def step(self):
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+
+        all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"]
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params])
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            # The below shape-based heuristic assumes that matrices have their input along the
+            # row dimension and their output along the columns. Gates are an exception.
+            is_gate = 'gate' in ref_param.label
+
+            if "second_momentum_buffer" not in group:
+                if is_gate:
+                    group["second_momentum_buffer"] = torch.zeros_like(updated_grads[..., :, :1])
+                else:
+                    group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1])
+                        if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                    )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if (is_gate or param_shape[-2] >= param_shape[-1]) else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx],
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete and copy results back into original parameter tensors.
+        for info in all_gather_infos:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str],lr: float = 1e-3, betas: tuple[float, float] = (0.9, 0.999), eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for label in label_order:
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.bfloat16, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-1]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @torch.compile
+    @torch.no_grad()
+    def step(self):
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        for group in self.param_groups:
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+
+                exp_avg = state["exp_avg"]
+                exp_avg_sq = state["exp_avg_sq"]
+                state["step"] += 1
+                t = state["step"]
+                # update running averages
+                exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+                # bias corrections
+                bias1 = 1 - beta1 ** t
+                bias2 = 1 - beta2 ** t
+                # compute step
+                denom = exp_avg_sq.sqrt().add_(eps)
+                step_size = lr * (bias2 ** 0.5 / bias1)
+                update = exp_avg.div(denom).mul_(step_size)
+                # cautious weight decay
+                mask = (update * p_slice) > 0
+                # lr as weight decay schedule
+                eff_weight_decay = lr * wd * getattr(param, "wd_mul", 1.0)
+                update.addcmul_(p_slice, mask, value=eff_weight_decay * lr)
+
+                p_slice.add_(other=update, alpha=-1.0)
+
+                if not is_small:
+                    all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+
+        self._reduce_scatter_futures.clear()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        self.attn_gate = CastedLinear(12, num_heads)
+        self.attn_gate.weight.label = 'attn_gate'
+
+        # only include gates on layers with value embeds used on forward pass
+        if layer_idx in [0,1,8,9,10]:
+            self.value_embed_gate = CastedLinear(12, num_heads)
+            self.value_embed_gate.weight.label = 'value_embed_gate'
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(self.value_embed_gate(x[..., :self.value_embed_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(self.attn_gate(x[..., :self.attn_gate.weight.size(-1)])).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        #self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.5/448, grad_s=0.75/448)
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig, skew = None):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset = key_offset[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if skew is None:
+            logits = 23 * torch.sigmoid((logits+5) / 7.5)
+        else:
+            logits = 23 * torch.sigmoid((logits+skew) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+
+        adam_labels = ['lm_head', 'value_embed', 'smear_gate', 'skip_gate', 'x0_lambdas', 'embed']
+        scalar_labels = ['scalars']
+        muon_labels = ['attn_gate', 'value_embed_gate', 'attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        scalar_params = [p for p in model.parameters() if getattr(p, 'label', None) in scalar_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + scalar_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, lr=0.008, betas=(0.65, 0.95), eps=1e-8, weight_decay=0.005)
+        self.scalar_opt = DistAdam(scalar_params, scalar_labels, lr=0.008, betas=(0.9, 0.99), eps=1e-8, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.scalar_opt, self.muon_opt]
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.freeze_timer = 0
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+        self.scalar_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = [0]
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            if opt.freeze_timer > 0:
+                opt.freeze_timer -= 1
+                opt.zero_grad(set_to_none=True)
+            else:
+                if self._is_active_step(opt, step):
+                    for group in opt.param_groups:
+                        group["lr"] = group["initial_lr"] * step_lr
+                    opt.step()
+                    opt.zero_grad(set_to_none=True)
+                    if opt.odd_step_only:
+                        opt.should_sync = False
+        
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+
+    def start_transition(self, freeze_count=40):
+        # freeze scalar weights during transition
+        self.scalar_opt.freeze_timer = freeze_count
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1805  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+warmup_steps = sorted(set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0))
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+def log_parameter_norms(model):
+    norms = {}
+    for name, param in model.named_parameters():
+        if param.requires_grad:
+            norms[f"param_norm/{name}"] = param.norm().item()
+            norms[f"param_max/{name}"] = param.max().item()
+            norms[f"param_min/{name}"] = param.min().item()
+            if param.grad is not None:
+                norms[f"grad_norm/{name}"] = param.grad.norm().item()
+                norms[f"grad_max/{name}"] = param.grad.max().item()
+    
+    # Total norms
+    total_param_norm = sum(p.norm().item() ** 2 for p in model.parameters()) ** 0.5
+    total_grad_norm = sum(p.grad.norm().item() ** 2 for p in model.parameters() if p.grad is not None) ** 0.5
+    
+    norms["param_norm/total"] = total_param_norm
+    norms["grad_norm/total"] = total_grad_norm
+    
+    return norms
+
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+# import wandb
+# if master_process:
+#     wandb.init(
+#         project="nano4",
+#         name="baseline"
+#     )
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    # if master_process and step%2==1:
+    #     wandb.log({
+    #         "loss": loss.item(),
+    #         **log_parameter_norms(model)  # Add all norms
+    #     })
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+====================================================================================================
+Running Python 3.10.12 (main, Aug 15 2025, 14:32:43) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Dec 29 05:51:48 2025       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.90.07              Driver Version: 550.90.07      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   29C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   26C    P0            111W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            108W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   39C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   27C    P0            112W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   29C    P0            111W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   29C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 601, 602, 603, 1203, 1204, 1205, 1804, 1805, 1806] for warmup
+Resetting Model
+step:0/1845 val_loss:10.8284 train_time:0ms step_avg:0.03ms
+step:1/1845 train_time:72ms step_avg:72.24ms
+step:2/1845 train_time:96ms step_avg:48.13ms
+step:3/1845 train_time:118ms step_avg:39.20ms
+step:4/1845 train_time:152ms step_avg:37.88ms
+step:5/1845 train_time:186ms step_avg:37.17ms
+step:6/1845 train_time:289ms step_avg:48.18ms
+step:7/1845 train_time:307ms step_avg:43.88ms
+step:8/1845 train_time:336ms step_avg:42.04ms
+step:9/1845 train_time:371ms step_avg:41.18ms
+step:10/1845 train_time:405ms step_avg:40.46ms
+step:11/1845 train_time:439ms step_avg:39.94ms
+step:12/1845 train_time:473ms step_avg:39.44ms
+step:13/1845 train_time:508ms step_avg:39.07ms
+step:14/1845 train_time:542ms step_avg:38.72ms
+step:15/1845 train_time:576ms step_avg:38.42ms
+step:16/1845 train_time:610ms step_avg:38.15ms
+step:17/1845 train_time:645ms step_avg:37.93ms
+step:18/1845 train_time:679ms step_avg:37.72ms
+step:19/1845 train_time:714ms step_avg:37.56ms
+step:20/1845 train_time:748ms step_avg:37.38ms
+step:21/1845 train_time:782ms step_avg:37.25ms
+step:22/1845 train_time:816ms step_avg:37.10ms
+step:23/1845 train_time:851ms step_avg:36.99ms
+step:24/1845 train_time:885ms step_avg:36.87ms
+step:25/1845 train_time:919ms step_avg:36.78ms
+step:26/1845 train_time:954ms step_avg:36.68ms
+step:27/1845 train_time:988ms step_avg:36.59ms
+step:28/1845 train_time:1022ms step_avg:36.51ms
+step:29/1845 train_time:1057ms step_avg:36.45ms
+step:30/1845 train_time:1091ms step_avg:36.36ms
+step:31/1845 train_time:1126ms step_avg:36.31ms
+step:32/1845 train_time:1160ms step_avg:36.24ms
+step:33/1845 train_time:1194ms step_avg:36.19ms
+step:34/1845 train_time:1228ms step_avg:36.13ms
+step:35/1845 train_time:1263ms step_avg:36.10ms
+step:36/1845 train_time:1297ms step_avg:36.04ms
+step:37/1845 train_time:1332ms step_avg:36.00ms
+step:38/1845 train_time:1367ms step_avg:35.97ms
+step:39/1845 train_time:1401ms step_avg:35.93ms
+step:40/1845 train_time:1435ms step_avg:35.88ms
+step:41/1845 train_time:1470ms step_avg:35.85ms
+step:42/1845 train_time:1504ms step_avg:35.81ms
+step:43/1845 train_time:1539ms step_avg:35.79ms
+step:44/1845 train_time:1573ms step_avg:35.75ms
+step:45/1845 train_time:1607ms step_avg:35.72ms
+step:46/1845 train_time:1641ms step_avg:35.68ms
+step:47/1845 train_time:1676ms step_avg:35.67ms
+step:48/1845 train_time:1710ms step_avg:35.63ms
+step:49/1845 train_time:1745ms step_avg:35.61ms
+step:50/1845 train_time:1779ms step_avg:35.58ms
+step:51/1845 train_time:1814ms step_avg:35.57ms
+step:52/1845 train_time:1848ms step_avg:35.55ms
+step:53/1845 train_time:1883ms step_avg:35.53ms
+step:54/1845 train_time:1917ms step_avg:35.50ms
+step:55/1845 train_time:1952ms step_avg:35.48ms
+step:56/1845 train_time:1986ms step_avg:35.46ms
+step:57/1845 train_time:2020ms step_avg:35.45ms
+step:58/1845 train_time:2054ms step_avg:35.42ms
+step:59/1845 train_time:2089ms step_avg:35.41ms
+step:60/1845 train_time:2123ms step_avg:35.38ms
+step:61/1845 train_time:2158ms step_avg:35.38ms
+step:62/1845 train_time:2192ms step_avg:35.35ms
+step:63/1845 train_time:2227ms step_avg:35.34ms
+step:64/1845 train_time:2261ms step_avg:35.32ms
+step:65/1845 train_time:2295ms step_avg:35.31ms
+step:66/1845 train_time:2329ms step_avg:35.29ms
+step:67/1845 train_time:2364ms step_avg:35.29ms
+step:68/1845 train_time:2398ms step_avg:35.27ms
+step:69/1845 train_time:2433ms step_avg:35.26ms
+step:70/1845 train_time:2467ms step_avg:35.25ms
+step:71/1845 train_time:2502ms step_avg:35.24ms
+step:72/1845 train_time:2536ms step_avg:35.22ms
+step:73/1845 train_time:2571ms step_avg:35.21ms
+step:74/1845 train_time:2605ms step_avg:35.20ms
+step:75/1845 train_time:2639ms step_avg:35.19ms
+step:76/1845 train_time:2673ms step_avg:35.17ms
+step:77/1845 train_time:2708ms step_avg:35.17ms
+step:78/1845 train_time:2742ms step_avg:35.15ms
+step:79/1845 train_time:2776ms step_avg:35.14ms
+step:80/1845 train_time:2810ms step_avg:35.13ms
+step:81/1845 train_time:2845ms step_avg:35.12ms
+step:82/1845 train_time:2879ms step_avg:35.11ms
+step:83/1845 train_time:2914ms step_avg:35.10ms
+step:84/1845 train_time:2948ms step_avg:35.09ms
+step:85/1845 train_time:2982ms step_avg:35.09ms
+step:86/1845 train_time:3016ms step_avg:35.07ms
+step:87/1845 train_time:3051ms step_avg:35.07ms
+step:88/1845 train_time:3085ms step_avg:35.06ms
+step:89/1845 train_time:3120ms step_avg:35.06ms
+step:90/1845 train_time:3154ms step_avg:35.04ms
+step:91/1845 train_time:3189ms step_avg:35.04ms
+step:92/1845 train_time:3223ms step_avg:35.03ms
+step:93/1845 train_time:3257ms step_avg:35.02ms
+step:94/1845 train_time:3291ms step_avg:35.01ms
+step:95/1845 train_time:3326ms step_avg:35.01ms
+step:96/1845 train_time:3360ms step_avg:35.00ms
+step:97/1845 train_time:3395ms step_avg:35.00ms
+step:98/1845 train_time:3429ms step_avg:34.98ms
+step:99/1845 train_time:3463ms step_avg:34.98ms
+step:100/1845 train_time:3497ms step_avg:34.97ms
+step:101/1845 train_time:3532ms step_avg:34.97ms
+step:102/1845 train_time:3566ms step_avg:34.96ms
+step:103/1845 train_time:3600ms step_avg:34.96ms
+step:104/1845 train_time:3634ms step_avg:34.95ms
+step:105/1845 train_time:3669ms step_avg:34.94ms
+step:106/1845 train_time:3703ms step_avg:34.93ms
+step:107/1845 train_time:3737ms step_avg:34.93ms
+step:108/1845 train_time:3771ms step_avg:34.92ms
+step:109/1845 train_time:3806ms step_avg:34.92ms
+step:110/1845 train_time:3840ms step_avg:34.91ms
+step:111/1845 train_time:3874ms step_avg:34.90ms
+step:112/1845 train_time:3908ms step_avg:34.90ms
+step:113/1845 train_time:3943ms step_avg:34.89ms
+step:114/1845 train_time:3977ms step_avg:34.89ms
+step:115/1845 train_time:4012ms step_avg:34.88ms
+step:116/1845 train_time:4045ms step_avg:34.87ms
+step:117/1845 train_time:4080ms step_avg:34.87ms
+step:118/1845 train_time:4114ms step_avg:34.87ms
+step:119/1845 train_time:4149ms step_avg:34.86ms
+step:120/1845 train_time:4183ms step_avg:34.86ms
+step:121/1845 train_time:4218ms step_avg:34.86ms
+step:122/1845 train_time:4252ms step_avg:34.85ms
+step:123/1845 train_time:4286ms step_avg:34.85ms
+step:124/1845 train_time:4320ms step_avg:34.84ms
+step:125/1845 train_time:4355ms step_avg:34.84ms
+step:126/1845 train_time:4389ms step_avg:34.84ms
+step:127/1845 train_time:4424ms step_avg:34.83ms
+step:128/1845 train_time:4458ms step_avg:34.83ms
+step:129/1845 train_time:4492ms step_avg:34.82ms
+step:130/1845 train_time:4526ms step_avg:34.82ms
+step:131/1845 train_time:4561ms step_avg:34.82ms
+step:132/1845 train_time:4595ms step_avg:34.81ms
+step:133/1845 train_time:4629ms step_avg:34.81ms
+step:134/1845 train_time:4664ms step_avg:34.80ms
+step:135/1845 train_time:4698ms step_avg:34.80ms
+step:136/1845 train_time:4732ms step_avg:34.80ms
+step:137/1845 train_time:4767ms step_avg:34.80ms
+step:138/1845 train_time:4801ms step_avg:34.79ms
+step:139/1845 train_time:4836ms step_avg:34.79ms
+step:140/1845 train_time:4870ms step_avg:34.78ms
+step:141/1845 train_time:4904ms step_avg:34.78ms
+step:142/1845 train_time:4938ms step_avg:34.78ms
+step:143/1845 train_time:4973ms step_avg:34.77ms
+step:144/1845 train_time:5007ms step_avg:34.77ms
+step:145/1845 train_time:5041ms step_avg:34.77ms
+step:146/1845 train_time:5075ms step_avg:34.76ms
+step:147/1845 train_time:5110ms step_avg:34.76ms
+step:148/1845 train_time:5143ms step_avg:34.75ms
+step:149/1845 train_time:5178ms step_avg:34.75ms
+step:150/1845 train_time:5212ms step_avg:34.75ms
+step:151/1845 train_time:5247ms step_avg:34.75ms
+step:152/1845 train_time:5281ms step_avg:34.74ms
+step:153/1845 train_time:5316ms step_avg:34.74ms
+step:154/1845 train_time:5350ms step_avg:34.74ms
+step:155/1845 train_time:5384ms step_avg:34.74ms
+step:156/1845 train_time:5418ms step_avg:34.73ms
+step:157/1845 train_time:5453ms step_avg:34.73ms
+step:158/1845 train_time:5487ms step_avg:34.73ms
+step:159/1845 train_time:5522ms step_avg:34.73ms
+step:160/1845 train_time:5556ms step_avg:34.72ms
+step:161/1845 train_time:5590ms step_avg:34.72ms
+step:162/1845 train_time:5624ms step_avg:34.72ms
+step:163/1845 train_time:5659ms step_avg:34.72ms
+step:164/1845 train_time:5693ms step_avg:34.71ms
+step:165/1845 train_time:5727ms step_avg:34.71ms
+step:166/1845 train_time:5762ms step_avg:34.71ms
+step:167/1845 train_time:5796ms step_avg:34.71ms
+step:168/1845 train_time:5830ms step_avg:34.70ms
+step:169/1845 train_time:5865ms step_avg:34.70ms
+step:170/1845 train_time:5899ms step_avg:34.70ms
+step:171/1845 train_time:5933ms step_avg:34.70ms
+step:172/1845 train_time:5967ms step_avg:34.69ms
+step:173/1845 train_time:6002ms step_avg:34.69ms
+step:174/1845 train_time:6035ms step_avg:34.69ms
+step:175/1845 train_time:6070ms step_avg:34.68ms
+step:176/1845 train_time:6104ms step_avg:34.68ms
+step:177/1845 train_time:6138ms step_avg:34.68ms
+step:178/1845 train_time:6172ms step_avg:34.68ms
+step:179/1845 train_time:6207ms step_avg:34.68ms
+step:180/1845 train_time:6241ms step_avg:34.67ms
+step:181/1845 train_time:6276ms step_avg:34.67ms
+step:182/1845 train_time:6309ms step_avg:34.67ms
+step:183/1845 train_time:6344ms step_avg:34.67ms
+step:184/1845 train_time:6378ms step_avg:34.66ms
+step:185/1845 train_time:6413ms step_avg:34.66ms
+step:186/1845 train_time:6447ms step_avg:34.66ms
+step:187/1845 train_time:6481ms step_avg:34.66ms
+step:188/1845 train_time:6515ms step_avg:34.66ms
+step:189/1845 train_time:6550ms step_avg:34.66ms
+step:190/1845 train_time:6584ms step_avg:34.65ms
+step:191/1845 train_time:6619ms step_avg:34.66ms
+step:192/1845 train_time:6653ms step_avg:34.65ms
+step:193/1845 train_time:6688ms step_avg:34.65ms
+step:194/1845 train_time:6722ms step_avg:34.65ms
+step:195/1845 train_time:6756ms step_avg:34.65ms
+step:196/1845 train_time:6790ms step_avg:34.64ms
+step:197/1845 train_time:6825ms step_avg:34.65ms
+step:198/1845 train_time:6859ms step_avg:34.64ms
+step:199/1845 train_time:6893ms step_avg:34.64ms
+step:200/1845 train_time:6927ms step_avg:34.64ms
+step:201/1845 train_time:6962ms step_avg:34.64ms
+step:202/1845 train_time:6996ms step_avg:34.63ms
+step:203/1845 train_time:7030ms step_avg:34.63ms
+step:204/1845 train_time:7064ms step_avg:34.63ms
+step:205/1845 train_time:7099ms step_avg:34.63ms
+step:206/1845 train_time:7133ms step_avg:34.63ms
+step:207/1845 train_time:7167ms step_avg:34.62ms
+step:208/1845 train_time:7201ms step_avg:34.62ms
+step:209/1845 train_time:7236ms step_avg:34.62ms
+step:210/1845 train_time:7270ms step_avg:34.62ms
+step:211/1845 train_time:7304ms step_avg:34.62ms
+step:212/1845 train_time:7338ms step_avg:34.61ms
+step:213/1845 train_time:7373ms step_avg:34.61ms
+step:214/1845 train_time:7407ms step_avg:34.61ms
+step:215/1845 train_time:7441ms step_avg:34.61ms
+step:216/1845 train_time:7475ms step_avg:34.61ms
+step:217/1845 train_time:7510ms step_avg:34.61ms
+step:218/1845 train_time:7544ms step_avg:34.60ms
+step:219/1845 train_time:7579ms step_avg:34.61ms
+step:220/1845 train_time:7613ms step_avg:34.60ms
+step:221/1845 train_time:7647ms step_avg:34.60ms
+step:222/1845 train_time:7681ms step_avg:34.60ms
+step:223/1845 train_time:7716ms step_avg:34.60ms
+step:224/1845 train_time:7750ms step_avg:34.60ms
+step:225/1845 train_time:7785ms step_avg:34.60ms
+step:226/1845 train_time:7819ms step_avg:34.60ms
+step:227/1845 train_time:7853ms step_avg:34.59ms
+step:228/1845 train_time:7887ms step_avg:34.59ms
+step:229/1845 train_time:7922ms step_avg:34.59ms
+step:230/1845 train_time:7955ms step_avg:34.59ms
+step:231/1845 train_time:7990ms step_avg:34.59ms
+step:232/1845 train_time:8024ms step_avg:34.58ms
+step:233/1845 train_time:8058ms step_avg:34.59ms
+step:234/1845 train_time:8092ms step_avg:34.58ms
+step:235/1845 train_time:8127ms step_avg:34.58ms
+step:236/1845 train_time:8161ms step_avg:34.58ms
+step:237/1845 train_time:8195ms step_avg:34.58ms
+step:238/1845 train_time:8229ms step_avg:34.58ms
+step:239/1845 train_time:8264ms step_avg:34.58ms
+step:240/1845 train_time:8298ms step_avg:34.57ms
+step:241/1845 train_time:8332ms step_avg:34.57ms
+step:242/1845 train_time:8366ms step_avg:34.57ms
+step:243/1845 train_time:8400ms step_avg:34.57ms
+step:244/1845 train_time:8434ms step_avg:34.57ms
+step:245/1845 train_time:8469ms step_avg:34.57ms
+step:246/1845 train_time:8503ms step_avg:34.56ms
+step:247/1845 train_time:8537ms step_avg:34.56ms
+step:248/1845 train_time:8571ms step_avg:34.56ms
+step:249/1845 train_time:8606ms step_avg:34.56ms
+step:250/1845 train_time:8640ms step_avg:34.56ms
+step:250/1845 val_loss:4.6111 train_time:8676ms step_avg:34.70ms
+step:251/1845 train_time:8696ms step_avg:34.64ms
+step:252/1845 train_time:8716ms step_avg:34.59ms
+step:253/1845 train_time:8745ms step_avg:34.57ms
+step:254/1845 train_time:8780ms step_avg:34.56ms
+step:255/1845 train_time:8815ms step_avg:34.57ms
+step:256/1845 train_time:8849ms step_avg:34.57ms
+step:257/1845 train_time:8884ms step_avg:34.57ms
+step:258/1845 train_time:8918ms step_avg:34.57ms
+step:259/1845 train_time:8953ms step_avg:34.57ms
+step:260/1845 train_time:8987ms step_avg:34.56ms
+step:261/1845 train_time:9021ms step_avg:34.56ms
+step:262/1845 train_time:9055ms step_avg:34.56ms
+step:263/1845 train_time:9089ms step_avg:34.56ms
+step:264/1845 train_time:9123ms step_avg:34.56ms
+step:265/1845 train_time:9157ms step_avg:34.56ms
+step:266/1845 train_time:9191ms step_avg:34.55ms
+step:267/1845 train_time:9226ms step_avg:34.55ms
+step:268/1845 train_time:9260ms step_avg:34.55ms
+step:269/1845 train_time:9294ms step_avg:34.55ms
+step:270/1845 train_time:9328ms step_avg:34.55ms
+step:271/1845 train_time:9362ms step_avg:34.55ms
+step:272/1845 train_time:9396ms step_avg:34.54ms
+step:273/1845 train_time:9430ms step_avg:34.54ms
+step:274/1845 train_time:9464ms step_avg:34.54ms
+step:275/1845 train_time:9498ms step_avg:34.54ms
+step:276/1845 train_time:9532ms step_avg:34.54ms
+step:277/1845 train_time:9566ms step_avg:34.54ms
+step:278/1845 train_time:9600ms step_avg:34.53ms
+step:279/1845 train_time:9635ms step_avg:34.53ms
+step:280/1845 train_time:9669ms step_avg:34.53ms
+step:281/1845 train_time:9703ms step_avg:34.53ms
+step:282/1845 train_time:9738ms step_avg:34.53ms
+step:283/1845 train_time:9772ms step_avg:34.53ms
+step:284/1845 train_time:9806ms step_avg:34.53ms
+step:285/1845 train_time:9841ms step_avg:34.53ms
+step:286/1845 train_time:9875ms step_avg:34.53ms
+step:287/1845 train_time:9909ms step_avg:34.53ms
+step:288/1845 train_time:9944ms step_avg:34.53ms
+step:289/1845 train_time:9978ms step_avg:34.53ms
+step:290/1845 train_time:10012ms step_avg:34.52ms
+step:291/1845 train_time:10046ms step_avg:34.52ms
+step:292/1845 train_time:10080ms step_avg:34.52ms
+step:293/1845 train_time:10115ms step_avg:34.52ms
+step:294/1845 train_time:10149ms step_avg:34.52ms
+step:295/1845 train_time:10183ms step_avg:34.52ms
+step:296/1845 train_time:10218ms step_avg:34.52ms
+step:297/1845 train_time:10252ms step_avg:34.52ms
+step:298/1845 train_time:10285ms step_avg:34.52ms
+step:299/1845 train_time:10320ms step_avg:34.51ms
+step:300/1845 train_time:10354ms step_avg:34.51ms
+step:301/1845 train_time:10388ms step_avg:34.51ms
+step:302/1845 train_time:10422ms step_avg:34.51ms
+step:303/1845 train_time:10456ms step_avg:34.51ms
+step:304/1845 train_time:10490ms step_avg:34.51ms
+step:305/1845 train_time:10525ms step_avg:34.51ms
+step:306/1845 train_time:10559ms step_avg:34.51ms
+step:307/1845 train_time:10593ms step_avg:34.51ms
+step:308/1845 train_time:10627ms step_avg:34.50ms
+step:309/1845 train_time:10661ms step_avg:34.50ms
+step:310/1845 train_time:10695ms step_avg:34.50ms
+step:311/1845 train_time:10730ms step_avg:34.50ms
+step:312/1845 train_time:10764ms step_avg:34.50ms
+step:313/1845 train_time:10798ms step_avg:34.50ms
+step:314/1845 train_time:10832ms step_avg:34.50ms
+step:315/1845 train_time:10866ms step_avg:34.50ms
+step:316/1845 train_time:10900ms step_avg:34.49ms
+step:317/1845 train_time:10935ms step_avg:34.49ms
+step:318/1845 train_time:10968ms step_avg:34.49ms
+step:319/1845 train_time:11003ms step_avg:34.49ms
+step:320/1845 train_time:11037ms step_avg:34.49ms
+step:321/1845 train_time:11072ms step_avg:34.49ms
+step:322/1845 train_time:11106ms step_avg:34.49ms
+step:323/1845 train_time:11140ms step_avg:34.49ms
+step:324/1845 train_time:11174ms step_avg:34.49ms
+step:325/1845 train_time:11209ms step_avg:34.49ms
+step:326/1845 train_time:11243ms step_avg:34.49ms
+step:327/1845 train_time:11278ms step_avg:34.49ms
+step:328/1845 train_time:11311ms step_avg:34.49ms
+step:329/1845 train_time:11346ms step_avg:34.49ms
+step:330/1845 train_time:11380ms step_avg:34.48ms
+step:331/1845 train_time:11414ms step_avg:34.48ms
+step:332/1845 train_time:11448ms step_avg:34.48ms
+step:333/1845 train_time:11482ms step_avg:34.48ms
+step:334/1845 train_time:11516ms step_avg:34.48ms
+step:335/1845 train_time:11550ms step_avg:34.48ms
+step:336/1845 train_time:11584ms step_avg:34.48ms
+step:337/1845 train_time:11619ms step_avg:34.48ms
+step:338/1845 train_time:11653ms step_avg:34.48ms
+step:339/1845 train_time:11687ms step_avg:34.48ms
+step:340/1845 train_time:11721ms step_avg:34.47ms
+step:341/1845 train_time:11756ms step_avg:34.48ms
+step:342/1845 train_time:11790ms step_avg:34.47ms
+step:343/1845 train_time:11824ms step_avg:34.47ms
+step:344/1845 train_time:11859ms step_avg:34.47ms
+step:345/1845 train_time:11893ms step_avg:34.47ms
+step:346/1845 train_time:11927ms step_avg:34.47ms
+step:347/1845 train_time:11962ms step_avg:34.47ms
+step:348/1845 train_time:11996ms step_avg:34.47ms
+step:349/1845 train_time:12030ms step_avg:34.47ms
+step:350/1845 train_time:12063ms step_avg:34.47ms
+step:351/1845 train_time:12098ms step_avg:34.47ms
+step:352/1845 train_time:12132ms step_avg:34.47ms
+step:353/1845 train_time:12166ms step_avg:34.47ms
+step:354/1845 train_time:12200ms step_avg:34.46ms
+step:355/1845 train_time:12234ms step_avg:34.46ms
+step:356/1845 train_time:12268ms step_avg:34.46ms
+step:357/1845 train_time:12303ms step_avg:34.46ms
+step:358/1845 train_time:12337ms step_avg:34.46ms
+step:359/1845 train_time:12371ms step_avg:34.46ms
+step:360/1845 train_time:12405ms step_avg:34.46ms
+step:361/1845 train_time:12440ms step_avg:34.46ms
+step:362/1845 train_time:12474ms step_avg:34.46ms
+step:363/1845 train_time:12508ms step_avg:34.46ms
+step:364/1845 train_time:12542ms step_avg:34.46ms
+step:365/1845 train_time:12576ms step_avg:34.45ms
+step:366/1845 train_time:12610ms step_avg:34.45ms
+step:367/1845 train_time:12644ms step_avg:34.45ms
+step:368/1845 train_time:12678ms step_avg:34.45ms
+step:369/1845 train_time:12712ms step_avg:34.45ms
+step:370/1845 train_time:12746ms step_avg:34.45ms
+step:371/1845 train_time:12780ms step_avg:34.45ms
+step:372/1845 train_time:12814ms step_avg:34.45ms
+step:373/1845 train_time:12849ms step_avg:34.45ms
+step:374/1845 train_time:12883ms step_avg:34.45ms
+step:375/1845 train_time:12917ms step_avg:34.45ms
+step:376/1845 train_time:12951ms step_avg:34.44ms
+step:377/1845 train_time:12985ms step_avg:34.44ms
+step:378/1845 train_time:13019ms step_avg:34.44ms
+step:379/1845 train_time:13054ms step_avg:34.44ms
+step:380/1845 train_time:13088ms step_avg:34.44ms
+step:381/1845 train_time:13122ms step_avg:34.44ms
+step:382/1845 train_time:13156ms step_avg:34.44ms
+step:383/1845 train_time:13190ms step_avg:34.44ms
+step:384/1845 train_time:13224ms step_avg:34.44ms
+step:385/1845 train_time:13259ms step_avg:34.44ms
+step:386/1845 train_time:13293ms step_avg:34.44ms
+step:387/1845 train_time:13327ms step_avg:34.44ms
+step:388/1845 train_time:13361ms step_avg:34.44ms
+step:389/1845 train_time:13395ms step_avg:34.44ms
+step:390/1845 train_time:13429ms step_avg:34.43ms
+step:391/1845 train_time:13464ms step_avg:34.43ms
+step:392/1845 train_time:13498ms step_avg:34.43ms
+step:393/1845 train_time:13532ms step_avg:34.43ms
+step:394/1845 train_time:13566ms step_avg:34.43ms
+step:395/1845 train_time:13600ms step_avg:34.43ms
+step:396/1845 train_time:13634ms step_avg:34.43ms
+step:397/1845 train_time:13668ms step_avg:34.43ms
+step:398/1845 train_time:13702ms step_avg:34.43ms
+step:399/1845 train_time:13736ms step_avg:34.43ms
+step:400/1845 train_time:13770ms step_avg:34.43ms
+step:401/1845 train_time:13804ms step_avg:34.43ms
+step:402/1845 train_time:13838ms step_avg:34.42ms
+step:403/1845 train_time:13873ms step_avg:34.42ms
+step:404/1845 train_time:13907ms step_avg:34.42ms
+step:405/1845 train_time:13942ms step_avg:34.42ms
+step:406/1845 train_time:13976ms step_avg:34.42ms
+step:407/1845 train_time:14010ms step_avg:34.42ms
+step:408/1845 train_time:14044ms step_avg:34.42ms
+step:409/1845 train_time:14078ms step_avg:34.42ms
+step:410/1845 train_time:14112ms step_avg:34.42ms
+step:411/1845 train_time:14146ms step_avg:34.42ms
+step:412/1845 train_time:14180ms step_avg:34.42ms
+step:413/1845 train_time:14215ms step_avg:34.42ms
+step:414/1845 train_time:14248ms step_avg:34.42ms
+step:415/1845 train_time:14283ms step_avg:34.42ms
+step:416/1845 train_time:14317ms step_avg:34.42ms
+step:417/1845 train_time:14351ms step_avg:34.41ms
+step:418/1845 train_time:14385ms step_avg:34.41ms
+step:419/1845 train_time:14419ms step_avg:34.41ms
+step:420/1845 train_time:14453ms step_avg:34.41ms
+step:421/1845 train_time:14488ms step_avg:34.41ms
+step:422/1845 train_time:14521ms step_avg:34.41ms
+step:423/1845 train_time:14556ms step_avg:34.41ms
+step:424/1845 train_time:14590ms step_avg:34.41ms
+step:425/1845 train_time:14624ms step_avg:34.41ms
+step:426/1845 train_time:14658ms step_avg:34.41ms
+step:427/1845 train_time:14693ms step_avg:34.41ms
+step:428/1845 train_time:14727ms step_avg:34.41ms
+step:429/1845 train_time:14761ms step_avg:34.41ms
+step:430/1845 train_time:14795ms step_avg:34.41ms
+step:431/1845 train_time:14829ms step_avg:34.41ms
+step:432/1845 train_time:14863ms step_avg:34.41ms
+step:433/1845 train_time:14897ms step_avg:34.41ms
+step:434/1845 train_time:14931ms step_avg:34.40ms
+step:435/1845 train_time:14965ms step_avg:34.40ms
+step:436/1845 train_time:14999ms step_avg:34.40ms
+step:437/1845 train_time:15034ms step_avg:34.40ms
+step:438/1845 train_time:15068ms step_avg:34.40ms
+step:439/1845 train_time:15102ms step_avg:34.40ms
+step:440/1845 train_time:15136ms step_avg:34.40ms
+step:441/1845 train_time:15170ms step_avg:34.40ms
+step:442/1845 train_time:15204ms step_avg:34.40ms
+step:443/1845 train_time:15238ms step_avg:34.40ms
+step:444/1845 train_time:15272ms step_avg:34.40ms
+step:445/1845 train_time:15307ms step_avg:34.40ms
+step:446/1845 train_time:15341ms step_avg:34.40ms
+step:447/1845 train_time:15375ms step_avg:34.40ms
+step:448/1845 train_time:15409ms step_avg:34.40ms
+step:449/1845 train_time:15444ms step_avg:34.40ms
+step:450/1845 train_time:15478ms step_avg:34.40ms
+step:451/1845 train_time:15512ms step_avg:34.39ms
+step:452/1845 train_time:15546ms step_avg:34.39ms
+step:453/1845 train_time:15581ms step_avg:34.39ms
+step:454/1845 train_time:15614ms step_avg:34.39ms
+step:455/1845 train_time:15649ms step_avg:34.39ms
+step:456/1845 train_time:15683ms step_avg:34.39ms
+step:457/1845 train_time:15717ms step_avg:34.39ms
+step:458/1845 train_time:15752ms step_avg:34.39ms
+step:459/1845 train_time:15786ms step_avg:34.39ms
+step:460/1845 train_time:15820ms step_avg:34.39ms
+step:461/1845 train_time:15854ms step_avg:34.39ms
+step:462/1845 train_time:15888ms step_avg:34.39ms
+step:463/1845 train_time:15922ms step_avg:34.39ms
+step:464/1845 train_time:15956ms step_avg:34.39ms
+step:465/1845 train_time:15990ms step_avg:34.39ms
+step:466/1845 train_time:16024ms step_avg:34.39ms
+step:467/1845 train_time:16058ms step_avg:34.39ms
+step:468/1845 train_time:16092ms step_avg:34.39ms
+step:469/1845 train_time:16127ms step_avg:34.39ms
+step:470/1845 train_time:16161ms step_avg:34.38ms
+step:471/1845 train_time:16195ms step_avg:34.38ms
+step:472/1845 train_time:16229ms step_avg:34.38ms
+step:473/1845 train_time:16263ms step_avg:34.38ms
+step:474/1845 train_time:16298ms step_avg:34.38ms
+step:475/1845 train_time:16332ms step_avg:34.38ms
+step:476/1845 train_time:16366ms step_avg:34.38ms
+step:477/1845 train_time:16400ms step_avg:34.38ms
+step:478/1845 train_time:16434ms step_avg:34.38ms
+step:479/1845 train_time:16469ms step_avg:34.38ms
+step:480/1845 train_time:16503ms step_avg:34.38ms
+step:481/1845 train_time:16537ms step_avg:34.38ms
+step:482/1845 train_time:16571ms step_avg:34.38ms
+step:483/1845 train_time:16606ms step_avg:34.38ms
+step:484/1845 train_time:16640ms step_avg:34.38ms
+step:485/1845 train_time:16674ms step_avg:34.38ms
+step:486/1845 train_time:16708ms step_avg:34.38ms
+step:487/1845 train_time:16743ms step_avg:34.38ms
+step:488/1845 train_time:16777ms step_avg:34.38ms
+step:489/1845 train_time:16811ms step_avg:34.38ms
+step:490/1845 train_time:16845ms step_avg:34.38ms
+step:491/1845 train_time:16879ms step_avg:34.38ms
+step:492/1845 train_time:16913ms step_avg:34.38ms
+step:493/1845 train_time:16947ms step_avg:34.38ms
+step:494/1845 train_time:16981ms step_avg:34.38ms
+step:495/1845 train_time:17016ms step_avg:34.38ms
+step:496/1845 train_time:17050ms step_avg:34.37ms
+step:497/1845 train_time:17084ms step_avg:34.37ms
+step:498/1845 train_time:17118ms step_avg:34.37ms
+step:499/1845 train_time:17152ms step_avg:34.37ms
+step:500/1845 train_time:17186ms step_avg:34.37ms
+step:500/1845 val_loss:4.2847 train_time:17223ms step_avg:34.45ms
+step:501/1845 train_time:17242ms step_avg:34.42ms
+step:502/1845 train_time:17263ms step_avg:34.39ms
+step:503/1845 train_time:17291ms step_avg:34.38ms
+step:504/1845 train_time:17326ms step_avg:34.38ms
+step:505/1845 train_time:17362ms step_avg:34.38ms
+step:506/1845 train_time:17396ms step_avg:34.38ms
+step:507/1845 train_time:17431ms step_avg:34.38ms
+step:508/1845 train_time:17465ms step_avg:34.38ms
+step:509/1845 train_time:17499ms step_avg:34.38ms
+step:510/1845 train_time:17533ms step_avg:34.38ms
+step:511/1845 train_time:17567ms step_avg:34.38ms
+step:512/1845 train_time:17601ms step_avg:34.38ms
+step:513/1845 train_time:17635ms step_avg:34.38ms
+step:514/1845 train_time:17669ms step_avg:34.38ms
+step:515/1845 train_time:17704ms step_avg:34.38ms
+step:516/1845 train_time:17738ms step_avg:34.38ms
+step:517/1845 train_time:17772ms step_avg:34.37ms
+step:518/1845 train_time:17806ms step_avg:34.37ms
+step:519/1845 train_time:17840ms step_avg:34.37ms
+step:520/1845 train_time:17874ms step_avg:34.37ms
+step:521/1845 train_time:17908ms step_avg:34.37ms
+step:522/1845 train_time:17942ms step_avg:34.37ms
+step:523/1845 train_time:17976ms step_avg:34.37ms
+step:524/1845 train_time:18010ms step_avg:34.37ms
+step:525/1845 train_time:18045ms step_avg:34.37ms
+step:526/1845 train_time:18079ms step_avg:34.37ms
+step:527/1845 train_time:18113ms step_avg:34.37ms
+step:528/1845 train_time:18147ms step_avg:34.37ms
+step:529/1845 train_time:18181ms step_avg:34.37ms
+step:530/1845 train_time:18215ms step_avg:34.37ms
+step:531/1845 train_time:18250ms step_avg:34.37ms
+step:532/1845 train_time:18284ms step_avg:34.37ms
+step:533/1845 train_time:18318ms step_avg:34.37ms
+step:534/1845 train_time:18352ms step_avg:34.37ms
+step:535/1845 train_time:18387ms step_avg:34.37ms
+step:536/1845 train_time:18421ms step_avg:34.37ms
+step:537/1845 train_time:18455ms step_avg:34.37ms
+step:538/1845 train_time:18489ms step_avg:34.37ms
+step:539/1845 train_time:18524ms step_avg:34.37ms
+step:540/1845 train_time:18557ms step_avg:34.37ms
+step:541/1845 train_time:18592ms step_avg:34.37ms
+step:542/1845 train_time:18625ms step_avg:34.36ms
+step:543/1845 train_time:18660ms step_avg:34.36ms
+step:544/1845 train_time:18694ms step_avg:34.36ms
+step:545/1845 train_time:18728ms step_avg:34.36ms
+step:546/1845 train_time:18762ms step_avg:34.36ms
+step:547/1845 train_time:18796ms step_avg:34.36ms
+step:548/1845 train_time:18830ms step_avg:34.36ms
+step:549/1845 train_time:18865ms step_avg:34.36ms
+step:550/1845 train_time:18899ms step_avg:34.36ms
+step:551/1845 train_time:18933ms step_avg:34.36ms
+step:552/1845 train_time:18967ms step_avg:34.36ms
+step:553/1845 train_time:19001ms step_avg:34.36ms
+step:554/1845 train_time:19035ms step_avg:34.36ms
+step:555/1845 train_time:19070ms step_avg:34.36ms
+step:556/1845 train_time:19104ms step_avg:34.36ms
+step:557/1845 train_time:19138ms step_avg:34.36ms
+step:558/1845 train_time:19172ms step_avg:34.36ms
+step:559/1845 train_time:19206ms step_avg:34.36ms
+step:560/1845 train_time:19240ms step_avg:34.36ms
+step:561/1845 train_time:19275ms step_avg:34.36ms
+step:562/1845 train_time:19309ms step_avg:34.36ms
+step:563/1845 train_time:19344ms step_avg:34.36ms
+step:564/1845 train_time:19378ms step_avg:34.36ms
+step:565/1845 train_time:19412ms step_avg:34.36ms
+step:566/1845 train_time:19446ms step_avg:34.36ms
+step:567/1845 train_time:19481ms step_avg:34.36ms
+step:568/1845 train_time:19515ms step_avg:34.36ms
+step:569/1845 train_time:19549ms step_avg:34.36ms
+step:570/1845 train_time:19583ms step_avg:34.36ms
+step:571/1845 train_time:19617ms step_avg:34.36ms
+step:572/1845 train_time:19651ms step_avg:34.36ms
+step:573/1845 train_time:19686ms step_avg:34.36ms
+step:574/1845 train_time:19720ms step_avg:34.35ms
+step:575/1845 train_time:19754ms step_avg:34.35ms
+step:576/1845 train_time:19788ms step_avg:34.35ms
+step:577/1845 train_time:19823ms step_avg:34.35ms
+step:578/1845 train_time:19856ms step_avg:34.35ms
+step:579/1845 train_time:19891ms step_avg:34.35ms
+step:580/1845 train_time:19925ms step_avg:34.35ms
+step:581/1845 train_time:19959ms step_avg:34.35ms
+step:582/1845 train_time:19993ms step_avg:34.35ms
+step:583/1845 train_time:20027ms step_avg:34.35ms
+step:584/1845 train_time:20061ms step_avg:34.35ms
+step:585/1845 train_time:20095ms step_avg:34.35ms
+step:586/1845 train_time:20129ms step_avg:34.35ms
+step:587/1845 train_time:20164ms step_avg:34.35ms
+step:588/1845 train_time:20198ms step_avg:34.35ms
+step:589/1845 train_time:20232ms step_avg:34.35ms
+step:590/1845 train_time:20266ms step_avg:34.35ms
+step:591/1845 train_time:20300ms step_avg:34.35ms
+step:592/1845 train_time:20334ms step_avg:34.35ms
+step:593/1845 train_time:20369ms step_avg:34.35ms
+step:594/1845 train_time:20403ms step_avg:34.35ms
+step:595/1845 train_time:20437ms step_avg:34.35ms
+step:596/1845 train_time:20471ms step_avg:34.35ms
+step:597/1845 train_time:20506ms step_avg:34.35ms
+step:598/1845 train_time:20540ms step_avg:34.35ms
+step:599/1845 train_time:20574ms step_avg:34.35ms
+step:600/1845 train_time:20608ms step_avg:34.35ms
+step:601/1845 train_time:20642ms step_avg:34.35ms
+step:602/1845 train_time:20676ms step_avg:34.35ms
+step:603/1845 train_time:20712ms step_avg:34.35ms
+step:604/1845 train_time:20772ms step_avg:34.39ms
+step:605/1845 train_time:20834ms step_avg:34.44ms
+step:606/1845 train_time:20895ms step_avg:34.48ms
+step:607/1845 train_time:20957ms step_avg:34.53ms
+step:608/1845 train_time:21017ms step_avg:34.57ms
+step:609/1845 train_time:21080ms step_avg:34.61ms
+step:610/1845 train_time:21140ms step_avg:34.66ms
+step:611/1845 train_time:21203ms step_avg:34.70ms
+step:612/1845 train_time:21264ms step_avg:34.74ms
+step:613/1845 train_time:21327ms step_avg:34.79ms
+step:614/1845 train_time:21387ms step_avg:34.83ms
+step:615/1845 train_time:21450ms step_avg:34.88ms
+step:616/1845 train_time:21511ms step_avg:34.92ms
+step:617/1845 train_time:21573ms step_avg:34.96ms
+step:618/1845 train_time:21634ms step_avg:35.01ms
+step:619/1845 train_time:21696ms step_avg:35.05ms
+step:620/1845 train_time:21757ms step_avg:35.09ms
+step:621/1845 train_time:21819ms step_avg:35.14ms
+step:622/1845 train_time:21880ms step_avg:35.18ms
+step:623/1845 train_time:21944ms step_avg:35.22ms
+step:624/1845 train_time:22004ms step_avg:35.26ms
+step:625/1845 train_time:22066ms step_avg:35.31ms
+step:626/1845 train_time:22127ms step_avg:35.35ms
+step:627/1845 train_time:22190ms step_avg:35.39ms
+step:628/1845 train_time:22251ms step_avg:35.43ms
+step:629/1845 train_time:22314ms step_avg:35.48ms
+step:630/1845 train_time:22375ms step_avg:35.52ms
+step:631/1845 train_time:22438ms step_avg:35.56ms
+step:632/1845 train_time:22498ms step_avg:35.60ms
+step:633/1845 train_time:22561ms step_avg:35.64ms
+step:634/1845 train_time:22622ms step_avg:35.68ms
+step:635/1845 train_time:22685ms step_avg:35.72ms
+step:636/1845 train_time:22746ms step_avg:35.76ms
+step:637/1845 train_time:22808ms step_avg:35.81ms
+step:638/1845 train_time:22870ms step_avg:35.85ms
+step:639/1845 train_time:22933ms step_avg:35.89ms
+step:640/1845 train_time:22994ms step_avg:35.93ms
+step:641/1845 train_time:23056ms step_avg:35.97ms
+step:642/1845 train_time:23117ms step_avg:36.01ms
+step:643/1845 train_time:23179ms step_avg:36.05ms
+step:644/1845 train_time:23240ms step_avg:36.09ms
+step:645/1845 train_time:23302ms step_avg:36.13ms
+step:646/1845 train_time:23363ms step_avg:36.17ms
+step:647/1845 train_time:23425ms step_avg:36.21ms
+step:648/1845 train_time:23487ms step_avg:36.25ms
+step:649/1845 train_time:23549ms step_avg:36.29ms
+step:650/1845 train_time:23610ms step_avg:36.32ms
+step:651/1845 train_time:23673ms step_avg:36.36ms
+step:652/1845 train_time:23734ms step_avg:36.40ms
+step:653/1845 train_time:23797ms step_avg:36.44ms
+step:654/1845 train_time:23857ms step_avg:36.48ms
+step:655/1845 train_time:23920ms step_avg:36.52ms
+step:656/1845 train_time:23980ms step_avg:36.55ms
+step:657/1845 train_time:24042ms step_avg:36.59ms
+step:658/1845 train_time:24103ms step_avg:36.63ms
+step:659/1845 train_time:24166ms step_avg:36.67ms
+step:660/1845 train_time:24226ms step_avg:36.71ms
+step:661/1845 train_time:24290ms step_avg:36.75ms
+step:662/1845 train_time:24351ms step_avg:36.78ms
+step:663/1845 train_time:24414ms step_avg:36.82ms
+step:664/1845 train_time:24475ms step_avg:36.86ms
+step:665/1845 train_time:24537ms step_avg:36.90ms
+step:666/1845 train_time:24598ms step_avg:36.93ms
+step:667/1845 train_time:24661ms step_avg:36.97ms
+step:668/1845 train_time:24721ms step_avg:37.01ms
+step:669/1845 train_time:24784ms step_avg:37.05ms
+step:670/1845 train_time:24846ms step_avg:37.08ms
+step:671/1845 train_time:24908ms step_avg:37.12ms
+step:672/1845 train_time:24969ms step_avg:37.16ms
+step:673/1845 train_time:25031ms step_avg:37.19ms
+step:674/1845 train_time:25092ms step_avg:37.23ms
+step:675/1845 train_time:25155ms step_avg:37.27ms
+step:676/1845 train_time:25215ms step_avg:37.30ms
+step:677/1845 train_time:25278ms step_avg:37.34ms
+step:678/1845 train_time:25338ms step_avg:37.37ms
+step:679/1845 train_time:25400ms step_avg:37.41ms
+step:680/1845 train_time:25461ms step_avg:37.44ms
+step:681/1845 train_time:25523ms step_avg:37.48ms
+step:682/1845 train_time:25584ms step_avg:37.51ms
+step:683/1845 train_time:25647ms step_avg:37.55ms
+step:684/1845 train_time:25708ms step_avg:37.58ms
+step:685/1845 train_time:25770ms step_avg:37.62ms
+step:686/1845 train_time:25831ms step_avg:37.66ms
+step:687/1845 train_time:25894ms step_avg:37.69ms
+step:688/1845 train_time:25955ms step_avg:37.72ms
+step:689/1845 train_time:26017ms step_avg:37.76ms
+step:690/1845 train_time:26077ms step_avg:37.79ms
+step:691/1845 train_time:26139ms step_avg:37.83ms
+step:692/1845 train_time:26200ms step_avg:37.86ms
+step:693/1845 train_time:26262ms step_avg:37.90ms
+step:694/1845 train_time:26323ms step_avg:37.93ms
+step:695/1845 train_time:26385ms step_avg:37.96ms
+step:696/1845 train_time:26446ms step_avg:38.00ms
+step:697/1845 train_time:26509ms step_avg:38.03ms
+step:698/1845 train_time:26570ms step_avg:38.07ms
+step:699/1845 train_time:26633ms step_avg:38.10ms
+step:700/1845 train_time:26693ms step_avg:38.13ms
+step:701/1845 train_time:26756ms step_avg:38.17ms
+step:702/1845 train_time:26817ms step_avg:38.20ms
+step:703/1845 train_time:26879ms step_avg:38.23ms
+step:704/1845 train_time:26940ms step_avg:38.27ms
+step:705/1845 train_time:27002ms step_avg:38.30ms
+step:706/1845 train_time:27063ms step_avg:38.33ms
+step:707/1845 train_time:27125ms step_avg:38.37ms
+step:708/1845 train_time:27186ms step_avg:38.40ms
+step:709/1845 train_time:27249ms step_avg:38.43ms
+step:710/1845 train_time:27310ms step_avg:38.46ms
+step:711/1845 train_time:27373ms step_avg:38.50ms
+step:712/1845 train_time:27434ms step_avg:38.53ms
+step:713/1845 train_time:27496ms step_avg:38.56ms
+step:714/1845 train_time:27556ms step_avg:38.59ms
+step:715/1845 train_time:27619ms step_avg:38.63ms
+step:716/1845 train_time:27679ms step_avg:38.66ms
+step:717/1845 train_time:27741ms step_avg:38.69ms
+step:718/1845 train_time:27802ms step_avg:38.72ms
+step:719/1845 train_time:27864ms step_avg:38.75ms
+step:720/1845 train_time:27925ms step_avg:38.78ms
+step:721/1845 train_time:27988ms step_avg:38.82ms
+step:722/1845 train_time:28050ms step_avg:38.85ms
+step:723/1845 train_time:28113ms step_avg:38.88ms
+step:724/1845 train_time:28174ms step_avg:38.91ms
+step:725/1845 train_time:28236ms step_avg:38.95ms
+step:726/1845 train_time:28297ms step_avg:38.98ms
+step:727/1845 train_time:28360ms step_avg:39.01ms
+step:728/1845 train_time:28421ms step_avg:39.04ms
+step:729/1845 train_time:28483ms step_avg:39.07ms
+step:730/1845 train_time:28544ms step_avg:39.10ms
+step:731/1845 train_time:28607ms step_avg:39.13ms
+step:732/1845 train_time:28668ms step_avg:39.16ms
+step:733/1845 train_time:28730ms step_avg:39.20ms
+step:734/1845 train_time:28791ms step_avg:39.23ms
+step:735/1845 train_time:28854ms step_avg:39.26ms
+step:736/1845 train_time:28915ms step_avg:39.29ms
+step:737/1845 train_time:28977ms step_avg:39.32ms
+step:738/1845 train_time:29038ms step_avg:39.35ms
+step:739/1845 train_time:29100ms step_avg:39.38ms
+step:740/1845 train_time:29161ms step_avg:39.41ms
+step:741/1845 train_time:29223ms step_avg:39.44ms
+step:742/1845 train_time:29284ms step_avg:39.47ms
+step:743/1845 train_time:29347ms step_avg:39.50ms
+step:744/1845 train_time:29408ms step_avg:39.53ms
+step:745/1845 train_time:29470ms step_avg:39.56ms
+step:746/1845 train_time:29531ms step_avg:39.59ms
+step:747/1845 train_time:29594ms step_avg:39.62ms
+step:748/1845 train_time:29654ms step_avg:39.64ms
+step:749/1845 train_time:29717ms step_avg:39.68ms
+step:750/1845 train_time:29777ms step_avg:39.70ms
+step:750/1845 val_loss:4.0301 train_time:29840ms step_avg:39.79ms
+step:751/1845 train_time:29860ms step_avg:39.76ms
+step:752/1845 train_time:29902ms step_avg:39.76ms
+step:753/1845 train_time:29968ms step_avg:39.80ms
+step:754/1845 train_time:30029ms step_avg:39.83ms
+step:755/1845 train_time:30092ms step_avg:39.86ms
+step:756/1845 train_time:30153ms step_avg:39.88ms
+step:757/1845 train_time:30214ms step_avg:39.91ms
+step:758/1845 train_time:30275ms step_avg:39.94ms
+step:759/1845 train_time:30337ms step_avg:39.97ms
+step:760/1845 train_time:30397ms step_avg:40.00ms
+step:761/1845 train_time:30459ms step_avg:40.03ms
+step:762/1845 train_time:30520ms step_avg:40.05ms
+step:763/1845 train_time:30582ms step_avg:40.08ms
+step:764/1845 train_time:30642ms step_avg:40.11ms
+step:765/1845 train_time:30704ms step_avg:40.14ms
+step:766/1845 train_time:30766ms step_avg:40.16ms
+step:767/1845 train_time:30829ms step_avg:40.19ms
+step:768/1845 train_time:30891ms step_avg:40.22ms
+step:769/1845 train_time:30955ms step_avg:40.25ms
+step:770/1845 train_time:31017ms step_avg:40.28ms
+step:771/1845 train_time:31080ms step_avg:40.31ms
+step:772/1845 train_time:31141ms step_avg:40.34ms
+step:773/1845 train_time:31203ms step_avg:40.37ms
+step:774/1845 train_time:31263ms step_avg:40.39ms
+step:775/1845 train_time:31325ms step_avg:40.42ms
+step:776/1845 train_time:31386ms step_avg:40.45ms
+step:777/1845 train_time:31447ms step_avg:40.47ms
+step:778/1845 train_time:31508ms step_avg:40.50ms
+step:779/1845 train_time:31570ms step_avg:40.53ms
+step:780/1845 train_time:31631ms step_avg:40.55ms
+step:781/1845 train_time:31694ms step_avg:40.58ms
+step:782/1845 train_time:31755ms step_avg:40.61ms
+step:783/1845 train_time:31818ms step_avg:40.64ms
+step:784/1845 train_time:31879ms step_avg:40.66ms
+step:785/1845 train_time:31942ms step_avg:40.69ms
+step:786/1845 train_time:32003ms step_avg:40.72ms
+step:787/1845 train_time:32066ms step_avg:40.74ms
+step:788/1845 train_time:32126ms step_avg:40.77ms
+step:789/1845 train_time:32188ms step_avg:40.80ms
+step:790/1845 train_time:32249ms step_avg:40.82ms
+step:791/1845 train_time:32312ms step_avg:40.85ms
+step:792/1845 train_time:32373ms step_avg:40.87ms
+step:793/1845 train_time:32435ms step_avg:40.90ms
+step:794/1845 train_time:32495ms step_avg:40.93ms
+step:795/1845 train_time:32558ms step_avg:40.95ms
+step:796/1845 train_time:32618ms step_avg:40.98ms
+step:797/1845 train_time:32681ms step_avg:41.00ms
+step:798/1845 train_time:32741ms step_avg:41.03ms
+step:799/1845 train_time:32804ms step_avg:41.06ms
+step:800/1845 train_time:32865ms step_avg:41.08ms
+step:801/1845 train_time:32928ms step_avg:41.11ms
+step:802/1845 train_time:32989ms step_avg:41.13ms
+step:803/1845 train_time:33052ms step_avg:41.16ms
+step:804/1845 train_time:33113ms step_avg:41.18ms
+step:805/1845 train_time:33176ms step_avg:41.21ms
+step:806/1845 train_time:33237ms step_avg:41.24ms
+step:807/1845 train_time:33300ms step_avg:41.26ms
+step:808/1845 train_time:33361ms step_avg:41.29ms
+step:809/1845 train_time:33423ms step_avg:41.31ms
+step:810/1845 train_time:33483ms step_avg:41.34ms
+step:811/1845 train_time:33545ms step_avg:41.36ms
+step:812/1845 train_time:33605ms step_avg:41.39ms
+step:813/1845 train_time:33668ms step_avg:41.41ms
+step:814/1845 train_time:33729ms step_avg:41.44ms
+step:815/1845 train_time:33791ms step_avg:41.46ms
+step:816/1845 train_time:33853ms step_avg:41.49ms
+step:817/1845 train_time:33915ms step_avg:41.51ms
+step:818/1845 train_time:33976ms step_avg:41.54ms
+step:819/1845 train_time:34039ms step_avg:41.56ms
+step:820/1845 train_time:34100ms step_avg:41.59ms
+step:821/1845 train_time:34163ms step_avg:41.61ms
+step:822/1845 train_time:34224ms step_avg:41.63ms
+step:823/1845 train_time:34287ms step_avg:41.66ms
+step:824/1845 train_time:34347ms step_avg:41.68ms
+step:825/1845 train_time:34410ms step_avg:41.71ms
+step:826/1845 train_time:34470ms step_avg:41.73ms
+step:827/1845 train_time:34533ms step_avg:41.76ms
+step:828/1845 train_time:34594ms step_avg:41.78ms
+step:829/1845 train_time:34657ms step_avg:41.81ms
+step:830/1845 train_time:34718ms step_avg:41.83ms
+step:831/1845 train_time:34781ms step_avg:41.85ms
+step:832/1845 train_time:34841ms step_avg:41.88ms
+step:833/1845 train_time:34904ms step_avg:41.90ms
+step:834/1845 train_time:34964ms step_avg:41.92ms
+step:835/1845 train_time:35026ms step_avg:41.95ms
+step:836/1845 train_time:35087ms step_avg:41.97ms
+step:837/1845 train_time:35150ms step_avg:41.99ms
+step:838/1845 train_time:35211ms step_avg:42.02ms
+step:839/1845 train_time:35273ms step_avg:42.04ms
+step:840/1845 train_time:35334ms step_avg:42.06ms
+step:841/1845 train_time:35396ms step_avg:42.09ms
+step:842/1845 train_time:35458ms step_avg:42.11ms
+step:843/1845 train_time:35520ms step_avg:42.14ms
+step:844/1845 train_time:35581ms step_avg:42.16ms
+step:845/1845 train_time:35643ms step_avg:42.18ms
+step:846/1845 train_time:35704ms step_avg:42.20ms
+step:847/1845 train_time:35766ms step_avg:42.23ms
+step:848/1845 train_time:35827ms step_avg:42.25ms
+step:849/1845 train_time:35890ms step_avg:42.27ms
+step:850/1845 train_time:35950ms step_avg:42.29ms
+step:851/1845 train_time:36012ms step_avg:42.32ms
+step:852/1845 train_time:36074ms step_avg:42.34ms
+step:853/1845 train_time:36136ms step_avg:42.36ms
+step:854/1845 train_time:36197ms step_avg:42.39ms
+step:855/1845 train_time:36260ms step_avg:42.41ms
+step:856/1845 train_time:36320ms step_avg:42.43ms
+step:857/1845 train_time:36384ms step_avg:42.45ms
+step:858/1845 train_time:36443ms step_avg:42.47ms
+step:859/1845 train_time:36505ms step_avg:42.50ms
+step:860/1845 train_time:36566ms step_avg:42.52ms
+step:861/1845 train_time:36629ms step_avg:42.54ms
+step:862/1845 train_time:36690ms step_avg:42.56ms
+step:863/1845 train_time:36751ms step_avg:42.59ms
+step:864/1845 train_time:36812ms step_avg:42.61ms
+step:865/1845 train_time:36875ms step_avg:42.63ms
+step:866/1845 train_time:36935ms step_avg:42.65ms
+step:867/1845 train_time:36998ms step_avg:42.67ms
+step:868/1845 train_time:37059ms step_avg:42.69ms
+step:869/1845 train_time:37121ms step_avg:42.72ms
+step:870/1845 train_time:37182ms step_avg:42.74ms
+step:871/1845 train_time:37244ms step_avg:42.76ms
+step:872/1845 train_time:37305ms step_avg:42.78ms
+step:873/1845 train_time:37368ms step_avg:42.80ms
+step:874/1845 train_time:37428ms step_avg:42.82ms
+step:875/1845 train_time:37491ms step_avg:42.85ms
+step:876/1845 train_time:37552ms step_avg:42.87ms
+step:877/1845 train_time:37614ms step_avg:42.89ms
+step:878/1845 train_time:37675ms step_avg:42.91ms
+step:879/1845 train_time:37738ms step_avg:42.93ms
+step:880/1845 train_time:37798ms step_avg:42.95ms
+step:881/1845 train_time:37861ms step_avg:42.98ms
+step:882/1845 train_time:37922ms step_avg:43.00ms
+step:883/1845 train_time:37984ms step_avg:43.02ms
+step:884/1845 train_time:38044ms step_avg:43.04ms
+step:885/1845 train_time:38106ms step_avg:43.06ms
+step:886/1845 train_time:38167ms step_avg:43.08ms
+step:887/1845 train_time:38229ms step_avg:43.10ms
+step:888/1845 train_time:38290ms step_avg:43.12ms
+step:889/1845 train_time:38352ms step_avg:43.14ms
+step:890/1845 train_time:38413ms step_avg:43.16ms
+step:891/1845 train_time:38475ms step_avg:43.18ms
+step:892/1845 train_time:38537ms step_avg:43.20ms
+step:893/1845 train_time:38599ms step_avg:43.22ms
+step:894/1845 train_time:38660ms step_avg:43.24ms
+step:895/1845 train_time:38722ms step_avg:43.27ms
+step:896/1845 train_time:38783ms step_avg:43.28ms
+step:897/1845 train_time:38845ms step_avg:43.31ms
+step:898/1845 train_time:38906ms step_avg:43.32ms
+step:899/1845 train_time:38968ms step_avg:43.35ms
+step:900/1845 train_time:39029ms step_avg:43.37ms
+step:901/1845 train_time:39091ms step_avg:43.39ms
+step:902/1845 train_time:39152ms step_avg:43.41ms
+step:903/1845 train_time:39215ms step_avg:43.43ms
+step:904/1845 train_time:39275ms step_avg:43.45ms
+step:905/1845 train_time:39338ms step_avg:43.47ms
+step:906/1845 train_time:39399ms step_avg:43.49ms
+step:907/1845 train_time:39462ms step_avg:43.51ms
+step:908/1845 train_time:39523ms step_avg:43.53ms
+step:909/1845 train_time:39585ms step_avg:43.55ms
+step:910/1845 train_time:39645ms step_avg:43.57ms
+step:911/1845 train_time:39708ms step_avg:43.59ms
+step:912/1845 train_time:39770ms step_avg:43.61ms
+step:913/1845 train_time:39832ms step_avg:43.63ms
+step:914/1845 train_time:39893ms step_avg:43.65ms
+step:915/1845 train_time:39956ms step_avg:43.67ms
+step:916/1845 train_time:40017ms step_avg:43.69ms
+step:917/1845 train_time:40079ms step_avg:43.71ms
+step:918/1845 train_time:40140ms step_avg:43.73ms
+step:919/1845 train_time:40202ms step_avg:43.75ms
+step:920/1845 train_time:40263ms step_avg:43.76ms
+step:921/1845 train_time:40325ms step_avg:43.78ms
+step:922/1845 train_time:40386ms step_avg:43.80ms
+step:923/1845 train_time:40449ms step_avg:43.82ms
+step:924/1845 train_time:40509ms step_avg:43.84ms
+step:925/1845 train_time:40572ms step_avg:43.86ms
+step:926/1845 train_time:40633ms step_avg:43.88ms
+step:927/1845 train_time:40696ms step_avg:43.90ms
+step:928/1845 train_time:40757ms step_avg:43.92ms
+step:929/1845 train_time:40820ms step_avg:43.94ms
+step:930/1845 train_time:40881ms step_avg:43.96ms
+step:931/1845 train_time:40944ms step_avg:43.98ms
+step:932/1845 train_time:41004ms step_avg:44.00ms
+step:933/1845 train_time:41066ms step_avg:44.02ms
+step:934/1845 train_time:41127ms step_avg:44.03ms
+step:935/1845 train_time:41190ms step_avg:44.05ms
+step:936/1845 train_time:41251ms step_avg:44.07ms
+step:937/1845 train_time:41313ms step_avg:44.09ms
+step:938/1845 train_time:41374ms step_avg:44.11ms
+step:939/1845 train_time:41437ms step_avg:44.13ms
+step:940/1845 train_time:41498ms step_avg:44.15ms
+step:941/1845 train_time:41561ms step_avg:44.17ms
+step:942/1845 train_time:41621ms step_avg:44.18ms
+step:943/1845 train_time:41684ms step_avg:44.20ms
+step:944/1845 train_time:41744ms step_avg:44.22ms
+step:945/1845 train_time:41806ms step_avg:44.24ms
+step:946/1845 train_time:41868ms step_avg:44.26ms
+step:947/1845 train_time:41930ms step_avg:44.28ms
+step:948/1845 train_time:41991ms step_avg:44.29ms
+step:949/1845 train_time:42053ms step_avg:44.31ms
+step:950/1845 train_time:42114ms step_avg:44.33ms
+step:951/1845 train_time:42177ms step_avg:44.35ms
+step:952/1845 train_time:42238ms step_avg:44.37ms
+step:953/1845 train_time:42300ms step_avg:44.39ms
+step:954/1845 train_time:42361ms step_avg:44.40ms
+step:955/1845 train_time:42423ms step_avg:44.42ms
+step:956/1845 train_time:42484ms step_avg:44.44ms
+step:957/1845 train_time:42546ms step_avg:44.46ms
+step:958/1845 train_time:42607ms step_avg:44.47ms
+step:959/1845 train_time:42670ms step_avg:44.49ms
+step:960/1845 train_time:42731ms step_avg:44.51ms
+step:961/1845 train_time:42793ms step_avg:44.53ms
+step:962/1845 train_time:42854ms step_avg:44.55ms
+step:963/1845 train_time:42916ms step_avg:44.57ms
+step:964/1845 train_time:42978ms step_avg:44.58ms
+step:965/1845 train_time:43040ms step_avg:44.60ms
+step:966/1845 train_time:43101ms step_avg:44.62ms
+step:967/1845 train_time:43164ms step_avg:44.64ms
+step:968/1845 train_time:43224ms step_avg:44.65ms
+step:969/1845 train_time:43287ms step_avg:44.67ms
+step:970/1845 train_time:43348ms step_avg:44.69ms
+step:971/1845 train_time:43411ms step_avg:44.71ms
+step:972/1845 train_time:43471ms step_avg:44.72ms
+step:973/1845 train_time:43533ms step_avg:44.74ms
+step:974/1845 train_time:43594ms step_avg:44.76ms
+step:975/1845 train_time:43657ms step_avg:44.78ms
+step:976/1845 train_time:43719ms step_avg:44.79ms
+step:977/1845 train_time:43781ms step_avg:44.81ms
+step:978/1845 train_time:43842ms step_avg:44.83ms
+step:979/1845 train_time:43904ms step_avg:44.85ms
+step:980/1845 train_time:43964ms step_avg:44.86ms
+step:981/1845 train_time:44026ms step_avg:44.88ms
+step:982/1845 train_time:44087ms step_avg:44.90ms
+step:983/1845 train_time:44149ms step_avg:44.91ms
+step:984/1845 train_time:44211ms step_avg:44.93ms
+step:985/1845 train_time:44273ms step_avg:44.95ms
+step:986/1845 train_time:44334ms step_avg:44.96ms
+step:987/1845 train_time:44396ms step_avg:44.98ms
+step:988/1845 train_time:44457ms step_avg:45.00ms
+step:989/1845 train_time:44519ms step_avg:45.01ms
+step:990/1845 train_time:44581ms step_avg:45.03ms
+step:991/1845 train_time:44643ms step_avg:45.05ms
+step:992/1845 train_time:44704ms step_avg:45.06ms
+step:993/1845 train_time:44766ms step_avg:45.08ms
+step:994/1845 train_time:44827ms step_avg:45.10ms
+step:995/1845 train_time:44890ms step_avg:45.12ms
+step:996/1845 train_time:44950ms step_avg:45.13ms
+step:997/1845 train_time:45013ms step_avg:45.15ms
+step:998/1845 train_time:45073ms step_avg:45.16ms
+step:999/1845 train_time:45136ms step_avg:45.18ms
+step:1000/1845 train_time:45197ms step_avg:45.20ms
+step:1000/1845 val_loss:3.7747 train_time:45261ms step_avg:45.26ms
+step:1001/1845 train_time:45281ms step_avg:45.24ms
+step:1002/1845 train_time:45324ms step_avg:45.23ms
+step:1003/1845 train_time:45388ms step_avg:45.25ms
+step:1004/1845 train_time:45450ms step_avg:45.27ms
+step:1005/1845 train_time:45512ms step_avg:45.29ms
+step:1006/1845 train_time:45572ms step_avg:45.30ms
+step:1007/1845 train_time:45634ms step_avg:45.32ms
+step:1008/1845 train_time:45694ms step_avg:45.33ms
+step:1009/1845 train_time:45756ms step_avg:45.35ms
+step:1010/1845 train_time:45816ms step_avg:45.36ms
+step:1011/1845 train_time:45878ms step_avg:45.38ms
+step:1012/1845 train_time:45938ms step_avg:45.39ms
+step:1013/1845 train_time:46000ms step_avg:45.41ms
+step:1014/1845 train_time:46061ms step_avg:45.42ms
+step:1015/1845 train_time:46122ms step_avg:45.44ms
+step:1016/1845 train_time:46183ms step_avg:45.46ms
+step:1017/1845 train_time:46246ms step_avg:45.47ms
+step:1018/1845 train_time:46308ms step_avg:45.49ms
+step:1019/1845 train_time:46371ms step_avg:45.51ms
+step:1020/1845 train_time:46433ms step_avg:45.52ms
+step:1021/1845 train_time:46495ms step_avg:45.54ms
+step:1022/1845 train_time:46556ms step_avg:45.55ms
+step:1023/1845 train_time:46617ms step_avg:45.57ms
+step:1024/1845 train_time:46678ms step_avg:45.58ms
+step:1025/1845 train_time:46740ms step_avg:45.60ms
+step:1026/1845 train_time:46800ms step_avg:45.61ms
+step:1027/1845 train_time:46862ms step_avg:45.63ms
+step:1028/1845 train_time:46923ms step_avg:45.64ms
+step:1029/1845 train_time:46985ms step_avg:45.66ms
+step:1030/1845 train_time:47045ms step_avg:45.67ms
+step:1031/1845 train_time:47107ms step_avg:45.69ms
+step:1032/1845 train_time:47168ms step_avg:45.71ms
+step:1033/1845 train_time:47231ms step_avg:45.72ms
+step:1034/1845 train_time:47292ms step_avg:45.74ms
+step:1035/1845 train_time:47354ms step_avg:45.75ms
+step:1036/1845 train_time:47415ms step_avg:45.77ms
+step:1037/1845 train_time:47479ms step_avg:45.78ms
+step:1038/1845 train_time:47540ms step_avg:45.80ms
+step:1039/1845 train_time:47602ms step_avg:45.82ms
+step:1040/1845 train_time:47663ms step_avg:45.83ms
+step:1041/1845 train_time:47726ms step_avg:45.85ms
+step:1042/1845 train_time:47786ms step_avg:45.86ms
+step:1043/1845 train_time:47849ms step_avg:45.88ms
+step:1044/1845 train_time:47910ms step_avg:45.89ms
+step:1045/1845 train_time:47972ms step_avg:45.91ms
+step:1046/1845 train_time:48032ms step_avg:45.92ms
+step:1047/1845 train_time:48094ms step_avg:45.94ms
+step:1048/1845 train_time:48155ms step_avg:45.95ms
+step:1049/1845 train_time:48217ms step_avg:45.96ms
+step:1050/1845 train_time:48278ms step_avg:45.98ms
+step:1051/1845 train_time:48341ms step_avg:46.00ms
+step:1052/1845 train_time:48402ms step_avg:46.01ms
+step:1053/1845 train_time:48466ms step_avg:46.03ms
+step:1054/1845 train_time:48526ms step_avg:46.04ms
+step:1055/1845 train_time:48589ms step_avg:46.06ms
+step:1056/1845 train_time:48650ms step_avg:46.07ms
+step:1057/1845 train_time:48712ms step_avg:46.08ms
+step:1058/1845 train_time:48772ms step_avg:46.10ms
+step:1059/1845 train_time:48834ms step_avg:46.11ms
+step:1060/1845 train_time:48895ms step_avg:46.13ms
+step:1061/1845 train_time:48957ms step_avg:46.14ms
+step:1062/1845 train_time:49018ms step_avg:46.16ms
+step:1063/1845 train_time:49080ms step_avg:46.17ms
+step:1064/1845 train_time:49141ms step_avg:46.19ms
+step:1065/1845 train_time:49204ms step_avg:46.20ms
+step:1066/1845 train_time:49264ms step_avg:46.21ms
+step:1067/1845 train_time:49326ms step_avg:46.23ms
+step:1068/1845 train_time:49387ms step_avg:46.24ms
+step:1069/1845 train_time:49450ms step_avg:46.26ms
+step:1070/1845 train_time:49511ms step_avg:46.27ms
+step:1071/1845 train_time:49574ms step_avg:46.29ms
+step:1072/1845 train_time:49635ms step_avg:46.30ms
+step:1073/1845 train_time:49697ms step_avg:46.32ms
+step:1074/1845 train_time:49758ms step_avg:46.33ms
+step:1075/1845 train_time:49820ms step_avg:46.34ms
+step:1076/1845 train_time:49881ms step_avg:46.36ms
+step:1077/1845 train_time:49942ms step_avg:46.37ms
+step:1078/1845 train_time:50003ms step_avg:46.39ms
+step:1079/1845 train_time:50065ms step_avg:46.40ms
+step:1080/1845 train_time:50126ms step_avg:46.41ms
+step:1081/1845 train_time:50188ms step_avg:46.43ms
+step:1082/1845 train_time:50249ms step_avg:46.44ms
+step:1083/1845 train_time:50312ms step_avg:46.46ms
+step:1084/1845 train_time:50372ms step_avg:46.47ms
+step:1085/1845 train_time:50434ms step_avg:46.48ms
+step:1086/1845 train_time:50495ms step_avg:46.50ms
+step:1087/1845 train_time:50557ms step_avg:46.51ms
+step:1088/1845 train_time:50618ms step_avg:46.52ms
+step:1089/1845 train_time:50680ms step_avg:46.54ms
+step:1090/1845 train_time:50741ms step_avg:46.55ms
+step:1091/1845 train_time:50804ms step_avg:46.57ms
+step:1092/1845 train_time:50866ms step_avg:46.58ms
+step:1093/1845 train_time:50928ms step_avg:46.59ms
+step:1094/1845 train_time:50989ms step_avg:46.61ms
+step:1095/1845 train_time:51051ms step_avg:46.62ms
+step:1096/1845 train_time:51111ms step_avg:46.63ms
+step:1097/1845 train_time:51173ms step_avg:46.65ms
+step:1098/1845 train_time:51233ms step_avg:46.66ms
+step:1099/1845 train_time:51296ms step_avg:46.68ms
+step:1100/1845 train_time:51357ms step_avg:46.69ms
+step:1101/1845 train_time:51419ms step_avg:46.70ms
+step:1102/1845 train_time:51480ms step_avg:46.72ms
+step:1103/1845 train_time:51543ms step_avg:46.73ms
+step:1104/1845 train_time:51604ms step_avg:46.74ms
+step:1105/1845 train_time:51666ms step_avg:46.76ms
+step:1106/1845 train_time:51727ms step_avg:46.77ms
+step:1107/1845 train_time:51790ms step_avg:46.78ms
+step:1108/1845 train_time:51851ms step_avg:46.80ms
+step:1109/1845 train_time:51913ms step_avg:46.81ms
+step:1110/1845 train_time:51973ms step_avg:46.82ms
+step:1111/1845 train_time:52035ms step_avg:46.84ms
+step:1112/1845 train_time:52096ms step_avg:46.85ms
+step:1113/1845 train_time:52158ms step_avg:46.86ms
+step:1114/1845 train_time:52219ms step_avg:46.88ms
+step:1115/1845 train_time:52282ms step_avg:46.89ms
+step:1116/1845 train_time:52342ms step_avg:46.90ms
+step:1117/1845 train_time:52404ms step_avg:46.92ms
+step:1118/1845 train_time:52466ms step_avg:46.93ms
+step:1119/1845 train_time:52528ms step_avg:46.94ms
+step:1120/1845 train_time:52589ms step_avg:46.95ms
+step:1121/1845 train_time:52651ms step_avg:46.97ms
+step:1122/1845 train_time:52711ms step_avg:46.98ms
+step:1123/1845 train_time:52774ms step_avg:46.99ms
+step:1124/1845 train_time:52834ms step_avg:47.01ms
+step:1125/1845 train_time:52897ms step_avg:47.02ms
+step:1126/1845 train_time:52957ms step_avg:47.03ms
+step:1127/1845 train_time:53021ms step_avg:47.05ms
+step:1128/1845 train_time:53081ms step_avg:47.06ms
+step:1129/1845 train_time:53143ms step_avg:47.07ms
+step:1130/1845 train_time:53203ms step_avg:47.08ms
+step:1131/1845 train_time:53266ms step_avg:47.10ms
+step:1132/1845 train_time:53327ms step_avg:47.11ms
+step:1133/1845 train_time:53389ms step_avg:47.12ms
+step:1134/1845 train_time:53450ms step_avg:47.13ms
+step:1135/1845 train_time:53513ms step_avg:47.15ms
+step:1136/1845 train_time:53574ms step_avg:47.16ms
+step:1137/1845 train_time:53636ms step_avg:47.17ms
+step:1138/1845 train_time:53697ms step_avg:47.19ms
+step:1139/1845 train_time:53759ms step_avg:47.20ms
+step:1140/1845 train_time:53820ms step_avg:47.21ms
+step:1141/1845 train_time:53883ms step_avg:47.22ms
+step:1142/1845 train_time:53944ms step_avg:47.24ms
+step:1143/1845 train_time:54007ms step_avg:47.25ms
+step:1144/1845 train_time:54068ms step_avg:47.26ms
+step:1145/1845 train_time:54130ms step_avg:47.28ms
+step:1146/1845 train_time:54190ms step_avg:47.29ms
+step:1147/1845 train_time:54252ms step_avg:47.30ms
+step:1148/1845 train_time:54313ms step_avg:47.31ms
+step:1149/1845 train_time:54376ms step_avg:47.32ms
+step:1150/1845 train_time:54437ms step_avg:47.34ms
+step:1151/1845 train_time:54500ms step_avg:47.35ms
+step:1152/1845 train_time:54561ms step_avg:47.36ms
+step:1153/1845 train_time:54624ms step_avg:47.38ms
+step:1154/1845 train_time:54685ms step_avg:47.39ms
+step:1155/1845 train_time:54748ms step_avg:47.40ms
+step:1156/1845 train_time:54809ms step_avg:47.41ms
+step:1157/1845 train_time:54872ms step_avg:47.43ms
+step:1158/1845 train_time:54933ms step_avg:47.44ms
+step:1159/1845 train_time:54995ms step_avg:47.45ms
+step:1160/1845 train_time:55056ms step_avg:47.46ms
+step:1161/1845 train_time:55119ms step_avg:47.48ms
+step:1162/1845 train_time:55180ms step_avg:47.49ms
+step:1163/1845 train_time:55242ms step_avg:47.50ms
+step:1164/1845 train_time:55303ms step_avg:47.51ms
+step:1165/1845 train_time:55365ms step_avg:47.52ms
+step:1166/1845 train_time:55427ms step_avg:47.54ms
+step:1167/1845 train_time:55489ms step_avg:47.55ms
+step:1168/1845 train_time:55550ms step_avg:47.56ms
+step:1169/1845 train_time:55613ms step_avg:47.57ms
+step:1170/1845 train_time:55673ms step_avg:47.58ms
+step:1171/1845 train_time:55735ms step_avg:47.60ms
+step:1172/1845 train_time:55795ms step_avg:47.61ms
+step:1173/1845 train_time:55857ms step_avg:47.62ms
+step:1174/1845 train_time:55918ms step_avg:47.63ms
+step:1175/1845 train_time:55980ms step_avg:47.64ms
+step:1176/1845 train_time:56041ms step_avg:47.65ms
+step:1177/1845 train_time:56104ms step_avg:47.67ms
+step:1178/1845 train_time:56165ms step_avg:47.68ms
+step:1179/1845 train_time:56226ms step_avg:47.69ms
+step:1180/1845 train_time:56287ms step_avg:47.70ms
+step:1181/1845 train_time:56351ms step_avg:47.71ms
+step:1182/1845 train_time:56411ms step_avg:47.72ms
+step:1183/1845 train_time:56473ms step_avg:47.74ms
+step:1184/1845 train_time:56533ms step_avg:47.75ms
+step:1185/1845 train_time:56596ms step_avg:47.76ms
+step:1186/1845 train_time:56657ms step_avg:47.77ms
+step:1187/1845 train_time:56720ms step_avg:47.78ms
+step:1188/1845 train_time:56781ms step_avg:47.80ms
+step:1189/1845 train_time:56842ms step_avg:47.81ms
+step:1190/1845 train_time:56903ms step_avg:47.82ms
+step:1191/1845 train_time:56965ms step_avg:47.83ms
+step:1192/1845 train_time:57026ms step_avg:47.84ms
+step:1193/1845 train_time:57089ms step_avg:47.85ms
+step:1194/1845 train_time:57150ms step_avg:47.86ms
+step:1195/1845 train_time:57212ms step_avg:47.88ms
+step:1196/1845 train_time:57273ms step_avg:47.89ms
+step:1197/1845 train_time:57335ms step_avg:47.90ms
+step:1198/1845 train_time:57395ms step_avg:47.91ms
+step:1199/1845 train_time:57458ms step_avg:47.92ms
+step:1200/1845 train_time:57518ms step_avg:47.93ms
+step:1201/1845 train_time:57580ms step_avg:47.94ms
+step:1202/1845 train_time:57641ms step_avg:47.95ms
+step:1203/1845 train_time:57704ms step_avg:47.97ms
+step:1204/1845 train_time:57764ms step_avg:47.98ms
+step:1205/1845 train_time:57827ms step_avg:47.99ms
+step:1206/1845 train_time:57914ms step_avg:48.02ms
+step:1207/1845 train_time:58004ms step_avg:48.06ms
+step:1208/1845 train_time:58091ms step_avg:48.09ms
+step:1209/1845 train_time:58181ms step_avg:48.12ms
+step:1210/1845 train_time:58269ms step_avg:48.16ms
+step:1211/1845 train_time:58358ms step_avg:48.19ms
+step:1212/1845 train_time:58444ms step_avg:48.22ms
+step:1213/1845 train_time:58533ms step_avg:48.25ms
+step:1214/1845 train_time:58620ms step_avg:48.29ms
+step:1215/1845 train_time:58708ms step_avg:48.32ms
+step:1216/1845 train_time:58796ms step_avg:48.35ms
+step:1217/1845 train_time:58884ms step_avg:48.38ms
+step:1218/1845 train_time:58971ms step_avg:48.42ms
+step:1219/1845 train_time:59060ms step_avg:48.45ms
+step:1220/1845 train_time:59147ms step_avg:48.48ms
+step:1221/1845 train_time:59236ms step_avg:48.51ms
+step:1222/1845 train_time:59323ms step_avg:48.55ms
+step:1223/1845 train_time:59412ms step_avg:48.58ms
+step:1224/1845 train_time:59501ms step_avg:48.61ms
+step:1225/1845 train_time:59589ms step_avg:48.64ms
+step:1226/1845 train_time:59676ms step_avg:48.68ms
+step:1227/1845 train_time:59764ms step_avg:48.71ms
+step:1228/1845 train_time:59851ms step_avg:48.74ms
+step:1229/1845 train_time:59939ms step_avg:48.77ms
+step:1230/1845 train_time:60027ms step_avg:48.80ms
+step:1231/1845 train_time:60115ms step_avg:48.83ms
+step:1232/1845 train_time:60203ms step_avg:48.87ms
+step:1233/1845 train_time:60291ms step_avg:48.90ms
+step:1234/1845 train_time:60380ms step_avg:48.93ms
+step:1235/1845 train_time:60468ms step_avg:48.96ms
+step:1236/1845 train_time:60555ms step_avg:48.99ms
+step:1237/1845 train_time:60643ms step_avg:49.02ms
+step:1238/1845 train_time:60731ms step_avg:49.06ms
+step:1239/1845 train_time:60818ms step_avg:49.09ms
+step:1240/1845 train_time:60905ms step_avg:49.12ms
+step:1241/1845 train_time:60993ms step_avg:49.15ms
+step:1242/1845 train_time:61082ms step_avg:49.18ms
+step:1243/1845 train_time:61170ms step_avg:49.21ms
+step:1244/1845 train_time:61258ms step_avg:49.24ms
+step:1245/1845 train_time:61346ms step_avg:49.27ms
+step:1246/1845 train_time:61433ms step_avg:49.30ms
+step:1247/1845 train_time:61522ms step_avg:49.34ms
+step:1248/1845 train_time:61608ms step_avg:49.37ms
+step:1249/1845 train_time:61697ms step_avg:49.40ms
+step:1250/1845 train_time:61784ms step_avg:49.43ms
+step:1250/1845 val_loss:3.5363 train_time:61874ms step_avg:49.50ms
+step:1251/1845 train_time:61894ms step_avg:49.48ms
+step:1252/1845 train_time:61961ms step_avg:49.49ms
+step:1253/1845 train_time:62056ms step_avg:49.53ms
+step:1254/1845 train_time:62144ms step_avg:49.56ms
+step:1255/1845 train_time:62233ms step_avg:49.59ms
+step:1256/1845 train_time:62319ms step_avg:49.62ms
+step:1257/1845 train_time:62406ms step_avg:49.65ms
+step:1258/1845 train_time:62492ms step_avg:49.68ms
+step:1259/1845 train_time:62580ms step_avg:49.71ms
+step:1260/1845 train_time:62666ms step_avg:49.73ms
+step:1261/1845 train_time:62754ms step_avg:49.77ms
+step:1262/1845 train_time:62843ms step_avg:49.80ms
+step:1263/1845 train_time:62933ms step_avg:49.83ms
+step:1264/1845 train_time:63024ms step_avg:49.86ms
+step:1265/1845 train_time:63114ms step_avg:49.89ms
+step:1266/1845 train_time:63202ms step_avg:49.92ms
+step:1267/1845 train_time:63290ms step_avg:49.95ms
+step:1268/1845 train_time:63376ms step_avg:49.98ms
+step:1269/1845 train_time:63464ms step_avg:50.01ms
+step:1270/1845 train_time:63550ms step_avg:50.04ms
+step:1271/1845 train_time:63637ms step_avg:50.07ms
+step:1272/1845 train_time:63724ms step_avg:50.10ms
+step:1273/1845 train_time:63812ms step_avg:50.13ms
+step:1274/1845 train_time:63900ms step_avg:50.16ms
+step:1275/1845 train_time:63989ms step_avg:50.19ms
+step:1276/1845 train_time:64078ms step_avg:50.22ms
+step:1277/1845 train_time:64168ms step_avg:50.25ms
+step:1278/1845 train_time:64256ms step_avg:50.28ms
+step:1279/1845 train_time:64343ms step_avg:50.31ms
+step:1280/1845 train_time:64429ms step_avg:50.34ms
+step:1281/1845 train_time:64517ms step_avg:50.36ms
+step:1282/1845 train_time:64603ms step_avg:50.39ms
+step:1283/1845 train_time:64691ms step_avg:50.42ms
+step:1284/1845 train_time:64778ms step_avg:50.45ms
+step:1285/1845 train_time:64867ms step_avg:50.48ms
+step:1286/1845 train_time:64955ms step_avg:50.51ms
+step:1287/1845 train_time:65045ms step_avg:50.54ms
+step:1288/1845 train_time:65134ms step_avg:50.57ms
+step:1289/1845 train_time:65223ms step_avg:50.60ms
+step:1290/1845 train_time:65310ms step_avg:50.63ms
+step:1291/1845 train_time:65400ms step_avg:50.66ms
+step:1292/1845 train_time:65486ms step_avg:50.69ms
+step:1293/1845 train_time:65574ms step_avg:50.71ms
+step:1294/1845 train_time:65660ms step_avg:50.74ms
+step:1295/1845 train_time:65748ms step_avg:50.77ms
+step:1296/1845 train_time:65836ms step_avg:50.80ms
+step:1297/1845 train_time:65925ms step_avg:50.83ms
+step:1298/1845 train_time:66013ms step_avg:50.86ms
+step:1299/1845 train_time:66103ms step_avg:50.89ms
+step:1300/1845 train_time:66192ms step_avg:50.92ms
+step:1301/1845 train_time:66280ms step_avg:50.95ms
+step:1302/1845 train_time:66368ms step_avg:50.97ms
+step:1303/1845 train_time:66457ms step_avg:51.00ms
+step:1304/1845 train_time:66544ms step_avg:51.03ms
+step:1305/1845 train_time:66632ms step_avg:51.06ms
+step:1306/1845 train_time:66718ms step_avg:51.09ms
+step:1307/1845 train_time:66807ms step_avg:51.11ms
+step:1308/1845 train_time:66894ms step_avg:51.14ms
+step:1309/1845 train_time:66983ms step_avg:51.17ms
+step:1310/1845 train_time:67070ms step_avg:51.20ms
+step:1311/1845 train_time:67160ms step_avg:51.23ms
+step:1312/1845 train_time:67247ms step_avg:51.26ms
+step:1313/1845 train_time:67335ms step_avg:51.28ms
+step:1314/1845 train_time:67424ms step_avg:51.31ms
+step:1315/1845 train_time:67511ms step_avg:51.34ms
+step:1316/1845 train_time:67599ms step_avg:51.37ms
+step:1317/1845 train_time:67686ms step_avg:51.39ms
+step:1318/1845 train_time:67773ms step_avg:51.42ms
+step:1319/1845 train_time:67862ms step_avg:51.45ms
+step:1320/1845 train_time:67948ms step_avg:51.48ms
+step:1321/1845 train_time:68037ms step_avg:51.50ms
+step:1322/1845 train_time:68125ms step_avg:51.53ms
+step:1323/1845 train_time:68213ms step_avg:51.56ms
+step:1324/1845 train_time:68302ms step_avg:51.59ms
+step:1325/1845 train_time:68390ms step_avg:51.62ms
+step:1326/1845 train_time:68477ms step_avg:51.64ms
+step:1327/1845 train_time:68565ms step_avg:51.67ms
+step:1328/1845 train_time:68652ms step_avg:51.70ms
+step:1329/1845 train_time:68741ms step_avg:51.72ms
+step:1330/1845 train_time:68828ms step_avg:51.75ms
+step:1331/1845 train_time:68916ms step_avg:51.78ms
+step:1332/1845 train_time:69004ms step_avg:51.80ms
+step:1333/1845 train_time:69093ms step_avg:51.83ms
+step:1334/1845 train_time:69181ms step_avg:51.86ms
+step:1335/1845 train_time:69269ms step_avg:51.89ms
+step:1336/1845 train_time:69357ms step_avg:51.91ms
+step:1337/1845 train_time:69446ms step_avg:51.94ms
+step:1338/1845 train_time:69534ms step_avg:51.97ms
+step:1339/1845 train_time:69623ms step_avg:52.00ms
+step:1340/1845 train_time:69710ms step_avg:52.02ms
+step:1341/1845 train_time:69799ms step_avg:52.05ms
+step:1342/1845 train_time:69886ms step_avg:52.08ms
+step:1343/1845 train_time:69975ms step_avg:52.10ms
+step:1344/1845 train_time:70062ms step_avg:52.13ms
+step:1345/1845 train_time:70150ms step_avg:52.16ms
+step:1346/1845 train_time:70238ms step_avg:52.18ms
+step:1347/1845 train_time:70326ms step_avg:52.21ms
+step:1348/1845 train_time:70414ms step_avg:52.24ms
+step:1349/1845 train_time:70502ms step_avg:52.26ms
+step:1350/1845 train_time:70589ms step_avg:52.29ms
+step:1351/1845 train_time:70678ms step_avg:52.32ms
+step:1352/1845 train_time:70765ms step_avg:52.34ms
+step:1353/1845 train_time:70852ms step_avg:52.37ms
+step:1354/1845 train_time:70940ms step_avg:52.39ms
+step:1355/1845 train_time:71027ms step_avg:52.42ms
+step:1356/1845 train_time:71114ms step_avg:52.44ms
+step:1357/1845 train_time:71204ms step_avg:52.47ms
+step:1358/1845 train_time:71292ms step_avg:52.50ms
+step:1359/1845 train_time:71381ms step_avg:52.52ms
+step:1360/1845 train_time:71469ms step_avg:52.55ms
+step:1361/1845 train_time:71557ms step_avg:52.58ms
+step:1362/1845 train_time:71644ms step_avg:52.60ms
+step:1363/1845 train_time:71733ms step_avg:52.63ms
+step:1364/1845 train_time:71820ms step_avg:52.65ms
+step:1365/1845 train_time:71908ms step_avg:52.68ms
+step:1366/1845 train_time:71997ms step_avg:52.71ms
+step:1367/1845 train_time:72086ms step_avg:52.73ms
+step:1368/1845 train_time:72173ms step_avg:52.76ms
+step:1369/1845 train_time:72262ms step_avg:52.78ms
+step:1370/1845 train_time:72349ms step_avg:52.81ms
+step:1371/1845 train_time:72438ms step_avg:52.84ms
+step:1372/1845 train_time:72524ms step_avg:52.86ms
+step:1373/1845 train_time:72612ms step_avg:52.89ms
+step:1374/1845 train_time:72700ms step_avg:52.91ms
+step:1375/1845 train_time:72789ms step_avg:52.94ms
+step:1376/1845 train_time:72876ms step_avg:52.96ms
+step:1377/1845 train_time:72964ms step_avg:52.99ms
+step:1378/1845 train_time:73051ms step_avg:53.01ms
+step:1379/1845 train_time:73140ms step_avg:53.04ms
+step:1380/1845 train_time:73227ms step_avg:53.06ms
+step:1381/1845 train_time:73317ms step_avg:53.09ms
+step:1382/1845 train_time:73405ms step_avg:53.11ms
+step:1383/1845 train_time:73493ms step_avg:53.14ms
+step:1384/1845 train_time:73581ms step_avg:53.17ms
+step:1385/1845 train_time:73668ms step_avg:53.19ms
+step:1386/1845 train_time:73756ms step_avg:53.22ms
+step:1387/1845 train_time:73845ms step_avg:53.24ms
+step:1388/1845 train_time:73932ms step_avg:53.26ms
+step:1389/1845 train_time:74020ms step_avg:53.29ms
+step:1390/1845 train_time:74107ms step_avg:53.31ms
+step:1391/1845 train_time:74196ms step_avg:53.34ms
+step:1392/1845 train_time:74282ms step_avg:53.36ms
+step:1393/1845 train_time:74371ms step_avg:53.39ms
+step:1394/1845 train_time:74459ms step_avg:53.41ms
+step:1395/1845 train_time:74546ms step_avg:53.44ms
+step:1396/1845 train_time:74634ms step_avg:53.46ms
+step:1397/1845 train_time:74723ms step_avg:53.49ms
+step:1398/1845 train_time:74810ms step_avg:53.51ms
+step:1399/1845 train_time:74899ms step_avg:53.54ms
+step:1400/1845 train_time:74985ms step_avg:53.56ms
+step:1401/1845 train_time:75073ms step_avg:53.59ms
+step:1402/1845 train_time:75160ms step_avg:53.61ms
+step:1403/1845 train_time:75249ms step_avg:53.63ms
+step:1404/1845 train_time:75337ms step_avg:53.66ms
+step:1405/1845 train_time:75426ms step_avg:53.68ms
+step:1406/1845 train_time:75512ms step_avg:53.71ms
+step:1407/1845 train_time:75602ms step_avg:53.73ms
+step:1408/1845 train_time:75689ms step_avg:53.76ms
+step:1409/1845 train_time:75778ms step_avg:53.78ms
+step:1410/1845 train_time:75864ms step_avg:53.80ms
+step:1411/1845 train_time:75952ms step_avg:53.83ms
+step:1412/1845 train_time:76039ms step_avg:53.85ms
+step:1413/1845 train_time:76127ms step_avg:53.88ms
+step:1414/1845 train_time:76215ms step_avg:53.90ms
+step:1415/1845 train_time:76304ms step_avg:53.93ms
+step:1416/1845 train_time:76392ms step_avg:53.95ms
+step:1417/1845 train_time:76480ms step_avg:53.97ms
+step:1418/1845 train_time:76567ms step_avg:54.00ms
+step:1419/1845 train_time:76656ms step_avg:54.02ms
+step:1420/1845 train_time:76744ms step_avg:54.04ms
+step:1421/1845 train_time:76832ms step_avg:54.07ms
+step:1422/1845 train_time:76919ms step_avg:54.09ms
+step:1423/1845 train_time:77008ms step_avg:54.12ms
+step:1424/1845 train_time:77096ms step_avg:54.14ms
+step:1425/1845 train_time:77184ms step_avg:54.16ms
+step:1426/1845 train_time:77271ms step_avg:54.19ms
+step:1427/1845 train_time:77360ms step_avg:54.21ms
+step:1428/1845 train_time:77447ms step_avg:54.23ms
+step:1429/1845 train_time:77535ms step_avg:54.26ms
+step:1430/1845 train_time:77623ms step_avg:54.28ms
+step:1431/1845 train_time:77711ms step_avg:54.31ms
+step:1432/1845 train_time:77799ms step_avg:54.33ms
+step:1433/1845 train_time:77886ms step_avg:54.35ms
+step:1434/1845 train_time:77974ms step_avg:54.38ms
+step:1435/1845 train_time:78062ms step_avg:54.40ms
+step:1436/1845 train_time:78149ms step_avg:54.42ms
+step:1437/1845 train_time:78237ms step_avg:54.44ms
+step:1438/1845 train_time:78326ms step_avg:54.47ms
+step:1439/1845 train_time:78413ms step_avg:54.49ms
+step:1440/1845 train_time:78500ms step_avg:54.51ms
+step:1441/1845 train_time:78588ms step_avg:54.54ms
+step:1442/1845 train_time:78676ms step_avg:54.56ms
+step:1443/1845 train_time:78764ms step_avg:54.58ms
+step:1444/1845 train_time:78851ms step_avg:54.61ms
+step:1445/1845 train_time:78940ms step_avg:54.63ms
+step:1446/1845 train_time:79027ms step_avg:54.65ms
+step:1447/1845 train_time:79116ms step_avg:54.68ms
+step:1448/1845 train_time:79203ms step_avg:54.70ms
+step:1449/1845 train_time:79290ms step_avg:54.72ms
+step:1450/1845 train_time:79378ms step_avg:54.74ms
+step:1451/1845 train_time:79466ms step_avg:54.77ms
+step:1452/1845 train_time:79553ms step_avg:54.79ms
+step:1453/1845 train_time:79643ms step_avg:54.81ms
+step:1454/1845 train_time:79729ms step_avg:54.83ms
+step:1455/1845 train_time:79818ms step_avg:54.86ms
+step:1456/1845 train_time:79905ms step_avg:54.88ms
+step:1457/1845 train_time:79993ms step_avg:54.90ms
+step:1458/1845 train_time:80080ms step_avg:54.92ms
+step:1459/1845 train_time:80168ms step_avg:54.95ms
+step:1460/1845 train_time:80256ms step_avg:54.97ms
+step:1461/1845 train_time:80345ms step_avg:54.99ms
+step:1462/1845 train_time:80432ms step_avg:55.02ms
+step:1463/1845 train_time:80521ms step_avg:55.04ms
+step:1464/1845 train_time:80609ms step_avg:55.06ms
+step:1465/1845 train_time:80697ms step_avg:55.08ms
+step:1466/1845 train_time:80785ms step_avg:55.11ms
+step:1467/1845 train_time:80873ms step_avg:55.13ms
+step:1468/1845 train_time:80960ms step_avg:55.15ms
+step:1469/1845 train_time:81048ms step_avg:55.17ms
+step:1470/1845 train_time:81136ms step_avg:55.19ms
+step:1471/1845 train_time:81224ms step_avg:55.22ms
+step:1472/1845 train_time:81311ms step_avg:55.24ms
+step:1473/1845 train_time:81400ms step_avg:55.26ms
+step:1474/1845 train_time:81487ms step_avg:55.28ms
+step:1475/1845 train_time:81575ms step_avg:55.31ms
+step:1476/1845 train_time:81662ms step_avg:55.33ms
+step:1477/1845 train_time:81751ms step_avg:55.35ms
+step:1478/1845 train_time:81839ms step_avg:55.37ms
+step:1479/1845 train_time:81926ms step_avg:55.39ms
+step:1480/1845 train_time:82014ms step_avg:55.41ms
+step:1481/1845 train_time:82102ms step_avg:55.44ms
+step:1482/1845 train_time:82189ms step_avg:55.46ms
+step:1483/1845 train_time:82278ms step_avg:55.48ms
+step:1484/1845 train_time:82365ms step_avg:55.50ms
+step:1485/1845 train_time:82453ms step_avg:55.52ms
+step:1486/1845 train_time:82540ms step_avg:55.55ms
+step:1487/1845 train_time:82629ms step_avg:55.57ms
+step:1488/1845 train_time:82717ms step_avg:55.59ms
+step:1489/1845 train_time:82805ms step_avg:55.61ms
+step:1490/1845 train_time:82893ms step_avg:55.63ms
+step:1491/1845 train_time:82981ms step_avg:55.65ms
+step:1492/1845 train_time:83069ms step_avg:55.68ms
+step:1493/1845 train_time:83157ms step_avg:55.70ms
+step:1494/1845 train_time:83244ms step_avg:55.72ms
+step:1495/1845 train_time:83332ms step_avg:55.74ms
+step:1496/1845 train_time:83419ms step_avg:55.76ms
+step:1497/1845 train_time:83507ms step_avg:55.78ms
+step:1498/1845 train_time:83595ms step_avg:55.80ms
+step:1499/1845 train_time:83683ms step_avg:55.83ms
+step:1500/1845 train_time:83770ms step_avg:55.85ms
+step:1500/1845 val_loss:3.4038 train_time:83860ms step_avg:55.91ms
+step:1501/1845 train_time:83880ms step_avg:55.88ms
+step:1502/1845 train_time:83951ms step_avg:55.89ms
+step:1503/1845 train_time:84044ms step_avg:55.92ms
+step:1504/1845 train_time:84132ms step_avg:55.94ms
+step:1505/1845 train_time:84220ms step_avg:55.96ms
+step:1506/1845 train_time:84306ms step_avg:55.98ms
+step:1507/1845 train_time:84394ms step_avg:56.00ms
+step:1508/1845 train_time:84480ms step_avg:56.02ms
+step:1509/1845 train_time:84567ms step_avg:56.04ms
+step:1510/1845 train_time:84654ms step_avg:56.06ms
+step:1511/1845 train_time:84742ms step_avg:56.08ms
+step:1512/1845 train_time:84830ms step_avg:56.10ms
+step:1513/1845 train_time:84921ms step_avg:56.13ms
+step:1514/1845 train_time:85010ms step_avg:56.15ms
+step:1515/1845 train_time:85100ms step_avg:56.17ms
+step:1516/1845 train_time:85187ms step_avg:56.19ms
+step:1517/1845 train_time:85275ms step_avg:56.21ms
+step:1518/1845 train_time:85361ms step_avg:56.23ms
+step:1519/1845 train_time:85449ms step_avg:56.25ms
+step:1520/1845 train_time:85536ms step_avg:56.27ms
+step:1521/1845 train_time:85623ms step_avg:56.29ms
+step:1522/1845 train_time:85709ms step_avg:56.31ms
+step:1523/1845 train_time:85799ms step_avg:56.34ms
+step:1524/1845 train_time:85886ms step_avg:56.36ms
+step:1525/1845 train_time:85977ms step_avg:56.38ms
+step:1526/1845 train_time:86065ms step_avg:56.40ms
+step:1527/1845 train_time:86155ms step_avg:56.42ms
+step:1528/1845 train_time:86242ms step_avg:56.44ms
+step:1529/1845 train_time:86330ms step_avg:56.46ms
+step:1530/1845 train_time:86417ms step_avg:56.48ms
+step:1531/1845 train_time:86504ms step_avg:56.50ms
+step:1532/1845 train_time:86591ms step_avg:56.52ms
+step:1533/1845 train_time:86679ms step_avg:56.54ms
+step:1534/1845 train_time:86767ms step_avg:56.56ms
+step:1535/1845 train_time:86856ms step_avg:56.58ms
+step:1536/1845 train_time:86944ms step_avg:56.60ms
+step:1537/1845 train_time:87033ms step_avg:56.63ms
+step:1538/1845 train_time:87121ms step_avg:56.65ms
+step:1539/1845 train_time:87209ms step_avg:56.67ms
+step:1540/1845 train_time:87296ms step_avg:56.69ms
+step:1541/1845 train_time:87384ms step_avg:56.71ms
+step:1542/1845 train_time:87471ms step_avg:56.73ms
+step:1543/1845 train_time:87559ms step_avg:56.75ms
+step:1544/1845 train_time:87647ms step_avg:56.77ms
+step:1545/1845 train_time:87734ms step_avg:56.79ms
+step:1546/1845 train_time:87821ms step_avg:56.81ms
+step:1547/1845 train_time:87910ms step_avg:56.83ms
+step:1548/1845 train_time:87998ms step_avg:56.85ms
+step:1549/1845 train_time:88087ms step_avg:56.87ms
+step:1550/1845 train_time:88174ms step_avg:56.89ms
+step:1551/1845 train_time:88263ms step_avg:56.91ms
+step:1552/1845 train_time:88349ms step_avg:56.93ms
+step:1553/1845 train_time:88437ms step_avg:56.95ms
+step:1554/1845 train_time:88524ms step_avg:56.97ms
+step:1555/1845 train_time:88612ms step_avg:56.99ms
+step:1556/1845 train_time:88699ms step_avg:57.00ms
+step:1557/1845 train_time:88787ms step_avg:57.02ms
+step:1558/1845 train_time:88876ms step_avg:57.04ms
+step:1559/1845 train_time:88965ms step_avg:57.07ms
+step:1560/1845 train_time:89053ms step_avg:57.09ms
+step:1561/1845 train_time:89142ms step_avg:57.11ms
+step:1562/1845 train_time:89229ms step_avg:57.13ms
+step:1563/1845 train_time:89317ms step_avg:57.14ms
+step:1564/1845 train_time:89404ms step_avg:57.16ms
+step:1565/1845 train_time:89491ms step_avg:57.18ms
+step:1566/1845 train_time:89579ms step_avg:57.20ms
+step:1567/1845 train_time:89667ms step_avg:57.22ms
+step:1568/1845 train_time:89754ms step_avg:57.24ms
+step:1569/1845 train_time:89843ms step_avg:57.26ms
+step:1570/1845 train_time:89931ms step_avg:57.28ms
+step:1571/1845 train_time:90019ms step_avg:57.30ms
+step:1572/1845 train_time:90106ms step_avg:57.32ms
+step:1573/1845 train_time:90194ms step_avg:57.34ms
+step:1574/1845 train_time:90281ms step_avg:57.36ms
+step:1575/1845 train_time:90370ms step_avg:57.38ms
+step:1576/1845 train_time:90458ms step_avg:57.40ms
+step:1577/1845 train_time:90546ms step_avg:57.42ms
+step:1578/1845 train_time:90633ms step_avg:57.44ms
+step:1579/1845 train_time:90722ms step_avg:57.46ms
+step:1580/1845 train_time:90809ms step_avg:57.47ms
+step:1581/1845 train_time:90897ms step_avg:57.49ms
+step:1582/1845 train_time:90985ms step_avg:57.51ms
+step:1583/1845 train_time:91073ms step_avg:57.53ms
+step:1584/1845 train_time:91160ms step_avg:57.55ms
+step:1585/1845 train_time:91248ms step_avg:57.57ms
+step:1586/1845 train_time:91337ms step_avg:57.59ms
+step:1587/1845 train_time:91426ms step_avg:57.61ms
+step:1588/1845 train_time:91512ms step_avg:57.63ms
+step:1589/1845 train_time:91601ms step_avg:57.65ms
+step:1590/1845 train_time:91689ms step_avg:57.67ms
+step:1591/1845 train_time:91778ms step_avg:57.69ms
+step:1592/1845 train_time:91865ms step_avg:57.70ms
+step:1593/1845 train_time:91953ms step_avg:57.72ms
+step:1594/1845 train_time:92040ms step_avg:57.74ms
+step:1595/1845 train_time:92128ms step_avg:57.76ms
+step:1596/1845 train_time:92215ms step_avg:57.78ms
+step:1597/1845 train_time:92304ms step_avg:57.80ms
+step:1598/1845 train_time:92391ms step_avg:57.82ms
+step:1599/1845 train_time:92480ms step_avg:57.84ms
+step:1600/1845 train_time:92567ms step_avg:57.85ms
+step:1601/1845 train_time:92655ms step_avg:57.87ms
+step:1602/1845 train_time:92743ms step_avg:57.89ms
+step:1603/1845 train_time:92831ms step_avg:57.91ms
+step:1604/1845 train_time:92918ms step_avg:57.93ms
+step:1605/1845 train_time:93007ms step_avg:57.95ms
+step:1606/1845 train_time:93094ms step_avg:57.97ms
+step:1607/1845 train_time:93183ms step_avg:57.99ms
+step:1608/1845 train_time:93270ms step_avg:58.00ms
+step:1609/1845 train_time:93360ms step_avg:58.02ms
+step:1610/1845 train_time:93447ms step_avg:58.04ms
+step:1611/1845 train_time:93536ms step_avg:58.06ms
+step:1612/1845 train_time:93623ms step_avg:58.08ms
+step:1613/1845 train_time:93711ms step_avg:58.10ms
+step:1614/1845 train_time:93799ms step_avg:58.12ms
+step:1615/1845 train_time:93887ms step_avg:58.13ms
+step:1616/1845 train_time:93975ms step_avg:58.15ms
+step:1617/1845 train_time:94063ms step_avg:58.17ms
+step:1618/1845 train_time:94150ms step_avg:58.19ms
+step:1619/1845 train_time:94239ms step_avg:58.21ms
+step:1620/1845 train_time:94326ms step_avg:58.23ms
+step:1621/1845 train_time:94416ms step_avg:58.25ms
+step:1622/1845 train_time:94503ms step_avg:58.26ms
+step:1623/1845 train_time:94591ms step_avg:58.28ms
+step:1624/1845 train_time:94679ms step_avg:58.30ms
+step:1625/1845 train_time:94767ms step_avg:58.32ms
+step:1626/1845 train_time:94854ms step_avg:58.34ms
+step:1627/1845 train_time:94943ms step_avg:58.35ms
+step:1628/1845 train_time:95031ms step_avg:58.37ms
+step:1629/1845 train_time:95118ms step_avg:58.39ms
+step:1630/1845 train_time:95206ms step_avg:58.41ms
+step:1631/1845 train_time:95294ms step_avg:58.43ms
+step:1632/1845 train_time:95381ms step_avg:58.44ms
+step:1633/1845 train_time:95470ms step_avg:58.46ms
+step:1634/1845 train_time:95558ms step_avg:58.48ms
+step:1635/1845 train_time:95646ms step_avg:58.50ms
+step:1636/1845 train_time:95733ms step_avg:58.52ms
+step:1637/1845 train_time:95821ms step_avg:58.53ms
+step:1638/1845 train_time:95908ms step_avg:58.55ms
+step:1639/1845 train_time:95996ms step_avg:58.57ms
+step:1640/1845 train_time:96083ms step_avg:58.59ms
+step:1641/1845 train_time:96172ms step_avg:58.61ms
+step:1642/1845 train_time:96259ms step_avg:58.62ms
+step:1643/1845 train_time:96347ms step_avg:58.64ms
+step:1644/1845 train_time:96435ms step_avg:58.66ms
+step:1645/1845 train_time:96523ms step_avg:58.68ms
+step:1646/1845 train_time:96611ms step_avg:58.69ms
+step:1647/1845 train_time:96700ms step_avg:58.71ms
+step:1648/1845 train_time:96786ms step_avg:58.73ms
+step:1649/1845 train_time:96875ms step_avg:58.75ms
+step:1650/1845 train_time:96962ms step_avg:58.77ms
+step:1651/1845 train_time:97051ms step_avg:58.78ms
+step:1652/1845 train_time:97140ms step_avg:58.80ms
+step:1653/1845 train_time:97227ms step_avg:58.82ms
+step:1654/1845 train_time:97315ms step_avg:58.84ms
+step:1655/1845 train_time:97402ms step_avg:58.85ms
+step:1656/1845 train_time:97488ms step_avg:58.87ms
+step:1657/1845 train_time:97578ms step_avg:58.89ms
+step:1658/1845 train_time:97665ms step_avg:58.91ms
+step:1659/1845 train_time:97754ms step_avg:58.92ms
+step:1660/1845 train_time:97841ms step_avg:58.94ms
+step:1661/1845 train_time:97929ms step_avg:58.96ms
+step:1662/1845 train_time:98017ms step_avg:58.98ms
+step:1663/1845 train_time:98106ms step_avg:58.99ms
+step:1664/1845 train_time:98193ms step_avg:59.01ms
+step:1665/1845 train_time:98282ms step_avg:59.03ms
+step:1666/1845 train_time:98369ms step_avg:59.04ms
+step:1667/1845 train_time:98458ms step_avg:59.06ms
+step:1668/1845 train_time:98545ms step_avg:59.08ms
+step:1669/1845 train_time:98633ms step_avg:59.10ms
+step:1670/1845 train_time:98720ms step_avg:59.11ms
+step:1671/1845 train_time:98808ms step_avg:59.13ms
+step:1672/1845 train_time:98895ms step_avg:59.15ms
+step:1673/1845 train_time:98984ms step_avg:59.17ms
+step:1674/1845 train_time:99072ms step_avg:59.18ms
+step:1675/1845 train_time:99160ms step_avg:59.20ms
+step:1676/1845 train_time:99247ms step_avg:59.22ms
+step:1677/1845 train_time:99335ms step_avg:59.23ms
+step:1678/1845 train_time:99423ms step_avg:59.25ms
+step:1679/1845 train_time:99512ms step_avg:59.27ms
+step:1680/1845 train_time:99600ms step_avg:59.29ms
+step:1681/1845 train_time:99688ms step_avg:59.30ms
+step:1682/1845 train_time:99776ms step_avg:59.32ms
+step:1683/1845 train_time:99865ms step_avg:59.34ms
+step:1684/1845 train_time:99952ms step_avg:59.35ms
+step:1685/1845 train_time:100041ms step_avg:59.37ms
+step:1686/1845 train_time:100129ms step_avg:59.39ms
+step:1687/1845 train_time:100217ms step_avg:59.41ms
+step:1688/1845 train_time:100305ms step_avg:59.42ms
+step:1689/1845 train_time:100394ms step_avg:59.44ms
+step:1690/1845 train_time:100482ms step_avg:59.46ms
+step:1691/1845 train_time:100570ms step_avg:59.47ms
+step:1692/1845 train_time:100657ms step_avg:59.49ms
+step:1693/1845 train_time:100745ms step_avg:59.51ms
+step:1694/1845 train_time:100833ms step_avg:59.52ms
+step:1695/1845 train_time:100921ms step_avg:59.54ms
+step:1696/1845 train_time:101008ms step_avg:59.56ms
+step:1697/1845 train_time:101098ms step_avg:59.57ms
+step:1698/1845 train_time:101185ms step_avg:59.59ms
+step:1699/1845 train_time:101274ms step_avg:59.61ms
+step:1700/1845 train_time:101361ms step_avg:59.62ms
+step:1701/1845 train_time:101449ms step_avg:59.64ms
+step:1702/1845 train_time:101536ms step_avg:59.66ms
+step:1703/1845 train_time:101624ms step_avg:59.67ms
+step:1704/1845 train_time:101712ms step_avg:59.69ms
+step:1705/1845 train_time:101800ms step_avg:59.71ms
+step:1706/1845 train_time:101887ms step_avg:59.72ms
+step:1707/1845 train_time:101975ms step_avg:59.74ms
+step:1708/1845 train_time:102063ms step_avg:59.76ms
+step:1709/1845 train_time:102151ms step_avg:59.77ms
+step:1710/1845 train_time:102239ms step_avg:59.79ms
+step:1711/1845 train_time:102327ms step_avg:59.81ms
+step:1712/1845 train_time:102415ms step_avg:59.82ms
+step:1713/1845 train_time:102502ms step_avg:59.84ms
+step:1714/1845 train_time:102590ms step_avg:59.85ms
+step:1715/1845 train_time:102679ms step_avg:59.87ms
+step:1716/1845 train_time:102766ms step_avg:59.89ms
+step:1717/1845 train_time:102854ms step_avg:59.90ms
+step:1718/1845 train_time:102942ms step_avg:59.92ms
+step:1719/1845 train_time:103030ms step_avg:59.94ms
+step:1720/1845 train_time:103118ms step_avg:59.95ms
+step:1721/1845 train_time:103206ms step_avg:59.97ms
+step:1722/1845 train_time:103293ms step_avg:59.98ms
+step:1723/1845 train_time:103383ms step_avg:60.00ms
+step:1724/1845 train_time:103471ms step_avg:60.02ms
+step:1725/1845 train_time:103558ms step_avg:60.03ms
+step:1726/1845 train_time:103645ms step_avg:60.05ms
+step:1727/1845 train_time:103734ms step_avg:60.07ms
+step:1728/1845 train_time:103821ms step_avg:60.08ms
+step:1729/1845 train_time:103910ms step_avg:60.10ms
+step:1730/1845 train_time:103997ms step_avg:60.11ms
+step:1731/1845 train_time:104086ms step_avg:60.13ms
+step:1732/1845 train_time:104172ms step_avg:60.15ms
+step:1733/1845 train_time:104261ms step_avg:60.16ms
+step:1734/1845 train_time:104348ms step_avg:60.18ms
+step:1735/1845 train_time:104437ms step_avg:60.19ms
+step:1736/1845 train_time:104523ms step_avg:60.21ms
+step:1737/1845 train_time:104612ms step_avg:60.23ms
+step:1738/1845 train_time:104699ms step_avg:60.24ms
+step:1739/1845 train_time:104787ms step_avg:60.26ms
+step:1740/1845 train_time:104875ms step_avg:60.27ms
+step:1741/1845 train_time:104964ms step_avg:60.29ms
+step:1742/1845 train_time:105052ms step_avg:60.31ms
+step:1743/1845 train_time:105141ms step_avg:60.32ms
+step:1744/1845 train_time:105227ms step_avg:60.34ms
+step:1745/1845 train_time:105316ms step_avg:60.35ms
+step:1746/1845 train_time:105403ms step_avg:60.37ms
+step:1747/1845 train_time:105491ms step_avg:60.38ms
+step:1748/1845 train_time:105580ms step_avg:60.40ms
+step:1749/1845 train_time:105668ms step_avg:60.42ms
+step:1750/1845 train_time:105755ms step_avg:60.43ms
+step:1750/1845 val_loss:3.3048 train_time:105845ms step_avg:60.48ms
+step:1751/1845 train_time:105865ms step_avg:60.46ms
+step:1752/1845 train_time:105935ms step_avg:60.46ms
+step:1753/1845 train_time:106027ms step_avg:60.48ms
+step:1754/1845 train_time:106115ms step_avg:60.50ms
+step:1755/1845 train_time:106203ms step_avg:60.51ms
+step:1756/1845 train_time:106290ms step_avg:60.53ms
+step:1757/1845 train_time:106378ms step_avg:60.55ms
+step:1758/1845 train_time:106464ms step_avg:60.56ms
+step:1759/1845 train_time:106553ms step_avg:60.58ms
+step:1760/1845 train_time:106640ms step_avg:60.59ms
+step:1761/1845 train_time:106728ms step_avg:60.61ms
+step:1762/1845 train_time:106816ms step_avg:60.62ms
+step:1763/1845 train_time:106906ms step_avg:60.64ms
+step:1764/1845 train_time:106996ms step_avg:60.66ms
+step:1765/1845 train_time:107084ms step_avg:60.67ms
+step:1766/1845 train_time:107173ms step_avg:60.69ms
+step:1767/1845 train_time:107261ms step_avg:60.70ms
+step:1768/1845 train_time:107347ms step_avg:60.72ms
+step:1769/1845 train_time:107435ms step_avg:60.73ms
+step:1770/1845 train_time:107522ms step_avg:60.75ms
+step:1771/1845 train_time:107609ms step_avg:60.76ms
+step:1772/1845 train_time:107696ms step_avg:60.78ms
+step:1773/1845 train_time:107784ms step_avg:60.79ms
+step:1774/1845 train_time:107873ms step_avg:60.81ms
+step:1775/1845 train_time:107962ms step_avg:60.82ms
+step:1776/1845 train_time:108051ms step_avg:60.84ms
+step:1777/1845 train_time:108140ms step_avg:60.86ms
+step:1778/1845 train_time:108227ms step_avg:60.87ms
+step:1779/1845 train_time:108315ms step_avg:60.89ms
+step:1780/1845 train_time:108401ms step_avg:60.90ms
+step:1781/1845 train_time:108490ms step_avg:60.92ms
+step:1782/1845 train_time:108578ms step_avg:60.93ms
+step:1783/1845 train_time:108666ms step_avg:60.95ms
+step:1784/1845 train_time:108753ms step_avg:60.96ms
+step:1785/1845 train_time:108843ms step_avg:60.98ms
+step:1786/1845 train_time:108931ms step_avg:60.99ms
+step:1787/1845 train_time:109020ms step_avg:61.01ms
+step:1788/1845 train_time:109108ms step_avg:61.02ms
+step:1789/1845 train_time:109197ms step_avg:61.04ms
+step:1790/1845 train_time:109285ms step_avg:61.05ms
+step:1791/1845 train_time:109372ms step_avg:61.07ms
+step:1792/1845 train_time:109459ms step_avg:61.08ms
+step:1793/1845 train_time:109547ms step_avg:61.10ms
+step:1794/1845 train_time:109634ms step_avg:61.11ms
+step:1795/1845 train_time:109723ms step_avg:61.13ms
+step:1796/1845 train_time:109811ms step_avg:61.14ms
+step:1797/1845 train_time:109900ms step_avg:61.16ms
+step:1798/1845 train_time:109988ms step_avg:61.17ms
+step:1799/1845 train_time:110077ms step_avg:61.19ms
+step:1800/1845 train_time:110164ms step_avg:61.20ms
+step:1801/1845 train_time:110253ms step_avg:61.22ms
+step:1802/1845 train_time:110341ms step_avg:61.23ms
+step:1803/1845 train_time:110429ms step_avg:61.25ms
+step:1804/1845 train_time:110517ms step_avg:61.26ms
+step:1805/1845 train_time:110605ms step_avg:61.28ms
+step:1806/1845 train_time:110693ms step_avg:61.29ms
+step:1807/1845 train_time:110783ms step_avg:61.31ms
+step:1808/1845 train_time:110870ms step_avg:61.32ms
+step:1809/1845 train_time:110960ms step_avg:61.34ms
+step:1810/1845 train_time:111048ms step_avg:61.35ms
+step:1811/1845 train_time:111137ms step_avg:61.37ms
+step:1812/1845 train_time:111224ms step_avg:61.38ms
+step:1813/1845 train_time:111313ms step_avg:61.40ms
+step:1814/1845 train_time:111400ms step_avg:61.41ms
+step:1815/1845 train_time:111488ms step_avg:61.43ms
+step:1816/1845 train_time:111576ms step_avg:61.44ms
+step:1817/1845 train_time:111664ms step_avg:61.46ms
+step:1818/1845 train_time:111752ms step_avg:61.47ms
+step:1819/1845 train_time:111841ms step_avg:61.48ms
+step:1820/1845 train_time:111927ms step_avg:61.50ms
+step:1821/1845 train_time:112016ms step_avg:61.51ms
+step:1822/1845 train_time:112104ms step_avg:61.53ms
+step:1823/1845 train_time:112193ms step_avg:61.54ms
+step:1824/1845 train_time:112280ms step_avg:61.56ms
+step:1825/1845 train_time:112369ms step_avg:61.57ms
+step:1826/1845 train_time:112456ms step_avg:61.59ms
+step:1827/1845 train_time:112544ms step_avg:61.60ms
+step:1828/1845 train_time:112632ms step_avg:61.61ms
+step:1829/1845 train_time:112721ms step_avg:61.63ms
+step:1830/1845 train_time:112809ms step_avg:61.64ms
+step:1831/1845 train_time:112897ms step_avg:61.66ms
+step:1832/1845 train_time:112984ms step_avg:61.67ms
+step:1833/1845 train_time:113073ms step_avg:61.69ms
+step:1834/1845 train_time:113160ms step_avg:61.70ms
+step:1835/1845 train_time:113249ms step_avg:61.72ms
+step:1836/1845 train_time:113337ms step_avg:61.73ms
+step:1837/1845 train_time:113425ms step_avg:61.74ms
+step:1838/1845 train_time:113512ms step_avg:61.76ms
+step:1839/1845 train_time:113602ms step_avg:61.77ms
+step:1840/1845 train_time:113690ms step_avg:61.79ms
+step:1841/1845 train_time:113779ms step_avg:61.80ms
+step:1842/1845 train_time:113866ms step_avg:61.82ms
+step:1843/1845 train_time:113956ms step_avg:61.83ms
+step:1844/1845 train_time:114043ms step_avg:61.85ms
+step:1845/1845 train_time:114132ms step_avg:61.86ms
+step:1845/1845 val_loss:3.2784 train_time:114220ms step_avg:61.91ms
+peak memory allocated: 29405 MiB reserved: 44398 MiB


### PR DESCRIPTION
Updates in PR:
* Add gates to value embeds, using same structure as attention gates (first 12 dims of residual stream)
* Add gate to skip connection, using same structure as smear gate
* Update w_s from 1.5/448 to 1.6/448
* Add wd_mul 5 to value embeds, wd_mul 150x to embed and lm_head.
* Drop 35 steps

When I tested re-adding the frozen scalars for 40 steps (that got removed last PR) I got worse loss, so I kept it off for now. Maybe worthwhile to re-add for just the first window transition, not sure. The biggest change here is the value_embed gates. Loss is around 3.2830 without them. The skip_gate is pretty marginal, but it only costs ~300ms to add and seems to slightly pay for itself. I haven't heavily ablated the weight decay parameters, there's a chance one of those is actually detrimental. At some point we should update the notation of how weight decay is calculated to be lr/init_lr * lr instead of lr^2. lr^2 is making the wd_mul rather unintuitive.

I also tested adding gates for the x0 contributions but saw no improvement and higher runtime.

Motivation for w_s change was I started seeing very high variance results at some point during testing and recalled that the fp8_scales was how variance was previously resolved. Recent changes have increased the lm_head weights by roughly 10%, which aligns with the 1.5 -> 1.6 increase of w_s.

<img width="452" height="361" alt="image" src="https://github.com/user-attachments/assets/1b80e602-bfb1-47d2-9086-d53a58c033f6" />

(notation in graph: old=record back with prior tuned fp8 scales, baseline=this PR. only plotting odd steps so step count is halved)

## Timing and Validation
```
import scipy.stats
import torch

losses = [3.279, 3.2795, 3.2774, 3.2779, 3.2784, 3.2792, 3.28]
times = [114.508, 114.464, 114.373, 114.343, 114.22, 114.401, 114.369]

print("p=%.4f" % scipy.stats.ttest_1samp(losses, 3.28, alternative="less").pvalue)
# p=0.0061

print("losses:", torch.std_mean(torch.tensor(losses)))
# losses: (tensor(0.0009), tensor(3.2788))

print("time:", torch.std_mean(torch.tensor(times)))
# time: (tensor(0.0922), tensor(114.3826))
```

retiming prior record (faster machine this time): 115.686 [115.669, 115.717, 115.674]

If no changes, will merge at 115.1s to be consistent with 1.3s improvement.

I tried a large number of variants of gradient clipping and some custom ones, nothing I tested showed an improvement. I also tried a custom relu where non active neurons simulate the gradient as if they were at 0.01, performed much worse. Also tried a version of attention where the keys retrieve value deltas instead of values, performed worse.