### PR TITLE
New Record: Mixed Precision Interweaved Optimizer (-1.0s)

### DIFF
--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/41f606b6-1b9c-46a3-b46e-2beff1521d18.txt
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/41f606b6-1b9c-46a3-b46e-2beff1521d18.txt
@@ -1,0 +1,3786 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+    """
+    Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+    Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+    bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+    float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+    """
+    assert p.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    wd_factor = wd_tensor.to(torch.float32)
+    lr_factor = lr_tensor.to(torch.float32)
+    p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    p_precise = p_precise_raw.view(torch.float32)
+    mask = (grad * p_precise) >= 0
+    p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+    p.copy_((p_precise_raw >> 16).to(torch.uint16))
+    mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        2. reduce scatter attn/mlp round 2 (16 mlp params)
+        3. wait on step 1, then compute update of 1 and schedule all gather
+        4. wait on step 2, then compute update of 2 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        5. wait for each all gather to complete and update params
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["mantissa"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn', 'mlp']
+        group_sizes = [16, 16]  # 10 attn + 6 mlp, then 16 mlp
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    def step(self):
+        self.step_p1()
+        self.step_p2()
+        self.step_p3()
+        
+    @torch.no_grad()
+    def step_p1(self):
+        """
+        Part 1: Launch distributed reduce_scatter operations for parameter groups.
+        """
+        rank = dist.get_rank()
+        self.group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            self.group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+    
+    @torch.no_grad()
+    def step_p2(self):
+        """
+        Part 2: Compute gradient updates and launch all_gather operations
+        Wait for all gather to complete for all parameter groups except final one
+        """
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = self.group_infos
+        
+        self.all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"].float()
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params], dtype=torch.float32)
+                
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            if "second_momentum_buffer" not in group:
+                group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1], dtype=torch.float32)
+                    if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if param_shape[-2] >= param_shape[-1] else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk, dtype=torch.bfloat16)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                if "mantissa" not in group:
+                    group["mantissa"] = torch.zeros_like(param_chunk, dtype=torch.uint16)
+                mantissa = group["mantissa"]
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx].view(torch.uint16),
+                        mantissa[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx]
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            self.all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete for all except final and copy results back into original parameter tensors.
+        for info in self.all_gather_infos[:-1]:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+    @torch.no_grad()
+    def step_p3(self):
+        """
+        Part 3: Wait for final all gather to complete and copy results back into original parameter tensors
+        """
+        info = self.all_gather_infos[-1]
+        info["gather_future"].wait()
+        stacked_params = info["stacked_params"]
+        orig_params = info["orig_params"]
+
+        unstacked_params = torch.unbind(stacked_params)
+        for i, p in enumerate(orig_params):
+            p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str], betas: list[list[float]], lr: float = 1e-3, eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for idx, label in enumerate(label_order):
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label], betas=betas[idx]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+        # tag the final param for optimizer pipelining, run all gather after muon copy
+        param_groups[-1]['params'][-1].is_final_param = True
+        
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        # 0-D CPU tensors to avoid recompilation in _update_step
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    def load_state_dict(self, state_dict):
+        """Override to preserve optimizer state dtypes (avoid BFloat16->Float32 cast that causes recompilation)."""
+        # Save original state dtypes before loading
+        original_dtypes = {}
+        for p, s in self.state.items():
+            original_dtypes[p] = {k: v.dtype for k, v in s.items() if isinstance(v, torch.Tensor)}
+        
+        # Call parent load_state_dict (which may cast dtypes to match param dtype)
+        super().load_state_dict(state_dict)
+        
+        # Restore original dtypes
+        for p, s in self.state.items():
+            if p in original_dtypes:
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor) and k in original_dtypes[p]:
+                        if v.dtype != original_dtypes[p][k]:
+                            s[k] = v.to(original_dtypes[p][k])
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-2]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step. step_size_t and eff_wd_t are 0-D CPU tensors to avoid recompilation."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)  # exp_avg = beta1 * exp_avg + (1 - beta1) * g_slice
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)  # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * g_slice^2
+        # compute step
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)  # update = (exp_avg / (sqrt(exp_avg_sq) + eps)) * step_size
+        # cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)  # update += eff_wd_t * p_slice * mask
+        p_slice.add_(other=update, alpha=-1.0)  # p_slice -= update
+
+    @torch.no_grad()
+    def step(self, muon_opt):
+        muon_opt.step_p1()
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        last_param = None
+        last_p_slice = None
+        for group in self.param_groups:      
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+                state["step"] += 1
+                t = state["step"]
+                
+                # Pre-compute changing values as 0-D CPU tensors to avoid recompilation.
+                # `.fill_(value)` is the same as "= value", but doesn't change the tensor object.
+                bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+                self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+                self._eff_wd_t.fill_(lr * lr * wd * getattr(param, "wd_mul", 1.0)) # `lr` included twice to serve as weight decay schedule.
+
+                DistAdam._update_step(p_slice, g_slice, state["exp_avg"], state["exp_avg_sq"],
+                                      beta1, beta2, eps, self._step_size_t, self._eff_wd_t)
+
+                if not is_small:
+                    if getattr(param, "is_final_param", False):
+                        last_param = param
+                        last_p_slice = p_slice
+                    else:
+                        all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+        self._reduce_scatter_futures.clear()
+
+        muon_opt.step_p2()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+        if last_param is not None:
+            last_all_gather_future = dist.all_gather_into_tensor(last_param, last_p_slice, async_op=True).get_future()
+        muon_opt.step_p3()
+        torch.futures.collect_all([last_all_gather_future]).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        adam_betas = {
+            'lm_head': [0.5, 0.95],
+            'smear_gate': [0.9, 0.99],
+            'attn_gate_bank': [0.9, 0.99],
+            've_gate_bank': [0.9, 0.99],
+            'skip_gate': [0.9, 0.99],
+            'x0_lambdas': [0.65, 0.95],
+            'scalars': [0.9, 0.99],
+            'embed': [0.5, 0.95],
+            'value_embed': [0.75, 0.95]
+        }
+        adam_labels = list(adam_betas.keys())
+        adam_beta_values = list(adam_betas.values())
+        muon_labels = ['attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, adam_beta_values, lr=0.008, eps=1e-10, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.muon_opt]
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * step_lr
+                
+        if self._is_active_step(self.adam_opt, step):
+            # adam will interleave calls to muon step
+            self.adam_opt.step(self.muon_opt)
+            self.model.zero_grad(set_to_none=True)
+            self.adam_opt.should_sync = False
+        else:
+            self.muon_opt.step()
+            self.muon_opt.zero_grad(set_to_none=True)
+            
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1800  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan  5 08:13:53 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   42C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   34C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   43C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     60352      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     60353      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     60354      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     60355      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     60356      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     60357      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     60358      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     60359      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 599, 600, 601, 1199, 1200, 1201, 1799, 1800, 1801] for warmup
+Resetting Model
+step:0/1840 val_loss:10.8289 train_time:0ms step_avg:0.04ms
+step:1/1840 train_time:62ms step_avg:61.72ms
+step:2/1840 train_time:84ms step_avg:41.99ms
+step:3/1840 train_time:104ms step_avg:34.56ms
+step:4/1840 train_time:138ms step_avg:34.40ms
+step:5/1840 train_time:169ms step_avg:33.89ms
+step:6/1840 train_time:246ms step_avg:41.08ms
+step:7/1840 train_time:264ms step_avg:37.64ms
+step:8/1840 train_time:298ms step_avg:37.23ms
+step:9/1840 train_time:330ms step_avg:36.64ms
+step:10/1840 train_time:364ms step_avg:36.36ms
+step:11/1840 train_time:396ms step_avg:35.98ms
+step:12/1840 train_time:430ms step_avg:35.83ms
+step:13/1840 train_time:462ms step_avg:35.53ms
+step:14/1840 train_time:496ms step_avg:35.42ms
+step:15/1840 train_time:528ms step_avg:35.20ms
+step:16/1840 train_time:562ms step_avg:35.13ms
+step:17/1840 train_time:594ms step_avg:34.95ms
+step:18/1840 train_time:628ms step_avg:34.91ms
+step:19/1840 train_time:660ms step_avg:34.75ms
+step:20/1840 train_time:694ms step_avg:34.72ms
+step:21/1840 train_time:727ms step_avg:34.60ms
+step:22/1840 train_time:761ms step_avg:34.57ms
+step:23/1840 train_time:793ms step_avg:34.46ms
+step:24/1840 train_time:827ms step_avg:34.44ms
+step:25/1840 train_time:859ms step_avg:34.34ms
+step:26/1840 train_time:893ms step_avg:34.34ms
+step:27/1840 train_time:925ms step_avg:34.26ms
+step:28/1840 train_time:959ms step_avg:34.25ms
+step:29/1840 train_time:991ms step_avg:34.17ms
+step:30/1840 train_time:1025ms step_avg:34.17ms
+step:31/1840 train_time:1057ms step_avg:34.10ms
+step:32/1840 train_time:1091ms step_avg:34.11ms
+step:33/1840 train_time:1123ms step_avg:34.04ms
+step:34/1840 train_time:1158ms step_avg:34.06ms
+step:35/1840 train_time:1191ms step_avg:34.03ms
+step:36/1840 train_time:1226ms step_avg:34.06ms
+step:37/1840 train_time:1259ms step_avg:34.02ms
+step:38/1840 train_time:1293ms step_avg:34.03ms
+step:39/1840 train_time:1325ms step_avg:33.98ms
+step:40/1840 train_time:1360ms step_avg:34.00ms
+step:41/1840 train_time:1392ms step_avg:33.96ms
+step:42/1840 train_time:1427ms step_avg:33.97ms
+step:43/1840 train_time:1459ms step_avg:33.93ms
+step:44/1840 train_time:1493ms step_avg:33.94ms
+step:45/1840 train_time:1525ms step_avg:33.89ms
+step:46/1840 train_time:1559ms step_avg:33.89ms
+step:47/1840 train_time:1591ms step_avg:33.86ms
+step:48/1840 train_time:1626ms step_avg:33.87ms
+step:49/1840 train_time:1658ms step_avg:33.83ms
+step:50/1840 train_time:1692ms step_avg:33.84ms
+step:51/1840 train_time:1724ms step_avg:33.81ms
+step:52/1840 train_time:1758ms step_avg:33.82ms
+step:53/1840 train_time:1791ms step_avg:33.78ms
+step:54/1840 train_time:1825ms step_avg:33.79ms
+step:55/1840 train_time:1857ms step_avg:33.76ms
+step:56/1840 train_time:1891ms step_avg:33.76ms
+step:57/1840 train_time:1923ms step_avg:33.73ms
+step:58/1840 train_time:1957ms step_avg:33.74ms
+step:59/1840 train_time:1989ms step_avg:33.71ms
+step:60/1840 train_time:2023ms step_avg:33.72ms
+step:61/1840 train_time:2055ms step_avg:33.69ms
+step:62/1840 train_time:2089ms step_avg:33.70ms
+step:63/1840 train_time:2121ms step_avg:33.67ms
+step:64/1840 train_time:2156ms step_avg:33.68ms
+step:65/1840 train_time:2188ms step_avg:33.67ms
+step:66/1840 train_time:2223ms step_avg:33.68ms
+step:67/1840 train_time:2255ms step_avg:33.66ms
+step:68/1840 train_time:2290ms step_avg:33.67ms
+step:69/1840 train_time:2322ms step_avg:33.65ms
+step:70/1840 train_time:2357ms step_avg:33.67ms
+step:71/1840 train_time:2389ms step_avg:33.65ms
+step:72/1840 train_time:2423ms step_avg:33.66ms
+step:73/1840 train_time:2456ms step_avg:33.64ms
+step:74/1840 train_time:2490ms step_avg:33.65ms
+step:75/1840 train_time:2522ms step_avg:33.63ms
+step:76/1840 train_time:2557ms step_avg:33.64ms
+step:77/1840 train_time:2589ms step_avg:33.62ms
+step:78/1840 train_time:2623ms step_avg:33.63ms
+step:79/1840 train_time:2655ms step_avg:33.61ms
+step:80/1840 train_time:2690ms step_avg:33.62ms
+step:81/1840 train_time:2722ms step_avg:33.60ms
+step:82/1840 train_time:2756ms step_avg:33.61ms
+step:83/1840 train_time:2788ms step_avg:33.59ms
+step:84/1840 train_time:2823ms step_avg:33.60ms
+step:85/1840 train_time:2854ms step_avg:33.58ms
+step:86/1840 train_time:2888ms step_avg:33.59ms
+step:87/1840 train_time:2920ms step_avg:33.57ms
+step:88/1840 train_time:2955ms step_avg:33.58ms
+step:89/1840 train_time:2987ms step_avg:33.56ms
+step:90/1840 train_time:3021ms step_avg:33.56ms
+step:91/1840 train_time:3053ms step_avg:33.55ms
+step:92/1840 train_time:3087ms step_avg:33.55ms
+step:93/1840 train_time:3119ms step_avg:33.54ms
+step:94/1840 train_time:3153ms step_avg:33.55ms
+step:95/1840 train_time:3185ms step_avg:33.53ms
+step:96/1840 train_time:3220ms step_avg:33.54ms
+step:97/1840 train_time:3251ms step_avg:33.52ms
+step:98/1840 train_time:3286ms step_avg:33.53ms
+step:99/1840 train_time:3318ms step_avg:33.52ms
+step:100/1840 train_time:3354ms step_avg:33.54ms
+step:101/1840 train_time:3385ms step_avg:33.51ms
+step:102/1840 train_time:3419ms step_avg:33.52ms
+step:103/1840 train_time:3451ms step_avg:33.50ms
+step:104/1840 train_time:3485ms step_avg:33.51ms
+step:105/1840 train_time:3517ms step_avg:33.50ms
+step:106/1840 train_time:3551ms step_avg:33.50ms
+step:107/1840 train_time:3583ms step_avg:33.49ms
+step:108/1840 train_time:3618ms step_avg:33.50ms
+step:109/1840 train_time:3650ms step_avg:33.49ms
+step:110/1840 train_time:3684ms step_avg:33.49ms
+step:111/1840 train_time:3717ms step_avg:33.48ms
+step:112/1840 train_time:3751ms step_avg:33.49ms
+step:113/1840 train_time:3783ms step_avg:33.47ms
+step:114/1840 train_time:3817ms step_avg:33.48ms
+step:115/1840 train_time:3849ms step_avg:33.47ms
+step:116/1840 train_time:3883ms step_avg:33.48ms
+step:117/1840 train_time:3916ms step_avg:33.47ms
+step:118/1840 train_time:3950ms step_avg:33.47ms
+step:119/1840 train_time:3982ms step_avg:33.46ms
+step:120/1840 train_time:4016ms step_avg:33.47ms
+step:121/1840 train_time:4048ms step_avg:33.46ms
+step:122/1840 train_time:4083ms step_avg:33.46ms
+step:123/1840 train_time:4115ms step_avg:33.45ms
+step:124/1840 train_time:4149ms step_avg:33.46ms
+step:125/1840 train_time:4181ms step_avg:33.45ms
+step:126/1840 train_time:4215ms step_avg:33.46ms
+step:127/1840 train_time:4248ms step_avg:33.45ms
+step:128/1840 train_time:4282ms step_avg:33.45ms
+step:129/1840 train_time:4314ms step_avg:33.44ms
+step:130/1840 train_time:4348ms step_avg:33.45ms
+step:131/1840 train_time:4381ms step_avg:33.44ms
+step:132/1840 train_time:4415ms step_avg:33.45ms
+step:133/1840 train_time:4447ms step_avg:33.44ms
+step:134/1840 train_time:4482ms step_avg:33.45ms
+step:135/1840 train_time:4514ms step_avg:33.44ms
+step:136/1840 train_time:4548ms step_avg:33.44ms
+step:137/1840 train_time:4580ms step_avg:33.43ms
+step:138/1840 train_time:4614ms step_avg:33.44ms
+step:139/1840 train_time:4646ms step_avg:33.43ms
+step:140/1840 train_time:4680ms step_avg:33.43ms
+step:141/1840 train_time:4712ms step_avg:33.42ms
+step:142/1840 train_time:4747ms step_avg:33.43ms
+step:143/1840 train_time:4779ms step_avg:33.42ms
+step:144/1840 train_time:4813ms step_avg:33.42ms
+step:145/1840 train_time:4845ms step_avg:33.41ms
+step:146/1840 train_time:4879ms step_avg:33.42ms
+step:147/1840 train_time:4911ms step_avg:33.41ms
+step:148/1840 train_time:4945ms step_avg:33.41ms
+step:149/1840 train_time:4977ms step_avg:33.40ms
+step:150/1840 train_time:5012ms step_avg:33.41ms
+step:151/1840 train_time:5044ms step_avg:33.40ms
+step:152/1840 train_time:5078ms step_avg:33.40ms
+step:153/1840 train_time:5110ms step_avg:33.40ms
+step:154/1840 train_time:5144ms step_avg:33.40ms
+step:155/1840 train_time:5176ms step_avg:33.39ms
+step:156/1840 train_time:5210ms step_avg:33.40ms
+step:157/1840 train_time:5242ms step_avg:33.39ms
+step:158/1840 train_time:5276ms step_avg:33.39ms
+step:159/1840 train_time:5309ms step_avg:33.39ms
+step:160/1840 train_time:5343ms step_avg:33.40ms
+step:161/1840 train_time:5376ms step_avg:33.39ms
+step:162/1840 train_time:5410ms step_avg:33.40ms
+step:163/1840 train_time:5443ms step_avg:33.39ms
+step:164/1840 train_time:5477ms step_avg:33.40ms
+step:165/1840 train_time:5509ms step_avg:33.39ms
+step:166/1840 train_time:5544ms step_avg:33.39ms
+step:167/1840 train_time:5576ms step_avg:33.39ms
+step:168/1840 train_time:5610ms step_avg:33.39ms
+step:169/1840 train_time:5642ms step_avg:33.39ms
+step:170/1840 train_time:5676ms step_avg:33.39ms
+step:171/1840 train_time:5708ms step_avg:33.38ms
+step:172/1840 train_time:5743ms step_avg:33.39ms
+step:173/1840 train_time:5775ms step_avg:33.38ms
+step:174/1840 train_time:5809ms step_avg:33.38ms
+step:175/1840 train_time:5841ms step_avg:33.38ms
+step:176/1840 train_time:5876ms step_avg:33.38ms
+step:177/1840 train_time:5908ms step_avg:33.38ms
+step:178/1840 train_time:5942ms step_avg:33.38ms
+step:179/1840 train_time:5974ms step_avg:33.38ms
+step:180/1840 train_time:6008ms step_avg:33.38ms
+step:181/1840 train_time:6040ms step_avg:33.37ms
+step:182/1840 train_time:6075ms step_avg:33.38ms
+step:183/1840 train_time:6107ms step_avg:33.37ms
+step:184/1840 train_time:6141ms step_avg:33.38ms
+step:185/1840 train_time:6173ms step_avg:33.37ms
+step:186/1840 train_time:6207ms step_avg:33.37ms
+step:187/1840 train_time:6239ms step_avg:33.37ms
+step:188/1840 train_time:6273ms step_avg:33.37ms
+step:189/1840 train_time:6305ms step_avg:33.36ms
+step:190/1840 train_time:6340ms step_avg:33.37ms
+step:191/1840 train_time:6372ms step_avg:33.36ms
+step:192/1840 train_time:6406ms step_avg:33.36ms
+step:193/1840 train_time:6438ms step_avg:33.36ms
+step:194/1840 train_time:6473ms step_avg:33.36ms
+step:195/1840 train_time:6505ms step_avg:33.36ms
+step:196/1840 train_time:6539ms step_avg:33.36ms
+step:197/1840 train_time:6571ms step_avg:33.36ms
+step:198/1840 train_time:6605ms step_avg:33.36ms
+step:199/1840 train_time:6637ms step_avg:33.35ms
+step:200/1840 train_time:6672ms step_avg:33.36ms
+step:201/1840 train_time:6704ms step_avg:33.35ms
+step:202/1840 train_time:6738ms step_avg:33.36ms
+step:203/1840 train_time:6771ms step_avg:33.35ms
+step:204/1840 train_time:6805ms step_avg:33.36ms
+step:205/1840 train_time:6837ms step_avg:33.35ms
+step:206/1840 train_time:6872ms step_avg:33.36ms
+step:207/1840 train_time:6904ms step_avg:33.35ms
+step:208/1840 train_time:6938ms step_avg:33.35ms
+step:209/1840 train_time:6970ms step_avg:33.35ms
+step:210/1840 train_time:7004ms step_avg:33.35ms
+step:211/1840 train_time:7037ms step_avg:33.35ms
+step:212/1840 train_time:7071ms step_avg:33.35ms
+step:213/1840 train_time:7103ms step_avg:33.35ms
+step:214/1840 train_time:7137ms step_avg:33.35ms
+step:215/1840 train_time:7169ms step_avg:33.35ms
+step:216/1840 train_time:7203ms step_avg:33.35ms
+step:217/1840 train_time:7235ms step_avg:33.34ms
+step:218/1840 train_time:7270ms step_avg:33.35ms
+step:219/1840 train_time:7302ms step_avg:33.34ms
+step:220/1840 train_time:7336ms step_avg:33.35ms
+step:221/1840 train_time:7368ms step_avg:33.34ms
+step:222/1840 train_time:7403ms step_avg:33.35ms
+step:223/1840 train_time:7435ms step_avg:33.34ms
+step:224/1840 train_time:7469ms step_avg:33.34ms
+step:225/1840 train_time:7501ms step_avg:33.34ms
+step:226/1840 train_time:7535ms step_avg:33.34ms
+step:227/1840 train_time:7567ms step_avg:33.34ms
+step:228/1840 train_time:7602ms step_avg:33.34ms
+step:229/1840 train_time:7634ms step_avg:33.33ms
+step:230/1840 train_time:7667ms step_avg:33.34ms
+step:231/1840 train_time:7699ms step_avg:33.33ms
+step:232/1840 train_time:7733ms step_avg:33.33ms
+step:233/1840 train_time:7766ms step_avg:33.33ms
+step:234/1840 train_time:7800ms step_avg:33.33ms
+step:235/1840 train_time:7832ms step_avg:33.33ms
+step:236/1840 train_time:7866ms step_avg:33.33ms
+step:237/1840 train_time:7898ms step_avg:33.33ms
+step:238/1840 train_time:7933ms step_avg:33.33ms
+step:239/1840 train_time:7964ms step_avg:33.32ms
+step:240/1840 train_time:7998ms step_avg:33.33ms
+step:241/1840 train_time:8031ms step_avg:33.32ms
+step:242/1840 train_time:8065ms step_avg:33.33ms
+step:243/1840 train_time:8097ms step_avg:33.32ms
+step:244/1840 train_time:8132ms step_avg:33.33ms
+step:245/1840 train_time:8163ms step_avg:33.32ms
+step:246/1840 train_time:8197ms step_avg:33.32ms
+step:247/1840 train_time:8230ms step_avg:33.32ms
+step:248/1840 train_time:8264ms step_avg:33.32ms
+step:249/1840 train_time:8296ms step_avg:33.32ms
+step:250/1840 train_time:8330ms step_avg:33.32ms
+step:250/1840 val_loss:4.6059 train_time:8372ms step_avg:33.49ms
+step:251/1840 train_time:8390ms step_avg:33.43ms
+step:252/1840 train_time:8408ms step_avg:33.37ms
+step:253/1840 train_time:8430ms step_avg:33.32ms
+step:254/1840 train_time:8466ms step_avg:33.33ms
+step:255/1840 train_time:8500ms step_avg:33.33ms
+step:256/1840 train_time:8536ms step_avg:33.34ms
+step:257/1840 train_time:8568ms step_avg:33.34ms
+step:258/1840 train_time:8602ms step_avg:33.34ms
+step:259/1840 train_time:8634ms step_avg:33.34ms
+step:260/1840 train_time:8668ms step_avg:33.34ms
+step:261/1840 train_time:8700ms step_avg:33.33ms
+step:262/1840 train_time:8734ms step_avg:33.34ms
+step:263/1840 train_time:8766ms step_avg:33.33ms
+step:264/1840 train_time:8800ms step_avg:33.33ms
+step:265/1840 train_time:8832ms step_avg:33.33ms
+step:266/1840 train_time:8866ms step_avg:33.33ms
+step:267/1840 train_time:8898ms step_avg:33.33ms
+step:268/1840 train_time:8932ms step_avg:33.33ms
+step:269/1840 train_time:8964ms step_avg:33.32ms
+step:270/1840 train_time:8998ms step_avg:33.33ms
+step:271/1840 train_time:9030ms step_avg:33.32ms
+step:272/1840 train_time:9064ms step_avg:33.32ms
+step:273/1840 train_time:9096ms step_avg:33.32ms
+step:274/1840 train_time:9129ms step_avg:33.32ms
+step:275/1840 train_time:9161ms step_avg:33.31ms
+step:276/1840 train_time:9196ms step_avg:33.32ms
+step:277/1840 train_time:9228ms step_avg:33.31ms
+step:278/1840 train_time:9261ms step_avg:33.31ms
+step:279/1840 train_time:9293ms step_avg:33.31ms
+step:280/1840 train_time:9328ms step_avg:33.31ms
+step:281/1840 train_time:9361ms step_avg:33.31ms
+step:282/1840 train_time:9395ms step_avg:33.31ms
+step:283/1840 train_time:9427ms step_avg:33.31ms
+step:284/1840 train_time:9463ms step_avg:33.32ms
+step:285/1840 train_time:9495ms step_avg:33.31ms
+step:286/1840 train_time:9529ms step_avg:33.32ms
+step:287/1840 train_time:9562ms step_avg:33.32ms
+step:288/1840 train_time:9596ms step_avg:33.32ms
+step:289/1840 train_time:9628ms step_avg:33.32ms
+step:290/1840 train_time:9663ms step_avg:33.32ms
+step:291/1840 train_time:9695ms step_avg:33.32ms
+step:292/1840 train_time:9730ms step_avg:33.32ms
+step:293/1840 train_time:9762ms step_avg:33.32ms
+step:294/1840 train_time:9796ms step_avg:33.32ms
+step:295/1840 train_time:9828ms step_avg:33.31ms
+step:296/1840 train_time:9862ms step_avg:33.32ms
+step:297/1840 train_time:9894ms step_avg:33.31ms
+step:298/1840 train_time:9927ms step_avg:33.31ms
+step:299/1840 train_time:9959ms step_avg:33.31ms
+step:300/1840 train_time:9993ms step_avg:33.31ms
+step:301/1840 train_time:10025ms step_avg:33.31ms
+step:302/1840 train_time:10059ms step_avg:33.31ms
+step:303/1840 train_time:10091ms step_avg:33.30ms
+step:304/1840 train_time:10126ms step_avg:33.31ms
+step:305/1840 train_time:10158ms step_avg:33.30ms
+step:306/1840 train_time:10192ms step_avg:33.31ms
+step:307/1840 train_time:10224ms step_avg:33.30ms
+step:308/1840 train_time:10258ms step_avg:33.30ms
+step:309/1840 train_time:10289ms step_avg:33.30ms
+step:310/1840 train_time:10325ms step_avg:33.31ms
+step:311/1840 train_time:10357ms step_avg:33.30ms
+step:312/1840 train_time:10391ms step_avg:33.30ms
+step:313/1840 train_time:10423ms step_avg:33.30ms
+step:314/1840 train_time:10458ms step_avg:33.31ms
+step:315/1840 train_time:10491ms step_avg:33.30ms
+step:316/1840 train_time:10525ms step_avg:33.31ms
+step:317/1840 train_time:10557ms step_avg:33.30ms
+step:318/1840 train_time:10592ms step_avg:33.31ms
+step:319/1840 train_time:10624ms step_avg:33.30ms
+step:320/1840 train_time:10658ms step_avg:33.31ms
+step:321/1840 train_time:10691ms step_avg:33.30ms
+step:322/1840 train_time:10725ms step_avg:33.31ms
+step:323/1840 train_time:10758ms step_avg:33.30ms
+step:324/1840 train_time:10792ms step_avg:33.31ms
+step:325/1840 train_time:10824ms step_avg:33.30ms
+step:326/1840 train_time:10858ms step_avg:33.31ms
+step:327/1840 train_time:10890ms step_avg:33.30ms
+step:328/1840 train_time:10924ms step_avg:33.31ms
+step:329/1840 train_time:10956ms step_avg:33.30ms
+step:330/1840 train_time:10990ms step_avg:33.30ms
+step:331/1840 train_time:11022ms step_avg:33.30ms
+step:332/1840 train_time:11056ms step_avg:33.30ms
+step:333/1840 train_time:11088ms step_avg:33.30ms
+step:334/1840 train_time:11123ms step_avg:33.30ms
+step:335/1840 train_time:11155ms step_avg:33.30ms
+step:336/1840 train_time:11189ms step_avg:33.30ms
+step:337/1840 train_time:11221ms step_avg:33.30ms
+step:338/1840 train_time:11255ms step_avg:33.30ms
+step:339/1840 train_time:11287ms step_avg:33.30ms
+step:340/1840 train_time:11321ms step_avg:33.30ms
+step:341/1840 train_time:11353ms step_avg:33.29ms
+step:342/1840 train_time:11388ms step_avg:33.30ms
+step:343/1840 train_time:11420ms step_avg:33.30ms
+step:344/1840 train_time:11454ms step_avg:33.30ms
+step:345/1840 train_time:11486ms step_avg:33.29ms
+step:346/1840 train_time:11521ms step_avg:33.30ms
+step:347/1840 train_time:11553ms step_avg:33.29ms
+step:348/1840 train_time:11588ms step_avg:33.30ms
+step:349/1840 train_time:11620ms step_avg:33.29ms
+step:350/1840 train_time:11654ms step_avg:33.30ms
+step:351/1840 train_time:11686ms step_avg:33.29ms
+step:352/1840 train_time:11721ms step_avg:33.30ms
+step:353/1840 train_time:11753ms step_avg:33.30ms
+step:354/1840 train_time:11787ms step_avg:33.30ms
+step:355/1840 train_time:11820ms step_avg:33.30ms
+step:356/1840 train_time:11854ms step_avg:33.30ms
+step:357/1840 train_time:11886ms step_avg:33.29ms
+step:358/1840 train_time:11920ms step_avg:33.30ms
+step:359/1840 train_time:11952ms step_avg:33.29ms
+step:360/1840 train_time:11986ms step_avg:33.30ms
+step:361/1840 train_time:12018ms step_avg:33.29ms
+step:362/1840 train_time:12053ms step_avg:33.29ms
+step:363/1840 train_time:12084ms step_avg:33.29ms
+step:364/1840 train_time:12119ms step_avg:33.29ms
+step:365/1840 train_time:12150ms step_avg:33.29ms
+step:366/1840 train_time:12185ms step_avg:33.29ms
+step:367/1840 train_time:12217ms step_avg:33.29ms
+step:368/1840 train_time:12251ms step_avg:33.29ms
+step:369/1840 train_time:12284ms step_avg:33.29ms
+step:370/1840 train_time:12318ms step_avg:33.29ms
+step:371/1840 train_time:12350ms step_avg:33.29ms
+step:372/1840 train_time:12384ms step_avg:33.29ms
+step:373/1840 train_time:12416ms step_avg:33.29ms
+step:374/1840 train_time:12450ms step_avg:33.29ms
+step:375/1840 train_time:12482ms step_avg:33.29ms
+step:376/1840 train_time:12516ms step_avg:33.29ms
+step:377/1840 train_time:12548ms step_avg:33.28ms
+step:378/1840 train_time:12583ms step_avg:33.29ms
+step:379/1840 train_time:12615ms step_avg:33.28ms
+step:380/1840 train_time:12649ms step_avg:33.29ms
+step:381/1840 train_time:12681ms step_avg:33.28ms
+step:382/1840 train_time:12715ms step_avg:33.29ms
+step:383/1840 train_time:12747ms step_avg:33.28ms
+step:384/1840 train_time:12782ms step_avg:33.29ms
+step:385/1840 train_time:12813ms step_avg:33.28ms
+step:386/1840 train_time:12848ms step_avg:33.28ms
+step:387/1840 train_time:12880ms step_avg:33.28ms
+step:388/1840 train_time:12914ms step_avg:33.28ms
+step:389/1840 train_time:12946ms step_avg:33.28ms
+step:390/1840 train_time:12980ms step_avg:33.28ms
+step:391/1840 train_time:13012ms step_avg:33.28ms
+step:392/1840 train_time:13046ms step_avg:33.28ms
+step:393/1840 train_time:13078ms step_avg:33.28ms
+step:394/1840 train_time:13112ms step_avg:33.28ms
+step:395/1840 train_time:13144ms step_avg:33.28ms
+step:396/1840 train_time:13178ms step_avg:33.28ms
+step:397/1840 train_time:13210ms step_avg:33.28ms
+step:398/1840 train_time:13245ms step_avg:33.28ms
+step:399/1840 train_time:13277ms step_avg:33.28ms
+step:400/1840 train_time:13311ms step_avg:33.28ms
+step:401/1840 train_time:13343ms step_avg:33.27ms
+step:402/1840 train_time:13377ms step_avg:33.28ms
+step:403/1840 train_time:13409ms step_avg:33.27ms
+step:404/1840 train_time:13443ms step_avg:33.28ms
+step:405/1840 train_time:13475ms step_avg:33.27ms
+step:406/1840 train_time:13509ms step_avg:33.27ms
+step:407/1840 train_time:13541ms step_avg:33.27ms
+step:408/1840 train_time:13576ms step_avg:33.27ms
+step:409/1840 train_time:13608ms step_avg:33.27ms
+step:410/1840 train_time:13642ms step_avg:33.27ms
+step:411/1840 train_time:13674ms step_avg:33.27ms
+step:412/1840 train_time:13708ms step_avg:33.27ms
+step:413/1840 train_time:13740ms step_avg:33.27ms
+step:414/1840 train_time:13775ms step_avg:33.27ms
+step:415/1840 train_time:13807ms step_avg:33.27ms
+step:416/1840 train_time:13841ms step_avg:33.27ms
+step:417/1840 train_time:13873ms step_avg:33.27ms
+step:418/1840 train_time:13908ms step_avg:33.27ms
+step:419/1840 train_time:13940ms step_avg:33.27ms
+step:420/1840 train_time:13974ms step_avg:33.27ms
+step:421/1840 train_time:14006ms step_avg:33.27ms
+step:422/1840 train_time:14040ms step_avg:33.27ms
+step:423/1840 train_time:14071ms step_avg:33.27ms
+step:424/1840 train_time:14106ms step_avg:33.27ms
+step:425/1840 train_time:14138ms step_avg:33.27ms
+step:426/1840 train_time:14172ms step_avg:33.27ms
+step:427/1840 train_time:14204ms step_avg:33.26ms
+step:428/1840 train_time:14238ms step_avg:33.27ms
+step:429/1840 train_time:14271ms step_avg:33.26ms
+step:430/1840 train_time:14305ms step_avg:33.27ms
+step:431/1840 train_time:14337ms step_avg:33.26ms
+step:432/1840 train_time:14371ms step_avg:33.27ms
+step:433/1840 train_time:14403ms step_avg:33.26ms
+step:434/1840 train_time:14437ms step_avg:33.27ms
+step:435/1840 train_time:14469ms step_avg:33.26ms
+step:436/1840 train_time:14504ms step_avg:33.27ms
+step:437/1840 train_time:14536ms step_avg:33.26ms
+step:438/1840 train_time:14571ms step_avg:33.27ms
+step:439/1840 train_time:14603ms step_avg:33.26ms
+step:440/1840 train_time:14637ms step_avg:33.27ms
+step:441/1840 train_time:14669ms step_avg:33.26ms
+step:442/1840 train_time:14703ms step_avg:33.27ms
+step:443/1840 train_time:14736ms step_avg:33.26ms
+step:444/1840 train_time:14770ms step_avg:33.27ms
+step:445/1840 train_time:14802ms step_avg:33.26ms
+step:446/1840 train_time:14836ms step_avg:33.26ms
+step:447/1840 train_time:14868ms step_avg:33.26ms
+step:448/1840 train_time:14902ms step_avg:33.26ms
+step:449/1840 train_time:14934ms step_avg:33.26ms
+step:450/1840 train_time:14968ms step_avg:33.26ms
+step:451/1840 train_time:15000ms step_avg:33.26ms
+step:452/1840 train_time:15034ms step_avg:33.26ms
+step:453/1840 train_time:15066ms step_avg:33.26ms
+step:454/1840 train_time:15100ms step_avg:33.26ms
+step:455/1840 train_time:15132ms step_avg:33.26ms
+step:456/1840 train_time:15166ms step_avg:33.26ms
+step:457/1840 train_time:15198ms step_avg:33.26ms
+step:458/1840 train_time:15233ms step_avg:33.26ms
+step:459/1840 train_time:15265ms step_avg:33.26ms
+step:460/1840 train_time:15299ms step_avg:33.26ms
+step:461/1840 train_time:15331ms step_avg:33.26ms
+step:462/1840 train_time:15365ms step_avg:33.26ms
+step:463/1840 train_time:15397ms step_avg:33.26ms
+step:464/1840 train_time:15432ms step_avg:33.26ms
+step:465/1840 train_time:15464ms step_avg:33.26ms
+step:466/1840 train_time:15498ms step_avg:33.26ms
+step:467/1840 train_time:15530ms step_avg:33.26ms
+step:468/1840 train_time:15565ms step_avg:33.26ms
+step:469/1840 train_time:15597ms step_avg:33.26ms
+step:470/1840 train_time:15631ms step_avg:33.26ms
+step:471/1840 train_time:15663ms step_avg:33.26ms
+step:472/1840 train_time:15697ms step_avg:33.26ms
+step:473/1840 train_time:15729ms step_avg:33.25ms
+step:474/1840 train_time:15764ms step_avg:33.26ms
+step:475/1840 train_time:15796ms step_avg:33.26ms
+step:476/1840 train_time:15830ms step_avg:33.26ms
+step:477/1840 train_time:15863ms step_avg:33.26ms
+step:478/1840 train_time:15897ms step_avg:33.26ms
+step:479/1840 train_time:15929ms step_avg:33.25ms
+step:480/1840 train_time:15963ms step_avg:33.26ms
+step:481/1840 train_time:15995ms step_avg:33.25ms
+step:482/1840 train_time:16029ms step_avg:33.26ms
+step:483/1840 train_time:16061ms step_avg:33.25ms
+step:484/1840 train_time:16095ms step_avg:33.25ms
+step:485/1840 train_time:16127ms step_avg:33.25ms
+step:486/1840 train_time:16161ms step_avg:33.25ms
+step:487/1840 train_time:16193ms step_avg:33.25ms
+step:488/1840 train_time:16227ms step_avg:33.25ms
+step:489/1840 train_time:16259ms step_avg:33.25ms
+step:490/1840 train_time:16293ms step_avg:33.25ms
+step:491/1840 train_time:16326ms step_avg:33.25ms
+step:492/1840 train_time:16360ms step_avg:33.25ms
+step:493/1840 train_time:16392ms step_avg:33.25ms
+step:494/1840 train_time:16427ms step_avg:33.25ms
+step:495/1840 train_time:16459ms step_avg:33.25ms
+step:496/1840 train_time:16493ms step_avg:33.25ms
+step:497/1840 train_time:16525ms step_avg:33.25ms
+step:498/1840 train_time:16559ms step_avg:33.25ms
+step:499/1840 train_time:16591ms step_avg:33.25ms
+step:500/1840 train_time:16626ms step_avg:33.25ms
+step:500/1840 val_loss:4.2909 train_time:16668ms step_avg:33.34ms
+step:501/1840 train_time:16688ms step_avg:33.31ms
+step:502/1840 train_time:16706ms step_avg:33.28ms
+step:503/1840 train_time:16727ms step_avg:33.26ms
+step:504/1840 train_time:16763ms step_avg:33.26ms
+step:505/1840 train_time:16797ms step_avg:33.26ms
+step:506/1840 train_time:16833ms step_avg:33.27ms
+step:507/1840 train_time:16866ms step_avg:33.27ms
+step:508/1840 train_time:16900ms step_avg:33.27ms
+step:509/1840 train_time:16932ms step_avg:33.27ms
+step:510/1840 train_time:16966ms step_avg:33.27ms
+step:511/1840 train_time:16999ms step_avg:33.27ms
+step:512/1840 train_time:17033ms step_avg:33.27ms
+step:513/1840 train_time:17065ms step_avg:33.27ms
+step:514/1840 train_time:17099ms step_avg:33.27ms
+step:515/1840 train_time:17131ms step_avg:33.26ms
+step:516/1840 train_time:17165ms step_avg:33.27ms
+step:517/1840 train_time:17197ms step_avg:33.26ms
+step:518/1840 train_time:17230ms step_avg:33.26ms
+step:519/1840 train_time:17262ms step_avg:33.26ms
+step:520/1840 train_time:17296ms step_avg:33.26ms
+step:521/1840 train_time:17328ms step_avg:33.26ms
+step:522/1840 train_time:17362ms step_avg:33.26ms
+step:523/1840 train_time:17394ms step_avg:33.26ms
+step:524/1840 train_time:17428ms step_avg:33.26ms
+step:525/1840 train_time:17460ms step_avg:33.26ms
+step:526/1840 train_time:17494ms step_avg:33.26ms
+step:527/1840 train_time:17526ms step_avg:33.26ms
+step:528/1840 train_time:17560ms step_avg:33.26ms
+step:529/1840 train_time:17592ms step_avg:33.26ms
+step:530/1840 train_time:17626ms step_avg:33.26ms
+step:531/1840 train_time:17658ms step_avg:33.26ms
+step:532/1840 train_time:17693ms step_avg:33.26ms
+step:533/1840 train_time:17726ms step_avg:33.26ms
+step:534/1840 train_time:17760ms step_avg:33.26ms
+step:535/1840 train_time:17793ms step_avg:33.26ms
+step:536/1840 train_time:17828ms step_avg:33.26ms
+step:537/1840 train_time:17861ms step_avg:33.26ms
+step:538/1840 train_time:17895ms step_avg:33.26ms
+step:539/1840 train_time:17928ms step_avg:33.26ms
+step:540/1840 train_time:17962ms step_avg:33.26ms
+step:541/1840 train_time:17995ms step_avg:33.26ms
+step:542/1840 train_time:18029ms step_avg:33.26ms
+step:543/1840 train_time:18061ms step_avg:33.26ms
+step:544/1840 train_time:18095ms step_avg:33.26ms
+step:545/1840 train_time:18127ms step_avg:33.26ms
+step:546/1840 train_time:18162ms step_avg:33.26ms
+step:547/1840 train_time:18194ms step_avg:33.26ms
+step:548/1840 train_time:18228ms step_avg:33.26ms
+step:549/1840 train_time:18260ms step_avg:33.26ms
+step:550/1840 train_time:18294ms step_avg:33.26ms
+step:551/1840 train_time:18326ms step_avg:33.26ms
+step:552/1840 train_time:18360ms step_avg:33.26ms
+step:553/1840 train_time:18392ms step_avg:33.26ms
+step:554/1840 train_time:18426ms step_avg:33.26ms
+step:555/1840 train_time:18458ms step_avg:33.26ms
+step:556/1840 train_time:18492ms step_avg:33.26ms
+step:557/1840 train_time:18524ms step_avg:33.26ms
+step:558/1840 train_time:18558ms step_avg:33.26ms
+step:559/1840 train_time:18590ms step_avg:33.26ms
+step:560/1840 train_time:18624ms step_avg:33.26ms
+step:561/1840 train_time:18656ms step_avg:33.25ms
+step:562/1840 train_time:18690ms step_avg:33.26ms
+step:563/1840 train_time:18723ms step_avg:33.26ms
+step:564/1840 train_time:18757ms step_avg:33.26ms
+step:565/1840 train_time:18790ms step_avg:33.26ms
+step:566/1840 train_time:18824ms step_avg:33.26ms
+step:567/1840 train_time:18856ms step_avg:33.26ms
+step:568/1840 train_time:18891ms step_avg:33.26ms
+step:569/1840 train_time:18923ms step_avg:33.26ms
+step:570/1840 train_time:18957ms step_avg:33.26ms
+step:571/1840 train_time:18989ms step_avg:33.26ms
+step:572/1840 train_time:19024ms step_avg:33.26ms
+step:573/1840 train_time:19056ms step_avg:33.26ms
+step:574/1840 train_time:19090ms step_avg:33.26ms
+step:575/1840 train_time:19123ms step_avg:33.26ms
+step:576/1840 train_time:19157ms step_avg:33.26ms
+step:577/1840 train_time:19189ms step_avg:33.26ms
+step:578/1840 train_time:19223ms step_avg:33.26ms
+step:579/1840 train_time:19255ms step_avg:33.26ms
+step:580/1840 train_time:19289ms step_avg:33.26ms
+step:581/1840 train_time:19322ms step_avg:33.26ms
+step:582/1840 train_time:19356ms step_avg:33.26ms
+step:583/1840 train_time:19388ms step_avg:33.26ms
+step:584/1840 train_time:19422ms step_avg:33.26ms
+step:585/1840 train_time:19454ms step_avg:33.25ms
+step:586/1840 train_time:19488ms step_avg:33.26ms
+step:587/1840 train_time:19520ms step_avg:33.25ms
+step:588/1840 train_time:19554ms step_avg:33.26ms
+step:589/1840 train_time:19586ms step_avg:33.25ms
+step:590/1840 train_time:19620ms step_avg:33.25ms
+step:591/1840 train_time:19652ms step_avg:33.25ms
+step:592/1840 train_time:19687ms step_avg:33.25ms
+step:593/1840 train_time:19719ms step_avg:33.25ms
+step:594/1840 train_time:19753ms step_avg:33.26ms
+step:595/1840 train_time:19786ms step_avg:33.25ms
+step:596/1840 train_time:19820ms step_avg:33.25ms
+step:597/1840 train_time:19852ms step_avg:33.25ms
+step:598/1840 train_time:19886ms step_avg:33.25ms
+step:599/1840 train_time:19918ms step_avg:33.25ms
+step:600/1840 train_time:19953ms step_avg:33.25ms
+step:601/1840 train_time:19987ms step_avg:33.26ms
+step:602/1840 train_time:20046ms step_avg:33.30ms
+step:603/1840 train_time:20106ms step_avg:33.34ms
+step:604/1840 train_time:20168ms step_avg:33.39ms
+step:605/1840 train_time:20228ms step_avg:33.43ms
+step:606/1840 train_time:20290ms step_avg:33.48ms
+step:607/1840 train_time:20349ms step_avg:33.52ms
+step:608/1840 train_time:20411ms step_avg:33.57ms
+step:609/1840 train_time:20472ms step_avg:33.61ms
+step:610/1840 train_time:20534ms step_avg:33.66ms
+step:611/1840 train_time:20593ms step_avg:33.70ms
+step:612/1840 train_time:20655ms step_avg:33.75ms
+step:613/1840 train_time:20715ms step_avg:33.79ms
+step:614/1840 train_time:20777ms step_avg:33.84ms
+step:615/1840 train_time:20837ms step_avg:33.88ms
+step:616/1840 train_time:20899ms step_avg:33.93ms
+step:617/1840 train_time:20958ms step_avg:33.97ms
+step:618/1840 train_time:21021ms step_avg:34.01ms
+step:619/1840 train_time:21081ms step_avg:34.06ms
+step:620/1840 train_time:21143ms step_avg:34.10ms
+step:621/1840 train_time:21203ms step_avg:34.14ms
+step:622/1840 train_time:21266ms step_avg:34.19ms
+step:623/1840 train_time:21325ms step_avg:34.23ms
+step:624/1840 train_time:21388ms step_avg:34.28ms
+step:625/1840 train_time:21448ms step_avg:34.32ms
+step:626/1840 train_time:21510ms step_avg:34.36ms
+step:627/1840 train_time:21569ms step_avg:34.40ms
+step:628/1840 train_time:21632ms step_avg:34.45ms
+step:629/1840 train_time:21692ms step_avg:34.49ms
+step:630/1840 train_time:21754ms step_avg:34.53ms
+step:631/1840 train_time:21814ms step_avg:34.57ms
+step:632/1840 train_time:21877ms step_avg:34.62ms
+step:633/1840 train_time:21936ms step_avg:34.65ms
+step:634/1840 train_time:21999ms step_avg:34.70ms
+step:635/1840 train_time:22058ms step_avg:34.74ms
+step:636/1840 train_time:22120ms step_avg:34.78ms
+step:637/1840 train_time:22181ms step_avg:34.82ms
+step:638/1840 train_time:22244ms step_avg:34.86ms
+step:639/1840 train_time:22303ms step_avg:34.90ms
+step:640/1840 train_time:22365ms step_avg:34.95ms
+step:641/1840 train_time:22425ms step_avg:34.98ms
+step:642/1840 train_time:22487ms step_avg:35.03ms
+step:643/1840 train_time:22547ms step_avg:35.06ms
+step:644/1840 train_time:22609ms step_avg:35.11ms
+step:645/1840 train_time:22668ms step_avg:35.14ms
+step:646/1840 train_time:22731ms step_avg:35.19ms
+step:647/1840 train_time:22791ms step_avg:35.23ms
+step:648/1840 train_time:22854ms step_avg:35.27ms
+step:649/1840 train_time:22915ms step_avg:35.31ms
+step:650/1840 train_time:22977ms step_avg:35.35ms
+step:651/1840 train_time:23037ms step_avg:35.39ms
+step:652/1840 train_time:23099ms step_avg:35.43ms
+step:653/1840 train_time:23158ms step_avg:35.46ms
+step:654/1840 train_time:23220ms step_avg:35.50ms
+step:655/1840 train_time:23280ms step_avg:35.54ms
+step:656/1840 train_time:23342ms step_avg:35.58ms
+step:657/1840 train_time:23403ms step_avg:35.62ms
+step:658/1840 train_time:23464ms step_avg:35.66ms
+step:659/1840 train_time:23524ms step_avg:35.70ms
+step:660/1840 train_time:23586ms step_avg:35.74ms
+step:661/1840 train_time:23647ms step_avg:35.77ms
+step:662/1840 train_time:23709ms step_avg:35.81ms
+step:663/1840 train_time:23769ms step_avg:35.85ms
+step:664/1840 train_time:23832ms step_avg:35.89ms
+step:665/1840 train_time:23893ms step_avg:35.93ms
+step:666/1840 train_time:23955ms step_avg:35.97ms
+step:667/1840 train_time:24015ms step_avg:36.00ms
+step:668/1840 train_time:24077ms step_avg:36.04ms
+step:669/1840 train_time:24137ms step_avg:36.08ms
+step:670/1840 train_time:24200ms step_avg:36.12ms
+step:671/1840 train_time:24259ms step_avg:36.15ms
+step:672/1840 train_time:24322ms step_avg:36.19ms
+step:673/1840 train_time:24381ms step_avg:36.23ms
+step:674/1840 train_time:24444ms step_avg:36.27ms
+step:675/1840 train_time:24504ms step_avg:36.30ms
+step:676/1840 train_time:24565ms step_avg:36.34ms
+step:677/1840 train_time:24626ms step_avg:36.38ms
+step:678/1840 train_time:24689ms step_avg:36.41ms
+step:679/1840 train_time:24749ms step_avg:36.45ms
+step:680/1840 train_time:24812ms step_avg:36.49ms
+step:681/1840 train_time:24873ms step_avg:36.52ms
+step:682/1840 train_time:24935ms step_avg:36.56ms
+step:683/1840 train_time:24996ms step_avg:36.60ms
+step:684/1840 train_time:25058ms step_avg:36.63ms
+step:685/1840 train_time:25118ms step_avg:36.67ms
+step:686/1840 train_time:25180ms step_avg:36.71ms
+step:687/1840 train_time:25240ms step_avg:36.74ms
+step:688/1840 train_time:25301ms step_avg:36.78ms
+step:689/1840 train_time:25361ms step_avg:36.81ms
+step:690/1840 train_time:25424ms step_avg:36.85ms
+step:691/1840 train_time:25483ms step_avg:36.88ms
+step:692/1840 train_time:25546ms step_avg:36.92ms
+step:693/1840 train_time:25606ms step_avg:36.95ms
+step:694/1840 train_time:25668ms step_avg:36.99ms
+step:695/1840 train_time:25728ms step_avg:37.02ms
+step:696/1840 train_time:25791ms step_avg:37.06ms
+step:697/1840 train_time:25851ms step_avg:37.09ms
+step:698/1840 train_time:25913ms step_avg:37.12ms
+step:699/1840 train_time:25974ms step_avg:37.16ms
+step:700/1840 train_time:26036ms step_avg:37.19ms
+step:701/1840 train_time:26097ms step_avg:37.23ms
+step:702/1840 train_time:26159ms step_avg:37.26ms
+step:703/1840 train_time:26219ms step_avg:37.30ms
+step:704/1840 train_time:26282ms step_avg:37.33ms
+step:705/1840 train_time:26342ms step_avg:37.36ms
+step:706/1840 train_time:26403ms step_avg:37.40ms
+step:707/1840 train_time:26462ms step_avg:37.43ms
+step:708/1840 train_time:26525ms step_avg:37.47ms
+step:709/1840 train_time:26585ms step_avg:37.50ms
+step:710/1840 train_time:26647ms step_avg:37.53ms
+step:711/1840 train_time:26707ms step_avg:37.56ms
+step:712/1840 train_time:26770ms step_avg:37.60ms
+step:713/1840 train_time:26830ms step_avg:37.63ms
+step:714/1840 train_time:26892ms step_avg:37.66ms
+step:715/1840 train_time:26953ms step_avg:37.70ms
+step:716/1840 train_time:27016ms step_avg:37.73ms
+step:717/1840 train_time:27076ms step_avg:37.76ms
+step:718/1840 train_time:27138ms step_avg:37.80ms
+step:719/1840 train_time:27197ms step_avg:37.83ms
+step:720/1840 train_time:27259ms step_avg:37.86ms
+step:721/1840 train_time:27319ms step_avg:37.89ms
+step:722/1840 train_time:27382ms step_avg:37.93ms
+step:723/1840 train_time:27442ms step_avg:37.96ms
+step:724/1840 train_time:27505ms step_avg:37.99ms
+step:725/1840 train_time:27564ms step_avg:38.02ms
+step:726/1840 train_time:27626ms step_avg:38.05ms
+step:727/1840 train_time:27686ms step_avg:38.08ms
+step:728/1840 train_time:27748ms step_avg:38.12ms
+step:729/1840 train_time:27808ms step_avg:38.15ms
+step:730/1840 train_time:27871ms step_avg:38.18ms
+step:731/1840 train_time:27933ms step_avg:38.21ms
+step:732/1840 train_time:27995ms step_avg:38.25ms
+step:733/1840 train_time:28056ms step_avg:38.28ms
+step:734/1840 train_time:28118ms step_avg:38.31ms
+step:735/1840 train_time:28178ms step_avg:38.34ms
+step:736/1840 train_time:28240ms step_avg:38.37ms
+step:737/1840 train_time:28301ms step_avg:38.40ms
+step:738/1840 train_time:28363ms step_avg:38.43ms
+step:739/1840 train_time:28423ms step_avg:38.46ms
+step:740/1840 train_time:28485ms step_avg:38.49ms
+step:741/1840 train_time:28544ms step_avg:38.52ms
+step:742/1840 train_time:28607ms step_avg:38.55ms
+step:743/1840 train_time:28666ms step_avg:38.58ms
+step:744/1840 train_time:28728ms step_avg:38.61ms
+step:745/1840 train_time:28788ms step_avg:38.64ms
+step:746/1840 train_time:28850ms step_avg:38.67ms
+step:747/1840 train_time:28910ms step_avg:38.70ms
+step:748/1840 train_time:28973ms step_avg:38.73ms
+step:749/1840 train_time:29034ms step_avg:38.76ms
+step:750/1840 train_time:29096ms step_avg:38.79ms
+step:750/1840 val_loss:4.0140 train_time:29168ms step_avg:38.89ms
+step:751/1840 train_time:29189ms step_avg:38.87ms
+step:752/1840 train_time:29222ms step_avg:38.86ms
+step:753/1840 train_time:29283ms step_avg:38.89ms
+step:754/1840 train_time:29348ms step_avg:38.92ms
+step:755/1840 train_time:29411ms step_avg:38.95ms
+step:756/1840 train_time:29473ms step_avg:38.98ms
+step:757/1840 train_time:29532ms step_avg:39.01ms
+step:758/1840 train_time:29593ms step_avg:39.04ms
+step:759/1840 train_time:29652ms step_avg:39.07ms
+step:760/1840 train_time:29713ms step_avg:39.10ms
+step:761/1840 train_time:29772ms step_avg:39.12ms
+step:762/1840 train_time:29834ms step_avg:39.15ms
+step:763/1840 train_time:29892ms step_avg:39.18ms
+step:764/1840 train_time:29953ms step_avg:39.21ms
+step:765/1840 train_time:30012ms step_avg:39.23ms
+step:766/1840 train_time:30074ms step_avg:39.26ms
+step:767/1840 train_time:30135ms step_avg:39.29ms
+step:768/1840 train_time:30200ms step_avg:39.32ms
+step:769/1840 train_time:30262ms step_avg:39.35ms
+step:770/1840 train_time:30326ms step_avg:39.38ms
+step:771/1840 train_time:30386ms step_avg:39.41ms
+step:772/1840 train_time:30448ms step_avg:39.44ms
+step:773/1840 train_time:30508ms step_avg:39.47ms
+step:774/1840 train_time:30570ms step_avg:39.50ms
+step:775/1840 train_time:30629ms step_avg:39.52ms
+step:776/1840 train_time:30691ms step_avg:39.55ms
+step:777/1840 train_time:30750ms step_avg:39.58ms
+step:778/1840 train_time:30812ms step_avg:39.60ms
+step:779/1840 train_time:30871ms step_avg:39.63ms
+step:780/1840 train_time:30933ms step_avg:39.66ms
+step:781/1840 train_time:30991ms step_avg:39.68ms
+step:782/1840 train_time:31054ms step_avg:39.71ms
+step:783/1840 train_time:31113ms step_avg:39.74ms
+step:784/1840 train_time:31177ms step_avg:39.77ms
+step:785/1840 train_time:31239ms step_avg:39.80ms
+step:786/1840 train_time:31302ms step_avg:39.82ms
+step:787/1840 train_time:31363ms step_avg:39.85ms
+step:788/1840 train_time:31426ms step_avg:39.88ms
+step:789/1840 train_time:31486ms step_avg:39.91ms
+step:790/1840 train_time:31548ms step_avg:39.93ms
+step:791/1840 train_time:31608ms step_avg:39.96ms
+step:792/1840 train_time:31670ms step_avg:39.99ms
+step:793/1840 train_time:31729ms step_avg:40.01ms
+step:794/1840 train_time:31791ms step_avg:40.04ms
+step:795/1840 train_time:31850ms step_avg:40.06ms
+step:796/1840 train_time:31913ms step_avg:40.09ms
+step:797/1840 train_time:31972ms step_avg:40.12ms
+step:798/1840 train_time:32034ms step_avg:40.14ms
+step:799/1840 train_time:32093ms step_avg:40.17ms
+step:800/1840 train_time:32156ms step_avg:40.19ms
+step:801/1840 train_time:32216ms step_avg:40.22ms
+step:802/1840 train_time:32280ms step_avg:40.25ms
+step:803/1840 train_time:32341ms step_avg:40.28ms
+step:804/1840 train_time:32403ms step_avg:40.30ms
+step:805/1840 train_time:32463ms step_avg:40.33ms
+step:806/1840 train_time:32526ms step_avg:40.35ms
+step:807/1840 train_time:32586ms step_avg:40.38ms
+step:808/1840 train_time:32647ms step_avg:40.40ms
+step:809/1840 train_time:32707ms step_avg:40.43ms
+step:810/1840 train_time:32769ms step_avg:40.46ms
+step:811/1840 train_time:32828ms step_avg:40.48ms
+step:812/1840 train_time:32890ms step_avg:40.50ms
+step:813/1840 train_time:32950ms step_avg:40.53ms
+step:814/1840 train_time:33012ms step_avg:40.56ms
+step:815/1840 train_time:33072ms step_avg:40.58ms
+step:816/1840 train_time:33135ms step_avg:40.61ms
+step:817/1840 train_time:33194ms step_avg:40.63ms
+step:818/1840 train_time:33257ms step_avg:40.66ms
+step:819/1840 train_time:33317ms step_avg:40.68ms
+step:820/1840 train_time:33380ms step_avg:40.71ms
+step:821/1840 train_time:33440ms step_avg:40.73ms
+step:822/1840 train_time:33503ms step_avg:40.76ms
+step:823/1840 train_time:33563ms step_avg:40.78ms
+step:824/1840 train_time:33627ms step_avg:40.81ms
+step:825/1840 train_time:33686ms step_avg:40.83ms
+step:826/1840 train_time:33748ms step_avg:40.86ms
+step:827/1840 train_time:33807ms step_avg:40.88ms
+step:828/1840 train_time:33869ms step_avg:40.91ms
+step:829/1840 train_time:33930ms step_avg:40.93ms
+step:830/1840 train_time:33991ms step_avg:40.95ms
+step:831/1840 train_time:34052ms step_avg:40.98ms
+step:832/1840 train_time:34115ms step_avg:41.00ms
+step:833/1840 train_time:34174ms step_avg:41.03ms
+step:834/1840 train_time:34237ms step_avg:41.05ms
+step:835/1840 train_time:34297ms step_avg:41.07ms
+step:836/1840 train_time:34360ms step_avg:41.10ms
+step:837/1840 train_time:34419ms step_avg:41.12ms
+step:838/1840 train_time:34482ms step_avg:41.15ms
+step:839/1840 train_time:34542ms step_avg:41.17ms
+step:840/1840 train_time:34605ms step_avg:41.20ms
+step:841/1840 train_time:34665ms step_avg:41.22ms
+step:842/1840 train_time:34727ms step_avg:41.24ms
+step:843/1840 train_time:34787ms step_avg:41.27ms
+step:844/1840 train_time:34849ms step_avg:41.29ms
+step:845/1840 train_time:34910ms step_avg:41.31ms
+step:846/1840 train_time:34971ms step_avg:41.34ms
+step:847/1840 train_time:35032ms step_avg:41.36ms
+step:848/1840 train_time:35093ms step_avg:41.38ms
+step:849/1840 train_time:35153ms step_avg:41.41ms
+step:850/1840 train_time:35215ms step_avg:41.43ms
+step:851/1840 train_time:35275ms step_avg:41.45ms
+step:852/1840 train_time:35337ms step_avg:41.48ms
+step:853/1840 train_time:35397ms step_avg:41.50ms
+step:854/1840 train_time:35460ms step_avg:41.52ms
+step:855/1840 train_time:35520ms step_avg:41.54ms
+step:856/1840 train_time:35582ms step_avg:41.57ms
+step:857/1840 train_time:35643ms step_avg:41.59ms
+step:858/1840 train_time:35705ms step_avg:41.61ms
+step:859/1840 train_time:35765ms step_avg:41.64ms
+step:860/1840 train_time:35828ms step_avg:41.66ms
+step:861/1840 train_time:35888ms step_avg:41.68ms
+step:862/1840 train_time:35950ms step_avg:41.71ms
+step:863/1840 train_time:36010ms step_avg:41.73ms
+step:864/1840 train_time:36072ms step_avg:41.75ms
+step:865/1840 train_time:36132ms step_avg:41.77ms
+step:866/1840 train_time:36194ms step_avg:41.79ms
+step:867/1840 train_time:36254ms step_avg:41.82ms
+step:868/1840 train_time:36317ms step_avg:41.84ms
+step:869/1840 train_time:36376ms step_avg:41.86ms
+step:870/1840 train_time:36438ms step_avg:41.88ms
+step:871/1840 train_time:36498ms step_avg:41.90ms
+step:872/1840 train_time:36560ms step_avg:41.93ms
+step:873/1840 train_time:36620ms step_avg:41.95ms
+step:874/1840 train_time:36684ms step_avg:41.97ms
+step:875/1840 train_time:36745ms step_avg:41.99ms
+step:876/1840 train_time:36808ms step_avg:42.02ms
+step:877/1840 train_time:36867ms step_avg:42.04ms
+step:878/1840 train_time:36929ms step_avg:42.06ms
+step:879/1840 train_time:36989ms step_avg:42.08ms
+step:880/1840 train_time:37051ms step_avg:42.10ms
+step:881/1840 train_time:37111ms step_avg:42.12ms
+step:882/1840 train_time:37173ms step_avg:42.15ms
+step:883/1840 train_time:37233ms step_avg:42.17ms
+step:884/1840 train_time:37295ms step_avg:42.19ms
+step:885/1840 train_time:37355ms step_avg:42.21ms
+step:886/1840 train_time:37417ms step_avg:42.23ms
+step:887/1840 train_time:37477ms step_avg:42.25ms
+step:888/1840 train_time:37540ms step_avg:42.27ms
+step:889/1840 train_time:37600ms step_avg:42.30ms
+step:890/1840 train_time:37663ms step_avg:42.32ms
+step:891/1840 train_time:37724ms step_avg:42.34ms
+step:892/1840 train_time:37786ms step_avg:42.36ms
+step:893/1840 train_time:37846ms step_avg:42.38ms
+step:894/1840 train_time:37908ms step_avg:42.40ms
+step:895/1840 train_time:37968ms step_avg:42.42ms
+step:896/1840 train_time:38030ms step_avg:42.44ms
+step:897/1840 train_time:38091ms step_avg:42.46ms
+step:898/1840 train_time:38152ms step_avg:42.49ms
+step:899/1840 train_time:38211ms step_avg:42.50ms
+step:900/1840 train_time:38274ms step_avg:42.53ms
+step:901/1840 train_time:38334ms step_avg:42.55ms
+step:902/1840 train_time:38397ms step_avg:42.57ms
+step:903/1840 train_time:38457ms step_avg:42.59ms
+step:904/1840 train_time:38519ms step_avg:42.61ms
+step:905/1840 train_time:38578ms step_avg:42.63ms
+step:906/1840 train_time:38641ms step_avg:42.65ms
+step:907/1840 train_time:38702ms step_avg:42.67ms
+step:908/1840 train_time:38764ms step_avg:42.69ms
+step:909/1840 train_time:38824ms step_avg:42.71ms
+step:910/1840 train_time:38888ms step_avg:42.73ms
+step:911/1840 train_time:38948ms step_avg:42.75ms
+step:912/1840 train_time:39010ms step_avg:42.77ms
+step:913/1840 train_time:39069ms step_avg:42.79ms
+step:914/1840 train_time:39132ms step_avg:42.81ms
+step:915/1840 train_time:39192ms step_avg:42.83ms
+step:916/1840 train_time:39254ms step_avg:42.85ms
+step:917/1840 train_time:39313ms step_avg:42.87ms
+step:918/1840 train_time:39375ms step_avg:42.89ms
+step:919/1840 train_time:39435ms step_avg:42.91ms
+step:920/1840 train_time:39497ms step_avg:42.93ms
+step:921/1840 train_time:39558ms step_avg:42.95ms
+step:922/1840 train_time:39620ms step_avg:42.97ms
+step:923/1840 train_time:39680ms step_avg:42.99ms
+step:924/1840 train_time:39743ms step_avg:43.01ms
+step:925/1840 train_time:39803ms step_avg:43.03ms
+step:926/1840 train_time:39866ms step_avg:43.05ms
+step:927/1840 train_time:39925ms step_avg:43.07ms
+step:928/1840 train_time:39988ms step_avg:43.09ms
+step:929/1840 train_time:40047ms step_avg:43.11ms
+step:930/1840 train_time:40110ms step_avg:43.13ms
+step:931/1840 train_time:40169ms step_avg:43.15ms
+step:932/1840 train_time:40231ms step_avg:43.17ms
+step:933/1840 train_time:40290ms step_avg:43.18ms
+step:934/1840 train_time:40353ms step_avg:43.20ms
+step:935/1840 train_time:40413ms step_avg:43.22ms
+step:936/1840 train_time:40476ms step_avg:43.24ms
+step:937/1840 train_time:40536ms step_avg:43.26ms
+step:938/1840 train_time:40598ms step_avg:43.28ms
+step:939/1840 train_time:40658ms step_avg:43.30ms
+step:940/1840 train_time:40722ms step_avg:43.32ms
+step:941/1840 train_time:40781ms step_avg:43.34ms
+step:942/1840 train_time:40845ms step_avg:43.36ms
+step:943/1840 train_time:40905ms step_avg:43.38ms
+step:944/1840 train_time:40968ms step_avg:43.40ms
+step:945/1840 train_time:41028ms step_avg:43.42ms
+step:946/1840 train_time:41089ms step_avg:43.43ms
+step:947/1840 train_time:41149ms step_avg:43.45ms
+step:948/1840 train_time:41211ms step_avg:43.47ms
+step:949/1840 train_time:41271ms step_avg:43.49ms
+step:950/1840 train_time:41332ms step_avg:43.51ms
+step:951/1840 train_time:41392ms step_avg:43.52ms
+step:952/1840 train_time:41454ms step_avg:43.54ms
+step:953/1840 train_time:41514ms step_avg:43.56ms
+step:954/1840 train_time:41576ms step_avg:43.58ms
+step:955/1840 train_time:41636ms step_avg:43.60ms
+step:956/1840 train_time:41699ms step_avg:43.62ms
+step:957/1840 train_time:41758ms step_avg:43.63ms
+step:958/1840 train_time:41821ms step_avg:43.65ms
+step:959/1840 train_time:41882ms step_avg:43.67ms
+step:960/1840 train_time:41945ms step_avg:43.69ms
+step:961/1840 train_time:42006ms step_avg:43.71ms
+step:962/1840 train_time:42068ms step_avg:43.73ms
+step:963/1840 train_time:42127ms step_avg:43.75ms
+step:964/1840 train_time:42189ms step_avg:43.76ms
+step:965/1840 train_time:42249ms step_avg:43.78ms
+step:966/1840 train_time:42312ms step_avg:43.80ms
+step:967/1840 train_time:42371ms step_avg:43.82ms
+step:968/1840 train_time:42433ms step_avg:43.84ms
+step:969/1840 train_time:42493ms step_avg:43.85ms
+step:970/1840 train_time:42555ms step_avg:43.87ms
+step:971/1840 train_time:42615ms step_avg:43.89ms
+step:972/1840 train_time:42677ms step_avg:43.91ms
+step:973/1840 train_time:42737ms step_avg:43.92ms
+step:974/1840 train_time:42799ms step_avg:43.94ms
+step:975/1840 train_time:42861ms step_avg:43.96ms
+step:976/1840 train_time:42924ms step_avg:43.98ms
+step:977/1840 train_time:42985ms step_avg:44.00ms
+step:978/1840 train_time:43046ms step_avg:44.01ms
+step:979/1840 train_time:43107ms step_avg:44.03ms
+step:980/1840 train_time:43168ms step_avg:44.05ms
+step:981/1840 train_time:43228ms step_avg:44.07ms
+step:982/1840 train_time:43290ms step_avg:44.08ms
+step:983/1840 train_time:43350ms step_avg:44.10ms
+step:984/1840 train_time:43412ms step_avg:44.12ms
+step:985/1840 train_time:43471ms step_avg:44.13ms
+step:986/1840 train_time:43534ms step_avg:44.15ms
+step:987/1840 train_time:43593ms step_avg:44.17ms
+step:988/1840 train_time:43656ms step_avg:44.19ms
+step:989/1840 train_time:43715ms step_avg:44.20ms
+step:990/1840 train_time:43778ms step_avg:44.22ms
+step:991/1840 train_time:43839ms step_avg:44.24ms
+step:992/1840 train_time:43902ms step_avg:44.26ms
+step:993/1840 train_time:43963ms step_avg:44.27ms
+step:994/1840 train_time:44026ms step_avg:44.29ms
+step:995/1840 train_time:44087ms step_avg:44.31ms
+step:996/1840 train_time:44148ms step_avg:44.33ms
+step:997/1840 train_time:44208ms step_avg:44.34ms
+step:998/1840 train_time:44270ms step_avg:44.36ms
+step:999/1840 train_time:44330ms step_avg:44.37ms
+step:1000/1840 train_time:44392ms step_avg:44.39ms
+step:1000/1840 val_loss:3.7744 train_time:44463ms step_avg:44.46ms
+step:1001/1840 train_time:44482ms step_avg:44.44ms
+step:1002/1840 train_time:44516ms step_avg:44.43ms
+step:1003/1840 train_time:44578ms step_avg:44.45ms
+step:1004/1840 train_time:44641ms step_avg:44.46ms
+step:1005/1840 train_time:44703ms step_avg:44.48ms
+step:1006/1840 train_time:44765ms step_avg:44.50ms
+step:1007/1840 train_time:44823ms step_avg:44.51ms
+step:1008/1840 train_time:44885ms step_avg:44.53ms
+step:1009/1840 train_time:44944ms step_avg:44.54ms
+step:1010/1840 train_time:45005ms step_avg:44.56ms
+step:1011/1840 train_time:45065ms step_avg:44.57ms
+step:1012/1840 train_time:45127ms step_avg:44.59ms
+step:1013/1840 train_time:45187ms step_avg:44.61ms
+step:1014/1840 train_time:45249ms step_avg:44.62ms
+step:1015/1840 train_time:45309ms step_avg:44.64ms
+step:1016/1840 train_time:45372ms step_avg:44.66ms
+step:1017/1840 train_time:45432ms step_avg:44.67ms
+step:1018/1840 train_time:45495ms step_avg:44.69ms
+step:1019/1840 train_time:45555ms step_avg:44.71ms
+step:1020/1840 train_time:45618ms step_avg:44.72ms
+step:1021/1840 train_time:45678ms step_avg:44.74ms
+step:1022/1840 train_time:45741ms step_avg:44.76ms
+step:1023/1840 train_time:45801ms step_avg:44.77ms
+step:1024/1840 train_time:45863ms step_avg:44.79ms
+step:1025/1840 train_time:45922ms step_avg:44.80ms
+step:1026/1840 train_time:45984ms step_avg:44.82ms
+step:1027/1840 train_time:46042ms step_avg:44.83ms
+step:1028/1840 train_time:46104ms step_avg:44.85ms
+step:1029/1840 train_time:46163ms step_avg:44.86ms
+step:1030/1840 train_time:46225ms step_avg:44.88ms
+step:1031/1840 train_time:46285ms step_avg:44.89ms
+step:1032/1840 train_time:46348ms step_avg:44.91ms
+step:1033/1840 train_time:46408ms step_avg:44.93ms
+step:1034/1840 train_time:46473ms step_avg:44.94ms
+step:1035/1840 train_time:46534ms step_avg:44.96ms
+step:1036/1840 train_time:46597ms step_avg:44.98ms
+step:1037/1840 train_time:46657ms step_avg:44.99ms
+step:1038/1840 train_time:46719ms step_avg:45.01ms
+step:1039/1840 train_time:46778ms step_avg:45.02ms
+step:1040/1840 train_time:46840ms step_avg:45.04ms
+step:1041/1840 train_time:46900ms step_avg:45.05ms
+step:1042/1840 train_time:46962ms step_avg:45.07ms
+step:1043/1840 train_time:47020ms step_avg:45.08ms
+step:1044/1840 train_time:47082ms step_avg:45.10ms
+step:1045/1840 train_time:47141ms step_avg:45.11ms
+step:1046/1840 train_time:47204ms step_avg:45.13ms
+step:1047/1840 train_time:47263ms step_avg:45.14ms
+step:1048/1840 train_time:47326ms step_avg:45.16ms
+step:1049/1840 train_time:47386ms step_avg:45.17ms
+step:1050/1840 train_time:47450ms step_avg:45.19ms
+step:1051/1840 train_time:47510ms step_avg:45.20ms
+step:1052/1840 train_time:47574ms step_avg:45.22ms
+step:1053/1840 train_time:47634ms step_avg:45.24ms
+step:1054/1840 train_time:47696ms step_avg:45.25ms
+step:1055/1840 train_time:47756ms step_avg:45.27ms
+step:1056/1840 train_time:47818ms step_avg:45.28ms
+step:1057/1840 train_time:47878ms step_avg:45.30ms
+step:1058/1840 train_time:47940ms step_avg:45.31ms
+step:1059/1840 train_time:47999ms step_avg:45.33ms
+step:1060/1840 train_time:48061ms step_avg:45.34ms
+step:1061/1840 train_time:48120ms step_avg:45.35ms
+step:1062/1840 train_time:48182ms step_avg:45.37ms
+step:1063/1840 train_time:48242ms step_avg:45.38ms
+step:1064/1840 train_time:48304ms step_avg:45.40ms
+step:1065/1840 train_time:48364ms step_avg:45.41ms
+step:1066/1840 train_time:48427ms step_avg:45.43ms
+step:1067/1840 train_time:48488ms step_avg:45.44ms
+step:1068/1840 train_time:48552ms step_avg:45.46ms
+step:1069/1840 train_time:48613ms step_avg:45.48ms
+step:1070/1840 train_time:48675ms step_avg:45.49ms
+step:1071/1840 train_time:48735ms step_avg:45.50ms
+step:1072/1840 train_time:48797ms step_avg:45.52ms
+step:1073/1840 train_time:48857ms step_avg:45.53ms
+step:1074/1840 train_time:48918ms step_avg:45.55ms
+step:1075/1840 train_time:48978ms step_avg:45.56ms
+step:1076/1840 train_time:49040ms step_avg:45.58ms
+step:1077/1840 train_time:49100ms step_avg:45.59ms
+step:1078/1840 train_time:49162ms step_avg:45.60ms
+step:1079/1840 train_time:49221ms step_avg:45.62ms
+step:1080/1840 train_time:49283ms step_avg:45.63ms
+step:1081/1840 train_time:49343ms step_avg:45.65ms
+step:1082/1840 train_time:49405ms step_avg:45.66ms
+step:1083/1840 train_time:49466ms step_avg:45.68ms
+step:1084/1840 train_time:49529ms step_avg:45.69ms
+step:1085/1840 train_time:49589ms step_avg:45.70ms
+step:1086/1840 train_time:49651ms step_avg:45.72ms
+step:1087/1840 train_time:49712ms step_avg:45.73ms
+step:1088/1840 train_time:49775ms step_avg:45.75ms
+step:1089/1840 train_time:49835ms step_avg:45.76ms
+step:1090/1840 train_time:49896ms step_avg:45.78ms
+step:1091/1840 train_time:49956ms step_avg:45.79ms
+step:1092/1840 train_time:50018ms step_avg:45.80ms
+step:1093/1840 train_time:50079ms step_avg:45.82ms
+step:1094/1840 train_time:50140ms step_avg:45.83ms
+step:1095/1840 train_time:50200ms step_avg:45.84ms
+step:1096/1840 train_time:50262ms step_avg:45.86ms
+step:1097/1840 train_time:50321ms step_avg:45.87ms
+step:1098/1840 train_time:50385ms step_avg:45.89ms
+step:1099/1840 train_time:50444ms step_avg:45.90ms
+step:1100/1840 train_time:50507ms step_avg:45.92ms
+step:1101/1840 train_time:50567ms step_avg:45.93ms
+step:1102/1840 train_time:50629ms step_avg:45.94ms
+step:1103/1840 train_time:50690ms step_avg:45.96ms
+step:1104/1840 train_time:50753ms step_avg:45.97ms
+step:1105/1840 train_time:50813ms step_avg:45.98ms
+step:1106/1840 train_time:50876ms step_avg:46.00ms
+step:1107/1840 train_time:50936ms step_avg:46.01ms
+step:1108/1840 train_time:50998ms step_avg:46.03ms
+step:1109/1840 train_time:51057ms step_avg:46.04ms
+step:1110/1840 train_time:51120ms step_avg:46.05ms
+step:1111/1840 train_time:51179ms step_avg:46.07ms
+step:1112/1840 train_time:51242ms step_avg:46.08ms
+step:1113/1840 train_time:51301ms step_avg:46.09ms
+step:1114/1840 train_time:51364ms step_avg:46.11ms
+step:1115/1840 train_time:51424ms step_avg:46.12ms
+step:1116/1840 train_time:51485ms step_avg:46.13ms
+step:1117/1840 train_time:51545ms step_avg:46.15ms
+step:1118/1840 train_time:51609ms step_avg:46.16ms
+step:1119/1840 train_time:51668ms step_avg:46.17ms
+step:1120/1840 train_time:51730ms step_avg:46.19ms
+step:1121/1840 train_time:51791ms step_avg:46.20ms
+step:1122/1840 train_time:51854ms step_avg:46.22ms
+step:1123/1840 train_time:51915ms step_avg:46.23ms
+step:1124/1840 train_time:51976ms step_avg:46.24ms
+step:1125/1840 train_time:52037ms step_avg:46.26ms
+step:1126/1840 train_time:52099ms step_avg:46.27ms
+step:1127/1840 train_time:52158ms step_avg:46.28ms
+step:1128/1840 train_time:52219ms step_avg:46.29ms
+step:1129/1840 train_time:52279ms step_avg:46.31ms
+step:1130/1840 train_time:52341ms step_avg:46.32ms
+step:1131/1840 train_time:52401ms step_avg:46.33ms
+step:1132/1840 train_time:52464ms step_avg:46.35ms
+step:1133/1840 train_time:52523ms step_avg:46.36ms
+step:1134/1840 train_time:52585ms step_avg:46.37ms
+step:1135/1840 train_time:52645ms step_avg:46.38ms
+step:1136/1840 train_time:52707ms step_avg:46.40ms
+step:1137/1840 train_time:52767ms step_avg:46.41ms
+step:1138/1840 train_time:52830ms step_avg:46.42ms
+step:1139/1840 train_time:52891ms step_avg:46.44ms
+step:1140/1840 train_time:52954ms step_avg:46.45ms
+step:1141/1840 train_time:53014ms step_avg:46.46ms
+step:1142/1840 train_time:53077ms step_avg:46.48ms
+step:1143/1840 train_time:53137ms step_avg:46.49ms
+step:1144/1840 train_time:53198ms step_avg:46.50ms
+step:1145/1840 train_time:53258ms step_avg:46.51ms
+step:1146/1840 train_time:53320ms step_avg:46.53ms
+step:1147/1840 train_time:53379ms step_avg:46.54ms
+step:1148/1840 train_time:53442ms step_avg:46.55ms
+step:1149/1840 train_time:53501ms step_avg:46.56ms
+step:1150/1840 train_time:53564ms step_avg:46.58ms
+step:1151/1840 train_time:53623ms step_avg:46.59ms
+step:1152/1840 train_time:53685ms step_avg:46.60ms
+step:1153/1840 train_time:53746ms step_avg:46.61ms
+step:1154/1840 train_time:53808ms step_avg:46.63ms
+step:1155/1840 train_time:53869ms step_avg:46.64ms
+step:1156/1840 train_time:53932ms step_avg:46.65ms
+step:1157/1840 train_time:53993ms step_avg:46.67ms
+step:1158/1840 train_time:54056ms step_avg:46.68ms
+step:1159/1840 train_time:54116ms step_avg:46.69ms
+step:1160/1840 train_time:54178ms step_avg:46.70ms
+step:1161/1840 train_time:54237ms step_avg:46.72ms
+step:1162/1840 train_time:54299ms step_avg:46.73ms
+step:1163/1840 train_time:54359ms step_avg:46.74ms
+step:1164/1840 train_time:54420ms step_avg:46.75ms
+step:1165/1840 train_time:54480ms step_avg:46.76ms
+step:1166/1840 train_time:54542ms step_avg:46.78ms
+step:1167/1840 train_time:54601ms step_avg:46.79ms
+step:1168/1840 train_time:54665ms step_avg:46.80ms
+step:1169/1840 train_time:54724ms step_avg:46.81ms
+step:1170/1840 train_time:54787ms step_avg:46.83ms
+step:1171/1840 train_time:54847ms step_avg:46.84ms
+step:1172/1840 train_time:54910ms step_avg:46.85ms
+step:1173/1840 train_time:54972ms step_avg:46.86ms
+step:1174/1840 train_time:55034ms step_avg:46.88ms
+step:1175/1840 train_time:55095ms step_avg:46.89ms
+step:1176/1840 train_time:55157ms step_avg:46.90ms
+step:1177/1840 train_time:55217ms step_avg:46.91ms
+step:1178/1840 train_time:55278ms step_avg:46.93ms
+step:1179/1840 train_time:55338ms step_avg:46.94ms
+step:1180/1840 train_time:55401ms step_avg:46.95ms
+step:1181/1840 train_time:55460ms step_avg:46.96ms
+step:1182/1840 train_time:55521ms step_avg:46.97ms
+step:1183/1840 train_time:55582ms step_avg:46.98ms
+step:1184/1840 train_time:55643ms step_avg:47.00ms
+step:1185/1840 train_time:55702ms step_avg:47.01ms
+step:1186/1840 train_time:55766ms step_avg:47.02ms
+step:1187/1840 train_time:55826ms step_avg:47.03ms
+step:1188/1840 train_time:55889ms step_avg:47.04ms
+step:1189/1840 train_time:55950ms step_avg:47.06ms
+step:1190/1840 train_time:56013ms step_avg:47.07ms
+step:1191/1840 train_time:56073ms step_avg:47.08ms
+step:1192/1840 train_time:56135ms step_avg:47.09ms
+step:1193/1840 train_time:56195ms step_avg:47.10ms
+step:1194/1840 train_time:56257ms step_avg:47.12ms
+step:1195/1840 train_time:56317ms step_avg:47.13ms
+step:1196/1840 train_time:56379ms step_avg:47.14ms
+step:1197/1840 train_time:56438ms step_avg:47.15ms
+step:1198/1840 train_time:56500ms step_avg:47.16ms
+step:1199/1840 train_time:56560ms step_avg:47.17ms
+step:1200/1840 train_time:56622ms step_avg:47.18ms
+step:1201/1840 train_time:56683ms step_avg:47.20ms
+step:1202/1840 train_time:56767ms step_avg:47.23ms
+step:1203/1840 train_time:56856ms step_avg:47.26ms
+step:1204/1840 train_time:56947ms step_avg:47.30ms
+step:1205/1840 train_time:57034ms step_avg:47.33ms
+step:1206/1840 train_time:57125ms step_avg:47.37ms
+step:1207/1840 train_time:57212ms step_avg:47.40ms
+step:1208/1840 train_time:57301ms step_avg:47.43ms
+step:1209/1840 train_time:57389ms step_avg:47.47ms
+step:1210/1840 train_time:57478ms step_avg:47.50ms
+step:1211/1840 train_time:57565ms step_avg:47.53ms
+step:1212/1840 train_time:57654ms step_avg:47.57ms
+step:1213/1840 train_time:57740ms step_avg:47.60ms
+step:1214/1840 train_time:57828ms step_avg:47.63ms
+step:1215/1840 train_time:57916ms step_avg:47.67ms
+step:1216/1840 train_time:58005ms step_avg:47.70ms
+step:1217/1840 train_time:58092ms step_avg:47.73ms
+step:1218/1840 train_time:58181ms step_avg:47.77ms
+step:1219/1840 train_time:58267ms step_avg:47.80ms
+step:1220/1840 train_time:58356ms step_avg:47.83ms
+step:1221/1840 train_time:58443ms step_avg:47.87ms
+step:1222/1840 train_time:58531ms step_avg:47.90ms
+step:1223/1840 train_time:58617ms step_avg:47.93ms
+step:1224/1840 train_time:58705ms step_avg:47.96ms
+step:1225/1840 train_time:58792ms step_avg:47.99ms
+step:1226/1840 train_time:58881ms step_avg:48.03ms
+step:1227/1840 train_time:58967ms step_avg:48.06ms
+step:1228/1840 train_time:59056ms step_avg:48.09ms
+step:1229/1840 train_time:59144ms step_avg:48.12ms
+step:1230/1840 train_time:59231ms step_avg:48.16ms
+step:1231/1840 train_time:59318ms step_avg:48.19ms
+step:1232/1840 train_time:59407ms step_avg:48.22ms
+step:1233/1840 train_time:59493ms step_avg:48.25ms
+step:1234/1840 train_time:59583ms step_avg:48.28ms
+step:1235/1840 train_time:59668ms step_avg:48.31ms
+step:1236/1840 train_time:59756ms step_avg:48.35ms
+step:1237/1840 train_time:59843ms step_avg:48.38ms
+step:1238/1840 train_time:59931ms step_avg:48.41ms
+step:1239/1840 train_time:60017ms step_avg:48.44ms
+step:1240/1840 train_time:60107ms step_avg:48.47ms
+step:1241/1840 train_time:60192ms step_avg:48.50ms
+step:1242/1840 train_time:60281ms step_avg:48.54ms
+step:1243/1840 train_time:60367ms step_avg:48.57ms
+step:1244/1840 train_time:60457ms step_avg:48.60ms
+step:1245/1840 train_time:60543ms step_avg:48.63ms
+step:1246/1840 train_time:60632ms step_avg:48.66ms
+step:1247/1840 train_time:60720ms step_avg:48.69ms
+step:1248/1840 train_time:60807ms step_avg:48.72ms
+step:1249/1840 train_time:60892ms step_avg:48.75ms
+step:1250/1840 train_time:60983ms step_avg:48.79ms
+step:1250/1840 val_loss:3.5321 train_time:61083ms step_avg:48.87ms
+step:1251/1840 train_time:61102ms step_avg:48.84ms
+step:1252/1840 train_time:61160ms step_avg:48.85ms
+step:1253/1840 train_time:61252ms step_avg:48.88ms
+step:1254/1840 train_time:61343ms step_avg:48.92ms
+step:1255/1840 train_time:61428ms step_avg:48.95ms
+step:1256/1840 train_time:61517ms step_avg:48.98ms
+step:1257/1840 train_time:61603ms step_avg:49.01ms
+step:1258/1840 train_time:61690ms step_avg:49.04ms
+step:1259/1840 train_time:61777ms step_avg:49.07ms
+step:1260/1840 train_time:61864ms step_avg:49.10ms
+step:1261/1840 train_time:61950ms step_avg:49.13ms
+step:1262/1840 train_time:62038ms step_avg:49.16ms
+step:1263/1840 train_time:62129ms step_avg:49.19ms
+step:1264/1840 train_time:62220ms step_avg:49.22ms
+step:1265/1840 train_time:62307ms step_avg:49.25ms
+step:1266/1840 train_time:62396ms step_avg:49.29ms
+step:1267/1840 train_time:62481ms step_avg:49.31ms
+step:1268/1840 train_time:62570ms step_avg:49.35ms
+step:1269/1840 train_time:62656ms step_avg:49.37ms
+step:1270/1840 train_time:62745ms step_avg:49.41ms
+step:1271/1840 train_time:62830ms step_avg:49.43ms
+step:1272/1840 train_time:62917ms step_avg:49.46ms
+step:1273/1840 train_time:63004ms step_avg:49.49ms
+step:1274/1840 train_time:63092ms step_avg:49.52ms
+step:1275/1840 train_time:63181ms step_avg:49.55ms
+step:1276/1840 train_time:63270ms step_avg:49.58ms
+step:1277/1840 train_time:63356ms step_avg:49.61ms
+step:1278/1840 train_time:63446ms step_avg:49.64ms
+step:1279/1840 train_time:63531ms step_avg:49.67ms
+step:1280/1840 train_time:63619ms step_avg:49.70ms
+step:1281/1840 train_time:63706ms step_avg:49.73ms
+step:1282/1840 train_time:63793ms step_avg:49.76ms
+step:1283/1840 train_time:63879ms step_avg:49.79ms
+step:1284/1840 train_time:63967ms step_avg:49.82ms
+step:1285/1840 train_time:64053ms step_avg:49.85ms
+step:1286/1840 train_time:64146ms step_avg:49.88ms
+step:1287/1840 train_time:64232ms step_avg:49.91ms
+step:1288/1840 train_time:64323ms step_avg:49.94ms
+step:1289/1840 train_time:64408ms step_avg:49.97ms
+step:1290/1840 train_time:64497ms step_avg:50.00ms
+step:1291/1840 train_time:64583ms step_avg:50.03ms
+step:1292/1840 train_time:64670ms step_avg:50.05ms
+step:1293/1840 train_time:64757ms step_avg:50.08ms
+step:1294/1840 train_time:64845ms step_avg:50.11ms
+step:1295/1840 train_time:64930ms step_avg:50.14ms
+step:1296/1840 train_time:65020ms step_avg:50.17ms
+step:1297/1840 train_time:65107ms step_avg:50.20ms
+step:1298/1840 train_time:65197ms step_avg:50.23ms
+step:1299/1840 train_time:65284ms step_avg:50.26ms
+step:1300/1840 train_time:65372ms step_avg:50.29ms
+step:1301/1840 train_time:65459ms step_avg:50.31ms
+step:1302/1840 train_time:65548ms step_avg:50.34ms
+step:1303/1840 train_time:65633ms step_avg:50.37ms
+step:1304/1840 train_time:65722ms step_avg:50.40ms
+step:1305/1840 train_time:65808ms step_avg:50.43ms
+step:1306/1840 train_time:65896ms step_avg:50.46ms
+step:1307/1840 train_time:65982ms step_avg:50.48ms
+step:1308/1840 train_time:66071ms step_avg:50.51ms
+step:1309/1840 train_time:66158ms step_avg:50.54ms
+step:1310/1840 train_time:66248ms step_avg:50.57ms
+step:1311/1840 train_time:66334ms step_avg:50.60ms
+step:1312/1840 train_time:66423ms step_avg:50.63ms
+step:1313/1840 train_time:66510ms step_avg:50.65ms
+step:1314/1840 train_time:66599ms step_avg:50.68ms
+step:1315/1840 train_time:66685ms step_avg:50.71ms
+step:1316/1840 train_time:66773ms step_avg:50.74ms
+step:1317/1840 train_time:66859ms step_avg:50.77ms
+step:1318/1840 train_time:66947ms step_avg:50.79ms
+step:1319/1840 train_time:67032ms step_avg:50.82ms
+step:1320/1840 train_time:67124ms step_avg:50.85ms
+step:1321/1840 train_time:67210ms step_avg:50.88ms
+step:1322/1840 train_time:67299ms step_avg:50.91ms
+step:1323/1840 train_time:67386ms step_avg:50.93ms
+step:1324/1840 train_time:67474ms step_avg:50.96ms
+step:1325/1840 train_time:67559ms step_avg:50.99ms
+step:1326/1840 train_time:67648ms step_avg:51.02ms
+step:1327/1840 train_time:67734ms step_avg:51.04ms
+step:1328/1840 train_time:67823ms step_avg:51.07ms
+step:1329/1840 train_time:67910ms step_avg:51.10ms
+step:1330/1840 train_time:67999ms step_avg:51.13ms
+step:1331/1840 train_time:68086ms step_avg:51.15ms
+step:1332/1840 train_time:68175ms step_avg:51.18ms
+step:1333/1840 train_time:68262ms step_avg:51.21ms
+step:1334/1840 train_time:68350ms step_avg:51.24ms
+step:1335/1840 train_time:68436ms step_avg:51.26ms
+step:1336/1840 train_time:68524ms step_avg:51.29ms
+step:1337/1840 train_time:68612ms step_avg:51.32ms
+step:1338/1840 train_time:68703ms step_avg:51.35ms
+step:1339/1840 train_time:68789ms step_avg:51.37ms
+step:1340/1840 train_time:68876ms step_avg:51.40ms
+step:1341/1840 train_time:68962ms step_avg:51.43ms
+step:1342/1840 train_time:69050ms step_avg:51.45ms
+step:1343/1840 train_time:69138ms step_avg:51.48ms
+step:1344/1840 train_time:69227ms step_avg:51.51ms
+step:1345/1840 train_time:69312ms step_avg:51.53ms
+step:1346/1840 train_time:69402ms step_avg:51.56ms
+step:1347/1840 train_time:69488ms step_avg:51.59ms
+step:1348/1840 train_time:69576ms step_avg:51.61ms
+step:1349/1840 train_time:69663ms step_avg:51.64ms
+step:1350/1840 train_time:69750ms step_avg:51.67ms
+step:1351/1840 train_time:69837ms step_avg:51.69ms
+step:1352/1840 train_time:69926ms step_avg:51.72ms
+step:1353/1840 train_time:70011ms step_avg:51.75ms
+step:1354/1840 train_time:70100ms step_avg:51.77ms
+step:1355/1840 train_time:70186ms step_avg:51.80ms
+step:1356/1840 train_time:70275ms step_avg:51.83ms
+step:1357/1840 train_time:70361ms step_avg:51.85ms
+step:1358/1840 train_time:70449ms step_avg:51.88ms
+step:1359/1840 train_time:70535ms step_avg:51.90ms
+step:1360/1840 train_time:70624ms step_avg:51.93ms
+step:1361/1840 train_time:70710ms step_avg:51.95ms
+step:1362/1840 train_time:70799ms step_avg:51.98ms
+step:1363/1840 train_time:70886ms step_avg:52.01ms
+step:1364/1840 train_time:70974ms step_avg:52.03ms
+step:1365/1840 train_time:71060ms step_avg:52.06ms
+step:1366/1840 train_time:71149ms step_avg:52.09ms
+step:1367/1840 train_time:71235ms step_avg:52.11ms
+step:1368/1840 train_time:71325ms step_avg:52.14ms
+step:1369/1840 train_time:71410ms step_avg:52.16ms
+step:1370/1840 train_time:71498ms step_avg:52.19ms
+step:1371/1840 train_time:71585ms step_avg:52.21ms
+step:1372/1840 train_time:71674ms step_avg:52.24ms
+step:1373/1840 train_time:71760ms step_avg:52.26ms
+step:1374/1840 train_time:71849ms step_avg:52.29ms
+step:1375/1840 train_time:71935ms step_avg:52.32ms
+step:1376/1840 train_time:72024ms step_avg:52.34ms
+step:1377/1840 train_time:72109ms step_avg:52.37ms
+step:1378/1840 train_time:72199ms step_avg:52.39ms
+step:1379/1840 train_time:72285ms step_avg:52.42ms
+step:1380/1840 train_time:72374ms step_avg:52.44ms
+step:1381/1840 train_time:72460ms step_avg:52.47ms
+step:1382/1840 train_time:72549ms step_avg:52.50ms
+step:1383/1840 train_time:72635ms step_avg:52.52ms
+step:1384/1840 train_time:72724ms step_avg:52.55ms
+step:1385/1840 train_time:72812ms step_avg:52.57ms
+step:1386/1840 train_time:72902ms step_avg:52.60ms
+step:1387/1840 train_time:72987ms step_avg:52.62ms
+step:1388/1840 train_time:73076ms step_avg:52.65ms
+step:1389/1840 train_time:73163ms step_avg:52.67ms
+step:1390/1840 train_time:73250ms step_avg:52.70ms
+step:1391/1840 train_time:73337ms step_avg:52.72ms
+step:1392/1840 train_time:73426ms step_avg:52.75ms
+step:1393/1840 train_time:73512ms step_avg:52.77ms
+step:1394/1840 train_time:73600ms step_avg:52.80ms
+step:1395/1840 train_time:73686ms step_avg:52.82ms
+step:1396/1840 train_time:73775ms step_avg:52.85ms
+step:1397/1840 train_time:73861ms step_avg:52.87ms
+step:1398/1840 train_time:73949ms step_avg:52.90ms
+step:1399/1840 train_time:74035ms step_avg:52.92ms
+step:1400/1840 train_time:74124ms step_avg:52.95ms
+step:1401/1840 train_time:74210ms step_avg:52.97ms
+step:1402/1840 train_time:74299ms step_avg:53.00ms
+step:1403/1840 train_time:74386ms step_avg:53.02ms
+step:1404/1840 train_time:74473ms step_avg:53.04ms
+step:1405/1840 train_time:74560ms step_avg:53.07ms
+step:1406/1840 train_time:74649ms step_avg:53.09ms
+step:1407/1840 train_time:74734ms step_avg:53.12ms
+step:1408/1840 train_time:74824ms step_avg:53.14ms
+step:1409/1840 train_time:74911ms step_avg:53.17ms
+step:1410/1840 train_time:75000ms step_avg:53.19ms
+step:1411/1840 train_time:75086ms step_avg:53.21ms
+step:1412/1840 train_time:75175ms step_avg:53.24ms
+step:1413/1840 train_time:75261ms step_avg:53.26ms
+step:1414/1840 train_time:75350ms step_avg:53.29ms
+step:1415/1840 train_time:75437ms step_avg:53.31ms
+step:1416/1840 train_time:75526ms step_avg:53.34ms
+step:1417/1840 train_time:75614ms step_avg:53.36ms
+step:1418/1840 train_time:75702ms step_avg:53.39ms
+step:1419/1840 train_time:75787ms step_avg:53.41ms
+step:1420/1840 train_time:75877ms step_avg:53.43ms
+step:1421/1840 train_time:75963ms step_avg:53.46ms
+step:1422/1840 train_time:76050ms step_avg:53.48ms
+step:1423/1840 train_time:76136ms step_avg:53.50ms
+step:1424/1840 train_time:76226ms step_avg:53.53ms
+step:1425/1840 train_time:76312ms step_avg:53.55ms
+step:1426/1840 train_time:76401ms step_avg:53.58ms
+step:1427/1840 train_time:76486ms step_avg:53.60ms
+step:1428/1840 train_time:76577ms step_avg:53.63ms
+step:1429/1840 train_time:76664ms step_avg:53.65ms
+step:1430/1840 train_time:76751ms step_avg:53.67ms
+step:1431/1840 train_time:76838ms step_avg:53.70ms
+step:1432/1840 train_time:76927ms step_avg:53.72ms
+step:1433/1840 train_time:77013ms step_avg:53.74ms
+step:1434/1840 train_time:77103ms step_avg:53.77ms
+step:1435/1840 train_time:77189ms step_avg:53.79ms
+step:1436/1840 train_time:77277ms step_avg:53.81ms
+step:1437/1840 train_time:77363ms step_avg:53.84ms
+step:1438/1840 train_time:77450ms step_avg:53.86ms
+step:1439/1840 train_time:77537ms step_avg:53.88ms
+step:1440/1840 train_time:77626ms step_avg:53.91ms
+step:1441/1840 train_time:77712ms step_avg:53.93ms
+step:1442/1840 train_time:77800ms step_avg:53.95ms
+step:1443/1840 train_time:77887ms step_avg:53.98ms
+step:1444/1840 train_time:77976ms step_avg:54.00ms
+step:1445/1840 train_time:78063ms step_avg:54.02ms
+step:1446/1840 train_time:78150ms step_avg:54.05ms
+step:1447/1840 train_time:78237ms step_avg:54.07ms
+step:1448/1840 train_time:78326ms step_avg:54.09ms
+step:1449/1840 train_time:78412ms step_avg:54.11ms
+step:1450/1840 train_time:78502ms step_avg:54.14ms
+step:1451/1840 train_time:78588ms step_avg:54.16ms
+step:1452/1840 train_time:78676ms step_avg:54.18ms
+step:1453/1840 train_time:78763ms step_avg:54.21ms
+step:1454/1840 train_time:78852ms step_avg:54.23ms
+step:1455/1840 train_time:78939ms step_avg:54.25ms
+step:1456/1840 train_time:79028ms step_avg:54.28ms
+step:1457/1840 train_time:79113ms step_avg:54.30ms
+step:1458/1840 train_time:79204ms step_avg:54.32ms
+step:1459/1840 train_time:79289ms step_avg:54.34ms
+step:1460/1840 train_time:79377ms step_avg:54.37ms
+step:1461/1840 train_time:79464ms step_avg:54.39ms
+step:1462/1840 train_time:79551ms step_avg:54.41ms
+step:1463/1840 train_time:79637ms step_avg:54.43ms
+step:1464/1840 train_time:79726ms step_avg:54.46ms
+step:1465/1840 train_time:79812ms step_avg:54.48ms
+step:1466/1840 train_time:79901ms step_avg:54.50ms
+step:1467/1840 train_time:79987ms step_avg:54.52ms
+step:1468/1840 train_time:80077ms step_avg:54.55ms
+step:1469/1840 train_time:80164ms step_avg:54.57ms
+step:1470/1840 train_time:80251ms step_avg:54.59ms
+step:1471/1840 train_time:80336ms step_avg:54.61ms
+step:1472/1840 train_time:80427ms step_avg:54.64ms
+step:1473/1840 train_time:80513ms step_avg:54.66ms
+step:1474/1840 train_time:80602ms step_avg:54.68ms
+step:1475/1840 train_time:80688ms step_avg:54.70ms
+step:1476/1840 train_time:80777ms step_avg:54.73ms
+step:1477/1840 train_time:80863ms step_avg:54.75ms
+step:1478/1840 train_time:80950ms step_avg:54.77ms
+step:1479/1840 train_time:81037ms step_avg:54.79ms
+step:1480/1840 train_time:81127ms step_avg:54.82ms
+step:1481/1840 train_time:81213ms step_avg:54.84ms
+step:1482/1840 train_time:81303ms step_avg:54.86ms
+step:1483/1840 train_time:81388ms step_avg:54.88ms
+step:1484/1840 train_time:81476ms step_avg:54.90ms
+step:1485/1840 train_time:81562ms step_avg:54.92ms
+step:1486/1840 train_time:81650ms step_avg:54.95ms
+step:1487/1840 train_time:81736ms step_avg:54.97ms
+step:1488/1840 train_time:81826ms step_avg:54.99ms
+step:1489/1840 train_time:81913ms step_avg:55.01ms
+step:1490/1840 train_time:82002ms step_avg:55.04ms
+step:1491/1840 train_time:82087ms step_avg:55.06ms
+step:1492/1840 train_time:82177ms step_avg:55.08ms
+step:1493/1840 train_time:82264ms step_avg:55.10ms
+step:1494/1840 train_time:82351ms step_avg:55.12ms
+step:1495/1840 train_time:82437ms step_avg:55.14ms
+step:1496/1840 train_time:82526ms step_avg:55.16ms
+step:1497/1840 train_time:82612ms step_avg:55.19ms
+step:1498/1840 train_time:82702ms step_avg:55.21ms
+step:1499/1840 train_time:82787ms step_avg:55.23ms
+step:1500/1840 train_time:82877ms step_avg:55.25ms
+step:1500/1840 val_loss:3.3997 train_time:82976ms step_avg:55.32ms
+step:1501/1840 train_time:82999ms step_avg:55.30ms
+step:1502/1840 train_time:83055ms step_avg:55.30ms
+step:1503/1840 train_time:83146ms step_avg:55.32ms
+step:1504/1840 train_time:83234ms step_avg:55.34ms
+step:1505/1840 train_time:83320ms step_avg:55.36ms
+step:1506/1840 train_time:83408ms step_avg:55.38ms
+step:1507/1840 train_time:83493ms step_avg:55.40ms
+step:1508/1840 train_time:83580ms step_avg:55.42ms
+step:1509/1840 train_time:83666ms step_avg:55.44ms
+step:1510/1840 train_time:83754ms step_avg:55.47ms
+step:1511/1840 train_time:83838ms step_avg:55.49ms
+step:1512/1840 train_time:83929ms step_avg:55.51ms
+step:1513/1840 train_time:84018ms step_avg:55.53ms
+step:1514/1840 train_time:84109ms step_avg:55.55ms
+step:1515/1840 train_time:84198ms step_avg:55.58ms
+step:1516/1840 train_time:84286ms step_avg:55.60ms
+step:1517/1840 train_time:84373ms step_avg:55.62ms
+step:1518/1840 train_time:84462ms step_avg:55.64ms
+step:1519/1840 train_time:84548ms step_avg:55.66ms
+step:1520/1840 train_time:84636ms step_avg:55.68ms
+step:1521/1840 train_time:84721ms step_avg:55.70ms
+step:1522/1840 train_time:84810ms step_avg:55.72ms
+step:1523/1840 train_time:84897ms step_avg:55.74ms
+step:1524/1840 train_time:84987ms step_avg:55.77ms
+step:1525/1840 train_time:85073ms step_avg:55.79ms
+step:1526/1840 train_time:85165ms step_avg:55.81ms
+step:1527/1840 train_time:85252ms step_avg:55.83ms
+step:1528/1840 train_time:85342ms step_avg:55.85ms
+step:1529/1840 train_time:85428ms step_avg:55.87ms
+step:1530/1840 train_time:85516ms step_avg:55.89ms
+step:1531/1840 train_time:85602ms step_avg:55.91ms
+step:1532/1840 train_time:85689ms step_avg:55.93ms
+step:1533/1840 train_time:85774ms step_avg:55.95ms
+step:1534/1840 train_time:85863ms step_avg:55.97ms
+step:1535/1840 train_time:85949ms step_avg:55.99ms
+step:1536/1840 train_time:86039ms step_avg:56.02ms
+step:1537/1840 train_time:86126ms step_avg:56.04ms
+step:1538/1840 train_time:86216ms step_avg:56.06ms
+step:1539/1840 train_time:86303ms step_avg:56.08ms
+step:1540/1840 train_time:86391ms step_avg:56.10ms
+step:1541/1840 train_time:86477ms step_avg:56.12ms
+step:1542/1840 train_time:86565ms step_avg:56.14ms
+step:1543/1840 train_time:86650ms step_avg:56.16ms
+step:1544/1840 train_time:86740ms step_avg:56.18ms
+step:1545/1840 train_time:86826ms step_avg:56.20ms
+step:1546/1840 train_time:86915ms step_avg:56.22ms
+step:1547/1840 train_time:87002ms step_avg:56.24ms
+step:1548/1840 train_time:87090ms step_avg:56.26ms
+step:1549/1840 train_time:87177ms step_avg:56.28ms
+step:1550/1840 train_time:87267ms step_avg:56.30ms
+step:1551/1840 train_time:87353ms step_avg:56.32ms
+step:1552/1840 train_time:87441ms step_avg:56.34ms
+step:1553/1840 train_time:87528ms step_avg:56.36ms
+step:1554/1840 train_time:87616ms step_avg:56.38ms
+step:1555/1840 train_time:87701ms step_avg:56.40ms
+step:1556/1840 train_time:87789ms step_avg:56.42ms
+step:1557/1840 train_time:87876ms step_avg:56.44ms
+step:1558/1840 train_time:87965ms step_avg:56.46ms
+step:1559/1840 train_time:88051ms step_avg:56.48ms
+step:1560/1840 train_time:88140ms step_avg:56.50ms
+step:1561/1840 train_time:88228ms step_avg:56.52ms
+step:1562/1840 train_time:88318ms step_avg:56.54ms
+step:1563/1840 train_time:88403ms step_avg:56.56ms
+step:1564/1840 train_time:88491ms step_avg:56.58ms
+step:1565/1840 train_time:88577ms step_avg:56.60ms
+step:1566/1840 train_time:88666ms step_avg:56.62ms
+step:1567/1840 train_time:88751ms step_avg:56.64ms
+step:1568/1840 train_time:88840ms step_avg:56.66ms
+step:1569/1840 train_time:88927ms step_avg:56.68ms
+step:1570/1840 train_time:89016ms step_avg:56.70ms
+step:1571/1840 train_time:89103ms step_avg:56.72ms
+step:1572/1840 train_time:89192ms step_avg:56.74ms
+step:1573/1840 train_time:89277ms step_avg:56.76ms
+step:1574/1840 train_time:89367ms step_avg:56.78ms
+step:1575/1840 train_time:89453ms step_avg:56.80ms
+step:1576/1840 train_time:89544ms step_avg:56.82ms
+step:1577/1840 train_time:89630ms step_avg:56.84ms
+step:1578/1840 train_time:89718ms step_avg:56.86ms
+step:1579/1840 train_time:89803ms step_avg:56.87ms
+step:1580/1840 train_time:89891ms step_avg:56.89ms
+step:1581/1840 train_time:89978ms step_avg:56.91ms
+step:1582/1840 train_time:90067ms step_avg:56.93ms
+step:1583/1840 train_time:90155ms step_avg:56.95ms
+step:1584/1840 train_time:90244ms step_avg:56.97ms
+step:1585/1840 train_time:90330ms step_avg:56.99ms
+step:1586/1840 train_time:90420ms step_avg:57.01ms
+step:1587/1840 train_time:90505ms step_avg:57.03ms
+step:1588/1840 train_time:90594ms step_avg:57.05ms
+step:1589/1840 train_time:90680ms step_avg:57.07ms
+step:1590/1840 train_time:90769ms step_avg:57.09ms
+step:1591/1840 train_time:90854ms step_avg:57.10ms
+step:1592/1840 train_time:90943ms step_avg:57.12ms
+step:1593/1840 train_time:91029ms step_avg:57.14ms
+step:1594/1840 train_time:91119ms step_avg:57.16ms
+step:1595/1840 train_time:91205ms step_avg:57.18ms
+step:1596/1840 train_time:91294ms step_avg:57.20ms
+step:1597/1840 train_time:91380ms step_avg:57.22ms
+step:1598/1840 train_time:91468ms step_avg:57.24ms
+step:1599/1840 train_time:91555ms step_avg:57.26ms
+step:1600/1840 train_time:91644ms step_avg:57.28ms
+step:1601/1840 train_time:91729ms step_avg:57.29ms
+step:1602/1840 train_time:91818ms step_avg:57.31ms
+step:1603/1840 train_time:91905ms step_avg:57.33ms
+step:1604/1840 train_time:91993ms step_avg:57.35ms
+step:1605/1840 train_time:92080ms step_avg:57.37ms
+step:1606/1840 train_time:92169ms step_avg:57.39ms
+step:1607/1840 train_time:92255ms step_avg:57.41ms
+step:1608/1840 train_time:92344ms step_avg:57.43ms
+step:1609/1840 train_time:92429ms step_avg:57.44ms
+step:1610/1840 train_time:92518ms step_avg:57.46ms
+step:1611/1840 train_time:92603ms step_avg:57.48ms
+step:1612/1840 train_time:92691ms step_avg:57.50ms
+step:1613/1840 train_time:92777ms step_avg:57.52ms
+step:1614/1840 train_time:92867ms step_avg:57.54ms
+step:1615/1840 train_time:92953ms step_avg:57.56ms
+step:1616/1840 train_time:93042ms step_avg:57.58ms
+step:1617/1840 train_time:93130ms step_avg:57.59ms
+step:1618/1840 train_time:93218ms step_avg:57.61ms
+step:1619/1840 train_time:93305ms step_avg:57.63ms
+step:1620/1840 train_time:93394ms step_avg:57.65ms
+step:1621/1840 train_time:93479ms step_avg:57.67ms
+step:1622/1840 train_time:93568ms step_avg:57.69ms
+step:1623/1840 train_time:93654ms step_avg:57.70ms
+step:1624/1840 train_time:93742ms step_avg:57.72ms
+step:1625/1840 train_time:93829ms step_avg:57.74ms
+step:1626/1840 train_time:93916ms step_avg:57.76ms
+step:1627/1840 train_time:94002ms step_avg:57.78ms
+step:1628/1840 train_time:94090ms step_avg:57.79ms
+step:1629/1840 train_time:94177ms step_avg:57.81ms
+step:1630/1840 train_time:94267ms step_avg:57.83ms
+step:1631/1840 train_time:94352ms step_avg:57.85ms
+step:1632/1840 train_time:94441ms step_avg:57.87ms
+step:1633/1840 train_time:94527ms step_avg:57.89ms
+step:1634/1840 train_time:94616ms step_avg:57.90ms
+step:1635/1840 train_time:94702ms step_avg:57.92ms
+step:1636/1840 train_time:94790ms step_avg:57.94ms
+step:1637/1840 train_time:94876ms step_avg:57.96ms
+step:1638/1840 train_time:94966ms step_avg:57.98ms
+step:1639/1840 train_time:95052ms step_avg:57.99ms
+step:1640/1840 train_time:95140ms step_avg:58.01ms
+step:1641/1840 train_time:95228ms step_avg:58.03ms
+step:1642/1840 train_time:95316ms step_avg:58.05ms
+step:1643/1840 train_time:95401ms step_avg:58.07ms
+step:1644/1840 train_time:95489ms step_avg:58.08ms
+step:1645/1840 train_time:95575ms step_avg:58.10ms
+step:1646/1840 train_time:95664ms step_avg:58.12ms
+step:1647/1840 train_time:95749ms step_avg:58.14ms
+step:1648/1840 train_time:95839ms step_avg:58.15ms
+step:1649/1840 train_time:95926ms step_avg:58.17ms
+step:1650/1840 train_time:96016ms step_avg:58.19ms
+step:1651/1840 train_time:96102ms step_avg:58.21ms
+step:1652/1840 train_time:96191ms step_avg:58.23ms
+step:1653/1840 train_time:96277ms step_avg:58.24ms
+step:1654/1840 train_time:96367ms step_avg:58.26ms
+step:1655/1840 train_time:96452ms step_avg:58.28ms
+step:1656/1840 train_time:96542ms step_avg:58.30ms
+step:1657/1840 train_time:96629ms step_avg:58.32ms
+step:1658/1840 train_time:96718ms step_avg:58.33ms
+step:1659/1840 train_time:96804ms step_avg:58.35ms
+step:1660/1840 train_time:96892ms step_avg:58.37ms
+step:1661/1840 train_time:96978ms step_avg:58.39ms
+step:1662/1840 train_time:97067ms step_avg:58.40ms
+step:1663/1840 train_time:97153ms step_avg:58.42ms
+step:1664/1840 train_time:97242ms step_avg:58.44ms
+step:1665/1840 train_time:97328ms step_avg:58.46ms
+step:1666/1840 train_time:97418ms step_avg:58.47ms
+step:1667/1840 train_time:97504ms step_avg:58.49ms
+step:1668/1840 train_time:97592ms step_avg:58.51ms
+step:1669/1840 train_time:97679ms step_avg:58.53ms
+step:1670/1840 train_time:97768ms step_avg:58.54ms
+step:1671/1840 train_time:97853ms step_avg:58.56ms
+step:1672/1840 train_time:97942ms step_avg:58.58ms
+step:1673/1840 train_time:98027ms step_avg:58.59ms
+step:1674/1840 train_time:98117ms step_avg:58.61ms
+step:1675/1840 train_time:98204ms step_avg:58.63ms
+step:1676/1840 train_time:98293ms step_avg:58.65ms
+step:1677/1840 train_time:98379ms step_avg:58.66ms
+step:1678/1840 train_time:98468ms step_avg:58.68ms
+step:1679/1840 train_time:98553ms step_avg:58.70ms
+step:1680/1840 train_time:98643ms step_avg:58.72ms
+step:1681/1840 train_time:98730ms step_avg:58.73ms
+step:1682/1840 train_time:98818ms step_avg:58.75ms
+step:1683/1840 train_time:98903ms step_avg:58.77ms
+step:1684/1840 train_time:98991ms step_avg:58.78ms
+step:1685/1840 train_time:99078ms step_avg:58.80ms
+step:1686/1840 train_time:99168ms step_avg:58.82ms
+step:1687/1840 train_time:99254ms step_avg:58.83ms
+step:1688/1840 train_time:99343ms step_avg:58.85ms
+step:1689/1840 train_time:99430ms step_avg:58.87ms
+step:1690/1840 train_time:99518ms step_avg:58.89ms
+step:1691/1840 train_time:99605ms step_avg:58.90ms
+step:1692/1840 train_time:99695ms step_avg:58.92ms
+step:1693/1840 train_time:99781ms step_avg:58.94ms
+step:1694/1840 train_time:99869ms step_avg:58.95ms
+step:1695/1840 train_time:99954ms step_avg:58.97ms
+step:1696/1840 train_time:100044ms step_avg:58.99ms
+step:1697/1840 train_time:100130ms step_avg:59.00ms
+step:1698/1840 train_time:100220ms step_avg:59.02ms
+step:1699/1840 train_time:100306ms step_avg:59.04ms
+step:1700/1840 train_time:100394ms step_avg:59.06ms
+step:1701/1840 train_time:100480ms step_avg:59.07ms
+step:1702/1840 train_time:100570ms step_avg:59.09ms
+step:1703/1840 train_time:100655ms step_avg:59.10ms
+step:1704/1840 train_time:100745ms step_avg:59.12ms
+step:1705/1840 train_time:100831ms step_avg:59.14ms
+step:1706/1840 train_time:100918ms step_avg:59.16ms
+step:1707/1840 train_time:101005ms step_avg:59.17ms
+step:1708/1840 train_time:101093ms step_avg:59.19ms
+step:1709/1840 train_time:101179ms step_avg:59.20ms
+step:1710/1840 train_time:101269ms step_avg:59.22ms
+step:1711/1840 train_time:101354ms step_avg:59.24ms
+step:1712/1840 train_time:101444ms step_avg:59.25ms
+step:1713/1840 train_time:101530ms step_avg:59.27ms
+step:1714/1840 train_time:101618ms step_avg:59.29ms
+step:1715/1840 train_time:101706ms step_avg:59.30ms
+step:1716/1840 train_time:101794ms step_avg:59.32ms
+step:1717/1840 train_time:101880ms step_avg:59.34ms
+step:1718/1840 train_time:101969ms step_avg:59.35ms
+step:1719/1840 train_time:102056ms step_avg:59.37ms
+step:1720/1840 train_time:102146ms step_avg:59.39ms
+step:1721/1840 train_time:102231ms step_avg:59.40ms
+step:1722/1840 train_time:102320ms step_avg:59.42ms
+step:1723/1840 train_time:102407ms step_avg:59.44ms
+step:1724/1840 train_time:102496ms step_avg:59.45ms
+step:1725/1840 train_time:102582ms step_avg:59.47ms
+step:1726/1840 train_time:102670ms step_avg:59.48ms
+step:1727/1840 train_time:102756ms step_avg:59.50ms
+step:1728/1840 train_time:102845ms step_avg:59.52ms
+step:1729/1840 train_time:102931ms step_avg:59.53ms
+step:1730/1840 train_time:103020ms step_avg:59.55ms
+step:1731/1840 train_time:103107ms step_avg:59.56ms
+step:1732/1840 train_time:103196ms step_avg:59.58ms
+step:1733/1840 train_time:103282ms step_avg:59.60ms
+step:1734/1840 train_time:103370ms step_avg:59.61ms
+step:1735/1840 train_time:103457ms step_avg:59.63ms
+step:1736/1840 train_time:103547ms step_avg:59.65ms
+step:1737/1840 train_time:103632ms step_avg:59.66ms
+step:1738/1840 train_time:103721ms step_avg:59.68ms
+step:1739/1840 train_time:103808ms step_avg:59.69ms
+step:1740/1840 train_time:103897ms step_avg:59.71ms
+step:1741/1840 train_time:103982ms step_avg:59.73ms
+step:1742/1840 train_time:104071ms step_avg:59.74ms
+step:1743/1840 train_time:104157ms step_avg:59.76ms
+step:1744/1840 train_time:104246ms step_avg:59.77ms
+step:1745/1840 train_time:104332ms step_avg:59.79ms
+step:1746/1840 train_time:104420ms step_avg:59.81ms
+step:1747/1840 train_time:104506ms step_avg:59.82ms
+step:1748/1840 train_time:104595ms step_avg:59.84ms
+step:1749/1840 train_time:104681ms step_avg:59.85ms
+step:1750/1840 train_time:104769ms step_avg:59.87ms
+step:1750/1840 val_loss:3.3015 train_time:104870ms step_avg:59.93ms
+step:1751/1840 train_time:104892ms step_avg:59.90ms
+step:1752/1840 train_time:104950ms step_avg:59.90ms
+step:1753/1840 train_time:105039ms step_avg:59.92ms
+step:1754/1840 train_time:105127ms step_avg:59.94ms
+step:1755/1840 train_time:105213ms step_avg:59.95ms
+step:1756/1840 train_time:105302ms step_avg:59.97ms
+step:1757/1840 train_time:105387ms step_avg:59.98ms
+step:1758/1840 train_time:105474ms step_avg:60.00ms
+step:1759/1840 train_time:105560ms step_avg:60.01ms
+step:1760/1840 train_time:105646ms step_avg:60.03ms
+step:1761/1840 train_time:105732ms step_avg:60.04ms
+step:1762/1840 train_time:105825ms step_avg:60.06ms
+step:1763/1840 train_time:105913ms step_avg:60.08ms
+step:1764/1840 train_time:106006ms step_avg:60.09ms
+step:1765/1840 train_time:106092ms step_avg:60.11ms
+step:1766/1840 train_time:106182ms step_avg:60.13ms
+step:1767/1840 train_time:106268ms step_avg:60.14ms
+step:1768/1840 train_time:106356ms step_avg:60.16ms
+step:1769/1840 train_time:106441ms step_avg:60.17ms
+step:1770/1840 train_time:106529ms step_avg:60.19ms
+step:1771/1840 train_time:106613ms step_avg:60.20ms
+step:1772/1840 train_time:106701ms step_avg:60.22ms
+step:1773/1840 train_time:106789ms step_avg:60.23ms
+step:1774/1840 train_time:106881ms step_avg:60.25ms
+step:1775/1840 train_time:106968ms step_avg:60.26ms
+step:1776/1840 train_time:107057ms step_avg:60.28ms
+step:1777/1840 train_time:107144ms step_avg:60.29ms
+step:1778/1840 train_time:107231ms step_avg:60.31ms
+step:1779/1840 train_time:107318ms step_avg:60.32ms
+step:1780/1840 train_time:107405ms step_avg:60.34ms
+step:1781/1840 train_time:107490ms step_avg:60.35ms
+step:1782/1840 train_time:107578ms step_avg:60.37ms
+step:1783/1840 train_time:107665ms step_avg:60.38ms
+step:1784/1840 train_time:107755ms step_avg:60.40ms
+step:1785/1840 train_time:107842ms step_avg:60.42ms
+step:1786/1840 train_time:107930ms step_avg:60.43ms
+step:1787/1840 train_time:108018ms step_avg:60.45ms
+step:1788/1840 train_time:108107ms step_avg:60.46ms
+step:1789/1840 train_time:108193ms step_avg:60.48ms
+step:1790/1840 train_time:108281ms step_avg:60.49ms
+step:1791/1840 train_time:108367ms step_avg:60.51ms
+step:1792/1840 train_time:108455ms step_avg:60.52ms
+step:1793/1840 train_time:108542ms step_avg:60.54ms
+step:1794/1840 train_time:108629ms step_avg:60.55ms
+step:1795/1840 train_time:108715ms step_avg:60.57ms
+step:1796/1840 train_time:108804ms step_avg:60.58ms
+step:1797/1840 train_time:108892ms step_avg:60.60ms
+step:1798/1840 train_time:108981ms step_avg:60.61ms
+step:1799/1840 train_time:109068ms step_avg:60.63ms
+step:1800/1840 train_time:109158ms step_avg:60.64ms
+step:1801/1840 train_time:109247ms step_avg:60.66ms
+step:1802/1840 train_time:109334ms step_avg:60.67ms
+step:1803/1840 train_time:109421ms step_avg:60.69ms
+step:1804/1840 train_time:109509ms step_avg:60.70ms
+step:1805/1840 train_time:109594ms step_avg:60.72ms
+step:1806/1840 train_time:109684ms step_avg:60.73ms
+step:1807/1840 train_time:109770ms step_avg:60.75ms
+step:1808/1840 train_time:109859ms step_avg:60.76ms
+step:1809/1840 train_time:109947ms step_avg:60.78ms
+step:1810/1840 train_time:110036ms step_avg:60.79ms
+step:1811/1840 train_time:110124ms step_avg:60.81ms
+step:1812/1840 train_time:110213ms step_avg:60.82ms
+step:1813/1840 train_time:110300ms step_avg:60.84ms
+step:1814/1840 train_time:110388ms step_avg:60.85ms
+step:1815/1840 train_time:110473ms step_avg:60.87ms
+step:1816/1840 train_time:110563ms step_avg:60.88ms
+step:1817/1840 train_time:110648ms step_avg:60.90ms
+step:1818/1840 train_time:110738ms step_avg:60.91ms
+step:1819/1840 train_time:110824ms step_avg:60.93ms
+step:1820/1840 train_time:110914ms step_avg:60.94ms
+step:1821/1840 train_time:111000ms step_avg:60.96ms
+step:1822/1840 train_time:111089ms step_avg:60.97ms
+step:1823/1840 train_time:111175ms step_avg:60.98ms
+step:1824/1840 train_time:111265ms step_avg:61.00ms
+step:1825/1840 train_time:111351ms step_avg:61.01ms
+step:1826/1840 train_time:111440ms step_avg:61.03ms
+step:1827/1840 train_time:111527ms step_avg:61.04ms
+step:1828/1840 train_time:111615ms step_avg:61.06ms
+step:1829/1840 train_time:111701ms step_avg:61.07ms
+step:1830/1840 train_time:111790ms step_avg:61.09ms
+step:1831/1840 train_time:111876ms step_avg:61.10ms
+step:1832/1840 train_time:111967ms step_avg:61.12ms
+step:1833/1840 train_time:112053ms step_avg:61.13ms
+step:1834/1840 train_time:112143ms step_avg:61.15ms
+step:1835/1840 train_time:112229ms step_avg:61.16ms
+step:1836/1840 train_time:112318ms step_avg:61.18ms
+step:1837/1840 train_time:112404ms step_avg:61.19ms
+step:1838/1840 train_time:112492ms step_avg:61.20ms
+step:1839/1840 train_time:112579ms step_avg:61.22ms
+step:1840/1840 train_time:112667ms step_avg:61.23ms
+step:1840/1840 val_loss:3.2763 train_time:112767ms step_avg:61.29ms
+peak memory allocated: 28507 MiB reserved: 43898 MiB

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/46b0fb47-f894-47de-9aa5-da390ac19e78.txt
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/46b0fb47-f894-47de-9aa5-da390ac19e78.txt
@@ -1,0 +1,3786 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+    """
+    Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+    Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+    bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+    float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+    """
+    assert p.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    wd_factor = wd_tensor.to(torch.float32)
+    lr_factor = lr_tensor.to(torch.float32)
+    p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    p_precise = p_precise_raw.view(torch.float32)
+    mask = (grad * p_precise) >= 0
+    p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+    p.copy_((p_precise_raw >> 16).to(torch.uint16))
+    mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        2. reduce scatter attn/mlp round 2 (16 mlp params)
+        3. wait on step 1, then compute update of 1 and schedule all gather
+        4. wait on step 2, then compute update of 2 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        5. wait for each all gather to complete and update params
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["mantissa"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn', 'mlp']
+        group_sizes = [16, 16]  # 10 attn + 6 mlp, then 16 mlp
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    def step(self):
+        self.step_p1()
+        self.step_p2()
+        self.step_p3()
+        
+    @torch.no_grad()
+    def step_p1(self):
+        """
+        Part 1: Launch distributed reduce_scatter operations for parameter groups.
+        """
+        rank = dist.get_rank()
+        self.group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            self.group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+    
+    @torch.no_grad()
+    def step_p2(self):
+        """
+        Part 2: Compute gradient updates and launch all_gather operations
+        Wait for all gather to complete for all parameter groups except final one
+        """
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = self.group_infos
+        
+        self.all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"].float()
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params], dtype=torch.float32)
+                
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            if "second_momentum_buffer" not in group:
+                group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1], dtype=torch.float32)
+                    if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if param_shape[-2] >= param_shape[-1] else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk, dtype=torch.bfloat16)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                if "mantissa" not in group:
+                    group["mantissa"] = torch.zeros_like(param_chunk, dtype=torch.uint16)
+                mantissa = group["mantissa"]
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx].view(torch.uint16),
+                        mantissa[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx]
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            self.all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete for all except final and copy results back into original parameter tensors.
+        for info in self.all_gather_infos[:-1]:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+    @torch.no_grad()
+    def step_p3(self):
+        """
+        Part 3: Wait for final all gather to complete and copy results back into original parameter tensors
+        """
+        info = self.all_gather_infos[-1]
+        info["gather_future"].wait()
+        stacked_params = info["stacked_params"]
+        orig_params = info["orig_params"]
+
+        unstacked_params = torch.unbind(stacked_params)
+        for i, p in enumerate(orig_params):
+            p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str], betas: list[list[float]], lr: float = 1e-3, eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for idx, label in enumerate(label_order):
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label], betas=betas[idx]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+        # tag the final param for optimizer pipelining, run all gather after muon copy
+        param_groups[-1]['params'][-1].is_final_param = True
+        
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        # 0-D CPU tensors to avoid recompilation in _update_step
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    def load_state_dict(self, state_dict):
+        """Override to preserve optimizer state dtypes (avoid BFloat16->Float32 cast that causes recompilation)."""
+        # Save original state dtypes before loading
+        original_dtypes = {}
+        for p, s in self.state.items():
+            original_dtypes[p] = {k: v.dtype for k, v in s.items() if isinstance(v, torch.Tensor)}
+        
+        # Call parent load_state_dict (which may cast dtypes to match param dtype)
+        super().load_state_dict(state_dict)
+        
+        # Restore original dtypes
+        for p, s in self.state.items():
+            if p in original_dtypes:
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor) and k in original_dtypes[p]:
+                        if v.dtype != original_dtypes[p][k]:
+                            s[k] = v.to(original_dtypes[p][k])
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-2]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step. step_size_t and eff_wd_t are 0-D CPU tensors to avoid recompilation."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)  # exp_avg = beta1 * exp_avg + (1 - beta1) * g_slice
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)  # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * g_slice^2
+        # compute step
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)  # update = (exp_avg / (sqrt(exp_avg_sq) + eps)) * step_size
+        # cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)  # update += eff_wd_t * p_slice * mask
+        p_slice.add_(other=update, alpha=-1.0)  # p_slice -= update
+
+    @torch.no_grad()
+    def step(self, muon_opt):
+        muon_opt.step_p1()
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        last_param = None
+        last_p_slice = None
+        for group in self.param_groups:      
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+                state["step"] += 1
+                t = state["step"]
+                
+                # Pre-compute changing values as 0-D CPU tensors to avoid recompilation.
+                # `.fill_(value)` is the same as "= value", but doesn't change the tensor object.
+                bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+                self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+                self._eff_wd_t.fill_(lr * lr * wd * getattr(param, "wd_mul", 1.0)) # `lr` included twice to serve as weight decay schedule.
+
+                DistAdam._update_step(p_slice, g_slice, state["exp_avg"], state["exp_avg_sq"],
+                                      beta1, beta2, eps, self._step_size_t, self._eff_wd_t)
+
+                if not is_small:
+                    if getattr(param, "is_final_param", False):
+                        last_param = param
+                        last_p_slice = p_slice
+                    else:
+                        all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+        self._reduce_scatter_futures.clear()
+
+        muon_opt.step_p2()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+        if last_param is not None:
+            last_all_gather_future = dist.all_gather_into_tensor(last_param, last_p_slice, async_op=True).get_future()
+        muon_opt.step_p3()
+        torch.futures.collect_all([last_all_gather_future]).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        adam_betas = {
+            'lm_head': [0.5, 0.95],
+            'smear_gate': [0.9, 0.99],
+            'attn_gate_bank': [0.9, 0.99],
+            've_gate_bank': [0.9, 0.99],
+            'skip_gate': [0.9, 0.99],
+            'x0_lambdas': [0.65, 0.95],
+            'scalars': [0.9, 0.99],
+            'embed': [0.5, 0.95],
+            'value_embed': [0.75, 0.95]
+        }
+        adam_labels = list(adam_betas.keys())
+        adam_beta_values = list(adam_betas.values())
+        muon_labels = ['attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, adam_beta_values, lr=0.008, eps=1e-10, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.muon_opt]
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * step_lr
+                
+        if self._is_active_step(self.adam_opt, step):
+            # adam will interleave calls to muon step
+            self.adam_opt.step(self.muon_opt)
+            self.model.zero_grad(set_to_none=True)
+            self.adam_opt.should_sync = False
+        else:
+            self.muon_opt.step()
+            self.muon_opt.zero_grad(set_to_none=True)
+            
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1800  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan  5 08:17:35 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            129W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            128W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   42C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   44C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   42C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     62306      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     62307      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     62308      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     62309      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     62310      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     62311      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     62312      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     62313      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 599, 600, 601, 1199, 1200, 1201, 1799, 1800, 1801] for warmup
+Resetting Model
+step:0/1840 val_loss:10.8315 train_time:0ms step_avg:0.04ms
+step:1/1840 train_time:72ms step_avg:72.30ms
+step:2/1840 train_time:95ms step_avg:47.46ms
+step:3/1840 train_time:114ms step_avg:38.12ms
+step:4/1840 train_time:147ms step_avg:36.80ms
+step:5/1840 train_time:179ms step_avg:35.86ms
+step:6/1840 train_time:278ms step_avg:46.34ms
+step:7/1840 train_time:295ms step_avg:42.17ms
+step:8/1840 train_time:424ms step_avg:53.01ms
+step:9/1840 train_time:456ms step_avg:50.64ms
+step:10/1840 train_time:490ms step_avg:48.97ms
+step:11/1840 train_time:521ms step_avg:47.41ms
+step:12/1840 train_time:556ms step_avg:46.30ms
+step:13/1840 train_time:587ms step_avg:45.19ms
+step:14/1840 train_time:622ms step_avg:44.41ms
+step:15/1840 train_time:654ms step_avg:43.59ms
+step:16/1840 train_time:688ms step_avg:42.99ms
+step:17/1840 train_time:720ms step_avg:42.34ms
+step:18/1840 train_time:754ms step_avg:41.88ms
+step:19/1840 train_time:786ms step_avg:41.38ms
+step:20/1840 train_time:820ms step_avg:41.00ms
+step:21/1840 train_time:852ms step_avg:40.59ms
+step:22/1840 train_time:887ms step_avg:40.30ms
+step:23/1840 train_time:919ms step_avg:39.94ms
+step:24/1840 train_time:953ms step_avg:39.69ms
+step:25/1840 train_time:985ms step_avg:39.38ms
+step:26/1840 train_time:1019ms step_avg:39.19ms
+step:27/1840 train_time:1051ms step_avg:38.92ms
+step:28/1840 train_time:1085ms step_avg:38.75ms
+step:29/1840 train_time:1117ms step_avg:38.52ms
+step:30/1840 train_time:1151ms step_avg:38.38ms
+step:31/1840 train_time:1183ms step_avg:38.17ms
+step:32/1840 train_time:1217ms step_avg:38.04ms
+step:33/1840 train_time:1249ms step_avg:37.85ms
+step:34/1840 train_time:1284ms step_avg:37.77ms
+step:35/1840 train_time:1318ms step_avg:37.65ms
+step:36/1840 train_time:1353ms step_avg:37.58ms
+step:37/1840 train_time:1386ms step_avg:37.45ms
+step:38/1840 train_time:1420ms step_avg:37.38ms
+step:39/1840 train_time:1453ms step_avg:37.25ms
+step:40/1840 train_time:1487ms step_avg:37.18ms
+step:41/1840 train_time:1519ms step_avg:37.06ms
+step:42/1840 train_time:1554ms step_avg:36.99ms
+step:43/1840 train_time:1586ms step_avg:36.88ms
+step:44/1840 train_time:1620ms step_avg:36.81ms
+step:45/1840 train_time:1652ms step_avg:36.71ms
+step:46/1840 train_time:1686ms step_avg:36.66ms
+step:47/1840 train_time:1718ms step_avg:36.56ms
+step:48/1840 train_time:1753ms step_avg:36.51ms
+step:49/1840 train_time:1784ms step_avg:36.42ms
+step:50/1840 train_time:1819ms step_avg:36.38ms
+step:51/1840 train_time:1851ms step_avg:36.29ms
+step:52/1840 train_time:1885ms step_avg:36.24ms
+step:53/1840 train_time:1917ms step_avg:36.17ms
+step:54/1840 train_time:1951ms step_avg:36.14ms
+step:55/1840 train_time:1984ms step_avg:36.06ms
+step:56/1840 train_time:2018ms step_avg:36.03ms
+step:57/1840 train_time:2049ms step_avg:35.96ms
+step:58/1840 train_time:2084ms step_avg:35.93ms
+step:59/1840 train_time:2116ms step_avg:35.86ms
+step:60/1840 train_time:2150ms step_avg:35.83ms
+step:61/1840 train_time:2182ms step_avg:35.77ms
+step:62/1840 train_time:2216ms step_avg:35.74ms
+step:63/1840 train_time:2248ms step_avg:35.68ms
+step:64/1840 train_time:2283ms step_avg:35.67ms
+step:65/1840 train_time:2315ms step_avg:35.62ms
+step:66/1840 train_time:2349ms step_avg:35.60ms
+step:67/1840 train_time:2382ms step_avg:35.55ms
+step:68/1840 train_time:2416ms step_avg:35.54ms
+step:69/1840 train_time:2449ms step_avg:35.49ms
+step:70/1840 train_time:2483ms step_avg:35.47ms
+step:71/1840 train_time:2516ms step_avg:35.43ms
+step:72/1840 train_time:2550ms step_avg:35.41ms
+step:73/1840 train_time:2582ms step_avg:35.38ms
+step:74/1840 train_time:2617ms step_avg:35.36ms
+step:75/1840 train_time:2649ms step_avg:35.31ms
+step:76/1840 train_time:2683ms step_avg:35.30ms
+step:77/1840 train_time:2715ms step_avg:35.26ms
+step:78/1840 train_time:2750ms step_avg:35.25ms
+step:79/1840 train_time:2782ms step_avg:35.21ms
+step:80/1840 train_time:2816ms step_avg:35.20ms
+step:81/1840 train_time:2848ms step_avg:35.17ms
+step:82/1840 train_time:2882ms step_avg:35.15ms
+step:83/1840 train_time:2914ms step_avg:35.11ms
+step:84/1840 train_time:2949ms step_avg:35.10ms
+step:85/1840 train_time:2981ms step_avg:35.07ms
+step:86/1840 train_time:3015ms step_avg:35.06ms
+step:87/1840 train_time:3047ms step_avg:35.02ms
+step:88/1840 train_time:3081ms step_avg:35.02ms
+step:89/1840 train_time:3114ms step_avg:34.98ms
+step:90/1840 train_time:3148ms step_avg:34.98ms
+step:91/1840 train_time:3180ms step_avg:34.95ms
+step:92/1840 train_time:3214ms step_avg:34.94ms
+step:93/1840 train_time:3246ms step_avg:34.91ms
+step:94/1840 train_time:3281ms step_avg:34.90ms
+step:95/1840 train_time:3313ms step_avg:34.87ms
+step:96/1840 train_time:3348ms step_avg:34.87ms
+step:97/1840 train_time:3380ms step_avg:34.84ms
+step:98/1840 train_time:3414ms step_avg:34.84ms
+step:99/1840 train_time:3447ms step_avg:34.82ms
+step:100/1840 train_time:3481ms step_avg:34.81ms
+step:101/1840 train_time:3513ms step_avg:34.79ms
+step:102/1840 train_time:3548ms step_avg:34.78ms
+step:103/1840 train_time:3580ms step_avg:34.76ms
+step:104/1840 train_time:3614ms step_avg:34.75ms
+step:105/1840 train_time:3646ms step_avg:34.73ms
+step:106/1840 train_time:3681ms step_avg:34.72ms
+step:107/1840 train_time:3713ms step_avg:34.70ms
+step:108/1840 train_time:3747ms step_avg:34.69ms
+step:109/1840 train_time:3779ms step_avg:34.67ms
+step:110/1840 train_time:3813ms step_avg:34.67ms
+step:111/1840 train_time:3845ms step_avg:34.64ms
+step:112/1840 train_time:3879ms step_avg:34.64ms
+step:113/1840 train_time:3911ms step_avg:34.61ms
+step:114/1840 train_time:3946ms step_avg:34.61ms
+step:115/1840 train_time:3978ms step_avg:34.59ms
+step:116/1840 train_time:4012ms step_avg:34.59ms
+step:117/1840 train_time:4044ms step_avg:34.57ms
+step:118/1840 train_time:4079ms step_avg:34.56ms
+step:119/1840 train_time:4111ms step_avg:34.54ms
+step:120/1840 train_time:4145ms step_avg:34.54ms
+step:121/1840 train_time:4177ms step_avg:34.52ms
+step:122/1840 train_time:4211ms step_avg:34.51ms
+step:123/1840 train_time:4243ms step_avg:34.49ms
+step:124/1840 train_time:4277ms step_avg:34.49ms
+step:125/1840 train_time:4309ms step_avg:34.47ms
+step:126/1840 train_time:4344ms step_avg:34.47ms
+step:127/1840 train_time:4376ms step_avg:34.45ms
+step:128/1840 train_time:4410ms step_avg:34.45ms
+step:129/1840 train_time:4442ms step_avg:34.43ms
+step:130/1840 train_time:4476ms step_avg:34.43ms
+step:131/1840 train_time:4508ms step_avg:34.41ms
+step:132/1840 train_time:4543ms step_avg:34.42ms
+step:133/1840 train_time:4575ms step_avg:34.40ms
+step:134/1840 train_time:4609ms step_avg:34.40ms
+step:135/1840 train_time:4641ms step_avg:34.38ms
+step:136/1840 train_time:4676ms step_avg:34.38ms
+step:137/1840 train_time:4708ms step_avg:34.36ms
+step:138/1840 train_time:4742ms step_avg:34.36ms
+step:139/1840 train_time:4774ms step_avg:34.35ms
+step:140/1840 train_time:4808ms step_avg:34.34ms
+step:141/1840 train_time:4840ms step_avg:34.33ms
+step:142/1840 train_time:4875ms step_avg:34.33ms
+step:143/1840 train_time:4907ms step_avg:34.31ms
+step:144/1840 train_time:4941ms step_avg:34.31ms
+step:145/1840 train_time:4973ms step_avg:34.30ms
+step:146/1840 train_time:5007ms step_avg:34.30ms
+step:147/1840 train_time:5040ms step_avg:34.28ms
+step:148/1840 train_time:5074ms step_avg:34.29ms
+step:149/1840 train_time:5106ms step_avg:34.27ms
+step:150/1840 train_time:5141ms step_avg:34.27ms
+step:151/1840 train_time:5173ms step_avg:34.26ms
+step:152/1840 train_time:5207ms step_avg:34.26ms
+step:153/1840 train_time:5239ms step_avg:34.24ms
+step:154/1840 train_time:5273ms step_avg:34.24ms
+step:155/1840 train_time:5304ms step_avg:34.22ms
+step:156/1840 train_time:5339ms step_avg:34.22ms
+step:157/1840 train_time:5370ms step_avg:34.21ms
+step:158/1840 train_time:5405ms step_avg:34.21ms
+step:159/1840 train_time:5437ms step_avg:34.20ms
+step:160/1840 train_time:5472ms step_avg:34.20ms
+step:161/1840 train_time:5504ms step_avg:34.19ms
+step:162/1840 train_time:5538ms step_avg:34.19ms
+step:163/1840 train_time:5570ms step_avg:34.17ms
+step:164/1840 train_time:5604ms step_avg:34.17ms
+step:165/1840 train_time:5637ms step_avg:34.16ms
+step:166/1840 train_time:5671ms step_avg:34.16ms
+step:167/1840 train_time:5703ms step_avg:34.15ms
+step:168/1840 train_time:5737ms step_avg:34.15ms
+step:169/1840 train_time:5769ms step_avg:34.14ms
+step:170/1840 train_time:5804ms step_avg:34.14ms
+step:171/1840 train_time:5836ms step_avg:34.13ms
+step:172/1840 train_time:5870ms step_avg:34.13ms
+step:173/1840 train_time:5902ms step_avg:34.11ms
+step:174/1840 train_time:5936ms step_avg:34.12ms
+step:175/1840 train_time:5968ms step_avg:34.10ms
+step:176/1840 train_time:6003ms step_avg:34.11ms
+step:177/1840 train_time:6035ms step_avg:34.09ms
+step:178/1840 train_time:6069ms step_avg:34.09ms
+step:179/1840 train_time:6101ms step_avg:34.08ms
+step:180/1840 train_time:6136ms step_avg:34.09ms
+step:181/1840 train_time:6168ms step_avg:34.08ms
+step:182/1840 train_time:6202ms step_avg:34.08ms
+step:183/1840 train_time:6234ms step_avg:34.07ms
+step:184/1840 train_time:6269ms step_avg:34.07ms
+step:185/1840 train_time:6301ms step_avg:34.06ms
+step:186/1840 train_time:6335ms step_avg:34.06ms
+step:187/1840 train_time:6367ms step_avg:34.05ms
+step:188/1840 train_time:6402ms step_avg:34.05ms
+step:189/1840 train_time:6434ms step_avg:34.04ms
+step:190/1840 train_time:6468ms step_avg:34.04ms
+step:191/1840 train_time:6500ms step_avg:34.03ms
+step:192/1840 train_time:6534ms step_avg:34.03ms
+step:193/1840 train_time:6566ms step_avg:34.02ms
+step:194/1840 train_time:6601ms step_avg:34.03ms
+step:195/1840 train_time:6633ms step_avg:34.02ms
+step:196/1840 train_time:6667ms step_avg:34.02ms
+step:197/1840 train_time:6700ms step_avg:34.01ms
+step:198/1840 train_time:6734ms step_avg:34.01ms
+step:199/1840 train_time:6765ms step_avg:34.00ms
+step:200/1840 train_time:6800ms step_avg:34.00ms
+step:201/1840 train_time:6832ms step_avg:33.99ms
+step:202/1840 train_time:6866ms step_avg:33.99ms
+step:203/1840 train_time:6898ms step_avg:33.98ms
+step:204/1840 train_time:6932ms step_avg:33.98ms
+step:205/1840 train_time:6964ms step_avg:33.97ms
+step:206/1840 train_time:6998ms step_avg:33.97ms
+step:207/1840 train_time:7030ms step_avg:33.96ms
+step:208/1840 train_time:7065ms step_avg:33.96ms
+step:209/1840 train_time:7097ms step_avg:33.96ms
+step:210/1840 train_time:7131ms step_avg:33.96ms
+step:211/1840 train_time:7163ms step_avg:33.95ms
+step:212/1840 train_time:7197ms step_avg:33.95ms
+step:213/1840 train_time:7229ms step_avg:33.94ms
+step:214/1840 train_time:7263ms step_avg:33.94ms
+step:215/1840 train_time:7295ms step_avg:33.93ms
+step:216/1840 train_time:7329ms step_avg:33.93ms
+step:217/1840 train_time:7361ms step_avg:33.92ms
+step:218/1840 train_time:7396ms step_avg:33.93ms
+step:219/1840 train_time:7428ms step_avg:33.92ms
+step:220/1840 train_time:7462ms step_avg:33.92ms
+step:221/1840 train_time:7495ms step_avg:33.91ms
+step:222/1840 train_time:7529ms step_avg:33.91ms
+step:223/1840 train_time:7561ms step_avg:33.90ms
+step:224/1840 train_time:7595ms step_avg:33.91ms
+step:225/1840 train_time:7627ms step_avg:33.90ms
+step:226/1840 train_time:7662ms step_avg:33.90ms
+step:227/1840 train_time:7694ms step_avg:33.89ms
+step:228/1840 train_time:7728ms step_avg:33.89ms
+step:229/1840 train_time:7760ms step_avg:33.89ms
+step:230/1840 train_time:7794ms step_avg:33.89ms
+step:231/1840 train_time:7826ms step_avg:33.88ms
+step:232/1840 train_time:7860ms step_avg:33.88ms
+step:233/1840 train_time:7893ms step_avg:33.88ms
+step:234/1840 train_time:7927ms step_avg:33.88ms
+step:235/1840 train_time:7960ms step_avg:33.87ms
+step:236/1840 train_time:7994ms step_avg:33.87ms
+step:237/1840 train_time:8026ms step_avg:33.86ms
+step:238/1840 train_time:8060ms step_avg:33.87ms
+step:239/1840 train_time:8092ms step_avg:33.86ms
+step:240/1840 train_time:8127ms step_avg:33.86ms
+step:241/1840 train_time:8159ms step_avg:33.85ms
+step:242/1840 train_time:8193ms step_avg:33.85ms
+step:243/1840 train_time:8225ms step_avg:33.85ms
+step:244/1840 train_time:8259ms step_avg:33.85ms
+step:245/1840 train_time:8291ms step_avg:33.84ms
+step:246/1840 train_time:8325ms step_avg:33.84ms
+step:247/1840 train_time:8357ms step_avg:33.84ms
+step:248/1840 train_time:8391ms step_avg:33.84ms
+step:249/1840 train_time:8423ms step_avg:33.83ms
+step:250/1840 train_time:8458ms step_avg:33.83ms
+step:250/1840 val_loss:4.6212 train_time:8499ms step_avg:34.00ms
+step:251/1840 train_time:8517ms step_avg:33.93ms
+step:252/1840 train_time:8536ms step_avg:33.87ms
+step:253/1840 train_time:8558ms step_avg:33.82ms
+step:254/1840 train_time:8593ms step_avg:33.83ms
+step:255/1840 train_time:8625ms step_avg:33.82ms
+step:256/1840 train_time:8660ms step_avg:33.83ms
+step:257/1840 train_time:8693ms step_avg:33.82ms
+step:258/1840 train_time:8727ms step_avg:33.83ms
+step:259/1840 train_time:8759ms step_avg:33.82ms
+step:260/1840 train_time:8793ms step_avg:33.82ms
+step:261/1840 train_time:8825ms step_avg:33.81ms
+step:262/1840 train_time:8859ms step_avg:33.81ms
+step:263/1840 train_time:8891ms step_avg:33.81ms
+step:264/1840 train_time:8925ms step_avg:33.81ms
+step:265/1840 train_time:8957ms step_avg:33.80ms
+step:266/1840 train_time:8991ms step_avg:33.80ms
+step:267/1840 train_time:9023ms step_avg:33.79ms
+step:268/1840 train_time:9057ms step_avg:33.79ms
+step:269/1840 train_time:9089ms step_avg:33.79ms
+step:270/1840 train_time:9122ms step_avg:33.79ms
+step:271/1840 train_time:9154ms step_avg:33.78ms
+step:272/1840 train_time:9188ms step_avg:33.78ms
+step:273/1840 train_time:9220ms step_avg:33.77ms
+step:274/1840 train_time:9254ms step_avg:33.77ms
+step:275/1840 train_time:9286ms step_avg:33.77ms
+step:276/1840 train_time:9320ms step_avg:33.77ms
+step:277/1840 train_time:9352ms step_avg:33.76ms
+step:278/1840 train_time:9386ms step_avg:33.76ms
+step:279/1840 train_time:9418ms step_avg:33.75ms
+step:280/1840 train_time:9453ms step_avg:33.76ms
+step:281/1840 train_time:9485ms step_avg:33.76ms
+step:282/1840 train_time:9520ms step_avg:33.76ms
+step:283/1840 train_time:9553ms step_avg:33.76ms
+step:284/1840 train_time:9588ms step_avg:33.76ms
+step:285/1840 train_time:9620ms step_avg:33.75ms
+step:286/1840 train_time:9654ms step_avg:33.76ms
+step:287/1840 train_time:9687ms step_avg:33.75ms
+step:288/1840 train_time:9721ms step_avg:33.75ms
+step:289/1840 train_time:9753ms step_avg:33.75ms
+step:290/1840 train_time:9787ms step_avg:33.75ms
+step:291/1840 train_time:9819ms step_avg:33.74ms
+step:292/1840 train_time:9853ms step_avg:33.74ms
+step:293/1840 train_time:9885ms step_avg:33.74ms
+step:294/1840 train_time:9919ms step_avg:33.74ms
+step:295/1840 train_time:9951ms step_avg:33.73ms
+step:296/1840 train_time:9985ms step_avg:33.73ms
+step:297/1840 train_time:10017ms step_avg:33.73ms
+step:298/1840 train_time:10051ms step_avg:33.73ms
+step:299/1840 train_time:10083ms step_avg:33.72ms
+step:300/1840 train_time:10117ms step_avg:33.72ms
+step:301/1840 train_time:10149ms step_avg:33.72ms
+step:302/1840 train_time:10183ms step_avg:33.72ms
+step:303/1840 train_time:10215ms step_avg:33.71ms
+step:304/1840 train_time:10249ms step_avg:33.71ms
+step:305/1840 train_time:10281ms step_avg:33.71ms
+step:306/1840 train_time:10315ms step_avg:33.71ms
+step:307/1840 train_time:10347ms step_avg:33.70ms
+step:308/1840 train_time:10381ms step_avg:33.70ms
+step:309/1840 train_time:10413ms step_avg:33.70ms
+step:310/1840 train_time:10448ms step_avg:33.70ms
+step:311/1840 train_time:10480ms step_avg:33.70ms
+step:312/1840 train_time:10514ms step_avg:33.70ms
+step:313/1840 train_time:10546ms step_avg:33.69ms
+step:314/1840 train_time:10580ms step_avg:33.70ms
+step:315/1840 train_time:10613ms step_avg:33.69ms
+step:316/1840 train_time:10648ms step_avg:33.69ms
+step:317/1840 train_time:10680ms step_avg:33.69ms
+step:318/1840 train_time:10714ms step_avg:33.69ms
+step:319/1840 train_time:10746ms step_avg:33.69ms
+step:320/1840 train_time:10780ms step_avg:33.69ms
+step:321/1840 train_time:10812ms step_avg:33.68ms
+step:322/1840 train_time:10847ms step_avg:33.69ms
+step:323/1840 train_time:10878ms step_avg:33.68ms
+step:324/1840 train_time:10913ms step_avg:33.68ms
+step:325/1840 train_time:10945ms step_avg:33.68ms
+step:326/1840 train_time:10979ms step_avg:33.68ms
+step:327/1840 train_time:11011ms step_avg:33.67ms
+step:328/1840 train_time:11045ms step_avg:33.67ms
+step:329/1840 train_time:11077ms step_avg:33.67ms
+step:330/1840 train_time:11112ms step_avg:33.67ms
+step:331/1840 train_time:11143ms step_avg:33.67ms
+step:332/1840 train_time:11178ms step_avg:33.67ms
+step:333/1840 train_time:11209ms step_avg:33.66ms
+step:334/1840 train_time:11244ms step_avg:33.66ms
+step:335/1840 train_time:11275ms step_avg:33.66ms
+step:336/1840 train_time:11310ms step_avg:33.66ms
+step:337/1840 train_time:11342ms step_avg:33.66ms
+step:338/1840 train_time:11376ms step_avg:33.66ms
+step:339/1840 train_time:11408ms step_avg:33.65ms
+step:340/1840 train_time:11442ms step_avg:33.65ms
+step:341/1840 train_time:11474ms step_avg:33.65ms
+step:342/1840 train_time:11508ms step_avg:33.65ms
+step:343/1840 train_time:11541ms step_avg:33.65ms
+step:344/1840 train_time:11575ms step_avg:33.65ms
+step:345/1840 train_time:11608ms step_avg:33.65ms
+step:346/1840 train_time:11642ms step_avg:33.65ms
+step:347/1840 train_time:11674ms step_avg:33.64ms
+step:348/1840 train_time:11709ms step_avg:33.65ms
+step:349/1840 train_time:11741ms step_avg:33.64ms
+step:350/1840 train_time:11775ms step_avg:33.64ms
+step:351/1840 train_time:11807ms step_avg:33.64ms
+step:352/1840 train_time:11842ms step_avg:33.64ms
+step:353/1840 train_time:11873ms step_avg:33.64ms
+step:354/1840 train_time:11908ms step_avg:33.64ms
+step:355/1840 train_time:11940ms step_avg:33.63ms
+step:356/1840 train_time:11974ms step_avg:33.63ms
+step:357/1840 train_time:12006ms step_avg:33.63ms
+step:358/1840 train_time:12040ms step_avg:33.63ms
+step:359/1840 train_time:12072ms step_avg:33.63ms
+step:360/1840 train_time:12106ms step_avg:33.63ms
+step:361/1840 train_time:12138ms step_avg:33.62ms
+step:362/1840 train_time:12172ms step_avg:33.62ms
+step:363/1840 train_time:12204ms step_avg:33.62ms
+step:364/1840 train_time:12238ms step_avg:33.62ms
+step:365/1840 train_time:12270ms step_avg:33.62ms
+step:366/1840 train_time:12305ms step_avg:33.62ms
+step:367/1840 train_time:12337ms step_avg:33.61ms
+step:368/1840 train_time:12370ms step_avg:33.62ms
+step:369/1840 train_time:12403ms step_avg:33.61ms
+step:370/1840 train_time:12437ms step_avg:33.61ms
+step:371/1840 train_time:12469ms step_avg:33.61ms
+step:372/1840 train_time:12504ms step_avg:33.61ms
+step:373/1840 train_time:12536ms step_avg:33.61ms
+step:374/1840 train_time:12570ms step_avg:33.61ms
+step:375/1840 train_time:12603ms step_avg:33.61ms
+step:376/1840 train_time:12637ms step_avg:33.61ms
+step:377/1840 train_time:12669ms step_avg:33.60ms
+step:378/1840 train_time:12703ms step_avg:33.61ms
+step:379/1840 train_time:12735ms step_avg:33.60ms
+step:380/1840 train_time:12769ms step_avg:33.60ms
+step:381/1840 train_time:12802ms step_avg:33.60ms
+step:382/1840 train_time:12836ms step_avg:33.60ms
+step:383/1840 train_time:12868ms step_avg:33.60ms
+step:384/1840 train_time:12902ms step_avg:33.60ms
+step:385/1840 train_time:12935ms step_avg:33.60ms
+step:386/1840 train_time:12969ms step_avg:33.60ms
+step:387/1840 train_time:13001ms step_avg:33.59ms
+step:388/1840 train_time:13035ms step_avg:33.60ms
+step:389/1840 train_time:13067ms step_avg:33.59ms
+step:390/1840 train_time:13101ms step_avg:33.59ms
+step:391/1840 train_time:13133ms step_avg:33.59ms
+step:392/1840 train_time:13167ms step_avg:33.59ms
+step:393/1840 train_time:13199ms step_avg:33.58ms
+step:394/1840 train_time:13233ms step_avg:33.59ms
+step:395/1840 train_time:13265ms step_avg:33.58ms
+step:396/1840 train_time:13299ms step_avg:33.58ms
+step:397/1840 train_time:13331ms step_avg:33.58ms
+step:398/1840 train_time:13365ms step_avg:33.58ms
+step:399/1840 train_time:13397ms step_avg:33.58ms
+step:400/1840 train_time:13431ms step_avg:33.58ms
+step:401/1840 train_time:13463ms step_avg:33.57ms
+step:402/1840 train_time:13497ms step_avg:33.58ms
+step:403/1840 train_time:13529ms step_avg:33.57ms
+step:404/1840 train_time:13563ms step_avg:33.57ms
+step:405/1840 train_time:13595ms step_avg:33.57ms
+step:406/1840 train_time:13630ms step_avg:33.57ms
+step:407/1840 train_time:13662ms step_avg:33.57ms
+step:408/1840 train_time:13696ms step_avg:33.57ms
+step:409/1840 train_time:13729ms step_avg:33.57ms
+step:410/1840 train_time:13763ms step_avg:33.57ms
+step:411/1840 train_time:13795ms step_avg:33.56ms
+step:412/1840 train_time:13829ms step_avg:33.57ms
+step:413/1840 train_time:13861ms step_avg:33.56ms
+step:414/1840 train_time:13895ms step_avg:33.56ms
+step:415/1840 train_time:13928ms step_avg:33.56ms
+step:416/1840 train_time:13962ms step_avg:33.56ms
+step:417/1840 train_time:13994ms step_avg:33.56ms
+step:418/1840 train_time:14028ms step_avg:33.56ms
+step:419/1840 train_time:14060ms step_avg:33.56ms
+step:420/1840 train_time:14095ms step_avg:33.56ms
+step:421/1840 train_time:14127ms step_avg:33.56ms
+step:422/1840 train_time:14161ms step_avg:33.56ms
+step:423/1840 train_time:14193ms step_avg:33.55ms
+step:424/1840 train_time:14227ms step_avg:33.55ms
+step:425/1840 train_time:14259ms step_avg:33.55ms
+step:426/1840 train_time:14293ms step_avg:33.55ms
+step:427/1840 train_time:14325ms step_avg:33.55ms
+step:428/1840 train_time:14359ms step_avg:33.55ms
+step:429/1840 train_time:14391ms step_avg:33.55ms
+step:430/1840 train_time:14425ms step_avg:33.55ms
+step:431/1840 train_time:14457ms step_avg:33.54ms
+step:432/1840 train_time:14492ms step_avg:33.55ms
+step:433/1840 train_time:14524ms step_avg:33.54ms
+step:434/1840 train_time:14558ms step_avg:33.54ms
+step:435/1840 train_time:14590ms step_avg:33.54ms
+step:436/1840 train_time:14624ms step_avg:33.54ms
+step:437/1840 train_time:14656ms step_avg:33.54ms
+step:438/1840 train_time:14690ms step_avg:33.54ms
+step:439/1840 train_time:14722ms step_avg:33.54ms
+step:440/1840 train_time:14757ms step_avg:33.54ms
+step:441/1840 train_time:14789ms step_avg:33.53ms
+step:442/1840 train_time:14823ms step_avg:33.54ms
+step:443/1840 train_time:14855ms step_avg:33.53ms
+step:444/1840 train_time:14889ms step_avg:33.53ms
+step:445/1840 train_time:14921ms step_avg:33.53ms
+step:446/1840 train_time:14955ms step_avg:33.53ms
+step:447/1840 train_time:14987ms step_avg:33.53ms
+step:448/1840 train_time:15022ms step_avg:33.53ms
+step:449/1840 train_time:15054ms step_avg:33.53ms
+step:450/1840 train_time:15088ms step_avg:33.53ms
+step:451/1840 train_time:15120ms step_avg:33.53ms
+step:452/1840 train_time:15154ms step_avg:33.53ms
+step:453/1840 train_time:15186ms step_avg:33.52ms
+step:454/1840 train_time:15220ms step_avg:33.52ms
+step:455/1840 train_time:15253ms step_avg:33.52ms
+step:456/1840 train_time:15287ms step_avg:33.52ms
+step:457/1840 train_time:15319ms step_avg:33.52ms
+step:458/1840 train_time:15353ms step_avg:33.52ms
+step:459/1840 train_time:15385ms step_avg:33.52ms
+step:460/1840 train_time:15419ms step_avg:33.52ms
+step:461/1840 train_time:15451ms step_avg:33.52ms
+step:462/1840 train_time:15486ms step_avg:33.52ms
+step:463/1840 train_time:15518ms step_avg:33.52ms
+step:464/1840 train_time:15552ms step_avg:33.52ms
+step:465/1840 train_time:15584ms step_avg:33.51ms
+step:466/1840 train_time:15618ms step_avg:33.51ms
+step:467/1840 train_time:15650ms step_avg:33.51ms
+step:468/1840 train_time:15684ms step_avg:33.51ms
+step:469/1840 train_time:15716ms step_avg:33.51ms
+step:470/1840 train_time:15751ms step_avg:33.51ms
+step:471/1840 train_time:15783ms step_avg:33.51ms
+step:472/1840 train_time:15817ms step_avg:33.51ms
+step:473/1840 train_time:15849ms step_avg:33.51ms
+step:474/1840 train_time:15883ms step_avg:33.51ms
+step:475/1840 train_time:15915ms step_avg:33.51ms
+step:476/1840 train_time:15949ms step_avg:33.51ms
+step:477/1840 train_time:15981ms step_avg:33.50ms
+step:478/1840 train_time:16016ms step_avg:33.51ms
+step:479/1840 train_time:16048ms step_avg:33.50ms
+step:480/1840 train_time:16081ms step_avg:33.50ms
+step:481/1840 train_time:16113ms step_avg:33.50ms
+step:482/1840 train_time:16148ms step_avg:33.50ms
+step:483/1840 train_time:16180ms step_avg:33.50ms
+step:484/1840 train_time:16214ms step_avg:33.50ms
+step:485/1840 train_time:16246ms step_avg:33.50ms
+step:486/1840 train_time:16280ms step_avg:33.50ms
+step:487/1840 train_time:16312ms step_avg:33.50ms
+step:488/1840 train_time:16346ms step_avg:33.50ms
+step:489/1840 train_time:16378ms step_avg:33.49ms
+step:490/1840 train_time:16413ms step_avg:33.50ms
+step:491/1840 train_time:16445ms step_avg:33.49ms
+step:492/1840 train_time:16479ms step_avg:33.49ms
+step:493/1840 train_time:16511ms step_avg:33.49ms
+step:494/1840 train_time:16545ms step_avg:33.49ms
+step:495/1840 train_time:16577ms step_avg:33.49ms
+step:496/1840 train_time:16611ms step_avg:33.49ms
+step:497/1840 train_time:16643ms step_avg:33.49ms
+step:498/1840 train_time:16677ms step_avg:33.49ms
+step:499/1840 train_time:16709ms step_avg:33.49ms
+step:500/1840 train_time:16743ms step_avg:33.49ms
+step:500/1840 val_loss:4.2933 train_time:16786ms step_avg:33.57ms
+step:501/1840 train_time:16804ms step_avg:33.54ms
+step:502/1840 train_time:16822ms step_avg:33.51ms
+step:503/1840 train_time:16845ms step_avg:33.49ms
+step:504/1840 train_time:16879ms step_avg:33.49ms
+step:505/1840 train_time:16912ms step_avg:33.49ms
+step:506/1840 train_time:16947ms step_avg:33.49ms
+step:507/1840 train_time:16980ms step_avg:33.49ms
+step:508/1840 train_time:17014ms step_avg:33.49ms
+step:509/1840 train_time:17046ms step_avg:33.49ms
+step:510/1840 train_time:17080ms step_avg:33.49ms
+step:511/1840 train_time:17112ms step_avg:33.49ms
+step:512/1840 train_time:17146ms step_avg:33.49ms
+step:513/1840 train_time:17178ms step_avg:33.49ms
+step:514/1840 train_time:17212ms step_avg:33.49ms
+step:515/1840 train_time:17244ms step_avg:33.48ms
+step:516/1840 train_time:17278ms step_avg:33.49ms
+step:517/1840 train_time:17310ms step_avg:33.48ms
+step:518/1840 train_time:17344ms step_avg:33.48ms
+step:519/1840 train_time:17376ms step_avg:33.48ms
+step:520/1840 train_time:17410ms step_avg:33.48ms
+step:521/1840 train_time:17442ms step_avg:33.48ms
+step:522/1840 train_time:17476ms step_avg:33.48ms
+step:523/1840 train_time:17508ms step_avg:33.48ms
+step:524/1840 train_time:17542ms step_avg:33.48ms
+step:525/1840 train_time:17574ms step_avg:33.47ms
+step:526/1840 train_time:17608ms step_avg:33.48ms
+step:527/1840 train_time:17640ms step_avg:33.47ms
+step:528/1840 train_time:17674ms step_avg:33.47ms
+step:529/1840 train_time:17706ms step_avg:33.47ms
+step:530/1840 train_time:17741ms step_avg:33.47ms
+step:531/1840 train_time:17773ms step_avg:33.47ms
+step:532/1840 train_time:17808ms step_avg:33.47ms
+step:533/1840 train_time:17840ms step_avg:33.47ms
+step:534/1840 train_time:17875ms step_avg:33.47ms
+step:535/1840 train_time:17907ms step_avg:33.47ms
+step:536/1840 train_time:17942ms step_avg:33.47ms
+step:537/1840 train_time:17974ms step_avg:33.47ms
+step:538/1840 train_time:18009ms step_avg:33.47ms
+step:539/1840 train_time:18041ms step_avg:33.47ms
+step:540/1840 train_time:18075ms step_avg:33.47ms
+step:541/1840 train_time:18107ms step_avg:33.47ms
+step:542/1840 train_time:18141ms step_avg:33.47ms
+step:543/1840 train_time:18173ms step_avg:33.47ms
+step:544/1840 train_time:18207ms step_avg:33.47ms
+step:545/1840 train_time:18239ms step_avg:33.47ms
+step:546/1840 train_time:18273ms step_avg:33.47ms
+step:547/1840 train_time:18305ms step_avg:33.46ms
+step:548/1840 train_time:18339ms step_avg:33.47ms
+step:549/1840 train_time:18371ms step_avg:33.46ms
+step:550/1840 train_time:18405ms step_avg:33.46ms
+step:551/1840 train_time:18437ms step_avg:33.46ms
+step:552/1840 train_time:18470ms step_avg:33.46ms
+step:553/1840 train_time:18502ms step_avg:33.46ms
+step:554/1840 train_time:18536ms step_avg:33.46ms
+step:555/1840 train_time:18568ms step_avg:33.46ms
+step:556/1840 train_time:18602ms step_avg:33.46ms
+step:557/1840 train_time:18634ms step_avg:33.45ms
+step:558/1840 train_time:18668ms step_avg:33.46ms
+step:559/1840 train_time:18700ms step_avg:33.45ms
+step:560/1840 train_time:18734ms step_avg:33.45ms
+step:561/1840 train_time:18767ms step_avg:33.45ms
+step:562/1840 train_time:18802ms step_avg:33.45ms
+step:563/1840 train_time:18834ms step_avg:33.45ms
+step:564/1840 train_time:18868ms step_avg:33.45ms
+step:565/1840 train_time:18900ms step_avg:33.45ms
+step:566/1840 train_time:18935ms step_avg:33.45ms
+step:567/1840 train_time:18967ms step_avg:33.45ms
+step:568/1840 train_time:19001ms step_avg:33.45ms
+step:569/1840 train_time:19034ms step_avg:33.45ms
+step:570/1840 train_time:19068ms step_avg:33.45ms
+step:571/1840 train_time:19100ms step_avg:33.45ms
+step:572/1840 train_time:19134ms step_avg:33.45ms
+step:573/1840 train_time:19166ms step_avg:33.45ms
+step:574/1840 train_time:19200ms step_avg:33.45ms
+step:575/1840 train_time:19232ms step_avg:33.45ms
+step:576/1840 train_time:19267ms step_avg:33.45ms
+step:577/1840 train_time:19298ms step_avg:33.45ms
+step:578/1840 train_time:19332ms step_avg:33.45ms
+step:579/1840 train_time:19365ms step_avg:33.44ms
+step:580/1840 train_time:19399ms step_avg:33.45ms
+step:581/1840 train_time:19431ms step_avg:33.44ms
+step:582/1840 train_time:19465ms step_avg:33.44ms
+step:583/1840 train_time:19497ms step_avg:33.44ms
+step:584/1840 train_time:19531ms step_avg:33.44ms
+step:585/1840 train_time:19563ms step_avg:33.44ms
+step:586/1840 train_time:19597ms step_avg:33.44ms
+step:587/1840 train_time:19629ms step_avg:33.44ms
+step:588/1840 train_time:19663ms step_avg:33.44ms
+step:589/1840 train_time:19695ms step_avg:33.44ms
+step:590/1840 train_time:19730ms step_avg:33.44ms
+step:591/1840 train_time:19762ms step_avg:33.44ms
+step:592/1840 train_time:19796ms step_avg:33.44ms
+step:593/1840 train_time:19829ms step_avg:33.44ms
+step:594/1840 train_time:19863ms step_avg:33.44ms
+step:595/1840 train_time:19895ms step_avg:33.44ms
+step:596/1840 train_time:19929ms step_avg:33.44ms
+step:597/1840 train_time:19961ms step_avg:33.44ms
+step:598/1840 train_time:19996ms step_avg:33.44ms
+step:599/1840 train_time:20028ms step_avg:33.44ms
+step:600/1840 train_time:20063ms step_avg:33.44ms
+step:601/1840 train_time:20097ms step_avg:33.44ms
+step:602/1840 train_time:20155ms step_avg:33.48ms
+step:603/1840 train_time:20214ms step_avg:33.52ms
+step:604/1840 train_time:20276ms step_avg:33.57ms
+step:605/1840 train_time:20335ms step_avg:33.61ms
+step:606/1840 train_time:20397ms step_avg:33.66ms
+step:607/1840 train_time:20457ms step_avg:33.70ms
+step:608/1840 train_time:20519ms step_avg:33.75ms
+step:609/1840 train_time:20578ms step_avg:33.79ms
+step:610/1840 train_time:20640ms step_avg:33.84ms
+step:611/1840 train_time:20700ms step_avg:33.88ms
+step:612/1840 train_time:20762ms step_avg:33.93ms
+step:613/1840 train_time:20822ms step_avg:33.97ms
+step:614/1840 train_time:20885ms step_avg:34.01ms
+step:615/1840 train_time:20945ms step_avg:34.06ms
+step:616/1840 train_time:21008ms step_avg:34.10ms
+step:617/1840 train_time:21068ms step_avg:34.15ms
+step:618/1840 train_time:21130ms step_avg:34.19ms
+step:619/1840 train_time:21190ms step_avg:34.23ms
+step:620/1840 train_time:21252ms step_avg:34.28ms
+step:621/1840 train_time:21312ms step_avg:34.32ms
+step:622/1840 train_time:21374ms step_avg:34.36ms
+step:623/1840 train_time:21433ms step_avg:34.40ms
+step:624/1840 train_time:21495ms step_avg:34.45ms
+step:625/1840 train_time:21555ms step_avg:34.49ms
+step:626/1840 train_time:21617ms step_avg:34.53ms
+step:627/1840 train_time:21677ms step_avg:34.57ms
+step:628/1840 train_time:21739ms step_avg:34.62ms
+step:629/1840 train_time:21799ms step_avg:34.66ms
+step:630/1840 train_time:21861ms step_avg:34.70ms
+step:631/1840 train_time:21922ms step_avg:34.74ms
+step:632/1840 train_time:21985ms step_avg:34.79ms
+step:633/1840 train_time:22045ms step_avg:34.83ms
+step:634/1840 train_time:22108ms step_avg:34.87ms
+step:635/1840 train_time:22169ms step_avg:34.91ms
+step:636/1840 train_time:22231ms step_avg:34.96ms
+step:637/1840 train_time:22291ms step_avg:34.99ms
+step:638/1840 train_time:22353ms step_avg:35.04ms
+step:639/1840 train_time:22412ms step_avg:35.07ms
+step:640/1840 train_time:22474ms step_avg:35.12ms
+step:641/1840 train_time:22533ms step_avg:35.15ms
+step:642/1840 train_time:22595ms step_avg:35.19ms
+step:643/1840 train_time:22655ms step_avg:35.23ms
+step:644/1840 train_time:22717ms step_avg:35.27ms
+step:645/1840 train_time:22776ms step_avg:35.31ms
+step:646/1840 train_time:22838ms step_avg:35.35ms
+step:647/1840 train_time:22897ms step_avg:35.39ms
+step:648/1840 train_time:22960ms step_avg:35.43ms
+step:649/1840 train_time:23021ms step_avg:35.47ms
+step:650/1840 train_time:23084ms step_avg:35.51ms
+step:651/1840 train_time:23144ms step_avg:35.55ms
+step:652/1840 train_time:23207ms step_avg:35.59ms
+step:653/1840 train_time:23266ms step_avg:35.63ms
+step:654/1840 train_time:23329ms step_avg:35.67ms
+step:655/1840 train_time:23389ms step_avg:35.71ms
+step:656/1840 train_time:23451ms step_avg:35.75ms
+step:657/1840 train_time:23511ms step_avg:35.79ms
+step:658/1840 train_time:23572ms step_avg:35.82ms
+step:659/1840 train_time:23633ms step_avg:35.86ms
+step:660/1840 train_time:23695ms step_avg:35.90ms
+step:661/1840 train_time:23755ms step_avg:35.94ms
+step:662/1840 train_time:23817ms step_avg:35.98ms
+step:663/1840 train_time:23877ms step_avg:36.01ms
+step:664/1840 train_time:23940ms step_avg:36.05ms
+step:665/1840 train_time:23999ms step_avg:36.09ms
+step:666/1840 train_time:24062ms step_avg:36.13ms
+step:667/1840 train_time:24123ms step_avg:36.17ms
+step:668/1840 train_time:24185ms step_avg:36.21ms
+step:669/1840 train_time:24245ms step_avg:36.24ms
+step:670/1840 train_time:24307ms step_avg:36.28ms
+step:671/1840 train_time:24367ms step_avg:36.31ms
+step:672/1840 train_time:24430ms step_avg:36.35ms
+step:673/1840 train_time:24490ms step_avg:36.39ms
+step:674/1840 train_time:24553ms step_avg:36.43ms
+step:675/1840 train_time:24612ms step_avg:36.46ms
+step:676/1840 train_time:24674ms step_avg:36.50ms
+step:677/1840 train_time:24734ms step_avg:36.54ms
+step:678/1840 train_time:24796ms step_avg:36.57ms
+step:679/1840 train_time:24856ms step_avg:36.61ms
+step:680/1840 train_time:24918ms step_avg:36.64ms
+step:681/1840 train_time:24977ms step_avg:36.68ms
+step:682/1840 train_time:25040ms step_avg:36.72ms
+step:683/1840 train_time:25100ms step_avg:36.75ms
+step:684/1840 train_time:25162ms step_avg:36.79ms
+step:685/1840 train_time:25222ms step_avg:36.82ms
+step:686/1840 train_time:25285ms step_avg:36.86ms
+step:687/1840 train_time:25346ms step_avg:36.89ms
+step:688/1840 train_time:25408ms step_avg:36.93ms
+step:689/1840 train_time:25469ms step_avg:36.97ms
+step:690/1840 train_time:25532ms step_avg:37.00ms
+step:691/1840 train_time:25591ms step_avg:37.03ms
+step:692/1840 train_time:25653ms step_avg:37.07ms
+step:693/1840 train_time:25712ms step_avg:37.10ms
+step:694/1840 train_time:25774ms step_avg:37.14ms
+step:695/1840 train_time:25834ms step_avg:37.17ms
+step:696/1840 train_time:25896ms step_avg:37.21ms
+step:697/1840 train_time:25955ms step_avg:37.24ms
+step:698/1840 train_time:26017ms step_avg:37.27ms
+step:699/1840 train_time:26077ms step_avg:37.31ms
+step:700/1840 train_time:26140ms step_avg:37.34ms
+step:701/1840 train_time:26200ms step_avg:37.38ms
+step:702/1840 train_time:26262ms step_avg:37.41ms
+step:703/1840 train_time:26322ms step_avg:37.44ms
+step:704/1840 train_time:26385ms step_avg:37.48ms
+step:705/1840 train_time:26445ms step_avg:37.51ms
+step:706/1840 train_time:26508ms step_avg:37.55ms
+step:707/1840 train_time:26568ms step_avg:37.58ms
+step:708/1840 train_time:26631ms step_avg:37.61ms
+step:709/1840 train_time:26691ms step_avg:37.65ms
+step:710/1840 train_time:26753ms step_avg:37.68ms
+step:711/1840 train_time:26813ms step_avg:37.71ms
+step:712/1840 train_time:26875ms step_avg:37.75ms
+step:713/1840 train_time:26934ms step_avg:37.78ms
+step:714/1840 train_time:26995ms step_avg:37.81ms
+step:715/1840 train_time:27055ms step_avg:37.84ms
+step:716/1840 train_time:27118ms step_avg:37.87ms
+step:717/1840 train_time:27178ms step_avg:37.91ms
+step:718/1840 train_time:27241ms step_avg:37.94ms
+step:719/1840 train_time:27301ms step_avg:37.97ms
+step:720/1840 train_time:27364ms step_avg:38.01ms
+step:721/1840 train_time:27424ms step_avg:38.04ms
+step:722/1840 train_time:27487ms step_avg:38.07ms
+step:723/1840 train_time:27547ms step_avg:38.10ms
+step:724/1840 train_time:27610ms step_avg:38.13ms
+step:725/1840 train_time:27670ms step_avg:38.17ms
+step:726/1840 train_time:27732ms step_avg:38.20ms
+step:727/1840 train_time:27791ms step_avg:38.23ms
+step:728/1840 train_time:27854ms step_avg:38.26ms
+step:729/1840 train_time:27914ms step_avg:38.29ms
+step:730/1840 train_time:27975ms step_avg:38.32ms
+step:731/1840 train_time:28036ms step_avg:38.35ms
+step:732/1840 train_time:28097ms step_avg:38.38ms
+step:733/1840 train_time:28157ms step_avg:38.41ms
+step:734/1840 train_time:28220ms step_avg:38.45ms
+step:735/1840 train_time:28279ms step_avg:38.48ms
+step:736/1840 train_time:28342ms step_avg:38.51ms
+step:737/1840 train_time:28402ms step_avg:38.54ms
+step:738/1840 train_time:28465ms step_avg:38.57ms
+step:739/1840 train_time:28525ms step_avg:38.60ms
+step:740/1840 train_time:28589ms step_avg:38.63ms
+step:741/1840 train_time:28649ms step_avg:38.66ms
+step:742/1840 train_time:28712ms step_avg:38.70ms
+step:743/1840 train_time:28771ms step_avg:38.72ms
+step:744/1840 train_time:28833ms step_avg:38.75ms
+step:745/1840 train_time:28893ms step_avg:38.78ms
+step:746/1840 train_time:28956ms step_avg:38.81ms
+step:747/1840 train_time:29016ms step_avg:38.84ms
+step:748/1840 train_time:29079ms step_avg:38.88ms
+step:749/1840 train_time:29138ms step_avg:38.90ms
+step:750/1840 train_time:29200ms step_avg:38.93ms
+step:750/1840 val_loss:4.0207 train_time:29272ms step_avg:39.03ms
+step:751/1840 train_time:29291ms step_avg:39.00ms
+step:752/1840 train_time:29323ms step_avg:38.99ms
+step:753/1840 train_time:29384ms step_avg:39.02ms
+step:754/1840 train_time:29448ms step_avg:39.06ms
+step:755/1840 train_time:29509ms step_avg:39.08ms
+step:756/1840 train_time:29571ms step_avg:39.11ms
+step:757/1840 train_time:29629ms step_avg:39.14ms
+step:758/1840 train_time:29691ms step_avg:39.17ms
+step:759/1840 train_time:29751ms step_avg:39.20ms
+step:760/1840 train_time:29813ms step_avg:39.23ms
+step:761/1840 train_time:29872ms step_avg:39.25ms
+step:762/1840 train_time:29935ms step_avg:39.29ms
+step:763/1840 train_time:29997ms step_avg:39.31ms
+step:764/1840 train_time:30059ms step_avg:39.34ms
+step:765/1840 train_time:30118ms step_avg:39.37ms
+step:766/1840 train_time:30180ms step_avg:39.40ms
+step:767/1840 train_time:30241ms step_avg:39.43ms
+step:768/1840 train_time:30303ms step_avg:39.46ms
+step:769/1840 train_time:30365ms step_avg:39.49ms
+step:770/1840 train_time:30427ms step_avg:39.52ms
+step:771/1840 train_time:30487ms step_avg:39.54ms
+step:772/1840 train_time:30550ms step_avg:39.57ms
+step:773/1840 train_time:30609ms step_avg:39.60ms
+step:774/1840 train_time:30670ms step_avg:39.63ms
+step:775/1840 train_time:30729ms step_avg:39.65ms
+step:776/1840 train_time:30791ms step_avg:39.68ms
+step:777/1840 train_time:30851ms step_avg:39.70ms
+step:778/1840 train_time:30913ms step_avg:39.73ms
+step:779/1840 train_time:30973ms step_avg:39.76ms
+step:780/1840 train_time:31035ms step_avg:39.79ms
+step:781/1840 train_time:31095ms step_avg:39.81ms
+step:782/1840 train_time:31157ms step_avg:39.84ms
+step:783/1840 train_time:31217ms step_avg:39.87ms
+step:784/1840 train_time:31279ms step_avg:39.90ms
+step:785/1840 train_time:31340ms step_avg:39.92ms
+step:786/1840 train_time:31403ms step_avg:39.95ms
+step:787/1840 train_time:31463ms step_avg:39.98ms
+step:788/1840 train_time:31527ms step_avg:40.01ms
+step:789/1840 train_time:31587ms step_avg:40.03ms
+step:790/1840 train_time:31649ms step_avg:40.06ms
+step:791/1840 train_time:31708ms step_avg:40.09ms
+step:792/1840 train_time:31770ms step_avg:40.11ms
+step:793/1840 train_time:31830ms step_avg:40.14ms
+step:794/1840 train_time:31891ms step_avg:40.17ms
+step:795/1840 train_time:31950ms step_avg:40.19ms
+step:796/1840 train_time:32012ms step_avg:40.22ms
+step:797/1840 train_time:32072ms step_avg:40.24ms
+step:798/1840 train_time:32134ms step_avg:40.27ms
+step:799/1840 train_time:32194ms step_avg:40.29ms
+step:800/1840 train_time:32257ms step_avg:40.32ms
+step:801/1840 train_time:32318ms step_avg:40.35ms
+step:802/1840 train_time:32381ms step_avg:40.38ms
+step:803/1840 train_time:32441ms step_avg:40.40ms
+step:804/1840 train_time:32504ms step_avg:40.43ms
+step:805/1840 train_time:32564ms step_avg:40.45ms
+step:806/1840 train_time:32626ms step_avg:40.48ms
+step:807/1840 train_time:32686ms step_avg:40.50ms
+step:808/1840 train_time:32749ms step_avg:40.53ms
+step:809/1840 train_time:32808ms step_avg:40.55ms
+step:810/1840 train_time:32870ms step_avg:40.58ms
+step:811/1840 train_time:32929ms step_avg:40.60ms
+step:812/1840 train_time:32992ms step_avg:40.63ms
+step:813/1840 train_time:33051ms step_avg:40.65ms
+step:814/1840 train_time:33113ms step_avg:40.68ms
+step:815/1840 train_time:33173ms step_avg:40.70ms
+step:816/1840 train_time:33236ms step_avg:40.73ms
+step:817/1840 train_time:33296ms step_avg:40.75ms
+step:818/1840 train_time:33359ms step_avg:40.78ms
+step:819/1840 train_time:33419ms step_avg:40.81ms
+step:820/1840 train_time:33482ms step_avg:40.83ms
+step:821/1840 train_time:33542ms step_avg:40.86ms
+step:822/1840 train_time:33605ms step_avg:40.88ms
+step:823/1840 train_time:33664ms step_avg:40.90ms
+step:824/1840 train_time:33727ms step_avg:40.93ms
+step:825/1840 train_time:33787ms step_avg:40.95ms
+step:826/1840 train_time:33850ms step_avg:40.98ms
+step:827/1840 train_time:33910ms step_avg:41.00ms
+step:828/1840 train_time:33971ms step_avg:41.03ms
+step:829/1840 train_time:34029ms step_avg:41.05ms
+step:830/1840 train_time:34092ms step_avg:41.07ms
+step:831/1840 train_time:34151ms step_avg:41.10ms
+step:832/1840 train_time:34214ms step_avg:41.12ms
+step:833/1840 train_time:34274ms step_avg:41.14ms
+step:834/1840 train_time:34336ms step_avg:41.17ms
+step:835/1840 train_time:34397ms step_avg:41.19ms
+step:836/1840 train_time:34461ms step_avg:41.22ms
+step:837/1840 train_time:34521ms step_avg:41.24ms
+step:838/1840 train_time:34583ms step_avg:41.27ms
+step:839/1840 train_time:34643ms step_avg:41.29ms
+step:840/1840 train_time:34706ms step_avg:41.32ms
+step:841/1840 train_time:34766ms step_avg:41.34ms
+step:842/1840 train_time:34829ms step_avg:41.36ms
+step:843/1840 train_time:34888ms step_avg:41.39ms
+step:844/1840 train_time:34951ms step_avg:41.41ms
+step:845/1840 train_time:35011ms step_avg:41.43ms
+step:846/1840 train_time:35072ms step_avg:41.46ms
+step:847/1840 train_time:35132ms step_avg:41.48ms
+step:848/1840 train_time:35194ms step_avg:41.50ms
+step:849/1840 train_time:35254ms step_avg:41.52ms
+step:850/1840 train_time:35316ms step_avg:41.55ms
+step:851/1840 train_time:35377ms step_avg:41.57ms
+step:852/1840 train_time:35439ms step_avg:41.60ms
+step:853/1840 train_time:35500ms step_avg:41.62ms
+step:854/1840 train_time:35562ms step_avg:41.64ms
+step:855/1840 train_time:35622ms step_avg:41.66ms
+step:856/1840 train_time:35684ms step_avg:41.69ms
+step:857/1840 train_time:35745ms step_avg:41.71ms
+step:858/1840 train_time:35807ms step_avg:41.73ms
+step:859/1840 train_time:35866ms step_avg:41.75ms
+step:860/1840 train_time:35928ms step_avg:41.78ms
+step:861/1840 train_time:35988ms step_avg:41.80ms
+step:862/1840 train_time:36051ms step_avg:41.82ms
+step:863/1840 train_time:36110ms step_avg:41.84ms
+step:864/1840 train_time:36172ms step_avg:41.87ms
+step:865/1840 train_time:36232ms step_avg:41.89ms
+step:866/1840 train_time:36295ms step_avg:41.91ms
+step:867/1840 train_time:36355ms step_avg:41.93ms
+step:868/1840 train_time:36417ms step_avg:41.96ms
+step:869/1840 train_time:36477ms step_avg:41.98ms
+step:870/1840 train_time:36541ms step_avg:42.00ms
+step:871/1840 train_time:36602ms step_avg:42.02ms
+step:872/1840 train_time:36664ms step_avg:42.05ms
+step:873/1840 train_time:36724ms step_avg:42.07ms
+step:874/1840 train_time:36787ms step_avg:42.09ms
+step:875/1840 train_time:36846ms step_avg:42.11ms
+step:876/1840 train_time:36908ms step_avg:42.13ms
+step:877/1840 train_time:36967ms step_avg:42.15ms
+step:878/1840 train_time:37030ms step_avg:42.17ms
+step:879/1840 train_time:37089ms step_avg:42.19ms
+step:880/1840 train_time:37151ms step_avg:42.22ms
+step:881/1840 train_time:37211ms step_avg:42.24ms
+step:882/1840 train_time:37273ms step_avg:42.26ms
+step:883/1840 train_time:37333ms step_avg:42.28ms
+step:884/1840 train_time:37395ms step_avg:42.30ms
+step:885/1840 train_time:37456ms step_avg:42.32ms
+step:886/1840 train_time:37519ms step_avg:42.35ms
+step:887/1840 train_time:37579ms step_avg:42.37ms
+step:888/1840 train_time:37642ms step_avg:42.39ms
+step:889/1840 train_time:37703ms step_avg:42.41ms
+step:890/1840 train_time:37765ms step_avg:42.43ms
+step:891/1840 train_time:37825ms step_avg:42.45ms
+step:892/1840 train_time:37887ms step_avg:42.47ms
+step:893/1840 train_time:37946ms step_avg:42.49ms
+step:894/1840 train_time:38008ms step_avg:42.52ms
+step:895/1840 train_time:38068ms step_avg:42.53ms
+step:896/1840 train_time:38131ms step_avg:42.56ms
+step:897/1840 train_time:38190ms step_avg:42.58ms
+step:898/1840 train_time:38252ms step_avg:42.60ms
+step:899/1840 train_time:38312ms step_avg:42.62ms
+step:900/1840 train_time:38375ms step_avg:42.64ms
+step:901/1840 train_time:38435ms step_avg:42.66ms
+step:902/1840 train_time:38498ms step_avg:42.68ms
+step:903/1840 train_time:38558ms step_avg:42.70ms
+step:904/1840 train_time:38620ms step_avg:42.72ms
+step:905/1840 train_time:38681ms step_avg:42.74ms
+step:906/1840 train_time:38743ms step_avg:42.76ms
+step:907/1840 train_time:38803ms step_avg:42.78ms
+step:908/1840 train_time:38866ms step_avg:42.80ms
+step:909/1840 train_time:38926ms step_avg:42.82ms
+step:910/1840 train_time:38988ms step_avg:42.84ms
+step:911/1840 train_time:39047ms step_avg:42.86ms
+step:912/1840 train_time:39109ms step_avg:42.88ms
+step:913/1840 train_time:39168ms step_avg:42.90ms
+step:914/1840 train_time:39230ms step_avg:42.92ms
+step:915/1840 train_time:39290ms step_avg:42.94ms
+step:916/1840 train_time:39352ms step_avg:42.96ms
+step:917/1840 train_time:39412ms step_avg:42.98ms
+step:918/1840 train_time:39474ms step_avg:43.00ms
+step:919/1840 train_time:39534ms step_avg:43.02ms
+step:920/1840 train_time:39597ms step_avg:43.04ms
+step:921/1840 train_time:39658ms step_avg:43.06ms
+step:922/1840 train_time:39721ms step_avg:43.08ms
+step:923/1840 train_time:39781ms step_avg:43.10ms
+step:924/1840 train_time:39844ms step_avg:43.12ms
+step:925/1840 train_time:39904ms step_avg:43.14ms
+step:926/1840 train_time:39966ms step_avg:43.16ms
+step:927/1840 train_time:40026ms step_avg:43.18ms
+step:928/1840 train_time:40088ms step_avg:43.20ms
+step:929/1840 train_time:40149ms step_avg:43.22ms
+step:930/1840 train_time:40211ms step_avg:43.24ms
+step:931/1840 train_time:40270ms step_avg:43.25ms
+step:932/1840 train_time:40333ms step_avg:43.28ms
+step:933/1840 train_time:40393ms step_avg:43.29ms
+step:934/1840 train_time:40455ms step_avg:43.31ms
+step:935/1840 train_time:40515ms step_avg:43.33ms
+step:936/1840 train_time:40579ms step_avg:43.35ms
+step:937/1840 train_time:40639ms step_avg:43.37ms
+step:938/1840 train_time:40701ms step_avg:43.39ms
+step:939/1840 train_time:40761ms step_avg:43.41ms
+step:940/1840 train_time:40823ms step_avg:43.43ms
+step:941/1840 train_time:40883ms step_avg:43.45ms
+step:942/1840 train_time:40946ms step_avg:43.47ms
+step:943/1840 train_time:41005ms step_avg:43.48ms
+step:944/1840 train_time:41068ms step_avg:43.50ms
+step:945/1840 train_time:41128ms step_avg:43.52ms
+step:946/1840 train_time:41191ms step_avg:43.54ms
+step:947/1840 train_time:41251ms step_avg:43.56ms
+step:948/1840 train_time:41313ms step_avg:43.58ms
+step:949/1840 train_time:41372ms step_avg:43.60ms
+step:950/1840 train_time:41434ms step_avg:43.61ms
+step:951/1840 train_time:41493ms step_avg:43.63ms
+step:952/1840 train_time:41556ms step_avg:43.65ms
+step:953/1840 train_time:41616ms step_avg:43.67ms
+step:954/1840 train_time:41678ms step_avg:43.69ms
+step:955/1840 train_time:41738ms step_avg:43.70ms
+step:956/1840 train_time:41799ms step_avg:43.72ms
+step:957/1840 train_time:41859ms step_avg:43.74ms
+step:958/1840 train_time:41922ms step_avg:43.76ms
+step:959/1840 train_time:41983ms step_avg:43.78ms
+step:960/1840 train_time:42045ms step_avg:43.80ms
+step:961/1840 train_time:42105ms step_avg:43.81ms
+step:962/1840 train_time:42167ms step_avg:43.83ms
+step:963/1840 train_time:42227ms step_avg:43.85ms
+step:964/1840 train_time:42289ms step_avg:43.87ms
+step:965/1840 train_time:42348ms step_avg:43.88ms
+step:966/1840 train_time:42411ms step_avg:43.90ms
+step:967/1840 train_time:42471ms step_avg:43.92ms
+step:968/1840 train_time:42533ms step_avg:43.94ms
+step:969/1840 train_time:42593ms step_avg:43.96ms
+step:970/1840 train_time:42655ms step_avg:43.97ms
+step:971/1840 train_time:42715ms step_avg:43.99ms
+step:972/1840 train_time:42778ms step_avg:44.01ms
+step:973/1840 train_time:42838ms step_avg:44.03ms
+step:974/1840 train_time:42901ms step_avg:44.05ms
+step:975/1840 train_time:42962ms step_avg:44.06ms
+step:976/1840 train_time:43024ms step_avg:44.08ms
+step:977/1840 train_time:43085ms step_avg:44.10ms
+step:978/1840 train_time:43146ms step_avg:44.12ms
+step:979/1840 train_time:43206ms step_avg:44.13ms
+step:980/1840 train_time:43267ms step_avg:44.15ms
+step:981/1840 train_time:43327ms step_avg:44.17ms
+step:982/1840 train_time:43389ms step_avg:44.18ms
+step:983/1840 train_time:43449ms step_avg:44.20ms
+step:984/1840 train_time:43511ms step_avg:44.22ms
+step:985/1840 train_time:43571ms step_avg:44.23ms
+step:986/1840 train_time:43634ms step_avg:44.25ms
+step:987/1840 train_time:43694ms step_avg:44.27ms
+step:988/1840 train_time:43756ms step_avg:44.29ms
+step:989/1840 train_time:43816ms step_avg:44.30ms
+step:990/1840 train_time:43878ms step_avg:44.32ms
+step:991/1840 train_time:43939ms step_avg:44.34ms
+step:992/1840 train_time:44001ms step_avg:44.36ms
+step:993/1840 train_time:44062ms step_avg:44.37ms
+step:994/1840 train_time:44124ms step_avg:44.39ms
+step:995/1840 train_time:44184ms step_avg:44.41ms
+step:996/1840 train_time:44246ms step_avg:44.42ms
+step:997/1840 train_time:44306ms step_avg:44.44ms
+step:998/1840 train_time:44369ms step_avg:44.46ms
+step:999/1840 train_time:44428ms step_avg:44.47ms
+step:1000/1840 train_time:44490ms step_avg:44.49ms
+step:1000/1840 val_loss:3.7755 train_time:44562ms step_avg:44.56ms
+step:1001/1840 train_time:44581ms step_avg:44.54ms
+step:1002/1840 train_time:44615ms step_avg:44.53ms
+step:1003/1840 train_time:44678ms step_avg:44.54ms
+step:1004/1840 train_time:44742ms step_avg:44.56ms
+step:1005/1840 train_time:44802ms step_avg:44.58ms
+step:1006/1840 train_time:44864ms step_avg:44.60ms
+step:1007/1840 train_time:44924ms step_avg:44.61ms
+step:1008/1840 train_time:44985ms step_avg:44.63ms
+step:1009/1840 train_time:45045ms step_avg:44.64ms
+step:1010/1840 train_time:45107ms step_avg:44.66ms
+step:1011/1840 train_time:45165ms step_avg:44.67ms
+step:1012/1840 train_time:45227ms step_avg:44.69ms
+step:1013/1840 train_time:45287ms step_avg:44.71ms
+step:1014/1840 train_time:45348ms step_avg:44.72ms
+step:1015/1840 train_time:45407ms step_avg:44.74ms
+step:1016/1840 train_time:45468ms step_avg:44.75ms
+step:1017/1840 train_time:45530ms step_avg:44.77ms
+step:1018/1840 train_time:45595ms step_avg:44.79ms
+step:1019/1840 train_time:45658ms step_avg:44.81ms
+step:1020/1840 train_time:45721ms step_avg:44.82ms
+step:1021/1840 train_time:45781ms step_avg:44.84ms
+step:1022/1840 train_time:45842ms step_avg:44.86ms
+step:1023/1840 train_time:45902ms step_avg:44.87ms
+step:1024/1840 train_time:45963ms step_avg:44.89ms
+step:1025/1840 train_time:46022ms step_avg:44.90ms
+step:1026/1840 train_time:46084ms step_avg:44.92ms
+step:1027/1840 train_time:46143ms step_avg:44.93ms
+step:1028/1840 train_time:46205ms step_avg:44.95ms
+step:1029/1840 train_time:46264ms step_avg:44.96ms
+step:1030/1840 train_time:46326ms step_avg:44.98ms
+step:1031/1840 train_time:46385ms step_avg:44.99ms
+step:1032/1840 train_time:46447ms step_avg:45.01ms
+step:1033/1840 train_time:46507ms step_avg:45.02ms
+step:1034/1840 train_time:46570ms step_avg:45.04ms
+step:1035/1840 train_time:46632ms step_avg:45.05ms
+step:1036/1840 train_time:46695ms step_avg:45.07ms
+step:1037/1840 train_time:46756ms step_avg:45.09ms
+step:1038/1840 train_time:46819ms step_avg:45.10ms
+step:1039/1840 train_time:46878ms step_avg:45.12ms
+step:1040/1840 train_time:46941ms step_avg:45.14ms
+step:1041/1840 train_time:47001ms step_avg:45.15ms
+step:1042/1840 train_time:47062ms step_avg:45.17ms
+step:1043/1840 train_time:47122ms step_avg:45.18ms
+step:1044/1840 train_time:47184ms step_avg:45.20ms
+step:1045/1840 train_time:47243ms step_avg:45.21ms
+step:1046/1840 train_time:47304ms step_avg:45.22ms
+step:1047/1840 train_time:47363ms step_avg:45.24ms
+step:1048/1840 train_time:47426ms step_avg:45.25ms
+step:1049/1840 train_time:47485ms step_avg:45.27ms
+step:1050/1840 train_time:47549ms step_avg:45.28ms
+step:1051/1840 train_time:47609ms step_avg:45.30ms
+step:1052/1840 train_time:47672ms step_avg:45.32ms
+step:1053/1840 train_time:47733ms step_avg:45.33ms
+step:1054/1840 train_time:47795ms step_avg:45.35ms
+step:1055/1840 train_time:47855ms step_avg:45.36ms
+step:1056/1840 train_time:47917ms step_avg:45.38ms
+step:1057/1840 train_time:47977ms step_avg:45.39ms
+step:1058/1840 train_time:48039ms step_avg:45.41ms
+step:1059/1840 train_time:48098ms step_avg:45.42ms
+step:1060/1840 train_time:48160ms step_avg:45.43ms
+step:1061/1840 train_time:48220ms step_avg:45.45ms
+step:1062/1840 train_time:48282ms step_avg:45.46ms
+step:1063/1840 train_time:48342ms step_avg:45.48ms
+step:1064/1840 train_time:48404ms step_avg:45.49ms
+step:1065/1840 train_time:48464ms step_avg:45.51ms
+step:1066/1840 train_time:48526ms step_avg:45.52ms
+step:1067/1840 train_time:48586ms step_avg:45.53ms
+step:1068/1840 train_time:48649ms step_avg:45.55ms
+step:1069/1840 train_time:48710ms step_avg:45.57ms
+step:1070/1840 train_time:48771ms step_avg:45.58ms
+step:1071/1840 train_time:48831ms step_avg:45.59ms
+step:1072/1840 train_time:48893ms step_avg:45.61ms
+step:1073/1840 train_time:48953ms step_avg:45.62ms
+step:1074/1840 train_time:49016ms step_avg:45.64ms
+step:1075/1840 train_time:49075ms step_avg:45.65ms
+step:1076/1840 train_time:49138ms step_avg:45.67ms
+step:1077/1840 train_time:49198ms step_avg:45.68ms
+step:1078/1840 train_time:49260ms step_avg:45.70ms
+step:1079/1840 train_time:49320ms step_avg:45.71ms
+step:1080/1840 train_time:49382ms step_avg:45.72ms
+step:1081/1840 train_time:49442ms step_avg:45.74ms
+step:1082/1840 train_time:49504ms step_avg:45.75ms
+step:1083/1840 train_time:49564ms step_avg:45.77ms
+step:1084/1840 train_time:49627ms step_avg:45.78ms
+step:1085/1840 train_time:49687ms step_avg:45.79ms
+step:1086/1840 train_time:49749ms step_avg:45.81ms
+step:1087/1840 train_time:49809ms step_avg:45.82ms
+step:1088/1840 train_time:49871ms step_avg:45.84ms
+step:1089/1840 train_time:49932ms step_avg:45.85ms
+step:1090/1840 train_time:49994ms step_avg:45.87ms
+step:1091/1840 train_time:50053ms step_avg:45.88ms
+step:1092/1840 train_time:50115ms step_avg:45.89ms
+step:1093/1840 train_time:50176ms step_avg:45.91ms
+step:1094/1840 train_time:50238ms step_avg:45.92ms
+step:1095/1840 train_time:50299ms step_avg:45.93ms
+step:1096/1840 train_time:50361ms step_avg:45.95ms
+step:1097/1840 train_time:50421ms step_avg:45.96ms
+step:1098/1840 train_time:50483ms step_avg:45.98ms
+step:1099/1840 train_time:50543ms step_avg:45.99ms
+step:1100/1840 train_time:50606ms step_avg:46.01ms
+step:1101/1840 train_time:50664ms step_avg:46.02ms
+step:1102/1840 train_time:50727ms step_avg:46.03ms
+step:1103/1840 train_time:50787ms step_avg:46.04ms
+step:1104/1840 train_time:50850ms step_avg:46.06ms
+step:1105/1840 train_time:50910ms step_avg:46.07ms
+step:1106/1840 train_time:50972ms step_avg:46.09ms
+step:1107/1840 train_time:51033ms step_avg:46.10ms
+step:1108/1840 train_time:51095ms step_avg:46.11ms
+step:1109/1840 train_time:51155ms step_avg:46.13ms
+step:1110/1840 train_time:51218ms step_avg:46.14ms
+step:1111/1840 train_time:51277ms step_avg:46.15ms
+step:1112/1840 train_time:51340ms step_avg:46.17ms
+step:1113/1840 train_time:51400ms step_avg:46.18ms
+step:1114/1840 train_time:51462ms step_avg:46.20ms
+step:1115/1840 train_time:51523ms step_avg:46.21ms
+step:1116/1840 train_time:51585ms step_avg:46.22ms
+step:1117/1840 train_time:51645ms step_avg:46.24ms
+step:1118/1840 train_time:51707ms step_avg:46.25ms
+step:1119/1840 train_time:51766ms step_avg:46.26ms
+step:1120/1840 train_time:51829ms step_avg:46.28ms
+step:1121/1840 train_time:51889ms step_avg:46.29ms
+step:1122/1840 train_time:51951ms step_avg:46.30ms
+step:1123/1840 train_time:52011ms step_avg:46.31ms
+step:1124/1840 train_time:52074ms step_avg:46.33ms
+step:1125/1840 train_time:52134ms step_avg:46.34ms
+step:1126/1840 train_time:52196ms step_avg:46.36ms
+step:1127/1840 train_time:52256ms step_avg:46.37ms
+step:1128/1840 train_time:52318ms step_avg:46.38ms
+step:1129/1840 train_time:52378ms step_avg:46.39ms
+step:1130/1840 train_time:52441ms step_avg:46.41ms
+step:1131/1840 train_time:52501ms step_avg:46.42ms
+step:1132/1840 train_time:52563ms step_avg:46.43ms
+step:1133/1840 train_time:52623ms step_avg:46.45ms
+step:1134/1840 train_time:52685ms step_avg:46.46ms
+step:1135/1840 train_time:52746ms step_avg:46.47ms
+step:1136/1840 train_time:52808ms step_avg:46.49ms
+step:1137/1840 train_time:52867ms step_avg:46.50ms
+step:1138/1840 train_time:52929ms step_avg:46.51ms
+step:1139/1840 train_time:52989ms step_avg:46.52ms
+step:1140/1840 train_time:53052ms step_avg:46.54ms
+step:1141/1840 train_time:53113ms step_avg:46.55ms
+step:1142/1840 train_time:53175ms step_avg:46.56ms
+step:1143/1840 train_time:53234ms step_avg:46.57ms
+step:1144/1840 train_time:53297ms step_avg:46.59ms
+step:1145/1840 train_time:53357ms step_avg:46.60ms
+step:1146/1840 train_time:53419ms step_avg:46.61ms
+step:1147/1840 train_time:53480ms step_avg:46.63ms
+step:1148/1840 train_time:53542ms step_avg:46.64ms
+step:1149/1840 train_time:53602ms step_avg:46.65ms
+step:1150/1840 train_time:53664ms step_avg:46.66ms
+step:1151/1840 train_time:53723ms step_avg:46.68ms
+step:1152/1840 train_time:53786ms step_avg:46.69ms
+step:1153/1840 train_time:53845ms step_avg:46.70ms
+step:1154/1840 train_time:53909ms step_avg:46.71ms
+step:1155/1840 train_time:53967ms step_avg:46.73ms
+step:1156/1840 train_time:54031ms step_avg:46.74ms
+step:1157/1840 train_time:54090ms step_avg:46.75ms
+step:1158/1840 train_time:54153ms step_avg:46.76ms
+step:1159/1840 train_time:54213ms step_avg:46.78ms
+step:1160/1840 train_time:54275ms step_avg:46.79ms
+step:1161/1840 train_time:54335ms step_avg:46.80ms
+step:1162/1840 train_time:54398ms step_avg:46.81ms
+step:1163/1840 train_time:54458ms step_avg:46.83ms
+step:1164/1840 train_time:54520ms step_avg:46.84ms
+step:1165/1840 train_time:54580ms step_avg:46.85ms
+step:1166/1840 train_time:54644ms step_avg:46.86ms
+step:1167/1840 train_time:54704ms step_avg:46.88ms
+step:1168/1840 train_time:54766ms step_avg:46.89ms
+step:1169/1840 train_time:54826ms step_avg:46.90ms
+step:1170/1840 train_time:54888ms step_avg:46.91ms
+step:1171/1840 train_time:54947ms step_avg:46.92ms
+step:1172/1840 train_time:55010ms step_avg:46.94ms
+step:1173/1840 train_time:55069ms step_avg:46.95ms
+step:1174/1840 train_time:55131ms step_avg:46.96ms
+step:1175/1840 train_time:55191ms step_avg:46.97ms
+step:1176/1840 train_time:55254ms step_avg:46.98ms
+step:1177/1840 train_time:55313ms step_avg:47.00ms
+step:1178/1840 train_time:55376ms step_avg:47.01ms
+step:1179/1840 train_time:55436ms step_avg:47.02ms
+step:1180/1840 train_time:55499ms step_avg:47.03ms
+step:1181/1840 train_time:55560ms step_avg:47.05ms
+step:1182/1840 train_time:55622ms step_avg:47.06ms
+step:1183/1840 train_time:55683ms step_avg:47.07ms
+step:1184/1840 train_time:55745ms step_avg:47.08ms
+step:1185/1840 train_time:55804ms step_avg:47.09ms
+step:1186/1840 train_time:55866ms step_avg:47.10ms
+step:1187/1840 train_time:55925ms step_avg:47.11ms
+step:1188/1840 train_time:55988ms step_avg:47.13ms
+step:1189/1840 train_time:56047ms step_avg:47.14ms
+step:1190/1840 train_time:56110ms step_avg:47.15ms
+step:1191/1840 train_time:56169ms step_avg:47.16ms
+step:1192/1840 train_time:56232ms step_avg:47.17ms
+step:1193/1840 train_time:56292ms step_avg:47.19ms
+step:1194/1840 train_time:56354ms step_avg:47.20ms
+step:1195/1840 train_time:56414ms step_avg:47.21ms
+step:1196/1840 train_time:56477ms step_avg:47.22ms
+step:1197/1840 train_time:56538ms step_avg:47.23ms
+step:1198/1840 train_time:56601ms step_avg:47.25ms
+step:1199/1840 train_time:56661ms step_avg:47.26ms
+step:1200/1840 train_time:56723ms step_avg:47.27ms
+step:1201/1840 train_time:56785ms step_avg:47.28ms
+step:1202/1840 train_time:56870ms step_avg:47.31ms
+step:1203/1840 train_time:56955ms step_avg:47.34ms
+step:1204/1840 train_time:57045ms step_avg:47.38ms
+step:1205/1840 train_time:57131ms step_avg:47.41ms
+step:1206/1840 train_time:57220ms step_avg:47.45ms
+step:1207/1840 train_time:57307ms step_avg:47.48ms
+step:1208/1840 train_time:57394ms step_avg:47.51ms
+step:1209/1840 train_time:57482ms step_avg:47.55ms
+step:1210/1840 train_time:57572ms step_avg:47.58ms
+step:1211/1840 train_time:57660ms step_avg:47.61ms
+step:1212/1840 train_time:57750ms step_avg:47.65ms
+step:1213/1840 train_time:57836ms step_avg:47.68ms
+step:1214/1840 train_time:57926ms step_avg:47.71ms
+step:1215/1840 train_time:58012ms step_avg:47.75ms
+step:1216/1840 train_time:58100ms step_avg:47.78ms
+step:1217/1840 train_time:58185ms step_avg:47.81ms
+step:1218/1840 train_time:58274ms step_avg:47.84ms
+step:1219/1840 train_time:58360ms step_avg:47.88ms
+step:1220/1840 train_time:58450ms step_avg:47.91ms
+step:1221/1840 train_time:58537ms step_avg:47.94ms
+step:1222/1840 train_time:58626ms step_avg:47.98ms
+step:1223/1840 train_time:58712ms step_avg:48.01ms
+step:1224/1840 train_time:58803ms step_avg:48.04ms
+step:1225/1840 train_time:58890ms step_avg:48.07ms
+step:1226/1840 train_time:58978ms step_avg:48.11ms
+step:1227/1840 train_time:59063ms step_avg:48.14ms
+step:1228/1840 train_time:59152ms step_avg:48.17ms
+step:1229/1840 train_time:59237ms step_avg:48.20ms
+step:1230/1840 train_time:59327ms step_avg:48.23ms
+step:1231/1840 train_time:59412ms step_avg:48.26ms
+step:1232/1840 train_time:59500ms step_avg:48.30ms
+step:1233/1840 train_time:59587ms step_avg:48.33ms
+step:1234/1840 train_time:59676ms step_avg:48.36ms
+step:1235/1840 train_time:59762ms step_avg:48.39ms
+step:1236/1840 train_time:59852ms step_avg:48.42ms
+step:1237/1840 train_time:59939ms step_avg:48.46ms
+step:1238/1840 train_time:60028ms step_avg:48.49ms
+step:1239/1840 train_time:60113ms step_avg:48.52ms
+step:1240/1840 train_time:60202ms step_avg:48.55ms
+step:1241/1840 train_time:60288ms step_avg:48.58ms
+step:1242/1840 train_time:60376ms step_avg:48.61ms
+step:1243/1840 train_time:60463ms step_avg:48.64ms
+step:1244/1840 train_time:60553ms step_avg:48.68ms
+step:1245/1840 train_time:60640ms step_avg:48.71ms
+step:1246/1840 train_time:60729ms step_avg:48.74ms
+step:1247/1840 train_time:60816ms step_avg:48.77ms
+step:1248/1840 train_time:60903ms step_avg:48.80ms
+step:1249/1840 train_time:60991ms step_avg:48.83ms
+step:1250/1840 train_time:61079ms step_avg:48.86ms
+step:1250/1840 val_loss:3.5353 train_time:61180ms step_avg:48.94ms
+step:1251/1840 train_time:61199ms step_avg:48.92ms
+step:1252/1840 train_time:61259ms step_avg:48.93ms
+step:1253/1840 train_time:61351ms step_avg:48.96ms
+step:1254/1840 train_time:61440ms step_avg:49.00ms
+step:1255/1840 train_time:61525ms step_avg:49.02ms
+step:1256/1840 train_time:61612ms step_avg:49.05ms
+step:1257/1840 train_time:61697ms step_avg:49.08ms
+step:1258/1840 train_time:61784ms step_avg:49.11ms
+step:1259/1840 train_time:61869ms step_avg:49.14ms
+step:1260/1840 train_time:61958ms step_avg:49.17ms
+step:1261/1840 train_time:62043ms step_avg:49.20ms
+step:1262/1840 train_time:62132ms step_avg:49.23ms
+step:1263/1840 train_time:62222ms step_avg:49.27ms
+step:1264/1840 train_time:62314ms step_avg:49.30ms
+step:1265/1840 train_time:62402ms step_avg:49.33ms
+step:1266/1840 train_time:62490ms step_avg:49.36ms
+step:1267/1840 train_time:62576ms step_avg:49.39ms
+step:1268/1840 train_time:62664ms step_avg:49.42ms
+step:1269/1840 train_time:62749ms step_avg:49.45ms
+step:1270/1840 train_time:62836ms step_avg:49.48ms
+step:1271/1840 train_time:62920ms step_avg:49.50ms
+step:1272/1840 train_time:63009ms step_avg:49.54ms
+step:1273/1840 train_time:63094ms step_avg:49.56ms
+step:1274/1840 train_time:63183ms step_avg:49.59ms
+step:1275/1840 train_time:63272ms step_avg:49.62ms
+step:1276/1840 train_time:63362ms step_avg:49.66ms
+step:1277/1840 train_time:63450ms step_avg:49.69ms
+step:1278/1840 train_time:63538ms step_avg:49.72ms
+step:1279/1840 train_time:63624ms step_avg:49.74ms
+step:1280/1840 train_time:63711ms step_avg:49.77ms
+step:1281/1840 train_time:63797ms step_avg:49.80ms
+step:1282/1840 train_time:63883ms step_avg:49.83ms
+step:1283/1840 train_time:63968ms step_avg:49.86ms
+step:1284/1840 train_time:64058ms step_avg:49.89ms
+step:1285/1840 train_time:64143ms step_avg:49.92ms
+step:1286/1840 train_time:64234ms step_avg:49.95ms
+step:1287/1840 train_time:64321ms step_avg:49.98ms
+step:1288/1840 train_time:64412ms step_avg:50.01ms
+step:1289/1840 train_time:64499ms step_avg:50.04ms
+step:1290/1840 train_time:64587ms step_avg:50.07ms
+step:1291/1840 train_time:64672ms step_avg:50.09ms
+step:1292/1840 train_time:64761ms step_avg:50.12ms
+step:1293/1840 train_time:64846ms step_avg:50.15ms
+step:1294/1840 train_time:64934ms step_avg:50.18ms
+step:1295/1840 train_time:65020ms step_avg:50.21ms
+step:1296/1840 train_time:65108ms step_avg:50.24ms
+step:1297/1840 train_time:65196ms step_avg:50.27ms
+step:1298/1840 train_time:65285ms step_avg:50.30ms
+step:1299/1840 train_time:65372ms step_avg:50.33ms
+step:1300/1840 train_time:65461ms step_avg:50.35ms
+step:1301/1840 train_time:65546ms step_avg:50.38ms
+step:1302/1840 train_time:65636ms step_avg:50.41ms
+step:1303/1840 train_time:65721ms step_avg:50.44ms
+step:1304/1840 train_time:65810ms step_avg:50.47ms
+step:1305/1840 train_time:65896ms step_avg:50.49ms
+step:1306/1840 train_time:65983ms step_avg:50.52ms
+step:1307/1840 train_time:66069ms step_avg:50.55ms
+step:1308/1840 train_time:66159ms step_avg:50.58ms
+step:1309/1840 train_time:66246ms step_avg:50.61ms
+step:1310/1840 train_time:66335ms step_avg:50.64ms
+step:1311/1840 train_time:66421ms step_avg:50.66ms
+step:1312/1840 train_time:66509ms step_avg:50.69ms
+step:1313/1840 train_time:66597ms step_avg:50.72ms
+step:1314/1840 train_time:66685ms step_avg:50.75ms
+step:1315/1840 train_time:66771ms step_avg:50.78ms
+step:1316/1840 train_time:66859ms step_avg:50.81ms
+step:1317/1840 train_time:66945ms step_avg:50.83ms
+step:1318/1840 train_time:67035ms step_avg:50.86ms
+step:1319/1840 train_time:67121ms step_avg:50.89ms
+step:1320/1840 train_time:67210ms step_avg:50.92ms
+step:1321/1840 train_time:67296ms step_avg:50.94ms
+step:1322/1840 train_time:67385ms step_avg:50.97ms
+step:1323/1840 train_time:67472ms step_avg:51.00ms
+step:1324/1840 train_time:67560ms step_avg:51.03ms
+step:1325/1840 train_time:67646ms step_avg:51.05ms
+step:1326/1840 train_time:67734ms step_avg:51.08ms
+step:1327/1840 train_time:67820ms step_avg:51.11ms
+step:1328/1840 train_time:67909ms step_avg:51.14ms
+step:1329/1840 train_time:67994ms step_avg:51.16ms
+step:1330/1840 train_time:68082ms step_avg:51.19ms
+step:1331/1840 train_time:68169ms step_avg:51.22ms
+step:1332/1840 train_time:68259ms step_avg:51.25ms
+step:1333/1840 train_time:68344ms step_avg:51.27ms
+step:1334/1840 train_time:68433ms step_avg:51.30ms
+step:1335/1840 train_time:68520ms step_avg:51.33ms
+step:1336/1840 train_time:68608ms step_avg:51.35ms
+step:1337/1840 train_time:68693ms step_avg:51.38ms
+step:1338/1840 train_time:68782ms step_avg:51.41ms
+step:1339/1840 train_time:68867ms step_avg:51.43ms
+step:1340/1840 train_time:68956ms step_avg:51.46ms
+step:1341/1840 train_time:69042ms step_avg:51.49ms
+step:1342/1840 train_time:69130ms step_avg:51.51ms
+step:1343/1840 train_time:69217ms step_avg:51.54ms
+step:1344/1840 train_time:69304ms step_avg:51.57ms
+step:1345/1840 train_time:69391ms step_avg:51.59ms
+step:1346/1840 train_time:69480ms step_avg:51.62ms
+step:1347/1840 train_time:69565ms step_avg:51.64ms
+step:1348/1840 train_time:69654ms step_avg:51.67ms
+step:1349/1840 train_time:69740ms step_avg:51.70ms
+step:1350/1840 train_time:69829ms step_avg:51.72ms
+step:1351/1840 train_time:69914ms step_avg:51.75ms
+step:1352/1840 train_time:70002ms step_avg:51.78ms
+step:1353/1840 train_time:70087ms step_avg:51.80ms
+step:1354/1840 train_time:70177ms step_avg:51.83ms
+step:1355/1840 train_time:70263ms step_avg:51.85ms
+step:1356/1840 train_time:70352ms step_avg:51.88ms
+step:1357/1840 train_time:70439ms step_avg:51.91ms
+step:1358/1840 train_time:70528ms step_avg:51.93ms
+step:1359/1840 train_time:70613ms step_avg:51.96ms
+step:1360/1840 train_time:70702ms step_avg:51.99ms
+step:1361/1840 train_time:70787ms step_avg:52.01ms
+step:1362/1840 train_time:70876ms step_avg:52.04ms
+step:1363/1840 train_time:70962ms step_avg:52.06ms
+step:1364/1840 train_time:71050ms step_avg:52.09ms
+step:1365/1840 train_time:71137ms step_avg:52.11ms
+step:1366/1840 train_time:71225ms step_avg:52.14ms
+step:1367/1840 train_time:71311ms step_avg:52.17ms
+step:1368/1840 train_time:71400ms step_avg:52.19ms
+step:1369/1840 train_time:71486ms step_avg:52.22ms
+step:1370/1840 train_time:71575ms step_avg:52.24ms
+step:1371/1840 train_time:71661ms step_avg:52.27ms
+step:1372/1840 train_time:71750ms step_avg:52.30ms
+step:1373/1840 train_time:71835ms step_avg:52.32ms
+step:1374/1840 train_time:71923ms step_avg:52.35ms
+step:1375/1840 train_time:72010ms step_avg:52.37ms
+step:1376/1840 train_time:72098ms step_avg:52.40ms
+step:1377/1840 train_time:72183ms step_avg:52.42ms
+step:1378/1840 train_time:72272ms step_avg:52.45ms
+step:1379/1840 train_time:72359ms step_avg:52.47ms
+step:1380/1840 train_time:72447ms step_avg:52.50ms
+step:1381/1840 train_time:72534ms step_avg:52.52ms
+step:1382/1840 train_time:72621ms step_avg:52.55ms
+step:1383/1840 train_time:72706ms step_avg:52.57ms
+step:1384/1840 train_time:72796ms step_avg:52.60ms
+step:1385/1840 train_time:72882ms step_avg:52.62ms
+step:1386/1840 train_time:72970ms step_avg:52.65ms
+step:1387/1840 train_time:73056ms step_avg:52.67ms
+step:1388/1840 train_time:73144ms step_avg:52.70ms
+step:1389/1840 train_time:73231ms step_avg:52.72ms
+step:1390/1840 train_time:73320ms step_avg:52.75ms
+step:1391/1840 train_time:73406ms step_avg:52.77ms
+step:1392/1840 train_time:73495ms step_avg:52.80ms
+step:1393/1840 train_time:73581ms step_avg:52.82ms
+step:1394/1840 train_time:73669ms step_avg:52.85ms
+step:1395/1840 train_time:73756ms step_avg:52.87ms
+step:1396/1840 train_time:73842ms step_avg:52.90ms
+step:1397/1840 train_time:73929ms step_avg:52.92ms
+step:1398/1840 train_time:74019ms step_avg:52.95ms
+step:1399/1840 train_time:74104ms step_avg:52.97ms
+step:1400/1840 train_time:74194ms step_avg:53.00ms
+step:1401/1840 train_time:74281ms step_avg:53.02ms
+step:1402/1840 train_time:74369ms step_avg:53.04ms
+step:1403/1840 train_time:74455ms step_avg:53.07ms
+step:1404/1840 train_time:74543ms step_avg:53.09ms
+step:1405/1840 train_time:74630ms step_avg:53.12ms
+step:1406/1840 train_time:74719ms step_avg:53.14ms
+step:1407/1840 train_time:74803ms step_avg:53.17ms
+step:1408/1840 train_time:74893ms step_avg:53.19ms
+step:1409/1840 train_time:74980ms step_avg:53.22ms
+step:1410/1840 train_time:75069ms step_avg:53.24ms
+step:1411/1840 train_time:75154ms step_avg:53.26ms
+step:1412/1840 train_time:75243ms step_avg:53.29ms
+step:1413/1840 train_time:75328ms step_avg:53.31ms
+step:1414/1840 train_time:75418ms step_avg:53.34ms
+step:1415/1840 train_time:75503ms step_avg:53.36ms
+step:1416/1840 train_time:75592ms step_avg:53.38ms
+step:1417/1840 train_time:75678ms step_avg:53.41ms
+step:1418/1840 train_time:75768ms step_avg:53.43ms
+step:1419/1840 train_time:75855ms step_avg:53.46ms
+step:1420/1840 train_time:75943ms step_avg:53.48ms
+step:1421/1840 train_time:76030ms step_avg:53.50ms
+step:1422/1840 train_time:76118ms step_avg:53.53ms
+step:1423/1840 train_time:76203ms step_avg:53.55ms
+step:1424/1840 train_time:76292ms step_avg:53.58ms
+step:1425/1840 train_time:76378ms step_avg:53.60ms
+step:1426/1840 train_time:76466ms step_avg:53.62ms
+step:1427/1840 train_time:76552ms step_avg:53.65ms
+step:1428/1840 train_time:76640ms step_avg:53.67ms
+step:1429/1840 train_time:76726ms step_avg:53.69ms
+step:1430/1840 train_time:76815ms step_avg:53.72ms
+step:1431/1840 train_time:76901ms step_avg:53.74ms
+step:1432/1840 train_time:76991ms step_avg:53.76ms
+step:1433/1840 train_time:77077ms step_avg:53.79ms
+step:1434/1840 train_time:77165ms step_avg:53.81ms
+step:1435/1840 train_time:77251ms step_avg:53.83ms
+step:1436/1840 train_time:77338ms step_avg:53.86ms
+step:1437/1840 train_time:77424ms step_avg:53.88ms
+step:1438/1840 train_time:77513ms step_avg:53.90ms
+step:1439/1840 train_time:77600ms step_avg:53.93ms
+step:1440/1840 train_time:77689ms step_avg:53.95ms
+step:1441/1840 train_time:77775ms step_avg:53.97ms
+step:1442/1840 train_time:77862ms step_avg:54.00ms
+step:1443/1840 train_time:77948ms step_avg:54.02ms
+step:1444/1840 train_time:78037ms step_avg:54.04ms
+step:1445/1840 train_time:78124ms step_avg:54.06ms
+step:1446/1840 train_time:78213ms step_avg:54.09ms
+step:1447/1840 train_time:78299ms step_avg:54.11ms
+step:1448/1840 train_time:78387ms step_avg:54.13ms
+step:1449/1840 train_time:78473ms step_avg:54.16ms
+step:1450/1840 train_time:78563ms step_avg:54.18ms
+step:1451/1840 train_time:78648ms step_avg:54.20ms
+step:1452/1840 train_time:78737ms step_avg:54.23ms
+step:1453/1840 train_time:78824ms step_avg:54.25ms
+step:1454/1840 train_time:78913ms step_avg:54.27ms
+step:1455/1840 train_time:79000ms step_avg:54.30ms
+step:1456/1840 train_time:79088ms step_avg:54.32ms
+step:1457/1840 train_time:79173ms step_avg:54.34ms
+step:1458/1840 train_time:79262ms step_avg:54.36ms
+step:1459/1840 train_time:79348ms step_avg:54.39ms
+step:1460/1840 train_time:79436ms step_avg:54.41ms
+step:1461/1840 train_time:79521ms step_avg:54.43ms
+step:1462/1840 train_time:79610ms step_avg:54.45ms
+step:1463/1840 train_time:79697ms step_avg:54.48ms
+step:1464/1840 train_time:79785ms step_avg:54.50ms
+step:1465/1840 train_time:79872ms step_avg:54.52ms
+step:1466/1840 train_time:79961ms step_avg:54.54ms
+step:1467/1840 train_time:80047ms step_avg:54.56ms
+step:1468/1840 train_time:80135ms step_avg:54.59ms
+step:1469/1840 train_time:80221ms step_avg:54.61ms
+step:1470/1840 train_time:80310ms step_avg:54.63ms
+step:1471/1840 train_time:80396ms step_avg:54.65ms
+step:1472/1840 train_time:80483ms step_avg:54.68ms
+step:1473/1840 train_time:80570ms step_avg:54.70ms
+step:1474/1840 train_time:80659ms step_avg:54.72ms
+step:1475/1840 train_time:80745ms step_avg:54.74ms
+step:1476/1840 train_time:80835ms step_avg:54.77ms
+step:1477/1840 train_time:80921ms step_avg:54.79ms
+step:1478/1840 train_time:81009ms step_avg:54.81ms
+step:1479/1840 train_time:81095ms step_avg:54.83ms
+step:1480/1840 train_time:81182ms step_avg:54.85ms
+step:1481/1840 train_time:81269ms step_avg:54.87ms
+step:1482/1840 train_time:81359ms step_avg:54.90ms
+step:1483/1840 train_time:81445ms step_avg:54.92ms
+step:1484/1840 train_time:81533ms step_avg:54.94ms
+step:1485/1840 train_time:81620ms step_avg:54.96ms
+step:1486/1840 train_time:81708ms step_avg:54.99ms
+step:1487/1840 train_time:81793ms step_avg:55.01ms
+step:1488/1840 train_time:81883ms step_avg:55.03ms
+step:1489/1840 train_time:81969ms step_avg:55.05ms
+step:1490/1840 train_time:82059ms step_avg:55.07ms
+step:1491/1840 train_time:82144ms step_avg:55.09ms
+step:1492/1840 train_time:82232ms step_avg:55.12ms
+step:1493/1840 train_time:82319ms step_avg:55.14ms
+step:1494/1840 train_time:82407ms step_avg:55.16ms
+step:1495/1840 train_time:82493ms step_avg:55.18ms
+step:1496/1840 train_time:82582ms step_avg:55.20ms
+step:1497/1840 train_time:82667ms step_avg:55.22ms
+step:1498/1840 train_time:82758ms step_avg:55.25ms
+step:1499/1840 train_time:82842ms step_avg:55.26ms
+step:1500/1840 train_time:82931ms step_avg:55.29ms
+step:1500/1840 val_loss:3.4000 train_time:83032ms step_avg:55.35ms
+step:1501/1840 train_time:83051ms step_avg:55.33ms
+step:1502/1840 train_time:83111ms step_avg:55.33ms
+step:1503/1840 train_time:83201ms step_avg:55.36ms
+step:1504/1840 train_time:83290ms step_avg:55.38ms
+step:1505/1840 train_time:83376ms step_avg:55.40ms
+step:1506/1840 train_time:83465ms step_avg:55.42ms
+step:1507/1840 train_time:83549ms step_avg:55.44ms
+step:1508/1840 train_time:83637ms step_avg:55.46ms
+step:1509/1840 train_time:83723ms step_avg:55.48ms
+step:1510/1840 train_time:83810ms step_avg:55.50ms
+step:1511/1840 train_time:83896ms step_avg:55.52ms
+step:1512/1840 train_time:83988ms step_avg:55.55ms
+step:1513/1840 train_time:84077ms step_avg:55.57ms
+step:1514/1840 train_time:84167ms step_avg:55.59ms
+step:1515/1840 train_time:84254ms step_avg:55.61ms
+step:1516/1840 train_time:84342ms step_avg:55.63ms
+step:1517/1840 train_time:84429ms step_avg:55.66ms
+step:1518/1840 train_time:84517ms step_avg:55.68ms
+step:1519/1840 train_time:84603ms step_avg:55.70ms
+step:1520/1840 train_time:84690ms step_avg:55.72ms
+step:1521/1840 train_time:84776ms step_avg:55.74ms
+step:1522/1840 train_time:84865ms step_avg:55.76ms
+step:1523/1840 train_time:84951ms step_avg:55.78ms
+step:1524/1840 train_time:85041ms step_avg:55.80ms
+step:1525/1840 train_time:85130ms step_avg:55.82ms
+step:1526/1840 train_time:85221ms step_avg:55.85ms
+step:1527/1840 train_time:85307ms step_avg:55.87ms
+step:1528/1840 train_time:85396ms step_avg:55.89ms
+step:1529/1840 train_time:85481ms step_avg:55.91ms
+step:1530/1840 train_time:85569ms step_avg:55.93ms
+step:1531/1840 train_time:85655ms step_avg:55.95ms
+step:1532/1840 train_time:85744ms step_avg:55.97ms
+step:1533/1840 train_time:85829ms step_avg:55.99ms
+step:1534/1840 train_time:85919ms step_avg:56.01ms
+step:1535/1840 train_time:86006ms step_avg:56.03ms
+step:1536/1840 train_time:86095ms step_avg:56.05ms
+step:1537/1840 train_time:86182ms step_avg:56.07ms
+step:1538/1840 train_time:86270ms step_avg:56.09ms
+step:1539/1840 train_time:86357ms step_avg:56.11ms
+step:1540/1840 train_time:86447ms step_avg:56.13ms
+step:1541/1840 train_time:86532ms step_avg:56.15ms
+step:1542/1840 train_time:86620ms step_avg:56.17ms
+step:1543/1840 train_time:86706ms step_avg:56.19ms
+step:1544/1840 train_time:86794ms step_avg:56.21ms
+step:1545/1840 train_time:86881ms step_avg:56.23ms
+step:1546/1840 train_time:86970ms step_avg:56.25ms
+step:1547/1840 train_time:87056ms step_avg:56.27ms
+step:1548/1840 train_time:87146ms step_avg:56.30ms
+step:1549/1840 train_time:87231ms step_avg:56.31ms
+step:1550/1840 train_time:87320ms step_avg:56.34ms
+step:1551/1840 train_time:87407ms step_avg:56.36ms
+step:1552/1840 train_time:87497ms step_avg:56.38ms
+step:1553/1840 train_time:87582ms step_avg:56.40ms
+step:1554/1840 train_time:87670ms step_avg:56.42ms
+step:1555/1840 train_time:87755ms step_avg:56.43ms
+step:1556/1840 train_time:87845ms step_avg:56.46ms
+step:1557/1840 train_time:87931ms step_avg:56.47ms
+step:1558/1840 train_time:88021ms step_avg:56.50ms
+step:1559/1840 train_time:88109ms step_avg:56.52ms
+step:1560/1840 train_time:88197ms step_avg:56.54ms
+step:1561/1840 train_time:88283ms step_avg:56.56ms
+step:1562/1840 train_time:88372ms step_avg:56.58ms
+step:1563/1840 train_time:88458ms step_avg:56.60ms
+step:1564/1840 train_time:88546ms step_avg:56.61ms
+step:1565/1840 train_time:88631ms step_avg:56.63ms
+step:1566/1840 train_time:88720ms step_avg:56.65ms
+step:1567/1840 train_time:88806ms step_avg:56.67ms
+step:1568/1840 train_time:88897ms step_avg:56.69ms
+step:1569/1840 train_time:88983ms step_avg:56.71ms
+step:1570/1840 train_time:89071ms step_avg:56.73ms
+step:1571/1840 train_time:89158ms step_avg:56.75ms
+step:1572/1840 train_time:89248ms step_avg:56.77ms
+step:1573/1840 train_time:89334ms step_avg:56.79ms
+step:1574/1840 train_time:89422ms step_avg:56.81ms
+step:1575/1840 train_time:89509ms step_avg:56.83ms
+step:1576/1840 train_time:89596ms step_avg:56.85ms
+step:1577/1840 train_time:89682ms step_avg:56.87ms
+step:1578/1840 train_time:89770ms step_avg:56.89ms
+step:1579/1840 train_time:89857ms step_avg:56.91ms
+step:1580/1840 train_time:89947ms step_avg:56.93ms
+step:1581/1840 train_time:90033ms step_avg:56.95ms
+step:1582/1840 train_time:90122ms step_avg:56.97ms
+step:1583/1840 train_time:90211ms step_avg:56.99ms
+step:1584/1840 train_time:90300ms step_avg:57.01ms
+step:1585/1840 train_time:90386ms step_avg:57.03ms
+step:1586/1840 train_time:90474ms step_avg:57.05ms
+step:1587/1840 train_time:90559ms step_avg:57.06ms
+step:1588/1840 train_time:90648ms step_avg:57.08ms
+step:1589/1840 train_time:90732ms step_avg:57.10ms
+step:1590/1840 train_time:90822ms step_avg:57.12ms
+step:1591/1840 train_time:90909ms step_avg:57.14ms
+step:1592/1840 train_time:90997ms step_avg:57.16ms
+step:1593/1840 train_time:91083ms step_avg:57.18ms
+step:1594/1840 train_time:91171ms step_avg:57.20ms
+step:1595/1840 train_time:91257ms step_avg:57.21ms
+step:1596/1840 train_time:91347ms step_avg:57.23ms
+step:1597/1840 train_time:91433ms step_avg:57.25ms
+step:1598/1840 train_time:91522ms step_avg:57.27ms
+step:1599/1840 train_time:91608ms step_avg:57.29ms
+step:1600/1840 train_time:91697ms step_avg:57.31ms
+step:1601/1840 train_time:91782ms step_avg:57.33ms
+step:1602/1840 train_time:91870ms step_avg:57.35ms
+step:1603/1840 train_time:91958ms step_avg:57.37ms
+step:1604/1840 train_time:92047ms step_avg:57.39ms
+step:1605/1840 train_time:92131ms step_avg:57.40ms
+step:1606/1840 train_time:92221ms step_avg:57.42ms
+step:1607/1840 train_time:92308ms step_avg:57.44ms
+step:1608/1840 train_time:92396ms step_avg:57.46ms
+step:1609/1840 train_time:92482ms step_avg:57.48ms
+step:1610/1840 train_time:92570ms step_avg:57.50ms
+step:1611/1840 train_time:92655ms step_avg:57.51ms
+step:1612/1840 train_time:92745ms step_avg:57.53ms
+step:1613/1840 train_time:92830ms step_avg:57.55ms
+step:1614/1840 train_time:92919ms step_avg:57.57ms
+step:1615/1840 train_time:93006ms step_avg:57.59ms
+step:1616/1840 train_time:93094ms step_avg:57.61ms
+step:1617/1840 train_time:93180ms step_avg:57.63ms
+step:1618/1840 train_time:93269ms step_avg:57.64ms
+step:1619/1840 train_time:93355ms step_avg:57.66ms
+step:1620/1840 train_time:93445ms step_avg:57.68ms
+step:1621/1840 train_time:93530ms step_avg:57.70ms
+step:1622/1840 train_time:93619ms step_avg:57.72ms
+step:1623/1840 train_time:93705ms step_avg:57.74ms
+step:1624/1840 train_time:93793ms step_avg:57.75ms
+step:1625/1840 train_time:93880ms step_avg:57.77ms
+step:1626/1840 train_time:93968ms step_avg:57.79ms
+step:1627/1840 train_time:94054ms step_avg:57.81ms
+step:1628/1840 train_time:94143ms step_avg:57.83ms
+step:1629/1840 train_time:94229ms step_avg:57.84ms
+step:1630/1840 train_time:94320ms step_avg:57.87ms
+step:1631/1840 train_time:94408ms step_avg:57.88ms
+step:1632/1840 train_time:94497ms step_avg:57.90ms
+step:1633/1840 train_time:94582ms step_avg:57.92ms
+step:1634/1840 train_time:94670ms step_avg:57.94ms
+step:1635/1840 train_time:94756ms step_avg:57.95ms
+step:1636/1840 train_time:94845ms step_avg:57.97ms
+step:1637/1840 train_time:94931ms step_avg:57.99ms
+step:1638/1840 train_time:95021ms step_avg:58.01ms
+step:1639/1840 train_time:95108ms step_avg:58.03ms
+step:1640/1840 train_time:95198ms step_avg:58.05ms
+step:1641/1840 train_time:95285ms step_avg:58.07ms
+step:1642/1840 train_time:95373ms step_avg:58.08ms
+step:1643/1840 train_time:95460ms step_avg:58.10ms
+step:1644/1840 train_time:95549ms step_avg:58.12ms
+step:1645/1840 train_time:95634ms step_avg:58.14ms
+step:1646/1840 train_time:95723ms step_avg:58.15ms
+step:1647/1840 train_time:95809ms step_avg:58.17ms
+step:1648/1840 train_time:95899ms step_avg:58.19ms
+step:1649/1840 train_time:95986ms step_avg:58.21ms
+step:1650/1840 train_time:96074ms step_avg:58.23ms
+step:1651/1840 train_time:96161ms step_avg:58.24ms
+step:1652/1840 train_time:96250ms step_avg:58.26ms
+step:1653/1840 train_time:96337ms step_avg:58.28ms
+step:1654/1840 train_time:96425ms step_avg:58.30ms
+step:1655/1840 train_time:96510ms step_avg:58.31ms
+step:1656/1840 train_time:96600ms step_avg:58.33ms
+step:1657/1840 train_time:96685ms step_avg:58.35ms
+step:1658/1840 train_time:96773ms step_avg:58.37ms
+step:1659/1840 train_time:96860ms step_avg:58.38ms
+step:1660/1840 train_time:96949ms step_avg:58.40ms
+step:1661/1840 train_time:97034ms step_avg:58.42ms
+step:1662/1840 train_time:97124ms step_avg:58.44ms
+step:1663/1840 train_time:97210ms step_avg:58.45ms
+step:1664/1840 train_time:97300ms step_avg:58.47ms
+step:1665/1840 train_time:97387ms step_avg:58.49ms
+step:1666/1840 train_time:97475ms step_avg:58.51ms
+step:1667/1840 train_time:97560ms step_avg:58.52ms
+step:1668/1840 train_time:97649ms step_avg:58.54ms
+step:1669/1840 train_time:97735ms step_avg:58.56ms
+step:1670/1840 train_time:97824ms step_avg:58.58ms
+step:1671/1840 train_time:97910ms step_avg:58.59ms
+step:1672/1840 train_time:97999ms step_avg:58.61ms
+step:1673/1840 train_time:98087ms step_avg:58.63ms
+step:1674/1840 train_time:98175ms step_avg:58.65ms
+step:1675/1840 train_time:98260ms step_avg:58.66ms
+step:1676/1840 train_time:98349ms step_avg:58.68ms
+step:1677/1840 train_time:98435ms step_avg:58.70ms
+step:1678/1840 train_time:98525ms step_avg:58.72ms
+step:1679/1840 train_time:98610ms step_avg:58.73ms
+step:1680/1840 train_time:98700ms step_avg:58.75ms
+step:1681/1840 train_time:98786ms step_avg:58.77ms
+step:1682/1840 train_time:98874ms step_avg:58.78ms
+step:1683/1840 train_time:98960ms step_avg:58.80ms
+step:1684/1840 train_time:99049ms step_avg:58.82ms
+step:1685/1840 train_time:99135ms step_avg:58.83ms
+step:1686/1840 train_time:99225ms step_avg:58.85ms
+step:1687/1840 train_time:99311ms step_avg:58.87ms
+step:1688/1840 train_time:99400ms step_avg:58.89ms
+step:1689/1840 train_time:99487ms step_avg:58.90ms
+step:1690/1840 train_time:99575ms step_avg:58.92ms
+step:1691/1840 train_time:99662ms step_avg:58.94ms
+step:1692/1840 train_time:99750ms step_avg:58.95ms
+step:1693/1840 train_time:99836ms step_avg:58.97ms
+step:1694/1840 train_time:99925ms step_avg:58.99ms
+step:1695/1840 train_time:100010ms step_avg:59.00ms
+step:1696/1840 train_time:100100ms step_avg:59.02ms
+step:1697/1840 train_time:100188ms step_avg:59.04ms
+step:1698/1840 train_time:100278ms step_avg:59.06ms
+step:1699/1840 train_time:100365ms step_avg:59.07ms
+step:1700/1840 train_time:100452ms step_avg:59.09ms
+step:1701/1840 train_time:100538ms step_avg:59.11ms
+step:1702/1840 train_time:100627ms step_avg:59.12ms
+step:1703/1840 train_time:100713ms step_avg:59.14ms
+step:1704/1840 train_time:100801ms step_avg:59.16ms
+step:1705/1840 train_time:100888ms step_avg:59.17ms
+step:1706/1840 train_time:100976ms step_avg:59.19ms
+step:1707/1840 train_time:101061ms step_avg:59.20ms
+step:1708/1840 train_time:101150ms step_avg:59.22ms
+step:1709/1840 train_time:101235ms step_avg:59.24ms
+step:1710/1840 train_time:101326ms step_avg:59.25ms
+step:1711/1840 train_time:101411ms step_avg:59.27ms
+step:1712/1840 train_time:101500ms step_avg:59.29ms
+step:1713/1840 train_time:101586ms step_avg:59.30ms
+step:1714/1840 train_time:101673ms step_avg:59.32ms
+step:1715/1840 train_time:101760ms step_avg:59.34ms
+step:1716/1840 train_time:101849ms step_avg:59.35ms
+step:1717/1840 train_time:101935ms step_avg:59.37ms
+step:1718/1840 train_time:102024ms step_avg:59.39ms
+step:1719/1840 train_time:102110ms step_avg:59.40ms
+step:1720/1840 train_time:102200ms step_avg:59.42ms
+step:1721/1840 train_time:102287ms step_avg:59.43ms
+step:1722/1840 train_time:102376ms step_avg:59.45ms
+step:1723/1840 train_time:102462ms step_avg:59.47ms
+step:1724/1840 train_time:102550ms step_avg:59.48ms
+step:1725/1840 train_time:102636ms step_avg:59.50ms
+step:1726/1840 train_time:102726ms step_avg:59.52ms
+step:1727/1840 train_time:102811ms step_avg:59.53ms
+step:1728/1840 train_time:102900ms step_avg:59.55ms
+step:1729/1840 train_time:102986ms step_avg:59.56ms
+step:1730/1840 train_time:103074ms step_avg:59.58ms
+step:1731/1840 train_time:103161ms step_avg:59.60ms
+step:1732/1840 train_time:103249ms step_avg:59.61ms
+step:1733/1840 train_time:103335ms step_avg:59.63ms
+step:1734/1840 train_time:103424ms step_avg:59.64ms
+step:1735/1840 train_time:103510ms step_avg:59.66ms
+step:1736/1840 train_time:103599ms step_avg:59.68ms
+step:1737/1840 train_time:103685ms step_avg:59.69ms
+step:1738/1840 train_time:103773ms step_avg:59.71ms
+step:1739/1840 train_time:103860ms step_avg:59.72ms
+step:1740/1840 train_time:103948ms step_avg:59.74ms
+step:1741/1840 train_time:104036ms step_avg:59.76ms
+step:1742/1840 train_time:104125ms step_avg:59.77ms
+step:1743/1840 train_time:104211ms step_avg:59.79ms
+step:1744/1840 train_time:104301ms step_avg:59.81ms
+step:1745/1840 train_time:104388ms step_avg:59.82ms
+step:1746/1840 train_time:104476ms step_avg:59.84ms
+step:1747/1840 train_time:104561ms step_avg:59.85ms
+step:1748/1840 train_time:104649ms step_avg:59.87ms
+step:1749/1840 train_time:104736ms step_avg:59.88ms
+step:1750/1840 train_time:104825ms step_avg:59.90ms
+step:1750/1840 val_loss:3.3020 train_time:104926ms step_avg:59.96ms
+step:1751/1840 train_time:104945ms step_avg:59.93ms
+step:1752/1840 train_time:105002ms step_avg:59.93ms
+step:1753/1840 train_time:105092ms step_avg:59.95ms
+step:1754/1840 train_time:105184ms step_avg:59.97ms
+step:1755/1840 train_time:105270ms step_avg:59.98ms
+step:1756/1840 train_time:105357ms step_avg:60.00ms
+step:1757/1840 train_time:105441ms step_avg:60.01ms
+step:1758/1840 train_time:105529ms step_avg:60.03ms
+step:1759/1840 train_time:105614ms step_avg:60.04ms
+step:1760/1840 train_time:105702ms step_avg:60.06ms
+step:1761/1840 train_time:105788ms step_avg:60.07ms
+step:1762/1840 train_time:105877ms step_avg:60.09ms
+step:1763/1840 train_time:105968ms step_avg:60.11ms
+step:1764/1840 train_time:106059ms step_avg:60.12ms
+step:1765/1840 train_time:106148ms step_avg:60.14ms
+step:1766/1840 train_time:106237ms step_avg:60.16ms
+step:1767/1840 train_time:106322ms step_avg:60.17ms
+step:1768/1840 train_time:106410ms step_avg:60.19ms
+step:1769/1840 train_time:106495ms step_avg:60.20ms
+step:1770/1840 train_time:106584ms step_avg:60.22ms
+step:1771/1840 train_time:106669ms step_avg:60.23ms
+step:1772/1840 train_time:106755ms step_avg:60.25ms
+step:1773/1840 train_time:106842ms step_avg:60.26ms
+step:1774/1840 train_time:106934ms step_avg:60.28ms
+step:1775/1840 train_time:107022ms step_avg:60.29ms
+step:1776/1840 train_time:107112ms step_avg:60.31ms
+step:1777/1840 train_time:107199ms step_avg:60.33ms
+step:1778/1840 train_time:107287ms step_avg:60.34ms
+step:1779/1840 train_time:107372ms step_avg:60.36ms
+step:1780/1840 train_time:107461ms step_avg:60.37ms
+step:1781/1840 train_time:107547ms step_avg:60.39ms
+step:1782/1840 train_time:107635ms step_avg:60.40ms
+step:1783/1840 train_time:107720ms step_avg:60.42ms
+step:1784/1840 train_time:107810ms step_avg:60.43ms
+step:1785/1840 train_time:107896ms step_avg:60.45ms
+step:1786/1840 train_time:107987ms step_avg:60.46ms
+step:1787/1840 train_time:108073ms step_avg:60.48ms
+step:1788/1840 train_time:108163ms step_avg:60.49ms
+step:1789/1840 train_time:108249ms step_avg:60.51ms
+step:1790/1840 train_time:108337ms step_avg:60.52ms
+step:1791/1840 train_time:108422ms step_avg:60.54ms
+step:1792/1840 train_time:108510ms step_avg:60.55ms
+step:1793/1840 train_time:108595ms step_avg:60.57ms
+step:1794/1840 train_time:108683ms step_avg:60.58ms
+step:1795/1840 train_time:108770ms step_avg:60.60ms
+step:1796/1840 train_time:108858ms step_avg:60.61ms
+step:1797/1840 train_time:108946ms step_avg:60.63ms
+step:1798/1840 train_time:109034ms step_avg:60.64ms
+step:1799/1840 train_time:109122ms step_avg:60.66ms
+step:1800/1840 train_time:109212ms step_avg:60.67ms
+step:1801/1840 train_time:109299ms step_avg:60.69ms
+step:1802/1840 train_time:109386ms step_avg:60.70ms
+step:1803/1840 train_time:109472ms step_avg:60.72ms
+step:1804/1840 train_time:109561ms step_avg:60.73ms
+step:1805/1840 train_time:109646ms step_avg:60.75ms
+step:1806/1840 train_time:109735ms step_avg:60.76ms
+step:1807/1840 train_time:109822ms step_avg:60.78ms
+step:1808/1840 train_time:109913ms step_avg:60.79ms
+step:1809/1840 train_time:109999ms step_avg:60.81ms
+step:1810/1840 train_time:110089ms step_avg:60.82ms
+step:1811/1840 train_time:110176ms step_avg:60.84ms
+step:1812/1840 train_time:110266ms step_avg:60.85ms
+step:1813/1840 train_time:110353ms step_avg:60.87ms
+step:1814/1840 train_time:110442ms step_avg:60.88ms
+step:1815/1840 train_time:110527ms step_avg:60.90ms
+step:1816/1840 train_time:110615ms step_avg:60.91ms
+step:1817/1840 train_time:110702ms step_avg:60.93ms
+step:1818/1840 train_time:110791ms step_avg:60.94ms
+step:1819/1840 train_time:110876ms step_avg:60.95ms
+step:1820/1840 train_time:110967ms step_avg:60.97ms
+step:1821/1840 train_time:111054ms step_avg:60.99ms
+step:1822/1840 train_time:111144ms step_avg:61.00ms
+step:1823/1840 train_time:111230ms step_avg:61.02ms
+step:1824/1840 train_time:111319ms step_avg:61.03ms
+step:1825/1840 train_time:111405ms step_avg:61.04ms
+step:1826/1840 train_time:111493ms step_avg:61.06ms
+step:1827/1840 train_time:111579ms step_avg:61.07ms
+step:1828/1840 train_time:111668ms step_avg:61.09ms
+step:1829/1840 train_time:111754ms step_avg:61.10ms
+step:1830/1840 train_time:111843ms step_avg:61.12ms
+step:1831/1840 train_time:111930ms step_avg:61.13ms
+step:1832/1840 train_time:112018ms step_avg:61.15ms
+step:1833/1840 train_time:112105ms step_avg:61.16ms
+step:1834/1840 train_time:112194ms step_avg:61.17ms
+step:1835/1840 train_time:112280ms step_avg:61.19ms
+step:1836/1840 train_time:112369ms step_avg:61.20ms
+step:1837/1840 train_time:112455ms step_avg:61.22ms
+step:1838/1840 train_time:112544ms step_avg:61.23ms
+step:1839/1840 train_time:112631ms step_avg:61.25ms
+step:1840/1840 train_time:112721ms step_avg:61.26ms
+step:1840/1840 val_loss:3.2774 train_time:112822ms step_avg:61.32ms
+peak memory allocated: 28507 MiB reserved: 44038 MiB

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/4d72e694-0fa8-411e-a6a6-6d5f2e00ec8b.txt
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/4d72e694-0fa8-411e-a6a6-6d5f2e00ec8b.txt
@@ -1,0 +1,3786 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+    """
+    Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+    Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+    bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+    float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+    """
+    assert p.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    wd_factor = wd_tensor.to(torch.float32)
+    lr_factor = lr_tensor.to(torch.float32)
+    p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    p_precise = p_precise_raw.view(torch.float32)
+    mask = (grad * p_precise) >= 0
+    p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+    p.copy_((p_precise_raw >> 16).to(torch.uint16))
+    mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        2. reduce scatter attn/mlp round 2 (16 mlp params)
+        3. wait on step 1, then compute update of 1 and schedule all gather
+        4. wait on step 2, then compute update of 2 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        5. wait for each all gather to complete and update params
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["mantissa"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn', 'mlp']
+        group_sizes = [16, 16]  # 10 attn + 6 mlp, then 16 mlp
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    def step(self):
+        self.step_p1()
+        self.step_p2()
+        self.step_p3()
+        
+    @torch.no_grad()
+    def step_p1(self):
+        """
+        Part 1: Launch distributed reduce_scatter operations for parameter groups.
+        """
+        rank = dist.get_rank()
+        self.group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            self.group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+    
+    @torch.no_grad()
+    def step_p2(self):
+        """
+        Part 2: Compute gradient updates and launch all_gather operations
+        Wait for all gather to complete for all parameter groups except final one
+        """
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = self.group_infos
+        
+        self.all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"].float()
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params], dtype=torch.float32)
+                
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            if "second_momentum_buffer" not in group:
+                group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1], dtype=torch.float32)
+                    if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if param_shape[-2] >= param_shape[-1] else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk, dtype=torch.bfloat16)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                if "mantissa" not in group:
+                    group["mantissa"] = torch.zeros_like(param_chunk, dtype=torch.uint16)
+                mantissa = group["mantissa"]
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx].view(torch.uint16),
+                        mantissa[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx]
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            self.all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete for all except final and copy results back into original parameter tensors.
+        for info in self.all_gather_infos[:-1]:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+    @torch.no_grad()
+    def step_p3(self):
+        """
+        Part 3: Wait for final all gather to complete and copy results back into original parameter tensors
+        """
+        info = self.all_gather_infos[-1]
+        info["gather_future"].wait()
+        stacked_params = info["stacked_params"]
+        orig_params = info["orig_params"]
+
+        unstacked_params = torch.unbind(stacked_params)
+        for i, p in enumerate(orig_params):
+            p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str], betas: list[list[float]], lr: float = 1e-3, eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for idx, label in enumerate(label_order):
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label], betas=betas[idx]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+        # tag the final param for optimizer pipelining, run all gather after muon copy
+        param_groups[-1]['params'][-1].is_final_param = True
+        
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        # 0-D CPU tensors to avoid recompilation in _update_step
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    def load_state_dict(self, state_dict):
+        """Override to preserve optimizer state dtypes (avoid BFloat16->Float32 cast that causes recompilation)."""
+        # Save original state dtypes before loading
+        original_dtypes = {}
+        for p, s in self.state.items():
+            original_dtypes[p] = {k: v.dtype for k, v in s.items() if isinstance(v, torch.Tensor)}
+        
+        # Call parent load_state_dict (which may cast dtypes to match param dtype)
+        super().load_state_dict(state_dict)
+        
+        # Restore original dtypes
+        for p, s in self.state.items():
+            if p in original_dtypes:
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor) and k in original_dtypes[p]:
+                        if v.dtype != original_dtypes[p][k]:
+                            s[k] = v.to(original_dtypes[p][k])
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-2]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step. step_size_t and eff_wd_t are 0-D CPU tensors to avoid recompilation."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)  # exp_avg = beta1 * exp_avg + (1 - beta1) * g_slice
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)  # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * g_slice^2
+        # compute step
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)  # update = (exp_avg / (sqrt(exp_avg_sq) + eps)) * step_size
+        # cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)  # update += eff_wd_t * p_slice * mask
+        p_slice.add_(other=update, alpha=-1.0)  # p_slice -= update
+
+    @torch.no_grad()
+    def step(self, muon_opt):
+        muon_opt.step_p1()
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        last_param = None
+        last_p_slice = None
+        for group in self.param_groups:      
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+                state["step"] += 1
+                t = state["step"]
+                
+                # Pre-compute changing values as 0-D CPU tensors to avoid recompilation.
+                # `.fill_(value)` is the same as "= value", but doesn't change the tensor object.
+                bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+                self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+                self._eff_wd_t.fill_(lr * lr * wd * getattr(param, "wd_mul", 1.0)) # `lr` included twice to serve as weight decay schedule.
+
+                DistAdam._update_step(p_slice, g_slice, state["exp_avg"], state["exp_avg_sq"],
+                                      beta1, beta2, eps, self._step_size_t, self._eff_wd_t)
+
+                if not is_small:
+                    if getattr(param, "is_final_param", False):
+                        last_param = param
+                        last_p_slice = p_slice
+                    else:
+                        all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+        self._reduce_scatter_futures.clear()
+
+        muon_opt.step_p2()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+        if last_param is not None:
+            last_all_gather_future = dist.all_gather_into_tensor(last_param, last_p_slice, async_op=True).get_future()
+        muon_opt.step_p3()
+        torch.futures.collect_all([last_all_gather_future]).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        adam_betas = {
+            'lm_head': [0.5, 0.95],
+            'smear_gate': [0.9, 0.99],
+            'attn_gate_bank': [0.9, 0.99],
+            've_gate_bank': [0.9, 0.99],
+            'skip_gate': [0.9, 0.99],
+            'x0_lambdas': [0.65, 0.95],
+            'scalars': [0.9, 0.99],
+            'embed': [0.5, 0.95],
+            'value_embed': [0.75, 0.95]
+        }
+        adam_labels = list(adam_betas.keys())
+        adam_beta_values = list(adam_betas.values())
+        muon_labels = ['attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, adam_beta_values, lr=0.008, eps=1e-10, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.muon_opt]
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * step_lr
+                
+        if self._is_active_step(self.adam_opt, step):
+            # adam will interleave calls to muon step
+            self.adam_opt.step(self.muon_opt)
+            self.model.zero_grad(set_to_none=True)
+            self.adam_opt.should_sync = False
+        else:
+            self.muon_opt.step()
+            self.muon_opt.zero_grad(set_to_none=True)
+            
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1800  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan  5 07:55:28 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            128W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            128W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   42C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   44C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     50579      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     50580      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     50581      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     50582      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     50583      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     50584      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     50585      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     50586      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 599, 600, 601, 1199, 1200, 1201, 1799, 1800, 1801] for warmup
+Resetting Model
+step:0/1840 val_loss:10.8275 train_time:0ms step_avg:0.03ms
+step:1/1840 train_time:75ms step_avg:75.38ms
+step:2/1840 train_time:97ms step_avg:48.55ms
+step:3/1840 train_time:116ms step_avg:38.63ms
+step:4/1840 train_time:147ms step_avg:36.67ms
+step:5/1840 train_time:179ms step_avg:35.71ms
+step:6/1840 train_time:270ms step_avg:44.97ms
+step:7/1840 train_time:287ms step_avg:41.06ms
+step:8/1840 train_time:437ms step_avg:54.65ms
+step:9/1840 train_time:469ms step_avg:52.13ms
+step:10/1840 train_time:503ms step_avg:50.32ms
+step:11/1840 train_time:535ms step_avg:48.65ms
+step:12/1840 train_time:569ms step_avg:47.45ms
+step:13/1840 train_time:602ms step_avg:46.28ms
+step:14/1840 train_time:636ms step_avg:45.41ms
+step:15/1840 train_time:668ms step_avg:44.54ms
+step:16/1840 train_time:702ms step_avg:43.89ms
+step:17/1840 train_time:734ms step_avg:43.20ms
+step:18/1840 train_time:769ms step_avg:42.70ms
+step:19/1840 train_time:800ms step_avg:42.13ms
+step:20/1840 train_time:835ms step_avg:41.74ms
+step:21/1840 train_time:867ms step_avg:41.27ms
+step:22/1840 train_time:901ms step_avg:40.95ms
+step:23/1840 train_time:933ms step_avg:40.56ms
+step:24/1840 train_time:967ms step_avg:40.30ms
+step:25/1840 train_time:999ms step_avg:39.96ms
+step:26/1840 train_time:1033ms step_avg:39.74ms
+step:27/1840 train_time:1065ms step_avg:39.46ms
+step:28/1840 train_time:1099ms step_avg:39.27ms
+step:29/1840 train_time:1132ms step_avg:39.02ms
+step:30/1840 train_time:1166ms step_avg:38.85ms
+step:31/1840 train_time:1198ms step_avg:38.63ms
+step:32/1840 train_time:1232ms step_avg:38.50ms
+step:33/1840 train_time:1264ms step_avg:38.30ms
+step:34/1840 train_time:1299ms step_avg:38.20ms
+step:35/1840 train_time:1332ms step_avg:38.05ms
+step:36/1840 train_time:1367ms step_avg:37.97ms
+step:37/1840 train_time:1400ms step_avg:37.82ms
+step:38/1840 train_time:1434ms step_avg:37.74ms
+step:39/1840 train_time:1467ms step_avg:37.61ms
+step:40/1840 train_time:1501ms step_avg:37.53ms
+step:41/1840 train_time:1534ms step_avg:37.41ms
+step:42/1840 train_time:1568ms step_avg:37.34ms
+step:43/1840 train_time:1600ms step_avg:37.22ms
+step:44/1840 train_time:1635ms step_avg:37.16ms
+step:45/1840 train_time:1667ms step_avg:37.05ms
+step:46/1840 train_time:1702ms step_avg:36.99ms
+step:47/1840 train_time:1734ms step_avg:36.89ms
+step:48/1840 train_time:1768ms step_avg:36.84ms
+step:49/1840 train_time:1800ms step_avg:36.74ms
+step:50/1840 train_time:1835ms step_avg:36.70ms
+step:51/1840 train_time:1867ms step_avg:36.61ms
+step:52/1840 train_time:1901ms step_avg:36.56ms
+step:53/1840 train_time:1933ms step_avg:36.48ms
+step:54/1840 train_time:1967ms step_avg:36.43ms
+step:55/1840 train_time:2000ms step_avg:36.36ms
+step:56/1840 train_time:2034ms step_avg:36.33ms
+step:57/1840 train_time:2066ms step_avg:36.25ms
+step:58/1840 train_time:2100ms step_avg:36.21ms
+step:59/1840 train_time:2132ms step_avg:36.14ms
+step:60/1840 train_time:2166ms step_avg:36.11ms
+step:61/1840 train_time:2199ms step_avg:36.04ms
+step:62/1840 train_time:2233ms step_avg:36.01ms
+step:63/1840 train_time:2265ms step_avg:35.96ms
+step:64/1840 train_time:2300ms step_avg:35.93ms
+step:65/1840 train_time:2332ms step_avg:35.88ms
+step:66/1840 train_time:2367ms step_avg:35.86ms
+step:67/1840 train_time:2399ms step_avg:35.80ms
+step:68/1840 train_time:2433ms step_avg:35.79ms
+step:69/1840 train_time:2466ms step_avg:35.74ms
+step:70/1840 train_time:2501ms step_avg:35.72ms
+step:71/1840 train_time:2533ms step_avg:35.68ms
+step:72/1840 train_time:2568ms step_avg:35.67ms
+step:73/1840 train_time:2600ms step_avg:35.62ms
+step:74/1840 train_time:2634ms step_avg:35.60ms
+step:75/1840 train_time:2667ms step_avg:35.56ms
+step:76/1840 train_time:2701ms step_avg:35.55ms
+step:77/1840 train_time:2734ms step_avg:35.50ms
+step:78/1840 train_time:2768ms step_avg:35.49ms
+step:79/1840 train_time:2800ms step_avg:35.45ms
+step:80/1840 train_time:2835ms step_avg:35.43ms
+step:81/1840 train_time:2867ms step_avg:35.39ms
+step:82/1840 train_time:2901ms step_avg:35.38ms
+step:83/1840 train_time:2933ms step_avg:35.34ms
+step:84/1840 train_time:2967ms step_avg:35.33ms
+step:85/1840 train_time:2999ms step_avg:35.29ms
+step:86/1840 train_time:3034ms step_avg:35.28ms
+step:87/1840 train_time:3066ms step_avg:35.24ms
+step:88/1840 train_time:3100ms step_avg:35.23ms
+step:89/1840 train_time:3132ms step_avg:35.19ms
+step:90/1840 train_time:3167ms step_avg:35.19ms
+step:91/1840 train_time:3199ms step_avg:35.15ms
+step:92/1840 train_time:3233ms step_avg:35.14ms
+step:93/1840 train_time:3265ms step_avg:35.11ms
+step:94/1840 train_time:3299ms step_avg:35.10ms
+step:95/1840 train_time:3332ms step_avg:35.07ms
+step:96/1840 train_time:3366ms step_avg:35.07ms
+step:97/1840 train_time:3398ms step_avg:35.03ms
+step:98/1840 train_time:3433ms step_avg:35.03ms
+step:99/1840 train_time:3465ms step_avg:35.00ms
+step:100/1840 train_time:3500ms step_avg:35.00ms
+step:101/1840 train_time:3532ms step_avg:34.97ms
+step:102/1840 train_time:3566ms step_avg:34.96ms
+step:103/1840 train_time:3599ms step_avg:34.94ms
+step:104/1840 train_time:3633ms step_avg:34.93ms
+step:105/1840 train_time:3666ms step_avg:34.91ms
+step:106/1840 train_time:3700ms step_avg:34.91ms
+step:107/1840 train_time:3732ms step_avg:34.88ms
+step:108/1840 train_time:3767ms step_avg:34.88ms
+step:109/1840 train_time:3799ms step_avg:34.86ms
+step:110/1840 train_time:3834ms step_avg:34.85ms
+step:111/1840 train_time:3866ms step_avg:34.83ms
+step:112/1840 train_time:3900ms step_avg:34.82ms
+step:113/1840 train_time:3932ms step_avg:34.80ms
+step:114/1840 train_time:3967ms step_avg:34.80ms
+step:115/1840 train_time:3999ms step_avg:34.77ms
+step:116/1840 train_time:4033ms step_avg:34.77ms
+step:117/1840 train_time:4065ms step_avg:34.75ms
+step:118/1840 train_time:4100ms step_avg:34.74ms
+step:119/1840 train_time:4132ms step_avg:34.72ms
+step:120/1840 train_time:4166ms step_avg:34.71ms
+step:121/1840 train_time:4198ms step_avg:34.69ms
+step:122/1840 train_time:4232ms step_avg:34.69ms
+step:123/1840 train_time:4265ms step_avg:34.67ms
+step:124/1840 train_time:4299ms step_avg:34.67ms
+step:125/1840 train_time:4331ms step_avg:34.65ms
+step:126/1840 train_time:4365ms step_avg:34.64ms
+step:127/1840 train_time:4397ms step_avg:34.62ms
+step:128/1840 train_time:4432ms step_avg:34.62ms
+step:129/1840 train_time:4464ms step_avg:34.60ms
+step:130/1840 train_time:4498ms step_avg:34.60ms
+step:131/1840 train_time:4530ms step_avg:34.58ms
+step:132/1840 train_time:4564ms step_avg:34.58ms
+step:133/1840 train_time:4597ms step_avg:34.56ms
+step:134/1840 train_time:4631ms step_avg:34.56ms
+step:135/1840 train_time:4664ms step_avg:34.55ms
+step:136/1840 train_time:4698ms step_avg:34.54ms
+step:137/1840 train_time:4730ms step_avg:34.53ms
+step:138/1840 train_time:4764ms step_avg:34.52ms
+step:139/1840 train_time:4796ms step_avg:34.51ms
+step:140/1840 train_time:4831ms step_avg:34.51ms
+step:141/1840 train_time:4863ms step_avg:34.49ms
+step:142/1840 train_time:4898ms step_avg:34.49ms
+step:143/1840 train_time:4930ms step_avg:34.47ms
+step:144/1840 train_time:4964ms step_avg:34.47ms
+step:145/1840 train_time:4996ms step_avg:34.45ms
+step:146/1840 train_time:5030ms step_avg:34.45ms
+step:147/1840 train_time:5062ms step_avg:34.44ms
+step:148/1840 train_time:5097ms step_avg:34.44ms
+step:149/1840 train_time:5129ms step_avg:34.42ms
+step:150/1840 train_time:5163ms step_avg:34.42ms
+step:151/1840 train_time:5195ms step_avg:34.40ms
+step:152/1840 train_time:5229ms step_avg:34.40ms
+step:153/1840 train_time:5261ms step_avg:34.39ms
+step:154/1840 train_time:5295ms step_avg:34.39ms
+step:155/1840 train_time:5328ms step_avg:34.37ms
+step:156/1840 train_time:5362ms step_avg:34.37ms
+step:157/1840 train_time:5394ms step_avg:34.36ms
+step:158/1840 train_time:5428ms step_avg:34.36ms
+step:159/1840 train_time:5460ms step_avg:34.34ms
+step:160/1840 train_time:5495ms step_avg:34.34ms
+step:161/1840 train_time:5527ms step_avg:34.33ms
+step:162/1840 train_time:5561ms step_avg:34.33ms
+step:163/1840 train_time:5593ms step_avg:34.31ms
+step:164/1840 train_time:5627ms step_avg:34.31ms
+step:165/1840 train_time:5659ms step_avg:34.30ms
+step:166/1840 train_time:5694ms step_avg:34.30ms
+step:167/1840 train_time:5726ms step_avg:34.29ms
+step:168/1840 train_time:5760ms step_avg:34.29ms
+step:169/1840 train_time:5793ms step_avg:34.28ms
+step:170/1840 train_time:5827ms step_avg:34.28ms
+step:171/1840 train_time:5859ms step_avg:34.27ms
+step:172/1840 train_time:5894ms step_avg:34.27ms
+step:173/1840 train_time:5926ms step_avg:34.25ms
+step:174/1840 train_time:5960ms step_avg:34.25ms
+step:175/1840 train_time:5993ms step_avg:34.24ms
+step:176/1840 train_time:6027ms step_avg:34.24ms
+step:177/1840 train_time:6059ms step_avg:34.23ms
+step:178/1840 train_time:6093ms step_avg:34.23ms
+step:179/1840 train_time:6125ms step_avg:34.22ms
+step:180/1840 train_time:6159ms step_avg:34.22ms
+step:181/1840 train_time:6191ms step_avg:34.21ms
+step:182/1840 train_time:6226ms step_avg:34.21ms
+step:183/1840 train_time:6258ms step_avg:34.20ms
+step:184/1840 train_time:6293ms step_avg:34.20ms
+step:185/1840 train_time:6325ms step_avg:34.19ms
+step:186/1840 train_time:6359ms step_avg:34.19ms
+step:187/1840 train_time:6391ms step_avg:34.18ms
+step:188/1840 train_time:6426ms step_avg:34.18ms
+step:189/1840 train_time:6458ms step_avg:34.17ms
+step:190/1840 train_time:6492ms step_avg:34.17ms
+step:191/1840 train_time:6524ms step_avg:34.16ms
+step:192/1840 train_time:6558ms step_avg:34.16ms
+step:193/1840 train_time:6590ms step_avg:34.15ms
+step:194/1840 train_time:6625ms step_avg:34.15ms
+step:195/1840 train_time:6657ms step_avg:34.14ms
+step:196/1840 train_time:6691ms step_avg:34.14ms
+step:197/1840 train_time:6723ms step_avg:34.13ms
+step:198/1840 train_time:6758ms step_avg:34.13ms
+step:199/1840 train_time:6790ms step_avg:34.12ms
+step:200/1840 train_time:6824ms step_avg:34.12ms
+step:201/1840 train_time:6856ms step_avg:34.11ms
+step:202/1840 train_time:6891ms step_avg:34.11ms
+step:203/1840 train_time:6922ms step_avg:34.10ms
+step:204/1840 train_time:6957ms step_avg:34.10ms
+step:205/1840 train_time:6989ms step_avg:34.09ms
+step:206/1840 train_time:7023ms step_avg:34.09ms
+step:207/1840 train_time:7056ms step_avg:34.08ms
+step:208/1840 train_time:7089ms step_avg:34.08ms
+step:209/1840 train_time:7121ms step_avg:34.07ms
+step:210/1840 train_time:7156ms step_avg:34.07ms
+step:211/1840 train_time:7188ms step_avg:34.06ms
+step:212/1840 train_time:7222ms step_avg:34.07ms
+step:213/1840 train_time:7254ms step_avg:34.06ms
+step:214/1840 train_time:7288ms step_avg:34.06ms
+step:215/1840 train_time:7320ms step_avg:34.05ms
+step:216/1840 train_time:7355ms step_avg:34.05ms
+step:217/1840 train_time:7387ms step_avg:34.04ms
+step:218/1840 train_time:7421ms step_avg:34.04ms
+step:219/1840 train_time:7453ms step_avg:34.03ms
+step:220/1840 train_time:7488ms step_avg:34.03ms
+step:221/1840 train_time:7519ms step_avg:34.02ms
+step:222/1840 train_time:7554ms step_avg:34.03ms
+step:223/1840 train_time:7586ms step_avg:34.02ms
+step:224/1840 train_time:7621ms step_avg:34.02ms
+step:225/1840 train_time:7653ms step_avg:34.01ms
+step:226/1840 train_time:7687ms step_avg:34.01ms
+step:227/1840 train_time:7719ms step_avg:34.00ms
+step:228/1840 train_time:7753ms step_avg:34.01ms
+step:229/1840 train_time:7786ms step_avg:34.00ms
+step:230/1840 train_time:7820ms step_avg:34.00ms
+step:231/1840 train_time:7852ms step_avg:33.99ms
+step:232/1840 train_time:7886ms step_avg:33.99ms
+step:233/1840 train_time:7918ms step_avg:33.98ms
+step:234/1840 train_time:7953ms step_avg:33.99ms
+step:235/1840 train_time:7985ms step_avg:33.98ms
+step:236/1840 train_time:8019ms step_avg:33.98ms
+step:237/1840 train_time:8051ms step_avg:33.97ms
+step:238/1840 train_time:8085ms step_avg:33.97ms
+step:239/1840 train_time:8118ms step_avg:33.97ms
+step:240/1840 train_time:8152ms step_avg:33.97ms
+step:241/1840 train_time:8184ms step_avg:33.96ms
+step:242/1840 train_time:8218ms step_avg:33.96ms
+step:243/1840 train_time:8251ms step_avg:33.95ms
+step:244/1840 train_time:8285ms step_avg:33.95ms
+step:245/1840 train_time:8317ms step_avg:33.95ms
+step:246/1840 train_time:8352ms step_avg:33.95ms
+step:247/1840 train_time:8384ms step_avg:33.94ms
+step:248/1840 train_time:8418ms step_avg:33.94ms
+step:249/1840 train_time:8450ms step_avg:33.93ms
+step:250/1840 train_time:8484ms step_avg:33.93ms
+step:250/1840 val_loss:4.5966 train_time:8526ms step_avg:34.10ms
+step:251/1840 train_time:8545ms step_avg:34.04ms
+step:252/1840 train_time:8564ms step_avg:33.98ms
+step:253/1840 train_time:8586ms step_avg:33.94ms
+step:254/1840 train_time:8621ms step_avg:33.94ms
+step:255/1840 train_time:8653ms step_avg:33.93ms
+step:256/1840 train_time:8688ms step_avg:33.94ms
+step:257/1840 train_time:8721ms step_avg:33.93ms
+step:258/1840 train_time:8756ms step_avg:33.94ms
+step:259/1840 train_time:8789ms step_avg:33.93ms
+step:260/1840 train_time:8823ms step_avg:33.94ms
+step:261/1840 train_time:8856ms step_avg:33.93ms
+step:262/1840 train_time:8890ms step_avg:33.93ms
+step:263/1840 train_time:8922ms step_avg:33.93ms
+step:264/1840 train_time:8957ms step_avg:33.93ms
+step:265/1840 train_time:8989ms step_avg:33.92ms
+step:266/1840 train_time:9023ms step_avg:33.92ms
+step:267/1840 train_time:9055ms step_avg:33.91ms
+step:268/1840 train_time:9089ms step_avg:33.91ms
+step:269/1840 train_time:9121ms step_avg:33.91ms
+step:270/1840 train_time:9155ms step_avg:33.91ms
+step:271/1840 train_time:9187ms step_avg:33.90ms
+step:272/1840 train_time:9221ms step_avg:33.90ms
+step:273/1840 train_time:9253ms step_avg:33.89ms
+step:274/1840 train_time:9287ms step_avg:33.89ms
+step:275/1840 train_time:9318ms step_avg:33.89ms
+step:276/1840 train_time:9352ms step_avg:33.89ms
+step:277/1840 train_time:9384ms step_avg:33.88ms
+step:278/1840 train_time:9418ms step_avg:33.88ms
+step:279/1840 train_time:9451ms step_avg:33.88ms
+step:280/1840 train_time:9486ms step_avg:33.88ms
+step:281/1840 train_time:9518ms step_avg:33.87ms
+step:282/1840 train_time:9553ms step_avg:33.88ms
+step:283/1840 train_time:9586ms step_avg:33.87ms
+step:284/1840 train_time:9620ms step_avg:33.87ms
+step:285/1840 train_time:9653ms step_avg:33.87ms
+step:286/1840 train_time:9687ms step_avg:33.87ms
+step:287/1840 train_time:9719ms step_avg:33.86ms
+step:288/1840 train_time:9754ms step_avg:33.87ms
+step:289/1840 train_time:9786ms step_avg:33.86ms
+step:290/1840 train_time:9821ms step_avg:33.86ms
+step:291/1840 train_time:9853ms step_avg:33.86ms
+step:292/1840 train_time:9887ms step_avg:33.86ms
+step:293/1840 train_time:9919ms step_avg:33.85ms
+step:294/1840 train_time:9954ms step_avg:33.86ms
+step:295/1840 train_time:9986ms step_avg:33.85ms
+step:296/1840 train_time:10020ms step_avg:33.85ms
+step:297/1840 train_time:10053ms step_avg:33.85ms
+step:298/1840 train_time:10086ms step_avg:33.85ms
+step:299/1840 train_time:10118ms step_avg:33.84ms
+step:300/1840 train_time:10153ms step_avg:33.84ms
+step:301/1840 train_time:10184ms step_avg:33.84ms
+step:302/1840 train_time:10219ms step_avg:33.84ms
+step:303/1840 train_time:10251ms step_avg:33.83ms
+step:304/1840 train_time:10285ms step_avg:33.83ms
+step:305/1840 train_time:10317ms step_avg:33.83ms
+step:306/1840 train_time:10351ms step_avg:33.83ms
+step:307/1840 train_time:10383ms step_avg:33.82ms
+step:308/1840 train_time:10417ms step_avg:33.82ms
+step:309/1840 train_time:10450ms step_avg:33.82ms
+step:310/1840 train_time:10484ms step_avg:33.82ms
+step:311/1840 train_time:10516ms step_avg:33.81ms
+step:312/1840 train_time:10551ms step_avg:33.82ms
+step:313/1840 train_time:10583ms step_avg:33.81ms
+step:314/1840 train_time:10617ms step_avg:33.81ms
+step:315/1840 train_time:10649ms step_avg:33.81ms
+step:316/1840 train_time:10683ms step_avg:33.81ms
+step:317/1840 train_time:10716ms step_avg:33.80ms
+step:318/1840 train_time:10751ms step_avg:33.81ms
+step:319/1840 train_time:10783ms step_avg:33.80ms
+step:320/1840 train_time:10817ms step_avg:33.80ms
+step:321/1840 train_time:10850ms step_avg:33.80ms
+step:322/1840 train_time:10884ms step_avg:33.80ms
+step:323/1840 train_time:10916ms step_avg:33.79ms
+step:324/1840 train_time:10950ms step_avg:33.80ms
+step:325/1840 train_time:10982ms step_avg:33.79ms
+step:326/1840 train_time:11017ms step_avg:33.79ms
+step:327/1840 train_time:11049ms step_avg:33.79ms
+step:328/1840 train_time:11083ms step_avg:33.79ms
+step:329/1840 train_time:11115ms step_avg:33.79ms
+step:330/1840 train_time:11149ms step_avg:33.79ms
+step:331/1840 train_time:11181ms step_avg:33.78ms
+step:332/1840 train_time:11216ms step_avg:33.78ms
+step:333/1840 train_time:11248ms step_avg:33.78ms
+step:334/1840 train_time:11282ms step_avg:33.78ms
+step:335/1840 train_time:11314ms step_avg:33.77ms
+step:336/1840 train_time:11348ms step_avg:33.77ms
+step:337/1840 train_time:11381ms step_avg:33.77ms
+step:338/1840 train_time:11415ms step_avg:33.77ms
+step:339/1840 train_time:11447ms step_avg:33.77ms
+step:340/1840 train_time:11481ms step_avg:33.77ms
+step:341/1840 train_time:11514ms step_avg:33.76ms
+step:342/1840 train_time:11548ms step_avg:33.77ms
+step:343/1840 train_time:11580ms step_avg:33.76ms
+step:344/1840 train_time:11615ms step_avg:33.76ms
+step:345/1840 train_time:11647ms step_avg:33.76ms
+step:346/1840 train_time:11681ms step_avg:33.76ms
+step:347/1840 train_time:11713ms step_avg:33.76ms
+step:348/1840 train_time:11748ms step_avg:33.76ms
+step:349/1840 train_time:11780ms step_avg:33.75ms
+step:350/1840 train_time:11815ms step_avg:33.76ms
+step:351/1840 train_time:11847ms step_avg:33.75ms
+step:352/1840 train_time:11881ms step_avg:33.75ms
+step:353/1840 train_time:11913ms step_avg:33.75ms
+step:354/1840 train_time:11947ms step_avg:33.75ms
+step:355/1840 train_time:11979ms step_avg:33.74ms
+step:356/1840 train_time:12014ms step_avg:33.75ms
+step:357/1840 train_time:12046ms step_avg:33.74ms
+step:358/1840 train_time:12080ms step_avg:33.74ms
+step:359/1840 train_time:12113ms step_avg:33.74ms
+step:360/1840 train_time:12147ms step_avg:33.74ms
+step:361/1840 train_time:12179ms step_avg:33.74ms
+step:362/1840 train_time:12214ms step_avg:33.74ms
+step:363/1840 train_time:12245ms step_avg:33.73ms
+step:364/1840 train_time:12280ms step_avg:33.74ms
+step:365/1840 train_time:12312ms step_avg:33.73ms
+step:366/1840 train_time:12346ms step_avg:33.73ms
+step:367/1840 train_time:12378ms step_avg:33.73ms
+step:368/1840 train_time:12412ms step_avg:33.73ms
+step:369/1840 train_time:12444ms step_avg:33.72ms
+step:370/1840 train_time:12478ms step_avg:33.73ms
+step:371/1840 train_time:12511ms step_avg:33.72ms
+step:372/1840 train_time:12545ms step_avg:33.72ms
+step:373/1840 train_time:12577ms step_avg:33.72ms
+step:374/1840 train_time:12611ms step_avg:33.72ms
+step:375/1840 train_time:12643ms step_avg:33.71ms
+step:376/1840 train_time:12677ms step_avg:33.72ms
+step:377/1840 train_time:12709ms step_avg:33.71ms
+step:378/1840 train_time:12744ms step_avg:33.71ms
+step:379/1840 train_time:12776ms step_avg:33.71ms
+step:380/1840 train_time:12810ms step_avg:33.71ms
+step:381/1840 train_time:12842ms step_avg:33.71ms
+step:382/1840 train_time:12877ms step_avg:33.71ms
+step:383/1840 train_time:12909ms step_avg:33.71ms
+step:384/1840 train_time:12943ms step_avg:33.71ms
+step:385/1840 train_time:12975ms step_avg:33.70ms
+step:386/1840 train_time:13010ms step_avg:33.70ms
+step:387/1840 train_time:13042ms step_avg:33.70ms
+step:388/1840 train_time:13076ms step_avg:33.70ms
+step:389/1840 train_time:13108ms step_avg:33.70ms
+step:390/1840 train_time:13142ms step_avg:33.70ms
+step:391/1840 train_time:13174ms step_avg:33.69ms
+step:392/1840 train_time:13209ms step_avg:33.70ms
+step:393/1840 train_time:13241ms step_avg:33.69ms
+step:394/1840 train_time:13276ms step_avg:33.69ms
+step:395/1840 train_time:13308ms step_avg:33.69ms
+step:396/1840 train_time:13342ms step_avg:33.69ms
+step:397/1840 train_time:13374ms step_avg:33.69ms
+step:398/1840 train_time:13408ms step_avg:33.69ms
+step:399/1840 train_time:13440ms step_avg:33.69ms
+step:400/1840 train_time:13475ms step_avg:33.69ms
+step:401/1840 train_time:13508ms step_avg:33.68ms
+step:402/1840 train_time:13542ms step_avg:33.69ms
+step:403/1840 train_time:13574ms step_avg:33.68ms
+step:404/1840 train_time:13608ms step_avg:33.68ms
+step:405/1840 train_time:13640ms step_avg:33.68ms
+step:406/1840 train_time:13675ms step_avg:33.68ms
+step:407/1840 train_time:13707ms step_avg:33.68ms
+step:408/1840 train_time:13741ms step_avg:33.68ms
+step:409/1840 train_time:13773ms step_avg:33.67ms
+step:410/1840 train_time:13807ms step_avg:33.68ms
+step:411/1840 train_time:13839ms step_avg:33.67ms
+step:412/1840 train_time:13874ms step_avg:33.67ms
+step:413/1840 train_time:13906ms step_avg:33.67ms
+step:414/1840 train_time:13940ms step_avg:33.67ms
+step:415/1840 train_time:13973ms step_avg:33.67ms
+step:416/1840 train_time:14007ms step_avg:33.67ms
+step:417/1840 train_time:14039ms step_avg:33.67ms
+step:418/1840 train_time:14073ms step_avg:33.67ms
+step:419/1840 train_time:14105ms step_avg:33.66ms
+step:420/1840 train_time:14139ms step_avg:33.67ms
+step:421/1840 train_time:14172ms step_avg:33.66ms
+step:422/1840 train_time:14206ms step_avg:33.66ms
+step:423/1840 train_time:14238ms step_avg:33.66ms
+step:424/1840 train_time:14272ms step_avg:33.66ms
+step:425/1840 train_time:14305ms step_avg:33.66ms
+step:426/1840 train_time:14339ms step_avg:33.66ms
+step:427/1840 train_time:14371ms step_avg:33.66ms
+step:428/1840 train_time:14405ms step_avg:33.66ms
+step:429/1840 train_time:14438ms step_avg:33.65ms
+step:430/1840 train_time:14472ms step_avg:33.66ms
+step:431/1840 train_time:14504ms step_avg:33.65ms
+step:432/1840 train_time:14539ms step_avg:33.65ms
+step:433/1840 train_time:14571ms step_avg:33.65ms
+step:434/1840 train_time:14605ms step_avg:33.65ms
+step:435/1840 train_time:14637ms step_avg:33.65ms
+step:436/1840 train_time:14671ms step_avg:33.65ms
+step:437/1840 train_time:14703ms step_avg:33.65ms
+step:438/1840 train_time:14738ms step_avg:33.65ms
+step:439/1840 train_time:14770ms step_avg:33.64ms
+step:440/1840 train_time:14804ms step_avg:33.65ms
+step:441/1840 train_time:14836ms step_avg:33.64ms
+step:442/1840 train_time:14871ms step_avg:33.64ms
+step:443/1840 train_time:14903ms step_avg:33.64ms
+step:444/1840 train_time:14937ms step_avg:33.64ms
+step:445/1840 train_time:14970ms step_avg:33.64ms
+step:446/1840 train_time:15004ms step_avg:33.64ms
+step:447/1840 train_time:15036ms step_avg:33.64ms
+step:448/1840 train_time:15070ms step_avg:33.64ms
+step:449/1840 train_time:15102ms step_avg:33.64ms
+step:450/1840 train_time:15137ms step_avg:33.64ms
+step:451/1840 train_time:15169ms step_avg:33.63ms
+step:452/1840 train_time:15203ms step_avg:33.63ms
+step:453/1840 train_time:15235ms step_avg:33.63ms
+step:454/1840 train_time:15269ms step_avg:33.63ms
+step:455/1840 train_time:15302ms step_avg:33.63ms
+step:456/1840 train_time:15336ms step_avg:33.63ms
+step:457/1840 train_time:15368ms step_avg:33.63ms
+step:458/1840 train_time:15402ms step_avg:33.63ms
+step:459/1840 train_time:15435ms step_avg:33.63ms
+step:460/1840 train_time:15469ms step_avg:33.63ms
+step:461/1840 train_time:15501ms step_avg:33.62ms
+step:462/1840 train_time:15536ms step_avg:33.63ms
+step:463/1840 train_time:15568ms step_avg:33.62ms
+step:464/1840 train_time:15602ms step_avg:33.63ms
+step:465/1840 train_time:15634ms step_avg:33.62ms
+step:466/1840 train_time:15668ms step_avg:33.62ms
+step:467/1840 train_time:15701ms step_avg:33.62ms
+step:468/1840 train_time:15735ms step_avg:33.62ms
+step:469/1840 train_time:15767ms step_avg:33.62ms
+step:470/1840 train_time:15801ms step_avg:33.62ms
+step:471/1840 train_time:15834ms step_avg:33.62ms
+step:472/1840 train_time:15868ms step_avg:33.62ms
+step:473/1840 train_time:15900ms step_avg:33.62ms
+step:474/1840 train_time:15935ms step_avg:33.62ms
+step:475/1840 train_time:15968ms step_avg:33.62ms
+step:476/1840 train_time:16002ms step_avg:33.62ms
+step:477/1840 train_time:16034ms step_avg:33.61ms
+step:478/1840 train_time:16068ms step_avg:33.62ms
+step:479/1840 train_time:16100ms step_avg:33.61ms
+step:480/1840 train_time:16135ms step_avg:33.61ms
+step:481/1840 train_time:16167ms step_avg:33.61ms
+step:482/1840 train_time:16201ms step_avg:33.61ms
+step:483/1840 train_time:16233ms step_avg:33.61ms
+step:484/1840 train_time:16267ms step_avg:33.61ms
+step:485/1840 train_time:16299ms step_avg:33.61ms
+step:486/1840 train_time:16334ms step_avg:33.61ms
+step:487/1840 train_time:16366ms step_avg:33.60ms
+step:488/1840 train_time:16400ms step_avg:33.61ms
+step:489/1840 train_time:16432ms step_avg:33.60ms
+step:490/1840 train_time:16466ms step_avg:33.60ms
+step:491/1840 train_time:16498ms step_avg:33.60ms
+step:492/1840 train_time:16533ms step_avg:33.60ms
+step:493/1840 train_time:16565ms step_avg:33.60ms
+step:494/1840 train_time:16600ms step_avg:33.60ms
+step:495/1840 train_time:16632ms step_avg:33.60ms
+step:496/1840 train_time:16666ms step_avg:33.60ms
+step:497/1840 train_time:16698ms step_avg:33.60ms
+step:498/1840 train_time:16732ms step_avg:33.60ms
+step:499/1840 train_time:16764ms step_avg:33.60ms
+step:500/1840 train_time:16799ms step_avg:33.60ms
+step:500/1840 val_loss:4.3452 train_time:16841ms step_avg:33.68ms
+step:501/1840 train_time:16859ms step_avg:33.65ms
+step:502/1840 train_time:16878ms step_avg:33.62ms
+step:503/1840 train_time:16900ms step_avg:33.60ms
+step:504/1840 train_time:16936ms step_avg:33.60ms
+step:505/1840 train_time:16969ms step_avg:33.60ms
+step:506/1840 train_time:17004ms step_avg:33.61ms
+step:507/1840 train_time:17037ms step_avg:33.60ms
+step:508/1840 train_time:17071ms step_avg:33.60ms
+step:509/1840 train_time:17103ms step_avg:33.60ms
+step:510/1840 train_time:17138ms step_avg:33.60ms
+step:511/1840 train_time:17170ms step_avg:33.60ms
+step:512/1840 train_time:17204ms step_avg:33.60ms
+step:513/1840 train_time:17235ms step_avg:33.60ms
+step:514/1840 train_time:17270ms step_avg:33.60ms
+step:515/1840 train_time:17302ms step_avg:33.60ms
+step:516/1840 train_time:17336ms step_avg:33.60ms
+step:517/1840 train_time:17367ms step_avg:33.59ms
+step:518/1840 train_time:17402ms step_avg:33.59ms
+step:519/1840 train_time:17434ms step_avg:33.59ms
+step:520/1840 train_time:17468ms step_avg:33.59ms
+step:521/1840 train_time:17500ms step_avg:33.59ms
+step:522/1840 train_time:17534ms step_avg:33.59ms
+step:523/1840 train_time:17566ms step_avg:33.59ms
+step:524/1840 train_time:17600ms step_avg:33.59ms
+step:525/1840 train_time:17632ms step_avg:33.58ms
+step:526/1840 train_time:17666ms step_avg:33.59ms
+step:527/1840 train_time:17698ms step_avg:33.58ms
+step:528/1840 train_time:17732ms step_avg:33.58ms
+step:529/1840 train_time:17764ms step_avg:33.58ms
+step:530/1840 train_time:17798ms step_avg:33.58ms
+step:531/1840 train_time:17830ms step_avg:33.58ms
+step:532/1840 train_time:17865ms step_avg:33.58ms
+step:533/1840 train_time:17899ms step_avg:33.58ms
+step:534/1840 train_time:17933ms step_avg:33.58ms
+step:535/1840 train_time:17966ms step_avg:33.58ms
+step:536/1840 train_time:18000ms step_avg:33.58ms
+step:537/1840 train_time:18033ms step_avg:33.58ms
+step:538/1840 train_time:18067ms step_avg:33.58ms
+step:539/1840 train_time:18100ms step_avg:33.58ms
+step:540/1840 train_time:18134ms step_avg:33.58ms
+step:541/1840 train_time:18166ms step_avg:33.58ms
+step:542/1840 train_time:18201ms step_avg:33.58ms
+step:543/1840 train_time:18233ms step_avg:33.58ms
+step:544/1840 train_time:18268ms step_avg:33.58ms
+step:545/1840 train_time:18300ms step_avg:33.58ms
+step:546/1840 train_time:18334ms step_avg:33.58ms
+step:547/1840 train_time:18366ms step_avg:33.58ms
+step:548/1840 train_time:18400ms step_avg:33.58ms
+step:549/1840 train_time:18432ms step_avg:33.57ms
+step:550/1840 train_time:18466ms step_avg:33.57ms
+step:551/1840 train_time:18498ms step_avg:33.57ms
+step:552/1840 train_time:18532ms step_avg:33.57ms
+step:553/1840 train_time:18564ms step_avg:33.57ms
+step:554/1840 train_time:18598ms step_avg:33.57ms
+step:555/1840 train_time:18630ms step_avg:33.57ms
+step:556/1840 train_time:18664ms step_avg:33.57ms
+step:557/1840 train_time:18697ms step_avg:33.57ms
+step:558/1840 train_time:18731ms step_avg:33.57ms
+step:559/1840 train_time:18763ms step_avg:33.57ms
+step:560/1840 train_time:18798ms step_avg:33.57ms
+step:561/1840 train_time:18829ms step_avg:33.56ms
+step:562/1840 train_time:18864ms step_avg:33.57ms
+step:563/1840 train_time:18896ms step_avg:33.56ms
+step:564/1840 train_time:18931ms step_avg:33.56ms
+step:565/1840 train_time:18963ms step_avg:33.56ms
+step:566/1840 train_time:18998ms step_avg:33.56ms
+step:567/1840 train_time:19030ms step_avg:33.56ms
+step:568/1840 train_time:19064ms step_avg:33.56ms
+step:569/1840 train_time:19097ms step_avg:33.56ms
+step:570/1840 train_time:19131ms step_avg:33.56ms
+step:571/1840 train_time:19163ms step_avg:33.56ms
+step:572/1840 train_time:19198ms step_avg:33.56ms
+step:573/1840 train_time:19230ms step_avg:33.56ms
+step:574/1840 train_time:19264ms step_avg:33.56ms
+step:575/1840 train_time:19296ms step_avg:33.56ms
+step:576/1840 train_time:19330ms step_avg:33.56ms
+step:577/1840 train_time:19363ms step_avg:33.56ms
+step:578/1840 train_time:19397ms step_avg:33.56ms
+step:579/1840 train_time:19429ms step_avg:33.56ms
+step:580/1840 train_time:19463ms step_avg:33.56ms
+step:581/1840 train_time:19496ms step_avg:33.56ms
+step:582/1840 train_time:19530ms step_avg:33.56ms
+step:583/1840 train_time:19562ms step_avg:33.55ms
+step:584/1840 train_time:19596ms step_avg:33.55ms
+step:585/1840 train_time:19628ms step_avg:33.55ms
+step:586/1840 train_time:19663ms step_avg:33.55ms
+step:587/1840 train_time:19695ms step_avg:33.55ms
+step:588/1840 train_time:19729ms step_avg:33.55ms
+step:589/1840 train_time:19762ms step_avg:33.55ms
+step:590/1840 train_time:19796ms step_avg:33.55ms
+step:591/1840 train_time:19828ms step_avg:33.55ms
+step:592/1840 train_time:19862ms step_avg:33.55ms
+step:593/1840 train_time:19894ms step_avg:33.55ms
+step:594/1840 train_time:19929ms step_avg:33.55ms
+step:595/1840 train_time:19961ms step_avg:33.55ms
+step:596/1840 train_time:19996ms step_avg:33.55ms
+step:597/1840 train_time:20028ms step_avg:33.55ms
+step:598/1840 train_time:20063ms step_avg:33.55ms
+step:599/1840 train_time:20095ms step_avg:33.55ms
+step:600/1840 train_time:20130ms step_avg:33.55ms
+step:601/1840 train_time:20164ms step_avg:33.55ms
+step:602/1840 train_time:20223ms step_avg:33.59ms
+step:603/1840 train_time:20283ms step_avg:33.64ms
+step:604/1840 train_time:20345ms step_avg:33.68ms
+step:605/1840 train_time:20405ms step_avg:33.73ms
+step:606/1840 train_time:20467ms step_avg:33.77ms
+step:607/1840 train_time:20527ms step_avg:33.82ms
+step:608/1840 train_time:20589ms step_avg:33.86ms
+step:609/1840 train_time:20648ms step_avg:33.91ms
+step:610/1840 train_time:20710ms step_avg:33.95ms
+step:611/1840 train_time:20769ms step_avg:33.99ms
+step:612/1840 train_time:20832ms step_avg:34.04ms
+step:613/1840 train_time:20892ms step_avg:34.08ms
+step:614/1840 train_time:20954ms step_avg:34.13ms
+step:615/1840 train_time:21014ms step_avg:34.17ms
+step:616/1840 train_time:21077ms step_avg:34.22ms
+step:617/1840 train_time:21137ms step_avg:34.26ms
+step:618/1840 train_time:21199ms step_avg:34.30ms
+step:619/1840 train_time:21260ms step_avg:34.35ms
+step:620/1840 train_time:21323ms step_avg:34.39ms
+step:621/1840 train_time:21383ms step_avg:34.43ms
+step:622/1840 train_time:21446ms step_avg:34.48ms
+step:623/1840 train_time:21506ms step_avg:34.52ms
+step:624/1840 train_time:21567ms step_avg:34.56ms
+step:625/1840 train_time:21628ms step_avg:34.60ms
+step:626/1840 train_time:21690ms step_avg:34.65ms
+step:627/1840 train_time:21749ms step_avg:34.69ms
+step:628/1840 train_time:21811ms step_avg:34.73ms
+step:629/1840 train_time:21871ms step_avg:34.77ms
+step:630/1840 train_time:21933ms step_avg:34.81ms
+step:631/1840 train_time:21993ms step_avg:34.85ms
+step:632/1840 train_time:22055ms step_avg:34.90ms
+step:633/1840 train_time:22115ms step_avg:34.94ms
+step:634/1840 train_time:22177ms step_avg:34.98ms
+step:635/1840 train_time:22237ms step_avg:35.02ms
+step:636/1840 train_time:22299ms step_avg:35.06ms
+step:637/1840 train_time:22359ms step_avg:35.10ms
+step:638/1840 train_time:22422ms step_avg:35.14ms
+step:639/1840 train_time:22483ms step_avg:35.18ms
+step:640/1840 train_time:22545ms step_avg:35.23ms
+step:641/1840 train_time:22605ms step_avg:35.26ms
+step:642/1840 train_time:22666ms step_avg:35.31ms
+step:643/1840 train_time:22726ms step_avg:35.34ms
+step:644/1840 train_time:22789ms step_avg:35.39ms
+step:645/1840 train_time:22849ms step_avg:35.42ms
+step:646/1840 train_time:22911ms step_avg:35.47ms
+step:647/1840 train_time:22971ms step_avg:35.50ms
+step:648/1840 train_time:23034ms step_avg:35.55ms
+step:649/1840 train_time:23094ms step_avg:35.58ms
+step:650/1840 train_time:23156ms step_avg:35.62ms
+step:651/1840 train_time:23215ms step_avg:35.66ms
+step:652/1840 train_time:23278ms step_avg:35.70ms
+step:653/1840 train_time:23338ms step_avg:35.74ms
+step:654/1840 train_time:23401ms step_avg:35.78ms
+step:655/1840 train_time:23461ms step_avg:35.82ms
+step:656/1840 train_time:23524ms step_avg:35.86ms
+step:657/1840 train_time:23583ms step_avg:35.90ms
+step:658/1840 train_time:23645ms step_avg:35.93ms
+step:659/1840 train_time:23705ms step_avg:35.97ms
+step:660/1840 train_time:23768ms step_avg:36.01ms
+step:661/1840 train_time:23828ms step_avg:36.05ms
+step:662/1840 train_time:23890ms step_avg:36.09ms
+step:663/1840 train_time:23950ms step_avg:36.12ms
+step:664/1840 train_time:24012ms step_avg:36.16ms
+step:665/1840 train_time:24073ms step_avg:36.20ms
+step:666/1840 train_time:24135ms step_avg:36.24ms
+step:667/1840 train_time:24194ms step_avg:36.27ms
+step:668/1840 train_time:24257ms step_avg:36.31ms
+step:669/1840 train_time:24316ms step_avg:36.35ms
+step:670/1840 train_time:24378ms step_avg:36.38ms
+step:671/1840 train_time:24438ms step_avg:36.42ms
+step:672/1840 train_time:24500ms step_avg:36.46ms
+step:673/1840 train_time:24560ms step_avg:36.49ms
+step:674/1840 train_time:24624ms step_avg:36.53ms
+step:675/1840 train_time:24684ms step_avg:36.57ms
+step:676/1840 train_time:24745ms step_avg:36.61ms
+step:677/1840 train_time:24806ms step_avg:36.64ms
+step:678/1840 train_time:24868ms step_avg:36.68ms
+step:679/1840 train_time:24929ms step_avg:36.71ms
+step:680/1840 train_time:24992ms step_avg:36.75ms
+step:681/1840 train_time:25051ms step_avg:36.79ms
+step:682/1840 train_time:25114ms step_avg:36.82ms
+step:683/1840 train_time:25173ms step_avg:36.86ms
+step:684/1840 train_time:25235ms step_avg:36.89ms
+step:685/1840 train_time:25294ms step_avg:36.93ms
+step:686/1840 train_time:25356ms step_avg:36.96ms
+step:687/1840 train_time:25416ms step_avg:37.00ms
+step:688/1840 train_time:25478ms step_avg:37.03ms
+step:689/1840 train_time:25538ms step_avg:37.07ms
+step:690/1840 train_time:25602ms step_avg:37.10ms
+step:691/1840 train_time:25662ms step_avg:37.14ms
+step:692/1840 train_time:25724ms step_avg:37.17ms
+step:693/1840 train_time:25784ms step_avg:37.21ms
+step:694/1840 train_time:25847ms step_avg:37.24ms
+step:695/1840 train_time:25908ms step_avg:37.28ms
+step:696/1840 train_time:25970ms step_avg:37.31ms
+step:697/1840 train_time:26030ms step_avg:37.35ms
+step:698/1840 train_time:26092ms step_avg:37.38ms
+step:699/1840 train_time:26152ms step_avg:37.41ms
+step:700/1840 train_time:26214ms step_avg:37.45ms
+step:701/1840 train_time:26274ms step_avg:37.48ms
+step:702/1840 train_time:26336ms step_avg:37.52ms
+step:703/1840 train_time:26395ms step_avg:37.55ms
+step:704/1840 train_time:26458ms step_avg:37.58ms
+step:705/1840 train_time:26518ms step_avg:37.61ms
+step:706/1840 train_time:26581ms step_avg:37.65ms
+step:707/1840 train_time:26641ms step_avg:37.68ms
+step:708/1840 train_time:26704ms step_avg:37.72ms
+step:709/1840 train_time:26764ms step_avg:37.75ms
+step:710/1840 train_time:26828ms step_avg:37.79ms
+step:711/1840 train_time:26888ms step_avg:37.82ms
+step:712/1840 train_time:26950ms step_avg:37.85ms
+step:713/1840 train_time:27011ms step_avg:37.88ms
+step:714/1840 train_time:27073ms step_avg:37.92ms
+step:715/1840 train_time:27132ms step_avg:37.95ms
+step:716/1840 train_time:27194ms step_avg:37.98ms
+step:717/1840 train_time:27254ms step_avg:38.01ms
+step:718/1840 train_time:27316ms step_avg:38.04ms
+step:719/1840 train_time:27376ms step_avg:38.08ms
+step:720/1840 train_time:27439ms step_avg:38.11ms
+step:721/1840 train_time:27498ms step_avg:38.14ms
+step:722/1840 train_time:27561ms step_avg:38.17ms
+step:723/1840 train_time:27621ms step_avg:38.20ms
+step:724/1840 train_time:27684ms step_avg:38.24ms
+step:725/1840 train_time:27743ms step_avg:38.27ms
+step:726/1840 train_time:27806ms step_avg:38.30ms
+step:727/1840 train_time:27866ms step_avg:38.33ms
+step:728/1840 train_time:27929ms step_avg:38.36ms
+step:729/1840 train_time:27990ms step_avg:38.39ms
+step:730/1840 train_time:28051ms step_avg:38.43ms
+step:731/1840 train_time:28112ms step_avg:38.46ms
+step:732/1840 train_time:28173ms step_avg:38.49ms
+step:733/1840 train_time:28233ms step_avg:38.52ms
+step:734/1840 train_time:28294ms step_avg:38.55ms
+step:735/1840 train_time:28354ms step_avg:38.58ms
+step:736/1840 train_time:28416ms step_avg:38.61ms
+step:737/1840 train_time:28476ms step_avg:38.64ms
+step:738/1840 train_time:28539ms step_avg:38.67ms
+step:739/1840 train_time:28599ms step_avg:38.70ms
+step:740/1840 train_time:28662ms step_avg:38.73ms
+step:741/1840 train_time:28722ms step_avg:38.76ms
+step:742/1840 train_time:28786ms step_avg:38.79ms
+step:743/1840 train_time:28845ms step_avg:38.82ms
+step:744/1840 train_time:28908ms step_avg:38.85ms
+step:745/1840 train_time:28967ms step_avg:38.88ms
+step:746/1840 train_time:29029ms step_avg:38.91ms
+step:747/1840 train_time:29089ms step_avg:38.94ms
+step:748/1840 train_time:29152ms step_avg:38.97ms
+step:749/1840 train_time:29211ms step_avg:39.00ms
+step:750/1840 train_time:29274ms step_avg:39.03ms
+step:750/1840 val_loss:4.0177 train_time:29345ms step_avg:39.13ms
+step:751/1840 train_time:29365ms step_avg:39.10ms
+step:752/1840 train_time:29396ms step_avg:39.09ms
+step:753/1840 train_time:29457ms step_avg:39.12ms
+step:754/1840 train_time:29520ms step_avg:39.15ms
+step:755/1840 train_time:29580ms step_avg:39.18ms
+step:756/1840 train_time:29642ms step_avg:39.21ms
+step:757/1840 train_time:29701ms step_avg:39.23ms
+step:758/1840 train_time:29763ms step_avg:39.27ms
+step:759/1840 train_time:29823ms step_avg:39.29ms
+step:760/1840 train_time:29886ms step_avg:39.32ms
+step:761/1840 train_time:29946ms step_avg:39.35ms
+step:762/1840 train_time:30007ms step_avg:39.38ms
+step:763/1840 train_time:30066ms step_avg:39.41ms
+step:764/1840 train_time:30128ms step_avg:39.43ms
+step:765/1840 train_time:30188ms step_avg:39.46ms
+step:766/1840 train_time:30252ms step_avg:39.49ms
+step:767/1840 train_time:30316ms step_avg:39.52ms
+step:768/1840 train_time:30379ms step_avg:39.56ms
+step:769/1840 train_time:30439ms step_avg:39.58ms
+step:770/1840 train_time:30501ms step_avg:39.61ms
+step:771/1840 train_time:30561ms step_avg:39.64ms
+step:772/1840 train_time:30623ms step_avg:39.67ms
+step:773/1840 train_time:30682ms step_avg:39.69ms
+step:774/1840 train_time:30744ms step_avg:39.72ms
+step:775/1840 train_time:30803ms step_avg:39.75ms
+step:776/1840 train_time:30866ms step_avg:39.78ms
+step:777/1840 train_time:30925ms step_avg:39.80ms
+step:778/1840 train_time:30986ms step_avg:39.83ms
+step:779/1840 train_time:31046ms step_avg:39.85ms
+step:780/1840 train_time:31108ms step_avg:39.88ms
+step:781/1840 train_time:31167ms step_avg:39.91ms
+step:782/1840 train_time:31231ms step_avg:39.94ms
+step:783/1840 train_time:31293ms step_avg:39.97ms
+step:784/1840 train_time:31356ms step_avg:40.00ms
+step:785/1840 train_time:31416ms step_avg:40.02ms
+step:786/1840 train_time:31477ms step_avg:40.05ms
+step:787/1840 train_time:31537ms step_avg:40.07ms
+step:788/1840 train_time:31599ms step_avg:40.10ms
+step:789/1840 train_time:31658ms step_avg:40.12ms
+step:790/1840 train_time:31721ms step_avg:40.15ms
+step:791/1840 train_time:31780ms step_avg:40.18ms
+step:792/1840 train_time:31843ms step_avg:40.21ms
+step:793/1840 train_time:31903ms step_avg:40.23ms
+step:794/1840 train_time:31966ms step_avg:40.26ms
+step:795/1840 train_time:32026ms step_avg:40.28ms
+step:796/1840 train_time:32087ms step_avg:40.31ms
+step:797/1840 train_time:32147ms step_avg:40.34ms
+step:798/1840 train_time:32209ms step_avg:40.36ms
+step:799/1840 train_time:32270ms step_avg:40.39ms
+step:800/1840 train_time:32334ms step_avg:40.42ms
+step:801/1840 train_time:32394ms step_avg:40.44ms
+step:802/1840 train_time:32456ms step_avg:40.47ms
+step:803/1840 train_time:32516ms step_avg:40.49ms
+step:804/1840 train_time:32578ms step_avg:40.52ms
+step:805/1840 train_time:32638ms step_avg:40.54ms
+step:806/1840 train_time:32699ms step_avg:40.57ms
+step:807/1840 train_time:32759ms step_avg:40.59ms
+step:808/1840 train_time:32821ms step_avg:40.62ms
+step:809/1840 train_time:32880ms step_avg:40.64ms
+step:810/1840 train_time:32943ms step_avg:40.67ms
+step:811/1840 train_time:33003ms step_avg:40.69ms
+step:812/1840 train_time:33066ms step_avg:40.72ms
+step:813/1840 train_time:33126ms step_avg:40.75ms
+step:814/1840 train_time:33188ms step_avg:40.77ms
+step:815/1840 train_time:33248ms step_avg:40.79ms
+step:816/1840 train_time:33311ms step_avg:40.82ms
+step:817/1840 train_time:33372ms step_avg:40.85ms
+step:818/1840 train_time:33434ms step_avg:40.87ms
+step:819/1840 train_time:33494ms step_avg:40.90ms
+step:820/1840 train_time:33556ms step_avg:40.92ms
+step:821/1840 train_time:33616ms step_avg:40.95ms
+step:822/1840 train_time:33679ms step_avg:40.97ms
+step:823/1840 train_time:33738ms step_avg:40.99ms
+step:824/1840 train_time:33801ms step_avg:41.02ms
+step:825/1840 train_time:33859ms step_avg:41.04ms
+step:826/1840 train_time:33922ms step_avg:41.07ms
+step:827/1840 train_time:33981ms step_avg:41.09ms
+step:828/1840 train_time:34043ms step_avg:41.11ms
+step:829/1840 train_time:34104ms step_avg:41.14ms
+step:830/1840 train_time:34167ms step_avg:41.16ms
+step:831/1840 train_time:34227ms step_avg:41.19ms
+step:832/1840 train_time:34291ms step_avg:41.22ms
+step:833/1840 train_time:34352ms step_avg:41.24ms
+step:834/1840 train_time:34413ms step_avg:41.26ms
+step:835/1840 train_time:34474ms step_avg:41.29ms
+step:836/1840 train_time:34536ms step_avg:41.31ms
+step:837/1840 train_time:34596ms step_avg:41.33ms
+step:838/1840 train_time:34658ms step_avg:41.36ms
+step:839/1840 train_time:34716ms step_avg:41.38ms
+step:840/1840 train_time:34779ms step_avg:41.40ms
+step:841/1840 train_time:34839ms step_avg:41.43ms
+step:842/1840 train_time:34901ms step_avg:41.45ms
+step:843/1840 train_time:34961ms step_avg:41.47ms
+step:844/1840 train_time:35023ms step_avg:41.50ms
+step:845/1840 train_time:35083ms step_avg:41.52ms
+step:846/1840 train_time:35146ms step_avg:41.54ms
+step:847/1840 train_time:35206ms step_avg:41.57ms
+step:848/1840 train_time:35269ms step_avg:41.59ms
+step:849/1840 train_time:35329ms step_avg:41.61ms
+step:850/1840 train_time:35392ms step_avg:41.64ms
+step:851/1840 train_time:35453ms step_avg:41.66ms
+step:852/1840 train_time:35515ms step_avg:41.68ms
+step:853/1840 train_time:35575ms step_avg:41.71ms
+step:854/1840 train_time:35637ms step_avg:41.73ms
+step:855/1840 train_time:35697ms step_avg:41.75ms
+step:856/1840 train_time:35759ms step_avg:41.77ms
+step:857/1840 train_time:35819ms step_avg:41.80ms
+step:858/1840 train_time:35880ms step_avg:41.82ms
+step:859/1840 train_time:35939ms step_avg:41.84ms
+step:860/1840 train_time:36002ms step_avg:41.86ms
+step:861/1840 train_time:36063ms step_avg:41.89ms
+step:862/1840 train_time:36125ms step_avg:41.91ms
+step:863/1840 train_time:36185ms step_avg:41.93ms
+step:864/1840 train_time:36248ms step_avg:41.95ms
+step:865/1840 train_time:36308ms step_avg:41.98ms
+step:866/1840 train_time:36372ms step_avg:42.00ms
+step:867/1840 train_time:36432ms step_avg:42.02ms
+step:868/1840 train_time:36494ms step_avg:42.04ms
+step:869/1840 train_time:36554ms step_avg:42.06ms
+step:870/1840 train_time:36616ms step_avg:42.09ms
+step:871/1840 train_time:36676ms step_avg:42.11ms
+step:872/1840 train_time:36738ms step_avg:42.13ms
+step:873/1840 train_time:36797ms step_avg:42.15ms
+step:874/1840 train_time:36859ms step_avg:42.17ms
+step:875/1840 train_time:36918ms step_avg:42.19ms
+step:876/1840 train_time:36981ms step_avg:42.22ms
+step:877/1840 train_time:37040ms step_avg:42.23ms
+step:878/1840 train_time:37102ms step_avg:42.26ms
+step:879/1840 train_time:37162ms step_avg:42.28ms
+step:880/1840 train_time:37225ms step_avg:42.30ms
+step:881/1840 train_time:37285ms step_avg:42.32ms
+step:882/1840 train_time:37348ms step_avg:42.34ms
+step:883/1840 train_time:37408ms step_avg:42.36ms
+step:884/1840 train_time:37471ms step_avg:42.39ms
+step:885/1840 train_time:37531ms step_avg:42.41ms
+step:886/1840 train_time:37593ms step_avg:42.43ms
+step:887/1840 train_time:37653ms step_avg:42.45ms
+step:888/1840 train_time:37716ms step_avg:42.47ms
+step:889/1840 train_time:37775ms step_avg:42.49ms
+step:890/1840 train_time:37837ms step_avg:42.51ms
+step:891/1840 train_time:37896ms step_avg:42.53ms
+step:892/1840 train_time:37958ms step_avg:42.55ms
+step:893/1840 train_time:38018ms step_avg:42.57ms
+step:894/1840 train_time:38081ms step_avg:42.60ms
+step:895/1840 train_time:38140ms step_avg:42.62ms
+step:896/1840 train_time:38203ms step_avg:42.64ms
+step:897/1840 train_time:38263ms step_avg:42.66ms
+step:898/1840 train_time:38326ms step_avg:42.68ms
+step:899/1840 train_time:38387ms step_avg:42.70ms
+step:900/1840 train_time:38450ms step_avg:42.72ms
+step:901/1840 train_time:38510ms step_avg:42.74ms
+step:902/1840 train_time:38572ms step_avg:42.76ms
+step:903/1840 train_time:38632ms step_avg:42.78ms
+step:904/1840 train_time:38694ms step_avg:42.80ms
+step:905/1840 train_time:38754ms step_avg:42.82ms
+step:906/1840 train_time:38816ms step_avg:42.84ms
+step:907/1840 train_time:38876ms step_avg:42.86ms
+step:908/1840 train_time:38937ms step_avg:42.88ms
+step:909/1840 train_time:38997ms step_avg:42.90ms
+step:910/1840 train_time:39059ms step_avg:42.92ms
+step:911/1840 train_time:39119ms step_avg:42.94ms
+step:912/1840 train_time:39181ms step_avg:42.96ms
+step:913/1840 train_time:39241ms step_avg:42.98ms
+step:914/1840 train_time:39305ms step_avg:43.00ms
+step:915/1840 train_time:39366ms step_avg:43.02ms
+step:916/1840 train_time:39429ms step_avg:43.04ms
+step:917/1840 train_time:39489ms step_avg:43.06ms
+step:918/1840 train_time:39552ms step_avg:43.09ms
+step:919/1840 train_time:39612ms step_avg:43.10ms
+step:920/1840 train_time:39674ms step_avg:43.12ms
+step:921/1840 train_time:39734ms step_avg:43.14ms
+step:922/1840 train_time:39796ms step_avg:43.16ms
+step:923/1840 train_time:39855ms step_avg:43.18ms
+step:924/1840 train_time:39917ms step_avg:43.20ms
+step:925/1840 train_time:39976ms step_avg:43.22ms
+step:926/1840 train_time:40039ms step_avg:43.24ms
+step:927/1840 train_time:40099ms step_avg:43.26ms
+step:928/1840 train_time:40162ms step_avg:43.28ms
+step:929/1840 train_time:40220ms step_avg:43.29ms
+step:930/1840 train_time:40283ms step_avg:43.32ms
+step:931/1840 train_time:40344ms step_avg:43.33ms
+step:932/1840 train_time:40408ms step_avg:43.36ms
+step:933/1840 train_time:40468ms step_avg:43.37ms
+step:934/1840 train_time:40530ms step_avg:43.39ms
+step:935/1840 train_time:40590ms step_avg:43.41ms
+step:936/1840 train_time:40652ms step_avg:43.43ms
+step:937/1840 train_time:40713ms step_avg:43.45ms
+step:938/1840 train_time:40774ms step_avg:43.47ms
+step:939/1840 train_time:40834ms step_avg:43.49ms
+step:940/1840 train_time:40896ms step_avg:43.51ms
+step:941/1840 train_time:40956ms step_avg:43.52ms
+step:942/1840 train_time:41018ms step_avg:43.54ms
+step:943/1840 train_time:41078ms step_avg:43.56ms
+step:944/1840 train_time:41140ms step_avg:43.58ms
+step:945/1840 train_time:41199ms step_avg:43.60ms
+step:946/1840 train_time:41261ms step_avg:43.62ms
+step:947/1840 train_time:41322ms step_avg:43.63ms
+step:948/1840 train_time:41385ms step_avg:43.66ms
+step:949/1840 train_time:41445ms step_avg:43.67ms
+step:950/1840 train_time:41509ms step_avg:43.69ms
+step:951/1840 train_time:41569ms step_avg:43.71ms
+step:952/1840 train_time:41632ms step_avg:43.73ms
+step:953/1840 train_time:41691ms step_avg:43.75ms
+step:954/1840 train_time:41754ms step_avg:43.77ms
+step:955/1840 train_time:41814ms step_avg:43.78ms
+step:956/1840 train_time:41876ms step_avg:43.80ms
+step:957/1840 train_time:41936ms step_avg:43.82ms
+step:958/1840 train_time:41998ms step_avg:43.84ms
+step:959/1840 train_time:42057ms step_avg:43.85ms
+step:960/1840 train_time:42119ms step_avg:43.87ms
+step:961/1840 train_time:42178ms step_avg:43.89ms
+step:962/1840 train_time:42241ms step_avg:43.91ms
+step:963/1840 train_time:42301ms step_avg:43.93ms
+step:964/1840 train_time:42363ms step_avg:43.95ms
+step:965/1840 train_time:42423ms step_avg:43.96ms
+step:966/1840 train_time:42487ms step_avg:43.98ms
+step:967/1840 train_time:42548ms step_avg:44.00ms
+step:968/1840 train_time:42610ms step_avg:44.02ms
+step:969/1840 train_time:42670ms step_avg:44.04ms
+step:970/1840 train_time:42733ms step_avg:44.05ms
+step:971/1840 train_time:42793ms step_avg:44.07ms
+step:972/1840 train_time:42855ms step_avg:44.09ms
+step:973/1840 train_time:42916ms step_avg:44.11ms
+step:974/1840 train_time:42977ms step_avg:44.12ms
+step:975/1840 train_time:43037ms step_avg:44.14ms
+step:976/1840 train_time:43099ms step_avg:44.16ms
+step:977/1840 train_time:43158ms step_avg:44.17ms
+step:978/1840 train_time:43221ms step_avg:44.19ms
+step:979/1840 train_time:43280ms step_avg:44.21ms
+step:980/1840 train_time:43342ms step_avg:44.23ms
+step:981/1840 train_time:43402ms step_avg:44.24ms
+step:982/1840 train_time:43466ms step_avg:44.26ms
+step:983/1840 train_time:43526ms step_avg:44.28ms
+step:984/1840 train_time:43589ms step_avg:44.30ms
+step:985/1840 train_time:43649ms step_avg:44.31ms
+step:986/1840 train_time:43711ms step_avg:44.33ms
+step:987/1840 train_time:43771ms step_avg:44.35ms
+step:988/1840 train_time:43834ms step_avg:44.37ms
+step:989/1840 train_time:43894ms step_avg:44.38ms
+step:990/1840 train_time:43956ms step_avg:44.40ms
+step:991/1840 train_time:44016ms step_avg:44.42ms
+step:992/1840 train_time:44078ms step_avg:44.43ms
+step:993/1840 train_time:44139ms step_avg:44.45ms
+step:994/1840 train_time:44201ms step_avg:44.47ms
+step:995/1840 train_time:44261ms step_avg:44.48ms
+step:996/1840 train_time:44321ms step_avg:44.50ms
+step:997/1840 train_time:44381ms step_avg:44.51ms
+step:998/1840 train_time:44443ms step_avg:44.53ms
+step:999/1840 train_time:44504ms step_avg:44.55ms
+step:1000/1840 train_time:44567ms step_avg:44.57ms
+step:1000/1840 val_loss:3.7718 train_time:44639ms step_avg:44.64ms
+step:1001/1840 train_time:44659ms step_avg:44.61ms
+step:1002/1840 train_time:44691ms step_avg:44.60ms
+step:1003/1840 train_time:44753ms step_avg:44.62ms
+step:1004/1840 train_time:44818ms step_avg:44.64ms
+step:1005/1840 train_time:44879ms step_avg:44.66ms
+step:1006/1840 train_time:44941ms step_avg:44.67ms
+step:1007/1840 train_time:45000ms step_avg:44.69ms
+step:1008/1840 train_time:45061ms step_avg:44.70ms
+step:1009/1840 train_time:45122ms step_avg:44.72ms
+step:1010/1840 train_time:45183ms step_avg:44.74ms
+step:1011/1840 train_time:45242ms step_avg:44.75ms
+step:1012/1840 train_time:45304ms step_avg:44.77ms
+step:1013/1840 train_time:45363ms step_avg:44.78ms
+step:1014/1840 train_time:45424ms step_avg:44.80ms
+step:1015/1840 train_time:45483ms step_avg:44.81ms
+step:1016/1840 train_time:45545ms step_avg:44.83ms
+step:1017/1840 train_time:45607ms step_avg:44.84ms
+step:1018/1840 train_time:45672ms step_avg:44.86ms
+step:1019/1840 train_time:45733ms step_avg:44.88ms
+step:1020/1840 train_time:45796ms step_avg:44.90ms
+step:1021/1840 train_time:45856ms step_avg:44.91ms
+step:1022/1840 train_time:45919ms step_avg:44.93ms
+step:1023/1840 train_time:45978ms step_avg:44.94ms
+step:1024/1840 train_time:46041ms step_avg:44.96ms
+step:1025/1840 train_time:46100ms step_avg:44.98ms
+step:1026/1840 train_time:46162ms step_avg:44.99ms
+step:1027/1840 train_time:46222ms step_avg:45.01ms
+step:1028/1840 train_time:46284ms step_avg:45.02ms
+step:1029/1840 train_time:46342ms step_avg:45.04ms
+step:1030/1840 train_time:46404ms step_avg:45.05ms
+step:1031/1840 train_time:46463ms step_avg:45.07ms
+step:1032/1840 train_time:46525ms step_avg:45.08ms
+step:1033/1840 train_time:46586ms step_avg:45.10ms
+step:1034/1840 train_time:46648ms step_avg:45.11ms
+step:1035/1840 train_time:46710ms step_avg:45.13ms
+step:1036/1840 train_time:46774ms step_avg:45.15ms
+step:1037/1840 train_time:46834ms step_avg:45.16ms
+step:1038/1840 train_time:46896ms step_avg:45.18ms
+step:1039/1840 train_time:46956ms step_avg:45.19ms
+step:1040/1840 train_time:47019ms step_avg:45.21ms
+step:1041/1840 train_time:47078ms step_avg:45.22ms
+step:1042/1840 train_time:47141ms step_avg:45.24ms
+step:1043/1840 train_time:47201ms step_avg:45.25ms
+step:1044/1840 train_time:47262ms step_avg:45.27ms
+step:1045/1840 train_time:47322ms step_avg:45.28ms
+step:1046/1840 train_time:47383ms step_avg:45.30ms
+step:1047/1840 train_time:47443ms step_avg:45.31ms
+step:1048/1840 train_time:47505ms step_avg:45.33ms
+step:1049/1840 train_time:47565ms step_avg:45.34ms
+step:1050/1840 train_time:47628ms step_avg:45.36ms
+step:1051/1840 train_time:47688ms step_avg:45.37ms
+step:1052/1840 train_time:47750ms step_avg:45.39ms
+step:1053/1840 train_time:47810ms step_avg:45.40ms
+step:1054/1840 train_time:47873ms step_avg:45.42ms
+step:1055/1840 train_time:47933ms step_avg:45.43ms
+step:1056/1840 train_time:47997ms step_avg:45.45ms
+step:1057/1840 train_time:48057ms step_avg:45.47ms
+step:1058/1840 train_time:48120ms step_avg:45.48ms
+step:1059/1840 train_time:48179ms step_avg:45.50ms
+step:1060/1840 train_time:48241ms step_avg:45.51ms
+step:1061/1840 train_time:48301ms step_avg:45.52ms
+step:1062/1840 train_time:48363ms step_avg:45.54ms
+step:1063/1840 train_time:48423ms step_avg:45.55ms
+step:1064/1840 train_time:48485ms step_avg:45.57ms
+step:1065/1840 train_time:48545ms step_avg:45.58ms
+step:1066/1840 train_time:48607ms step_avg:45.60ms
+step:1067/1840 train_time:48667ms step_avg:45.61ms
+step:1068/1840 train_time:48729ms step_avg:45.63ms
+step:1069/1840 train_time:48789ms step_avg:45.64ms
+step:1070/1840 train_time:48851ms step_avg:45.66ms
+step:1071/1840 train_time:48911ms step_avg:45.67ms
+step:1072/1840 train_time:48973ms step_avg:45.68ms
+step:1073/1840 train_time:49034ms step_avg:45.70ms
+step:1074/1840 train_time:49097ms step_avg:45.71ms
+step:1075/1840 train_time:49157ms step_avg:45.73ms
+step:1076/1840 train_time:49219ms step_avg:45.74ms
+step:1077/1840 train_time:49279ms step_avg:45.76ms
+step:1078/1840 train_time:49341ms step_avg:45.77ms
+step:1079/1840 train_time:49401ms step_avg:45.78ms
+step:1080/1840 train_time:49463ms step_avg:45.80ms
+step:1081/1840 train_time:49523ms step_avg:45.81ms
+step:1082/1840 train_time:49585ms step_avg:45.83ms
+step:1083/1840 train_time:49645ms step_avg:45.84ms
+step:1084/1840 train_time:49706ms step_avg:45.85ms
+step:1085/1840 train_time:49767ms step_avg:45.87ms
+step:1086/1840 train_time:49829ms step_avg:45.88ms
+step:1087/1840 train_time:49889ms step_avg:45.90ms
+step:1088/1840 train_time:49952ms step_avg:45.91ms
+step:1089/1840 train_time:50012ms step_avg:45.92ms
+step:1090/1840 train_time:50075ms step_avg:45.94ms
+step:1091/1840 train_time:50135ms step_avg:45.95ms
+step:1092/1840 train_time:50197ms step_avg:45.97ms
+step:1093/1840 train_time:50256ms step_avg:45.98ms
+step:1094/1840 train_time:50319ms step_avg:46.00ms
+step:1095/1840 train_time:50380ms step_avg:46.01ms
+step:1096/1840 train_time:50442ms step_avg:46.02ms
+step:1097/1840 train_time:50503ms step_avg:46.04ms
+step:1098/1840 train_time:50565ms step_avg:46.05ms
+step:1099/1840 train_time:50624ms step_avg:46.06ms
+step:1100/1840 train_time:50686ms step_avg:46.08ms
+step:1101/1840 train_time:50746ms step_avg:46.09ms
+step:1102/1840 train_time:50809ms step_avg:46.11ms
+step:1103/1840 train_time:50868ms step_avg:46.12ms
+step:1104/1840 train_time:50930ms step_avg:46.13ms
+step:1105/1840 train_time:50990ms step_avg:46.14ms
+step:1106/1840 train_time:51052ms step_avg:46.16ms
+step:1107/1840 train_time:51112ms step_avg:46.17ms
+step:1108/1840 train_time:51174ms step_avg:46.19ms
+step:1109/1840 train_time:51235ms step_avg:46.20ms
+step:1110/1840 train_time:51298ms step_avg:46.21ms
+step:1111/1840 train_time:51358ms step_avg:46.23ms
+step:1112/1840 train_time:51421ms step_avg:46.24ms
+step:1113/1840 train_time:51481ms step_avg:46.25ms
+step:1114/1840 train_time:51543ms step_avg:46.27ms
+step:1115/1840 train_time:51603ms step_avg:46.28ms
+step:1116/1840 train_time:51665ms step_avg:46.30ms
+step:1117/1840 train_time:51725ms step_avg:46.31ms
+step:1118/1840 train_time:51787ms step_avg:46.32ms
+step:1119/1840 train_time:51847ms step_avg:46.33ms
+step:1120/1840 train_time:51909ms step_avg:46.35ms
+step:1121/1840 train_time:51968ms step_avg:46.36ms
+step:1122/1840 train_time:52031ms step_avg:46.37ms
+step:1123/1840 train_time:52090ms step_avg:46.39ms
+step:1124/1840 train_time:52153ms step_avg:46.40ms
+step:1125/1840 train_time:52213ms step_avg:46.41ms
+step:1126/1840 train_time:52277ms step_avg:46.43ms
+step:1127/1840 train_time:52337ms step_avg:46.44ms
+step:1128/1840 train_time:52400ms step_avg:46.45ms
+step:1129/1840 train_time:52460ms step_avg:46.47ms
+step:1130/1840 train_time:52523ms step_avg:46.48ms
+step:1131/1840 train_time:52583ms step_avg:46.49ms
+step:1132/1840 train_time:52645ms step_avg:46.51ms
+step:1133/1840 train_time:52705ms step_avg:46.52ms
+step:1134/1840 train_time:52767ms step_avg:46.53ms
+step:1135/1840 train_time:52827ms step_avg:46.54ms
+step:1136/1840 train_time:52890ms step_avg:46.56ms
+step:1137/1840 train_time:52948ms step_avg:46.57ms
+step:1138/1840 train_time:53011ms step_avg:46.58ms
+step:1139/1840 train_time:53070ms step_avg:46.59ms
+step:1140/1840 train_time:53132ms step_avg:46.61ms
+step:1141/1840 train_time:53192ms step_avg:46.62ms
+step:1142/1840 train_time:53256ms step_avg:46.63ms
+step:1143/1840 train_time:53316ms step_avg:46.65ms
+step:1144/1840 train_time:53379ms step_avg:46.66ms
+step:1145/1840 train_time:53439ms step_avg:46.67ms
+step:1146/1840 train_time:53502ms step_avg:46.69ms
+step:1147/1840 train_time:53562ms step_avg:46.70ms
+step:1148/1840 train_time:53624ms step_avg:46.71ms
+step:1149/1840 train_time:53684ms step_avg:46.72ms
+step:1150/1840 train_time:53746ms step_avg:46.74ms
+step:1151/1840 train_time:53805ms step_avg:46.75ms
+step:1152/1840 train_time:53867ms step_avg:46.76ms
+step:1153/1840 train_time:53927ms step_avg:46.77ms
+step:1154/1840 train_time:53989ms step_avg:46.78ms
+step:1155/1840 train_time:54049ms step_avg:46.80ms
+step:1156/1840 train_time:54110ms step_avg:46.81ms
+step:1157/1840 train_time:54170ms step_avg:46.82ms
+step:1158/1840 train_time:54233ms step_avg:46.83ms
+step:1159/1840 train_time:54293ms step_avg:46.85ms
+step:1160/1840 train_time:54356ms step_avg:46.86ms
+step:1161/1840 train_time:54417ms step_avg:46.87ms
+step:1162/1840 train_time:54480ms step_avg:46.88ms
+step:1163/1840 train_time:54540ms step_avg:46.90ms
+step:1164/1840 train_time:54603ms step_avg:46.91ms
+step:1165/1840 train_time:54663ms step_avg:46.92ms
+step:1166/1840 train_time:54725ms step_avg:46.93ms
+step:1167/1840 train_time:54784ms step_avg:46.94ms
+step:1168/1840 train_time:54846ms step_avg:46.96ms
+step:1169/1840 train_time:54905ms step_avg:46.97ms
+step:1170/1840 train_time:54968ms step_avg:46.98ms
+step:1171/1840 train_time:55028ms step_avg:46.99ms
+step:1172/1840 train_time:55091ms step_avg:47.01ms
+step:1173/1840 train_time:55150ms step_avg:47.02ms
+step:1174/1840 train_time:55212ms step_avg:47.03ms
+step:1175/1840 train_time:55273ms step_avg:47.04ms
+step:1176/1840 train_time:55335ms step_avg:47.05ms
+step:1177/1840 train_time:55395ms step_avg:47.06ms
+step:1178/1840 train_time:55458ms step_avg:47.08ms
+step:1179/1840 train_time:55518ms step_avg:47.09ms
+step:1180/1840 train_time:55581ms step_avg:47.10ms
+step:1181/1840 train_time:55641ms step_avg:47.11ms
+step:1182/1840 train_time:55704ms step_avg:47.13ms
+step:1183/1840 train_time:55764ms step_avg:47.14ms
+step:1184/1840 train_time:55825ms step_avg:47.15ms
+step:1185/1840 train_time:55885ms step_avg:47.16ms
+step:1186/1840 train_time:55947ms step_avg:47.17ms
+step:1187/1840 train_time:56007ms step_avg:47.18ms
+step:1188/1840 train_time:56069ms step_avg:47.20ms
+step:1189/1840 train_time:56129ms step_avg:47.21ms
+step:1190/1840 train_time:56191ms step_avg:47.22ms
+step:1191/1840 train_time:56251ms step_avg:47.23ms
+step:1192/1840 train_time:56313ms step_avg:47.24ms
+step:1193/1840 train_time:56373ms step_avg:47.25ms
+step:1194/1840 train_time:56435ms step_avg:47.27ms
+step:1195/1840 train_time:56496ms step_avg:47.28ms
+step:1196/1840 train_time:56558ms step_avg:47.29ms
+step:1197/1840 train_time:56619ms step_avg:47.30ms
+step:1198/1840 train_time:56682ms step_avg:47.31ms
+step:1199/1840 train_time:56742ms step_avg:47.32ms
+step:1200/1840 train_time:56804ms step_avg:47.34ms
+step:1201/1840 train_time:56864ms step_avg:47.35ms
+step:1202/1840 train_time:56950ms step_avg:47.38ms
+step:1203/1840 train_time:57036ms step_avg:47.41ms
+step:1204/1840 train_time:57125ms step_avg:47.45ms
+step:1205/1840 train_time:57212ms step_avg:47.48ms
+step:1206/1840 train_time:57301ms step_avg:47.51ms
+step:1207/1840 train_time:57386ms step_avg:47.54ms
+step:1208/1840 train_time:57475ms step_avg:47.58ms
+step:1209/1840 train_time:57563ms step_avg:47.61ms
+step:1210/1840 train_time:57654ms step_avg:47.65ms
+step:1211/1840 train_time:57742ms step_avg:47.68ms
+step:1212/1840 train_time:57832ms step_avg:47.72ms
+step:1213/1840 train_time:57918ms step_avg:47.75ms
+step:1214/1840 train_time:58007ms step_avg:47.78ms
+step:1215/1840 train_time:58093ms step_avg:47.81ms
+step:1216/1840 train_time:58182ms step_avg:47.85ms
+step:1217/1840 train_time:58268ms step_avg:47.88ms
+step:1218/1840 train_time:58355ms step_avg:47.91ms
+step:1219/1840 train_time:58442ms step_avg:47.94ms
+step:1220/1840 train_time:58532ms step_avg:47.98ms
+step:1221/1840 train_time:58619ms step_avg:48.01ms
+step:1222/1840 train_time:58710ms step_avg:48.04ms
+step:1223/1840 train_time:58795ms step_avg:48.07ms
+step:1224/1840 train_time:58884ms step_avg:48.11ms
+step:1225/1840 train_time:58972ms step_avg:48.14ms
+step:1226/1840 train_time:59059ms step_avg:48.17ms
+step:1227/1840 train_time:59145ms step_avg:48.20ms
+step:1228/1840 train_time:59233ms step_avg:48.24ms
+step:1229/1840 train_time:59319ms step_avg:48.27ms
+step:1230/1840 train_time:59409ms step_avg:48.30ms
+step:1231/1840 train_time:59494ms step_avg:48.33ms
+step:1232/1840 train_time:59584ms step_avg:48.36ms
+step:1233/1840 train_time:59671ms step_avg:48.40ms
+step:1234/1840 train_time:59759ms step_avg:48.43ms
+step:1235/1840 train_time:59846ms step_avg:48.46ms
+step:1236/1840 train_time:59935ms step_avg:48.49ms
+step:1237/1840 train_time:60021ms step_avg:48.52ms
+step:1238/1840 train_time:60110ms step_avg:48.55ms
+step:1239/1840 train_time:60195ms step_avg:48.58ms
+step:1240/1840 train_time:60285ms step_avg:48.62ms
+step:1241/1840 train_time:60371ms step_avg:48.65ms
+step:1242/1840 train_time:60458ms step_avg:48.68ms
+step:1243/1840 train_time:60546ms step_avg:48.71ms
+step:1244/1840 train_time:60634ms step_avg:48.74ms
+step:1245/1840 train_time:60721ms step_avg:48.77ms
+step:1246/1840 train_time:60810ms step_avg:48.80ms
+step:1247/1840 train_time:60895ms step_avg:48.83ms
+step:1248/1840 train_time:60984ms step_avg:48.87ms
+step:1249/1840 train_time:61070ms step_avg:48.90ms
+step:1250/1840 train_time:61158ms step_avg:48.93ms
+step:1250/1840 val_loss:3.5304 train_time:61259ms step_avg:49.01ms
+step:1251/1840 train_time:61279ms step_avg:48.98ms
+step:1252/1840 train_time:61336ms step_avg:48.99ms
+step:1253/1840 train_time:61425ms step_avg:49.02ms
+step:1254/1840 train_time:61515ms step_avg:49.05ms
+step:1255/1840 train_time:61603ms step_avg:49.09ms
+step:1256/1840 train_time:61692ms step_avg:49.12ms
+step:1257/1840 train_time:61777ms step_avg:49.15ms
+step:1258/1840 train_time:61866ms step_avg:49.18ms
+step:1259/1840 train_time:61951ms step_avg:49.21ms
+step:1260/1840 train_time:62039ms step_avg:49.24ms
+step:1261/1840 train_time:62125ms step_avg:49.27ms
+step:1262/1840 train_time:62214ms step_avg:49.30ms
+step:1263/1840 train_time:62305ms step_avg:49.33ms
+step:1264/1840 train_time:62395ms step_avg:49.36ms
+step:1265/1840 train_time:62481ms step_avg:49.39ms
+step:1266/1840 train_time:62573ms step_avg:49.43ms
+step:1267/1840 train_time:62658ms step_avg:49.45ms
+step:1268/1840 train_time:62749ms step_avg:49.49ms
+step:1269/1840 train_time:62835ms step_avg:49.52ms
+step:1270/1840 train_time:62923ms step_avg:49.55ms
+step:1271/1840 train_time:63008ms step_avg:49.57ms
+step:1272/1840 train_time:63097ms step_avg:49.60ms
+step:1273/1840 train_time:63183ms step_avg:49.63ms
+step:1274/1840 train_time:63273ms step_avg:49.66ms
+step:1275/1840 train_time:63360ms step_avg:49.69ms
+step:1276/1840 train_time:63450ms step_avg:49.73ms
+step:1277/1840 train_time:63536ms step_avg:49.75ms
+step:1278/1840 train_time:63626ms step_avg:49.79ms
+step:1279/1840 train_time:63711ms step_avg:49.81ms
+step:1280/1840 train_time:63800ms step_avg:49.84ms
+step:1281/1840 train_time:63886ms step_avg:49.87ms
+step:1282/1840 train_time:63972ms step_avg:49.90ms
+step:1283/1840 train_time:64059ms step_avg:49.93ms
+step:1284/1840 train_time:64148ms step_avg:49.96ms
+step:1285/1840 train_time:64234ms step_avg:49.99ms
+step:1286/1840 train_time:64326ms step_avg:50.02ms
+step:1287/1840 train_time:64413ms step_avg:50.05ms
+step:1288/1840 train_time:64503ms step_avg:50.08ms
+step:1289/1840 train_time:64590ms step_avg:50.11ms
+step:1290/1840 train_time:64677ms step_avg:50.14ms
+step:1291/1840 train_time:64765ms step_avg:50.17ms
+step:1292/1840 train_time:64852ms step_avg:50.20ms
+step:1293/1840 train_time:64938ms step_avg:50.22ms
+step:1294/1840 train_time:65029ms step_avg:50.25ms
+step:1295/1840 train_time:65114ms step_avg:50.28ms
+step:1296/1840 train_time:65203ms step_avg:50.31ms
+step:1297/1840 train_time:65290ms step_avg:50.34ms
+step:1298/1840 train_time:65380ms step_avg:50.37ms
+step:1299/1840 train_time:65467ms step_avg:50.40ms
+step:1300/1840 train_time:65555ms step_avg:50.43ms
+step:1301/1840 train_time:65641ms step_avg:50.45ms
+step:1302/1840 train_time:65731ms step_avg:50.48ms
+step:1303/1840 train_time:65816ms step_avg:50.51ms
+step:1304/1840 train_time:65906ms step_avg:50.54ms
+step:1305/1840 train_time:65991ms step_avg:50.57ms
+step:1306/1840 train_time:66079ms step_avg:50.60ms
+step:1307/1840 train_time:66166ms step_avg:50.62ms
+step:1308/1840 train_time:66254ms step_avg:50.65ms
+step:1309/1840 train_time:66342ms step_avg:50.68ms
+step:1310/1840 train_time:66432ms step_avg:50.71ms
+step:1311/1840 train_time:66519ms step_avg:50.74ms
+step:1312/1840 train_time:66607ms step_avg:50.77ms
+step:1313/1840 train_time:66693ms step_avg:50.79ms
+step:1314/1840 train_time:66782ms step_avg:50.82ms
+step:1315/1840 train_time:66869ms step_avg:50.85ms
+step:1316/1840 train_time:66957ms step_avg:50.88ms
+step:1317/1840 train_time:67044ms step_avg:50.91ms
+step:1318/1840 train_time:67132ms step_avg:50.93ms
+step:1319/1840 train_time:67218ms step_avg:50.96ms
+step:1320/1840 train_time:67307ms step_avg:50.99ms
+step:1321/1840 train_time:67392ms step_avg:51.02ms
+step:1322/1840 train_time:67482ms step_avg:51.05ms
+step:1323/1840 train_time:67570ms step_avg:51.07ms
+step:1324/1840 train_time:67658ms step_avg:51.10ms
+step:1325/1840 train_time:67744ms step_avg:51.13ms
+step:1326/1840 train_time:67833ms step_avg:51.16ms
+step:1327/1840 train_time:67919ms step_avg:51.18ms
+step:1328/1840 train_time:68009ms step_avg:51.21ms
+step:1329/1840 train_time:68095ms step_avg:51.24ms
+step:1330/1840 train_time:68183ms step_avg:51.27ms
+step:1331/1840 train_time:68269ms step_avg:51.29ms
+step:1332/1840 train_time:68359ms step_avg:51.32ms
+step:1333/1840 train_time:68446ms step_avg:51.35ms
+step:1334/1840 train_time:68533ms step_avg:51.37ms
+step:1335/1840 train_time:68619ms step_avg:51.40ms
+step:1336/1840 train_time:68709ms step_avg:51.43ms
+step:1337/1840 train_time:68794ms step_avg:51.45ms
+step:1338/1840 train_time:68883ms step_avg:51.48ms
+step:1339/1840 train_time:68971ms step_avg:51.51ms
+step:1340/1840 train_time:69060ms step_avg:51.54ms
+step:1341/1840 train_time:69146ms step_avg:51.56ms
+step:1342/1840 train_time:69234ms step_avg:51.59ms
+step:1343/1840 train_time:69319ms step_avg:51.62ms
+step:1344/1840 train_time:69410ms step_avg:51.64ms
+step:1345/1840 train_time:69496ms step_avg:51.67ms
+step:1346/1840 train_time:69586ms step_avg:51.70ms
+step:1347/1840 train_time:69673ms step_avg:51.72ms
+step:1348/1840 train_time:69760ms step_avg:51.75ms
+step:1349/1840 train_time:69847ms step_avg:51.78ms
+step:1350/1840 train_time:69935ms step_avg:51.80ms
+step:1351/1840 train_time:70022ms step_avg:51.83ms
+step:1352/1840 train_time:70111ms step_avg:51.86ms
+step:1353/1840 train_time:70197ms step_avg:51.88ms
+step:1354/1840 train_time:70286ms step_avg:51.91ms
+step:1355/1840 train_time:70371ms step_avg:51.93ms
+step:1356/1840 train_time:70460ms step_avg:51.96ms
+step:1357/1840 train_time:70547ms step_avg:51.99ms
+step:1358/1840 train_time:70635ms step_avg:52.01ms
+step:1359/1840 train_time:70721ms step_avg:52.04ms
+step:1360/1840 train_time:70811ms step_avg:52.07ms
+step:1361/1840 train_time:70896ms step_avg:52.09ms
+step:1362/1840 train_time:70986ms step_avg:52.12ms
+step:1363/1840 train_time:71072ms step_avg:52.14ms
+step:1364/1840 train_time:71159ms step_avg:52.17ms
+step:1365/1840 train_time:71246ms step_avg:52.20ms
+step:1366/1840 train_time:71335ms step_avg:52.22ms
+step:1367/1840 train_time:71424ms step_avg:52.25ms
+step:1368/1840 train_time:71512ms step_avg:52.27ms
+step:1369/1840 train_time:71598ms step_avg:52.30ms
+step:1370/1840 train_time:71686ms step_avg:52.33ms
+step:1371/1840 train_time:71772ms step_avg:52.35ms
+step:1372/1840 train_time:71862ms step_avg:52.38ms
+step:1373/1840 train_time:71948ms step_avg:52.40ms
+step:1374/1840 train_time:72036ms step_avg:52.43ms
+step:1375/1840 train_time:72123ms step_avg:52.45ms
+step:1376/1840 train_time:72211ms step_avg:52.48ms
+step:1377/1840 train_time:72296ms step_avg:52.50ms
+step:1378/1840 train_time:72387ms step_avg:52.53ms
+step:1379/1840 train_time:72473ms step_avg:52.55ms
+step:1380/1840 train_time:72562ms step_avg:52.58ms
+step:1381/1840 train_time:72649ms step_avg:52.61ms
+step:1382/1840 train_time:72736ms step_avg:52.63ms
+step:1383/1840 train_time:72824ms step_avg:52.66ms
+step:1384/1840 train_time:72911ms step_avg:52.68ms
+step:1385/1840 train_time:72998ms step_avg:52.71ms
+step:1386/1840 train_time:73088ms step_avg:52.73ms
+step:1387/1840 train_time:73173ms step_avg:52.76ms
+step:1388/1840 train_time:73261ms step_avg:52.78ms
+step:1389/1840 train_time:73349ms step_avg:52.81ms
+step:1390/1840 train_time:73437ms step_avg:52.83ms
+step:1391/1840 train_time:73525ms step_avg:52.86ms
+step:1392/1840 train_time:73613ms step_avg:52.88ms
+step:1393/1840 train_time:73700ms step_avg:52.91ms
+step:1394/1840 train_time:73789ms step_avg:52.93ms
+step:1395/1840 train_time:73875ms step_avg:52.96ms
+step:1396/1840 train_time:73965ms step_avg:52.98ms
+step:1397/1840 train_time:74051ms step_avg:53.01ms
+step:1398/1840 train_time:74139ms step_avg:53.03ms
+step:1399/1840 train_time:74226ms step_avg:53.06ms
+step:1400/1840 train_time:74314ms step_avg:53.08ms
+step:1401/1840 train_time:74400ms step_avg:53.11ms
+step:1402/1840 train_time:74490ms step_avg:53.13ms
+step:1403/1840 train_time:74575ms step_avg:53.15ms
+step:1404/1840 train_time:74665ms step_avg:53.18ms
+step:1405/1840 train_time:74750ms step_avg:53.20ms
+step:1406/1840 train_time:74839ms step_avg:53.23ms
+step:1407/1840 train_time:74927ms step_avg:53.25ms
+step:1408/1840 train_time:75016ms step_avg:53.28ms
+step:1409/1840 train_time:75103ms step_avg:53.30ms
+step:1410/1840 train_time:75191ms step_avg:53.33ms
+step:1411/1840 train_time:75277ms step_avg:53.35ms
+step:1412/1840 train_time:75368ms step_avg:53.38ms
+step:1413/1840 train_time:75453ms step_avg:53.40ms
+step:1414/1840 train_time:75543ms step_avg:53.42ms
+step:1415/1840 train_time:75630ms step_avg:53.45ms
+step:1416/1840 train_time:75717ms step_avg:53.47ms
+step:1417/1840 train_time:75804ms step_avg:53.50ms
+step:1418/1840 train_time:75892ms step_avg:53.52ms
+step:1419/1840 train_time:75978ms step_avg:53.54ms
+step:1420/1840 train_time:76070ms step_avg:53.57ms
+step:1421/1840 train_time:76156ms step_avg:53.59ms
+step:1422/1840 train_time:76244ms step_avg:53.62ms
+step:1423/1840 train_time:76330ms step_avg:53.64ms
+step:1424/1840 train_time:76418ms step_avg:53.66ms
+step:1425/1840 train_time:76504ms step_avg:53.69ms
+step:1426/1840 train_time:76593ms step_avg:53.71ms
+step:1427/1840 train_time:76677ms step_avg:53.73ms
+step:1428/1840 train_time:76768ms step_avg:53.76ms
+step:1429/1840 train_time:76854ms step_avg:53.78ms
+step:1430/1840 train_time:76943ms step_avg:53.81ms
+step:1431/1840 train_time:77031ms step_avg:53.83ms
+step:1432/1840 train_time:77120ms step_avg:53.85ms
+step:1433/1840 train_time:77206ms step_avg:53.88ms
+step:1434/1840 train_time:77294ms step_avg:53.90ms
+step:1435/1840 train_time:77380ms step_avg:53.92ms
+step:1436/1840 train_time:77470ms step_avg:53.95ms
+step:1437/1840 train_time:77556ms step_avg:53.97ms
+step:1438/1840 train_time:77645ms step_avg:53.99ms
+step:1439/1840 train_time:77731ms step_avg:54.02ms
+step:1440/1840 train_time:77820ms step_avg:54.04ms
+step:1441/1840 train_time:77907ms step_avg:54.06ms
+step:1442/1840 train_time:77994ms step_avg:54.09ms
+step:1443/1840 train_time:78080ms step_avg:54.11ms
+step:1444/1840 train_time:78170ms step_avg:54.13ms
+step:1445/1840 train_time:78255ms step_avg:54.16ms
+step:1446/1840 train_time:78344ms step_avg:54.18ms
+step:1447/1840 train_time:78431ms step_avg:54.20ms
+step:1448/1840 train_time:78518ms step_avg:54.23ms
+step:1449/1840 train_time:78604ms step_avg:54.25ms
+step:1450/1840 train_time:78693ms step_avg:54.27ms
+step:1451/1840 train_time:78779ms step_avg:54.29ms
+step:1452/1840 train_time:78870ms step_avg:54.32ms
+step:1453/1840 train_time:78956ms step_avg:54.34ms
+step:1454/1840 train_time:79044ms step_avg:54.36ms
+step:1455/1840 train_time:79131ms step_avg:54.39ms
+step:1456/1840 train_time:79219ms step_avg:54.41ms
+step:1457/1840 train_time:79304ms step_avg:54.43ms
+step:1458/1840 train_time:79393ms step_avg:54.45ms
+step:1459/1840 train_time:79479ms step_avg:54.47ms
+step:1460/1840 train_time:79569ms step_avg:54.50ms
+step:1461/1840 train_time:79654ms step_avg:54.52ms
+step:1462/1840 train_time:79743ms step_avg:54.54ms
+step:1463/1840 train_time:79831ms step_avg:54.57ms
+step:1464/1840 train_time:79919ms step_avg:54.59ms
+step:1465/1840 train_time:80006ms step_avg:54.61ms
+step:1466/1840 train_time:80094ms step_avg:54.63ms
+step:1467/1840 train_time:80180ms step_avg:54.66ms
+step:1468/1840 train_time:80270ms step_avg:54.68ms
+step:1469/1840 train_time:80357ms step_avg:54.70ms
+step:1470/1840 train_time:80446ms step_avg:54.73ms
+step:1471/1840 train_time:80531ms step_avg:54.75ms
+step:1472/1840 train_time:80620ms step_avg:54.77ms
+step:1473/1840 train_time:80707ms step_avg:54.79ms
+step:1474/1840 train_time:80796ms step_avg:54.81ms
+step:1475/1840 train_time:80882ms step_avg:54.84ms
+step:1476/1840 train_time:80971ms step_avg:54.86ms
+step:1477/1840 train_time:81057ms step_avg:54.88ms
+step:1478/1840 train_time:81145ms step_avg:54.90ms
+step:1479/1840 train_time:81231ms step_avg:54.92ms
+step:1480/1840 train_time:81321ms step_avg:54.95ms
+step:1481/1840 train_time:81408ms step_avg:54.97ms
+step:1482/1840 train_time:81496ms step_avg:54.99ms
+step:1483/1840 train_time:81581ms step_avg:55.01ms
+step:1484/1840 train_time:81672ms step_avg:55.03ms
+step:1485/1840 train_time:81759ms step_avg:55.06ms
+step:1486/1840 train_time:81848ms step_avg:55.08ms
+step:1487/1840 train_time:81933ms step_avg:55.10ms
+step:1488/1840 train_time:82023ms step_avg:55.12ms
+step:1489/1840 train_time:82110ms step_avg:55.14ms
+step:1490/1840 train_time:82198ms step_avg:55.17ms
+step:1491/1840 train_time:82283ms step_avg:55.19ms
+step:1492/1840 train_time:82372ms step_avg:55.21ms
+step:1493/1840 train_time:82458ms step_avg:55.23ms
+step:1494/1840 train_time:82547ms step_avg:55.25ms
+step:1495/1840 train_time:82632ms step_avg:55.27ms
+step:1496/1840 train_time:82720ms step_avg:55.29ms
+step:1497/1840 train_time:82807ms step_avg:55.32ms
+step:1498/1840 train_time:82895ms step_avg:55.34ms
+step:1499/1840 train_time:82981ms step_avg:55.36ms
+step:1500/1840 train_time:83071ms step_avg:55.38ms
+step:1500/1840 val_loss:3.4004 train_time:83171ms step_avg:55.45ms
+step:1501/1840 train_time:83191ms step_avg:55.42ms
+step:1502/1840 train_time:83249ms step_avg:55.43ms
+step:1503/1840 train_time:83338ms step_avg:55.45ms
+step:1504/1840 train_time:83425ms step_avg:55.47ms
+step:1505/1840 train_time:83510ms step_avg:55.49ms
+step:1506/1840 train_time:83599ms step_avg:55.51ms
+step:1507/1840 train_time:83684ms step_avg:55.53ms
+step:1508/1840 train_time:83772ms step_avg:55.55ms
+step:1509/1840 train_time:83857ms step_avg:55.57ms
+step:1510/1840 train_time:83945ms step_avg:55.59ms
+step:1511/1840 train_time:84031ms step_avg:55.61ms
+step:1512/1840 train_time:84123ms step_avg:55.64ms
+step:1513/1840 train_time:84213ms step_avg:55.66ms
+step:1514/1840 train_time:84304ms step_avg:55.68ms
+step:1515/1840 train_time:84392ms step_avg:55.70ms
+step:1516/1840 train_time:84479ms step_avg:55.73ms
+step:1517/1840 train_time:84565ms step_avg:55.74ms
+step:1518/1840 train_time:84654ms step_avg:55.77ms
+step:1519/1840 train_time:84741ms step_avg:55.79ms
+step:1520/1840 train_time:84828ms step_avg:55.81ms
+step:1521/1840 train_time:84914ms step_avg:55.83ms
+step:1522/1840 train_time:85002ms step_avg:55.85ms
+step:1523/1840 train_time:85088ms step_avg:55.87ms
+step:1524/1840 train_time:85180ms step_avg:55.89ms
+step:1525/1840 train_time:85268ms step_avg:55.91ms
+step:1526/1840 train_time:85357ms step_avg:55.93ms
+step:1527/1840 train_time:85443ms step_avg:55.95ms
+step:1528/1840 train_time:85531ms step_avg:55.98ms
+step:1529/1840 train_time:85616ms step_avg:56.00ms
+step:1530/1840 train_time:85705ms step_avg:56.02ms
+step:1531/1840 train_time:85790ms step_avg:56.03ms
+step:1532/1840 train_time:85879ms step_avg:56.06ms
+step:1533/1840 train_time:85964ms step_avg:56.08ms
+step:1534/1840 train_time:86052ms step_avg:56.10ms
+step:1535/1840 train_time:86141ms step_avg:56.12ms
+step:1536/1840 train_time:86231ms step_avg:56.14ms
+step:1537/1840 train_time:86317ms step_avg:56.16ms
+step:1538/1840 train_time:86406ms step_avg:56.18ms
+step:1539/1840 train_time:86491ms step_avg:56.20ms
+step:1540/1840 train_time:86581ms step_avg:56.22ms
+step:1541/1840 train_time:86668ms step_avg:56.24ms
+step:1542/1840 train_time:86757ms step_avg:56.26ms
+step:1543/1840 train_time:86842ms step_avg:56.28ms
+step:1544/1840 train_time:86931ms step_avg:56.30ms
+step:1545/1840 train_time:87017ms step_avg:56.32ms
+step:1546/1840 train_time:87106ms step_avg:56.34ms
+step:1547/1840 train_time:87191ms step_avg:56.36ms
+step:1548/1840 train_time:87282ms step_avg:56.38ms
+step:1549/1840 train_time:87368ms step_avg:56.40ms
+step:1550/1840 train_time:87457ms step_avg:56.42ms
+step:1551/1840 train_time:87542ms step_avg:56.44ms
+step:1552/1840 train_time:87631ms step_avg:56.46ms
+step:1553/1840 train_time:87717ms step_avg:56.48ms
+step:1554/1840 train_time:87805ms step_avg:56.50ms
+step:1555/1840 train_time:87891ms step_avg:56.52ms
+step:1556/1840 train_time:87981ms step_avg:56.54ms
+step:1557/1840 train_time:88067ms step_avg:56.56ms
+step:1558/1840 train_time:88156ms step_avg:56.58ms
+step:1559/1840 train_time:88244ms step_avg:56.60ms
+step:1560/1840 train_time:88332ms step_avg:56.62ms
+step:1561/1840 train_time:88418ms step_avg:56.64ms
+step:1562/1840 train_time:88506ms step_avg:56.66ms
+step:1563/1840 train_time:88592ms step_avg:56.68ms
+step:1564/1840 train_time:88681ms step_avg:56.70ms
+step:1565/1840 train_time:88767ms step_avg:56.72ms
+step:1566/1840 train_time:88856ms step_avg:56.74ms
+step:1567/1840 train_time:88943ms step_avg:56.76ms
+step:1568/1840 train_time:89032ms step_avg:56.78ms
+step:1569/1840 train_time:89118ms step_avg:56.80ms
+step:1570/1840 train_time:89206ms step_avg:56.82ms
+step:1571/1840 train_time:89292ms step_avg:56.84ms
+step:1572/1840 train_time:89382ms step_avg:56.86ms
+step:1573/1840 train_time:89468ms step_avg:56.88ms
+step:1574/1840 train_time:89557ms step_avg:56.90ms
+step:1575/1840 train_time:89643ms step_avg:56.92ms
+step:1576/1840 train_time:89731ms step_avg:56.94ms
+step:1577/1840 train_time:89817ms step_avg:56.95ms
+step:1578/1840 train_time:89905ms step_avg:56.97ms
+step:1579/1840 train_time:89991ms step_avg:56.99ms
+step:1580/1840 train_time:90083ms step_avg:57.01ms
+step:1581/1840 train_time:90168ms step_avg:57.03ms
+step:1582/1840 train_time:90257ms step_avg:57.05ms
+step:1583/1840 train_time:90345ms step_avg:57.07ms
+step:1584/1840 train_time:90433ms step_avg:57.09ms
+step:1585/1840 train_time:90519ms step_avg:57.11ms
+step:1586/1840 train_time:90607ms step_avg:57.13ms
+step:1587/1840 train_time:90693ms step_avg:57.15ms
+step:1588/1840 train_time:90782ms step_avg:57.17ms
+step:1589/1840 train_time:90867ms step_avg:57.18ms
+step:1590/1840 train_time:90956ms step_avg:57.21ms
+step:1591/1840 train_time:91043ms step_avg:57.22ms
+step:1592/1840 train_time:91132ms step_avg:57.24ms
+step:1593/1840 train_time:91219ms step_avg:57.26ms
+step:1594/1840 train_time:91307ms step_avg:57.28ms
+step:1595/1840 train_time:91392ms step_avg:57.30ms
+step:1596/1840 train_time:91483ms step_avg:57.32ms
+step:1597/1840 train_time:91568ms step_avg:57.34ms
+step:1598/1840 train_time:91657ms step_avg:57.36ms
+step:1599/1840 train_time:91743ms step_avg:57.38ms
+step:1600/1840 train_time:91831ms step_avg:57.39ms
+step:1601/1840 train_time:91917ms step_avg:57.41ms
+step:1602/1840 train_time:92005ms step_avg:57.43ms
+step:1603/1840 train_time:92092ms step_avg:57.45ms
+step:1604/1840 train_time:92182ms step_avg:57.47ms
+step:1605/1840 train_time:92267ms step_avg:57.49ms
+step:1606/1840 train_time:92357ms step_avg:57.51ms
+step:1607/1840 train_time:92443ms step_avg:57.53ms
+step:1608/1840 train_time:92531ms step_avg:57.54ms
+step:1609/1840 train_time:92616ms step_avg:57.56ms
+step:1610/1840 train_time:92705ms step_avg:57.58ms
+step:1611/1840 train_time:92791ms step_avg:57.60ms
+step:1612/1840 train_time:92882ms step_avg:57.62ms
+step:1613/1840 train_time:92967ms step_avg:57.64ms
+step:1614/1840 train_time:93056ms step_avg:57.66ms
+step:1615/1840 train_time:93142ms step_avg:57.67ms
+step:1616/1840 train_time:93231ms step_avg:57.69ms
+step:1617/1840 train_time:93318ms step_avg:57.71ms
+step:1618/1840 train_time:93406ms step_avg:57.73ms
+step:1619/1840 train_time:93492ms step_avg:57.75ms
+step:1620/1840 train_time:93582ms step_avg:57.77ms
+step:1621/1840 train_time:93667ms step_avg:57.78ms
+step:1622/1840 train_time:93756ms step_avg:57.80ms
+step:1623/1840 train_time:93843ms step_avg:57.82ms
+step:1624/1840 train_time:93930ms step_avg:57.84ms
+step:1625/1840 train_time:94017ms step_avg:57.86ms
+step:1626/1840 train_time:94106ms step_avg:57.88ms
+step:1627/1840 train_time:94191ms step_avg:57.89ms
+step:1628/1840 train_time:94282ms step_avg:57.91ms
+step:1629/1840 train_time:94367ms step_avg:57.93ms
+step:1630/1840 train_time:94456ms step_avg:57.95ms
+step:1631/1840 train_time:94544ms step_avg:57.97ms
+step:1632/1840 train_time:94632ms step_avg:57.99ms
+step:1633/1840 train_time:94718ms step_avg:58.00ms
+step:1634/1840 train_time:94805ms step_avg:58.02ms
+step:1635/1840 train_time:94891ms step_avg:58.04ms
+step:1636/1840 train_time:94982ms step_avg:58.06ms
+step:1637/1840 train_time:95067ms step_avg:58.07ms
+step:1638/1840 train_time:95157ms step_avg:58.09ms
+step:1639/1840 train_time:95244ms step_avg:58.11ms
+step:1640/1840 train_time:95332ms step_avg:58.13ms
+step:1641/1840 train_time:95417ms step_avg:58.15ms
+step:1642/1840 train_time:95505ms step_avg:58.16ms
+step:1643/1840 train_time:95592ms step_avg:58.18ms
+step:1644/1840 train_time:95683ms step_avg:58.20ms
+step:1645/1840 train_time:95769ms step_avg:58.22ms
+step:1646/1840 train_time:95858ms step_avg:58.24ms
+step:1647/1840 train_time:95944ms step_avg:58.25ms
+step:1648/1840 train_time:96033ms step_avg:58.27ms
+step:1649/1840 train_time:96119ms step_avg:58.29ms
+step:1650/1840 train_time:96208ms step_avg:58.31ms
+step:1651/1840 train_time:96294ms step_avg:58.32ms
+step:1652/1840 train_time:96382ms step_avg:58.34ms
+step:1653/1840 train_time:96468ms step_avg:58.36ms
+step:1654/1840 train_time:96558ms step_avg:58.38ms
+step:1655/1840 train_time:96644ms step_avg:58.40ms
+step:1656/1840 train_time:96734ms step_avg:58.41ms
+step:1657/1840 train_time:96820ms step_avg:58.43ms
+step:1658/1840 train_time:96907ms step_avg:58.45ms
+step:1659/1840 train_time:96993ms step_avg:58.47ms
+step:1660/1840 train_time:97083ms step_avg:58.48ms
+step:1661/1840 train_time:97169ms step_avg:58.50ms
+step:1662/1840 train_time:97260ms step_avg:58.52ms
+step:1663/1840 train_time:97345ms step_avg:58.54ms
+step:1664/1840 train_time:97434ms step_avg:58.55ms
+step:1665/1840 train_time:97520ms step_avg:58.57ms
+step:1666/1840 train_time:97609ms step_avg:58.59ms
+step:1667/1840 train_time:97695ms step_avg:58.61ms
+step:1668/1840 train_time:97784ms step_avg:58.62ms
+step:1669/1840 train_time:97869ms step_avg:58.64ms
+step:1670/1840 train_time:97958ms step_avg:58.66ms
+step:1671/1840 train_time:98044ms step_avg:58.67ms
+step:1672/1840 train_time:98133ms step_avg:58.69ms
+step:1673/1840 train_time:98219ms step_avg:58.71ms
+step:1674/1840 train_time:98306ms step_avg:58.73ms
+step:1675/1840 train_time:98391ms step_avg:58.74ms
+step:1676/1840 train_time:98481ms step_avg:58.76ms
+step:1677/1840 train_time:98567ms step_avg:58.78ms
+step:1678/1840 train_time:98657ms step_avg:58.79ms
+step:1679/1840 train_time:98743ms step_avg:58.81ms
+step:1680/1840 train_time:98831ms step_avg:58.83ms
+step:1681/1840 train_time:98917ms step_avg:58.84ms
+step:1682/1840 train_time:99005ms step_avg:58.86ms
+step:1683/1840 train_time:99091ms step_avg:58.88ms
+step:1684/1840 train_time:99183ms step_avg:58.90ms
+step:1685/1840 train_time:99268ms step_avg:58.91ms
+step:1686/1840 train_time:99357ms step_avg:58.93ms
+step:1687/1840 train_time:99443ms step_avg:58.95ms
+step:1688/1840 train_time:99531ms step_avg:58.96ms
+step:1689/1840 train_time:99618ms step_avg:58.98ms
+step:1690/1840 train_time:99706ms step_avg:59.00ms
+step:1691/1840 train_time:99793ms step_avg:59.01ms
+step:1692/1840 train_time:99883ms step_avg:59.03ms
+step:1693/1840 train_time:99968ms step_avg:59.05ms
+step:1694/1840 train_time:100057ms step_avg:59.07ms
+step:1695/1840 train_time:100143ms step_avg:59.08ms
+step:1696/1840 train_time:100232ms step_avg:59.10ms
+step:1697/1840 train_time:100318ms step_avg:59.11ms
+step:1698/1840 train_time:100406ms step_avg:59.13ms
+step:1699/1840 train_time:100491ms step_avg:59.15ms
+step:1700/1840 train_time:100582ms step_avg:59.17ms
+step:1701/1840 train_time:100667ms step_avg:59.18ms
+step:1702/1840 train_time:100756ms step_avg:59.20ms
+step:1703/1840 train_time:100843ms step_avg:59.21ms
+step:1704/1840 train_time:100931ms step_avg:59.23ms
+step:1705/1840 train_time:101017ms step_avg:59.25ms
+step:1706/1840 train_time:101105ms step_avg:59.26ms
+step:1707/1840 train_time:101191ms step_avg:59.28ms
+step:1708/1840 train_time:101281ms step_avg:59.30ms
+step:1709/1840 train_time:101367ms step_avg:59.31ms
+step:1710/1840 train_time:101456ms step_avg:59.33ms
+step:1711/1840 train_time:101543ms step_avg:59.35ms
+step:1712/1840 train_time:101632ms step_avg:59.36ms
+step:1713/1840 train_time:101718ms step_avg:59.38ms
+step:1714/1840 train_time:101805ms step_avg:59.40ms
+step:1715/1840 train_time:101891ms step_avg:59.41ms
+step:1716/1840 train_time:101981ms step_avg:59.43ms
+step:1717/1840 train_time:102066ms step_avg:59.44ms
+step:1718/1840 train_time:102155ms step_avg:59.46ms
+step:1719/1840 train_time:102242ms step_avg:59.48ms
+step:1720/1840 train_time:102330ms step_avg:59.49ms
+step:1721/1840 train_time:102416ms step_avg:59.51ms
+step:1722/1840 train_time:102505ms step_avg:59.53ms
+step:1723/1840 train_time:102591ms step_avg:59.54ms
+step:1724/1840 train_time:102681ms step_avg:59.56ms
+step:1725/1840 train_time:102768ms step_avg:59.58ms
+step:1726/1840 train_time:102857ms step_avg:59.59ms
+step:1727/1840 train_time:102943ms step_avg:59.61ms
+step:1728/1840 train_time:103031ms step_avg:59.62ms
+step:1729/1840 train_time:103117ms step_avg:59.64ms
+step:1730/1840 train_time:103206ms step_avg:59.66ms
+step:1731/1840 train_time:103292ms step_avg:59.67ms
+step:1732/1840 train_time:103382ms step_avg:59.69ms
+step:1733/1840 train_time:103467ms step_avg:59.70ms
+step:1734/1840 train_time:103556ms step_avg:59.72ms
+step:1735/1840 train_time:103643ms step_avg:59.74ms
+step:1736/1840 train_time:103732ms step_avg:59.75ms
+step:1737/1840 train_time:103818ms step_avg:59.77ms
+step:1738/1840 train_time:103906ms step_avg:59.78ms
+step:1739/1840 train_time:103991ms step_avg:59.80ms
+step:1740/1840 train_time:104082ms step_avg:59.82ms
+step:1741/1840 train_time:104167ms step_avg:59.83ms
+step:1742/1840 train_time:104256ms step_avg:59.85ms
+step:1743/1840 train_time:104343ms step_avg:59.86ms
+step:1744/1840 train_time:104430ms step_avg:59.88ms
+step:1745/1840 train_time:104517ms step_avg:59.90ms
+step:1746/1840 train_time:104606ms step_avg:59.91ms
+step:1747/1840 train_time:104692ms step_avg:59.93ms
+step:1748/1840 train_time:104782ms step_avg:59.94ms
+step:1749/1840 train_time:104867ms step_avg:59.96ms
+step:1750/1840 train_time:104958ms step_avg:59.98ms
+step:1750/1840 val_loss:3.3018 train_time:105058ms step_avg:60.03ms
+step:1751/1840 train_time:105078ms step_avg:60.01ms
+step:1752/1840 train_time:105133ms step_avg:60.01ms
+step:1753/1840 train_time:105224ms step_avg:60.02ms
+step:1754/1840 train_time:105317ms step_avg:60.04ms
+step:1755/1840 train_time:105402ms step_avg:60.06ms
+step:1756/1840 train_time:105492ms step_avg:60.08ms
+step:1757/1840 train_time:105576ms step_avg:60.09ms
+step:1758/1840 train_time:105664ms step_avg:60.10ms
+step:1759/1840 train_time:105748ms step_avg:60.12ms
+step:1760/1840 train_time:105836ms step_avg:60.13ms
+step:1761/1840 train_time:105920ms step_avg:60.15ms
+step:1762/1840 train_time:106010ms step_avg:60.16ms
+step:1763/1840 train_time:106101ms step_avg:60.18ms
+step:1764/1840 train_time:106193ms step_avg:60.20ms
+step:1765/1840 train_time:106280ms step_avg:60.22ms
+step:1766/1840 train_time:106370ms step_avg:60.23ms
+step:1767/1840 train_time:106456ms step_avg:60.25ms
+step:1768/1840 train_time:106544ms step_avg:60.26ms
+step:1769/1840 train_time:106630ms step_avg:60.28ms
+step:1770/1840 train_time:106717ms step_avg:60.29ms
+step:1771/1840 train_time:106802ms step_avg:60.31ms
+step:1772/1840 train_time:106890ms step_avg:60.32ms
+step:1773/1840 train_time:106977ms step_avg:60.34ms
+step:1774/1840 train_time:107066ms step_avg:60.35ms
+step:1775/1840 train_time:107155ms step_avg:60.37ms
+step:1776/1840 train_time:107244ms step_avg:60.38ms
+step:1777/1840 train_time:107333ms step_avg:60.40ms
+step:1778/1840 train_time:107421ms step_avg:60.42ms
+step:1779/1840 train_time:107507ms step_avg:60.43ms
+step:1780/1840 train_time:107596ms step_avg:60.45ms
+step:1781/1840 train_time:107682ms step_avg:60.46ms
+step:1782/1840 train_time:107769ms step_avg:60.48ms
+step:1783/1840 train_time:107855ms step_avg:60.49ms
+step:1784/1840 train_time:107943ms step_avg:60.51ms
+step:1785/1840 train_time:108031ms step_avg:60.52ms
+step:1786/1840 train_time:108121ms step_avg:60.54ms
+step:1787/1840 train_time:108207ms step_avg:60.55ms
+step:1788/1840 train_time:108296ms step_avg:60.57ms
+step:1789/1840 train_time:108382ms step_avg:60.58ms
+step:1790/1840 train_time:108470ms step_avg:60.60ms
+step:1791/1840 train_time:108556ms step_avg:60.61ms
+step:1792/1840 train_time:108644ms step_avg:60.63ms
+step:1793/1840 train_time:108730ms step_avg:60.64ms
+step:1794/1840 train_time:108818ms step_avg:60.66ms
+step:1795/1840 train_time:108904ms step_avg:60.67ms
+step:1796/1840 train_time:108992ms step_avg:60.69ms
+step:1797/1840 train_time:109081ms step_avg:60.70ms
+step:1798/1840 train_time:109170ms step_avg:60.72ms
+step:1799/1840 train_time:109258ms step_avg:60.73ms
+step:1800/1840 train_time:109345ms step_avg:60.75ms
+step:1801/1840 train_time:109435ms step_avg:60.76ms
+step:1802/1840 train_time:109523ms step_avg:60.78ms
+step:1803/1840 train_time:109607ms step_avg:60.79ms
+step:1804/1840 train_time:109696ms step_avg:60.81ms
+step:1805/1840 train_time:109782ms step_avg:60.82ms
+step:1806/1840 train_time:109871ms step_avg:60.84ms
+step:1807/1840 train_time:109959ms step_avg:60.85ms
+step:1808/1840 train_time:110046ms step_avg:60.87ms
+step:1809/1840 train_time:110134ms step_avg:60.88ms
+step:1810/1840 train_time:110223ms step_avg:60.90ms
+step:1811/1840 train_time:110309ms step_avg:60.91ms
+step:1812/1840 train_time:110400ms step_avg:60.93ms
+step:1813/1840 train_time:110486ms step_avg:60.94ms
+step:1814/1840 train_time:110574ms step_avg:60.96ms
+step:1815/1840 train_time:110660ms step_avg:60.97ms
+step:1816/1840 train_time:110748ms step_avg:60.98ms
+step:1817/1840 train_time:110834ms step_avg:61.00ms
+step:1818/1840 train_time:110923ms step_avg:61.01ms
+step:1819/1840 train_time:111010ms step_avg:61.03ms
+step:1820/1840 train_time:111099ms step_avg:61.04ms
+step:1821/1840 train_time:111185ms step_avg:61.06ms
+step:1822/1840 train_time:111275ms step_avg:61.07ms
+step:1823/1840 train_time:111362ms step_avg:61.09ms
+step:1824/1840 train_time:111451ms step_avg:61.10ms
+step:1825/1840 train_time:111537ms step_avg:61.12ms
+step:1826/1840 train_time:111626ms step_avg:61.13ms
+step:1827/1840 train_time:111712ms step_avg:61.14ms
+step:1828/1840 train_time:111801ms step_avg:61.16ms
+step:1829/1840 train_time:111887ms step_avg:61.17ms
+step:1830/1840 train_time:111977ms step_avg:61.19ms
+step:1831/1840 train_time:112064ms step_avg:61.20ms
+step:1832/1840 train_time:112154ms step_avg:61.22ms
+step:1833/1840 train_time:112240ms step_avg:61.23ms
+step:1834/1840 train_time:112328ms step_avg:61.25ms
+step:1835/1840 train_time:112415ms step_avg:61.26ms
+step:1836/1840 train_time:112503ms step_avg:61.28ms
+step:1837/1840 train_time:112588ms step_avg:61.29ms
+step:1838/1840 train_time:112678ms step_avg:61.30ms
+step:1839/1840 train_time:112764ms step_avg:61.32ms
+step:1840/1840 train_time:112852ms step_avg:61.33ms
+step:1840/1840 val_loss:3.2767 train_time:112953ms step_avg:61.39ms
+peak memory allocated: 28507 MiB reserved: 44038 MiB

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/74b57b98-46bf-41b4-8f24-f84ad1500026.txt
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/74b57b98-46bf-41b4-8f24-f84ad1500026.txt
@@ -1,0 +1,3786 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+    """
+    Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+    Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+    bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+    float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+    """
+    assert p.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    wd_factor = wd_tensor.to(torch.float32)
+    lr_factor = lr_tensor.to(torch.float32)
+    p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    p_precise = p_precise_raw.view(torch.float32)
+    mask = (grad * p_precise) >= 0
+    p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+    p.copy_((p_precise_raw >> 16).to(torch.uint16))
+    mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        2. reduce scatter attn/mlp round 2 (16 mlp params)
+        3. wait on step 1, then compute update of 1 and schedule all gather
+        4. wait on step 2, then compute update of 2 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        5. wait for each all gather to complete and update params
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["mantissa"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn', 'mlp']
+        group_sizes = [16, 16]  # 10 attn + 6 mlp, then 16 mlp
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    def step(self):
+        self.step_p1()
+        self.step_p2()
+        self.step_p3()
+        
+    @torch.no_grad()
+    def step_p1(self):
+        """
+        Part 1: Launch distributed reduce_scatter operations for parameter groups.
+        """
+        rank = dist.get_rank()
+        self.group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            self.group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+    
+    @torch.no_grad()
+    def step_p2(self):
+        """
+        Part 2: Compute gradient updates and launch all_gather operations
+        Wait for all gather to complete for all parameter groups except final one
+        """
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = self.group_infos
+        
+        self.all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"].float()
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params], dtype=torch.float32)
+                
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            if "second_momentum_buffer" not in group:
+                group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1], dtype=torch.float32)
+                    if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if param_shape[-2] >= param_shape[-1] else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk, dtype=torch.bfloat16)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                if "mantissa" not in group:
+                    group["mantissa"] = torch.zeros_like(param_chunk, dtype=torch.uint16)
+                mantissa = group["mantissa"]
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx].view(torch.uint16),
+                        mantissa[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx]
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            self.all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete for all except final and copy results back into original parameter tensors.
+        for info in self.all_gather_infos[:-1]:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+    @torch.no_grad()
+    def step_p3(self):
+        """
+        Part 3: Wait for final all gather to complete and copy results back into original parameter tensors
+        """
+        info = self.all_gather_infos[-1]
+        info["gather_future"].wait()
+        stacked_params = info["stacked_params"]
+        orig_params = info["orig_params"]
+
+        unstacked_params = torch.unbind(stacked_params)
+        for i, p in enumerate(orig_params):
+            p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str], betas: list[list[float]], lr: float = 1e-3, eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for idx, label in enumerate(label_order):
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label], betas=betas[idx]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+        # tag the final param for optimizer pipelining, run all gather after muon copy
+        param_groups[-1]['params'][-1].is_final_param = True
+        
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        # 0-D CPU tensors to avoid recompilation in _update_step
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    def load_state_dict(self, state_dict):
+        """Override to preserve optimizer state dtypes (avoid BFloat16->Float32 cast that causes recompilation)."""
+        # Save original state dtypes before loading
+        original_dtypes = {}
+        for p, s in self.state.items():
+            original_dtypes[p] = {k: v.dtype for k, v in s.items() if isinstance(v, torch.Tensor)}
+        
+        # Call parent load_state_dict (which may cast dtypes to match param dtype)
+        super().load_state_dict(state_dict)
+        
+        # Restore original dtypes
+        for p, s in self.state.items():
+            if p in original_dtypes:
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor) and k in original_dtypes[p]:
+                        if v.dtype != original_dtypes[p][k]:
+                            s[k] = v.to(original_dtypes[p][k])
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-2]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step. step_size_t and eff_wd_t are 0-D CPU tensors to avoid recompilation."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)  # exp_avg = beta1 * exp_avg + (1 - beta1) * g_slice
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)  # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * g_slice^2
+        # compute step
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)  # update = (exp_avg / (sqrt(exp_avg_sq) + eps)) * step_size
+        # cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)  # update += eff_wd_t * p_slice * mask
+        p_slice.add_(other=update, alpha=-1.0)  # p_slice -= update
+
+    @torch.no_grad()
+    def step(self, muon_opt):
+        muon_opt.step_p1()
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        last_param = None
+        last_p_slice = None
+        for group in self.param_groups:      
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+                state["step"] += 1
+                t = state["step"]
+                
+                # Pre-compute changing values as 0-D CPU tensors to avoid recompilation.
+                # `.fill_(value)` is the same as "= value", but doesn't change the tensor object.
+                bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+                self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+                self._eff_wd_t.fill_(lr * lr * wd * getattr(param, "wd_mul", 1.0)) # `lr` included twice to serve as weight decay schedule.
+
+                DistAdam._update_step(p_slice, g_slice, state["exp_avg"], state["exp_avg_sq"],
+                                      beta1, beta2, eps, self._step_size_t, self._eff_wd_t)
+
+                if not is_small:
+                    if getattr(param, "is_final_param", False):
+                        last_param = param
+                        last_p_slice = p_slice
+                    else:
+                        all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+        self._reduce_scatter_futures.clear()
+
+        muon_opt.step_p2()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+        if last_param is not None:
+            last_all_gather_future = dist.all_gather_into_tensor(last_param, last_p_slice, async_op=True).get_future()
+        muon_opt.step_p3()
+        torch.futures.collect_all([last_all_gather_future]).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        adam_betas = {
+            'lm_head': [0.5, 0.95],
+            'smear_gate': [0.9, 0.99],
+            'attn_gate_bank': [0.9, 0.99],
+            've_gate_bank': [0.9, 0.99],
+            'skip_gate': [0.9, 0.99],
+            'x0_lambdas': [0.65, 0.95],
+            'scalars': [0.9, 0.99],
+            'embed': [0.5, 0.95],
+            'value_embed': [0.75, 0.95]
+        }
+        adam_labels = list(adam_betas.keys())
+        adam_beta_values = list(adam_betas.values())
+        muon_labels = ['attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, adam_beta_values, lr=0.008, eps=1e-10, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.muon_opt]
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * step_lr
+                
+        if self._is_active_step(self.adam_opt, step):
+            # adam will interleave calls to muon step
+            self.adam_opt.step(self.muon_opt)
+            self.model.zero_grad(set_to_none=True)
+            self.adam_opt.should_sync = False
+        else:
+            self.muon_opt.step()
+            self.muon_opt.zero_grad(set_to_none=True)
+            
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1800  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan  5 07:48:04 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   42C    P0            128W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   34C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   32C    P0            128W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            129W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   43C    P0            132W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   35C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            126W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     46652      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     46653      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     46654      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     46655      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     46656      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     46657      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     46658      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     46659      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 599, 600, 601, 1199, 1200, 1201, 1799, 1800, 1801] for warmup
+Resetting Model
+step:0/1840 val_loss:10.8324 train_time:0ms step_avg:0.04ms
+step:1/1840 train_time:92ms step_avg:91.78ms
+step:2/1840 train_time:114ms step_avg:56.82ms
+step:3/1840 train_time:133ms step_avg:44.23ms
+step:4/1840 train_time:160ms step_avg:40.00ms
+step:5/1840 train_time:192ms step_avg:38.36ms
+step:6/1840 train_time:278ms step_avg:46.33ms
+step:7/1840 train_time:295ms step_avg:42.17ms
+step:8/1840 train_time:431ms step_avg:53.93ms
+step:9/1840 train_time:463ms step_avg:51.47ms
+step:10/1840 train_time:497ms step_avg:49.71ms
+step:11/1840 train_time:529ms step_avg:48.11ms
+step:12/1840 train_time:563ms step_avg:46.94ms
+step:13/1840 train_time:595ms step_avg:45.78ms
+step:14/1840 train_time:629ms step_avg:44.95ms
+step:15/1840 train_time:662ms step_avg:44.10ms
+step:16/1840 train_time:696ms step_avg:43.48ms
+step:17/1840 train_time:728ms step_avg:42.82ms
+step:18/1840 train_time:762ms step_avg:42.34ms
+step:19/1840 train_time:794ms step_avg:41.79ms
+step:20/1840 train_time:828ms step_avg:41.41ms
+step:21/1840 train_time:860ms step_avg:40.97ms
+step:22/1840 train_time:895ms step_avg:40.67ms
+step:23/1840 train_time:927ms step_avg:40.29ms
+step:24/1840 train_time:961ms step_avg:40.05ms
+step:25/1840 train_time:993ms step_avg:39.72ms
+step:26/1840 train_time:1027ms step_avg:39.51ms
+step:27/1840 train_time:1059ms step_avg:39.23ms
+step:28/1840 train_time:1093ms step_avg:39.05ms
+step:29/1840 train_time:1125ms step_avg:38.80ms
+step:30/1840 train_time:1160ms step_avg:38.65ms
+step:31/1840 train_time:1192ms step_avg:38.44ms
+step:32/1840 train_time:1226ms step_avg:38.32ms
+step:33/1840 train_time:1258ms step_avg:38.12ms
+step:34/1840 train_time:1292ms step_avg:38.00ms
+step:35/1840 train_time:1326ms step_avg:37.88ms
+step:36/1840 train_time:1361ms step_avg:37.81ms
+step:37/1840 train_time:1393ms step_avg:37.66ms
+step:38/1840 train_time:1428ms step_avg:37.59ms
+step:39/1840 train_time:1461ms step_avg:37.46ms
+step:40/1840 train_time:1495ms step_avg:37.38ms
+step:41/1840 train_time:1528ms step_avg:37.27ms
+step:42/1840 train_time:1563ms step_avg:37.21ms
+step:43/1840 train_time:1595ms step_avg:37.09ms
+step:44/1840 train_time:1630ms step_avg:37.04ms
+step:45/1840 train_time:1662ms step_avg:36.93ms
+step:46/1840 train_time:1696ms step_avg:36.87ms
+step:47/1840 train_time:1728ms step_avg:36.77ms
+step:48/1840 train_time:1763ms step_avg:36.72ms
+step:49/1840 train_time:1795ms step_avg:36.62ms
+step:50/1840 train_time:1829ms step_avg:36.58ms
+step:51/1840 train_time:1861ms step_avg:36.49ms
+step:52/1840 train_time:1895ms step_avg:36.45ms
+step:53/1840 train_time:1927ms step_avg:36.36ms
+step:54/1840 train_time:1962ms step_avg:36.33ms
+step:55/1840 train_time:1994ms step_avg:36.25ms
+step:56/1840 train_time:2028ms step_avg:36.21ms
+step:57/1840 train_time:2060ms step_avg:36.14ms
+step:58/1840 train_time:2094ms step_avg:36.10ms
+step:59/1840 train_time:2126ms step_avg:36.03ms
+step:60/1840 train_time:2160ms step_avg:36.00ms
+step:61/1840 train_time:2192ms step_avg:35.93ms
+step:62/1840 train_time:2226ms step_avg:35.91ms
+step:63/1840 train_time:2258ms step_avg:35.85ms
+step:64/1840 train_time:2293ms step_avg:35.83ms
+step:65/1840 train_time:2325ms step_avg:35.78ms
+step:66/1840 train_time:2360ms step_avg:35.76ms
+step:67/1840 train_time:2392ms step_avg:35.71ms
+step:68/1840 train_time:2427ms step_avg:35.69ms
+step:69/1840 train_time:2459ms step_avg:35.64ms
+step:70/1840 train_time:2493ms step_avg:35.62ms
+step:71/1840 train_time:2526ms step_avg:35.57ms
+step:72/1840 train_time:2560ms step_avg:35.56ms
+step:73/1840 train_time:2592ms step_avg:35.51ms
+step:74/1840 train_time:2627ms step_avg:35.50ms
+step:75/1840 train_time:2659ms step_avg:35.46ms
+step:76/1840 train_time:2693ms step_avg:35.44ms
+step:77/1840 train_time:2726ms step_avg:35.40ms
+step:78/1840 train_time:2760ms step_avg:35.38ms
+step:79/1840 train_time:2792ms step_avg:35.34ms
+step:80/1840 train_time:2826ms step_avg:35.33ms
+step:81/1840 train_time:2859ms step_avg:35.29ms
+step:82/1840 train_time:2893ms step_avg:35.28ms
+step:83/1840 train_time:2925ms step_avg:35.24ms
+step:84/1840 train_time:2959ms step_avg:35.23ms
+step:85/1840 train_time:2992ms step_avg:35.19ms
+step:86/1840 train_time:3026ms step_avg:35.18ms
+step:87/1840 train_time:3058ms step_avg:35.15ms
+step:88/1840 train_time:3092ms step_avg:35.13ms
+step:89/1840 train_time:3124ms step_avg:35.10ms
+step:90/1840 train_time:3158ms step_avg:35.09ms
+step:91/1840 train_time:3190ms step_avg:35.06ms
+step:92/1840 train_time:3225ms step_avg:35.05ms
+step:93/1840 train_time:3257ms step_avg:35.02ms
+step:94/1840 train_time:3292ms step_avg:35.02ms
+step:95/1840 train_time:3324ms step_avg:34.99ms
+step:96/1840 train_time:3358ms step_avg:34.98ms
+step:97/1840 train_time:3390ms step_avg:34.95ms
+step:98/1840 train_time:3425ms step_avg:34.95ms
+step:99/1840 train_time:3458ms step_avg:34.93ms
+step:100/1840 train_time:3492ms step_avg:34.92ms
+step:101/1840 train_time:3525ms step_avg:34.90ms
+step:102/1840 train_time:3559ms step_avg:34.89ms
+step:103/1840 train_time:3591ms step_avg:34.87ms
+step:104/1840 train_time:3626ms step_avg:34.87ms
+step:105/1840 train_time:3659ms step_avg:34.85ms
+step:106/1840 train_time:3693ms step_avg:34.84ms
+step:107/1840 train_time:3725ms step_avg:34.81ms
+step:108/1840 train_time:3760ms step_avg:34.81ms
+step:109/1840 train_time:3792ms step_avg:34.79ms
+step:110/1840 train_time:3826ms step_avg:34.78ms
+step:111/1840 train_time:3858ms step_avg:34.76ms
+step:112/1840 train_time:3892ms step_avg:34.75ms
+step:113/1840 train_time:3924ms step_avg:34.73ms
+step:114/1840 train_time:3959ms step_avg:34.73ms
+step:115/1840 train_time:3991ms step_avg:34.70ms
+step:116/1840 train_time:4025ms step_avg:34.70ms
+step:117/1840 train_time:4058ms step_avg:34.68ms
+step:118/1840 train_time:4092ms step_avg:34.68ms
+step:119/1840 train_time:4124ms step_avg:34.66ms
+step:120/1840 train_time:4158ms step_avg:34.65ms
+step:121/1840 train_time:4190ms step_avg:34.63ms
+step:122/1840 train_time:4225ms step_avg:34.63ms
+step:123/1840 train_time:4257ms step_avg:34.61ms
+step:124/1840 train_time:4291ms step_avg:34.60ms
+step:125/1840 train_time:4323ms step_avg:34.59ms
+step:126/1840 train_time:4358ms step_avg:34.58ms
+step:127/1840 train_time:4390ms step_avg:34.56ms
+step:128/1840 train_time:4424ms step_avg:34.56ms
+step:129/1840 train_time:4456ms step_avg:34.54ms
+step:130/1840 train_time:4491ms step_avg:34.54ms
+step:131/1840 train_time:4523ms step_avg:34.52ms
+step:132/1840 train_time:4557ms step_avg:34.52ms
+step:133/1840 train_time:4590ms step_avg:34.51ms
+step:134/1840 train_time:4624ms step_avg:34.51ms
+step:135/1840 train_time:4656ms step_avg:34.49ms
+step:136/1840 train_time:4691ms step_avg:34.49ms
+step:137/1840 train_time:4723ms step_avg:34.47ms
+step:138/1840 train_time:4757ms step_avg:34.47ms
+step:139/1840 train_time:4789ms step_avg:34.46ms
+step:140/1840 train_time:4824ms step_avg:34.45ms
+step:141/1840 train_time:4855ms step_avg:34.44ms
+step:142/1840 train_time:4890ms step_avg:34.44ms
+step:143/1840 train_time:4922ms step_avg:34.42ms
+step:144/1840 train_time:4956ms step_avg:34.42ms
+step:145/1840 train_time:4989ms step_avg:34.40ms
+step:146/1840 train_time:5023ms step_avg:34.40ms
+step:147/1840 train_time:5055ms step_avg:34.39ms
+step:148/1840 train_time:5089ms step_avg:34.38ms
+step:149/1840 train_time:5121ms step_avg:34.37ms
+step:150/1840 train_time:5156ms step_avg:34.37ms
+step:151/1840 train_time:5187ms step_avg:34.35ms
+step:152/1840 train_time:5222ms step_avg:34.35ms
+step:153/1840 train_time:5254ms step_avg:34.34ms
+step:154/1840 train_time:5288ms step_avg:34.34ms
+step:155/1840 train_time:5320ms step_avg:34.32ms
+step:156/1840 train_time:5354ms step_avg:34.32ms
+step:157/1840 train_time:5386ms step_avg:34.31ms
+step:158/1840 train_time:5421ms step_avg:34.31ms
+step:159/1840 train_time:5452ms step_avg:34.29ms
+step:160/1840 train_time:5487ms step_avg:34.29ms
+step:161/1840 train_time:5519ms step_avg:34.28ms
+step:162/1840 train_time:5554ms step_avg:34.28ms
+step:163/1840 train_time:5586ms step_avg:34.27ms
+step:164/1840 train_time:5620ms step_avg:34.27ms
+step:165/1840 train_time:5652ms step_avg:34.25ms
+step:166/1840 train_time:5686ms step_avg:34.25ms
+step:167/1840 train_time:5718ms step_avg:34.24ms
+step:168/1840 train_time:5752ms step_avg:34.24ms
+step:169/1840 train_time:5785ms step_avg:34.23ms
+step:170/1840 train_time:5819ms step_avg:34.23ms
+step:171/1840 train_time:5851ms step_avg:34.22ms
+step:172/1840 train_time:5885ms step_avg:34.22ms
+step:173/1840 train_time:5918ms step_avg:34.21ms
+step:174/1840 train_time:5952ms step_avg:34.21ms
+step:175/1840 train_time:5984ms step_avg:34.20ms
+step:176/1840 train_time:6018ms step_avg:34.20ms
+step:177/1840 train_time:6051ms step_avg:34.18ms
+step:178/1840 train_time:6084ms step_avg:34.18ms
+step:179/1840 train_time:6117ms step_avg:34.17ms
+step:180/1840 train_time:6151ms step_avg:34.17ms
+step:181/1840 train_time:6183ms step_avg:34.16ms
+step:182/1840 train_time:6217ms step_avg:34.16ms
+step:183/1840 train_time:6249ms step_avg:34.15ms
+step:184/1840 train_time:6284ms step_avg:34.15ms
+step:185/1840 train_time:6316ms step_avg:34.14ms
+step:186/1840 train_time:6350ms step_avg:34.14ms
+step:187/1840 train_time:6382ms step_avg:34.13ms
+step:188/1840 train_time:6417ms step_avg:34.13ms
+step:189/1840 train_time:6449ms step_avg:34.12ms
+step:190/1840 train_time:6484ms step_avg:34.13ms
+step:191/1840 train_time:6516ms step_avg:34.12ms
+step:192/1840 train_time:6550ms step_avg:34.12ms
+step:193/1840 train_time:6582ms step_avg:34.10ms
+step:194/1840 train_time:6616ms step_avg:34.10ms
+step:195/1840 train_time:6648ms step_avg:34.09ms
+step:196/1840 train_time:6683ms step_avg:34.10ms
+step:197/1840 train_time:6715ms step_avg:34.09ms
+step:198/1840 train_time:6749ms step_avg:34.09ms
+step:199/1840 train_time:6782ms step_avg:34.08ms
+step:200/1840 train_time:6816ms step_avg:34.08ms
+step:201/1840 train_time:6848ms step_avg:34.07ms
+step:202/1840 train_time:6882ms step_avg:34.07ms
+step:203/1840 train_time:6914ms step_avg:34.06ms
+step:204/1840 train_time:6948ms step_avg:34.06ms
+step:205/1840 train_time:6981ms step_avg:34.05ms
+step:206/1840 train_time:7015ms step_avg:34.05ms
+step:207/1840 train_time:7047ms step_avg:34.04ms
+step:208/1840 train_time:7081ms step_avg:34.04ms
+step:209/1840 train_time:7113ms step_avg:34.03ms
+step:210/1840 train_time:7147ms step_avg:34.03ms
+step:211/1840 train_time:7179ms step_avg:34.03ms
+step:212/1840 train_time:7213ms step_avg:34.03ms
+step:213/1840 train_time:7245ms step_avg:34.02ms
+step:214/1840 train_time:7280ms step_avg:34.02ms
+step:215/1840 train_time:7312ms step_avg:34.01ms
+step:216/1840 train_time:7346ms step_avg:34.01ms
+step:217/1840 train_time:7378ms step_avg:34.00ms
+step:218/1840 train_time:7412ms step_avg:34.00ms
+step:219/1840 train_time:7445ms step_avg:33.99ms
+step:220/1840 train_time:7479ms step_avg:34.00ms
+step:221/1840 train_time:7511ms step_avg:33.99ms
+step:222/1840 train_time:7545ms step_avg:33.99ms
+step:223/1840 train_time:7577ms step_avg:33.98ms
+step:224/1840 train_time:7612ms step_avg:33.98ms
+step:225/1840 train_time:7644ms step_avg:33.97ms
+step:226/1840 train_time:7678ms step_avg:33.97ms
+step:227/1840 train_time:7710ms step_avg:33.96ms
+step:228/1840 train_time:7744ms step_avg:33.97ms
+step:229/1840 train_time:7777ms step_avg:33.96ms
+step:230/1840 train_time:7811ms step_avg:33.96ms
+step:231/1840 train_time:7843ms step_avg:33.95ms
+step:232/1840 train_time:7877ms step_avg:33.95ms
+step:233/1840 train_time:7909ms step_avg:33.95ms
+step:234/1840 train_time:7944ms step_avg:33.95ms
+step:235/1840 train_time:7976ms step_avg:33.94ms
+step:236/1840 train_time:8010ms step_avg:33.94ms
+step:237/1840 train_time:8043ms step_avg:33.94ms
+step:238/1840 train_time:8077ms step_avg:33.94ms
+step:239/1840 train_time:8109ms step_avg:33.93ms
+step:240/1840 train_time:8144ms step_avg:33.93ms
+step:241/1840 train_time:8176ms step_avg:33.92ms
+step:242/1840 train_time:8210ms step_avg:33.92ms
+step:243/1840 train_time:8242ms step_avg:33.92ms
+step:244/1840 train_time:8276ms step_avg:33.92ms
+step:245/1840 train_time:8308ms step_avg:33.91ms
+step:246/1840 train_time:8343ms step_avg:33.91ms
+step:247/1840 train_time:8375ms step_avg:33.91ms
+step:248/1840 train_time:8409ms step_avg:33.91ms
+step:249/1840 train_time:8441ms step_avg:33.90ms
+step:250/1840 train_time:8475ms step_avg:33.90ms
+step:250/1840 val_loss:4.6172 train_time:8518ms step_avg:34.07ms
+step:251/1840 train_time:8537ms step_avg:34.01ms
+step:252/1840 train_time:8556ms step_avg:33.95ms
+step:253/1840 train_time:8576ms step_avg:33.90ms
+step:254/1840 train_time:8612ms step_avg:33.90ms
+step:255/1840 train_time:8646ms step_avg:33.91ms
+step:256/1840 train_time:8681ms step_avg:33.91ms
+step:257/1840 train_time:8713ms step_avg:33.90ms
+step:258/1840 train_time:8748ms step_avg:33.91ms
+step:259/1840 train_time:8780ms step_avg:33.90ms
+step:260/1840 train_time:8814ms step_avg:33.90ms
+step:261/1840 train_time:8846ms step_avg:33.89ms
+step:262/1840 train_time:8880ms step_avg:33.89ms
+step:263/1840 train_time:8912ms step_avg:33.88ms
+step:264/1840 train_time:8946ms step_avg:33.89ms
+step:265/1840 train_time:8978ms step_avg:33.88ms
+step:266/1840 train_time:9012ms step_avg:33.88ms
+step:267/1840 train_time:9044ms step_avg:33.87ms
+step:268/1840 train_time:9078ms step_avg:33.87ms
+step:269/1840 train_time:9110ms step_avg:33.86ms
+step:270/1840 train_time:9144ms step_avg:33.87ms
+step:271/1840 train_time:9175ms step_avg:33.86ms
+step:272/1840 train_time:9209ms step_avg:33.86ms
+step:273/1840 train_time:9242ms step_avg:33.85ms
+step:274/1840 train_time:9276ms step_avg:33.85ms
+step:275/1840 train_time:9308ms step_avg:33.85ms
+step:276/1840 train_time:9342ms step_avg:33.85ms
+step:277/1840 train_time:9373ms step_avg:33.84ms
+step:278/1840 train_time:9408ms step_avg:33.84ms
+step:279/1840 train_time:9440ms step_avg:33.83ms
+step:280/1840 train_time:9474ms step_avg:33.84ms
+step:281/1840 train_time:9507ms step_avg:33.83ms
+step:282/1840 train_time:9542ms step_avg:33.84ms
+step:283/1840 train_time:9575ms step_avg:33.83ms
+step:284/1840 train_time:9609ms step_avg:33.84ms
+step:285/1840 train_time:9642ms step_avg:33.83ms
+step:286/1840 train_time:9676ms step_avg:33.83ms
+step:287/1840 train_time:9709ms step_avg:33.83ms
+step:288/1840 train_time:9743ms step_avg:33.83ms
+step:289/1840 train_time:9775ms step_avg:33.82ms
+step:290/1840 train_time:9810ms step_avg:33.83ms
+step:291/1840 train_time:9842ms step_avg:33.82ms
+step:292/1840 train_time:9876ms step_avg:33.82ms
+step:293/1840 train_time:9908ms step_avg:33.82ms
+step:294/1840 train_time:9943ms step_avg:33.82ms
+step:295/1840 train_time:9974ms step_avg:33.81ms
+step:296/1840 train_time:10008ms step_avg:33.81ms
+step:297/1840 train_time:10040ms step_avg:33.81ms
+step:298/1840 train_time:10074ms step_avg:33.81ms
+step:299/1840 train_time:10106ms step_avg:33.80ms
+step:300/1840 train_time:10140ms step_avg:33.80ms
+step:301/1840 train_time:10172ms step_avg:33.79ms
+step:302/1840 train_time:10206ms step_avg:33.79ms
+step:303/1840 train_time:10238ms step_avg:33.79ms
+step:304/1840 train_time:10272ms step_avg:33.79ms
+step:305/1840 train_time:10304ms step_avg:33.78ms
+step:306/1840 train_time:10338ms step_avg:33.78ms
+step:307/1840 train_time:10370ms step_avg:33.78ms
+step:308/1840 train_time:10404ms step_avg:33.78ms
+step:309/1840 train_time:10436ms step_avg:33.77ms
+step:310/1840 train_time:10471ms step_avg:33.78ms
+step:311/1840 train_time:10503ms step_avg:33.77ms
+step:312/1840 train_time:10537ms step_avg:33.77ms
+step:313/1840 train_time:10570ms step_avg:33.77ms
+step:314/1840 train_time:10604ms step_avg:33.77ms
+step:315/1840 train_time:10636ms step_avg:33.77ms
+step:316/1840 train_time:10671ms step_avg:33.77ms
+step:317/1840 train_time:10703ms step_avg:33.76ms
+step:318/1840 train_time:10737ms step_avg:33.76ms
+step:319/1840 train_time:10769ms step_avg:33.76ms
+step:320/1840 train_time:10804ms step_avg:33.76ms
+step:321/1840 train_time:10836ms step_avg:33.76ms
+step:322/1840 train_time:10870ms step_avg:33.76ms
+step:323/1840 train_time:10903ms step_avg:33.75ms
+step:324/1840 train_time:10937ms step_avg:33.76ms
+step:325/1840 train_time:10969ms step_avg:33.75ms
+step:326/1840 train_time:11003ms step_avg:33.75ms
+step:327/1840 train_time:11035ms step_avg:33.75ms
+step:328/1840 train_time:11069ms step_avg:33.75ms
+step:329/1840 train_time:11101ms step_avg:33.74ms
+step:330/1840 train_time:11135ms step_avg:33.74ms
+step:331/1840 train_time:11168ms step_avg:33.74ms
+step:332/1840 train_time:11202ms step_avg:33.74ms
+step:333/1840 train_time:11234ms step_avg:33.73ms
+step:334/1840 train_time:11268ms step_avg:33.74ms
+step:335/1840 train_time:11300ms step_avg:33.73ms
+step:336/1840 train_time:11334ms step_avg:33.73ms
+step:337/1840 train_time:11366ms step_avg:33.73ms
+step:338/1840 train_time:11400ms step_avg:33.73ms
+step:339/1840 train_time:11432ms step_avg:33.72ms
+step:340/1840 train_time:11467ms step_avg:33.73ms
+step:341/1840 train_time:11499ms step_avg:33.72ms
+step:342/1840 train_time:11533ms step_avg:33.72ms
+step:343/1840 train_time:11565ms step_avg:33.72ms
+step:344/1840 train_time:11599ms step_avg:33.72ms
+step:345/1840 train_time:11632ms step_avg:33.72ms
+step:346/1840 train_time:11666ms step_avg:33.72ms
+step:347/1840 train_time:11698ms step_avg:33.71ms
+step:348/1840 train_time:11733ms step_avg:33.71ms
+step:349/1840 train_time:11765ms step_avg:33.71ms
+step:350/1840 train_time:11800ms step_avg:33.71ms
+step:351/1840 train_time:11832ms step_avg:33.71ms
+step:352/1840 train_time:11866ms step_avg:33.71ms
+step:353/1840 train_time:11898ms step_avg:33.71ms
+step:354/1840 train_time:11932ms step_avg:33.71ms
+step:355/1840 train_time:11965ms step_avg:33.70ms
+step:356/1840 train_time:11999ms step_avg:33.70ms
+step:357/1840 train_time:12031ms step_avg:33.70ms
+step:358/1840 train_time:12065ms step_avg:33.70ms
+step:359/1840 train_time:12097ms step_avg:33.70ms
+step:360/1840 train_time:12132ms step_avg:33.70ms
+step:361/1840 train_time:12164ms step_avg:33.69ms
+step:362/1840 train_time:12198ms step_avg:33.70ms
+step:363/1840 train_time:12230ms step_avg:33.69ms
+step:364/1840 train_time:12264ms step_avg:33.69ms
+step:365/1840 train_time:12296ms step_avg:33.69ms
+step:366/1840 train_time:12330ms step_avg:33.69ms
+step:367/1840 train_time:12362ms step_avg:33.68ms
+step:368/1840 train_time:12396ms step_avg:33.68ms
+step:369/1840 train_time:12428ms step_avg:33.68ms
+step:370/1840 train_time:12462ms step_avg:33.68ms
+step:371/1840 train_time:12494ms step_avg:33.68ms
+step:372/1840 train_time:12528ms step_avg:33.68ms
+step:373/1840 train_time:12560ms step_avg:33.67ms
+step:374/1840 train_time:12595ms step_avg:33.68ms
+step:375/1840 train_time:12627ms step_avg:33.67ms
+step:376/1840 train_time:12662ms step_avg:33.67ms
+step:377/1840 train_time:12694ms step_avg:33.67ms
+step:378/1840 train_time:12728ms step_avg:33.67ms
+step:379/1840 train_time:12760ms step_avg:33.67ms
+step:380/1840 train_time:12795ms step_avg:33.67ms
+step:381/1840 train_time:12827ms step_avg:33.67ms
+step:382/1840 train_time:12861ms step_avg:33.67ms
+step:383/1840 train_time:12893ms step_avg:33.66ms
+step:384/1840 train_time:12928ms step_avg:33.67ms
+step:385/1840 train_time:12960ms step_avg:33.66ms
+step:386/1840 train_time:12994ms step_avg:33.66ms
+step:387/1840 train_time:13026ms step_avg:33.66ms
+step:388/1840 train_time:13060ms step_avg:33.66ms
+step:389/1840 train_time:13092ms step_avg:33.66ms
+step:390/1840 train_time:13126ms step_avg:33.66ms
+step:391/1840 train_time:13158ms step_avg:33.65ms
+step:392/1840 train_time:13192ms step_avg:33.65ms
+step:393/1840 train_time:13225ms step_avg:33.65ms
+step:394/1840 train_time:13259ms step_avg:33.65ms
+step:395/1840 train_time:13291ms step_avg:33.65ms
+step:396/1840 train_time:13325ms step_avg:33.65ms
+step:397/1840 train_time:13357ms step_avg:33.64ms
+step:398/1840 train_time:13391ms step_avg:33.65ms
+step:399/1840 train_time:13423ms step_avg:33.64ms
+step:400/1840 train_time:13457ms step_avg:33.64ms
+step:401/1840 train_time:13489ms step_avg:33.64ms
+step:402/1840 train_time:13524ms step_avg:33.64ms
+step:403/1840 train_time:13556ms step_avg:33.64ms
+step:404/1840 train_time:13590ms step_avg:33.64ms
+step:405/1840 train_time:13623ms step_avg:33.64ms
+step:406/1840 train_time:13657ms step_avg:33.64ms
+step:407/1840 train_time:13689ms step_avg:33.63ms
+step:408/1840 train_time:13723ms step_avg:33.64ms
+step:409/1840 train_time:13755ms step_avg:33.63ms
+step:410/1840 train_time:13790ms step_avg:33.63ms
+step:411/1840 train_time:13822ms step_avg:33.63ms
+step:412/1840 train_time:13856ms step_avg:33.63ms
+step:413/1840 train_time:13888ms step_avg:33.63ms
+step:414/1840 train_time:13922ms step_avg:33.63ms
+step:415/1840 train_time:13954ms step_avg:33.62ms
+step:416/1840 train_time:13988ms step_avg:33.63ms
+step:417/1840 train_time:14020ms step_avg:33.62ms
+step:418/1840 train_time:14055ms step_avg:33.62ms
+step:419/1840 train_time:14087ms step_avg:33.62ms
+step:420/1840 train_time:14122ms step_avg:33.62ms
+step:421/1840 train_time:14154ms step_avg:33.62ms
+step:422/1840 train_time:14188ms step_avg:33.62ms
+step:423/1840 train_time:14220ms step_avg:33.62ms
+step:424/1840 train_time:14254ms step_avg:33.62ms
+step:425/1840 train_time:14287ms step_avg:33.62ms
+step:426/1840 train_time:14321ms step_avg:33.62ms
+step:427/1840 train_time:14353ms step_avg:33.61ms
+step:428/1840 train_time:14388ms step_avg:33.62ms
+step:429/1840 train_time:14420ms step_avg:33.61ms
+step:430/1840 train_time:14454ms step_avg:33.61ms
+step:431/1840 train_time:14486ms step_avg:33.61ms
+step:432/1840 train_time:14520ms step_avg:33.61ms
+step:433/1840 train_time:14552ms step_avg:33.61ms
+step:434/1840 train_time:14587ms step_avg:33.61ms
+step:435/1840 train_time:14619ms step_avg:33.61ms
+step:436/1840 train_time:14654ms step_avg:33.61ms
+step:437/1840 train_time:14686ms step_avg:33.61ms
+step:438/1840 train_time:14720ms step_avg:33.61ms
+step:439/1840 train_time:14752ms step_avg:33.60ms
+step:440/1840 train_time:14787ms step_avg:33.61ms
+step:441/1840 train_time:14820ms step_avg:33.60ms
+step:442/1840 train_time:14854ms step_avg:33.61ms
+step:443/1840 train_time:14886ms step_avg:33.60ms
+step:444/1840 train_time:14921ms step_avg:33.60ms
+step:445/1840 train_time:14953ms step_avg:33.60ms
+step:446/1840 train_time:14987ms step_avg:33.60ms
+step:447/1840 train_time:15019ms step_avg:33.60ms
+step:448/1840 train_time:15053ms step_avg:33.60ms
+step:449/1840 train_time:15086ms step_avg:33.60ms
+step:450/1840 train_time:15120ms step_avg:33.60ms
+step:451/1840 train_time:15152ms step_avg:33.60ms
+step:452/1840 train_time:15186ms step_avg:33.60ms
+step:453/1840 train_time:15219ms step_avg:33.60ms
+step:454/1840 train_time:15253ms step_avg:33.60ms
+step:455/1840 train_time:15285ms step_avg:33.59ms
+step:456/1840 train_time:15319ms step_avg:33.60ms
+step:457/1840 train_time:15351ms step_avg:33.59ms
+step:458/1840 train_time:15386ms step_avg:33.59ms
+step:459/1840 train_time:15418ms step_avg:33.59ms
+step:460/1840 train_time:15452ms step_avg:33.59ms
+step:461/1840 train_time:15484ms step_avg:33.59ms
+step:462/1840 train_time:15518ms step_avg:33.59ms
+step:463/1840 train_time:15550ms step_avg:33.59ms
+step:464/1840 train_time:15585ms step_avg:33.59ms
+step:465/1840 train_time:15617ms step_avg:33.58ms
+step:466/1840 train_time:15651ms step_avg:33.59ms
+step:467/1840 train_time:15683ms step_avg:33.58ms
+step:468/1840 train_time:15717ms step_avg:33.58ms
+step:469/1840 train_time:15749ms step_avg:33.58ms
+step:470/1840 train_time:15784ms step_avg:33.58ms
+step:471/1840 train_time:15816ms step_avg:33.58ms
+step:472/1840 train_time:15850ms step_avg:33.58ms
+step:473/1840 train_time:15883ms step_avg:33.58ms
+step:474/1840 train_time:15917ms step_avg:33.58ms
+step:475/1840 train_time:15949ms step_avg:33.58ms
+step:476/1840 train_time:15984ms step_avg:33.58ms
+step:477/1840 train_time:16016ms step_avg:33.58ms
+step:478/1840 train_time:16051ms step_avg:33.58ms
+step:479/1840 train_time:16083ms step_avg:33.58ms
+step:480/1840 train_time:16117ms step_avg:33.58ms
+step:481/1840 train_time:16149ms step_avg:33.57ms
+step:482/1840 train_time:16183ms step_avg:33.58ms
+step:483/1840 train_time:16215ms step_avg:33.57ms
+step:484/1840 train_time:16250ms step_avg:33.57ms
+step:485/1840 train_time:16282ms step_avg:33.57ms
+step:486/1840 train_time:16316ms step_avg:33.57ms
+step:487/1840 train_time:16348ms step_avg:33.57ms
+step:488/1840 train_time:16383ms step_avg:33.57ms
+step:489/1840 train_time:16415ms step_avg:33.57ms
+step:490/1840 train_time:16449ms step_avg:33.57ms
+step:491/1840 train_time:16481ms step_avg:33.57ms
+step:492/1840 train_time:16516ms step_avg:33.57ms
+step:493/1840 train_time:16547ms step_avg:33.56ms
+step:494/1840 train_time:16582ms step_avg:33.57ms
+step:495/1840 train_time:16613ms step_avg:33.56ms
+step:496/1840 train_time:16648ms step_avg:33.56ms
+step:497/1840 train_time:16680ms step_avg:33.56ms
+step:498/1840 train_time:16714ms step_avg:33.56ms
+step:499/1840 train_time:16747ms step_avg:33.56ms
+step:500/1840 train_time:16781ms step_avg:33.56ms
+step:500/1840 val_loss:4.2832 train_time:16823ms step_avg:33.65ms
+step:501/1840 train_time:16842ms step_avg:33.62ms
+step:502/1840 train_time:16860ms step_avg:33.59ms
+step:503/1840 train_time:16884ms step_avg:33.57ms
+step:504/1840 train_time:16919ms step_avg:33.57ms
+step:505/1840 train_time:16952ms step_avg:33.57ms
+step:506/1840 train_time:16987ms step_avg:33.57ms
+step:507/1840 train_time:17020ms step_avg:33.57ms
+step:508/1840 train_time:17054ms step_avg:33.57ms
+step:509/1840 train_time:17086ms step_avg:33.57ms
+step:510/1840 train_time:17121ms step_avg:33.57ms
+step:511/1840 train_time:17153ms step_avg:33.57ms
+step:512/1840 train_time:17188ms step_avg:33.57ms
+step:513/1840 train_time:17220ms step_avg:33.57ms
+step:514/1840 train_time:17254ms step_avg:33.57ms
+step:515/1840 train_time:17286ms step_avg:33.56ms
+step:516/1840 train_time:17320ms step_avg:33.57ms
+step:517/1840 train_time:17352ms step_avg:33.56ms
+step:518/1840 train_time:17386ms step_avg:33.56ms
+step:519/1840 train_time:17417ms step_avg:33.56ms
+step:520/1840 train_time:17452ms step_avg:33.56ms
+step:521/1840 train_time:17484ms step_avg:33.56ms
+step:522/1840 train_time:17518ms step_avg:33.56ms
+step:523/1840 train_time:17550ms step_avg:33.56ms
+step:524/1840 train_time:17583ms step_avg:33.56ms
+step:525/1840 train_time:17615ms step_avg:33.55ms
+step:526/1840 train_time:17649ms step_avg:33.55ms
+step:527/1840 train_time:17681ms step_avg:33.55ms
+step:528/1840 train_time:17715ms step_avg:33.55ms
+step:529/1840 train_time:17747ms step_avg:33.55ms
+step:530/1840 train_time:17782ms step_avg:33.55ms
+step:531/1840 train_time:17814ms step_avg:33.55ms
+step:532/1840 train_time:17849ms step_avg:33.55ms
+step:533/1840 train_time:17882ms step_avg:33.55ms
+step:534/1840 train_time:17916ms step_avg:33.55ms
+step:535/1840 train_time:17948ms step_avg:33.55ms
+step:536/1840 train_time:17983ms step_avg:33.55ms
+step:537/1840 train_time:18016ms step_avg:33.55ms
+step:538/1840 train_time:18050ms step_avg:33.55ms
+step:539/1840 train_time:18083ms step_avg:33.55ms
+step:540/1840 train_time:18117ms step_avg:33.55ms
+step:541/1840 train_time:18149ms step_avg:33.55ms
+step:542/1840 train_time:18184ms step_avg:33.55ms
+step:543/1840 train_time:18216ms step_avg:33.55ms
+step:544/1840 train_time:18250ms step_avg:33.55ms
+step:545/1840 train_time:18282ms step_avg:33.55ms
+step:546/1840 train_time:18316ms step_avg:33.55ms
+step:547/1840 train_time:18348ms step_avg:33.54ms
+step:548/1840 train_time:18383ms step_avg:33.54ms
+step:549/1840 train_time:18415ms step_avg:33.54ms
+step:550/1840 train_time:18449ms step_avg:33.54ms
+step:551/1840 train_time:18481ms step_avg:33.54ms
+step:552/1840 train_time:18515ms step_avg:33.54ms
+step:553/1840 train_time:18547ms step_avg:33.54ms
+step:554/1840 train_time:18581ms step_avg:33.54ms
+step:555/1840 train_time:18613ms step_avg:33.54ms
+step:556/1840 train_time:18647ms step_avg:33.54ms
+step:557/1840 train_time:18679ms step_avg:33.54ms
+step:558/1840 train_time:18713ms step_avg:33.54ms
+step:559/1840 train_time:18745ms step_avg:33.53ms
+step:560/1840 train_time:18780ms step_avg:33.53ms
+step:561/1840 train_time:18812ms step_avg:33.53ms
+step:562/1840 train_time:18846ms step_avg:33.53ms
+step:563/1840 train_time:18878ms step_avg:33.53ms
+step:564/1840 train_time:18913ms step_avg:33.53ms
+step:565/1840 train_time:18945ms step_avg:33.53ms
+step:566/1840 train_time:18979ms step_avg:33.53ms
+step:567/1840 train_time:19012ms step_avg:33.53ms
+step:568/1840 train_time:19046ms step_avg:33.53ms
+step:569/1840 train_time:19078ms step_avg:33.53ms
+step:570/1840 train_time:19113ms step_avg:33.53ms
+step:571/1840 train_time:19145ms step_avg:33.53ms
+step:572/1840 train_time:19179ms step_avg:33.53ms
+step:573/1840 train_time:19211ms step_avg:33.53ms
+step:574/1840 train_time:19246ms step_avg:33.53ms
+step:575/1840 train_time:19278ms step_avg:33.53ms
+step:576/1840 train_time:19312ms step_avg:33.53ms
+step:577/1840 train_time:19344ms step_avg:33.53ms
+step:578/1840 train_time:19378ms step_avg:33.53ms
+step:579/1840 train_time:19411ms step_avg:33.52ms
+step:580/1840 train_time:19445ms step_avg:33.53ms
+step:581/1840 train_time:19477ms step_avg:33.52ms
+step:582/1840 train_time:19511ms step_avg:33.52ms
+step:583/1840 train_time:19543ms step_avg:33.52ms
+step:584/1840 train_time:19577ms step_avg:33.52ms
+step:585/1840 train_time:19609ms step_avg:33.52ms
+step:586/1840 train_time:19644ms step_avg:33.52ms
+step:587/1840 train_time:19676ms step_avg:33.52ms
+step:588/1840 train_time:19710ms step_avg:33.52ms
+step:589/1840 train_time:19742ms step_avg:33.52ms
+step:590/1840 train_time:19777ms step_avg:33.52ms
+step:591/1840 train_time:19809ms step_avg:33.52ms
+step:592/1840 train_time:19844ms step_avg:33.52ms
+step:593/1840 train_time:19876ms step_avg:33.52ms
+step:594/1840 train_time:19910ms step_avg:33.52ms
+step:595/1840 train_time:19943ms step_avg:33.52ms
+step:596/1840 train_time:19977ms step_avg:33.52ms
+step:597/1840 train_time:20010ms step_avg:33.52ms
+step:598/1840 train_time:20044ms step_avg:33.52ms
+step:599/1840 train_time:20076ms step_avg:33.52ms
+step:600/1840 train_time:20111ms step_avg:33.52ms
+step:601/1840 train_time:20145ms step_avg:33.52ms
+step:602/1840 train_time:20203ms step_avg:33.56ms
+step:603/1840 train_time:20262ms step_avg:33.60ms
+step:604/1840 train_time:20324ms step_avg:33.65ms
+step:605/1840 train_time:20384ms step_avg:33.69ms
+step:606/1840 train_time:20447ms step_avg:33.74ms
+step:607/1840 train_time:20506ms step_avg:33.78ms
+step:608/1840 train_time:20569ms step_avg:33.83ms
+step:609/1840 train_time:20629ms step_avg:33.87ms
+step:610/1840 train_time:20691ms step_avg:33.92ms
+step:611/1840 train_time:20751ms step_avg:33.96ms
+step:612/1840 train_time:20813ms step_avg:34.01ms
+step:613/1840 train_time:20873ms step_avg:34.05ms
+step:614/1840 train_time:20935ms step_avg:34.10ms
+step:615/1840 train_time:20995ms step_avg:34.14ms
+step:616/1840 train_time:21057ms step_avg:34.18ms
+step:617/1840 train_time:21117ms step_avg:34.23ms
+step:618/1840 train_time:21179ms step_avg:34.27ms
+step:619/1840 train_time:21239ms step_avg:34.31ms
+step:620/1840 train_time:21301ms step_avg:34.36ms
+step:621/1840 train_time:21360ms step_avg:34.40ms
+step:622/1840 train_time:21422ms step_avg:34.44ms
+step:623/1840 train_time:21482ms step_avg:34.48ms
+step:624/1840 train_time:21544ms step_avg:34.53ms
+step:625/1840 train_time:21604ms step_avg:34.57ms
+step:626/1840 train_time:21667ms step_avg:34.61ms
+step:627/1840 train_time:21726ms step_avg:34.65ms
+step:628/1840 train_time:21789ms step_avg:34.70ms
+step:629/1840 train_time:21849ms step_avg:34.74ms
+step:630/1840 train_time:21911ms step_avg:34.78ms
+step:631/1840 train_time:21972ms step_avg:34.82ms
+step:632/1840 train_time:22034ms step_avg:34.86ms
+step:633/1840 train_time:22094ms step_avg:34.90ms
+step:634/1840 train_time:22157ms step_avg:34.95ms
+step:635/1840 train_time:22217ms step_avg:34.99ms
+step:636/1840 train_time:22279ms step_avg:35.03ms
+step:637/1840 train_time:22339ms step_avg:35.07ms
+step:638/1840 train_time:22401ms step_avg:35.11ms
+step:639/1840 train_time:22461ms step_avg:35.15ms
+step:640/1840 train_time:22523ms step_avg:35.19ms
+step:641/1840 train_time:22583ms step_avg:35.23ms
+step:642/1840 train_time:22645ms step_avg:35.27ms
+step:643/1840 train_time:22705ms step_avg:35.31ms
+step:644/1840 train_time:22768ms step_avg:35.35ms
+step:645/1840 train_time:22828ms step_avg:35.39ms
+step:646/1840 train_time:22892ms step_avg:35.44ms
+step:647/1840 train_time:22951ms step_avg:35.47ms
+step:648/1840 train_time:23013ms step_avg:35.51ms
+step:649/1840 train_time:23073ms step_avg:35.55ms
+step:650/1840 train_time:23136ms step_avg:35.59ms
+step:651/1840 train_time:23196ms step_avg:35.63ms
+step:652/1840 train_time:23258ms step_avg:35.67ms
+step:653/1840 train_time:23318ms step_avg:35.71ms
+step:654/1840 train_time:23380ms step_avg:35.75ms
+step:655/1840 train_time:23440ms step_avg:35.79ms
+step:656/1840 train_time:23502ms step_avg:35.83ms
+step:657/1840 train_time:23562ms step_avg:35.86ms
+step:658/1840 train_time:23624ms step_avg:35.90ms
+step:659/1840 train_time:23683ms step_avg:35.94ms
+step:660/1840 train_time:23746ms step_avg:35.98ms
+step:661/1840 train_time:23806ms step_avg:36.01ms
+step:662/1840 train_time:23870ms step_avg:36.06ms
+step:663/1840 train_time:23931ms step_avg:36.09ms
+step:664/1840 train_time:23993ms step_avg:36.13ms
+step:665/1840 train_time:24053ms step_avg:36.17ms
+step:666/1840 train_time:24116ms step_avg:36.21ms
+step:667/1840 train_time:24177ms step_avg:36.25ms
+step:668/1840 train_time:24239ms step_avg:36.29ms
+step:669/1840 train_time:24298ms step_avg:36.32ms
+step:670/1840 train_time:24360ms step_avg:36.36ms
+step:671/1840 train_time:24420ms step_avg:36.39ms
+step:672/1840 train_time:24482ms step_avg:36.43ms
+step:673/1840 train_time:24541ms step_avg:36.47ms
+step:674/1840 train_time:24603ms step_avg:36.50ms
+step:675/1840 train_time:24663ms step_avg:36.54ms
+step:676/1840 train_time:24726ms step_avg:36.58ms
+step:677/1840 train_time:24786ms step_avg:36.61ms
+step:678/1840 train_time:24849ms step_avg:36.65ms
+step:679/1840 train_time:24910ms step_avg:36.69ms
+step:680/1840 train_time:24972ms step_avg:36.72ms
+step:681/1840 train_time:25032ms step_avg:36.76ms
+step:682/1840 train_time:25095ms step_avg:36.80ms
+step:683/1840 train_time:25155ms step_avg:36.83ms
+step:684/1840 train_time:25217ms step_avg:36.87ms
+step:685/1840 train_time:25277ms step_avg:36.90ms
+step:686/1840 train_time:25339ms step_avg:36.94ms
+step:687/1840 train_time:25399ms step_avg:36.97ms
+step:688/1840 train_time:25461ms step_avg:37.01ms
+step:689/1840 train_time:25521ms step_avg:37.04ms
+step:690/1840 train_time:25582ms step_avg:37.08ms
+step:691/1840 train_time:25642ms step_avg:37.11ms
+step:692/1840 train_time:25704ms step_avg:37.15ms
+step:693/1840 train_time:25764ms step_avg:37.18ms
+step:694/1840 train_time:25827ms step_avg:37.21ms
+step:695/1840 train_time:25887ms step_avg:37.25ms
+step:696/1840 train_time:25949ms step_avg:37.28ms
+step:697/1840 train_time:26010ms step_avg:37.32ms
+step:698/1840 train_time:26073ms step_avg:37.35ms
+step:699/1840 train_time:26133ms step_avg:37.39ms
+step:700/1840 train_time:26196ms step_avg:37.42ms
+step:701/1840 train_time:26257ms step_avg:37.46ms
+step:702/1840 train_time:26319ms step_avg:37.49ms
+step:703/1840 train_time:26378ms step_avg:37.52ms
+step:704/1840 train_time:26441ms step_avg:37.56ms
+step:705/1840 train_time:26501ms step_avg:37.59ms
+step:706/1840 train_time:26563ms step_avg:37.62ms
+step:707/1840 train_time:26622ms step_avg:37.65ms
+step:708/1840 train_time:26684ms step_avg:37.69ms
+step:709/1840 train_time:26744ms step_avg:37.72ms
+step:710/1840 train_time:26806ms step_avg:37.76ms
+step:711/1840 train_time:26866ms step_avg:37.79ms
+step:712/1840 train_time:26929ms step_avg:37.82ms
+step:713/1840 train_time:26989ms step_avg:37.85ms
+step:714/1840 train_time:27052ms step_avg:37.89ms
+step:715/1840 train_time:27111ms step_avg:37.92ms
+step:716/1840 train_time:27175ms step_avg:37.95ms
+step:717/1840 train_time:27235ms step_avg:37.98ms
+step:718/1840 train_time:27297ms step_avg:38.02ms
+step:719/1840 train_time:27357ms step_avg:38.05ms
+step:720/1840 train_time:27419ms step_avg:38.08ms
+step:721/1840 train_time:27480ms step_avg:38.11ms
+step:722/1840 train_time:27542ms step_avg:38.15ms
+step:723/1840 train_time:27602ms step_avg:38.18ms
+step:724/1840 train_time:27664ms step_avg:38.21ms
+step:725/1840 train_time:27723ms step_avg:38.24ms
+step:726/1840 train_time:27785ms step_avg:38.27ms
+step:727/1840 train_time:27845ms step_avg:38.30ms
+step:728/1840 train_time:27907ms step_avg:38.33ms
+step:729/1840 train_time:27967ms step_avg:38.36ms
+step:730/1840 train_time:28030ms step_avg:38.40ms
+step:731/1840 train_time:28090ms step_avg:38.43ms
+step:732/1840 train_time:28153ms step_avg:38.46ms
+step:733/1840 train_time:28213ms step_avg:38.49ms
+step:734/1840 train_time:28275ms step_avg:38.52ms
+step:735/1840 train_time:28335ms step_avg:38.55ms
+step:736/1840 train_time:28398ms step_avg:38.58ms
+step:737/1840 train_time:28458ms step_avg:38.61ms
+step:738/1840 train_time:28521ms step_avg:38.65ms
+step:739/1840 train_time:28580ms step_avg:38.67ms
+step:740/1840 train_time:28642ms step_avg:38.70ms
+step:741/1840 train_time:28702ms step_avg:38.73ms
+step:742/1840 train_time:28764ms step_avg:38.77ms
+step:743/1840 train_time:28823ms step_avg:38.79ms
+step:744/1840 train_time:28885ms step_avg:38.82ms
+step:745/1840 train_time:28945ms step_avg:38.85ms
+step:746/1840 train_time:29009ms step_avg:38.89ms
+step:747/1840 train_time:29069ms step_avg:38.91ms
+step:748/1840 train_time:29131ms step_avg:38.95ms
+step:749/1840 train_time:29191ms step_avg:38.97ms
+step:750/1840 train_time:29253ms step_avg:39.00ms
+step:750/1840 val_loss:4.0232 train_time:29325ms step_avg:39.10ms
+step:751/1840 train_time:29344ms step_avg:39.07ms
+step:752/1840 train_time:29377ms step_avg:39.06ms
+step:753/1840 train_time:29437ms step_avg:39.09ms
+step:754/1840 train_time:29504ms step_avg:39.13ms
+step:755/1840 train_time:29564ms step_avg:39.16ms
+step:756/1840 train_time:29626ms step_avg:39.19ms
+step:757/1840 train_time:29685ms step_avg:39.21ms
+step:758/1840 train_time:29746ms step_avg:39.24ms
+step:759/1840 train_time:29805ms step_avg:39.27ms
+step:760/1840 train_time:29867ms step_avg:39.30ms
+step:761/1840 train_time:29926ms step_avg:39.32ms
+step:762/1840 train_time:29987ms step_avg:39.35ms
+step:763/1840 train_time:30046ms step_avg:39.38ms
+step:764/1840 train_time:30109ms step_avg:39.41ms
+step:765/1840 train_time:30170ms step_avg:39.44ms
+step:766/1840 train_time:30232ms step_avg:39.47ms
+step:767/1840 train_time:30294ms step_avg:39.50ms
+step:768/1840 train_time:30359ms step_avg:39.53ms
+step:769/1840 train_time:30420ms step_avg:39.56ms
+step:770/1840 train_time:30483ms step_avg:39.59ms
+step:771/1840 train_time:30544ms step_avg:39.62ms
+step:772/1840 train_time:30606ms step_avg:39.65ms
+step:773/1840 train_time:30665ms step_avg:39.67ms
+step:774/1840 train_time:30727ms step_avg:39.70ms
+step:775/1840 train_time:30786ms step_avg:39.72ms
+step:776/1840 train_time:30847ms step_avg:39.75ms
+step:777/1840 train_time:30907ms step_avg:39.78ms
+step:778/1840 train_time:30969ms step_avg:39.81ms
+step:779/1840 train_time:31028ms step_avg:39.83ms
+step:780/1840 train_time:31091ms step_avg:39.86ms
+step:781/1840 train_time:31149ms step_avg:39.88ms
+step:782/1840 train_time:31212ms step_avg:39.91ms
+step:783/1840 train_time:31272ms step_avg:39.94ms
+step:784/1840 train_time:31336ms step_avg:39.97ms
+step:785/1840 train_time:31397ms step_avg:40.00ms
+step:786/1840 train_time:31459ms step_avg:40.02ms
+step:787/1840 train_time:31520ms step_avg:40.05ms
+step:788/1840 train_time:31582ms step_avg:40.08ms
+step:789/1840 train_time:31642ms step_avg:40.10ms
+step:790/1840 train_time:31704ms step_avg:40.13ms
+step:791/1840 train_time:31764ms step_avg:40.16ms
+step:792/1840 train_time:31825ms step_avg:40.18ms
+step:793/1840 train_time:31884ms step_avg:40.21ms
+step:794/1840 train_time:31946ms step_avg:40.23ms
+step:795/1840 train_time:32006ms step_avg:40.26ms
+step:796/1840 train_time:32068ms step_avg:40.29ms
+step:797/1840 train_time:32127ms step_avg:40.31ms
+step:798/1840 train_time:32189ms step_avg:40.34ms
+step:799/1840 train_time:32249ms step_avg:40.36ms
+step:800/1840 train_time:32313ms step_avg:40.39ms
+step:801/1840 train_time:32373ms step_avg:40.42ms
+step:802/1840 train_time:32436ms step_avg:40.44ms
+step:803/1840 train_time:32496ms step_avg:40.47ms
+step:804/1840 train_time:32560ms step_avg:40.50ms
+step:805/1840 train_time:32620ms step_avg:40.52ms
+step:806/1840 train_time:32682ms step_avg:40.55ms
+step:807/1840 train_time:32741ms step_avg:40.57ms
+step:808/1840 train_time:32803ms step_avg:40.60ms
+step:809/1840 train_time:32862ms step_avg:40.62ms
+step:810/1840 train_time:32924ms step_avg:40.65ms
+step:811/1840 train_time:32984ms step_avg:40.67ms
+step:812/1840 train_time:33046ms step_avg:40.70ms
+step:813/1840 train_time:33106ms step_avg:40.72ms
+step:814/1840 train_time:33168ms step_avg:40.75ms
+step:815/1840 train_time:33228ms step_avg:40.77ms
+step:816/1840 train_time:33290ms step_avg:40.80ms
+step:817/1840 train_time:33351ms step_avg:40.82ms
+step:818/1840 train_time:33414ms step_avg:40.85ms
+step:819/1840 train_time:33474ms step_avg:40.87ms
+step:820/1840 train_time:33537ms step_avg:40.90ms
+step:821/1840 train_time:33597ms step_avg:40.92ms
+step:822/1840 train_time:33658ms step_avg:40.95ms
+step:823/1840 train_time:33718ms step_avg:40.97ms
+step:824/1840 train_time:33781ms step_avg:41.00ms
+step:825/1840 train_time:33840ms step_avg:41.02ms
+step:826/1840 train_time:33902ms step_avg:41.04ms
+step:827/1840 train_time:33962ms step_avg:41.07ms
+step:828/1840 train_time:34023ms step_avg:41.09ms
+step:829/1840 train_time:34083ms step_avg:41.11ms
+step:830/1840 train_time:34146ms step_avg:41.14ms
+step:831/1840 train_time:34207ms step_avg:41.16ms
+step:832/1840 train_time:34270ms step_avg:41.19ms
+step:833/1840 train_time:34329ms step_avg:41.21ms
+step:834/1840 train_time:34392ms step_avg:41.24ms
+step:835/1840 train_time:34452ms step_avg:41.26ms
+step:836/1840 train_time:34515ms step_avg:41.29ms
+step:837/1840 train_time:34574ms step_avg:41.31ms
+step:838/1840 train_time:34636ms step_avg:41.33ms
+step:839/1840 train_time:34696ms step_avg:41.35ms
+step:840/1840 train_time:34759ms step_avg:41.38ms
+step:841/1840 train_time:34819ms step_avg:41.40ms
+step:842/1840 train_time:34881ms step_avg:41.43ms
+step:843/1840 train_time:34940ms step_avg:41.45ms
+step:844/1840 train_time:35002ms step_avg:41.47ms
+step:845/1840 train_time:35062ms step_avg:41.49ms
+step:846/1840 train_time:35124ms step_avg:41.52ms
+step:847/1840 train_time:35185ms step_avg:41.54ms
+step:848/1840 train_time:35247ms step_avg:41.56ms
+step:849/1840 train_time:35307ms step_avg:41.59ms
+step:850/1840 train_time:35370ms step_avg:41.61ms
+step:851/1840 train_time:35429ms step_avg:41.63ms
+step:852/1840 train_time:35491ms step_avg:41.66ms
+step:853/1840 train_time:35551ms step_avg:41.68ms
+step:854/1840 train_time:35615ms step_avg:41.70ms
+step:855/1840 train_time:35674ms step_avg:41.72ms
+step:856/1840 train_time:35736ms step_avg:41.75ms
+step:857/1840 train_time:35796ms step_avg:41.77ms
+step:858/1840 train_time:35858ms step_avg:41.79ms
+step:859/1840 train_time:35918ms step_avg:41.81ms
+step:860/1840 train_time:35981ms step_avg:41.84ms
+step:861/1840 train_time:36041ms step_avg:41.86ms
+step:862/1840 train_time:36104ms step_avg:41.88ms
+step:863/1840 train_time:36165ms step_avg:41.91ms
+step:864/1840 train_time:36227ms step_avg:41.93ms
+step:865/1840 train_time:36287ms step_avg:41.95ms
+step:866/1840 train_time:36349ms step_avg:41.97ms
+step:867/1840 train_time:36409ms step_avg:41.99ms
+step:868/1840 train_time:36470ms step_avg:42.02ms
+step:869/1840 train_time:36530ms step_avg:42.04ms
+step:870/1840 train_time:36592ms step_avg:42.06ms
+step:871/1840 train_time:36652ms step_avg:42.08ms
+step:872/1840 train_time:36714ms step_avg:42.10ms
+step:873/1840 train_time:36774ms step_avg:42.12ms
+step:874/1840 train_time:36837ms step_avg:42.15ms
+step:875/1840 train_time:36897ms step_avg:42.17ms
+step:876/1840 train_time:36960ms step_avg:42.19ms
+step:877/1840 train_time:37020ms step_avg:42.21ms
+step:878/1840 train_time:37082ms step_avg:42.23ms
+step:879/1840 train_time:37142ms step_avg:42.25ms
+step:880/1840 train_time:37204ms step_avg:42.28ms
+step:881/1840 train_time:37264ms step_avg:42.30ms
+step:882/1840 train_time:37327ms step_avg:42.32ms
+step:883/1840 train_time:37388ms step_avg:42.34ms
+step:884/1840 train_time:37449ms step_avg:42.36ms
+step:885/1840 train_time:37509ms step_avg:42.38ms
+step:886/1840 train_time:37571ms step_avg:42.41ms
+step:887/1840 train_time:37632ms step_avg:42.43ms
+step:888/1840 train_time:37693ms step_avg:42.45ms
+step:889/1840 train_time:37753ms step_avg:42.47ms
+step:890/1840 train_time:37816ms step_avg:42.49ms
+step:891/1840 train_time:37875ms step_avg:42.51ms
+step:892/1840 train_time:37938ms step_avg:42.53ms
+step:893/1840 train_time:37998ms step_avg:42.55ms
+step:894/1840 train_time:38061ms step_avg:42.57ms
+step:895/1840 train_time:38122ms step_avg:42.59ms
+step:896/1840 train_time:38184ms step_avg:42.62ms
+step:897/1840 train_time:38244ms step_avg:42.64ms
+step:898/1840 train_time:38306ms step_avg:42.66ms
+step:899/1840 train_time:38366ms step_avg:42.68ms
+step:900/1840 train_time:38428ms step_avg:42.70ms
+step:901/1840 train_time:38488ms step_avg:42.72ms
+step:902/1840 train_time:38550ms step_avg:42.74ms
+step:903/1840 train_time:38610ms step_avg:42.76ms
+step:904/1840 train_time:38671ms step_avg:42.78ms
+step:905/1840 train_time:38732ms step_avg:42.80ms
+step:906/1840 train_time:38794ms step_avg:42.82ms
+step:907/1840 train_time:38853ms step_avg:42.84ms
+step:908/1840 train_time:38917ms step_avg:42.86ms
+step:909/1840 train_time:38977ms step_avg:42.88ms
+step:910/1840 train_time:39040ms step_avg:42.90ms
+step:911/1840 train_time:39099ms step_avg:42.92ms
+step:912/1840 train_time:39162ms step_avg:42.94ms
+step:913/1840 train_time:39222ms step_avg:42.96ms
+step:914/1840 train_time:39284ms step_avg:42.98ms
+step:915/1840 train_time:39344ms step_avg:43.00ms
+step:916/1840 train_time:39407ms step_avg:43.02ms
+step:917/1840 train_time:39467ms step_avg:43.04ms
+step:918/1840 train_time:39529ms step_avg:43.06ms
+step:919/1840 train_time:39589ms step_avg:43.08ms
+step:920/1840 train_time:39651ms step_avg:43.10ms
+step:921/1840 train_time:39711ms step_avg:43.12ms
+step:922/1840 train_time:39773ms step_avg:43.14ms
+step:923/1840 train_time:39833ms step_avg:43.16ms
+step:924/1840 train_time:39896ms step_avg:43.18ms
+step:925/1840 train_time:39956ms step_avg:43.20ms
+step:926/1840 train_time:40018ms step_avg:43.22ms
+step:927/1840 train_time:40078ms step_avg:43.23ms
+step:928/1840 train_time:40141ms step_avg:43.26ms
+step:929/1840 train_time:40201ms step_avg:43.27ms
+step:930/1840 train_time:40263ms step_avg:43.29ms
+step:931/1840 train_time:40323ms step_avg:43.31ms
+step:932/1840 train_time:40386ms step_avg:43.33ms
+step:933/1840 train_time:40446ms step_avg:43.35ms
+step:934/1840 train_time:40509ms step_avg:43.37ms
+step:935/1840 train_time:40568ms step_avg:43.39ms
+step:936/1840 train_time:40630ms step_avg:43.41ms
+step:937/1840 train_time:40690ms step_avg:43.43ms
+step:938/1840 train_time:40752ms step_avg:43.45ms
+step:939/1840 train_time:40811ms step_avg:43.46ms
+step:940/1840 train_time:40873ms step_avg:43.48ms
+step:941/1840 train_time:40933ms step_avg:43.50ms
+step:942/1840 train_time:40996ms step_avg:43.52ms
+step:943/1840 train_time:41055ms step_avg:43.54ms
+step:944/1840 train_time:41119ms step_avg:43.56ms
+step:945/1840 train_time:41179ms step_avg:43.58ms
+step:946/1840 train_time:41241ms step_avg:43.60ms
+step:947/1840 train_time:41301ms step_avg:43.61ms
+step:948/1840 train_time:41364ms step_avg:43.63ms
+step:949/1840 train_time:41424ms step_avg:43.65ms
+step:950/1840 train_time:41487ms step_avg:43.67ms
+step:951/1840 train_time:41548ms step_avg:43.69ms
+step:952/1840 train_time:41610ms step_avg:43.71ms
+step:953/1840 train_time:41669ms step_avg:43.72ms
+step:954/1840 train_time:41731ms step_avg:43.74ms
+step:955/1840 train_time:41791ms step_avg:43.76ms
+step:956/1840 train_time:41853ms step_avg:43.78ms
+step:957/1840 train_time:41913ms step_avg:43.80ms
+step:958/1840 train_time:41975ms step_avg:43.82ms
+step:959/1840 train_time:42035ms step_avg:43.83ms
+step:960/1840 train_time:42097ms step_avg:43.85ms
+step:961/1840 train_time:42158ms step_avg:43.87ms
+step:962/1840 train_time:42220ms step_avg:43.89ms
+step:963/1840 train_time:42279ms step_avg:43.90ms
+step:964/1840 train_time:42342ms step_avg:43.92ms
+step:965/1840 train_time:42402ms step_avg:43.94ms
+step:966/1840 train_time:42466ms step_avg:43.96ms
+step:967/1840 train_time:42526ms step_avg:43.98ms
+step:968/1840 train_time:42589ms step_avg:44.00ms
+step:969/1840 train_time:42648ms step_avg:44.01ms
+step:970/1840 train_time:42710ms step_avg:44.03ms
+step:971/1840 train_time:42771ms step_avg:44.05ms
+step:972/1840 train_time:42832ms step_avg:44.07ms
+step:973/1840 train_time:42892ms step_avg:44.08ms
+step:974/1840 train_time:42954ms step_avg:44.10ms
+step:975/1840 train_time:43014ms step_avg:44.12ms
+step:976/1840 train_time:43076ms step_avg:44.13ms
+step:977/1840 train_time:43136ms step_avg:44.15ms
+step:978/1840 train_time:43198ms step_avg:44.17ms
+step:979/1840 train_time:43259ms step_avg:44.19ms
+step:980/1840 train_time:43321ms step_avg:44.20ms
+step:981/1840 train_time:43381ms step_avg:44.22ms
+step:982/1840 train_time:43444ms step_avg:44.24ms
+step:983/1840 train_time:43504ms step_avg:44.26ms
+step:984/1840 train_time:43567ms step_avg:44.28ms
+step:985/1840 train_time:43627ms step_avg:44.29ms
+step:986/1840 train_time:43689ms step_avg:44.31ms
+step:987/1840 train_time:43749ms step_avg:44.33ms
+step:988/1840 train_time:43811ms step_avg:44.34ms
+step:989/1840 train_time:43870ms step_avg:44.36ms
+step:990/1840 train_time:43932ms step_avg:44.38ms
+step:991/1840 train_time:43993ms step_avg:44.39ms
+step:992/1840 train_time:44055ms step_avg:44.41ms
+step:993/1840 train_time:44115ms step_avg:44.43ms
+step:994/1840 train_time:44178ms step_avg:44.44ms
+step:995/1840 train_time:44238ms step_avg:44.46ms
+step:996/1840 train_time:44300ms step_avg:44.48ms
+step:997/1840 train_time:44360ms step_avg:44.49ms
+step:998/1840 train_time:44423ms step_avg:44.51ms
+step:999/1840 train_time:44483ms step_avg:44.53ms
+step:1000/1840 train_time:44545ms step_avg:44.54ms
+step:1000/1840 val_loss:3.7747 train_time:44616ms step_avg:44.62ms
+step:1001/1840 train_time:44635ms step_avg:44.59ms
+step:1002/1840 train_time:44668ms step_avg:44.58ms
+step:1003/1840 train_time:44730ms step_avg:44.60ms
+step:1004/1840 train_time:44798ms step_avg:44.62ms
+step:1005/1840 train_time:44857ms step_avg:44.63ms
+step:1006/1840 train_time:44919ms step_avg:44.65ms
+step:1007/1840 train_time:44978ms step_avg:44.67ms
+step:1008/1840 train_time:45039ms step_avg:44.68ms
+step:1009/1840 train_time:45099ms step_avg:44.70ms
+step:1010/1840 train_time:45160ms step_avg:44.71ms
+step:1011/1840 train_time:45219ms step_avg:44.73ms
+step:1012/1840 train_time:45282ms step_avg:44.75ms
+step:1013/1840 train_time:45341ms step_avg:44.76ms
+step:1014/1840 train_time:45402ms step_avg:44.78ms
+step:1015/1840 train_time:45462ms step_avg:44.79ms
+step:1016/1840 train_time:45523ms step_avg:44.81ms
+step:1017/1840 train_time:45585ms step_avg:44.82ms
+step:1018/1840 train_time:45650ms step_avg:44.84ms
+step:1019/1840 train_time:45712ms step_avg:44.86ms
+step:1020/1840 train_time:45776ms step_avg:44.88ms
+step:1021/1840 train_time:45835ms step_avg:44.89ms
+step:1022/1840 train_time:45897ms step_avg:44.91ms
+step:1023/1840 train_time:45957ms step_avg:44.92ms
+step:1024/1840 train_time:46018ms step_avg:44.94ms
+step:1025/1840 train_time:46077ms step_avg:44.95ms
+step:1026/1840 train_time:46140ms step_avg:44.97ms
+step:1027/1840 train_time:46199ms step_avg:44.98ms
+step:1028/1840 train_time:46260ms step_avg:45.00ms
+step:1029/1840 train_time:46320ms step_avg:45.01ms
+step:1030/1840 train_time:46382ms step_avg:45.03ms
+step:1031/1840 train_time:46441ms step_avg:45.05ms
+step:1032/1840 train_time:46504ms step_avg:45.06ms
+step:1033/1840 train_time:46564ms step_avg:45.08ms
+step:1034/1840 train_time:46628ms step_avg:45.09ms
+step:1035/1840 train_time:46689ms step_avg:45.11ms
+step:1036/1840 train_time:46752ms step_avg:45.13ms
+step:1037/1840 train_time:46813ms step_avg:45.14ms
+step:1038/1840 train_time:46875ms step_avg:45.16ms
+step:1039/1840 train_time:46935ms step_avg:45.17ms
+step:1040/1840 train_time:46997ms step_avg:45.19ms
+step:1041/1840 train_time:47055ms step_avg:45.20ms
+step:1042/1840 train_time:47118ms step_avg:45.22ms
+step:1043/1840 train_time:47176ms step_avg:45.23ms
+step:1044/1840 train_time:47238ms step_avg:45.25ms
+step:1045/1840 train_time:47298ms step_avg:45.26ms
+step:1046/1840 train_time:47359ms step_avg:45.28ms
+step:1047/1840 train_time:47419ms step_avg:45.29ms
+step:1048/1840 train_time:47481ms step_avg:45.31ms
+step:1049/1840 train_time:47541ms step_avg:45.32ms
+step:1050/1840 train_time:47604ms step_avg:45.34ms
+step:1051/1840 train_time:47664ms step_avg:45.35ms
+step:1052/1840 train_time:47728ms step_avg:45.37ms
+step:1053/1840 train_time:47789ms step_avg:45.38ms
+step:1054/1840 train_time:47851ms step_avg:45.40ms
+step:1055/1840 train_time:47912ms step_avg:45.41ms
+step:1056/1840 train_time:47974ms step_avg:45.43ms
+step:1057/1840 train_time:48034ms step_avg:45.44ms
+step:1058/1840 train_time:48096ms step_avg:45.46ms
+step:1059/1840 train_time:48155ms step_avg:45.47ms
+step:1060/1840 train_time:48217ms step_avg:45.49ms
+step:1061/1840 train_time:48276ms step_avg:45.50ms
+step:1062/1840 train_time:48339ms step_avg:45.52ms
+step:1063/1840 train_time:48398ms step_avg:45.53ms
+step:1064/1840 train_time:48460ms step_avg:45.55ms
+step:1065/1840 train_time:48520ms step_avg:45.56ms
+step:1066/1840 train_time:48583ms step_avg:45.57ms
+step:1067/1840 train_time:48643ms step_avg:45.59ms
+step:1068/1840 train_time:48706ms step_avg:45.61ms
+step:1069/1840 train_time:48767ms step_avg:45.62ms
+step:1070/1840 train_time:48830ms step_avg:45.64ms
+step:1071/1840 train_time:48890ms step_avg:45.65ms
+step:1072/1840 train_time:48952ms step_avg:45.66ms
+step:1073/1840 train_time:49013ms step_avg:45.68ms
+step:1074/1840 train_time:49075ms step_avg:45.69ms
+step:1075/1840 train_time:49134ms step_avg:45.71ms
+step:1076/1840 train_time:49196ms step_avg:45.72ms
+step:1077/1840 train_time:49256ms step_avg:45.73ms
+step:1078/1840 train_time:49318ms step_avg:45.75ms
+step:1079/1840 train_time:49377ms step_avg:45.76ms
+step:1080/1840 train_time:49439ms step_avg:45.78ms
+step:1081/1840 train_time:49498ms step_avg:45.79ms
+step:1082/1840 train_time:49560ms step_avg:45.80ms
+step:1083/1840 train_time:49621ms step_avg:45.82ms
+step:1084/1840 train_time:49684ms step_avg:45.83ms
+step:1085/1840 train_time:49745ms step_avg:45.85ms
+step:1086/1840 train_time:49808ms step_avg:45.86ms
+step:1087/1840 train_time:49867ms step_avg:45.88ms
+step:1088/1840 train_time:49930ms step_avg:45.89ms
+step:1089/1840 train_time:49991ms step_avg:45.91ms
+step:1090/1840 train_time:50053ms step_avg:45.92ms
+step:1091/1840 train_time:50113ms step_avg:45.93ms
+step:1092/1840 train_time:50175ms step_avg:45.95ms
+step:1093/1840 train_time:50234ms step_avg:45.96ms
+step:1094/1840 train_time:50297ms step_avg:45.98ms
+step:1095/1840 train_time:50357ms step_avg:45.99ms
+step:1096/1840 train_time:50419ms step_avg:46.00ms
+step:1097/1840 train_time:50477ms step_avg:46.01ms
+step:1098/1840 train_time:50540ms step_avg:46.03ms
+step:1099/1840 train_time:50599ms step_avg:46.04ms
+step:1100/1840 train_time:50663ms step_avg:46.06ms
+step:1101/1840 train_time:50723ms step_avg:46.07ms
+step:1102/1840 train_time:50786ms step_avg:46.09ms
+step:1103/1840 train_time:50846ms step_avg:46.10ms
+step:1104/1840 train_time:50910ms step_avg:46.11ms
+step:1105/1840 train_time:50970ms step_avg:46.13ms
+step:1106/1840 train_time:51033ms step_avg:46.14ms
+step:1107/1840 train_time:51093ms step_avg:46.15ms
+step:1108/1840 train_time:51155ms step_avg:46.17ms
+step:1109/1840 train_time:51214ms step_avg:46.18ms
+step:1110/1840 train_time:51276ms step_avg:46.19ms
+step:1111/1840 train_time:51335ms step_avg:46.21ms
+step:1112/1840 train_time:51397ms step_avg:46.22ms
+step:1113/1840 train_time:51458ms step_avg:46.23ms
+step:1114/1840 train_time:51520ms step_avg:46.25ms
+step:1115/1840 train_time:51580ms step_avg:46.26ms
+step:1116/1840 train_time:51643ms step_avg:46.28ms
+step:1117/1840 train_time:51703ms step_avg:46.29ms
+step:1118/1840 train_time:51766ms step_avg:46.30ms
+step:1119/1840 train_time:51827ms step_avg:46.32ms
+step:1120/1840 train_time:51890ms step_avg:46.33ms
+step:1121/1840 train_time:51949ms step_avg:46.34ms
+step:1122/1840 train_time:52013ms step_avg:46.36ms
+step:1123/1840 train_time:52073ms step_avg:46.37ms
+step:1124/1840 train_time:52135ms step_avg:46.38ms
+step:1125/1840 train_time:52194ms step_avg:46.39ms
+step:1126/1840 train_time:52256ms step_avg:46.41ms
+step:1127/1840 train_time:52315ms step_avg:46.42ms
+step:1128/1840 train_time:52377ms step_avg:46.43ms
+step:1129/1840 train_time:52436ms step_avg:46.44ms
+step:1130/1840 train_time:52499ms step_avg:46.46ms
+step:1131/1840 train_time:52559ms step_avg:46.47ms
+step:1132/1840 train_time:52623ms step_avg:46.49ms
+step:1133/1840 train_time:52683ms step_avg:46.50ms
+step:1134/1840 train_time:52745ms step_avg:46.51ms
+step:1135/1840 train_time:52806ms step_avg:46.52ms
+step:1136/1840 train_time:52868ms step_avg:46.54ms
+step:1137/1840 train_time:52928ms step_avg:46.55ms
+step:1138/1840 train_time:52991ms step_avg:46.57ms
+step:1139/1840 train_time:53051ms step_avg:46.58ms
+step:1140/1840 train_time:53114ms step_avg:46.59ms
+step:1141/1840 train_time:53174ms step_avg:46.60ms
+step:1142/1840 train_time:53236ms step_avg:46.62ms
+step:1143/1840 train_time:53296ms step_avg:46.63ms
+step:1144/1840 train_time:53357ms step_avg:46.64ms
+step:1145/1840 train_time:53417ms step_avg:46.65ms
+step:1146/1840 train_time:53479ms step_avg:46.67ms
+step:1147/1840 train_time:53538ms step_avg:46.68ms
+step:1148/1840 train_time:53600ms step_avg:46.69ms
+step:1149/1840 train_time:53660ms step_avg:46.70ms
+step:1150/1840 train_time:53724ms step_avg:46.72ms
+step:1151/1840 train_time:53784ms step_avg:46.73ms
+step:1152/1840 train_time:53847ms step_avg:46.74ms
+step:1153/1840 train_time:53908ms step_avg:46.75ms
+step:1154/1840 train_time:53971ms step_avg:46.77ms
+step:1155/1840 train_time:54030ms step_avg:46.78ms
+step:1156/1840 train_time:54093ms step_avg:46.79ms
+step:1157/1840 train_time:54153ms step_avg:46.80ms
+step:1158/1840 train_time:54215ms step_avg:46.82ms
+step:1159/1840 train_time:54275ms step_avg:46.83ms
+step:1160/1840 train_time:54337ms step_avg:46.84ms
+step:1161/1840 train_time:54397ms step_avg:46.85ms
+step:1162/1840 train_time:54458ms step_avg:46.87ms
+step:1163/1840 train_time:54519ms step_avg:46.88ms
+step:1164/1840 train_time:54580ms step_avg:46.89ms
+step:1165/1840 train_time:54640ms step_avg:46.90ms
+step:1166/1840 train_time:54703ms step_avg:46.91ms
+step:1167/1840 train_time:54763ms step_avg:46.93ms
+step:1168/1840 train_time:54826ms step_avg:46.94ms
+step:1169/1840 train_time:54886ms step_avg:46.95ms
+step:1170/1840 train_time:54948ms step_avg:46.96ms
+step:1171/1840 train_time:55008ms step_avg:46.98ms
+step:1172/1840 train_time:55070ms step_avg:46.99ms
+step:1173/1840 train_time:55130ms step_avg:47.00ms
+step:1174/1840 train_time:55192ms step_avg:47.01ms
+step:1175/1840 train_time:55253ms step_avg:47.02ms
+step:1176/1840 train_time:55314ms step_avg:47.04ms
+step:1177/1840 train_time:55375ms step_avg:47.05ms
+step:1178/1840 train_time:55437ms step_avg:47.06ms
+step:1179/1840 train_time:55497ms step_avg:47.07ms
+step:1180/1840 train_time:55559ms step_avg:47.08ms
+step:1181/1840 train_time:55619ms step_avg:47.09ms
+step:1182/1840 train_time:55680ms step_avg:47.11ms
+step:1183/1840 train_time:55741ms step_avg:47.12ms
+step:1184/1840 train_time:55804ms step_avg:47.13ms
+step:1185/1840 train_time:55864ms step_avg:47.14ms
+step:1186/1840 train_time:55927ms step_avg:47.16ms
+step:1187/1840 train_time:55987ms step_avg:47.17ms
+step:1188/1840 train_time:56049ms step_avg:47.18ms
+step:1189/1840 train_time:56109ms step_avg:47.19ms
+step:1190/1840 train_time:56171ms step_avg:47.20ms
+step:1191/1840 train_time:56231ms step_avg:47.21ms
+step:1192/1840 train_time:56294ms step_avg:47.23ms
+step:1193/1840 train_time:56354ms step_avg:47.24ms
+step:1194/1840 train_time:56417ms step_avg:47.25ms
+step:1195/1840 train_time:56476ms step_avg:47.26ms
+step:1196/1840 train_time:56539ms step_avg:47.27ms
+step:1197/1840 train_time:56598ms step_avg:47.28ms
+step:1198/1840 train_time:56660ms step_avg:47.30ms
+step:1199/1840 train_time:56720ms step_avg:47.31ms
+step:1200/1840 train_time:56783ms step_avg:47.32ms
+step:1201/1840 train_time:56844ms step_avg:47.33ms
+step:1202/1840 train_time:56928ms step_avg:47.36ms
+step:1203/1840 train_time:57017ms step_avg:47.40ms
+step:1204/1840 train_time:57107ms step_avg:47.43ms
+step:1205/1840 train_time:57196ms step_avg:47.47ms
+step:1206/1840 train_time:57286ms step_avg:47.50ms
+step:1207/1840 train_time:57373ms step_avg:47.53ms
+step:1208/1840 train_time:57462ms step_avg:47.57ms
+step:1209/1840 train_time:57548ms step_avg:47.60ms
+step:1210/1840 train_time:57637ms step_avg:47.63ms
+step:1211/1840 train_time:57723ms step_avg:47.67ms
+step:1212/1840 train_time:57811ms step_avg:47.70ms
+step:1213/1840 train_time:57898ms step_avg:47.73ms
+step:1214/1840 train_time:57987ms step_avg:47.77ms
+step:1215/1840 train_time:58074ms step_avg:47.80ms
+step:1216/1840 train_time:58163ms step_avg:47.83ms
+step:1217/1840 train_time:58251ms step_avg:47.86ms
+step:1218/1840 train_time:58342ms step_avg:47.90ms
+step:1219/1840 train_time:58427ms step_avg:47.93ms
+step:1220/1840 train_time:58516ms step_avg:47.96ms
+step:1221/1840 train_time:58603ms step_avg:48.00ms
+step:1222/1840 train_time:58691ms step_avg:48.03ms
+step:1223/1840 train_time:58776ms step_avg:48.06ms
+step:1224/1840 train_time:58864ms step_avg:48.09ms
+step:1225/1840 train_time:58952ms step_avg:48.12ms
+step:1226/1840 train_time:59041ms step_avg:48.16ms
+step:1227/1840 train_time:59127ms step_avg:48.19ms
+step:1228/1840 train_time:59218ms step_avg:48.22ms
+step:1229/1840 train_time:59304ms step_avg:48.25ms
+step:1230/1840 train_time:59393ms step_avg:48.29ms
+step:1231/1840 train_time:59481ms step_avg:48.32ms
+step:1232/1840 train_time:59569ms step_avg:48.35ms
+step:1233/1840 train_time:59655ms step_avg:48.38ms
+step:1234/1840 train_time:59744ms step_avg:48.41ms
+step:1235/1840 train_time:59829ms step_avg:48.44ms
+step:1236/1840 train_time:59919ms step_avg:48.48ms
+step:1237/1840 train_time:60004ms step_avg:48.51ms
+step:1238/1840 train_time:60096ms step_avg:48.54ms
+step:1239/1840 train_time:60182ms step_avg:48.57ms
+step:1240/1840 train_time:60270ms step_avg:48.60ms
+step:1241/1840 train_time:60355ms step_avg:48.63ms
+step:1242/1840 train_time:60445ms step_avg:48.67ms
+step:1243/1840 train_time:60531ms step_avg:48.70ms
+step:1244/1840 train_time:60620ms step_avg:48.73ms
+step:1245/1840 train_time:60706ms step_avg:48.76ms
+step:1246/1840 train_time:60795ms step_avg:48.79ms
+step:1247/1840 train_time:60882ms step_avg:48.82ms
+step:1248/1840 train_time:60969ms step_avg:48.85ms
+step:1249/1840 train_time:61056ms step_avg:48.88ms
+step:1250/1840 train_time:61145ms step_avg:48.92ms
+step:1250/1840 val_loss:3.5343 train_time:61246ms step_avg:49.00ms
+step:1251/1840 train_time:61266ms step_avg:48.97ms
+step:1252/1840 train_time:61322ms step_avg:48.98ms
+step:1253/1840 train_time:61411ms step_avg:49.01ms
+step:1254/1840 train_time:61502ms step_avg:49.04ms
+step:1255/1840 train_time:61587ms step_avg:49.07ms
+step:1256/1840 train_time:61676ms step_avg:49.11ms
+step:1257/1840 train_time:61761ms step_avg:49.13ms
+step:1258/1840 train_time:61848ms step_avg:49.16ms
+step:1259/1840 train_time:61934ms step_avg:49.19ms
+step:1260/1840 train_time:62023ms step_avg:49.22ms
+step:1261/1840 train_time:62108ms step_avg:49.25ms
+step:1262/1840 train_time:62199ms step_avg:49.29ms
+step:1263/1840 train_time:62288ms step_avg:49.32ms
+step:1264/1840 train_time:62381ms step_avg:49.35ms
+step:1265/1840 train_time:62468ms step_avg:49.38ms
+step:1266/1840 train_time:62558ms step_avg:49.41ms
+step:1267/1840 train_time:62643ms step_avg:49.44ms
+step:1268/1840 train_time:62732ms step_avg:49.47ms
+step:1269/1840 train_time:62817ms step_avg:49.50ms
+step:1270/1840 train_time:62905ms step_avg:49.53ms
+step:1271/1840 train_time:62990ms step_avg:49.56ms
+step:1272/1840 train_time:63079ms step_avg:49.59ms
+step:1273/1840 train_time:63166ms step_avg:49.62ms
+step:1274/1840 train_time:63257ms step_avg:49.65ms
+step:1275/1840 train_time:63347ms step_avg:49.68ms
+step:1276/1840 train_time:63436ms step_avg:49.71ms
+step:1277/1840 train_time:63523ms step_avg:49.74ms
+step:1278/1840 train_time:63611ms step_avg:49.77ms
+step:1279/1840 train_time:63696ms step_avg:49.80ms
+step:1280/1840 train_time:63785ms step_avg:49.83ms
+step:1281/1840 train_time:63870ms step_avg:49.86ms
+step:1282/1840 train_time:63958ms step_avg:49.89ms
+step:1283/1840 train_time:64043ms step_avg:49.92ms
+step:1284/1840 train_time:64132ms step_avg:49.95ms
+step:1285/1840 train_time:64218ms step_avg:49.98ms
+step:1286/1840 train_time:64308ms step_avg:50.01ms
+step:1287/1840 train_time:64395ms step_avg:50.04ms
+step:1288/1840 train_time:64485ms step_avg:50.07ms
+step:1289/1840 train_time:64570ms step_avg:50.09ms
+step:1290/1840 train_time:64659ms step_avg:50.12ms
+step:1291/1840 train_time:64745ms step_avg:50.15ms
+step:1292/1840 train_time:64833ms step_avg:50.18ms
+step:1293/1840 train_time:64919ms step_avg:50.21ms
+step:1294/1840 train_time:65007ms step_avg:50.24ms
+step:1295/1840 train_time:65092ms step_avg:50.26ms
+step:1296/1840 train_time:65184ms step_avg:50.30ms
+step:1297/1840 train_time:65270ms step_avg:50.32ms
+step:1298/1840 train_time:65361ms step_avg:50.36ms
+step:1299/1840 train_time:65447ms step_avg:50.38ms
+step:1300/1840 train_time:65536ms step_avg:50.41ms
+step:1301/1840 train_time:65623ms step_avg:50.44ms
+step:1302/1840 train_time:65712ms step_avg:50.47ms
+step:1303/1840 train_time:65797ms step_avg:50.50ms
+step:1304/1840 train_time:65885ms step_avg:50.53ms
+step:1305/1840 train_time:65971ms step_avg:50.55ms
+step:1306/1840 train_time:66060ms step_avg:50.58ms
+step:1307/1840 train_time:66147ms step_avg:50.61ms
+step:1308/1840 train_time:66236ms step_avg:50.64ms
+step:1309/1840 train_time:66323ms step_avg:50.67ms
+step:1310/1840 train_time:66410ms step_avg:50.69ms
+step:1311/1840 train_time:66497ms step_avg:50.72ms
+step:1312/1840 train_time:66584ms step_avg:50.75ms
+step:1313/1840 train_time:66671ms step_avg:50.78ms
+step:1314/1840 train_time:66760ms step_avg:50.81ms
+step:1315/1840 train_time:66845ms step_avg:50.83ms
+step:1316/1840 train_time:66935ms step_avg:50.86ms
+step:1317/1840 train_time:67021ms step_avg:50.89ms
+step:1318/1840 train_time:67108ms step_avg:50.92ms
+step:1319/1840 train_time:67196ms step_avg:50.94ms
+step:1320/1840 train_time:67287ms step_avg:50.97ms
+step:1321/1840 train_time:67372ms step_avg:51.00ms
+step:1322/1840 train_time:67461ms step_avg:51.03ms
+step:1323/1840 train_time:67547ms step_avg:51.06ms
+step:1324/1840 train_time:67635ms step_avg:51.08ms
+step:1325/1840 train_time:67721ms step_avg:51.11ms
+step:1326/1840 train_time:67808ms step_avg:51.14ms
+step:1327/1840 train_time:67897ms step_avg:51.17ms
+step:1328/1840 train_time:67986ms step_avg:51.19ms
+step:1329/1840 train_time:68071ms step_avg:51.22ms
+step:1330/1840 train_time:68161ms step_avg:51.25ms
+step:1331/1840 train_time:68246ms step_avg:51.27ms
+step:1332/1840 train_time:68337ms step_avg:51.30ms
+step:1333/1840 train_time:68424ms step_avg:51.33ms
+step:1334/1840 train_time:68512ms step_avg:51.36ms
+step:1335/1840 train_time:68598ms step_avg:51.38ms
+step:1336/1840 train_time:68686ms step_avg:51.41ms
+step:1337/1840 train_time:68771ms step_avg:51.44ms
+step:1338/1840 train_time:68862ms step_avg:51.47ms
+step:1339/1840 train_time:68948ms step_avg:51.49ms
+step:1340/1840 train_time:69037ms step_avg:51.52ms
+step:1341/1840 train_time:69124ms step_avg:51.55ms
+step:1342/1840 train_time:69212ms step_avg:51.57ms
+step:1343/1840 train_time:69299ms step_avg:51.60ms
+step:1344/1840 train_time:69388ms step_avg:51.63ms
+step:1345/1840 train_time:69474ms step_avg:51.65ms
+step:1346/1840 train_time:69564ms step_avg:51.68ms
+step:1347/1840 train_time:69649ms step_avg:51.71ms
+step:1348/1840 train_time:69738ms step_avg:51.73ms
+step:1349/1840 train_time:69824ms step_avg:51.76ms
+step:1350/1840 train_time:69915ms step_avg:51.79ms
+step:1351/1840 train_time:70001ms step_avg:51.81ms
+step:1352/1840 train_time:70088ms step_avg:51.84ms
+step:1353/1840 train_time:70174ms step_avg:51.87ms
+step:1354/1840 train_time:70264ms step_avg:51.89ms
+step:1355/1840 train_time:70349ms step_avg:51.92ms
+step:1356/1840 train_time:70439ms step_avg:51.95ms
+step:1357/1840 train_time:70526ms step_avg:51.97ms
+step:1358/1840 train_time:70616ms step_avg:52.00ms
+step:1359/1840 train_time:70702ms step_avg:52.02ms
+step:1360/1840 train_time:70791ms step_avg:52.05ms
+step:1361/1840 train_time:70878ms step_avg:52.08ms
+step:1362/1840 train_time:70967ms step_avg:52.10ms
+step:1363/1840 train_time:71052ms step_avg:52.13ms
+step:1364/1840 train_time:71142ms step_avg:52.16ms
+step:1365/1840 train_time:71228ms step_avg:52.18ms
+step:1366/1840 train_time:71317ms step_avg:52.21ms
+step:1367/1840 train_time:71404ms step_avg:52.23ms
+step:1368/1840 train_time:71493ms step_avg:52.26ms
+step:1369/1840 train_time:71578ms step_avg:52.29ms
+step:1370/1840 train_time:71667ms step_avg:52.31ms
+step:1371/1840 train_time:71753ms step_avg:52.34ms
+step:1372/1840 train_time:71841ms step_avg:52.36ms
+step:1373/1840 train_time:71927ms step_avg:52.39ms
+step:1374/1840 train_time:72016ms step_avg:52.41ms
+step:1375/1840 train_time:72104ms step_avg:52.44ms
+step:1376/1840 train_time:72192ms step_avg:52.47ms
+step:1377/1840 train_time:72277ms step_avg:52.49ms
+step:1378/1840 train_time:72366ms step_avg:52.52ms
+step:1379/1840 train_time:72452ms step_avg:52.54ms
+step:1380/1840 train_time:72541ms step_avg:52.57ms
+step:1381/1840 train_time:72627ms step_avg:52.59ms
+step:1382/1840 train_time:72716ms step_avg:52.62ms
+step:1383/1840 train_time:72804ms step_avg:52.64ms
+step:1384/1840 train_time:72892ms step_avg:52.67ms
+step:1385/1840 train_time:72979ms step_avg:52.69ms
+step:1386/1840 train_time:73068ms step_avg:52.72ms
+step:1387/1840 train_time:73153ms step_avg:52.74ms
+step:1388/1840 train_time:73244ms step_avg:52.77ms
+step:1389/1840 train_time:73329ms step_avg:52.79ms
+step:1390/1840 train_time:73417ms step_avg:52.82ms
+step:1391/1840 train_time:73504ms step_avg:52.84ms
+step:1392/1840 train_time:73593ms step_avg:52.87ms
+step:1393/1840 train_time:73680ms step_avg:52.89ms
+step:1394/1840 train_time:73768ms step_avg:52.92ms
+step:1395/1840 train_time:73855ms step_avg:52.94ms
+step:1396/1840 train_time:73944ms step_avg:52.97ms
+step:1397/1840 train_time:74030ms step_avg:52.99ms
+step:1398/1840 train_time:74117ms step_avg:53.02ms
+step:1399/1840 train_time:74204ms step_avg:53.04ms
+step:1400/1840 train_time:74293ms step_avg:53.07ms
+step:1401/1840 train_time:74379ms step_avg:53.09ms
+step:1402/1840 train_time:74467ms step_avg:53.11ms
+step:1403/1840 train_time:74553ms step_avg:53.14ms
+step:1404/1840 train_time:74642ms step_avg:53.16ms
+step:1405/1840 train_time:74727ms step_avg:53.19ms
+step:1406/1840 train_time:74816ms step_avg:53.21ms
+step:1407/1840 train_time:74904ms step_avg:53.24ms
+step:1408/1840 train_time:74993ms step_avg:53.26ms
+step:1409/1840 train_time:75079ms step_avg:53.29ms
+step:1410/1840 train_time:75167ms step_avg:53.31ms
+step:1411/1840 train_time:75254ms step_avg:53.33ms
+step:1412/1840 train_time:75343ms step_avg:53.36ms
+step:1413/1840 train_time:75430ms step_avg:53.38ms
+step:1414/1840 train_time:75518ms step_avg:53.41ms
+step:1415/1840 train_time:75604ms step_avg:53.43ms
+step:1416/1840 train_time:75691ms step_avg:53.45ms
+step:1417/1840 train_time:75780ms step_avg:53.48ms
+step:1418/1840 train_time:75868ms step_avg:53.50ms
+step:1419/1840 train_time:75955ms step_avg:53.53ms
+step:1420/1840 train_time:76045ms step_avg:53.55ms
+step:1421/1840 train_time:76131ms step_avg:53.58ms
+step:1422/1840 train_time:76220ms step_avg:53.60ms
+step:1423/1840 train_time:76306ms step_avg:53.62ms
+step:1424/1840 train_time:76394ms step_avg:53.65ms
+step:1425/1840 train_time:76480ms step_avg:53.67ms
+step:1426/1840 train_time:76568ms step_avg:53.69ms
+step:1427/1840 train_time:76653ms step_avg:53.72ms
+step:1428/1840 train_time:76744ms step_avg:53.74ms
+step:1429/1840 train_time:76830ms step_avg:53.76ms
+step:1430/1840 train_time:76918ms step_avg:53.79ms
+step:1431/1840 train_time:77005ms step_avg:53.81ms
+step:1432/1840 train_time:77094ms step_avg:53.84ms
+step:1433/1840 train_time:77180ms step_avg:53.86ms
+step:1434/1840 train_time:77268ms step_avg:53.88ms
+step:1435/1840 train_time:77354ms step_avg:53.91ms
+step:1436/1840 train_time:77443ms step_avg:53.93ms
+step:1437/1840 train_time:77529ms step_avg:53.95ms
+step:1438/1840 train_time:77618ms step_avg:53.98ms
+step:1439/1840 train_time:77706ms step_avg:54.00ms
+step:1440/1840 train_time:77795ms step_avg:54.02ms
+step:1441/1840 train_time:77881ms step_avg:54.05ms
+step:1442/1840 train_time:77968ms step_avg:54.07ms
+step:1443/1840 train_time:78055ms step_avg:54.09ms
+step:1444/1840 train_time:78145ms step_avg:54.12ms
+step:1445/1840 train_time:78232ms step_avg:54.14ms
+step:1446/1840 train_time:78320ms step_avg:54.16ms
+step:1447/1840 train_time:78406ms step_avg:54.19ms
+step:1448/1840 train_time:78495ms step_avg:54.21ms
+step:1449/1840 train_time:78581ms step_avg:54.23ms
+step:1450/1840 train_time:78670ms step_avg:54.26ms
+step:1451/1840 train_time:78757ms step_avg:54.28ms
+step:1452/1840 train_time:78845ms step_avg:54.30ms
+step:1453/1840 train_time:78932ms step_avg:54.32ms
+step:1454/1840 train_time:79020ms step_avg:54.35ms
+step:1455/1840 train_time:79106ms step_avg:54.37ms
+step:1456/1840 train_time:79195ms step_avg:54.39ms
+step:1457/1840 train_time:79281ms step_avg:54.41ms
+step:1458/1840 train_time:79369ms step_avg:54.44ms
+step:1459/1840 train_time:79456ms step_avg:54.46ms
+step:1460/1840 train_time:79545ms step_avg:54.48ms
+step:1461/1840 train_time:79631ms step_avg:54.50ms
+step:1462/1840 train_time:79719ms step_avg:54.53ms
+step:1463/1840 train_time:79806ms step_avg:54.55ms
+step:1464/1840 train_time:79894ms step_avg:54.57ms
+step:1465/1840 train_time:79980ms step_avg:54.59ms
+step:1466/1840 train_time:80068ms step_avg:54.62ms
+step:1467/1840 train_time:80154ms step_avg:54.64ms
+step:1468/1840 train_time:80243ms step_avg:54.66ms
+step:1469/1840 train_time:80329ms step_avg:54.68ms
+step:1470/1840 train_time:80418ms step_avg:54.71ms
+step:1471/1840 train_time:80506ms step_avg:54.73ms
+step:1472/1840 train_time:80594ms step_avg:54.75ms
+step:1473/1840 train_time:80679ms step_avg:54.77ms
+step:1474/1840 train_time:80767ms step_avg:54.79ms
+step:1475/1840 train_time:80854ms step_avg:54.82ms
+step:1476/1840 train_time:80944ms step_avg:54.84ms
+step:1477/1840 train_time:81029ms step_avg:54.86ms
+step:1478/1840 train_time:81118ms step_avg:54.88ms
+step:1479/1840 train_time:81205ms step_avg:54.91ms
+step:1480/1840 train_time:81293ms step_avg:54.93ms
+step:1481/1840 train_time:81380ms step_avg:54.95ms
+step:1482/1840 train_time:81468ms step_avg:54.97ms
+step:1483/1840 train_time:81555ms step_avg:54.99ms
+step:1484/1840 train_time:81644ms step_avg:55.02ms
+step:1485/1840 train_time:81731ms step_avg:55.04ms
+step:1486/1840 train_time:81821ms step_avg:55.06ms
+step:1487/1840 train_time:81907ms step_avg:55.08ms
+step:1488/1840 train_time:81997ms step_avg:55.11ms
+step:1489/1840 train_time:82083ms step_avg:55.13ms
+step:1490/1840 train_time:82170ms step_avg:55.15ms
+step:1491/1840 train_time:82257ms step_avg:55.17ms
+step:1492/1840 train_time:82346ms step_avg:55.19ms
+step:1493/1840 train_time:82431ms step_avg:55.21ms
+step:1494/1840 train_time:82520ms step_avg:55.23ms
+step:1495/1840 train_time:82606ms step_avg:55.25ms
+step:1496/1840 train_time:82696ms step_avg:55.28ms
+step:1497/1840 train_time:82782ms step_avg:55.30ms
+step:1498/1840 train_time:82870ms step_avg:55.32ms
+step:1499/1840 train_time:82957ms step_avg:55.34ms
+step:1500/1840 train_time:83046ms step_avg:55.36ms
+step:1500/1840 val_loss:3.4028 train_time:83148ms step_avg:55.43ms
+step:1501/1840 train_time:83169ms step_avg:55.41ms
+step:1502/1840 train_time:83228ms step_avg:55.41ms
+step:1503/1840 train_time:83317ms step_avg:55.43ms
+step:1504/1840 train_time:83406ms step_avg:55.46ms
+step:1505/1840 train_time:83492ms step_avg:55.48ms
+step:1506/1840 train_time:83580ms step_avg:55.50ms
+step:1507/1840 train_time:83665ms step_avg:55.52ms
+step:1508/1840 train_time:83753ms step_avg:55.54ms
+step:1509/1840 train_time:83838ms step_avg:55.56ms
+step:1510/1840 train_time:83926ms step_avg:55.58ms
+step:1511/1840 train_time:84011ms step_avg:55.60ms
+step:1512/1840 train_time:84101ms step_avg:55.62ms
+step:1513/1840 train_time:84191ms step_avg:55.65ms
+step:1514/1840 train_time:84284ms step_avg:55.67ms
+step:1515/1840 train_time:84371ms step_avg:55.69ms
+step:1516/1840 train_time:84459ms step_avg:55.71ms
+step:1517/1840 train_time:84546ms step_avg:55.73ms
+step:1518/1840 train_time:84632ms step_avg:55.75ms
+step:1519/1840 train_time:84718ms step_avg:55.77ms
+step:1520/1840 train_time:84807ms step_avg:55.79ms
+step:1521/1840 train_time:84892ms step_avg:55.81ms
+step:1522/1840 train_time:84981ms step_avg:55.84ms
+step:1523/1840 train_time:85068ms step_avg:55.86ms
+step:1524/1840 train_time:85158ms step_avg:55.88ms
+step:1525/1840 train_time:85246ms step_avg:55.90ms
+step:1526/1840 train_time:85333ms step_avg:55.92ms
+step:1527/1840 train_time:85422ms step_avg:55.94ms
+step:1528/1840 train_time:85510ms step_avg:55.96ms
+step:1529/1840 train_time:85595ms step_avg:55.98ms
+step:1530/1840 train_time:85685ms step_avg:56.00ms
+step:1531/1840 train_time:85769ms step_avg:56.02ms
+step:1532/1840 train_time:85858ms step_avg:56.04ms
+step:1533/1840 train_time:85943ms step_avg:56.06ms
+step:1534/1840 train_time:86031ms step_avg:56.08ms
+step:1535/1840 train_time:86121ms step_avg:56.10ms
+step:1536/1840 train_time:86210ms step_avg:56.13ms
+step:1537/1840 train_time:86296ms step_avg:56.15ms
+step:1538/1840 train_time:86388ms step_avg:56.17ms
+step:1539/1840 train_time:86473ms step_avg:56.19ms
+step:1540/1840 train_time:86564ms step_avg:56.21ms
+step:1541/1840 train_time:86649ms step_avg:56.23ms
+step:1542/1840 train_time:86737ms step_avg:56.25ms
+step:1543/1840 train_time:86823ms step_avg:56.27ms
+step:1544/1840 train_time:86910ms step_avg:56.29ms
+step:1545/1840 train_time:86997ms step_avg:56.31ms
+step:1546/1840 train_time:87087ms step_avg:56.33ms
+step:1547/1840 train_time:87173ms step_avg:56.35ms
+step:1548/1840 train_time:87262ms step_avg:56.37ms
+step:1549/1840 train_time:87349ms step_avg:56.39ms
+step:1550/1840 train_time:87438ms step_avg:56.41ms
+step:1551/1840 train_time:87525ms step_avg:56.43ms
+step:1552/1840 train_time:87612ms step_avg:56.45ms
+step:1553/1840 train_time:87697ms step_avg:56.47ms
+step:1554/1840 train_time:87788ms step_avg:56.49ms
+step:1555/1840 train_time:87872ms step_avg:56.51ms
+step:1556/1840 train_time:87962ms step_avg:56.53ms
+step:1557/1840 train_time:88048ms step_avg:56.55ms
+step:1558/1840 train_time:88138ms step_avg:56.57ms
+step:1559/1840 train_time:88225ms step_avg:56.59ms
+step:1560/1840 train_time:88313ms step_avg:56.61ms
+step:1561/1840 train_time:88400ms step_avg:56.63ms
+step:1562/1840 train_time:88490ms step_avg:56.65ms
+step:1563/1840 train_time:88574ms step_avg:56.67ms
+step:1564/1840 train_time:88662ms step_avg:56.69ms
+step:1565/1840 train_time:88747ms step_avg:56.71ms
+step:1566/1840 train_time:88836ms step_avg:56.73ms
+step:1567/1840 train_time:88921ms step_avg:56.75ms
+step:1568/1840 train_time:89010ms step_avg:56.77ms
+step:1569/1840 train_time:89097ms step_avg:56.79ms
+step:1570/1840 train_time:89186ms step_avg:56.81ms
+step:1571/1840 train_time:89271ms step_avg:56.82ms
+step:1572/1840 train_time:89362ms step_avg:56.85ms
+step:1573/1840 train_time:89449ms step_avg:56.87ms
+step:1574/1840 train_time:89537ms step_avg:56.89ms
+step:1575/1840 train_time:89622ms step_avg:56.90ms
+step:1576/1840 train_time:89711ms step_avg:56.92ms
+step:1577/1840 train_time:89797ms step_avg:56.94ms
+step:1578/1840 train_time:89886ms step_avg:56.96ms
+step:1579/1840 train_time:89971ms step_avg:56.98ms
+step:1580/1840 train_time:90061ms step_avg:57.00ms
+step:1581/1840 train_time:90147ms step_avg:57.02ms
+step:1582/1840 train_time:90234ms step_avg:57.04ms
+step:1583/1840 train_time:90323ms step_avg:57.06ms
+step:1584/1840 train_time:90411ms step_avg:57.08ms
+step:1585/1840 train_time:90498ms step_avg:57.10ms
+step:1586/1840 train_time:90588ms step_avg:57.12ms
+step:1587/1840 train_time:90673ms step_avg:57.13ms
+step:1588/1840 train_time:90761ms step_avg:57.15ms
+step:1589/1840 train_time:90847ms step_avg:57.17ms
+step:1590/1840 train_time:90936ms step_avg:57.19ms
+step:1591/1840 train_time:91023ms step_avg:57.21ms
+step:1592/1840 train_time:91111ms step_avg:57.23ms
+step:1593/1840 train_time:91197ms step_avg:57.25ms
+step:1594/1840 train_time:91288ms step_avg:57.27ms
+step:1595/1840 train_time:91373ms step_avg:57.29ms
+step:1596/1840 train_time:91462ms step_avg:57.31ms
+step:1597/1840 train_time:91548ms step_avg:57.32ms
+step:1598/1840 train_time:91637ms step_avg:57.34ms
+step:1599/1840 train_time:91723ms step_avg:57.36ms
+step:1600/1840 train_time:91811ms step_avg:57.38ms
+step:1601/1840 train_time:91897ms step_avg:57.40ms
+step:1602/1840 train_time:91987ms step_avg:57.42ms
+step:1603/1840 train_time:92073ms step_avg:57.44ms
+step:1604/1840 train_time:92161ms step_avg:57.46ms
+step:1605/1840 train_time:92247ms step_avg:57.47ms
+step:1606/1840 train_time:92336ms step_avg:57.49ms
+step:1607/1840 train_time:92423ms step_avg:57.51ms
+step:1608/1840 train_time:92511ms step_avg:57.53ms
+step:1609/1840 train_time:92597ms step_avg:57.55ms
+step:1610/1840 train_time:92688ms step_avg:57.57ms
+step:1611/1840 train_time:92773ms step_avg:57.59ms
+step:1612/1840 train_time:92862ms step_avg:57.61ms
+step:1613/1840 train_time:92948ms step_avg:57.62ms
+step:1614/1840 train_time:93037ms step_avg:57.64ms
+step:1615/1840 train_time:93125ms step_avg:57.66ms
+step:1616/1840 train_time:93213ms step_avg:57.68ms
+step:1617/1840 train_time:93299ms step_avg:57.70ms
+step:1618/1840 train_time:93389ms step_avg:57.72ms
+step:1619/1840 train_time:93475ms step_avg:57.74ms
+step:1620/1840 train_time:93564ms step_avg:57.76ms
+step:1621/1840 train_time:93650ms step_avg:57.77ms
+step:1622/1840 train_time:93737ms step_avg:57.79ms
+step:1623/1840 train_time:93825ms step_avg:57.81ms
+step:1624/1840 train_time:93912ms step_avg:57.83ms
+step:1625/1840 train_time:93999ms step_avg:57.85ms
+step:1626/1840 train_time:94088ms step_avg:57.86ms
+step:1627/1840 train_time:94175ms step_avg:57.88ms
+step:1628/1840 train_time:94264ms step_avg:57.90ms
+step:1629/1840 train_time:94349ms step_avg:57.92ms
+step:1630/1840 train_time:94437ms step_avg:57.94ms
+step:1631/1840 train_time:94524ms step_avg:57.95ms
+step:1632/1840 train_time:94612ms step_avg:57.97ms
+step:1633/1840 train_time:94698ms step_avg:57.99ms
+step:1634/1840 train_time:94787ms step_avg:58.01ms
+step:1635/1840 train_time:94872ms step_avg:58.03ms
+step:1636/1840 train_time:94961ms step_avg:58.04ms
+step:1637/1840 train_time:95048ms step_avg:58.06ms
+step:1638/1840 train_time:95137ms step_avg:58.08ms
+step:1639/1840 train_time:95224ms step_avg:58.10ms
+step:1640/1840 train_time:95312ms step_avg:58.12ms
+step:1641/1840 train_time:95398ms step_avg:58.13ms
+step:1642/1840 train_time:95487ms step_avg:58.15ms
+step:1643/1840 train_time:95572ms step_avg:58.17ms
+step:1644/1840 train_time:95661ms step_avg:58.19ms
+step:1645/1840 train_time:95748ms step_avg:58.21ms
+step:1646/1840 train_time:95835ms step_avg:58.22ms
+step:1647/1840 train_time:95922ms step_avg:58.24ms
+step:1648/1840 train_time:96009ms step_avg:58.26ms
+step:1649/1840 train_time:96096ms step_avg:58.28ms
+step:1650/1840 train_time:96187ms step_avg:58.30ms
+step:1651/1840 train_time:96272ms step_avg:58.31ms
+step:1652/1840 train_time:96362ms step_avg:58.33ms
+step:1653/1840 train_time:96449ms step_avg:58.35ms
+step:1654/1840 train_time:96537ms step_avg:58.37ms
+step:1655/1840 train_time:96622ms step_avg:58.38ms
+step:1656/1840 train_time:96710ms step_avg:58.40ms
+step:1657/1840 train_time:96797ms step_avg:58.42ms
+step:1658/1840 train_time:96887ms step_avg:58.44ms
+step:1659/1840 train_time:96972ms step_avg:58.45ms
+step:1660/1840 train_time:97062ms step_avg:58.47ms
+step:1661/1840 train_time:97148ms step_avg:58.49ms
+step:1662/1840 train_time:97236ms step_avg:58.51ms
+step:1663/1840 train_time:97323ms step_avg:58.52ms
+step:1664/1840 train_time:97411ms step_avg:58.54ms
+step:1665/1840 train_time:97497ms step_avg:58.56ms
+step:1666/1840 train_time:97588ms step_avg:58.58ms
+step:1667/1840 train_time:97672ms step_avg:58.59ms
+step:1668/1840 train_time:97762ms step_avg:58.61ms
+step:1669/1840 train_time:97848ms step_avg:58.63ms
+step:1670/1840 train_time:97936ms step_avg:58.64ms
+step:1671/1840 train_time:98023ms step_avg:58.66ms
+step:1672/1840 train_time:98110ms step_avg:58.68ms
+step:1673/1840 train_time:98197ms step_avg:58.69ms
+step:1674/1840 train_time:98287ms step_avg:58.71ms
+step:1675/1840 train_time:98373ms step_avg:58.73ms
+step:1676/1840 train_time:98462ms step_avg:58.75ms
+step:1677/1840 train_time:98548ms step_avg:58.76ms
+step:1678/1840 train_time:98636ms step_avg:58.78ms
+step:1679/1840 train_time:98723ms step_avg:58.80ms
+step:1680/1840 train_time:98810ms step_avg:58.82ms
+step:1681/1840 train_time:98895ms step_avg:58.83ms
+step:1682/1840 train_time:98986ms step_avg:58.85ms
+step:1683/1840 train_time:99072ms step_avg:58.87ms
+step:1684/1840 train_time:99161ms step_avg:58.88ms
+step:1685/1840 train_time:99248ms step_avg:58.90ms
+step:1686/1840 train_time:99336ms step_avg:58.92ms
+step:1687/1840 train_time:99422ms step_avg:58.93ms
+step:1688/1840 train_time:99511ms step_avg:58.95ms
+step:1689/1840 train_time:99598ms step_avg:58.97ms
+step:1690/1840 train_time:99687ms step_avg:58.99ms
+step:1691/1840 train_time:99772ms step_avg:59.00ms
+step:1692/1840 train_time:99861ms step_avg:59.02ms
+step:1693/1840 train_time:99948ms step_avg:59.04ms
+step:1694/1840 train_time:100037ms step_avg:59.05ms
+step:1695/1840 train_time:100122ms step_avg:59.07ms
+step:1696/1840 train_time:100211ms step_avg:59.09ms
+step:1697/1840 train_time:100298ms step_avg:59.10ms
+step:1698/1840 train_time:100389ms step_avg:59.12ms
+step:1699/1840 train_time:100474ms step_avg:59.14ms
+step:1700/1840 train_time:100563ms step_avg:59.15ms
+step:1701/1840 train_time:100649ms step_avg:59.17ms
+step:1702/1840 train_time:100737ms step_avg:59.19ms
+step:1703/1840 train_time:100823ms step_avg:59.20ms
+step:1704/1840 train_time:100911ms step_avg:59.22ms
+step:1705/1840 train_time:100997ms step_avg:59.24ms
+step:1706/1840 train_time:101087ms step_avg:59.25ms
+step:1707/1840 train_time:101172ms step_avg:59.27ms
+step:1708/1840 train_time:101262ms step_avg:59.29ms
+step:1709/1840 train_time:101349ms step_avg:59.30ms
+step:1710/1840 train_time:101439ms step_avg:59.32ms
+step:1711/1840 train_time:101524ms step_avg:59.34ms
+step:1712/1840 train_time:101612ms step_avg:59.35ms
+step:1713/1840 train_time:101697ms step_avg:59.37ms
+step:1714/1840 train_time:101787ms step_avg:59.39ms
+step:1715/1840 train_time:101873ms step_avg:59.40ms
+step:1716/1840 train_time:101962ms step_avg:59.42ms
+step:1717/1840 train_time:102048ms step_avg:59.43ms
+step:1718/1840 train_time:102136ms step_avg:59.45ms
+step:1719/1840 train_time:102223ms step_avg:59.47ms
+step:1720/1840 train_time:102311ms step_avg:59.48ms
+step:1721/1840 train_time:102397ms step_avg:59.50ms
+step:1722/1840 train_time:102487ms step_avg:59.52ms
+step:1723/1840 train_time:102573ms step_avg:59.53ms
+step:1724/1840 train_time:102662ms step_avg:59.55ms
+step:1725/1840 train_time:102748ms step_avg:59.56ms
+step:1726/1840 train_time:102837ms step_avg:59.58ms
+step:1727/1840 train_time:102923ms step_avg:59.60ms
+step:1728/1840 train_time:103010ms step_avg:59.61ms
+step:1729/1840 train_time:103096ms step_avg:59.63ms
+step:1730/1840 train_time:103187ms step_avg:59.65ms
+step:1731/1840 train_time:103272ms step_avg:59.66ms
+step:1732/1840 train_time:103362ms step_avg:59.68ms
+step:1733/1840 train_time:103448ms step_avg:59.69ms
+step:1734/1840 train_time:103535ms step_avg:59.71ms
+step:1735/1840 train_time:103622ms step_avg:59.72ms
+step:1736/1840 train_time:103711ms step_avg:59.74ms
+step:1737/1840 train_time:103796ms step_avg:59.76ms
+step:1738/1840 train_time:103887ms step_avg:59.77ms
+step:1739/1840 train_time:103972ms step_avg:59.79ms
+step:1740/1840 train_time:104061ms step_avg:59.81ms
+step:1741/1840 train_time:104147ms step_avg:59.82ms
+step:1742/1840 train_time:104236ms step_avg:59.84ms
+step:1743/1840 train_time:104322ms step_avg:59.85ms
+step:1744/1840 train_time:104410ms step_avg:59.87ms
+step:1745/1840 train_time:104496ms step_avg:59.88ms
+step:1746/1840 train_time:104586ms step_avg:59.90ms
+step:1747/1840 train_time:104670ms step_avg:59.91ms
+step:1748/1840 train_time:104760ms step_avg:59.93ms
+step:1749/1840 train_time:104846ms step_avg:59.95ms
+step:1750/1840 train_time:104934ms step_avg:59.96ms
+step:1750/1840 val_loss:3.3053 train_time:105035ms step_avg:60.02ms
+step:1751/1840 train_time:105055ms step_avg:60.00ms
+step:1752/1840 train_time:105113ms step_avg:60.00ms
+step:1753/1840 train_time:105204ms step_avg:60.01ms
+step:1754/1840 train_time:105293ms step_avg:60.03ms
+step:1755/1840 train_time:105377ms step_avg:60.04ms
+step:1756/1840 train_time:105465ms step_avg:60.06ms
+step:1757/1840 train_time:105549ms step_avg:60.07ms
+step:1758/1840 train_time:105636ms step_avg:60.09ms
+step:1759/1840 train_time:105723ms step_avg:60.10ms
+step:1760/1840 train_time:105810ms step_avg:60.12ms
+step:1761/1840 train_time:105896ms step_avg:60.13ms
+step:1762/1840 train_time:105987ms step_avg:60.15ms
+step:1763/1840 train_time:106077ms step_avg:60.17ms
+step:1764/1840 train_time:106169ms step_avg:60.19ms
+step:1765/1840 train_time:106255ms step_avg:60.20ms
+step:1766/1840 train_time:106346ms step_avg:60.22ms
+step:1767/1840 train_time:106431ms step_avg:60.23ms
+step:1768/1840 train_time:106519ms step_avg:60.25ms
+step:1769/1840 train_time:106605ms step_avg:60.26ms
+step:1770/1840 train_time:106692ms step_avg:60.28ms
+step:1771/1840 train_time:106776ms step_avg:60.29ms
+step:1772/1840 train_time:106864ms step_avg:60.31ms
+step:1773/1840 train_time:106950ms step_avg:60.32ms
+step:1774/1840 train_time:107043ms step_avg:60.34ms
+step:1775/1840 train_time:107131ms step_avg:60.36ms
+step:1776/1840 train_time:107220ms step_avg:60.37ms
+step:1777/1840 train_time:107308ms step_avg:60.39ms
+step:1778/1840 train_time:107396ms step_avg:60.40ms
+step:1779/1840 train_time:107480ms step_avg:60.42ms
+step:1780/1840 train_time:107568ms step_avg:60.43ms
+step:1781/1840 train_time:107653ms step_avg:60.45ms
+step:1782/1840 train_time:107742ms step_avg:60.46ms
+step:1783/1840 train_time:107826ms step_avg:60.47ms
+step:1784/1840 train_time:107915ms step_avg:60.49ms
+step:1785/1840 train_time:108002ms step_avg:60.51ms
+step:1786/1840 train_time:108091ms step_avg:60.52ms
+step:1787/1840 train_time:108180ms step_avg:60.54ms
+step:1788/1840 train_time:108269ms step_avg:60.55ms
+step:1789/1840 train_time:108356ms step_avg:60.57ms
+step:1790/1840 train_time:108445ms step_avg:60.58ms
+step:1791/1840 train_time:108530ms step_avg:60.60ms
+step:1792/1840 train_time:108618ms step_avg:60.61ms
+step:1793/1840 train_time:108705ms step_avg:60.63ms
+step:1794/1840 train_time:108792ms step_avg:60.64ms
+step:1795/1840 train_time:108878ms step_avg:60.66ms
+step:1796/1840 train_time:108967ms step_avg:60.67ms
+step:1797/1840 train_time:109054ms step_avg:60.69ms
+step:1798/1840 train_time:109144ms step_avg:60.70ms
+step:1799/1840 train_time:109230ms step_avg:60.72ms
+step:1800/1840 train_time:109320ms step_avg:60.73ms
+step:1801/1840 train_time:109409ms step_avg:60.75ms
+step:1802/1840 train_time:109495ms step_avg:60.76ms
+step:1803/1840 train_time:109582ms step_avg:60.78ms
+step:1804/1840 train_time:109670ms step_avg:60.79ms
+step:1805/1840 train_time:109756ms step_avg:60.81ms
+step:1806/1840 train_time:109846ms step_avg:60.82ms
+step:1807/1840 train_time:109932ms step_avg:60.84ms
+step:1808/1840 train_time:110020ms step_avg:60.85ms
+step:1809/1840 train_time:110108ms step_avg:60.87ms
+step:1810/1840 train_time:110197ms step_avg:60.88ms
+step:1811/1840 train_time:110285ms step_avg:60.90ms
+step:1812/1840 train_time:110375ms step_avg:60.91ms
+step:1813/1840 train_time:110460ms step_avg:60.93ms
+step:1814/1840 train_time:110548ms step_avg:60.94ms
+step:1815/1840 train_time:110634ms step_avg:60.96ms
+step:1816/1840 train_time:110725ms step_avg:60.97ms
+step:1817/1840 train_time:110811ms step_avg:60.99ms
+step:1818/1840 train_time:110900ms step_avg:61.00ms
+step:1819/1840 train_time:110987ms step_avg:61.02ms
+step:1820/1840 train_time:111077ms step_avg:61.03ms
+step:1821/1840 train_time:111164ms step_avg:61.05ms
+step:1822/1840 train_time:111252ms step_avg:61.06ms
+step:1823/1840 train_time:111338ms step_avg:61.07ms
+step:1824/1840 train_time:111428ms step_avg:61.09ms
+step:1825/1840 train_time:111514ms step_avg:61.10ms
+step:1826/1840 train_time:111604ms step_avg:61.12ms
+step:1827/1840 train_time:111690ms step_avg:61.13ms
+step:1828/1840 train_time:111779ms step_avg:61.15ms
+step:1829/1840 train_time:111865ms step_avg:61.16ms
+step:1830/1840 train_time:111954ms step_avg:61.18ms
+step:1831/1840 train_time:112041ms step_avg:61.19ms
+step:1832/1840 train_time:112130ms step_avg:61.21ms
+step:1833/1840 train_time:112216ms step_avg:61.22ms
+step:1834/1840 train_time:112306ms step_avg:61.24ms
+step:1835/1840 train_time:112393ms step_avg:61.25ms
+step:1836/1840 train_time:112481ms step_avg:61.26ms
+step:1837/1840 train_time:112567ms step_avg:61.28ms
+step:1838/1840 train_time:112656ms step_avg:61.29ms
+step:1839/1840 train_time:112743ms step_avg:61.31ms
+step:1840/1840 train_time:112831ms step_avg:61.32ms
+step:1840/1840 val_loss:3.2802 train_time:112932ms step_avg:61.38ms
+peak memory allocated: 28507 MiB reserved: 44038 MiB

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/7a952dd3-a2ec-46ae-a7c6-ebaf61a6cc09.txt
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/7a952dd3-a2ec-46ae-a7c6-ebaf61a6cc09.txt
@@ -1,0 +1,3786 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+    """
+    Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+    Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+    bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+    float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+    """
+    assert p.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    wd_factor = wd_tensor.to(torch.float32)
+    lr_factor = lr_tensor.to(torch.float32)
+    p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    p_precise = p_precise_raw.view(torch.float32)
+    mask = (grad * p_precise) >= 0
+    p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+    p.copy_((p_precise_raw >> 16).to(torch.uint16))
+    mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        2. reduce scatter attn/mlp round 2 (16 mlp params)
+        3. wait on step 1, then compute update of 1 and schedule all gather
+        4. wait on step 2, then compute update of 2 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        5. wait for each all gather to complete and update params
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["mantissa"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn', 'mlp']
+        group_sizes = [16, 16]  # 10 attn + 6 mlp, then 16 mlp
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    def step(self):
+        self.step_p1()
+        self.step_p2()
+        self.step_p3()
+        
+    @torch.no_grad()
+    def step_p1(self):
+        """
+        Part 1: Launch distributed reduce_scatter operations for parameter groups.
+        """
+        rank = dist.get_rank()
+        self.group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            self.group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+    
+    @torch.no_grad()
+    def step_p2(self):
+        """
+        Part 2: Compute gradient updates and launch all_gather operations
+        Wait for all gather to complete for all parameter groups except final one
+        """
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = self.group_infos
+        
+        self.all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"].float()
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params], dtype=torch.float32)
+                
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            if "second_momentum_buffer" not in group:
+                group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1], dtype=torch.float32)
+                    if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if param_shape[-2] >= param_shape[-1] else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk, dtype=torch.bfloat16)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                if "mantissa" not in group:
+                    group["mantissa"] = torch.zeros_like(param_chunk, dtype=torch.uint16)
+                mantissa = group["mantissa"]
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx].view(torch.uint16),
+                        mantissa[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx]
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            self.all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete for all except final and copy results back into original parameter tensors.
+        for info in self.all_gather_infos[:-1]:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+    @torch.no_grad()
+    def step_p3(self):
+        """
+        Part 3: Wait for final all gather to complete and copy results back into original parameter tensors
+        """
+        info = self.all_gather_infos[-1]
+        info["gather_future"].wait()
+        stacked_params = info["stacked_params"]
+        orig_params = info["orig_params"]
+
+        unstacked_params = torch.unbind(stacked_params)
+        for i, p in enumerate(orig_params):
+            p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str], betas: list[list[float]], lr: float = 1e-3, eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for idx, label in enumerate(label_order):
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label], betas=betas[idx]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+        # tag the final param for optimizer pipelining, run all gather after muon copy
+        param_groups[-1]['params'][-1].is_final_param = True
+        
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        # 0-D CPU tensors to avoid recompilation in _update_step
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    def load_state_dict(self, state_dict):
+        """Override to preserve optimizer state dtypes (avoid BFloat16->Float32 cast that causes recompilation)."""
+        # Save original state dtypes before loading
+        original_dtypes = {}
+        for p, s in self.state.items():
+            original_dtypes[p] = {k: v.dtype for k, v in s.items() if isinstance(v, torch.Tensor)}
+        
+        # Call parent load_state_dict (which may cast dtypes to match param dtype)
+        super().load_state_dict(state_dict)
+        
+        # Restore original dtypes
+        for p, s in self.state.items():
+            if p in original_dtypes:
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor) and k in original_dtypes[p]:
+                        if v.dtype != original_dtypes[p][k]:
+                            s[k] = v.to(original_dtypes[p][k])
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-2]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step. step_size_t and eff_wd_t are 0-D CPU tensors to avoid recompilation."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)  # exp_avg = beta1 * exp_avg + (1 - beta1) * g_slice
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)  # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * g_slice^2
+        # compute step
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)  # update = (exp_avg / (sqrt(exp_avg_sq) + eps)) * step_size
+        # cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)  # update += eff_wd_t * p_slice * mask
+        p_slice.add_(other=update, alpha=-1.0)  # p_slice -= update
+
+    @torch.no_grad()
+    def step(self, muon_opt):
+        muon_opt.step_p1()
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        last_param = None
+        last_p_slice = None
+        for group in self.param_groups:      
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+                state["step"] += 1
+                t = state["step"]
+                
+                # Pre-compute changing values as 0-D CPU tensors to avoid recompilation.
+                # `.fill_(value)` is the same as "= value", but doesn't change the tensor object.
+                bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+                self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+                self._eff_wd_t.fill_(lr * lr * wd * getattr(param, "wd_mul", 1.0)) # `lr` included twice to serve as weight decay schedule.
+
+                DistAdam._update_step(p_slice, g_slice, state["exp_avg"], state["exp_avg_sq"],
+                                      beta1, beta2, eps, self._step_size_t, self._eff_wd_t)
+
+                if not is_small:
+                    if getattr(param, "is_final_param", False):
+                        last_param = param
+                        last_p_slice = p_slice
+                    else:
+                        all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+        self._reduce_scatter_futures.clear()
+
+        muon_opt.step_p2()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+        if last_param is not None:
+            last_all_gather_future = dist.all_gather_into_tensor(last_param, last_p_slice, async_op=True).get_future()
+        muon_opt.step_p3()
+        torch.futures.collect_all([last_all_gather_future]).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        adam_betas = {
+            'lm_head': [0.5, 0.95],
+            'smear_gate': [0.9, 0.99],
+            'attn_gate_bank': [0.9, 0.99],
+            've_gate_bank': [0.9, 0.99],
+            'skip_gate': [0.9, 0.99],
+            'x0_lambdas': [0.65, 0.95],
+            'scalars': [0.9, 0.99],
+            'embed': [0.5, 0.95],
+            'value_embed': [0.75, 0.95]
+        }
+        adam_labels = list(adam_betas.keys())
+        adam_beta_values = list(adam_betas.values())
+        muon_labels = ['attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, adam_beta_values, lr=0.008, eps=1e-10, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.muon_opt]
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * step_lr
+                
+        if self._is_active_step(self.adam_opt, step):
+            # adam will interleave calls to muon step
+            self.adam_opt.step(self.muon_opt)
+            self.model.zero_grad(set_to_none=True)
+            self.adam_opt.should_sync = False
+        else:
+            self.muon_opt.step()
+            self.muon_opt.zero_grad(set_to_none=True)
+            
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1800  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan  5 07:59:09 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   42C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   42C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   44C    P0            133W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   35C    P0            126W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            128W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     52536      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     52537      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     52538      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     52539      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     52540      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     52541      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     52542      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     52543      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 599, 600, 601, 1199, 1200, 1201, 1799, 1800, 1801] for warmup
+Resetting Model
+step:0/1840 val_loss:10.8294 train_time:0ms step_avg:0.04ms
+step:1/1840 train_time:69ms step_avg:68.56ms
+step:2/1840 train_time:90ms step_avg:45.20ms
+step:3/1840 train_time:109ms step_avg:36.27ms
+step:4/1840 train_time:139ms step_avg:34.66ms
+step:5/1840 train_time:170ms step_avg:34.08ms
+step:6/1840 train_time:256ms step_avg:42.60ms
+step:7/1840 train_time:272ms step_avg:38.93ms
+step:8/1840 train_time:325ms step_avg:40.58ms
+step:9/1840 train_time:356ms step_avg:39.61ms
+step:10/1840 train_time:390ms step_avg:39.04ms
+step:11/1840 train_time:422ms step_avg:38.39ms
+step:12/1840 train_time:456ms step_avg:38.03ms
+step:13/1840 train_time:488ms step_avg:37.57ms
+step:14/1840 train_time:522ms step_avg:37.31ms
+step:15/1840 train_time:555ms step_avg:36.97ms
+step:16/1840 train_time:589ms step_avg:36.80ms
+step:17/1840 train_time:621ms step_avg:36.52ms
+step:18/1840 train_time:655ms step_avg:36.38ms
+step:19/1840 train_time:687ms step_avg:36.14ms
+step:20/1840 train_time:721ms step_avg:36.04ms
+step:21/1840 train_time:753ms step_avg:35.85ms
+step:22/1840 train_time:787ms step_avg:35.78ms
+step:23/1840 train_time:819ms step_avg:35.61ms
+step:24/1840 train_time:853ms step_avg:35.54ms
+step:25/1840 train_time:885ms step_avg:35.40ms
+step:26/1840 train_time:919ms step_avg:35.36ms
+step:27/1840 train_time:951ms step_avg:35.23ms
+step:28/1840 train_time:985ms step_avg:35.19ms
+step:29/1840 train_time:1017ms step_avg:35.08ms
+step:30/1840 train_time:1051ms step_avg:35.05ms
+step:31/1840 train_time:1083ms step_avg:34.95ms
+step:32/1840 train_time:1118ms step_avg:34.93ms
+step:33/1840 train_time:1150ms step_avg:34.84ms
+step:34/1840 train_time:1185ms step_avg:34.86ms
+step:35/1840 train_time:1219ms step_avg:34.82ms
+step:36/1840 train_time:1254ms step_avg:34.83ms
+step:37/1840 train_time:1287ms step_avg:34.77ms
+step:38/1840 train_time:1321ms step_avg:34.77ms
+step:39/1840 train_time:1353ms step_avg:34.70ms
+step:40/1840 train_time:1388ms step_avg:34.70ms
+step:41/1840 train_time:1420ms step_avg:34.64ms
+step:42/1840 train_time:1454ms step_avg:34.63ms
+step:43/1840 train_time:1487ms step_avg:34.57ms
+step:44/1840 train_time:1521ms step_avg:34.57ms
+step:45/1840 train_time:1553ms step_avg:34.51ms
+step:46/1840 train_time:1588ms step_avg:34.51ms
+step:47/1840 train_time:1620ms step_avg:34.46ms
+step:48/1840 train_time:1654ms step_avg:34.45ms
+step:49/1840 train_time:1686ms step_avg:34.40ms
+step:50/1840 train_time:1720ms step_avg:34.40ms
+step:51/1840 train_time:1752ms step_avg:34.36ms
+step:52/1840 train_time:1786ms step_avg:34.36ms
+step:53/1840 train_time:1819ms step_avg:34.31ms
+step:54/1840 train_time:1853ms step_avg:34.31ms
+step:55/1840 train_time:1885ms step_avg:34.27ms
+step:56/1840 train_time:1919ms step_avg:34.27ms
+step:57/1840 train_time:1951ms step_avg:34.23ms
+step:58/1840 train_time:1985ms step_avg:34.23ms
+step:59/1840 train_time:2017ms step_avg:34.19ms
+step:60/1840 train_time:2051ms step_avg:34.19ms
+step:61/1840 train_time:2083ms step_avg:34.15ms
+step:62/1840 train_time:2117ms step_avg:34.15ms
+step:63/1840 train_time:2149ms step_avg:34.12ms
+step:64/1840 train_time:2184ms step_avg:34.13ms
+step:65/1840 train_time:2217ms step_avg:34.11ms
+step:66/1840 train_time:2251ms step_avg:34.11ms
+step:67/1840 train_time:2283ms step_avg:34.08ms
+step:68/1840 train_time:2318ms step_avg:34.09ms
+step:69/1840 train_time:2350ms step_avg:34.05ms
+step:70/1840 train_time:2384ms step_avg:34.06ms
+step:71/1840 train_time:2417ms step_avg:34.04ms
+step:72/1840 train_time:2451ms step_avg:34.04ms
+step:73/1840 train_time:2483ms step_avg:34.02ms
+step:74/1840 train_time:2518ms step_avg:34.03ms
+step:75/1840 train_time:2550ms step_avg:34.00ms
+step:76/1840 train_time:2584ms step_avg:34.00ms
+step:77/1840 train_time:2616ms step_avg:33.98ms
+step:78/1840 train_time:2651ms step_avg:33.98ms
+step:79/1840 train_time:2683ms step_avg:33.96ms
+step:80/1840 train_time:2717ms step_avg:33.97ms
+step:81/1840 train_time:2749ms step_avg:33.94ms
+step:82/1840 train_time:2784ms step_avg:33.95ms
+step:83/1840 train_time:2816ms step_avg:33.92ms
+step:84/1840 train_time:2850ms step_avg:33.93ms
+step:85/1840 train_time:2882ms step_avg:33.91ms
+step:86/1840 train_time:2916ms step_avg:33.91ms
+step:87/1840 train_time:2948ms step_avg:33.89ms
+step:88/1840 train_time:2982ms step_avg:33.89ms
+step:89/1840 train_time:3014ms step_avg:33.87ms
+step:90/1840 train_time:3048ms step_avg:33.87ms
+step:91/1840 train_time:3081ms step_avg:33.86ms
+step:92/1840 train_time:3115ms step_avg:33.86ms
+step:93/1840 train_time:3147ms step_avg:33.84ms
+step:94/1840 train_time:3181ms step_avg:33.84ms
+step:95/1840 train_time:3214ms step_avg:33.83ms
+step:96/1840 train_time:3248ms step_avg:33.83ms
+step:97/1840 train_time:3280ms step_avg:33.82ms
+step:98/1840 train_time:3314ms step_avg:33.82ms
+step:99/1840 train_time:3346ms step_avg:33.80ms
+step:100/1840 train_time:3381ms step_avg:33.81ms
+step:101/1840 train_time:3413ms step_avg:33.79ms
+step:102/1840 train_time:3448ms step_avg:33.80ms
+step:103/1840 train_time:3480ms step_avg:33.78ms
+step:104/1840 train_time:3514ms step_avg:33.79ms
+step:105/1840 train_time:3546ms step_avg:33.78ms
+step:106/1840 train_time:3581ms step_avg:33.78ms
+step:107/1840 train_time:3613ms step_avg:33.76ms
+step:108/1840 train_time:3647ms step_avg:33.77ms
+step:109/1840 train_time:3679ms step_avg:33.76ms
+step:110/1840 train_time:3714ms step_avg:33.76ms
+step:111/1840 train_time:3746ms step_avg:33.75ms
+step:112/1840 train_time:3780ms step_avg:33.75ms
+step:113/1840 train_time:3812ms step_avg:33.73ms
+step:114/1840 train_time:3846ms step_avg:33.74ms
+step:115/1840 train_time:3878ms step_avg:33.72ms
+step:116/1840 train_time:3912ms step_avg:33.73ms
+step:117/1840 train_time:3944ms step_avg:33.71ms
+step:118/1840 train_time:3979ms step_avg:33.72ms
+step:119/1840 train_time:4011ms step_avg:33.70ms
+step:120/1840 train_time:4045ms step_avg:33.71ms
+step:121/1840 train_time:4077ms step_avg:33.70ms
+step:122/1840 train_time:4112ms step_avg:33.70ms
+step:123/1840 train_time:4144ms step_avg:33.69ms
+step:124/1840 train_time:4178ms step_avg:33.69ms
+step:125/1840 train_time:4210ms step_avg:33.68ms
+step:126/1840 train_time:4244ms step_avg:33.68ms
+step:127/1840 train_time:4277ms step_avg:33.67ms
+step:128/1840 train_time:4311ms step_avg:33.68ms
+step:129/1840 train_time:4343ms step_avg:33.67ms
+step:130/1840 train_time:4377ms step_avg:33.67ms
+step:131/1840 train_time:4409ms step_avg:33.66ms
+step:132/1840 train_time:4444ms step_avg:33.66ms
+step:133/1840 train_time:4476ms step_avg:33.65ms
+step:134/1840 train_time:4510ms step_avg:33.66ms
+step:135/1840 train_time:4542ms step_avg:33.65ms
+step:136/1840 train_time:4577ms step_avg:33.65ms
+step:137/1840 train_time:4609ms step_avg:33.64ms
+step:138/1840 train_time:4643ms step_avg:33.65ms
+step:139/1840 train_time:4675ms step_avg:33.63ms
+step:140/1840 train_time:4709ms step_avg:33.64ms
+step:141/1840 train_time:4742ms step_avg:33.63ms
+step:142/1840 train_time:4776ms step_avg:33.63ms
+step:143/1840 train_time:4808ms step_avg:33.62ms
+step:144/1840 train_time:4842ms step_avg:33.63ms
+step:145/1840 train_time:4875ms step_avg:33.62ms
+step:146/1840 train_time:4909ms step_avg:33.62ms
+step:147/1840 train_time:4941ms step_avg:33.61ms
+step:148/1840 train_time:4975ms step_avg:33.62ms
+step:149/1840 train_time:5008ms step_avg:33.61ms
+step:150/1840 train_time:5042ms step_avg:33.61ms
+step:151/1840 train_time:5074ms step_avg:33.60ms
+step:152/1840 train_time:5108ms step_avg:33.61ms
+step:153/1840 train_time:5140ms step_avg:33.60ms
+step:154/1840 train_time:5175ms step_avg:33.60ms
+step:155/1840 train_time:5207ms step_avg:33.59ms
+step:156/1840 train_time:5241ms step_avg:33.60ms
+step:157/1840 train_time:5273ms step_avg:33.59ms
+step:158/1840 train_time:5307ms step_avg:33.59ms
+step:159/1840 train_time:5340ms step_avg:33.58ms
+step:160/1840 train_time:5374ms step_avg:33.59ms
+step:161/1840 train_time:5406ms step_avg:33.58ms
+step:162/1840 train_time:5440ms step_avg:33.58ms
+step:163/1840 train_time:5472ms step_avg:33.57ms
+step:164/1840 train_time:5507ms step_avg:33.58ms
+step:165/1840 train_time:5539ms step_avg:33.57ms
+step:166/1840 train_time:5573ms step_avg:33.57ms
+step:167/1840 train_time:5605ms step_avg:33.56ms
+step:168/1840 train_time:5639ms step_avg:33.57ms
+step:169/1840 train_time:5671ms step_avg:33.56ms
+step:170/1840 train_time:5705ms step_avg:33.56ms
+step:171/1840 train_time:5737ms step_avg:33.55ms
+step:172/1840 train_time:5771ms step_avg:33.55ms
+step:173/1840 train_time:5803ms step_avg:33.54ms
+step:174/1840 train_time:5837ms step_avg:33.55ms
+step:175/1840 train_time:5869ms step_avg:33.54ms
+step:176/1840 train_time:5903ms step_avg:33.54ms
+step:177/1840 train_time:5936ms step_avg:33.53ms
+step:178/1840 train_time:5970ms step_avg:33.54ms
+step:179/1840 train_time:6002ms step_avg:33.53ms
+step:180/1840 train_time:6036ms step_avg:33.54ms
+step:181/1840 train_time:6069ms step_avg:33.53ms
+step:182/1840 train_time:6103ms step_avg:33.53ms
+step:183/1840 train_time:6135ms step_avg:33.53ms
+step:184/1840 train_time:6170ms step_avg:33.53ms
+step:185/1840 train_time:6202ms step_avg:33.52ms
+step:186/1840 train_time:6236ms step_avg:33.53ms
+step:187/1840 train_time:6269ms step_avg:33.52ms
+step:188/1840 train_time:6303ms step_avg:33.53ms
+step:189/1840 train_time:6335ms step_avg:33.52ms
+step:190/1840 train_time:6369ms step_avg:33.52ms
+step:191/1840 train_time:6402ms step_avg:33.52ms
+step:192/1840 train_time:6436ms step_avg:33.52ms
+step:193/1840 train_time:6468ms step_avg:33.51ms
+step:194/1840 train_time:6502ms step_avg:33.52ms
+step:195/1840 train_time:6534ms step_avg:33.51ms
+step:196/1840 train_time:6569ms step_avg:33.51ms
+step:197/1840 train_time:6601ms step_avg:33.51ms
+step:198/1840 train_time:6635ms step_avg:33.51ms
+step:199/1840 train_time:6667ms step_avg:33.50ms
+step:200/1840 train_time:6702ms step_avg:33.51ms
+step:201/1840 train_time:6734ms step_avg:33.50ms
+step:202/1840 train_time:6768ms step_avg:33.51ms
+step:203/1840 train_time:6800ms step_avg:33.50ms
+step:204/1840 train_time:6834ms step_avg:33.50ms
+step:205/1840 train_time:6866ms step_avg:33.49ms
+step:206/1840 train_time:6901ms step_avg:33.50ms
+step:207/1840 train_time:6933ms step_avg:33.49ms
+step:208/1840 train_time:6967ms step_avg:33.50ms
+step:209/1840 train_time:6999ms step_avg:33.49ms
+step:210/1840 train_time:7033ms step_avg:33.49ms
+step:211/1840 train_time:7065ms step_avg:33.49ms
+step:212/1840 train_time:7100ms step_avg:33.49ms
+step:213/1840 train_time:7132ms step_avg:33.48ms
+step:214/1840 train_time:7166ms step_avg:33.48ms
+step:215/1840 train_time:7198ms step_avg:33.48ms
+step:216/1840 train_time:7232ms step_avg:33.48ms
+step:217/1840 train_time:7264ms step_avg:33.48ms
+step:218/1840 train_time:7298ms step_avg:33.48ms
+step:219/1840 train_time:7330ms step_avg:33.47ms
+step:220/1840 train_time:7365ms step_avg:33.48ms
+step:221/1840 train_time:7397ms step_avg:33.47ms
+step:222/1840 train_time:7431ms step_avg:33.48ms
+step:223/1840 train_time:7464ms step_avg:33.47ms
+step:224/1840 train_time:7498ms step_avg:33.47ms
+step:225/1840 train_time:7530ms step_avg:33.47ms
+step:226/1840 train_time:7564ms step_avg:33.47ms
+step:227/1840 train_time:7596ms step_avg:33.46ms
+step:228/1840 train_time:7630ms step_avg:33.46ms
+step:229/1840 train_time:7663ms step_avg:33.46ms
+step:230/1840 train_time:7697ms step_avg:33.47ms
+step:231/1840 train_time:7729ms step_avg:33.46ms
+step:232/1840 train_time:7763ms step_avg:33.46ms
+step:233/1840 train_time:7795ms step_avg:33.46ms
+step:234/1840 train_time:7829ms step_avg:33.46ms
+step:235/1840 train_time:7862ms step_avg:33.45ms
+step:236/1840 train_time:7896ms step_avg:33.46ms
+step:237/1840 train_time:7928ms step_avg:33.45ms
+step:238/1840 train_time:7962ms step_avg:33.45ms
+step:239/1840 train_time:7994ms step_avg:33.45ms
+step:240/1840 train_time:8029ms step_avg:33.45ms
+step:241/1840 train_time:8061ms step_avg:33.45ms
+step:242/1840 train_time:8095ms step_avg:33.45ms
+step:243/1840 train_time:8127ms step_avg:33.44ms
+step:244/1840 train_time:8161ms step_avg:33.45ms
+step:245/1840 train_time:8194ms step_avg:33.44ms
+step:246/1840 train_time:8228ms step_avg:33.45ms
+step:247/1840 train_time:8260ms step_avg:33.44ms
+step:248/1840 train_time:8294ms step_avg:33.44ms
+step:249/1840 train_time:8326ms step_avg:33.44ms
+step:250/1840 train_time:8361ms step_avg:33.44ms
+step:250/1840 val_loss:4.6133 train_time:8403ms step_avg:33.61ms
+step:251/1840 train_time:8421ms step_avg:33.55ms
+step:252/1840 train_time:8439ms step_avg:33.49ms
+step:253/1840 train_time:8463ms step_avg:33.45ms
+step:254/1840 train_time:8497ms step_avg:33.45ms
+step:255/1840 train_time:8531ms step_avg:33.45ms
+step:256/1840 train_time:8566ms step_avg:33.46ms
+step:257/1840 train_time:8599ms step_avg:33.46ms
+step:258/1840 train_time:8634ms step_avg:33.47ms
+step:259/1840 train_time:8667ms step_avg:33.46ms
+step:260/1840 train_time:8701ms step_avg:33.47ms
+step:261/1840 train_time:8733ms step_avg:33.46ms
+step:262/1840 train_time:8767ms step_avg:33.46ms
+step:263/1840 train_time:8799ms step_avg:33.46ms
+step:264/1840 train_time:8833ms step_avg:33.46ms
+step:265/1840 train_time:8865ms step_avg:33.45ms
+step:266/1840 train_time:8899ms step_avg:33.46ms
+step:267/1840 train_time:8931ms step_avg:33.45ms
+step:268/1840 train_time:8965ms step_avg:33.45ms
+step:269/1840 train_time:8997ms step_avg:33.45ms
+step:270/1840 train_time:9031ms step_avg:33.45ms
+step:271/1840 train_time:9063ms step_avg:33.44ms
+step:272/1840 train_time:9097ms step_avg:33.44ms
+step:273/1840 train_time:9129ms step_avg:33.44ms
+step:274/1840 train_time:9163ms step_avg:33.44ms
+step:275/1840 train_time:9195ms step_avg:33.44ms
+step:276/1840 train_time:9229ms step_avg:33.44ms
+step:277/1840 train_time:9261ms step_avg:33.43ms
+step:278/1840 train_time:9295ms step_avg:33.44ms
+step:279/1840 train_time:9327ms step_avg:33.43ms
+step:280/1840 train_time:9362ms step_avg:33.43ms
+step:281/1840 train_time:9394ms step_avg:33.43ms
+step:282/1840 train_time:9429ms step_avg:33.43ms
+step:283/1840 train_time:9461ms step_avg:33.43ms
+step:284/1840 train_time:9496ms step_avg:33.44ms
+step:285/1840 train_time:9529ms step_avg:33.43ms
+step:286/1840 train_time:9563ms step_avg:33.44ms
+step:287/1840 train_time:9596ms step_avg:33.44ms
+step:288/1840 train_time:9630ms step_avg:33.44ms
+step:289/1840 train_time:9662ms step_avg:33.43ms
+step:290/1840 train_time:9697ms step_avg:33.44ms
+step:291/1840 train_time:9729ms step_avg:33.43ms
+step:292/1840 train_time:9763ms step_avg:33.43ms
+step:293/1840 train_time:9795ms step_avg:33.43ms
+step:294/1840 train_time:9830ms step_avg:33.43ms
+step:295/1840 train_time:9862ms step_avg:33.43ms
+step:296/1840 train_time:9896ms step_avg:33.43ms
+step:297/1840 train_time:9928ms step_avg:33.43ms
+step:298/1840 train_time:9962ms step_avg:33.43ms
+step:299/1840 train_time:9994ms step_avg:33.42ms
+step:300/1840 train_time:10028ms step_avg:33.43ms
+step:301/1840 train_time:10060ms step_avg:33.42ms
+step:302/1840 train_time:10094ms step_avg:33.42ms
+step:303/1840 train_time:10125ms step_avg:33.42ms
+step:304/1840 train_time:10159ms step_avg:33.42ms
+step:305/1840 train_time:10192ms step_avg:33.42ms
+step:306/1840 train_time:10226ms step_avg:33.42ms
+step:307/1840 train_time:10258ms step_avg:33.41ms
+step:308/1840 train_time:10292ms step_avg:33.42ms
+step:309/1840 train_time:10324ms step_avg:33.41ms
+step:310/1840 train_time:10358ms step_avg:33.41ms
+step:311/1840 train_time:10391ms step_avg:33.41ms
+step:312/1840 train_time:10426ms step_avg:33.42ms
+step:313/1840 train_time:10457ms step_avg:33.41ms
+step:314/1840 train_time:10492ms step_avg:33.41ms
+step:315/1840 train_time:10525ms step_avg:33.41ms
+step:316/1840 train_time:10559ms step_avg:33.41ms
+step:317/1840 train_time:10591ms step_avg:33.41ms
+step:318/1840 train_time:10626ms step_avg:33.41ms
+step:319/1840 train_time:10658ms step_avg:33.41ms
+step:320/1840 train_time:10693ms step_avg:33.41ms
+step:321/1840 train_time:10725ms step_avg:33.41ms
+step:322/1840 train_time:10759ms step_avg:33.41ms
+step:323/1840 train_time:10791ms step_avg:33.41ms
+step:324/1840 train_time:10826ms step_avg:33.41ms
+step:325/1840 train_time:10858ms step_avg:33.41ms
+step:326/1840 train_time:10892ms step_avg:33.41ms
+step:327/1840 train_time:10924ms step_avg:33.41ms
+step:328/1840 train_time:10959ms step_avg:33.41ms
+step:329/1840 train_time:10991ms step_avg:33.41ms
+step:330/1840 train_time:11025ms step_avg:33.41ms
+step:331/1840 train_time:11057ms step_avg:33.40ms
+step:332/1840 train_time:11091ms step_avg:33.41ms
+step:333/1840 train_time:11123ms step_avg:33.40ms
+step:334/1840 train_time:11157ms step_avg:33.41ms
+step:335/1840 train_time:11189ms step_avg:33.40ms
+step:336/1840 train_time:11224ms step_avg:33.40ms
+step:337/1840 train_time:11256ms step_avg:33.40ms
+step:338/1840 train_time:11290ms step_avg:33.40ms
+step:339/1840 train_time:11322ms step_avg:33.40ms
+step:340/1840 train_time:11356ms step_avg:33.40ms
+step:341/1840 train_time:11388ms step_avg:33.40ms
+step:342/1840 train_time:11423ms step_avg:33.40ms
+step:343/1840 train_time:11455ms step_avg:33.40ms
+step:344/1840 train_time:11489ms step_avg:33.40ms
+step:345/1840 train_time:11521ms step_avg:33.39ms
+step:346/1840 train_time:11555ms step_avg:33.40ms
+step:347/1840 train_time:11587ms step_avg:33.39ms
+step:348/1840 train_time:11621ms step_avg:33.40ms
+step:349/1840 train_time:11654ms step_avg:33.39ms
+step:350/1840 train_time:11688ms step_avg:33.39ms
+step:351/1840 train_time:11720ms step_avg:33.39ms
+step:352/1840 train_time:11754ms step_avg:33.39ms
+step:353/1840 train_time:11786ms step_avg:33.39ms
+step:354/1840 train_time:11820ms step_avg:33.39ms
+step:355/1840 train_time:11852ms step_avg:33.39ms
+step:356/1840 train_time:11887ms step_avg:33.39ms
+step:357/1840 train_time:11919ms step_avg:33.39ms
+step:358/1840 train_time:11953ms step_avg:33.39ms
+step:359/1840 train_time:11985ms step_avg:33.38ms
+step:360/1840 train_time:12019ms step_avg:33.39ms
+step:361/1840 train_time:12051ms step_avg:33.38ms
+step:362/1840 train_time:12085ms step_avg:33.38ms
+step:363/1840 train_time:12117ms step_avg:33.38ms
+step:364/1840 train_time:12152ms step_avg:33.38ms
+step:365/1840 train_time:12184ms step_avg:33.38ms
+step:366/1840 train_time:12218ms step_avg:33.38ms
+step:367/1840 train_time:12250ms step_avg:33.38ms
+step:368/1840 train_time:12284ms step_avg:33.38ms
+step:369/1840 train_time:12316ms step_avg:33.38ms
+step:370/1840 train_time:12350ms step_avg:33.38ms
+step:371/1840 train_time:12382ms step_avg:33.38ms
+step:372/1840 train_time:12417ms step_avg:33.38ms
+step:373/1840 train_time:12449ms step_avg:33.37ms
+step:374/1840 train_time:12483ms step_avg:33.38ms
+step:375/1840 train_time:12515ms step_avg:33.37ms
+step:376/1840 train_time:12549ms step_avg:33.38ms
+step:377/1840 train_time:12581ms step_avg:33.37ms
+step:378/1840 train_time:12616ms step_avg:33.38ms
+step:379/1840 train_time:12648ms step_avg:33.37ms
+step:380/1840 train_time:12682ms step_avg:33.37ms
+step:381/1840 train_time:12714ms step_avg:33.37ms
+step:382/1840 train_time:12749ms step_avg:33.37ms
+step:383/1840 train_time:12781ms step_avg:33.37ms
+step:384/1840 train_time:12815ms step_avg:33.37ms
+step:385/1840 train_time:12847ms step_avg:33.37ms
+step:386/1840 train_time:12881ms step_avg:33.37ms
+step:387/1840 train_time:12913ms step_avg:33.37ms
+step:388/1840 train_time:12948ms step_avg:33.37ms
+step:389/1840 train_time:12979ms step_avg:33.37ms
+step:390/1840 train_time:13014ms step_avg:33.37ms
+step:391/1840 train_time:13046ms step_avg:33.36ms
+step:392/1840 train_time:13080ms step_avg:33.37ms
+step:393/1840 train_time:13112ms step_avg:33.36ms
+step:394/1840 train_time:13146ms step_avg:33.37ms
+step:395/1840 train_time:13178ms step_avg:33.36ms
+step:396/1840 train_time:13212ms step_avg:33.36ms
+step:397/1840 train_time:13244ms step_avg:33.36ms
+step:398/1840 train_time:13279ms step_avg:33.36ms
+step:399/1840 train_time:13311ms step_avg:33.36ms
+step:400/1840 train_time:13345ms step_avg:33.36ms
+step:401/1840 train_time:13377ms step_avg:33.36ms
+step:402/1840 train_time:13412ms step_avg:33.36ms
+step:403/1840 train_time:13444ms step_avg:33.36ms
+step:404/1840 train_time:13478ms step_avg:33.36ms
+step:405/1840 train_time:13510ms step_avg:33.36ms
+step:406/1840 train_time:13544ms step_avg:33.36ms
+step:407/1840 train_time:13576ms step_avg:33.36ms
+step:408/1840 train_time:13610ms step_avg:33.36ms
+step:409/1840 train_time:13643ms step_avg:33.36ms
+step:410/1840 train_time:13677ms step_avg:33.36ms
+step:411/1840 train_time:13709ms step_avg:33.35ms
+step:412/1840 train_time:13743ms step_avg:33.36ms
+step:413/1840 train_time:13776ms step_avg:33.35ms
+step:414/1840 train_time:13810ms step_avg:33.36ms
+step:415/1840 train_time:13842ms step_avg:33.36ms
+step:416/1840 train_time:13877ms step_avg:33.36ms
+step:417/1840 train_time:13908ms step_avg:33.35ms
+step:418/1840 train_time:13943ms step_avg:33.36ms
+step:419/1840 train_time:13975ms step_avg:33.35ms
+step:420/1840 train_time:14010ms step_avg:33.36ms
+step:421/1840 train_time:14042ms step_avg:33.35ms
+step:422/1840 train_time:14077ms step_avg:33.36ms
+step:423/1840 train_time:14109ms step_avg:33.35ms
+step:424/1840 train_time:14143ms step_avg:33.36ms
+step:425/1840 train_time:14175ms step_avg:33.35ms
+step:426/1840 train_time:14209ms step_avg:33.36ms
+step:427/1840 train_time:14241ms step_avg:33.35ms
+step:428/1840 train_time:14276ms step_avg:33.35ms
+step:429/1840 train_time:14308ms step_avg:33.35ms
+step:430/1840 train_time:14342ms step_avg:33.35ms
+step:431/1840 train_time:14374ms step_avg:33.35ms
+step:432/1840 train_time:14408ms step_avg:33.35ms
+step:433/1840 train_time:14440ms step_avg:33.35ms
+step:434/1840 train_time:14474ms step_avg:33.35ms
+step:435/1840 train_time:14506ms step_avg:33.35ms
+step:436/1840 train_time:14541ms step_avg:33.35ms
+step:437/1840 train_time:14573ms step_avg:33.35ms
+step:438/1840 train_time:14607ms step_avg:33.35ms
+step:439/1840 train_time:14639ms step_avg:33.35ms
+step:440/1840 train_time:14673ms step_avg:33.35ms
+step:441/1840 train_time:14705ms step_avg:33.35ms
+step:442/1840 train_time:14739ms step_avg:33.35ms
+step:443/1840 train_time:14772ms step_avg:33.35ms
+step:444/1840 train_time:14806ms step_avg:33.35ms
+step:445/1840 train_time:14838ms step_avg:33.34ms
+step:446/1840 train_time:14873ms step_avg:33.35ms
+step:447/1840 train_time:14905ms step_avg:33.34ms
+step:448/1840 train_time:14939ms step_avg:33.35ms
+step:449/1840 train_time:14971ms step_avg:33.34ms
+step:450/1840 train_time:15006ms step_avg:33.35ms
+step:451/1840 train_time:15038ms step_avg:33.34ms
+step:452/1840 train_time:15072ms step_avg:33.35ms
+step:453/1840 train_time:15104ms step_avg:33.34ms
+step:454/1840 train_time:15138ms step_avg:33.34ms
+step:455/1840 train_time:15170ms step_avg:33.34ms
+step:456/1840 train_time:15205ms step_avg:33.34ms
+step:457/1840 train_time:15237ms step_avg:33.34ms
+step:458/1840 train_time:15271ms step_avg:33.34ms
+step:459/1840 train_time:15303ms step_avg:33.34ms
+step:460/1840 train_time:15337ms step_avg:33.34ms
+step:461/1840 train_time:15369ms step_avg:33.34ms
+step:462/1840 train_time:15403ms step_avg:33.34ms
+step:463/1840 train_time:15436ms step_avg:33.34ms
+step:464/1840 train_time:15470ms step_avg:33.34ms
+step:465/1840 train_time:15502ms step_avg:33.34ms
+step:466/1840 train_time:15537ms step_avg:33.34ms
+step:467/1840 train_time:15569ms step_avg:33.34ms
+step:468/1840 train_time:15603ms step_avg:33.34ms
+step:469/1840 train_time:15635ms step_avg:33.34ms
+step:470/1840 train_time:15669ms step_avg:33.34ms
+step:471/1840 train_time:15701ms step_avg:33.34ms
+step:472/1840 train_time:15736ms step_avg:33.34ms
+step:473/1840 train_time:15768ms step_avg:33.34ms
+step:474/1840 train_time:15802ms step_avg:33.34ms
+step:475/1840 train_time:15834ms step_avg:33.33ms
+step:476/1840 train_time:15868ms step_avg:33.34ms
+step:477/1840 train_time:15900ms step_avg:33.33ms
+step:478/1840 train_time:15934ms step_avg:33.33ms
+step:479/1840 train_time:15967ms step_avg:33.33ms
+step:480/1840 train_time:16001ms step_avg:33.34ms
+step:481/1840 train_time:16033ms step_avg:33.33ms
+step:482/1840 train_time:16068ms step_avg:33.34ms
+step:483/1840 train_time:16100ms step_avg:33.33ms
+step:484/1840 train_time:16134ms step_avg:33.33ms
+step:485/1840 train_time:16166ms step_avg:33.33ms
+step:486/1840 train_time:16200ms step_avg:33.33ms
+step:487/1840 train_time:16232ms step_avg:33.33ms
+step:488/1840 train_time:16267ms step_avg:33.33ms
+step:489/1840 train_time:16298ms step_avg:33.33ms
+step:490/1840 train_time:16333ms step_avg:33.33ms
+step:491/1840 train_time:16365ms step_avg:33.33ms
+step:492/1840 train_time:16400ms step_avg:33.33ms
+step:493/1840 train_time:16432ms step_avg:33.33ms
+step:494/1840 train_time:16466ms step_avg:33.33ms
+step:495/1840 train_time:16498ms step_avg:33.33ms
+step:496/1840 train_time:16532ms step_avg:33.33ms
+step:497/1840 train_time:16564ms step_avg:33.33ms
+step:498/1840 train_time:16598ms step_avg:33.33ms
+step:499/1840 train_time:16630ms step_avg:33.33ms
+step:500/1840 train_time:16665ms step_avg:33.33ms
+step:500/1840 val_loss:4.2924 train_time:16706ms step_avg:33.41ms
+step:501/1840 train_time:16724ms step_avg:33.38ms
+step:502/1840 train_time:16742ms step_avg:33.35ms
+step:503/1840 train_time:16766ms step_avg:33.33ms
+step:504/1840 train_time:16800ms step_avg:33.33ms
+step:505/1840 train_time:16834ms step_avg:33.34ms
+step:506/1840 train_time:16870ms step_avg:33.34ms
+step:507/1840 train_time:16903ms step_avg:33.34ms
+step:508/1840 train_time:16937ms step_avg:33.34ms
+step:509/1840 train_time:16969ms step_avg:33.34ms
+step:510/1840 train_time:17003ms step_avg:33.34ms
+step:511/1840 train_time:17035ms step_avg:33.34ms
+step:512/1840 train_time:17069ms step_avg:33.34ms
+step:513/1840 train_time:17101ms step_avg:33.34ms
+step:514/1840 train_time:17135ms step_avg:33.34ms
+step:515/1840 train_time:17167ms step_avg:33.33ms
+step:516/1840 train_time:17201ms step_avg:33.33ms
+step:517/1840 train_time:17233ms step_avg:33.33ms
+step:518/1840 train_time:17267ms step_avg:33.33ms
+step:519/1840 train_time:17298ms step_avg:33.33ms
+step:520/1840 train_time:17333ms step_avg:33.33ms
+step:521/1840 train_time:17365ms step_avg:33.33ms
+step:522/1840 train_time:17398ms step_avg:33.33ms
+step:523/1840 train_time:17430ms step_avg:33.33ms
+step:524/1840 train_time:17464ms step_avg:33.33ms
+step:525/1840 train_time:17496ms step_avg:33.33ms
+step:526/1840 train_time:17530ms step_avg:33.33ms
+step:527/1840 train_time:17562ms step_avg:33.32ms
+step:528/1840 train_time:17596ms step_avg:33.33ms
+step:529/1840 train_time:17629ms step_avg:33.32ms
+step:530/1840 train_time:17663ms step_avg:33.33ms
+step:531/1840 train_time:17696ms step_avg:33.33ms
+step:532/1840 train_time:17730ms step_avg:33.33ms
+step:533/1840 train_time:17763ms step_avg:33.33ms
+step:534/1840 train_time:17797ms step_avg:33.33ms
+step:535/1840 train_time:17830ms step_avg:33.33ms
+step:536/1840 train_time:17865ms step_avg:33.33ms
+step:537/1840 train_time:17897ms step_avg:33.33ms
+step:538/1840 train_time:17931ms step_avg:33.33ms
+step:539/1840 train_time:17963ms step_avg:33.33ms
+step:540/1840 train_time:17998ms step_avg:33.33ms
+step:541/1840 train_time:18030ms step_avg:33.33ms
+step:542/1840 train_time:18064ms step_avg:33.33ms
+step:543/1840 train_time:18096ms step_avg:33.33ms
+step:544/1840 train_time:18130ms step_avg:33.33ms
+step:545/1840 train_time:18162ms step_avg:33.32ms
+step:546/1840 train_time:18196ms step_avg:33.33ms
+step:547/1840 train_time:18228ms step_avg:33.32ms
+step:548/1840 train_time:18262ms step_avg:33.32ms
+step:549/1840 train_time:18294ms step_avg:33.32ms
+step:550/1840 train_time:18328ms step_avg:33.32ms
+step:551/1840 train_time:18360ms step_avg:33.32ms
+step:552/1840 train_time:18394ms step_avg:33.32ms
+step:553/1840 train_time:18426ms step_avg:33.32ms
+step:554/1840 train_time:18460ms step_avg:33.32ms
+step:555/1840 train_time:18492ms step_avg:33.32ms
+step:556/1840 train_time:18526ms step_avg:33.32ms
+step:557/1840 train_time:18558ms step_avg:33.32ms
+step:558/1840 train_time:18592ms step_avg:33.32ms
+step:559/1840 train_time:18624ms step_avg:33.32ms
+step:560/1840 train_time:18658ms step_avg:33.32ms
+step:561/1840 train_time:18691ms step_avg:33.32ms
+step:562/1840 train_time:18725ms step_avg:33.32ms
+step:563/1840 train_time:18758ms step_avg:33.32ms
+step:564/1840 train_time:18792ms step_avg:33.32ms
+step:565/1840 train_time:18824ms step_avg:33.32ms
+step:566/1840 train_time:18859ms step_avg:33.32ms
+step:567/1840 train_time:18892ms step_avg:33.32ms
+step:568/1840 train_time:18926ms step_avg:33.32ms
+step:569/1840 train_time:18959ms step_avg:33.32ms
+step:570/1840 train_time:18993ms step_avg:33.32ms
+step:571/1840 train_time:19026ms step_avg:33.32ms
+step:572/1840 train_time:19060ms step_avg:33.32ms
+step:573/1840 train_time:19092ms step_avg:33.32ms
+step:574/1840 train_time:19126ms step_avg:33.32ms
+step:575/1840 train_time:19158ms step_avg:33.32ms
+step:576/1840 train_time:19193ms step_avg:33.32ms
+step:577/1840 train_time:19225ms step_avg:33.32ms
+step:578/1840 train_time:19259ms step_avg:33.32ms
+step:579/1840 train_time:19291ms step_avg:33.32ms
+step:580/1840 train_time:19325ms step_avg:33.32ms
+step:581/1840 train_time:19357ms step_avg:33.32ms
+step:582/1840 train_time:19392ms step_avg:33.32ms
+step:583/1840 train_time:19424ms step_avg:33.32ms
+step:584/1840 train_time:19458ms step_avg:33.32ms
+step:585/1840 train_time:19490ms step_avg:33.32ms
+step:586/1840 train_time:19524ms step_avg:33.32ms
+step:587/1840 train_time:19556ms step_avg:33.31ms
+step:588/1840 train_time:19590ms step_avg:33.32ms
+step:589/1840 train_time:19622ms step_avg:33.31ms
+step:590/1840 train_time:19656ms step_avg:33.32ms
+step:591/1840 train_time:19688ms step_avg:33.31ms
+step:592/1840 train_time:19723ms step_avg:33.32ms
+step:593/1840 train_time:19755ms step_avg:33.31ms
+step:594/1840 train_time:19790ms step_avg:33.32ms
+step:595/1840 train_time:19822ms step_avg:33.31ms
+step:596/1840 train_time:19856ms step_avg:33.32ms
+step:597/1840 train_time:19889ms step_avg:33.31ms
+step:598/1840 train_time:19923ms step_avg:33.32ms
+step:599/1840 train_time:19955ms step_avg:33.31ms
+step:600/1840 train_time:19990ms step_avg:33.32ms
+step:601/1840 train_time:20024ms step_avg:33.32ms
+step:602/1840 train_time:20082ms step_avg:33.36ms
+step:603/1840 train_time:20142ms step_avg:33.40ms
+step:604/1840 train_time:20203ms step_avg:33.45ms
+step:605/1840 train_time:20263ms step_avg:33.49ms
+step:606/1840 train_time:20324ms step_avg:33.54ms
+step:607/1840 train_time:20383ms step_avg:33.58ms
+step:608/1840 train_time:20445ms step_avg:33.63ms
+step:609/1840 train_time:20505ms step_avg:33.67ms
+step:610/1840 train_time:20567ms step_avg:33.72ms
+step:611/1840 train_time:20627ms step_avg:33.76ms
+step:612/1840 train_time:20690ms step_avg:33.81ms
+step:613/1840 train_time:20750ms step_avg:33.85ms
+step:614/1840 train_time:20813ms step_avg:33.90ms
+step:615/1840 train_time:20873ms step_avg:33.94ms
+step:616/1840 train_time:20936ms step_avg:33.99ms
+step:617/1840 train_time:20996ms step_avg:34.03ms
+step:618/1840 train_time:21058ms step_avg:34.08ms
+step:619/1840 train_time:21118ms step_avg:34.12ms
+step:620/1840 train_time:21180ms step_avg:34.16ms
+step:621/1840 train_time:21240ms step_avg:34.20ms
+step:622/1840 train_time:21302ms step_avg:34.25ms
+step:623/1840 train_time:21361ms step_avg:34.29ms
+step:624/1840 train_time:21423ms step_avg:34.33ms
+step:625/1840 train_time:21482ms step_avg:34.37ms
+step:626/1840 train_time:21545ms step_avg:34.42ms
+step:627/1840 train_time:21604ms step_avg:34.46ms
+step:628/1840 train_time:21667ms step_avg:34.50ms
+step:629/1840 train_time:21727ms step_avg:34.54ms
+step:630/1840 train_time:21790ms step_avg:34.59ms
+step:631/1840 train_time:21850ms step_avg:34.63ms
+step:632/1840 train_time:21912ms step_avg:34.67ms
+step:633/1840 train_time:21972ms step_avg:34.71ms
+step:634/1840 train_time:22035ms step_avg:34.76ms
+step:635/1840 train_time:22095ms step_avg:34.80ms
+step:636/1840 train_time:22158ms step_avg:34.84ms
+step:637/1840 train_time:22219ms step_avg:34.88ms
+step:638/1840 train_time:22281ms step_avg:34.92ms
+step:639/1840 train_time:22340ms step_avg:34.96ms
+step:640/1840 train_time:22402ms step_avg:35.00ms
+step:641/1840 train_time:22461ms step_avg:35.04ms
+step:642/1840 train_time:22523ms step_avg:35.08ms
+step:643/1840 train_time:22583ms step_avg:35.12ms
+step:644/1840 train_time:22645ms step_avg:35.16ms
+step:645/1840 train_time:22704ms step_avg:35.20ms
+step:646/1840 train_time:22767ms step_avg:35.24ms
+step:647/1840 train_time:22827ms step_avg:35.28ms
+step:648/1840 train_time:22890ms step_avg:35.32ms
+step:649/1840 train_time:22951ms step_avg:35.36ms
+step:650/1840 train_time:23014ms step_avg:35.41ms
+step:651/1840 train_time:23074ms step_avg:35.44ms
+step:652/1840 train_time:23137ms step_avg:35.49ms
+step:653/1840 train_time:23198ms step_avg:35.52ms
+step:654/1840 train_time:23260ms step_avg:35.57ms
+step:655/1840 train_time:23319ms step_avg:35.60ms
+step:656/1840 train_time:23381ms step_avg:35.64ms
+step:657/1840 train_time:23441ms step_avg:35.68ms
+step:658/1840 train_time:23502ms step_avg:35.72ms
+step:659/1840 train_time:23562ms step_avg:35.75ms
+step:660/1840 train_time:23624ms step_avg:35.79ms
+step:661/1840 train_time:23683ms step_avg:35.83ms
+step:662/1840 train_time:23747ms step_avg:35.87ms
+step:663/1840 train_time:23806ms step_avg:35.91ms
+step:664/1840 train_time:23868ms step_avg:35.95ms
+step:665/1840 train_time:23929ms step_avg:35.98ms
+step:666/1840 train_time:23991ms step_avg:36.02ms
+step:667/1840 train_time:24052ms step_avg:36.06ms
+step:668/1840 train_time:24115ms step_avg:36.10ms
+step:669/1840 train_time:24176ms step_avg:36.14ms
+step:670/1840 train_time:24239ms step_avg:36.18ms
+step:671/1840 train_time:24299ms step_avg:36.21ms
+step:672/1840 train_time:24361ms step_avg:36.25ms
+step:673/1840 train_time:24420ms step_avg:36.29ms
+step:674/1840 train_time:24482ms step_avg:36.32ms
+step:675/1840 train_time:24542ms step_avg:36.36ms
+step:676/1840 train_time:24604ms step_avg:36.40ms
+step:677/1840 train_time:24663ms step_avg:36.43ms
+step:678/1840 train_time:24726ms step_avg:36.47ms
+step:679/1840 train_time:24785ms step_avg:36.50ms
+step:680/1840 train_time:24847ms step_avg:36.54ms
+step:681/1840 train_time:24906ms step_avg:36.57ms
+step:682/1840 train_time:24969ms step_avg:36.61ms
+step:683/1840 train_time:25029ms step_avg:36.65ms
+step:684/1840 train_time:25092ms step_avg:36.68ms
+step:685/1840 train_time:25153ms step_avg:36.72ms
+step:686/1840 train_time:25216ms step_avg:36.76ms
+step:687/1840 train_time:25277ms step_avg:36.79ms
+step:688/1840 train_time:25338ms step_avg:36.83ms
+step:689/1840 train_time:25398ms step_avg:36.86ms
+step:690/1840 train_time:25460ms step_avg:36.90ms
+step:691/1840 train_time:25521ms step_avg:36.93ms
+step:692/1840 train_time:25583ms step_avg:36.97ms
+step:693/1840 train_time:25643ms step_avg:37.00ms
+step:694/1840 train_time:25704ms step_avg:37.04ms
+step:695/1840 train_time:25763ms step_avg:37.07ms
+step:696/1840 train_time:25826ms step_avg:37.11ms
+step:697/1840 train_time:25886ms step_avg:37.14ms
+step:698/1840 train_time:25949ms step_avg:37.18ms
+step:699/1840 train_time:26008ms step_avg:37.21ms
+step:700/1840 train_time:26070ms step_avg:37.24ms
+step:701/1840 train_time:26130ms step_avg:37.28ms
+step:702/1840 train_time:26193ms step_avg:37.31ms
+step:703/1840 train_time:26252ms step_avg:37.34ms
+step:704/1840 train_time:26315ms step_avg:37.38ms
+step:705/1840 train_time:26375ms step_avg:37.41ms
+step:706/1840 train_time:26439ms step_avg:37.45ms
+step:707/1840 train_time:26499ms step_avg:37.48ms
+step:708/1840 train_time:26562ms step_avg:37.52ms
+step:709/1840 train_time:26621ms step_avg:37.55ms
+step:710/1840 train_time:26684ms step_avg:37.58ms
+step:711/1840 train_time:26743ms step_avg:37.61ms
+step:712/1840 train_time:26805ms step_avg:37.65ms
+step:713/1840 train_time:26864ms step_avg:37.68ms
+step:714/1840 train_time:26926ms step_avg:37.71ms
+step:715/1840 train_time:26986ms step_avg:37.74ms
+step:716/1840 train_time:27049ms step_avg:37.78ms
+step:717/1840 train_time:27109ms step_avg:37.81ms
+step:718/1840 train_time:27171ms step_avg:37.84ms
+step:719/1840 train_time:27232ms step_avg:37.87ms
+step:720/1840 train_time:27295ms step_avg:37.91ms
+step:721/1840 train_time:27355ms step_avg:37.94ms
+step:722/1840 train_time:27417ms step_avg:37.97ms
+step:723/1840 train_time:27478ms step_avg:38.01ms
+step:724/1840 train_time:27541ms step_avg:38.04ms
+step:725/1840 train_time:27601ms step_avg:38.07ms
+step:726/1840 train_time:27663ms step_avg:38.10ms
+step:727/1840 train_time:27722ms step_avg:38.13ms
+step:728/1840 train_time:27783ms step_avg:38.16ms
+step:729/1840 train_time:27844ms step_avg:38.20ms
+step:730/1840 train_time:27906ms step_avg:38.23ms
+step:731/1840 train_time:27965ms step_avg:38.26ms
+step:732/1840 train_time:28027ms step_avg:38.29ms
+step:733/1840 train_time:28086ms step_avg:38.32ms
+step:734/1840 train_time:28149ms step_avg:38.35ms
+step:735/1840 train_time:28210ms step_avg:38.38ms
+step:736/1840 train_time:28272ms step_avg:38.41ms
+step:737/1840 train_time:28333ms step_avg:38.44ms
+step:738/1840 train_time:28397ms step_avg:38.48ms
+step:739/1840 train_time:28458ms step_avg:38.51ms
+step:740/1840 train_time:28520ms step_avg:38.54ms
+step:741/1840 train_time:28580ms step_avg:38.57ms
+step:742/1840 train_time:28642ms step_avg:38.60ms
+step:743/1840 train_time:28701ms step_avg:38.63ms
+step:744/1840 train_time:28763ms step_avg:38.66ms
+step:745/1840 train_time:28822ms step_avg:38.69ms
+step:746/1840 train_time:28884ms step_avg:38.72ms
+step:747/1840 train_time:28944ms step_avg:38.75ms
+step:748/1840 train_time:29006ms step_avg:38.78ms
+step:749/1840 train_time:29065ms step_avg:38.81ms
+step:750/1840 train_time:29127ms step_avg:38.84ms
+step:750/1840 val_loss:4.0171 train_time:29200ms step_avg:38.93ms
+step:751/1840 train_time:29220ms step_avg:38.91ms
+step:752/1840 train_time:29252ms step_avg:38.90ms
+step:753/1840 train_time:29313ms step_avg:38.93ms
+step:754/1840 train_time:29375ms step_avg:38.96ms
+step:755/1840 train_time:29437ms step_avg:38.99ms
+step:756/1840 train_time:29500ms step_avg:39.02ms
+step:757/1840 train_time:29559ms step_avg:39.05ms
+step:758/1840 train_time:29621ms step_avg:39.08ms
+step:759/1840 train_time:29681ms step_avg:39.10ms
+step:760/1840 train_time:29743ms step_avg:39.14ms
+step:761/1840 train_time:29802ms step_avg:39.16ms
+step:762/1840 train_time:29863ms step_avg:39.19ms
+step:763/1840 train_time:29923ms step_avg:39.22ms
+step:764/1840 train_time:29986ms step_avg:39.25ms
+step:765/1840 train_time:30046ms step_avg:39.28ms
+step:766/1840 train_time:30109ms step_avg:39.31ms
+step:767/1840 train_time:30170ms step_avg:39.33ms
+step:768/1840 train_time:30233ms step_avg:39.37ms
+step:769/1840 train_time:30294ms step_avg:39.39ms
+step:770/1840 train_time:30356ms step_avg:39.42ms
+step:771/1840 train_time:30415ms step_avg:39.45ms
+step:772/1840 train_time:30478ms step_avg:39.48ms
+step:773/1840 train_time:30537ms step_avg:39.51ms
+step:774/1840 train_time:30599ms step_avg:39.53ms
+step:775/1840 train_time:30659ms step_avg:39.56ms
+step:776/1840 train_time:30722ms step_avg:39.59ms
+step:777/1840 train_time:30781ms step_avg:39.62ms
+step:778/1840 train_time:30843ms step_avg:39.64ms
+step:779/1840 train_time:30903ms step_avg:39.67ms
+step:780/1840 train_time:30966ms step_avg:39.70ms
+step:781/1840 train_time:31026ms step_avg:39.73ms
+step:782/1840 train_time:31088ms step_avg:39.76ms
+step:783/1840 train_time:31149ms step_avg:39.78ms
+step:784/1840 train_time:31211ms step_avg:39.81ms
+step:785/1840 train_time:31272ms step_avg:39.84ms
+step:786/1840 train_time:31335ms step_avg:39.87ms
+step:787/1840 train_time:31395ms step_avg:39.89ms
+step:788/1840 train_time:31456ms step_avg:39.92ms
+step:789/1840 train_time:31516ms step_avg:39.94ms
+step:790/1840 train_time:31577ms step_avg:39.97ms
+step:791/1840 train_time:31636ms step_avg:40.00ms
+step:792/1840 train_time:31699ms step_avg:40.02ms
+step:793/1840 train_time:31759ms step_avg:40.05ms
+step:794/1840 train_time:31821ms step_avg:40.08ms
+step:795/1840 train_time:31881ms step_avg:40.10ms
+step:796/1840 train_time:31943ms step_avg:40.13ms
+step:797/1840 train_time:32003ms step_avg:40.15ms
+step:798/1840 train_time:32066ms step_avg:40.18ms
+step:799/1840 train_time:32127ms step_avg:40.21ms
+step:800/1840 train_time:32190ms step_avg:40.24ms
+step:801/1840 train_time:32250ms step_avg:40.26ms
+step:802/1840 train_time:32313ms step_avg:40.29ms
+step:803/1840 train_time:32372ms step_avg:40.31ms
+step:804/1840 train_time:32435ms step_avg:40.34ms
+step:805/1840 train_time:32495ms step_avg:40.37ms
+step:806/1840 train_time:32556ms step_avg:40.39ms
+step:807/1840 train_time:32616ms step_avg:40.42ms
+step:808/1840 train_time:32678ms step_avg:40.44ms
+step:809/1840 train_time:32737ms step_avg:40.47ms
+step:810/1840 train_time:32799ms step_avg:40.49ms
+step:811/1840 train_time:32858ms step_avg:40.52ms
+step:812/1840 train_time:32920ms step_avg:40.54ms
+step:813/1840 train_time:32981ms step_avg:40.57ms
+step:814/1840 train_time:33044ms step_avg:40.59ms
+step:815/1840 train_time:33105ms step_avg:40.62ms
+step:816/1840 train_time:33168ms step_avg:40.65ms
+step:817/1840 train_time:33228ms step_avg:40.67ms
+step:818/1840 train_time:33290ms step_avg:40.70ms
+step:819/1840 train_time:33351ms step_avg:40.72ms
+step:820/1840 train_time:33413ms step_avg:40.75ms
+step:821/1840 train_time:33474ms step_avg:40.77ms
+step:822/1840 train_time:33535ms step_avg:40.80ms
+step:823/1840 train_time:33595ms step_avg:40.82ms
+step:824/1840 train_time:33657ms step_avg:40.85ms
+step:825/1840 train_time:33716ms step_avg:40.87ms
+step:826/1840 train_time:33779ms step_avg:40.89ms
+step:827/1840 train_time:33837ms step_avg:40.92ms
+step:828/1840 train_time:33900ms step_avg:40.94ms
+step:829/1840 train_time:33959ms step_avg:40.96ms
+step:830/1840 train_time:34022ms step_avg:40.99ms
+step:831/1840 train_time:34084ms step_avg:41.02ms
+step:832/1840 train_time:34147ms step_avg:41.04ms
+step:833/1840 train_time:34208ms step_avg:41.07ms
+step:834/1840 train_time:34270ms step_avg:41.09ms
+step:835/1840 train_time:34330ms step_avg:41.11ms
+step:836/1840 train_time:34392ms step_avg:41.14ms
+step:837/1840 train_time:34452ms step_avg:41.16ms
+step:838/1840 train_time:34514ms step_avg:41.19ms
+step:839/1840 train_time:34573ms step_avg:41.21ms
+step:840/1840 train_time:34635ms step_avg:41.23ms
+step:841/1840 train_time:34695ms step_avg:41.25ms
+step:842/1840 train_time:34756ms step_avg:41.28ms
+step:843/1840 train_time:34815ms step_avg:41.30ms
+step:844/1840 train_time:34877ms step_avg:41.32ms
+step:845/1840 train_time:34937ms step_avg:41.35ms
+step:846/1840 train_time:35000ms step_avg:41.37ms
+step:847/1840 train_time:35060ms step_avg:41.39ms
+step:848/1840 train_time:35123ms step_avg:41.42ms
+step:849/1840 train_time:35184ms step_avg:41.44ms
+step:850/1840 train_time:35247ms step_avg:41.47ms
+step:851/1840 train_time:35307ms step_avg:41.49ms
+step:852/1840 train_time:35369ms step_avg:41.51ms
+step:853/1840 train_time:35430ms step_avg:41.54ms
+step:854/1840 train_time:35492ms step_avg:41.56ms
+step:855/1840 train_time:35552ms step_avg:41.58ms
+step:856/1840 train_time:35613ms step_avg:41.60ms
+step:857/1840 train_time:35673ms step_avg:41.63ms
+step:858/1840 train_time:35736ms step_avg:41.65ms
+step:859/1840 train_time:35795ms step_avg:41.67ms
+step:860/1840 train_time:35857ms step_avg:41.69ms
+step:861/1840 train_time:35917ms step_avg:41.72ms
+step:862/1840 train_time:35979ms step_avg:41.74ms
+step:863/1840 train_time:36038ms step_avg:41.76ms
+step:864/1840 train_time:36102ms step_avg:41.78ms
+step:865/1840 train_time:36162ms step_avg:41.81ms
+step:866/1840 train_time:36225ms step_avg:41.83ms
+step:867/1840 train_time:36285ms step_avg:41.85ms
+step:868/1840 train_time:36348ms step_avg:41.88ms
+step:869/1840 train_time:36409ms step_avg:41.90ms
+step:870/1840 train_time:36472ms step_avg:41.92ms
+step:871/1840 train_time:36531ms step_avg:41.94ms
+step:872/1840 train_time:36593ms step_avg:41.96ms
+step:873/1840 train_time:36653ms step_avg:41.98ms
+step:874/1840 train_time:36715ms step_avg:42.01ms
+step:875/1840 train_time:36774ms step_avg:42.03ms
+step:876/1840 train_time:36836ms step_avg:42.05ms
+step:877/1840 train_time:36895ms step_avg:42.07ms
+step:878/1840 train_time:36957ms step_avg:42.09ms
+step:879/1840 train_time:37017ms step_avg:42.11ms
+step:880/1840 train_time:37079ms step_avg:42.14ms
+step:881/1840 train_time:37140ms step_avg:42.16ms
+step:882/1840 train_time:37203ms step_avg:42.18ms
+step:883/1840 train_time:37263ms step_avg:42.20ms
+step:884/1840 train_time:37325ms step_avg:42.22ms
+step:885/1840 train_time:37387ms step_avg:42.25ms
+step:886/1840 train_time:37449ms step_avg:42.27ms
+step:887/1840 train_time:37509ms step_avg:42.29ms
+step:888/1840 train_time:37572ms step_avg:42.31ms
+step:889/1840 train_time:37632ms step_avg:42.33ms
+step:890/1840 train_time:37693ms step_avg:42.35ms
+step:891/1840 train_time:37753ms step_avg:42.37ms
+step:892/1840 train_time:37815ms step_avg:42.39ms
+step:893/1840 train_time:37874ms step_avg:42.41ms
+step:894/1840 train_time:37936ms step_avg:42.43ms
+step:895/1840 train_time:37995ms step_avg:42.45ms
+step:896/1840 train_time:38058ms step_avg:42.48ms
+step:897/1840 train_time:38118ms step_avg:42.49ms
+step:898/1840 train_time:38181ms step_avg:42.52ms
+step:899/1840 train_time:38239ms step_avg:42.54ms
+step:900/1840 train_time:38302ms step_avg:42.56ms
+step:901/1840 train_time:38364ms step_avg:42.58ms
+step:902/1840 train_time:38426ms step_avg:42.60ms
+step:903/1840 train_time:38486ms step_avg:42.62ms
+step:904/1840 train_time:38549ms step_avg:42.64ms
+step:905/1840 train_time:38609ms step_avg:42.66ms
+step:906/1840 train_time:38671ms step_avg:42.68ms
+step:907/1840 train_time:38731ms step_avg:42.70ms
+step:908/1840 train_time:38793ms step_avg:42.72ms
+step:909/1840 train_time:38852ms step_avg:42.74ms
+step:910/1840 train_time:38915ms step_avg:42.76ms
+step:911/1840 train_time:38974ms step_avg:42.78ms
+step:912/1840 train_time:39035ms step_avg:42.80ms
+step:913/1840 train_time:39094ms step_avg:42.82ms
+step:914/1840 train_time:39158ms step_avg:42.84ms
+step:915/1840 train_time:39217ms step_avg:42.86ms
+step:916/1840 train_time:39280ms step_avg:42.88ms
+step:917/1840 train_time:39340ms step_avg:42.90ms
+step:918/1840 train_time:39404ms step_avg:42.92ms
+step:919/1840 train_time:39465ms step_avg:42.94ms
+step:920/1840 train_time:39528ms step_avg:42.97ms
+step:921/1840 train_time:39589ms step_avg:42.98ms
+step:922/1840 train_time:39652ms step_avg:43.01ms
+step:923/1840 train_time:39712ms step_avg:43.02ms
+step:924/1840 train_time:39774ms step_avg:43.04ms
+step:925/1840 train_time:39833ms step_avg:43.06ms
+step:926/1840 train_time:39895ms step_avg:43.08ms
+step:927/1840 train_time:39954ms step_avg:43.10ms
+step:928/1840 train_time:40016ms step_avg:43.12ms
+step:929/1840 train_time:40076ms step_avg:43.14ms
+step:930/1840 train_time:40138ms step_avg:43.16ms
+step:931/1840 train_time:40197ms step_avg:43.18ms
+step:932/1840 train_time:40260ms step_avg:43.20ms
+step:933/1840 train_time:40321ms step_avg:43.22ms
+step:934/1840 train_time:40383ms step_avg:43.24ms
+step:935/1840 train_time:40443ms step_avg:43.25ms
+step:936/1840 train_time:40507ms step_avg:43.28ms
+step:937/1840 train_time:40568ms step_avg:43.30ms
+step:938/1840 train_time:40630ms step_avg:43.32ms
+step:939/1840 train_time:40690ms step_avg:43.33ms
+step:940/1840 train_time:40753ms step_avg:43.35ms
+step:941/1840 train_time:40813ms step_avg:43.37ms
+step:942/1840 train_time:40875ms step_avg:43.39ms
+step:943/1840 train_time:40934ms step_avg:43.41ms
+step:944/1840 train_time:40996ms step_avg:43.43ms
+step:945/1840 train_time:41056ms step_avg:43.45ms
+step:946/1840 train_time:41117ms step_avg:43.46ms
+step:947/1840 train_time:41177ms step_avg:43.48ms
+step:948/1840 train_time:41240ms step_avg:43.50ms
+step:949/1840 train_time:41299ms step_avg:43.52ms
+step:950/1840 train_time:41362ms step_avg:43.54ms
+step:951/1840 train_time:41422ms step_avg:43.56ms
+step:952/1840 train_time:41486ms step_avg:43.58ms
+step:953/1840 train_time:41547ms step_avg:43.60ms
+step:954/1840 train_time:41609ms step_avg:43.62ms
+step:955/1840 train_time:41670ms step_avg:43.63ms
+step:956/1840 train_time:41732ms step_avg:43.65ms
+step:957/1840 train_time:41791ms step_avg:43.67ms
+step:958/1840 train_time:41854ms step_avg:43.69ms
+step:959/1840 train_time:41913ms step_avg:43.70ms
+step:960/1840 train_time:41975ms step_avg:43.72ms
+step:961/1840 train_time:42035ms step_avg:43.74ms
+step:962/1840 train_time:42097ms step_avg:43.76ms
+step:963/1840 train_time:42156ms step_avg:43.78ms
+step:964/1840 train_time:42219ms step_avg:43.80ms
+step:965/1840 train_time:42278ms step_avg:43.81ms
+step:966/1840 train_time:42341ms step_avg:43.83ms
+step:967/1840 train_time:42402ms step_avg:43.85ms
+step:968/1840 train_time:42465ms step_avg:43.87ms
+step:969/1840 train_time:42525ms step_avg:43.89ms
+step:970/1840 train_time:42588ms step_avg:43.91ms
+step:971/1840 train_time:42648ms step_avg:43.92ms
+step:972/1840 train_time:42710ms step_avg:43.94ms
+step:973/1840 train_time:42771ms step_avg:43.96ms
+step:974/1840 train_time:42833ms step_avg:43.98ms
+step:975/1840 train_time:42892ms step_avg:43.99ms
+step:976/1840 train_time:42954ms step_avg:44.01ms
+step:977/1840 train_time:43014ms step_avg:44.03ms
+step:978/1840 train_time:43075ms step_avg:44.04ms
+step:979/1840 train_time:43136ms step_avg:44.06ms
+step:980/1840 train_time:43197ms step_avg:44.08ms
+step:981/1840 train_time:43257ms step_avg:44.09ms
+step:982/1840 train_time:43319ms step_avg:44.11ms
+step:983/1840 train_time:43379ms step_avg:44.13ms
+step:984/1840 train_time:43442ms step_avg:44.15ms
+step:985/1840 train_time:43503ms step_avg:44.17ms
+step:986/1840 train_time:43565ms step_avg:44.18ms
+step:987/1840 train_time:43626ms step_avg:44.20ms
+step:988/1840 train_time:43689ms step_avg:44.22ms
+step:989/1840 train_time:43748ms step_avg:44.23ms
+step:990/1840 train_time:43810ms step_avg:44.25ms
+step:991/1840 train_time:43870ms step_avg:44.27ms
+step:992/1840 train_time:43932ms step_avg:44.29ms
+step:993/1840 train_time:43992ms step_avg:44.30ms
+step:994/1840 train_time:44054ms step_avg:44.32ms
+step:995/1840 train_time:44114ms step_avg:44.34ms
+step:996/1840 train_time:44176ms step_avg:44.35ms
+step:997/1840 train_time:44235ms step_avg:44.37ms
+step:998/1840 train_time:44297ms step_avg:44.39ms
+step:999/1840 train_time:44357ms step_avg:44.40ms
+step:1000/1840 train_time:44421ms step_avg:44.42ms
+step:1000/1840 val_loss:3.7666 train_time:44493ms step_avg:44.49ms
+step:1001/1840 train_time:44511ms step_avg:44.47ms
+step:1002/1840 train_time:44544ms step_avg:44.45ms
+step:1003/1840 train_time:44604ms step_avg:44.47ms
+step:1004/1840 train_time:44668ms step_avg:44.49ms
+step:1005/1840 train_time:44728ms step_avg:44.51ms
+step:1006/1840 train_time:44791ms step_avg:44.52ms
+step:1007/1840 train_time:44851ms step_avg:44.54ms
+step:1008/1840 train_time:44913ms step_avg:44.56ms
+step:1009/1840 train_time:44972ms step_avg:44.57ms
+step:1010/1840 train_time:45034ms step_avg:44.59ms
+step:1011/1840 train_time:45094ms step_avg:44.60ms
+step:1012/1840 train_time:45156ms step_avg:44.62ms
+step:1013/1840 train_time:45216ms step_avg:44.64ms
+step:1014/1840 train_time:45278ms step_avg:44.65ms
+step:1015/1840 train_time:45337ms step_avg:44.67ms
+step:1016/1840 train_time:45399ms step_avg:44.68ms
+step:1017/1840 train_time:45460ms step_avg:44.70ms
+step:1018/1840 train_time:45523ms step_avg:44.72ms
+step:1019/1840 train_time:45585ms step_avg:44.73ms
+step:1020/1840 train_time:45647ms step_avg:44.75ms
+step:1021/1840 train_time:45707ms step_avg:44.77ms
+step:1022/1840 train_time:45769ms step_avg:44.78ms
+step:1023/1840 train_time:45828ms step_avg:44.80ms
+step:1024/1840 train_time:45890ms step_avg:44.81ms
+step:1025/1840 train_time:45950ms step_avg:44.83ms
+step:1026/1840 train_time:46013ms step_avg:44.85ms
+step:1027/1840 train_time:46072ms step_avg:44.86ms
+step:1028/1840 train_time:46134ms step_avg:44.88ms
+step:1029/1840 train_time:46194ms step_avg:44.89ms
+step:1030/1840 train_time:46256ms step_avg:44.91ms
+step:1031/1840 train_time:46316ms step_avg:44.92ms
+step:1032/1840 train_time:46378ms step_avg:44.94ms
+step:1033/1840 train_time:46439ms step_avg:44.96ms
+step:1034/1840 train_time:46502ms step_avg:44.97ms
+step:1035/1840 train_time:46562ms step_avg:44.99ms
+step:1036/1840 train_time:46625ms step_avg:45.00ms
+step:1037/1840 train_time:46685ms step_avg:45.02ms
+step:1038/1840 train_time:46747ms step_avg:45.04ms
+step:1039/1840 train_time:46807ms step_avg:45.05ms
+step:1040/1840 train_time:46869ms step_avg:45.07ms
+step:1041/1840 train_time:46930ms step_avg:45.08ms
+step:1042/1840 train_time:46992ms step_avg:45.10ms
+step:1043/1840 train_time:47051ms step_avg:45.11ms
+step:1044/1840 train_time:47113ms step_avg:45.13ms
+step:1045/1840 train_time:47173ms step_avg:45.14ms
+step:1046/1840 train_time:47235ms step_avg:45.16ms
+step:1047/1840 train_time:47296ms step_avg:45.17ms
+step:1048/1840 train_time:47359ms step_avg:45.19ms
+step:1049/1840 train_time:47419ms step_avg:45.20ms
+step:1050/1840 train_time:47481ms step_avg:45.22ms
+step:1051/1840 train_time:47541ms step_avg:45.23ms
+step:1052/1840 train_time:47603ms step_avg:45.25ms
+step:1053/1840 train_time:47663ms step_avg:45.26ms
+step:1054/1840 train_time:47726ms step_avg:45.28ms
+step:1055/1840 train_time:47785ms step_avg:45.29ms
+step:1056/1840 train_time:47847ms step_avg:45.31ms
+step:1057/1840 train_time:47907ms step_avg:45.32ms
+step:1058/1840 train_time:47969ms step_avg:45.34ms
+step:1059/1840 train_time:48030ms step_avg:45.35ms
+step:1060/1840 train_time:48091ms step_avg:45.37ms
+step:1061/1840 train_time:48151ms step_avg:45.38ms
+step:1062/1840 train_time:48213ms step_avg:45.40ms
+step:1063/1840 train_time:48273ms step_avg:45.41ms
+step:1064/1840 train_time:48336ms step_avg:45.43ms
+step:1065/1840 train_time:48396ms step_avg:45.44ms
+step:1066/1840 train_time:48459ms step_avg:45.46ms
+step:1067/1840 train_time:48519ms step_avg:45.47ms
+step:1068/1840 train_time:48581ms step_avg:45.49ms
+step:1069/1840 train_time:48641ms step_avg:45.50ms
+step:1070/1840 train_time:48703ms step_avg:45.52ms
+step:1071/1840 train_time:48762ms step_avg:45.53ms
+step:1072/1840 train_time:48825ms step_avg:45.55ms
+step:1073/1840 train_time:48884ms step_avg:45.56ms
+step:1074/1840 train_time:48946ms step_avg:45.57ms
+step:1075/1840 train_time:49006ms step_avg:45.59ms
+step:1076/1840 train_time:49068ms step_avg:45.60ms
+step:1077/1840 train_time:49129ms step_avg:45.62ms
+step:1078/1840 train_time:49192ms step_avg:45.63ms
+step:1079/1840 train_time:49252ms step_avg:45.65ms
+step:1080/1840 train_time:49315ms step_avg:45.66ms
+step:1081/1840 train_time:49376ms step_avg:45.68ms
+step:1082/1840 train_time:49438ms step_avg:45.69ms
+step:1083/1840 train_time:49498ms step_avg:45.70ms
+step:1084/1840 train_time:49560ms step_avg:45.72ms
+step:1085/1840 train_time:49620ms step_avg:45.73ms
+step:1086/1840 train_time:49682ms step_avg:45.75ms
+step:1087/1840 train_time:49742ms step_avg:45.76ms
+step:1088/1840 train_time:49803ms step_avg:45.77ms
+step:1089/1840 train_time:49863ms step_avg:45.79ms
+step:1090/1840 train_time:49924ms step_avg:45.80ms
+step:1091/1840 train_time:49984ms step_avg:45.81ms
+step:1092/1840 train_time:50047ms step_avg:45.83ms
+step:1093/1840 train_time:50107ms step_avg:45.84ms
+step:1094/1840 train_time:50169ms step_avg:45.86ms
+step:1095/1840 train_time:50231ms step_avg:45.87ms
+step:1096/1840 train_time:50293ms step_avg:45.89ms
+step:1097/1840 train_time:50354ms step_avg:45.90ms
+step:1098/1840 train_time:50417ms step_avg:45.92ms
+step:1099/1840 train_time:50477ms step_avg:45.93ms
+step:1100/1840 train_time:50539ms step_avg:45.94ms
+step:1101/1840 train_time:50599ms step_avg:45.96ms
+step:1102/1840 train_time:50661ms step_avg:45.97ms
+step:1103/1840 train_time:50720ms step_avg:45.98ms
+step:1104/1840 train_time:50782ms step_avg:46.00ms
+step:1105/1840 train_time:50842ms step_avg:46.01ms
+step:1106/1840 train_time:50904ms step_avg:46.03ms
+step:1107/1840 train_time:50963ms step_avg:46.04ms
+step:1108/1840 train_time:51026ms step_avg:46.05ms
+step:1109/1840 train_time:51085ms step_avg:46.06ms
+step:1110/1840 train_time:51148ms step_avg:46.08ms
+step:1111/1840 train_time:51208ms step_avg:46.09ms
+step:1112/1840 train_time:51273ms step_avg:46.11ms
+step:1113/1840 train_time:51333ms step_avg:46.12ms
+step:1114/1840 train_time:51396ms step_avg:46.14ms
+step:1115/1840 train_time:51457ms step_avg:46.15ms
+step:1116/1840 train_time:51519ms step_avg:46.16ms
+step:1117/1840 train_time:51580ms step_avg:46.18ms
+step:1118/1840 train_time:51641ms step_avg:46.19ms
+step:1119/1840 train_time:51702ms step_avg:46.20ms
+step:1120/1840 train_time:51763ms step_avg:46.22ms
+step:1121/1840 train_time:51823ms step_avg:46.23ms
+step:1122/1840 train_time:51884ms step_avg:46.24ms
+step:1123/1840 train_time:51944ms step_avg:46.25ms
+step:1124/1840 train_time:52006ms step_avg:46.27ms
+step:1125/1840 train_time:52065ms step_avg:46.28ms
+step:1126/1840 train_time:52127ms step_avg:46.29ms
+step:1127/1840 train_time:52188ms step_avg:46.31ms
+step:1128/1840 train_time:52251ms step_avg:46.32ms
+step:1129/1840 train_time:52311ms step_avg:46.33ms
+step:1130/1840 train_time:52375ms step_avg:46.35ms
+step:1131/1840 train_time:52435ms step_avg:46.36ms
+step:1132/1840 train_time:52498ms step_avg:46.38ms
+step:1133/1840 train_time:52558ms step_avg:46.39ms
+step:1134/1840 train_time:52619ms step_avg:46.40ms
+step:1135/1840 train_time:52679ms step_avg:46.41ms
+step:1136/1840 train_time:52741ms step_avg:46.43ms
+step:1137/1840 train_time:52800ms step_avg:46.44ms
+step:1138/1840 train_time:52862ms step_avg:46.45ms
+step:1139/1840 train_time:52921ms step_avg:46.46ms
+step:1140/1840 train_time:52983ms step_avg:46.48ms
+step:1141/1840 train_time:53042ms step_avg:46.49ms
+step:1142/1840 train_time:53106ms step_avg:46.50ms
+step:1143/1840 train_time:53165ms step_avg:46.51ms
+step:1144/1840 train_time:53227ms step_avg:46.53ms
+step:1145/1840 train_time:53288ms step_avg:46.54ms
+step:1146/1840 train_time:53352ms step_avg:46.55ms
+step:1147/1840 train_time:53412ms step_avg:46.57ms
+step:1148/1840 train_time:53475ms step_avg:46.58ms
+step:1149/1840 train_time:53536ms step_avg:46.59ms
+step:1150/1840 train_time:53598ms step_avg:46.61ms
+step:1151/1840 train_time:53659ms step_avg:46.62ms
+step:1152/1840 train_time:53720ms step_avg:46.63ms
+step:1153/1840 train_time:53779ms step_avg:46.64ms
+step:1154/1840 train_time:53842ms step_avg:46.66ms
+step:1155/1840 train_time:53901ms step_avg:46.67ms
+step:1156/1840 train_time:53963ms step_avg:46.68ms
+step:1157/1840 train_time:54022ms step_avg:46.69ms
+step:1158/1840 train_time:54084ms step_avg:46.70ms
+step:1159/1840 train_time:54144ms step_avg:46.72ms
+step:1160/1840 train_time:54207ms step_avg:46.73ms
+step:1161/1840 train_time:54266ms step_avg:46.74ms
+step:1162/1840 train_time:54330ms step_avg:46.76ms
+step:1163/1840 train_time:54390ms step_avg:46.77ms
+step:1164/1840 train_time:54453ms step_avg:46.78ms
+step:1165/1840 train_time:54513ms step_avg:46.79ms
+step:1166/1840 train_time:54575ms step_avg:46.81ms
+step:1167/1840 train_time:54635ms step_avg:46.82ms
+step:1168/1840 train_time:54698ms step_avg:46.83ms
+step:1169/1840 train_time:54758ms step_avg:46.84ms
+step:1170/1840 train_time:54820ms step_avg:46.85ms
+step:1171/1840 train_time:54879ms step_avg:46.87ms
+step:1172/1840 train_time:54942ms step_avg:46.88ms
+step:1173/1840 train_time:55001ms step_avg:46.89ms
+step:1174/1840 train_time:55063ms step_avg:46.90ms
+step:1175/1840 train_time:55123ms step_avg:46.91ms
+step:1176/1840 train_time:55186ms step_avg:46.93ms
+step:1177/1840 train_time:55245ms step_avg:46.94ms
+step:1178/1840 train_time:55308ms step_avg:46.95ms
+step:1179/1840 train_time:55367ms step_avg:46.96ms
+step:1180/1840 train_time:55430ms step_avg:46.97ms
+step:1181/1840 train_time:55491ms step_avg:46.99ms
+step:1182/1840 train_time:55554ms step_avg:47.00ms
+step:1183/1840 train_time:55614ms step_avg:47.01ms
+step:1184/1840 train_time:55676ms step_avg:47.02ms
+step:1185/1840 train_time:55735ms step_avg:47.03ms
+step:1186/1840 train_time:55798ms step_avg:47.05ms
+step:1187/1840 train_time:55858ms step_avg:47.06ms
+step:1188/1840 train_time:55921ms step_avg:47.07ms
+step:1189/1840 train_time:55981ms step_avg:47.08ms
+step:1190/1840 train_time:56043ms step_avg:47.09ms
+step:1191/1840 train_time:56102ms step_avg:47.10ms
+step:1192/1840 train_time:56164ms step_avg:47.12ms
+step:1193/1840 train_time:56222ms step_avg:47.13ms
+step:1194/1840 train_time:56285ms step_avg:47.14ms
+step:1195/1840 train_time:56345ms step_avg:47.15ms
+step:1196/1840 train_time:56407ms step_avg:47.16ms
+step:1197/1840 train_time:56467ms step_avg:47.17ms
+step:1198/1840 train_time:56530ms step_avg:47.19ms
+step:1199/1840 train_time:56590ms step_avg:47.20ms
+step:1200/1840 train_time:56653ms step_avg:47.21ms
+step:1201/1840 train_time:56714ms step_avg:47.22ms
+step:1202/1840 train_time:56800ms step_avg:47.25ms
+step:1203/1840 train_time:56889ms step_avg:47.29ms
+step:1204/1840 train_time:56979ms step_avg:47.32ms
+step:1205/1840 train_time:57066ms step_avg:47.36ms
+step:1206/1840 train_time:57154ms step_avg:47.39ms
+step:1207/1840 train_time:57241ms step_avg:47.42ms
+step:1208/1840 train_time:57328ms step_avg:47.46ms
+step:1209/1840 train_time:57415ms step_avg:47.49ms
+step:1210/1840 train_time:57504ms step_avg:47.52ms
+step:1211/1840 train_time:57590ms step_avg:47.56ms
+step:1212/1840 train_time:57680ms step_avg:47.59ms
+step:1213/1840 train_time:57769ms step_avg:47.62ms
+step:1214/1840 train_time:57859ms step_avg:47.66ms
+step:1215/1840 train_time:57947ms step_avg:47.69ms
+step:1216/1840 train_time:58036ms step_avg:47.73ms
+step:1217/1840 train_time:58122ms step_avg:47.76ms
+step:1218/1840 train_time:58210ms step_avg:47.79ms
+step:1219/1840 train_time:58296ms step_avg:47.82ms
+step:1220/1840 train_time:58383ms step_avg:47.86ms
+step:1221/1840 train_time:58469ms step_avg:47.89ms
+step:1222/1840 train_time:58559ms step_avg:47.92ms
+step:1223/1840 train_time:58646ms step_avg:47.95ms
+step:1224/1840 train_time:58734ms step_avg:47.99ms
+step:1225/1840 train_time:58822ms step_avg:48.02ms
+step:1226/1840 train_time:58911ms step_avg:48.05ms
+step:1227/1840 train_time:58998ms step_avg:48.08ms
+step:1228/1840 train_time:59087ms step_avg:48.12ms
+step:1229/1840 train_time:59172ms step_avg:48.15ms
+step:1230/1840 train_time:59259ms step_avg:48.18ms
+step:1231/1840 train_time:59346ms step_avg:48.21ms
+step:1232/1840 train_time:59434ms step_avg:48.24ms
+step:1233/1840 train_time:59521ms step_avg:48.27ms
+step:1234/1840 train_time:59609ms step_avg:48.31ms
+step:1235/1840 train_time:59697ms step_avg:48.34ms
+step:1236/1840 train_time:59787ms step_avg:48.37ms
+step:1237/1840 train_time:59874ms step_avg:48.40ms
+step:1238/1840 train_time:59963ms step_avg:48.44ms
+step:1239/1840 train_time:60050ms step_avg:48.47ms
+step:1240/1840 train_time:60140ms step_avg:48.50ms
+step:1241/1840 train_time:60226ms step_avg:48.53ms
+step:1242/1840 train_time:60314ms step_avg:48.56ms
+step:1243/1840 train_time:60400ms step_avg:48.59ms
+step:1244/1840 train_time:60489ms step_avg:48.62ms
+step:1245/1840 train_time:60574ms step_avg:48.65ms
+step:1246/1840 train_time:60665ms step_avg:48.69ms
+step:1247/1840 train_time:60750ms step_avg:48.72ms
+step:1248/1840 train_time:60839ms step_avg:48.75ms
+step:1249/1840 train_time:60928ms step_avg:48.78ms
+step:1250/1840 train_time:61016ms step_avg:48.81ms
+step:1250/1840 val_loss:3.5341 train_time:61117ms step_avg:48.89ms
+step:1251/1840 train_time:61136ms step_avg:48.87ms
+step:1252/1840 train_time:61192ms step_avg:48.88ms
+step:1253/1840 train_time:61284ms step_avg:48.91ms
+step:1254/1840 train_time:61374ms step_avg:48.94ms
+step:1255/1840 train_time:61459ms step_avg:48.97ms
+step:1256/1840 train_time:61546ms step_avg:49.00ms
+step:1257/1840 train_time:61631ms step_avg:49.03ms
+step:1258/1840 train_time:61719ms step_avg:49.06ms
+step:1259/1840 train_time:61804ms step_avg:49.09ms
+step:1260/1840 train_time:61892ms step_avg:49.12ms
+step:1261/1840 train_time:61978ms step_avg:49.15ms
+step:1262/1840 train_time:62068ms step_avg:49.18ms
+step:1263/1840 train_time:62157ms step_avg:49.21ms
+step:1264/1840 train_time:62250ms step_avg:49.25ms
+step:1265/1840 train_time:62339ms step_avg:49.28ms
+step:1266/1840 train_time:62427ms step_avg:49.31ms
+step:1267/1840 train_time:62511ms step_avg:49.34ms
+step:1268/1840 train_time:62599ms step_avg:49.37ms
+step:1269/1840 train_time:62685ms step_avg:49.40ms
+step:1270/1840 train_time:62774ms step_avg:49.43ms
+step:1271/1840 train_time:62859ms step_avg:49.46ms
+step:1272/1840 train_time:62947ms step_avg:49.49ms
+step:1273/1840 train_time:63033ms step_avg:49.52ms
+step:1274/1840 train_time:63125ms step_avg:49.55ms
+step:1275/1840 train_time:63212ms step_avg:49.58ms
+step:1276/1840 train_time:63303ms step_avg:49.61ms
+step:1277/1840 train_time:63388ms step_avg:49.64ms
+step:1278/1840 train_time:63478ms step_avg:49.67ms
+step:1279/1840 train_time:63563ms step_avg:49.70ms
+step:1280/1840 train_time:63652ms step_avg:49.73ms
+step:1281/1840 train_time:63738ms step_avg:49.76ms
+step:1282/1840 train_time:63826ms step_avg:49.79ms
+step:1283/1840 train_time:63911ms step_avg:49.81ms
+step:1284/1840 train_time:63999ms step_avg:49.84ms
+step:1285/1840 train_time:64087ms step_avg:49.87ms
+step:1286/1840 train_time:64178ms step_avg:49.90ms
+step:1287/1840 train_time:64266ms step_avg:49.93ms
+step:1288/1840 train_time:64355ms step_avg:49.96ms
+step:1289/1840 train_time:64441ms step_avg:49.99ms
+step:1290/1840 train_time:64529ms step_avg:50.02ms
+step:1291/1840 train_time:64614ms step_avg:50.05ms
+step:1292/1840 train_time:64703ms step_avg:50.08ms
+step:1293/1840 train_time:64788ms step_avg:50.11ms
+step:1294/1840 train_time:64877ms step_avg:50.14ms
+step:1295/1840 train_time:64964ms step_avg:50.17ms
+step:1296/1840 train_time:65052ms step_avg:50.19ms
+step:1297/1840 train_time:65138ms step_avg:50.22ms
+step:1298/1840 train_time:65227ms step_avg:50.25ms
+step:1299/1840 train_time:65313ms step_avg:50.28ms
+step:1300/1840 train_time:65402ms step_avg:50.31ms
+step:1301/1840 train_time:65488ms step_avg:50.34ms
+step:1302/1840 train_time:65576ms step_avg:50.37ms
+step:1303/1840 train_time:65662ms step_avg:50.39ms
+step:1304/1840 train_time:65750ms step_avg:50.42ms
+step:1305/1840 train_time:65837ms step_avg:50.45ms
+step:1306/1840 train_time:65926ms step_avg:50.48ms
+step:1307/1840 train_time:66013ms step_avg:50.51ms
+step:1308/1840 train_time:66102ms step_avg:50.54ms
+step:1309/1840 train_time:66189ms step_avg:50.56ms
+step:1310/1840 train_time:66278ms step_avg:50.59ms
+step:1311/1840 train_time:66364ms step_avg:50.62ms
+step:1312/1840 train_time:66453ms step_avg:50.65ms
+step:1313/1840 train_time:66540ms step_avg:50.68ms
+step:1314/1840 train_time:66627ms step_avg:50.71ms
+step:1315/1840 train_time:66713ms step_avg:50.73ms
+step:1316/1840 train_time:66802ms step_avg:50.76ms
+step:1317/1840 train_time:66887ms step_avg:50.79ms
+step:1318/1840 train_time:66977ms step_avg:50.82ms
+step:1319/1840 train_time:67065ms step_avg:50.85ms
+step:1320/1840 train_time:67154ms step_avg:50.87ms
+step:1321/1840 train_time:67241ms step_avg:50.90ms
+step:1322/1840 train_time:67329ms step_avg:50.93ms
+step:1323/1840 train_time:67416ms step_avg:50.96ms
+step:1324/1840 train_time:67505ms step_avg:50.99ms
+step:1325/1840 train_time:67590ms step_avg:51.01ms
+step:1326/1840 train_time:67679ms step_avg:51.04ms
+step:1327/1840 train_time:67766ms step_avg:51.07ms
+step:1328/1840 train_time:67854ms step_avg:51.09ms
+step:1329/1840 train_time:67941ms step_avg:51.12ms
+step:1330/1840 train_time:68029ms step_avg:51.15ms
+step:1331/1840 train_time:68117ms step_avg:51.18ms
+step:1332/1840 train_time:68207ms step_avg:51.21ms
+step:1333/1840 train_time:68292ms step_avg:51.23ms
+step:1334/1840 train_time:68381ms step_avg:51.26ms
+step:1335/1840 train_time:68467ms step_avg:51.29ms
+step:1336/1840 train_time:68555ms step_avg:51.31ms
+step:1337/1840 train_time:68642ms step_avg:51.34ms
+step:1338/1840 train_time:68731ms step_avg:51.37ms
+step:1339/1840 train_time:68818ms step_avg:51.39ms
+step:1340/1840 train_time:68907ms step_avg:51.42ms
+step:1341/1840 train_time:68993ms step_avg:51.45ms
+step:1342/1840 train_time:69083ms step_avg:51.48ms
+step:1343/1840 train_time:69168ms step_avg:51.50ms
+step:1344/1840 train_time:69257ms step_avg:51.53ms
+step:1345/1840 train_time:69344ms step_avg:51.56ms
+step:1346/1840 train_time:69433ms step_avg:51.58ms
+step:1347/1840 train_time:69518ms step_avg:51.61ms
+step:1348/1840 train_time:69606ms step_avg:51.64ms
+step:1349/1840 train_time:69692ms step_avg:51.66ms
+step:1350/1840 train_time:69783ms step_avg:51.69ms
+step:1351/1840 train_time:69869ms step_avg:51.72ms
+step:1352/1840 train_time:69957ms step_avg:51.74ms
+step:1353/1840 train_time:70045ms step_avg:51.77ms
+step:1354/1840 train_time:70132ms step_avg:51.80ms
+step:1355/1840 train_time:70219ms step_avg:51.82ms
+step:1356/1840 train_time:70307ms step_avg:51.85ms
+step:1357/1840 train_time:70393ms step_avg:51.87ms
+step:1358/1840 train_time:70482ms step_avg:51.90ms
+step:1359/1840 train_time:70568ms step_avg:51.93ms
+step:1360/1840 train_time:70656ms step_avg:51.95ms
+step:1361/1840 train_time:70744ms step_avg:51.98ms
+step:1362/1840 train_time:70833ms step_avg:52.01ms
+step:1363/1840 train_time:70919ms step_avg:52.03ms
+step:1364/1840 train_time:71007ms step_avg:52.06ms
+step:1365/1840 train_time:71094ms step_avg:52.08ms
+step:1366/1840 train_time:71184ms step_avg:52.11ms
+step:1367/1840 train_time:71270ms step_avg:52.14ms
+step:1368/1840 train_time:71359ms step_avg:52.16ms
+step:1369/1840 train_time:71445ms step_avg:52.19ms
+step:1370/1840 train_time:71533ms step_avg:52.21ms
+step:1371/1840 train_time:71619ms step_avg:52.24ms
+step:1372/1840 train_time:71707ms step_avg:52.26ms
+step:1373/1840 train_time:71793ms step_avg:52.29ms
+step:1374/1840 train_time:71882ms step_avg:52.32ms
+step:1375/1840 train_time:71968ms step_avg:52.34ms
+step:1376/1840 train_time:72058ms step_avg:52.37ms
+step:1377/1840 train_time:72145ms step_avg:52.39ms
+step:1378/1840 train_time:72233ms step_avg:52.42ms
+step:1379/1840 train_time:72319ms step_avg:52.44ms
+step:1380/1840 train_time:72407ms step_avg:52.47ms
+step:1381/1840 train_time:72492ms step_avg:52.49ms
+step:1382/1840 train_time:72581ms step_avg:52.52ms
+step:1383/1840 train_time:72668ms step_avg:52.54ms
+step:1384/1840 train_time:72757ms step_avg:52.57ms
+step:1385/1840 train_time:72844ms step_avg:52.59ms
+step:1386/1840 train_time:72932ms step_avg:52.62ms
+step:1387/1840 train_time:73018ms step_avg:52.64ms
+step:1388/1840 train_time:73107ms step_avg:52.67ms
+step:1389/1840 train_time:73192ms step_avg:52.69ms
+step:1390/1840 train_time:73282ms step_avg:52.72ms
+step:1391/1840 train_time:73367ms step_avg:52.74ms
+step:1392/1840 train_time:73457ms step_avg:52.77ms
+step:1393/1840 train_time:73544ms step_avg:52.80ms
+step:1394/1840 train_time:73633ms step_avg:52.82ms
+step:1395/1840 train_time:73719ms step_avg:52.85ms
+step:1396/1840 train_time:73807ms step_avg:52.87ms
+step:1397/1840 train_time:73893ms step_avg:52.89ms
+step:1398/1840 train_time:73982ms step_avg:52.92ms
+step:1399/1840 train_time:74068ms step_avg:52.94ms
+step:1400/1840 train_time:74157ms step_avg:52.97ms
+step:1401/1840 train_time:74245ms step_avg:52.99ms
+step:1402/1840 train_time:74333ms step_avg:53.02ms
+step:1403/1840 train_time:74420ms step_avg:53.04ms
+step:1404/1840 train_time:74508ms step_avg:53.07ms
+step:1405/1840 train_time:74594ms step_avg:53.09ms
+step:1406/1840 train_time:74684ms step_avg:53.12ms
+step:1407/1840 train_time:74769ms step_avg:53.14ms
+step:1408/1840 train_time:74859ms step_avg:53.17ms
+step:1409/1840 train_time:74946ms step_avg:53.19ms
+step:1410/1840 train_time:75035ms step_avg:53.22ms
+step:1411/1840 train_time:75121ms step_avg:53.24ms
+step:1412/1840 train_time:75208ms step_avg:53.26ms
+step:1413/1840 train_time:75295ms step_avg:53.29ms
+step:1414/1840 train_time:75385ms step_avg:53.31ms
+step:1415/1840 train_time:75470ms step_avg:53.34ms
+step:1416/1840 train_time:75559ms step_avg:53.36ms
+step:1417/1840 train_time:75645ms step_avg:53.38ms
+step:1418/1840 train_time:75735ms step_avg:53.41ms
+step:1419/1840 train_time:75821ms step_avg:53.43ms
+step:1420/1840 train_time:75909ms step_avg:53.46ms
+step:1421/1840 train_time:75996ms step_avg:53.48ms
+step:1422/1840 train_time:76085ms step_avg:53.51ms
+step:1423/1840 train_time:76171ms step_avg:53.53ms
+step:1424/1840 train_time:76260ms step_avg:53.55ms
+step:1425/1840 train_time:76346ms step_avg:53.58ms
+step:1426/1840 train_time:76435ms step_avg:53.60ms
+step:1427/1840 train_time:76520ms step_avg:53.62ms
+step:1428/1840 train_time:76608ms step_avg:53.65ms
+step:1429/1840 train_time:76695ms step_avg:53.67ms
+step:1430/1840 train_time:76784ms step_avg:53.70ms
+step:1431/1840 train_time:76870ms step_avg:53.72ms
+step:1432/1840 train_time:76960ms step_avg:53.74ms
+step:1433/1840 train_time:77046ms step_avg:53.77ms
+step:1434/1840 train_time:77135ms step_avg:53.79ms
+step:1435/1840 train_time:77222ms step_avg:53.81ms
+step:1436/1840 train_time:77310ms step_avg:53.84ms
+step:1437/1840 train_time:77396ms step_avg:53.86ms
+step:1438/1840 train_time:77486ms step_avg:53.88ms
+step:1439/1840 train_time:77571ms step_avg:53.91ms
+step:1440/1840 train_time:77661ms step_avg:53.93ms
+step:1441/1840 train_time:77746ms step_avg:53.95ms
+step:1442/1840 train_time:77834ms step_avg:53.98ms
+step:1443/1840 train_time:77921ms step_avg:54.00ms
+step:1444/1840 train_time:78008ms step_avg:54.02ms
+step:1445/1840 train_time:78094ms step_avg:54.04ms
+step:1446/1840 train_time:78184ms step_avg:54.07ms
+step:1447/1840 train_time:78270ms step_avg:54.09ms
+step:1448/1840 train_time:78359ms step_avg:54.11ms
+step:1449/1840 train_time:78445ms step_avg:54.14ms
+step:1450/1840 train_time:78534ms step_avg:54.16ms
+step:1451/1840 train_time:78620ms step_avg:54.18ms
+step:1452/1840 train_time:78708ms step_avg:54.21ms
+step:1453/1840 train_time:78795ms step_avg:54.23ms
+step:1454/1840 train_time:78884ms step_avg:54.25ms
+step:1455/1840 train_time:78970ms step_avg:54.27ms
+step:1456/1840 train_time:79059ms step_avg:54.30ms
+step:1457/1840 train_time:79146ms step_avg:54.32ms
+step:1458/1840 train_time:79236ms step_avg:54.35ms
+step:1459/1840 train_time:79323ms step_avg:54.37ms
+step:1460/1840 train_time:79410ms step_avg:54.39ms
+step:1461/1840 train_time:79496ms step_avg:54.41ms
+step:1462/1840 train_time:79585ms step_avg:54.44ms
+step:1463/1840 train_time:79671ms step_avg:54.46ms
+step:1464/1840 train_time:79760ms step_avg:54.48ms
+step:1465/1840 train_time:79846ms step_avg:54.50ms
+step:1466/1840 train_time:79935ms step_avg:54.53ms
+step:1467/1840 train_time:80021ms step_avg:54.55ms
+step:1468/1840 train_time:80109ms step_avg:54.57ms
+step:1469/1840 train_time:80195ms step_avg:54.59ms
+step:1470/1840 train_time:80285ms step_avg:54.62ms
+step:1471/1840 train_time:80370ms step_avg:54.64ms
+step:1472/1840 train_time:80461ms step_avg:54.66ms
+step:1473/1840 train_time:80547ms step_avg:54.68ms
+step:1474/1840 train_time:80635ms step_avg:54.70ms
+step:1475/1840 train_time:80721ms step_avg:54.73ms
+step:1476/1840 train_time:80809ms step_avg:54.75ms
+step:1477/1840 train_time:80894ms step_avg:54.77ms
+step:1478/1840 train_time:80985ms step_avg:54.79ms
+step:1479/1840 train_time:81069ms step_avg:54.81ms
+step:1480/1840 train_time:81159ms step_avg:54.84ms
+step:1481/1840 train_time:81246ms step_avg:54.86ms
+step:1482/1840 train_time:81335ms step_avg:54.88ms
+step:1483/1840 train_time:81422ms step_avg:54.90ms
+step:1484/1840 train_time:81510ms step_avg:54.93ms
+step:1485/1840 train_time:81596ms step_avg:54.95ms
+step:1486/1840 train_time:81685ms step_avg:54.97ms
+step:1487/1840 train_time:81770ms step_avg:54.99ms
+step:1488/1840 train_time:81860ms step_avg:55.01ms
+step:1489/1840 train_time:81946ms step_avg:55.03ms
+step:1490/1840 train_time:82035ms step_avg:55.06ms
+step:1491/1840 train_time:82121ms step_avg:55.08ms
+step:1492/1840 train_time:82210ms step_avg:55.10ms
+step:1493/1840 train_time:82297ms step_avg:55.12ms
+step:1494/1840 train_time:82386ms step_avg:55.14ms
+step:1495/1840 train_time:82471ms step_avg:55.16ms
+step:1496/1840 train_time:82560ms step_avg:55.19ms
+step:1497/1840 train_time:82646ms step_avg:55.21ms
+step:1498/1840 train_time:82735ms step_avg:55.23ms
+step:1499/1840 train_time:82821ms step_avg:55.25ms
+step:1500/1840 train_time:82909ms step_avg:55.27ms
+step:1500/1840 val_loss:3.4007 train_time:83009ms step_avg:55.34ms
+step:1501/1840 train_time:83028ms step_avg:55.31ms
+step:1502/1840 train_time:83086ms step_avg:55.32ms
+step:1503/1840 train_time:83181ms step_avg:55.34ms
+step:1504/1840 train_time:83269ms step_avg:55.37ms
+step:1505/1840 train_time:83354ms step_avg:55.38ms
+step:1506/1840 train_time:83442ms step_avg:55.41ms
+step:1507/1840 train_time:83527ms step_avg:55.43ms
+step:1508/1840 train_time:83614ms step_avg:55.45ms
+step:1509/1840 train_time:83700ms step_avg:55.47ms
+step:1510/1840 train_time:83789ms step_avg:55.49ms
+step:1511/1840 train_time:83873ms step_avg:55.51ms
+step:1512/1840 train_time:83962ms step_avg:55.53ms
+step:1513/1840 train_time:84052ms step_avg:55.55ms
+step:1514/1840 train_time:84144ms step_avg:55.58ms
+step:1515/1840 train_time:84232ms step_avg:55.60ms
+step:1516/1840 train_time:84321ms step_avg:55.62ms
+step:1517/1840 train_time:84406ms step_avg:55.64ms
+step:1518/1840 train_time:84493ms step_avg:55.66ms
+step:1519/1840 train_time:84579ms step_avg:55.68ms
+step:1520/1840 train_time:84669ms step_avg:55.70ms
+step:1521/1840 train_time:84753ms step_avg:55.72ms
+step:1522/1840 train_time:84843ms step_avg:55.74ms
+step:1523/1840 train_time:84929ms step_avg:55.76ms
+step:1524/1840 train_time:85019ms step_avg:55.79ms
+step:1525/1840 train_time:85107ms step_avg:55.81ms
+step:1526/1840 train_time:85196ms step_avg:55.83ms
+step:1527/1840 train_time:85283ms step_avg:55.85ms
+step:1528/1840 train_time:85373ms step_avg:55.87ms
+step:1529/1840 train_time:85459ms step_avg:55.89ms
+step:1530/1840 train_time:85547ms step_avg:55.91ms
+step:1531/1840 train_time:85632ms step_avg:55.93ms
+step:1532/1840 train_time:85720ms step_avg:55.95ms
+step:1533/1840 train_time:85807ms step_avg:55.97ms
+step:1534/1840 train_time:85895ms step_avg:55.99ms
+step:1535/1840 train_time:85983ms step_avg:56.01ms
+step:1536/1840 train_time:86074ms step_avg:56.04ms
+step:1537/1840 train_time:86160ms step_avg:56.06ms
+step:1538/1840 train_time:86251ms step_avg:56.08ms
+step:1539/1840 train_time:86336ms step_avg:56.10ms
+step:1540/1840 train_time:86426ms step_avg:56.12ms
+step:1541/1840 train_time:86512ms step_avg:56.14ms
+step:1542/1840 train_time:86600ms step_avg:56.16ms
+step:1543/1840 train_time:86685ms step_avg:56.18ms
+step:1544/1840 train_time:86773ms step_avg:56.20ms
+step:1545/1840 train_time:86859ms step_avg:56.22ms
+step:1546/1840 train_time:86949ms step_avg:56.24ms
+step:1547/1840 train_time:87034ms step_avg:56.26ms
+step:1548/1840 train_time:87123ms step_avg:56.28ms
+step:1549/1840 train_time:87212ms step_avg:56.30ms
+step:1550/1840 train_time:87300ms step_avg:56.32ms
+step:1551/1840 train_time:87386ms step_avg:56.34ms
+step:1552/1840 train_time:87473ms step_avg:56.36ms
+step:1553/1840 train_time:87560ms step_avg:56.38ms
+step:1554/1840 train_time:87651ms step_avg:56.40ms
+step:1555/1840 train_time:87736ms step_avg:56.42ms
+step:1556/1840 train_time:87824ms step_avg:56.44ms
+step:1557/1840 train_time:87910ms step_avg:56.46ms
+step:1558/1840 train_time:87998ms step_avg:56.48ms
+step:1559/1840 train_time:88085ms step_avg:56.50ms
+step:1560/1840 train_time:88174ms step_avg:56.52ms
+step:1561/1840 train_time:88261ms step_avg:56.54ms
+step:1562/1840 train_time:88350ms step_avg:56.56ms
+step:1563/1840 train_time:88435ms step_avg:56.58ms
+step:1564/1840 train_time:88524ms step_avg:56.60ms
+step:1565/1840 train_time:88611ms step_avg:56.62ms
+step:1566/1840 train_time:88699ms step_avg:56.64ms
+step:1567/1840 train_time:88784ms step_avg:56.66ms
+step:1568/1840 train_time:88873ms step_avg:56.68ms
+step:1569/1840 train_time:88958ms step_avg:56.70ms
+step:1570/1840 train_time:89049ms step_avg:56.72ms
+step:1571/1840 train_time:89136ms step_avg:56.74ms
+step:1572/1840 train_time:89225ms step_avg:56.76ms
+step:1573/1840 train_time:89312ms step_avg:56.78ms
+step:1574/1840 train_time:89400ms step_avg:56.80ms
+step:1575/1840 train_time:89487ms step_avg:56.82ms
+step:1576/1840 train_time:89576ms step_avg:56.84ms
+step:1577/1840 train_time:89661ms step_avg:56.86ms
+step:1578/1840 train_time:89750ms step_avg:56.88ms
+step:1579/1840 train_time:89835ms step_avg:56.89ms
+step:1580/1840 train_time:89923ms step_avg:56.91ms
+step:1581/1840 train_time:90010ms step_avg:56.93ms
+step:1582/1840 train_time:90098ms step_avg:56.95ms
+step:1583/1840 train_time:90185ms step_avg:56.97ms
+step:1584/1840 train_time:90274ms step_avg:56.99ms
+step:1585/1840 train_time:90359ms step_avg:57.01ms
+step:1586/1840 train_time:90449ms step_avg:57.03ms
+step:1587/1840 train_time:90535ms step_avg:57.05ms
+step:1588/1840 train_time:90624ms step_avg:57.07ms
+step:1589/1840 train_time:90710ms step_avg:57.09ms
+step:1590/1840 train_time:90799ms step_avg:57.11ms
+step:1591/1840 train_time:90884ms step_avg:57.12ms
+step:1592/1840 train_time:90973ms step_avg:57.14ms
+step:1593/1840 train_time:91059ms step_avg:57.16ms
+step:1594/1840 train_time:91149ms step_avg:57.18ms
+step:1595/1840 train_time:91236ms step_avg:57.20ms
+step:1596/1840 train_time:91325ms step_avg:57.22ms
+step:1597/1840 train_time:91412ms step_avg:57.24ms
+step:1598/1840 train_time:91500ms step_avg:57.26ms
+step:1599/1840 train_time:91587ms step_avg:57.28ms
+step:1600/1840 train_time:91675ms step_avg:57.30ms
+step:1601/1840 train_time:91761ms step_avg:57.31ms
+step:1602/1840 train_time:91849ms step_avg:57.33ms
+step:1603/1840 train_time:91935ms step_avg:57.35ms
+step:1604/1840 train_time:92024ms step_avg:57.37ms
+step:1605/1840 train_time:92111ms step_avg:57.39ms
+step:1606/1840 train_time:92201ms step_avg:57.41ms
+step:1607/1840 train_time:92286ms step_avg:57.43ms
+step:1608/1840 train_time:92375ms step_avg:57.45ms
+step:1609/1840 train_time:92461ms step_avg:57.46ms
+step:1610/1840 train_time:92550ms step_avg:57.48ms
+step:1611/1840 train_time:92637ms step_avg:57.50ms
+step:1612/1840 train_time:92726ms step_avg:57.52ms
+step:1613/1840 train_time:92811ms step_avg:57.54ms
+step:1614/1840 train_time:92899ms step_avg:57.56ms
+step:1615/1840 train_time:92985ms step_avg:57.58ms
+step:1616/1840 train_time:93074ms step_avg:57.60ms
+step:1617/1840 train_time:93161ms step_avg:57.61ms
+step:1618/1840 train_time:93250ms step_avg:57.63ms
+step:1619/1840 train_time:93336ms step_avg:57.65ms
+step:1620/1840 train_time:93427ms step_avg:57.67ms
+step:1621/1840 train_time:93513ms step_avg:57.69ms
+step:1622/1840 train_time:93602ms step_avg:57.71ms
+step:1623/1840 train_time:93689ms step_avg:57.73ms
+step:1624/1840 train_time:93777ms step_avg:57.74ms
+step:1625/1840 train_time:93862ms step_avg:57.76ms
+step:1626/1840 train_time:93950ms step_avg:57.78ms
+step:1627/1840 train_time:94036ms step_avg:57.80ms
+step:1628/1840 train_time:94124ms step_avg:57.82ms
+step:1629/1840 train_time:94212ms step_avg:57.83ms
+step:1630/1840 train_time:94300ms step_avg:57.85ms
+step:1631/1840 train_time:94387ms step_avg:57.87ms
+step:1632/1840 train_time:94475ms step_avg:57.89ms
+step:1633/1840 train_time:94562ms step_avg:57.91ms
+step:1634/1840 train_time:94649ms step_avg:57.92ms
+step:1635/1840 train_time:94736ms step_avg:57.94ms
+step:1636/1840 train_time:94826ms step_avg:57.96ms
+step:1637/1840 train_time:94912ms step_avg:57.98ms
+step:1638/1840 train_time:95000ms step_avg:58.00ms
+step:1639/1840 train_time:95086ms step_avg:58.01ms
+step:1640/1840 train_time:95174ms step_avg:58.03ms
+step:1641/1840 train_time:95260ms step_avg:58.05ms
+step:1642/1840 train_time:95349ms step_avg:58.07ms
+step:1643/1840 train_time:95436ms step_avg:58.09ms
+step:1644/1840 train_time:95524ms step_avg:58.10ms
+step:1645/1840 train_time:95611ms step_avg:58.12ms
+step:1646/1840 train_time:95700ms step_avg:58.14ms
+step:1647/1840 train_time:95785ms step_avg:58.16ms
+step:1648/1840 train_time:95873ms step_avg:58.18ms
+step:1649/1840 train_time:95959ms step_avg:58.19ms
+step:1650/1840 train_time:96049ms step_avg:58.21ms
+step:1651/1840 train_time:96135ms step_avg:58.23ms
+step:1652/1840 train_time:96224ms step_avg:58.25ms
+step:1653/1840 train_time:96312ms step_avg:58.26ms
+step:1654/1840 train_time:96400ms step_avg:58.28ms
+step:1655/1840 train_time:96486ms step_avg:58.30ms
+step:1656/1840 train_time:96574ms step_avg:58.32ms
+step:1657/1840 train_time:96661ms step_avg:58.33ms
+step:1658/1840 train_time:96750ms step_avg:58.35ms
+step:1659/1840 train_time:96836ms step_avg:58.37ms
+step:1660/1840 train_time:96924ms step_avg:58.39ms
+step:1661/1840 train_time:97010ms step_avg:58.40ms
+step:1662/1840 train_time:97099ms step_avg:58.42ms
+step:1663/1840 train_time:97185ms step_avg:58.44ms
+step:1664/1840 train_time:97274ms step_avg:58.46ms
+step:1665/1840 train_time:97359ms step_avg:58.47ms
+step:1666/1840 train_time:97449ms step_avg:58.49ms
+step:1667/1840 train_time:97535ms step_avg:58.51ms
+step:1668/1840 train_time:97624ms step_avg:58.53ms
+step:1669/1840 train_time:97710ms step_avg:58.54ms
+step:1670/1840 train_time:97798ms step_avg:58.56ms
+step:1671/1840 train_time:97885ms step_avg:58.58ms
+step:1672/1840 train_time:97974ms step_avg:58.60ms
+step:1673/1840 train_time:98059ms step_avg:58.61ms
+step:1674/1840 train_time:98147ms step_avg:58.63ms
+step:1675/1840 train_time:98234ms step_avg:58.65ms
+step:1676/1840 train_time:98322ms step_avg:58.66ms
+step:1677/1840 train_time:98410ms step_avg:58.68ms
+step:1678/1840 train_time:98499ms step_avg:58.70ms
+step:1679/1840 train_time:98584ms step_avg:58.72ms
+step:1680/1840 train_time:98673ms step_avg:58.73ms
+step:1681/1840 train_time:98759ms step_avg:58.75ms
+step:1682/1840 train_time:98848ms step_avg:58.77ms
+step:1683/1840 train_time:98934ms step_avg:58.78ms
+step:1684/1840 train_time:99022ms step_avg:58.80ms
+step:1685/1840 train_time:99110ms step_avg:58.82ms
+step:1686/1840 train_time:99198ms step_avg:58.84ms
+step:1687/1840 train_time:99284ms step_avg:58.85ms
+step:1688/1840 train_time:99373ms step_avg:58.87ms
+step:1689/1840 train_time:99459ms step_avg:58.89ms
+step:1690/1840 train_time:99548ms step_avg:58.90ms
+step:1691/1840 train_time:99633ms step_avg:58.92ms
+step:1692/1840 train_time:99721ms step_avg:58.94ms
+step:1693/1840 train_time:99808ms step_avg:58.95ms
+step:1694/1840 train_time:99896ms step_avg:58.97ms
+step:1695/1840 train_time:99982ms step_avg:58.99ms
+step:1696/1840 train_time:100071ms step_avg:59.00ms
+step:1697/1840 train_time:100156ms step_avg:59.02ms
+step:1698/1840 train_time:100247ms step_avg:59.04ms
+step:1699/1840 train_time:100333ms step_avg:59.05ms
+step:1700/1840 train_time:100421ms step_avg:59.07ms
+step:1701/1840 train_time:100509ms step_avg:59.09ms
+step:1702/1840 train_time:100596ms step_avg:59.10ms
+step:1703/1840 train_time:100682ms step_avg:59.12ms
+step:1704/1840 train_time:100772ms step_avg:59.14ms
+step:1705/1840 train_time:100856ms step_avg:59.15ms
+step:1706/1840 train_time:100948ms step_avg:59.17ms
+step:1707/1840 train_time:101033ms step_avg:59.19ms
+step:1708/1840 train_time:101121ms step_avg:59.20ms
+step:1709/1840 train_time:101209ms step_avg:59.22ms
+step:1710/1840 train_time:101297ms step_avg:59.24ms
+step:1711/1840 train_time:101383ms step_avg:59.25ms
+step:1712/1840 train_time:101472ms step_avg:59.27ms
+step:1713/1840 train_time:101557ms step_avg:59.29ms
+step:1714/1840 train_time:101647ms step_avg:59.30ms
+step:1715/1840 train_time:101732ms step_avg:59.32ms
+step:1716/1840 train_time:101820ms step_avg:59.34ms
+step:1717/1840 train_time:101908ms step_avg:59.35ms
+step:1718/1840 train_time:101995ms step_avg:59.37ms
+step:1719/1840 train_time:102082ms step_avg:59.38ms
+step:1720/1840 train_time:102171ms step_avg:59.40ms
+step:1721/1840 train_time:102256ms step_avg:59.42ms
+step:1722/1840 train_time:102345ms step_avg:59.43ms
+step:1723/1840 train_time:102431ms step_avg:59.45ms
+step:1724/1840 train_time:102519ms step_avg:59.47ms
+step:1725/1840 train_time:102606ms step_avg:59.48ms
+step:1726/1840 train_time:102695ms step_avg:59.50ms
+step:1727/1840 train_time:102781ms step_avg:59.51ms
+step:1728/1840 train_time:102871ms step_avg:59.53ms
+step:1729/1840 train_time:102955ms step_avg:59.55ms
+step:1730/1840 train_time:103045ms step_avg:59.56ms
+step:1731/1840 train_time:103131ms step_avg:59.58ms
+step:1732/1840 train_time:103220ms step_avg:59.60ms
+step:1733/1840 train_time:103306ms step_avg:59.61ms
+step:1734/1840 train_time:103394ms step_avg:59.63ms
+step:1735/1840 train_time:103482ms step_avg:59.64ms
+step:1736/1840 train_time:103571ms step_avg:59.66ms
+step:1737/1840 train_time:103656ms step_avg:59.68ms
+step:1738/1840 train_time:103746ms step_avg:59.69ms
+step:1739/1840 train_time:103832ms step_avg:59.71ms
+step:1740/1840 train_time:103920ms step_avg:59.72ms
+step:1741/1840 train_time:104006ms step_avg:59.74ms
+step:1742/1840 train_time:104094ms step_avg:59.76ms
+step:1743/1840 train_time:104181ms step_avg:59.77ms
+step:1744/1840 train_time:104270ms step_avg:59.79ms
+step:1745/1840 train_time:104355ms step_avg:59.80ms
+step:1746/1840 train_time:104446ms step_avg:59.82ms
+step:1747/1840 train_time:104533ms step_avg:59.84ms
+step:1748/1840 train_time:104621ms step_avg:59.85ms
+step:1749/1840 train_time:104707ms step_avg:59.87ms
+step:1750/1840 train_time:104794ms step_avg:59.88ms
+step:1750/1840 val_loss:3.3028 train_time:104898ms step_avg:59.94ms
+step:1751/1840 train_time:104916ms step_avg:59.92ms
+step:1752/1840 train_time:104975ms step_avg:59.92ms
+step:1753/1840 train_time:105066ms step_avg:59.94ms
+step:1754/1840 train_time:105155ms step_avg:59.95ms
+step:1755/1840 train_time:105240ms step_avg:59.97ms
+step:1756/1840 train_time:105329ms step_avg:59.98ms
+step:1757/1840 train_time:105414ms step_avg:60.00ms
+step:1758/1840 train_time:105503ms step_avg:60.01ms
+step:1759/1840 train_time:105587ms step_avg:60.03ms
+step:1760/1840 train_time:105676ms step_avg:60.04ms
+step:1761/1840 train_time:105761ms step_avg:60.06ms
+step:1762/1840 train_time:105851ms step_avg:60.07ms
+step:1763/1840 train_time:105939ms step_avg:60.09ms
+step:1764/1840 train_time:106032ms step_avg:60.11ms
+step:1765/1840 train_time:106118ms step_avg:60.12ms
+step:1766/1840 train_time:106207ms step_avg:60.14ms
+step:1767/1840 train_time:106293ms step_avg:60.15ms
+step:1768/1840 train_time:106379ms step_avg:60.17ms
+step:1769/1840 train_time:106466ms step_avg:60.18ms
+step:1770/1840 train_time:106555ms step_avg:60.20ms
+step:1771/1840 train_time:106639ms step_avg:60.21ms
+step:1772/1840 train_time:106730ms step_avg:60.23ms
+step:1773/1840 train_time:106816ms step_avg:60.25ms
+step:1774/1840 train_time:106907ms step_avg:60.26ms
+step:1775/1840 train_time:106996ms step_avg:60.28ms
+step:1776/1840 train_time:107084ms step_avg:60.30ms
+step:1777/1840 train_time:107172ms step_avg:60.31ms
+step:1778/1840 train_time:107259ms step_avg:60.33ms
+step:1779/1840 train_time:107344ms step_avg:60.34ms
+step:1780/1840 train_time:107433ms step_avg:60.36ms
+step:1781/1840 train_time:107518ms step_avg:60.37ms
+step:1782/1840 train_time:107605ms step_avg:60.38ms
+step:1783/1840 train_time:107692ms step_avg:60.40ms
+step:1784/1840 train_time:107780ms step_avg:60.41ms
+step:1785/1840 train_time:107867ms step_avg:60.43ms
+step:1786/1840 train_time:107958ms step_avg:60.45ms
+step:1787/1840 train_time:108045ms step_avg:60.46ms
+step:1788/1840 train_time:108135ms step_avg:60.48ms
+step:1789/1840 train_time:108221ms step_avg:60.49ms
+step:1790/1840 train_time:108309ms step_avg:60.51ms
+step:1791/1840 train_time:108396ms step_avg:60.52ms
+step:1792/1840 train_time:108483ms step_avg:60.54ms
+step:1793/1840 train_time:108569ms step_avg:60.55ms
+step:1794/1840 train_time:108657ms step_avg:60.57ms
+step:1795/1840 train_time:108744ms step_avg:60.58ms
+step:1796/1840 train_time:108834ms step_avg:60.60ms
+step:1797/1840 train_time:108920ms step_avg:60.61ms
+step:1798/1840 train_time:109009ms step_avg:60.63ms
+step:1799/1840 train_time:109097ms step_avg:60.64ms
+step:1800/1840 train_time:109186ms step_avg:60.66ms
+step:1801/1840 train_time:109273ms step_avg:60.67ms
+step:1802/1840 train_time:109360ms step_avg:60.69ms
+step:1803/1840 train_time:109446ms step_avg:60.70ms
+step:1804/1840 train_time:109536ms step_avg:60.72ms
+step:1805/1840 train_time:109623ms step_avg:60.73ms
+step:1806/1840 train_time:109713ms step_avg:60.75ms
+step:1807/1840 train_time:109799ms step_avg:60.76ms
+step:1808/1840 train_time:109887ms step_avg:60.78ms
+step:1809/1840 train_time:109977ms step_avg:60.79ms
+step:1810/1840 train_time:110067ms step_avg:60.81ms
+step:1811/1840 train_time:110154ms step_avg:60.82ms
+step:1812/1840 train_time:110242ms step_avg:60.84ms
+step:1813/1840 train_time:110328ms step_avg:60.85ms
+step:1814/1840 train_time:110417ms step_avg:60.87ms
+step:1815/1840 train_time:110501ms step_avg:60.88ms
+step:1816/1840 train_time:110591ms step_avg:60.90ms
+step:1817/1840 train_time:110676ms step_avg:60.91ms
+step:1818/1840 train_time:110766ms step_avg:60.93ms
+step:1819/1840 train_time:110852ms step_avg:60.94ms
+step:1820/1840 train_time:110940ms step_avg:60.96ms
+step:1821/1840 train_time:111028ms step_avg:60.97ms
+step:1822/1840 train_time:111117ms step_avg:60.99ms
+step:1823/1840 train_time:111204ms step_avg:61.00ms
+step:1824/1840 train_time:111294ms step_avg:61.02ms
+step:1825/1840 train_time:111379ms step_avg:61.03ms
+step:1826/1840 train_time:111469ms step_avg:61.05ms
+step:1827/1840 train_time:111556ms step_avg:61.06ms
+step:1828/1840 train_time:111643ms step_avg:61.07ms
+step:1829/1840 train_time:111729ms step_avg:61.09ms
+step:1830/1840 train_time:111820ms step_avg:61.10ms
+step:1831/1840 train_time:111908ms step_avg:61.12ms
+step:1832/1840 train_time:111997ms step_avg:61.13ms
+step:1833/1840 train_time:112084ms step_avg:61.15ms
+step:1834/1840 train_time:112173ms step_avg:61.16ms
+step:1835/1840 train_time:112260ms step_avg:61.18ms
+step:1836/1840 train_time:112349ms step_avg:61.19ms
+step:1837/1840 train_time:112436ms step_avg:61.21ms
+step:1838/1840 train_time:112525ms step_avg:61.22ms
+step:1839/1840 train_time:112612ms step_avg:61.24ms
+step:1840/1840 train_time:112700ms step_avg:61.25ms
+step:1840/1840 val_loss:3.2780 train_time:112802ms step_avg:61.31ms
+peak memory allocated: 28507 MiB reserved: 43838 MiB

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/7c71bb08-8f66-4ef4-8505-6b31a66cbc55.txt
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/7c71bb08-8f66-4ef4-8505-6b31a66cbc55.txt
@@ -1,0 +1,3786 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+    """
+    Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+    Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+    bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+    float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+    """
+    assert p.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    wd_factor = wd_tensor.to(torch.float32)
+    lr_factor = lr_tensor.to(torch.float32)
+    p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    p_precise = p_precise_raw.view(torch.float32)
+    mask = (grad * p_precise) >= 0
+    p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+    p.copy_((p_precise_raw >> 16).to(torch.uint16))
+    mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        2. reduce scatter attn/mlp round 2 (16 mlp params)
+        3. wait on step 1, then compute update of 1 and schedule all gather
+        4. wait on step 2, then compute update of 2 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        5. wait for each all gather to complete and update params
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["mantissa"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn', 'mlp']
+        group_sizes = [16, 16]  # 10 attn + 6 mlp, then 16 mlp
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    def step(self):
+        self.step_p1()
+        self.step_p2()
+        self.step_p3()
+        
+    @torch.no_grad()
+    def step_p1(self):
+        """
+        Part 1: Launch distributed reduce_scatter operations for parameter groups.
+        """
+        rank = dist.get_rank()
+        self.group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            self.group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+    
+    @torch.no_grad()
+    def step_p2(self):
+        """
+        Part 2: Compute gradient updates and launch all_gather operations
+        Wait for all gather to complete for all parameter groups except final one
+        """
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = self.group_infos
+        
+        self.all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"].float()
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params], dtype=torch.float32)
+                
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            if "second_momentum_buffer" not in group:
+                group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1], dtype=torch.float32)
+                    if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if param_shape[-2] >= param_shape[-1] else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk, dtype=torch.bfloat16)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                if "mantissa" not in group:
+                    group["mantissa"] = torch.zeros_like(param_chunk, dtype=torch.uint16)
+                mantissa = group["mantissa"]
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx].view(torch.uint16),
+                        mantissa[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx]
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            self.all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete for all except final and copy results back into original parameter tensors.
+        for info in self.all_gather_infos[:-1]:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+    @torch.no_grad()
+    def step_p3(self):
+        """
+        Part 3: Wait for final all gather to complete and copy results back into original parameter tensors
+        """
+        info = self.all_gather_infos[-1]
+        info["gather_future"].wait()
+        stacked_params = info["stacked_params"]
+        orig_params = info["orig_params"]
+
+        unstacked_params = torch.unbind(stacked_params)
+        for i, p in enumerate(orig_params):
+            p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str], betas: list[list[float]], lr: float = 1e-3, eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for idx, label in enumerate(label_order):
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label], betas=betas[idx]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+        # tag the final param for optimizer pipelining, run all gather after muon copy
+        param_groups[-1]['params'][-1].is_final_param = True
+        
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        # 0-D CPU tensors to avoid recompilation in _update_step
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    def load_state_dict(self, state_dict):
+        """Override to preserve optimizer state dtypes (avoid BFloat16->Float32 cast that causes recompilation)."""
+        # Save original state dtypes before loading
+        original_dtypes = {}
+        for p, s in self.state.items():
+            original_dtypes[p] = {k: v.dtype for k, v in s.items() if isinstance(v, torch.Tensor)}
+        
+        # Call parent load_state_dict (which may cast dtypes to match param dtype)
+        super().load_state_dict(state_dict)
+        
+        # Restore original dtypes
+        for p, s in self.state.items():
+            if p in original_dtypes:
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor) and k in original_dtypes[p]:
+                        if v.dtype != original_dtypes[p][k]:
+                            s[k] = v.to(original_dtypes[p][k])
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-2]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step. step_size_t and eff_wd_t are 0-D CPU tensors to avoid recompilation."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)  # exp_avg = beta1 * exp_avg + (1 - beta1) * g_slice
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)  # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * g_slice^2
+        # compute step
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)  # update = (exp_avg / (sqrt(exp_avg_sq) + eps)) * step_size
+        # cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)  # update += eff_wd_t * p_slice * mask
+        p_slice.add_(other=update, alpha=-1.0)  # p_slice -= update
+
+    @torch.no_grad()
+    def step(self, muon_opt):
+        muon_opt.step_p1()
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        last_param = None
+        last_p_slice = None
+        for group in self.param_groups:      
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+                state["step"] += 1
+                t = state["step"]
+                
+                # Pre-compute changing values as 0-D CPU tensors to avoid recompilation.
+                # `.fill_(value)` is the same as "= value", but doesn't change the tensor object.
+                bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+                self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+                self._eff_wd_t.fill_(lr * lr * wd * getattr(param, "wd_mul", 1.0)) # `lr` included twice to serve as weight decay schedule.
+
+                DistAdam._update_step(p_slice, g_slice, state["exp_avg"], state["exp_avg_sq"],
+                                      beta1, beta2, eps, self._step_size_t, self._eff_wd_t)
+
+                if not is_small:
+                    if getattr(param, "is_final_param", False):
+                        last_param = param
+                        last_p_slice = p_slice
+                    else:
+                        all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+        self._reduce_scatter_futures.clear()
+
+        muon_opt.step_p2()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+        if last_param is not None:
+            last_all_gather_future = dist.all_gather_into_tensor(last_param, last_p_slice, async_op=True).get_future()
+        muon_opt.step_p3()
+        torch.futures.collect_all([last_all_gather_future]).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        adam_betas = {
+            'lm_head': [0.5, 0.95],
+            'smear_gate': [0.9, 0.99],
+            'attn_gate_bank': [0.9, 0.99],
+            've_gate_bank': [0.9, 0.99],
+            'skip_gate': [0.9, 0.99],
+            'x0_lambdas': [0.65, 0.95],
+            'scalars': [0.9, 0.99],
+            'embed': [0.5, 0.95],
+            'value_embed': [0.75, 0.95]
+        }
+        adam_labels = list(adam_betas.keys())
+        adam_beta_values = list(adam_betas.values())
+        muon_labels = ['attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, adam_beta_values, lr=0.008, eps=1e-10, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.muon_opt]
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * step_lr
+                
+        if self._is_active_step(self.adam_opt, step):
+            # adam will interleave calls to muon step
+            self.adam_opt.step(self.muon_opt)
+            self.model.zero_grad(set_to_none=True)
+            self.adam_opt.should_sync = False
+        else:
+            self.muon_opt.step()
+            self.muon_opt.zero_grad(set_to_none=True)
+            
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1800  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan  5 08:02:51 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   43C    P0            129W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   42C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   44C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            128W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     54487      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     54488      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     54489      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     54490      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     54491      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     54492      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     54493      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     54494      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 599, 600, 601, 1199, 1200, 1201, 1799, 1800, 1801] for warmup
+Resetting Model
+step:0/1840 val_loss:10.8310 train_time:0ms step_avg:0.04ms
+step:1/1840 train_time:71ms step_avg:70.70ms
+step:2/1840 train_time:94ms step_avg:46.92ms
+step:3/1840 train_time:114ms step_avg:37.95ms
+step:4/1840 train_time:138ms step_avg:34.55ms
+step:5/1840 train_time:170ms step_avg:34.01ms
+step:6/1840 train_time:258ms step_avg:43.03ms
+step:7/1840 train_time:276ms step_avg:39.45ms
+step:8/1840 train_time:298ms step_avg:37.21ms
+step:9/1840 train_time:330ms step_avg:36.62ms
+step:10/1840 train_time:364ms step_avg:36.38ms
+step:11/1840 train_time:396ms step_avg:35.97ms
+step:12/1840 train_time:430ms step_avg:35.81ms
+step:13/1840 train_time:462ms step_avg:35.53ms
+step:14/1840 train_time:496ms step_avg:35.43ms
+step:15/1840 train_time:528ms step_avg:35.21ms
+step:16/1840 train_time:562ms step_avg:35.15ms
+step:17/1840 train_time:594ms step_avg:34.97ms
+step:18/1840 train_time:629ms step_avg:34.92ms
+step:19/1840 train_time:660ms step_avg:34.76ms
+step:20/1840 train_time:694ms step_avg:34.72ms
+step:21/1840 train_time:727ms step_avg:34.60ms
+step:22/1840 train_time:761ms step_avg:34.59ms
+step:23/1840 train_time:793ms step_avg:34.47ms
+step:24/1840 train_time:827ms step_avg:34.46ms
+step:25/1840 train_time:859ms step_avg:34.36ms
+step:26/1840 train_time:893ms step_avg:34.34ms
+step:27/1840 train_time:925ms step_avg:34.27ms
+step:28/1840 train_time:960ms step_avg:34.28ms
+step:29/1840 train_time:992ms step_avg:34.20ms
+step:30/1840 train_time:1026ms step_avg:34.20ms
+step:31/1840 train_time:1058ms step_avg:34.14ms
+step:32/1840 train_time:1093ms step_avg:34.14ms
+step:33/1840 train_time:1125ms step_avg:34.10ms
+step:34/1840 train_time:1161ms step_avg:34.15ms
+step:35/1840 train_time:1194ms step_avg:34.11ms
+step:36/1840 train_time:1228ms step_avg:34.12ms
+step:37/1840 train_time:1261ms step_avg:34.09ms
+step:38/1840 train_time:1296ms step_avg:34.10ms
+step:39/1840 train_time:1328ms step_avg:34.06ms
+step:40/1840 train_time:1363ms step_avg:34.07ms
+step:41/1840 train_time:1395ms step_avg:34.03ms
+step:42/1840 train_time:1430ms step_avg:34.04ms
+step:43/1840 train_time:1462ms step_avg:33.99ms
+step:44/1840 train_time:1496ms step_avg:34.00ms
+step:45/1840 train_time:1528ms step_avg:33.96ms
+step:46/1840 train_time:1563ms step_avg:33.97ms
+step:47/1840 train_time:1595ms step_avg:33.93ms
+step:48/1840 train_time:1629ms step_avg:33.94ms
+step:49/1840 train_time:1661ms step_avg:33.90ms
+step:50/1840 train_time:1695ms step_avg:33.90ms
+step:51/1840 train_time:1727ms step_avg:33.86ms
+step:52/1840 train_time:1762ms step_avg:33.88ms
+step:53/1840 train_time:1794ms step_avg:33.84ms
+step:54/1840 train_time:1828ms step_avg:33.85ms
+step:55/1840 train_time:1860ms step_avg:33.82ms
+step:56/1840 train_time:1894ms step_avg:33.82ms
+step:57/1840 train_time:1926ms step_avg:33.79ms
+step:58/1840 train_time:1960ms step_avg:33.80ms
+step:59/1840 train_time:1992ms step_avg:33.77ms
+step:60/1840 train_time:2027ms step_avg:33.78ms
+step:61/1840 train_time:2059ms step_avg:33.76ms
+step:62/1840 train_time:2094ms step_avg:33.77ms
+step:63/1840 train_time:2126ms step_avg:33.75ms
+step:64/1840 train_time:2161ms step_avg:33.76ms
+step:65/1840 train_time:2193ms step_avg:33.74ms
+step:66/1840 train_time:2228ms step_avg:33.76ms
+step:67/1840 train_time:2260ms step_avg:33.73ms
+step:68/1840 train_time:2294ms step_avg:33.74ms
+step:69/1840 train_time:2327ms step_avg:33.72ms
+step:70/1840 train_time:2361ms step_avg:33.73ms
+step:71/1840 train_time:2393ms step_avg:33.71ms
+step:72/1840 train_time:2428ms step_avg:33.72ms
+step:73/1840 train_time:2460ms step_avg:33.70ms
+step:74/1840 train_time:2494ms step_avg:33.71ms
+step:75/1840 train_time:2527ms step_avg:33.69ms
+step:76/1840 train_time:2562ms step_avg:33.71ms
+step:77/1840 train_time:2594ms step_avg:33.69ms
+step:78/1840 train_time:2628ms step_avg:33.69ms
+step:79/1840 train_time:2660ms step_avg:33.67ms
+step:80/1840 train_time:2694ms step_avg:33.68ms
+step:81/1840 train_time:2727ms step_avg:33.66ms
+step:82/1840 train_time:2761ms step_avg:33.67ms
+step:83/1840 train_time:2793ms step_avg:33.65ms
+step:84/1840 train_time:2827ms step_avg:33.66ms
+step:85/1840 train_time:2859ms step_avg:33.64ms
+step:86/1840 train_time:2894ms step_avg:33.65ms
+step:87/1840 train_time:2926ms step_avg:33.63ms
+step:88/1840 train_time:2960ms step_avg:33.64ms
+step:89/1840 train_time:2992ms step_avg:33.62ms
+step:90/1840 train_time:3027ms step_avg:33.63ms
+step:91/1840 train_time:3059ms step_avg:33.61ms
+step:92/1840 train_time:3093ms step_avg:33.62ms
+step:93/1840 train_time:3125ms step_avg:33.61ms
+step:94/1840 train_time:3160ms step_avg:33.62ms
+step:95/1840 train_time:3192ms step_avg:33.60ms
+step:96/1840 train_time:3226ms step_avg:33.61ms
+step:97/1840 train_time:3259ms step_avg:33.60ms
+step:98/1840 train_time:3293ms step_avg:33.60ms
+step:99/1840 train_time:3325ms step_avg:33.59ms
+step:100/1840 train_time:3360ms step_avg:33.60ms
+step:101/1840 train_time:3392ms step_avg:33.58ms
+step:102/1840 train_time:3426ms step_avg:33.59ms
+step:103/1840 train_time:3459ms step_avg:33.58ms
+step:104/1840 train_time:3493ms step_avg:33.59ms
+step:105/1840 train_time:3525ms step_avg:33.57ms
+step:106/1840 train_time:3560ms step_avg:33.58ms
+step:107/1840 train_time:3592ms step_avg:33.57ms
+step:108/1840 train_time:3626ms step_avg:33.57ms
+step:109/1840 train_time:3658ms step_avg:33.56ms
+step:110/1840 train_time:3692ms step_avg:33.57ms
+step:111/1840 train_time:3724ms step_avg:33.55ms
+step:112/1840 train_time:3759ms step_avg:33.56ms
+step:113/1840 train_time:3791ms step_avg:33.55ms
+step:114/1840 train_time:3826ms step_avg:33.56ms
+step:115/1840 train_time:3858ms step_avg:33.55ms
+step:116/1840 train_time:3893ms step_avg:33.56ms
+step:117/1840 train_time:3925ms step_avg:33.54ms
+step:118/1840 train_time:3959ms step_avg:33.55ms
+step:119/1840 train_time:3991ms step_avg:33.54ms
+step:120/1840 train_time:4025ms step_avg:33.54ms
+step:121/1840 train_time:4058ms step_avg:33.53ms
+step:122/1840 train_time:4092ms step_avg:33.54ms
+step:123/1840 train_time:4124ms step_avg:33.53ms
+step:124/1840 train_time:4158ms step_avg:33.54ms
+step:125/1840 train_time:4191ms step_avg:33.52ms
+step:126/1840 train_time:4225ms step_avg:33.53ms
+step:127/1840 train_time:4257ms step_avg:33.52ms
+step:128/1840 train_time:4292ms step_avg:33.53ms
+step:129/1840 train_time:4324ms step_avg:33.52ms
+step:130/1840 train_time:4358ms step_avg:33.52ms
+step:131/1840 train_time:4390ms step_avg:33.51ms
+step:132/1840 train_time:4425ms step_avg:33.52ms
+step:133/1840 train_time:4457ms step_avg:33.51ms
+step:134/1840 train_time:4492ms step_avg:33.52ms
+step:135/1840 train_time:4524ms step_avg:33.51ms
+step:136/1840 train_time:4558ms step_avg:33.52ms
+step:137/1840 train_time:4591ms step_avg:33.51ms
+step:138/1840 train_time:4625ms step_avg:33.51ms
+step:139/1840 train_time:4657ms step_avg:33.50ms
+step:140/1840 train_time:4691ms step_avg:33.51ms
+step:141/1840 train_time:4723ms step_avg:33.50ms
+step:142/1840 train_time:4758ms step_avg:33.50ms
+step:143/1840 train_time:4790ms step_avg:33.49ms
+step:144/1840 train_time:4824ms step_avg:33.50ms
+step:145/1840 train_time:4856ms step_avg:33.49ms
+step:146/1840 train_time:4891ms step_avg:33.50ms
+step:147/1840 train_time:4923ms step_avg:33.49ms
+step:148/1840 train_time:4957ms step_avg:33.49ms
+step:149/1840 train_time:4989ms step_avg:33.48ms
+step:150/1840 train_time:5023ms step_avg:33.49ms
+step:151/1840 train_time:5056ms step_avg:33.48ms
+step:152/1840 train_time:5090ms step_avg:33.49ms
+step:153/1840 train_time:5122ms step_avg:33.48ms
+step:154/1840 train_time:5156ms step_avg:33.48ms
+step:155/1840 train_time:5188ms step_avg:33.47ms
+step:156/1840 train_time:5223ms step_avg:33.48ms
+step:157/1840 train_time:5255ms step_avg:33.47ms
+step:158/1840 train_time:5289ms step_avg:33.47ms
+step:159/1840 train_time:5321ms step_avg:33.46ms
+step:160/1840 train_time:5355ms step_avg:33.47ms
+step:161/1840 train_time:5387ms step_avg:33.46ms
+step:162/1840 train_time:5422ms step_avg:33.47ms
+step:163/1840 train_time:5454ms step_avg:33.46ms
+step:164/1840 train_time:5488ms step_avg:33.46ms
+step:165/1840 train_time:5520ms step_avg:33.45ms
+step:166/1840 train_time:5554ms step_avg:33.46ms
+step:167/1840 train_time:5587ms step_avg:33.45ms
+step:168/1840 train_time:5621ms step_avg:33.46ms
+step:169/1840 train_time:5653ms step_avg:33.45ms
+step:170/1840 train_time:5688ms step_avg:33.46ms
+step:171/1840 train_time:5720ms step_avg:33.45ms
+step:172/1840 train_time:5754ms step_avg:33.45ms
+step:173/1840 train_time:5786ms step_avg:33.45ms
+step:174/1840 train_time:5821ms step_avg:33.45ms
+step:175/1840 train_time:5853ms step_avg:33.44ms
+step:176/1840 train_time:5887ms step_avg:33.45ms
+step:177/1840 train_time:5919ms step_avg:33.44ms
+step:178/1840 train_time:5953ms step_avg:33.44ms
+step:179/1840 train_time:5985ms step_avg:33.44ms
+step:180/1840 train_time:6020ms step_avg:33.44ms
+step:181/1840 train_time:6052ms step_avg:33.44ms
+step:182/1840 train_time:6086ms step_avg:33.44ms
+step:183/1840 train_time:6119ms step_avg:33.43ms
+step:184/1840 train_time:6153ms step_avg:33.44ms
+step:185/1840 train_time:6185ms step_avg:33.43ms
+step:186/1840 train_time:6219ms step_avg:33.44ms
+step:187/1840 train_time:6251ms step_avg:33.43ms
+step:188/1840 train_time:6286ms step_avg:33.44ms
+step:189/1840 train_time:6318ms step_avg:33.43ms
+step:190/1840 train_time:6352ms step_avg:33.43ms
+step:191/1840 train_time:6385ms step_avg:33.43ms
+step:192/1840 train_time:6419ms step_avg:33.43ms
+step:193/1840 train_time:6451ms step_avg:33.42ms
+step:194/1840 train_time:6485ms step_avg:33.43ms
+step:195/1840 train_time:6518ms step_avg:33.42ms
+step:196/1840 train_time:6552ms step_avg:33.43ms
+step:197/1840 train_time:6584ms step_avg:33.42ms
+step:198/1840 train_time:6618ms step_avg:33.42ms
+step:199/1840 train_time:6650ms step_avg:33.42ms
+step:200/1840 train_time:6684ms step_avg:33.42ms
+step:201/1840 train_time:6717ms step_avg:33.42ms
+step:202/1840 train_time:6751ms step_avg:33.42ms
+step:203/1840 train_time:6783ms step_avg:33.41ms
+step:204/1840 train_time:6817ms step_avg:33.42ms
+step:205/1840 train_time:6849ms step_avg:33.41ms
+step:206/1840 train_time:6884ms step_avg:33.42ms
+step:207/1840 train_time:6916ms step_avg:33.41ms
+step:208/1840 train_time:6950ms step_avg:33.42ms
+step:209/1840 train_time:6983ms step_avg:33.41ms
+step:210/1840 train_time:7017ms step_avg:33.41ms
+step:211/1840 train_time:7049ms step_avg:33.41ms
+step:212/1840 train_time:7084ms step_avg:33.41ms
+step:213/1840 train_time:7116ms step_avg:33.41ms
+step:214/1840 train_time:7150ms step_avg:33.41ms
+step:215/1840 train_time:7182ms step_avg:33.40ms
+step:216/1840 train_time:7216ms step_avg:33.41ms
+step:217/1840 train_time:7248ms step_avg:33.40ms
+step:218/1840 train_time:7283ms step_avg:33.41ms
+step:219/1840 train_time:7315ms step_avg:33.40ms
+step:220/1840 train_time:7350ms step_avg:33.41ms
+step:221/1840 train_time:7382ms step_avg:33.40ms
+step:222/1840 train_time:7416ms step_avg:33.41ms
+step:223/1840 train_time:7448ms step_avg:33.40ms
+step:224/1840 train_time:7482ms step_avg:33.40ms
+step:225/1840 train_time:7514ms step_avg:33.40ms
+step:226/1840 train_time:7549ms step_avg:33.40ms
+step:227/1840 train_time:7581ms step_avg:33.40ms
+step:228/1840 train_time:7615ms step_avg:33.40ms
+step:229/1840 train_time:7647ms step_avg:33.39ms
+step:230/1840 train_time:7681ms step_avg:33.40ms
+step:231/1840 train_time:7713ms step_avg:33.39ms
+step:232/1840 train_time:7748ms step_avg:33.40ms
+step:233/1840 train_time:7780ms step_avg:33.39ms
+step:234/1840 train_time:7814ms step_avg:33.39ms
+step:235/1840 train_time:7846ms step_avg:33.39ms
+step:236/1840 train_time:7880ms step_avg:33.39ms
+step:237/1840 train_time:7912ms step_avg:33.38ms
+step:238/1840 train_time:7947ms step_avg:33.39ms
+step:239/1840 train_time:7979ms step_avg:33.38ms
+step:240/1840 train_time:8013ms step_avg:33.39ms
+step:241/1840 train_time:8045ms step_avg:33.38ms
+step:242/1840 train_time:8079ms step_avg:33.39ms
+step:243/1840 train_time:8111ms step_avg:33.38ms
+step:244/1840 train_time:8146ms step_avg:33.38ms
+step:245/1840 train_time:8178ms step_avg:33.38ms
+step:246/1840 train_time:8212ms step_avg:33.38ms
+step:247/1840 train_time:8244ms step_avg:33.38ms
+step:248/1840 train_time:8278ms step_avg:33.38ms
+step:249/1840 train_time:8310ms step_avg:33.38ms
+step:250/1840 train_time:8345ms step_avg:33.38ms
+step:250/1840 val_loss:4.6101 train_time:8387ms step_avg:33.55ms
+step:251/1840 train_time:8405ms step_avg:33.49ms
+step:252/1840 train_time:8424ms step_avg:33.43ms
+step:253/1840 train_time:8446ms step_avg:33.38ms
+step:254/1840 train_time:8481ms step_avg:33.39ms
+step:255/1840 train_time:8513ms step_avg:33.38ms
+step:256/1840 train_time:8548ms step_avg:33.39ms
+step:257/1840 train_time:8580ms step_avg:33.39ms
+step:258/1840 train_time:8615ms step_avg:33.39ms
+step:259/1840 train_time:8647ms step_avg:33.39ms
+step:260/1840 train_time:8681ms step_avg:33.39ms
+step:261/1840 train_time:8713ms step_avg:33.38ms
+step:262/1840 train_time:8747ms step_avg:33.39ms
+step:263/1840 train_time:8779ms step_avg:33.38ms
+step:264/1840 train_time:8813ms step_avg:33.38ms
+step:265/1840 train_time:8845ms step_avg:33.38ms
+step:266/1840 train_time:8879ms step_avg:33.38ms
+step:267/1840 train_time:8911ms step_avg:33.38ms
+step:268/1840 train_time:8945ms step_avg:33.38ms
+step:269/1840 train_time:8977ms step_avg:33.37ms
+step:270/1840 train_time:9011ms step_avg:33.37ms
+step:271/1840 train_time:9043ms step_avg:33.37ms
+step:272/1840 train_time:9077ms step_avg:33.37ms
+step:273/1840 train_time:9109ms step_avg:33.37ms
+step:274/1840 train_time:9143ms step_avg:33.37ms
+step:275/1840 train_time:9175ms step_avg:33.36ms
+step:276/1840 train_time:9209ms step_avg:33.37ms
+step:277/1840 train_time:9241ms step_avg:33.36ms
+step:278/1840 train_time:9275ms step_avg:33.36ms
+step:279/1840 train_time:9307ms step_avg:33.36ms
+step:280/1840 train_time:9342ms step_avg:33.36ms
+step:281/1840 train_time:9374ms step_avg:33.36ms
+step:282/1840 train_time:9409ms step_avg:33.37ms
+step:283/1840 train_time:9441ms step_avg:33.36ms
+step:284/1840 train_time:9476ms step_avg:33.37ms
+step:285/1840 train_time:9508ms step_avg:33.36ms
+step:286/1840 train_time:9543ms step_avg:33.37ms
+step:287/1840 train_time:9575ms step_avg:33.36ms
+step:288/1840 train_time:9610ms step_avg:33.37ms
+step:289/1840 train_time:9642ms step_avg:33.36ms
+step:290/1840 train_time:9676ms step_avg:33.37ms
+step:291/1840 train_time:9708ms step_avg:33.36ms
+step:292/1840 train_time:9743ms step_avg:33.37ms
+step:293/1840 train_time:9775ms step_avg:33.36ms
+step:294/1840 train_time:9809ms step_avg:33.37ms
+step:295/1840 train_time:9842ms step_avg:33.36ms
+step:296/1840 train_time:9876ms step_avg:33.37ms
+step:297/1840 train_time:9908ms step_avg:33.36ms
+step:298/1840 train_time:9943ms step_avg:33.36ms
+step:299/1840 train_time:9975ms step_avg:33.36ms
+step:300/1840 train_time:10009ms step_avg:33.36ms
+step:301/1840 train_time:10041ms step_avg:33.36ms
+step:302/1840 train_time:10075ms step_avg:33.36ms
+step:303/1840 train_time:10107ms step_avg:33.36ms
+step:304/1840 train_time:10141ms step_avg:33.36ms
+step:305/1840 train_time:10173ms step_avg:33.36ms
+step:306/1840 train_time:10207ms step_avg:33.36ms
+step:307/1840 train_time:10240ms step_avg:33.35ms
+step:308/1840 train_time:10274ms step_avg:33.36ms
+step:309/1840 train_time:10306ms step_avg:33.35ms
+step:310/1840 train_time:10341ms step_avg:33.36ms
+step:311/1840 train_time:10373ms step_avg:33.35ms
+step:312/1840 train_time:10408ms step_avg:33.36ms
+step:313/1840 train_time:10440ms step_avg:33.35ms
+step:314/1840 train_time:10474ms step_avg:33.36ms
+step:315/1840 train_time:10507ms step_avg:33.35ms
+step:316/1840 train_time:10541ms step_avg:33.36ms
+step:317/1840 train_time:10573ms step_avg:33.35ms
+step:318/1840 train_time:10608ms step_avg:33.36ms
+step:319/1840 train_time:10640ms step_avg:33.35ms
+step:320/1840 train_time:10674ms step_avg:33.36ms
+step:321/1840 train_time:10706ms step_avg:33.35ms
+step:322/1840 train_time:10741ms step_avg:33.36ms
+step:323/1840 train_time:10772ms step_avg:33.35ms
+step:324/1840 train_time:10807ms step_avg:33.36ms
+step:325/1840 train_time:10839ms step_avg:33.35ms
+step:326/1840 train_time:10873ms step_avg:33.35ms
+step:327/1840 train_time:10905ms step_avg:33.35ms
+step:328/1840 train_time:10940ms step_avg:33.35ms
+step:329/1840 train_time:10971ms step_avg:33.35ms
+step:330/1840 train_time:11005ms step_avg:33.35ms
+step:331/1840 train_time:11037ms step_avg:33.34ms
+step:332/1840 train_time:11072ms step_avg:33.35ms
+step:333/1840 train_time:11103ms step_avg:33.34ms
+step:334/1840 train_time:11137ms step_avg:33.35ms
+step:335/1840 train_time:11170ms step_avg:33.34ms
+step:336/1840 train_time:11204ms step_avg:33.34ms
+step:337/1840 train_time:11236ms step_avg:33.34ms
+step:338/1840 train_time:11270ms step_avg:33.34ms
+step:339/1840 train_time:11302ms step_avg:33.34ms
+step:340/1840 train_time:11336ms step_avg:33.34ms
+step:341/1840 train_time:11368ms step_avg:33.34ms
+step:342/1840 train_time:11403ms step_avg:33.34ms
+step:343/1840 train_time:11435ms step_avg:33.34ms
+step:344/1840 train_time:11469ms step_avg:33.34ms
+step:345/1840 train_time:11501ms step_avg:33.34ms
+step:346/1840 train_time:11535ms step_avg:33.34ms
+step:347/1840 train_time:11568ms step_avg:33.34ms
+step:348/1840 train_time:11602ms step_avg:33.34ms
+step:349/1840 train_time:11635ms step_avg:33.34ms
+step:350/1840 train_time:11669ms step_avg:33.34ms
+step:351/1840 train_time:11701ms step_avg:33.34ms
+step:352/1840 train_time:11736ms step_avg:33.34ms
+step:353/1840 train_time:11768ms step_avg:33.34ms
+step:354/1840 train_time:11802ms step_avg:33.34ms
+step:355/1840 train_time:11834ms step_avg:33.34ms
+step:356/1840 train_time:11868ms step_avg:33.34ms
+step:357/1840 train_time:11901ms step_avg:33.34ms
+step:358/1840 train_time:11935ms step_avg:33.34ms
+step:359/1840 train_time:11967ms step_avg:33.33ms
+step:360/1840 train_time:12001ms step_avg:33.34ms
+step:361/1840 train_time:12033ms step_avg:33.33ms
+step:362/1840 train_time:12068ms step_avg:33.34ms
+step:363/1840 train_time:12100ms step_avg:33.33ms
+step:364/1840 train_time:12134ms step_avg:33.33ms
+step:365/1840 train_time:12166ms step_avg:33.33ms
+step:366/1840 train_time:12200ms step_avg:33.33ms
+step:367/1840 train_time:12232ms step_avg:33.33ms
+step:368/1840 train_time:12266ms step_avg:33.33ms
+step:369/1840 train_time:12298ms step_avg:33.33ms
+step:370/1840 train_time:12333ms step_avg:33.33ms
+step:371/1840 train_time:12365ms step_avg:33.33ms
+step:372/1840 train_time:12399ms step_avg:33.33ms
+step:373/1840 train_time:12431ms step_avg:33.33ms
+step:374/1840 train_time:12465ms step_avg:33.33ms
+step:375/1840 train_time:12497ms step_avg:33.33ms
+step:376/1840 train_time:12532ms step_avg:33.33ms
+step:377/1840 train_time:12564ms step_avg:33.33ms
+step:378/1840 train_time:12598ms step_avg:33.33ms
+step:379/1840 train_time:12630ms step_avg:33.33ms
+step:380/1840 train_time:12665ms step_avg:33.33ms
+step:381/1840 train_time:12697ms step_avg:33.32ms
+step:382/1840 train_time:12731ms step_avg:33.33ms
+step:383/1840 train_time:12763ms step_avg:33.32ms
+step:384/1840 train_time:12797ms step_avg:33.33ms
+step:385/1840 train_time:12829ms step_avg:33.32ms
+step:386/1840 train_time:12864ms step_avg:33.33ms
+step:387/1840 train_time:12896ms step_avg:33.32ms
+step:388/1840 train_time:12930ms step_avg:33.32ms
+step:389/1840 train_time:12962ms step_avg:33.32ms
+step:390/1840 train_time:12996ms step_avg:33.32ms
+step:391/1840 train_time:13028ms step_avg:33.32ms
+step:392/1840 train_time:13063ms step_avg:33.32ms
+step:393/1840 train_time:13095ms step_avg:33.32ms
+step:394/1840 train_time:13129ms step_avg:33.32ms
+step:395/1840 train_time:13161ms step_avg:33.32ms
+step:396/1840 train_time:13195ms step_avg:33.32ms
+step:397/1840 train_time:13227ms step_avg:33.32ms
+step:398/1840 train_time:13262ms step_avg:33.32ms
+step:399/1840 train_time:13294ms step_avg:33.32ms
+step:400/1840 train_time:13328ms step_avg:33.32ms
+step:401/1840 train_time:13361ms step_avg:33.32ms
+step:402/1840 train_time:13395ms step_avg:33.32ms
+step:403/1840 train_time:13427ms step_avg:33.32ms
+step:404/1840 train_time:13462ms step_avg:33.32ms
+step:405/1840 train_time:13494ms step_avg:33.32ms
+step:406/1840 train_time:13528ms step_avg:33.32ms
+step:407/1840 train_time:13561ms step_avg:33.32ms
+step:408/1840 train_time:13595ms step_avg:33.32ms
+step:409/1840 train_time:13627ms step_avg:33.32ms
+step:410/1840 train_time:13661ms step_avg:33.32ms
+step:411/1840 train_time:13694ms step_avg:33.32ms
+step:412/1840 train_time:13728ms step_avg:33.32ms
+step:413/1840 train_time:13760ms step_avg:33.32ms
+step:414/1840 train_time:13795ms step_avg:33.32ms
+step:415/1840 train_time:13827ms step_avg:33.32ms
+step:416/1840 train_time:13861ms step_avg:33.32ms
+step:417/1840 train_time:13893ms step_avg:33.32ms
+step:418/1840 train_time:13927ms step_avg:33.32ms
+step:419/1840 train_time:13959ms step_avg:33.32ms
+step:420/1840 train_time:13994ms step_avg:33.32ms
+step:421/1840 train_time:14026ms step_avg:33.32ms
+step:422/1840 train_time:14060ms step_avg:33.32ms
+step:423/1840 train_time:14092ms step_avg:33.31ms
+step:424/1840 train_time:14126ms step_avg:33.32ms
+step:425/1840 train_time:14158ms step_avg:33.31ms
+step:426/1840 train_time:14192ms step_avg:33.32ms
+step:427/1840 train_time:14224ms step_avg:33.31ms
+step:428/1840 train_time:14258ms step_avg:33.31ms
+step:429/1840 train_time:14291ms step_avg:33.31ms
+step:430/1840 train_time:14325ms step_avg:33.31ms
+step:431/1840 train_time:14356ms step_avg:33.31ms
+step:432/1840 train_time:14391ms step_avg:33.31ms
+step:433/1840 train_time:14423ms step_avg:33.31ms
+step:434/1840 train_time:14457ms step_avg:33.31ms
+step:435/1840 train_time:14490ms step_avg:33.31ms
+step:436/1840 train_time:14524ms step_avg:33.31ms
+step:437/1840 train_time:14556ms step_avg:33.31ms
+step:438/1840 train_time:14590ms step_avg:33.31ms
+step:439/1840 train_time:14623ms step_avg:33.31ms
+step:440/1840 train_time:14657ms step_avg:33.31ms
+step:441/1840 train_time:14689ms step_avg:33.31ms
+step:442/1840 train_time:14723ms step_avg:33.31ms
+step:443/1840 train_time:14755ms step_avg:33.31ms
+step:444/1840 train_time:14790ms step_avg:33.31ms
+step:445/1840 train_time:14822ms step_avg:33.31ms
+step:446/1840 train_time:14856ms step_avg:33.31ms
+step:447/1840 train_time:14888ms step_avg:33.31ms
+step:448/1840 train_time:14923ms step_avg:33.31ms
+step:449/1840 train_time:14955ms step_avg:33.31ms
+step:450/1840 train_time:14990ms step_avg:33.31ms
+step:451/1840 train_time:15022ms step_avg:33.31ms
+step:452/1840 train_time:15056ms step_avg:33.31ms
+step:453/1840 train_time:15089ms step_avg:33.31ms
+step:454/1840 train_time:15123ms step_avg:33.31ms
+step:455/1840 train_time:15155ms step_avg:33.31ms
+step:456/1840 train_time:15190ms step_avg:33.31ms
+step:457/1840 train_time:15222ms step_avg:33.31ms
+step:458/1840 train_time:15256ms step_avg:33.31ms
+step:459/1840 train_time:15288ms step_avg:33.31ms
+step:460/1840 train_time:15323ms step_avg:33.31ms
+step:461/1840 train_time:15355ms step_avg:33.31ms
+step:462/1840 train_time:15389ms step_avg:33.31ms
+step:463/1840 train_time:15421ms step_avg:33.31ms
+step:464/1840 train_time:15455ms step_avg:33.31ms
+step:465/1840 train_time:15488ms step_avg:33.31ms
+step:466/1840 train_time:15522ms step_avg:33.31ms
+step:467/1840 train_time:15554ms step_avg:33.31ms
+step:468/1840 train_time:15588ms step_avg:33.31ms
+step:469/1840 train_time:15620ms step_avg:33.31ms
+step:470/1840 train_time:15654ms step_avg:33.31ms
+step:471/1840 train_time:15686ms step_avg:33.30ms
+step:472/1840 train_time:15721ms step_avg:33.31ms
+step:473/1840 train_time:15753ms step_avg:33.30ms
+step:474/1840 train_time:15787ms step_avg:33.31ms
+step:475/1840 train_time:15819ms step_avg:33.30ms
+step:476/1840 train_time:15854ms step_avg:33.31ms
+step:477/1840 train_time:15886ms step_avg:33.30ms
+step:478/1840 train_time:15920ms step_avg:33.31ms
+step:479/1840 train_time:15952ms step_avg:33.30ms
+step:480/1840 train_time:15987ms step_avg:33.31ms
+step:481/1840 train_time:16019ms step_avg:33.30ms
+step:482/1840 train_time:16053ms step_avg:33.31ms
+step:483/1840 train_time:16085ms step_avg:33.30ms
+step:484/1840 train_time:16120ms step_avg:33.31ms
+step:485/1840 train_time:16152ms step_avg:33.30ms
+step:486/1840 train_time:16186ms step_avg:33.30ms
+step:487/1840 train_time:16218ms step_avg:33.30ms
+step:488/1840 train_time:16252ms step_avg:33.30ms
+step:489/1840 train_time:16285ms step_avg:33.30ms
+step:490/1840 train_time:16319ms step_avg:33.30ms
+step:491/1840 train_time:16351ms step_avg:33.30ms
+step:492/1840 train_time:16386ms step_avg:33.30ms
+step:493/1840 train_time:16417ms step_avg:33.30ms
+step:494/1840 train_time:16452ms step_avg:33.30ms
+step:495/1840 train_time:16484ms step_avg:33.30ms
+step:496/1840 train_time:16518ms step_avg:33.30ms
+step:497/1840 train_time:16550ms step_avg:33.30ms
+step:498/1840 train_time:16585ms step_avg:33.30ms
+step:499/1840 train_time:16617ms step_avg:33.30ms
+step:500/1840 train_time:16652ms step_avg:33.30ms
+step:500/1840 val_loss:4.2809 train_time:16694ms step_avg:33.39ms
+step:501/1840 train_time:16712ms step_avg:33.36ms
+step:502/1840 train_time:16731ms step_avg:33.33ms
+step:503/1840 train_time:16752ms step_avg:33.30ms
+step:504/1840 train_time:16787ms step_avg:33.31ms
+step:505/1840 train_time:16820ms step_avg:33.31ms
+step:506/1840 train_time:16856ms step_avg:33.31ms
+step:507/1840 train_time:16888ms step_avg:33.31ms
+step:508/1840 train_time:16923ms step_avg:33.31ms
+step:509/1840 train_time:16955ms step_avg:33.31ms
+step:510/1840 train_time:16989ms step_avg:33.31ms
+step:511/1840 train_time:17022ms step_avg:33.31ms
+step:512/1840 train_time:17056ms step_avg:33.31ms
+step:513/1840 train_time:17088ms step_avg:33.31ms
+step:514/1840 train_time:17122ms step_avg:33.31ms
+step:515/1840 train_time:17154ms step_avg:33.31ms
+step:516/1840 train_time:17188ms step_avg:33.31ms
+step:517/1840 train_time:17220ms step_avg:33.31ms
+step:518/1840 train_time:17254ms step_avg:33.31ms
+step:519/1840 train_time:17286ms step_avg:33.31ms
+step:520/1840 train_time:17320ms step_avg:33.31ms
+step:521/1840 train_time:17352ms step_avg:33.31ms
+step:522/1840 train_time:17386ms step_avg:33.31ms
+step:523/1840 train_time:17418ms step_avg:33.30ms
+step:524/1840 train_time:17453ms step_avg:33.31ms
+step:525/1840 train_time:17484ms step_avg:33.30ms
+step:526/1840 train_time:17518ms step_avg:33.30ms
+step:527/1840 train_time:17550ms step_avg:33.30ms
+step:528/1840 train_time:17584ms step_avg:33.30ms
+step:529/1840 train_time:17617ms step_avg:33.30ms
+step:530/1840 train_time:17651ms step_avg:33.30ms
+step:531/1840 train_time:17684ms step_avg:33.30ms
+step:532/1840 train_time:17718ms step_avg:33.30ms
+step:533/1840 train_time:17751ms step_avg:33.30ms
+step:534/1840 train_time:17785ms step_avg:33.31ms
+step:535/1840 train_time:17818ms step_avg:33.30ms
+step:536/1840 train_time:17853ms step_avg:33.31ms
+step:537/1840 train_time:17885ms step_avg:33.31ms
+step:538/1840 train_time:17920ms step_avg:33.31ms
+step:539/1840 train_time:17952ms step_avg:33.31ms
+step:540/1840 train_time:17989ms step_avg:33.31ms
+step:541/1840 train_time:18019ms step_avg:33.31ms
+step:542/1840 train_time:18053ms step_avg:33.31ms
+step:543/1840 train_time:18085ms step_avg:33.31ms
+step:544/1840 train_time:18119ms step_avg:33.31ms
+step:545/1840 train_time:18152ms step_avg:33.31ms
+step:546/1840 train_time:18186ms step_avg:33.31ms
+step:547/1840 train_time:18218ms step_avg:33.30ms
+step:548/1840 train_time:18252ms step_avg:33.31ms
+step:549/1840 train_time:18284ms step_avg:33.30ms
+step:550/1840 train_time:18318ms step_avg:33.31ms
+step:551/1840 train_time:18350ms step_avg:33.30ms
+step:552/1840 train_time:18384ms step_avg:33.31ms
+step:553/1840 train_time:18416ms step_avg:33.30ms
+step:554/1840 train_time:18450ms step_avg:33.30ms
+step:555/1840 train_time:18482ms step_avg:33.30ms
+step:556/1840 train_time:18517ms step_avg:33.30ms
+step:557/1840 train_time:18548ms step_avg:33.30ms
+step:558/1840 train_time:18582ms step_avg:33.30ms
+step:559/1840 train_time:18615ms step_avg:33.30ms
+step:560/1840 train_time:18649ms step_avg:33.30ms
+step:561/1840 train_time:18681ms step_avg:33.30ms
+step:562/1840 train_time:18716ms step_avg:33.30ms
+step:563/1840 train_time:18748ms step_avg:33.30ms
+step:564/1840 train_time:18783ms step_avg:33.30ms
+step:565/1840 train_time:18815ms step_avg:33.30ms
+step:566/1840 train_time:18850ms step_avg:33.30ms
+step:567/1840 train_time:18882ms step_avg:33.30ms
+step:568/1840 train_time:18916ms step_avg:33.30ms
+step:569/1840 train_time:18949ms step_avg:33.30ms
+step:570/1840 train_time:18983ms step_avg:33.30ms
+step:571/1840 train_time:19015ms step_avg:33.30ms
+step:572/1840 train_time:19049ms step_avg:33.30ms
+step:573/1840 train_time:19082ms step_avg:33.30ms
+step:574/1840 train_time:19116ms step_avg:33.30ms
+step:575/1840 train_time:19148ms step_avg:33.30ms
+step:576/1840 train_time:19182ms step_avg:33.30ms
+step:577/1840 train_time:19214ms step_avg:33.30ms
+step:578/1840 train_time:19249ms step_avg:33.30ms
+step:579/1840 train_time:19281ms step_avg:33.30ms
+step:580/1840 train_time:19315ms step_avg:33.30ms
+step:581/1840 train_time:19347ms step_avg:33.30ms
+step:582/1840 train_time:19381ms step_avg:33.30ms
+step:583/1840 train_time:19413ms step_avg:33.30ms
+step:584/1840 train_time:19447ms step_avg:33.30ms
+step:585/1840 train_time:19479ms step_avg:33.30ms
+step:586/1840 train_time:19514ms step_avg:33.30ms
+step:587/1840 train_time:19545ms step_avg:33.30ms
+step:588/1840 train_time:19580ms step_avg:33.30ms
+step:589/1840 train_time:19612ms step_avg:33.30ms
+step:590/1840 train_time:19647ms step_avg:33.30ms
+step:591/1840 train_time:19679ms step_avg:33.30ms
+step:592/1840 train_time:19713ms step_avg:33.30ms
+step:593/1840 train_time:19745ms step_avg:33.30ms
+step:594/1840 train_time:19780ms step_avg:33.30ms
+step:595/1840 train_time:19812ms step_avg:33.30ms
+step:596/1840 train_time:19846ms step_avg:33.30ms
+step:597/1840 train_time:19878ms step_avg:33.30ms
+step:598/1840 train_time:19913ms step_avg:33.30ms
+step:599/1840 train_time:19945ms step_avg:33.30ms
+step:600/1840 train_time:19980ms step_avg:33.30ms
+step:601/1840 train_time:20014ms step_avg:33.30ms
+step:602/1840 train_time:20072ms step_avg:33.34ms
+step:603/1840 train_time:20131ms step_avg:33.38ms
+step:604/1840 train_time:20193ms step_avg:33.43ms
+step:605/1840 train_time:20252ms step_avg:33.47ms
+step:606/1840 train_time:20315ms step_avg:33.52ms
+step:607/1840 train_time:20375ms step_avg:33.57ms
+step:608/1840 train_time:20437ms step_avg:33.61ms
+step:609/1840 train_time:20497ms step_avg:33.66ms
+step:610/1840 train_time:20559ms step_avg:33.70ms
+step:611/1840 train_time:20619ms step_avg:33.75ms
+step:612/1840 train_time:20681ms step_avg:33.79ms
+step:613/1840 train_time:20741ms step_avg:33.84ms
+step:614/1840 train_time:20803ms step_avg:33.88ms
+step:615/1840 train_time:20863ms step_avg:33.92ms
+step:616/1840 train_time:20925ms step_avg:33.97ms
+step:617/1840 train_time:20985ms step_avg:34.01ms
+step:618/1840 train_time:21047ms step_avg:34.06ms
+step:619/1840 train_time:21107ms step_avg:34.10ms
+step:620/1840 train_time:21169ms step_avg:34.14ms
+step:621/1840 train_time:21228ms step_avg:34.18ms
+step:622/1840 train_time:21290ms step_avg:34.23ms
+step:623/1840 train_time:21349ms step_avg:34.27ms
+step:624/1840 train_time:21412ms step_avg:34.31ms
+step:625/1840 train_time:21471ms step_avg:34.35ms
+step:626/1840 train_time:21533ms step_avg:34.40ms
+step:627/1840 train_time:21593ms step_avg:34.44ms
+step:628/1840 train_time:21655ms step_avg:34.48ms
+step:629/1840 train_time:21717ms step_avg:34.53ms
+step:630/1840 train_time:21780ms step_avg:34.57ms
+step:631/1840 train_time:21840ms step_avg:34.61ms
+step:632/1840 train_time:21903ms step_avg:34.66ms
+step:633/1840 train_time:21963ms step_avg:34.70ms
+step:634/1840 train_time:22025ms step_avg:34.74ms
+step:635/1840 train_time:22086ms step_avg:34.78ms
+step:636/1840 train_time:22148ms step_avg:34.82ms
+step:637/1840 train_time:22208ms step_avg:34.86ms
+step:638/1840 train_time:22269ms step_avg:34.90ms
+step:639/1840 train_time:22329ms step_avg:34.94ms
+step:640/1840 train_time:22391ms step_avg:34.99ms
+step:641/1840 train_time:22450ms step_avg:35.02ms
+step:642/1840 train_time:22512ms step_avg:35.07ms
+step:643/1840 train_time:22572ms step_avg:35.10ms
+step:644/1840 train_time:22634ms step_avg:35.15ms
+step:645/1840 train_time:22694ms step_avg:35.18ms
+step:646/1840 train_time:22757ms step_avg:35.23ms
+step:647/1840 train_time:22817ms step_avg:35.27ms
+step:648/1840 train_time:22880ms step_avg:35.31ms
+step:649/1840 train_time:22939ms step_avg:35.35ms
+step:650/1840 train_time:23004ms step_avg:35.39ms
+step:651/1840 train_time:23064ms step_avg:35.43ms
+step:652/1840 train_time:23126ms step_avg:35.47ms
+step:653/1840 train_time:23186ms step_avg:35.51ms
+step:654/1840 train_time:23247ms step_avg:35.55ms
+step:655/1840 train_time:23308ms step_avg:35.58ms
+step:656/1840 train_time:23370ms step_avg:35.62ms
+step:657/1840 train_time:23430ms step_avg:35.66ms
+step:658/1840 train_time:23491ms step_avg:35.70ms
+step:659/1840 train_time:23550ms step_avg:35.74ms
+step:660/1840 train_time:23613ms step_avg:35.78ms
+step:661/1840 train_time:23672ms step_avg:35.81ms
+step:662/1840 train_time:23735ms step_avg:35.85ms
+step:663/1840 train_time:23794ms step_avg:35.89ms
+step:664/1840 train_time:23857ms step_avg:35.93ms
+step:665/1840 train_time:23918ms step_avg:35.97ms
+step:666/1840 train_time:23982ms step_avg:36.01ms
+step:667/1840 train_time:24042ms step_avg:36.05ms
+step:668/1840 train_time:24105ms step_avg:36.09ms
+step:669/1840 train_time:24166ms step_avg:36.12ms
+step:670/1840 train_time:24227ms step_avg:36.16ms
+step:671/1840 train_time:24287ms step_avg:36.19ms
+step:672/1840 train_time:24349ms step_avg:36.23ms
+step:673/1840 train_time:24408ms step_avg:36.27ms
+step:674/1840 train_time:24470ms step_avg:36.31ms
+step:675/1840 train_time:24530ms step_avg:36.34ms
+step:676/1840 train_time:24591ms step_avg:36.38ms
+step:677/1840 train_time:24651ms step_avg:36.41ms
+step:678/1840 train_time:24713ms step_avg:36.45ms
+step:679/1840 train_time:24774ms step_avg:36.49ms
+step:680/1840 train_time:24836ms step_avg:36.52ms
+step:681/1840 train_time:24896ms step_avg:36.56ms
+step:682/1840 train_time:24959ms step_avg:36.60ms
+step:683/1840 train_time:25020ms step_avg:36.63ms
+step:684/1840 train_time:25083ms step_avg:36.67ms
+step:685/1840 train_time:25144ms step_avg:36.71ms
+step:686/1840 train_time:25206ms step_avg:36.74ms
+step:687/1840 train_time:25266ms step_avg:36.78ms
+step:688/1840 train_time:25327ms step_avg:36.81ms
+step:689/1840 train_time:25387ms step_avg:36.85ms
+step:690/1840 train_time:25449ms step_avg:36.88ms
+step:691/1840 train_time:25509ms step_avg:36.92ms
+step:692/1840 train_time:25571ms step_avg:36.95ms
+step:693/1840 train_time:25631ms step_avg:36.99ms
+step:694/1840 train_time:25693ms step_avg:37.02ms
+step:695/1840 train_time:25752ms step_avg:37.05ms
+step:696/1840 train_time:25815ms step_avg:37.09ms
+step:697/1840 train_time:25875ms step_avg:37.12ms
+step:698/1840 train_time:25937ms step_avg:37.16ms
+step:699/1840 train_time:25998ms step_avg:37.19ms
+step:700/1840 train_time:26061ms step_avg:37.23ms
+step:701/1840 train_time:26122ms step_avg:37.26ms
+step:702/1840 train_time:26185ms step_avg:37.30ms
+step:703/1840 train_time:26244ms step_avg:37.33ms
+step:704/1840 train_time:26306ms step_avg:37.37ms
+step:705/1840 train_time:26366ms step_avg:37.40ms
+step:706/1840 train_time:26429ms step_avg:37.43ms
+step:707/1840 train_time:26488ms step_avg:37.46ms
+step:708/1840 train_time:26550ms step_avg:37.50ms
+step:709/1840 train_time:26609ms step_avg:37.53ms
+step:710/1840 train_time:26672ms step_avg:37.57ms
+step:711/1840 train_time:26731ms step_avg:37.60ms
+step:712/1840 train_time:26793ms step_avg:37.63ms
+step:713/1840 train_time:26853ms step_avg:37.66ms
+step:714/1840 train_time:26915ms step_avg:37.70ms
+step:715/1840 train_time:26975ms step_avg:37.73ms
+step:716/1840 train_time:27037ms step_avg:37.76ms
+step:717/1840 train_time:27098ms step_avg:37.79ms
+step:718/1840 train_time:27162ms step_avg:37.83ms
+step:719/1840 train_time:27222ms step_avg:37.86ms
+step:720/1840 train_time:27284ms step_avg:37.90ms
+step:721/1840 train_time:27345ms step_avg:37.93ms
+step:722/1840 train_time:27407ms step_avg:37.96ms
+step:723/1840 train_time:27467ms step_avg:37.99ms
+step:724/1840 train_time:27529ms step_avg:38.02ms
+step:725/1840 train_time:27588ms step_avg:38.05ms
+step:726/1840 train_time:27650ms step_avg:38.08ms
+step:727/1840 train_time:27710ms step_avg:38.12ms
+step:728/1840 train_time:27771ms step_avg:38.15ms
+step:729/1840 train_time:27831ms step_avg:38.18ms
+step:730/1840 train_time:27893ms step_avg:38.21ms
+step:731/1840 train_time:27952ms step_avg:38.24ms
+step:732/1840 train_time:28015ms step_avg:38.27ms
+step:733/1840 train_time:28075ms step_avg:38.30ms
+step:734/1840 train_time:28139ms step_avg:38.34ms
+step:735/1840 train_time:28200ms step_avg:38.37ms
+step:736/1840 train_time:28264ms step_avg:38.40ms
+step:737/1840 train_time:28324ms step_avg:38.43ms
+step:738/1840 train_time:28386ms step_avg:38.46ms
+step:739/1840 train_time:28446ms step_avg:38.49ms
+step:740/1840 train_time:28508ms step_avg:38.52ms
+step:741/1840 train_time:28568ms step_avg:38.55ms
+step:742/1840 train_time:28631ms step_avg:38.59ms
+step:743/1840 train_time:28690ms step_avg:38.61ms
+step:744/1840 train_time:28751ms step_avg:38.64ms
+step:745/1840 train_time:28811ms step_avg:38.67ms
+step:746/1840 train_time:28873ms step_avg:38.70ms
+step:747/1840 train_time:28932ms step_avg:38.73ms
+step:748/1840 train_time:28995ms step_avg:38.76ms
+step:749/1840 train_time:29055ms step_avg:38.79ms
+step:750/1840 train_time:29118ms step_avg:38.82ms
+step:750/1840 val_loss:4.0204 train_time:29190ms step_avg:38.92ms
+step:751/1840 train_time:29213ms step_avg:38.90ms
+step:752/1840 train_time:29242ms step_avg:38.89ms
+step:753/1840 train_time:29302ms step_avg:38.91ms
+step:754/1840 train_time:29366ms step_avg:38.95ms
+step:755/1840 train_time:29426ms step_avg:38.97ms
+step:756/1840 train_time:29488ms step_avg:39.00ms
+step:757/1840 train_time:29548ms step_avg:39.03ms
+step:758/1840 train_time:29609ms step_avg:39.06ms
+step:759/1840 train_time:29668ms step_avg:39.09ms
+step:760/1840 train_time:29731ms step_avg:39.12ms
+step:761/1840 train_time:29790ms step_avg:39.15ms
+step:762/1840 train_time:29852ms step_avg:39.18ms
+step:763/1840 train_time:29910ms step_avg:39.20ms
+step:764/1840 train_time:29972ms step_avg:39.23ms
+step:765/1840 train_time:30032ms step_avg:39.26ms
+step:766/1840 train_time:30094ms step_avg:39.29ms
+step:767/1840 train_time:30155ms step_avg:39.32ms
+step:768/1840 train_time:30219ms step_avg:39.35ms
+step:769/1840 train_time:30280ms step_avg:39.38ms
+step:770/1840 train_time:30342ms step_avg:39.40ms
+step:771/1840 train_time:30402ms step_avg:39.43ms
+step:772/1840 train_time:30464ms step_avg:39.46ms
+step:773/1840 train_time:30523ms step_avg:39.49ms
+step:774/1840 train_time:30585ms step_avg:39.52ms
+step:775/1840 train_time:30644ms step_avg:39.54ms
+step:776/1840 train_time:30706ms step_avg:39.57ms
+step:777/1840 train_time:30765ms step_avg:39.59ms
+step:778/1840 train_time:30827ms step_avg:39.62ms
+step:779/1840 train_time:30886ms step_avg:39.65ms
+step:780/1840 train_time:30948ms step_avg:39.68ms
+step:781/1840 train_time:31007ms step_avg:39.70ms
+step:782/1840 train_time:31069ms step_avg:39.73ms
+step:783/1840 train_time:31130ms step_avg:39.76ms
+step:784/1840 train_time:31194ms step_avg:39.79ms
+step:785/1840 train_time:31255ms step_avg:39.82ms
+step:786/1840 train_time:31319ms step_avg:39.85ms
+step:787/1840 train_time:31379ms step_avg:39.87ms
+step:788/1840 train_time:31442ms step_avg:39.90ms
+step:789/1840 train_time:31501ms step_avg:39.93ms
+step:790/1840 train_time:31563ms step_avg:39.95ms
+step:791/1840 train_time:31623ms step_avg:39.98ms
+step:792/1840 train_time:31684ms step_avg:40.01ms
+step:793/1840 train_time:31743ms step_avg:40.03ms
+step:794/1840 train_time:31806ms step_avg:40.06ms
+step:795/1840 train_time:31865ms step_avg:40.08ms
+step:796/1840 train_time:31927ms step_avg:40.11ms
+step:797/1840 train_time:31986ms step_avg:40.13ms
+step:798/1840 train_time:32048ms step_avg:40.16ms
+step:799/1840 train_time:32108ms step_avg:40.19ms
+step:800/1840 train_time:32172ms step_avg:40.21ms
+step:801/1840 train_time:32232ms step_avg:40.24ms
+step:802/1840 train_time:32294ms step_avg:40.27ms
+step:803/1840 train_time:32354ms step_avg:40.29ms
+step:804/1840 train_time:32419ms step_avg:40.32ms
+step:805/1840 train_time:32479ms step_avg:40.35ms
+step:806/1840 train_time:32541ms step_avg:40.37ms
+step:807/1840 train_time:32600ms step_avg:40.40ms
+step:808/1840 train_time:32662ms step_avg:40.42ms
+step:809/1840 train_time:32721ms step_avg:40.45ms
+step:810/1840 train_time:32783ms step_avg:40.47ms
+step:811/1840 train_time:32843ms step_avg:40.50ms
+step:812/1840 train_time:32905ms step_avg:40.52ms
+step:813/1840 train_time:32964ms step_avg:40.55ms
+step:814/1840 train_time:33027ms step_avg:40.57ms
+step:815/1840 train_time:33086ms step_avg:40.60ms
+step:816/1840 train_time:33148ms step_avg:40.62ms
+step:817/1840 train_time:33208ms step_avg:40.65ms
+step:818/1840 train_time:33271ms step_avg:40.67ms
+step:819/1840 train_time:33331ms step_avg:40.70ms
+step:820/1840 train_time:33394ms step_avg:40.72ms
+step:821/1840 train_time:33455ms step_avg:40.75ms
+step:822/1840 train_time:33518ms step_avg:40.78ms
+step:823/1840 train_time:33579ms step_avg:40.80ms
+step:824/1840 train_time:33641ms step_avg:40.83ms
+step:825/1840 train_time:33701ms step_avg:40.85ms
+step:826/1840 train_time:33762ms step_avg:40.87ms
+step:827/1840 train_time:33822ms step_avg:40.90ms
+step:828/1840 train_time:33884ms step_avg:40.92ms
+step:829/1840 train_time:33944ms step_avg:40.95ms
+step:830/1840 train_time:34007ms step_avg:40.97ms
+step:831/1840 train_time:34066ms step_avg:40.99ms
+step:832/1840 train_time:34128ms step_avg:41.02ms
+step:833/1840 train_time:34187ms step_avg:41.04ms
+step:834/1840 train_time:34249ms step_avg:41.07ms
+step:835/1840 train_time:34309ms step_avg:41.09ms
+step:836/1840 train_time:34373ms step_avg:41.12ms
+step:837/1840 train_time:34433ms step_avg:41.14ms
+step:838/1840 train_time:34497ms step_avg:41.17ms
+step:839/1840 train_time:34557ms step_avg:41.19ms
+step:840/1840 train_time:34620ms step_avg:41.21ms
+step:841/1840 train_time:34679ms step_avg:41.24ms
+step:842/1840 train_time:34741ms step_avg:41.26ms
+step:843/1840 train_time:34801ms step_avg:41.28ms
+step:844/1840 train_time:34863ms step_avg:41.31ms
+step:845/1840 train_time:34923ms step_avg:41.33ms
+step:846/1840 train_time:34986ms step_avg:41.35ms
+step:847/1840 train_time:35045ms step_avg:41.38ms
+step:848/1840 train_time:35106ms step_avg:41.40ms
+step:849/1840 train_time:35166ms step_avg:41.42ms
+step:850/1840 train_time:35229ms step_avg:41.45ms
+step:851/1840 train_time:35287ms step_avg:41.47ms
+step:852/1840 train_time:35350ms step_avg:41.49ms
+step:853/1840 train_time:35410ms step_avg:41.51ms
+step:854/1840 train_time:35473ms step_avg:41.54ms
+step:855/1840 train_time:35533ms step_avg:41.56ms
+step:856/1840 train_time:35597ms step_avg:41.59ms
+step:857/1840 train_time:35658ms step_avg:41.61ms
+step:858/1840 train_time:35721ms step_avg:41.63ms
+step:859/1840 train_time:35781ms step_avg:41.65ms
+step:860/1840 train_time:35842ms step_avg:41.68ms
+step:861/1840 train_time:35903ms step_avg:41.70ms
+step:862/1840 train_time:35965ms step_avg:41.72ms
+step:863/1840 train_time:36025ms step_avg:41.74ms
+step:864/1840 train_time:36087ms step_avg:41.77ms
+step:865/1840 train_time:36146ms step_avg:41.79ms
+step:866/1840 train_time:36208ms step_avg:41.81ms
+step:867/1840 train_time:36267ms step_avg:41.83ms
+step:868/1840 train_time:36330ms step_avg:41.85ms
+step:869/1840 train_time:36390ms step_avg:41.88ms
+step:870/1840 train_time:36452ms step_avg:41.90ms
+step:871/1840 train_time:36512ms step_avg:41.92ms
+step:872/1840 train_time:36575ms step_avg:41.94ms
+step:873/1840 train_time:36636ms step_avg:41.97ms
+step:874/1840 train_time:36700ms step_avg:41.99ms
+step:875/1840 train_time:36760ms step_avg:42.01ms
+step:876/1840 train_time:36822ms step_avg:42.03ms
+step:877/1840 train_time:36881ms step_avg:42.05ms
+step:878/1840 train_time:36943ms step_avg:42.08ms
+step:879/1840 train_time:37002ms step_avg:42.10ms
+step:880/1840 train_time:37065ms step_avg:42.12ms
+step:881/1840 train_time:37124ms step_avg:42.14ms
+step:882/1840 train_time:37187ms step_avg:42.16ms
+step:883/1840 train_time:37246ms step_avg:42.18ms
+step:884/1840 train_time:37308ms step_avg:42.20ms
+step:885/1840 train_time:37368ms step_avg:42.22ms
+step:886/1840 train_time:37431ms step_avg:42.25ms
+step:887/1840 train_time:37490ms step_avg:42.27ms
+step:888/1840 train_time:37553ms step_avg:42.29ms
+step:889/1840 train_time:37613ms step_avg:42.31ms
+step:890/1840 train_time:37676ms step_avg:42.33ms
+step:891/1840 train_time:37736ms step_avg:42.35ms
+step:892/1840 train_time:37800ms step_avg:42.38ms
+step:893/1840 train_time:37860ms step_avg:42.40ms
+step:894/1840 train_time:37922ms step_avg:42.42ms
+step:895/1840 train_time:37982ms step_avg:42.44ms
+step:896/1840 train_time:38044ms step_avg:42.46ms
+step:897/1840 train_time:38104ms step_avg:42.48ms
+step:898/1840 train_time:38166ms step_avg:42.50ms
+step:899/1840 train_time:38226ms step_avg:42.52ms
+step:900/1840 train_time:38288ms step_avg:42.54ms
+step:901/1840 train_time:38347ms step_avg:42.56ms
+step:902/1840 train_time:38409ms step_avg:42.58ms
+step:903/1840 train_time:38469ms step_avg:42.60ms
+step:904/1840 train_time:38532ms step_avg:42.62ms
+step:905/1840 train_time:38592ms step_avg:42.64ms
+step:906/1840 train_time:38655ms step_avg:42.67ms
+step:907/1840 train_time:38715ms step_avg:42.68ms
+step:908/1840 train_time:38778ms step_avg:42.71ms
+step:909/1840 train_time:38839ms step_avg:42.73ms
+step:910/1840 train_time:38902ms step_avg:42.75ms
+step:911/1840 train_time:38962ms step_avg:42.77ms
+step:912/1840 train_time:39024ms step_avg:42.79ms
+step:913/1840 train_time:39085ms step_avg:42.81ms
+step:914/1840 train_time:39147ms step_avg:42.83ms
+step:915/1840 train_time:39207ms step_avg:42.85ms
+step:916/1840 train_time:39268ms step_avg:42.87ms
+step:917/1840 train_time:39327ms step_avg:42.89ms
+step:918/1840 train_time:39389ms step_avg:42.91ms
+step:919/1840 train_time:39449ms step_avg:42.93ms
+step:920/1840 train_time:39511ms step_avg:42.95ms
+step:921/1840 train_time:39571ms step_avg:42.96ms
+step:922/1840 train_time:39633ms step_avg:42.99ms
+step:923/1840 train_time:39693ms step_avg:43.00ms
+step:924/1840 train_time:39757ms step_avg:43.03ms
+step:925/1840 train_time:39817ms step_avg:43.05ms
+step:926/1840 train_time:39879ms step_avg:43.07ms
+step:927/1840 train_time:39940ms step_avg:43.09ms
+step:928/1840 train_time:40003ms step_avg:43.11ms
+step:929/1840 train_time:40063ms step_avg:43.12ms
+step:930/1840 train_time:40126ms step_avg:43.15ms
+step:931/1840 train_time:40185ms step_avg:43.16ms
+step:932/1840 train_time:40247ms step_avg:43.18ms
+step:933/1840 train_time:40307ms step_avg:43.20ms
+step:934/1840 train_time:40369ms step_avg:43.22ms
+step:935/1840 train_time:40428ms step_avg:43.24ms
+step:936/1840 train_time:40490ms step_avg:43.26ms
+step:937/1840 train_time:40549ms step_avg:43.28ms
+step:938/1840 train_time:40612ms step_avg:43.30ms
+step:939/1840 train_time:40672ms step_avg:43.31ms
+step:940/1840 train_time:40734ms step_avg:43.33ms
+step:941/1840 train_time:40795ms step_avg:43.35ms
+step:942/1840 train_time:40858ms step_avg:43.37ms
+step:943/1840 train_time:40919ms step_avg:43.39ms
+step:944/1840 train_time:40981ms step_avg:43.41ms
+step:945/1840 train_time:41041ms step_avg:43.43ms
+step:946/1840 train_time:41103ms step_avg:43.45ms
+step:947/1840 train_time:41164ms step_avg:43.47ms
+step:948/1840 train_time:41226ms step_avg:43.49ms
+step:949/1840 train_time:41285ms step_avg:43.50ms
+step:950/1840 train_time:41347ms step_avg:43.52ms
+step:951/1840 train_time:41406ms step_avg:43.54ms
+step:952/1840 train_time:41468ms step_avg:43.56ms
+step:953/1840 train_time:41528ms step_avg:43.58ms
+step:954/1840 train_time:41590ms step_avg:43.60ms
+step:955/1840 train_time:41650ms step_avg:43.61ms
+step:956/1840 train_time:41713ms step_avg:43.63ms
+step:957/1840 train_time:41775ms step_avg:43.65ms
+step:958/1840 train_time:41838ms step_avg:43.67ms
+step:959/1840 train_time:41898ms step_avg:43.69ms
+step:960/1840 train_time:41961ms step_avg:43.71ms
+step:961/1840 train_time:42021ms step_avg:43.73ms
+step:962/1840 train_time:42083ms step_avg:43.75ms
+step:963/1840 train_time:42142ms step_avg:43.76ms
+step:964/1840 train_time:42204ms step_avg:43.78ms
+step:965/1840 train_time:42264ms step_avg:43.80ms
+step:966/1840 train_time:42327ms step_avg:43.82ms
+step:967/1840 train_time:42386ms step_avg:43.83ms
+step:968/1840 train_time:42447ms step_avg:43.85ms
+step:969/1840 train_time:42507ms step_avg:43.87ms
+step:970/1840 train_time:42569ms step_avg:43.89ms
+step:971/1840 train_time:42628ms step_avg:43.90ms
+step:972/1840 train_time:42691ms step_avg:43.92ms
+step:973/1840 train_time:42751ms step_avg:43.94ms
+step:974/1840 train_time:42814ms step_avg:43.96ms
+step:975/1840 train_time:42875ms step_avg:43.97ms
+step:976/1840 train_time:42939ms step_avg:43.99ms
+step:977/1840 train_time:43000ms step_avg:44.01ms
+step:978/1840 train_time:43062ms step_avg:44.03ms
+step:979/1840 train_time:43122ms step_avg:44.05ms
+step:980/1840 train_time:43184ms step_avg:44.07ms
+step:981/1840 train_time:43243ms step_avg:44.08ms
+step:982/1840 train_time:43306ms step_avg:44.10ms
+step:983/1840 train_time:43365ms step_avg:44.11ms
+step:984/1840 train_time:43427ms step_avg:44.13ms
+step:985/1840 train_time:43486ms step_avg:44.15ms
+step:986/1840 train_time:43548ms step_avg:44.17ms
+step:987/1840 train_time:43608ms step_avg:44.18ms
+step:988/1840 train_time:43670ms step_avg:44.20ms
+step:989/1840 train_time:43729ms step_avg:44.22ms
+step:990/1840 train_time:43793ms step_avg:44.23ms
+step:991/1840 train_time:43853ms step_avg:44.25ms
+step:992/1840 train_time:43917ms step_avg:44.27ms
+step:993/1840 train_time:43977ms step_avg:44.29ms
+step:994/1840 train_time:44040ms step_avg:44.31ms
+step:995/1840 train_time:44100ms step_avg:44.32ms
+step:996/1840 train_time:44163ms step_avg:44.34ms
+step:997/1840 train_time:44223ms step_avg:44.36ms
+step:998/1840 train_time:44284ms step_avg:44.37ms
+step:999/1840 train_time:44344ms step_avg:44.39ms
+step:1000/1840 train_time:44406ms step_avg:44.41ms
+step:1000/1840 val_loss:3.7789 train_time:44477ms step_avg:44.48ms
+step:1001/1840 train_time:44496ms step_avg:44.45ms
+step:1002/1840 train_time:44529ms step_avg:44.44ms
+step:1003/1840 train_time:44591ms step_avg:44.46ms
+step:1004/1840 train_time:44655ms step_avg:44.48ms
+step:1005/1840 train_time:44715ms step_avg:44.49ms
+step:1006/1840 train_time:44777ms step_avg:44.51ms
+step:1007/1840 train_time:44836ms step_avg:44.52ms
+step:1008/1840 train_time:44898ms step_avg:44.54ms
+step:1009/1840 train_time:44957ms step_avg:44.56ms
+step:1010/1840 train_time:45017ms step_avg:44.57ms
+step:1011/1840 train_time:45076ms step_avg:44.59ms
+step:1012/1840 train_time:45138ms step_avg:44.60ms
+step:1013/1840 train_time:45196ms step_avg:44.62ms
+step:1014/1840 train_time:45258ms step_avg:44.63ms
+step:1015/1840 train_time:45317ms step_avg:44.65ms
+step:1016/1840 train_time:45379ms step_avg:44.66ms
+step:1017/1840 train_time:45441ms step_avg:44.68ms
+step:1018/1840 train_time:45505ms step_avg:44.70ms
+step:1019/1840 train_time:45567ms step_avg:44.72ms
+step:1020/1840 train_time:45630ms step_avg:44.73ms
+step:1021/1840 train_time:45690ms step_avg:44.75ms
+step:1022/1840 train_time:45753ms step_avg:44.77ms
+step:1023/1840 train_time:45812ms step_avg:44.78ms
+step:1024/1840 train_time:45874ms step_avg:44.80ms
+step:1025/1840 train_time:45934ms step_avg:44.81ms
+step:1026/1840 train_time:45995ms step_avg:44.83ms
+step:1027/1840 train_time:46055ms step_avg:44.84ms
+step:1028/1840 train_time:46116ms step_avg:44.86ms
+step:1029/1840 train_time:46175ms step_avg:44.87ms
+step:1030/1840 train_time:46237ms step_avg:44.89ms
+step:1031/1840 train_time:46297ms step_avg:44.90ms
+step:1032/1840 train_time:46359ms step_avg:44.92ms
+step:1033/1840 train_time:46420ms step_avg:44.94ms
+step:1034/1840 train_time:46482ms step_avg:44.95ms
+step:1035/1840 train_time:46542ms step_avg:44.97ms
+step:1036/1840 train_time:46605ms step_avg:44.99ms
+step:1037/1840 train_time:46666ms step_avg:45.00ms
+step:1038/1840 train_time:46728ms step_avg:45.02ms
+step:1039/1840 train_time:46788ms step_avg:45.03ms
+step:1040/1840 train_time:46850ms step_avg:45.05ms
+step:1041/1840 train_time:46910ms step_avg:45.06ms
+step:1042/1840 train_time:46972ms step_avg:45.08ms
+step:1043/1840 train_time:47032ms step_avg:45.09ms
+step:1044/1840 train_time:47094ms step_avg:45.11ms
+step:1045/1840 train_time:47154ms step_avg:45.12ms
+step:1046/1840 train_time:47216ms step_avg:45.14ms
+step:1047/1840 train_time:47275ms step_avg:45.15ms
+step:1048/1840 train_time:47337ms step_avg:45.17ms
+step:1049/1840 train_time:47397ms step_avg:45.18ms
+step:1050/1840 train_time:47460ms step_avg:45.20ms
+step:1051/1840 train_time:47519ms step_avg:45.21ms
+step:1052/1840 train_time:47582ms step_avg:45.23ms
+step:1053/1840 train_time:47642ms step_avg:45.24ms
+step:1054/1840 train_time:47704ms step_avg:45.26ms
+step:1055/1840 train_time:47764ms step_avg:45.27ms
+step:1056/1840 train_time:47826ms step_avg:45.29ms
+step:1057/1840 train_time:47887ms step_avg:45.30ms
+step:1058/1840 train_time:47949ms step_avg:45.32ms
+step:1059/1840 train_time:48009ms step_avg:45.33ms
+step:1060/1840 train_time:48072ms step_avg:45.35ms
+step:1061/1840 train_time:48131ms step_avg:45.36ms
+step:1062/1840 train_time:48194ms step_avg:45.38ms
+step:1063/1840 train_time:48254ms step_avg:45.39ms
+step:1064/1840 train_time:48316ms step_avg:45.41ms
+step:1065/1840 train_time:48376ms step_avg:45.42ms
+step:1066/1840 train_time:48439ms step_avg:45.44ms
+step:1067/1840 train_time:48498ms step_avg:45.45ms
+step:1068/1840 train_time:48560ms step_avg:45.47ms
+step:1069/1840 train_time:48620ms step_avg:45.48ms
+step:1070/1840 train_time:48682ms step_avg:45.50ms
+step:1071/1840 train_time:48742ms step_avg:45.51ms
+step:1072/1840 train_time:48804ms step_avg:45.53ms
+step:1073/1840 train_time:48864ms step_avg:45.54ms
+step:1074/1840 train_time:48927ms step_avg:45.56ms
+step:1075/1840 train_time:48987ms step_avg:45.57ms
+step:1076/1840 train_time:49050ms step_avg:45.59ms
+step:1077/1840 train_time:49110ms step_avg:45.60ms
+step:1078/1840 train_time:49172ms step_avg:45.61ms
+step:1079/1840 train_time:49232ms step_avg:45.63ms
+step:1080/1840 train_time:49295ms step_avg:45.64ms
+step:1081/1840 train_time:49355ms step_avg:45.66ms
+step:1082/1840 train_time:49417ms step_avg:45.67ms
+step:1083/1840 train_time:49477ms step_avg:45.69ms
+step:1084/1840 train_time:49539ms step_avg:45.70ms
+step:1085/1840 train_time:49599ms step_avg:45.71ms
+step:1086/1840 train_time:49661ms step_avg:45.73ms
+step:1087/1840 train_time:49721ms step_avg:45.74ms
+step:1088/1840 train_time:49782ms step_avg:45.76ms
+step:1089/1840 train_time:49842ms step_avg:45.77ms
+step:1090/1840 train_time:49905ms step_avg:45.78ms
+step:1091/1840 train_time:49965ms step_avg:45.80ms
+step:1092/1840 train_time:50027ms step_avg:45.81ms
+step:1093/1840 train_time:50087ms step_avg:45.83ms
+step:1094/1840 train_time:50150ms step_avg:45.84ms
+step:1095/1840 train_time:50211ms step_avg:45.86ms
+step:1096/1840 train_time:50274ms step_avg:45.87ms
+step:1097/1840 train_time:50334ms step_avg:45.88ms
+step:1098/1840 train_time:50396ms step_avg:45.90ms
+step:1099/1840 train_time:50456ms step_avg:45.91ms
+step:1100/1840 train_time:50518ms step_avg:45.93ms
+step:1101/1840 train_time:50578ms step_avg:45.94ms
+step:1102/1840 train_time:50640ms step_avg:45.95ms
+step:1103/1840 train_time:50700ms step_avg:45.97ms
+step:1104/1840 train_time:50763ms step_avg:45.98ms
+step:1105/1840 train_time:50821ms step_avg:45.99ms
+step:1106/1840 train_time:50884ms step_avg:46.01ms
+step:1107/1840 train_time:50943ms step_avg:46.02ms
+step:1108/1840 train_time:51005ms step_avg:46.03ms
+step:1109/1840 train_time:51065ms step_avg:46.05ms
+step:1110/1840 train_time:51127ms step_avg:46.06ms
+step:1111/1840 train_time:51187ms step_avg:46.07ms
+step:1112/1840 train_time:51250ms step_avg:46.09ms
+step:1113/1840 train_time:51311ms step_avg:46.10ms
+step:1114/1840 train_time:51374ms step_avg:46.12ms
+step:1115/1840 train_time:51434ms step_avg:46.13ms
+step:1116/1840 train_time:51496ms step_avg:46.14ms
+step:1117/1840 train_time:51556ms step_avg:46.16ms
+step:1118/1840 train_time:51619ms step_avg:46.17ms
+step:1119/1840 train_time:51679ms step_avg:46.18ms
+step:1120/1840 train_time:51741ms step_avg:46.20ms
+step:1121/1840 train_time:51800ms step_avg:46.21ms
+step:1122/1840 train_time:51863ms step_avg:46.22ms
+step:1123/1840 train_time:51922ms step_avg:46.24ms
+step:1124/1840 train_time:51985ms step_avg:46.25ms
+step:1125/1840 train_time:52044ms step_avg:46.26ms
+step:1126/1840 train_time:52106ms step_avg:46.28ms
+step:1127/1840 train_time:52166ms step_avg:46.29ms
+step:1128/1840 train_time:52229ms step_avg:46.30ms
+step:1129/1840 train_time:52289ms step_avg:46.31ms
+step:1130/1840 train_time:52353ms step_avg:46.33ms
+step:1131/1840 train_time:52413ms step_avg:46.34ms
+step:1132/1840 train_time:52475ms step_avg:46.36ms
+step:1133/1840 train_time:52536ms step_avg:46.37ms
+step:1134/1840 train_time:52598ms step_avg:46.38ms
+step:1135/1840 train_time:52659ms step_avg:46.40ms
+step:1136/1840 train_time:52721ms step_avg:46.41ms
+step:1137/1840 train_time:52781ms step_avg:46.42ms
+step:1138/1840 train_time:52842ms step_avg:46.43ms
+step:1139/1840 train_time:52902ms step_avg:46.45ms
+step:1140/1840 train_time:52964ms step_avg:46.46ms
+step:1141/1840 train_time:53022ms step_avg:46.47ms
+step:1142/1840 train_time:53085ms step_avg:46.48ms
+step:1143/1840 train_time:53145ms step_avg:46.50ms
+step:1144/1840 train_time:53207ms step_avg:46.51ms
+step:1145/1840 train_time:53267ms step_avg:46.52ms
+step:1146/1840 train_time:53330ms step_avg:46.54ms
+step:1147/1840 train_time:53390ms step_avg:46.55ms
+step:1148/1840 train_time:53453ms step_avg:46.56ms
+step:1149/1840 train_time:53513ms step_avg:46.57ms
+step:1150/1840 train_time:53576ms step_avg:46.59ms
+step:1151/1840 train_time:53637ms step_avg:46.60ms
+step:1152/1840 train_time:53699ms step_avg:46.61ms
+step:1153/1840 train_time:53758ms step_avg:46.62ms
+step:1154/1840 train_time:53821ms step_avg:46.64ms
+step:1155/1840 train_time:53881ms step_avg:46.65ms
+step:1156/1840 train_time:53942ms step_avg:46.66ms
+step:1157/1840 train_time:54002ms step_avg:46.67ms
+step:1158/1840 train_time:54064ms step_avg:46.69ms
+step:1159/1840 train_time:54124ms step_avg:46.70ms
+step:1160/1840 train_time:54186ms step_avg:46.71ms
+step:1161/1840 train_time:54246ms step_avg:46.72ms
+step:1162/1840 train_time:54308ms step_avg:46.74ms
+step:1163/1840 train_time:54368ms step_avg:46.75ms
+step:1164/1840 train_time:54431ms step_avg:46.76ms
+step:1165/1840 train_time:54491ms step_avg:46.77ms
+step:1166/1840 train_time:54554ms step_avg:46.79ms
+step:1167/1840 train_time:54615ms step_avg:46.80ms
+step:1168/1840 train_time:54677ms step_avg:46.81ms
+step:1169/1840 train_time:54738ms step_avg:46.82ms
+step:1170/1840 train_time:54800ms step_avg:46.84ms
+step:1171/1840 train_time:54859ms step_avg:46.85ms
+step:1172/1840 train_time:54922ms step_avg:46.86ms
+step:1173/1840 train_time:54982ms step_avg:46.87ms
+step:1174/1840 train_time:55043ms step_avg:46.88ms
+step:1175/1840 train_time:55103ms step_avg:46.90ms
+step:1176/1840 train_time:55165ms step_avg:46.91ms
+step:1177/1840 train_time:55224ms step_avg:46.92ms
+step:1178/1840 train_time:55287ms step_avg:46.93ms
+step:1179/1840 train_time:55346ms step_avg:46.94ms
+step:1180/1840 train_time:55409ms step_avg:46.96ms
+step:1181/1840 train_time:55470ms step_avg:46.97ms
+step:1182/1840 train_time:55533ms step_avg:46.98ms
+step:1183/1840 train_time:55594ms step_avg:46.99ms
+step:1184/1840 train_time:55656ms step_avg:47.01ms
+step:1185/1840 train_time:55716ms step_avg:47.02ms
+step:1186/1840 train_time:55779ms step_avg:47.03ms
+step:1187/1840 train_time:55839ms step_avg:47.04ms
+step:1188/1840 train_time:55901ms step_avg:47.05ms
+step:1189/1840 train_time:55961ms step_avg:47.07ms
+step:1190/1840 train_time:56022ms step_avg:47.08ms
+step:1191/1840 train_time:56082ms step_avg:47.09ms
+step:1192/1840 train_time:56144ms step_avg:47.10ms
+step:1193/1840 train_time:56203ms step_avg:47.11ms
+step:1194/1840 train_time:56266ms step_avg:47.12ms
+step:1195/1840 train_time:56325ms step_avg:47.13ms
+step:1196/1840 train_time:56387ms step_avg:47.15ms
+step:1197/1840 train_time:56448ms step_avg:47.16ms
+step:1198/1840 train_time:56511ms step_avg:47.17ms
+step:1199/1840 train_time:56571ms step_avg:47.18ms
+step:1200/1840 train_time:56634ms step_avg:47.20ms
+step:1201/1840 train_time:56696ms step_avg:47.21ms
+step:1202/1840 train_time:56783ms step_avg:47.24ms
+step:1203/1840 train_time:56870ms step_avg:47.27ms
+step:1204/1840 train_time:56959ms step_avg:47.31ms
+step:1205/1840 train_time:57046ms step_avg:47.34ms
+step:1206/1840 train_time:57134ms step_avg:47.37ms
+step:1207/1840 train_time:57221ms step_avg:47.41ms
+step:1208/1840 train_time:57308ms step_avg:47.44ms
+step:1209/1840 train_time:57395ms step_avg:47.47ms
+step:1210/1840 train_time:57485ms step_avg:47.51ms
+step:1211/1840 train_time:57572ms step_avg:47.54ms
+step:1212/1840 train_time:57661ms step_avg:47.58ms
+step:1213/1840 train_time:57749ms step_avg:47.61ms
+step:1214/1840 train_time:57838ms step_avg:47.64ms
+step:1215/1840 train_time:57926ms step_avg:47.68ms
+step:1216/1840 train_time:58015ms step_avg:47.71ms
+step:1217/1840 train_time:58102ms step_avg:47.74ms
+step:1218/1840 train_time:58190ms step_avg:47.78ms
+step:1219/1840 train_time:58276ms step_avg:47.81ms
+step:1220/1840 train_time:58365ms step_avg:47.84ms
+step:1221/1840 train_time:58451ms step_avg:47.87ms
+step:1222/1840 train_time:58539ms step_avg:47.90ms
+step:1223/1840 train_time:58625ms step_avg:47.94ms
+step:1224/1840 train_time:58714ms step_avg:47.97ms
+step:1225/1840 train_time:58801ms step_avg:48.00ms
+step:1226/1840 train_time:58891ms step_avg:48.03ms
+step:1227/1840 train_time:58977ms step_avg:48.07ms
+step:1228/1840 train_time:59066ms step_avg:48.10ms
+step:1229/1840 train_time:59152ms step_avg:48.13ms
+step:1230/1840 train_time:59240ms step_avg:48.16ms
+step:1231/1840 train_time:59327ms step_avg:48.19ms
+step:1232/1840 train_time:59416ms step_avg:48.23ms
+step:1233/1840 train_time:59503ms step_avg:48.26ms
+step:1234/1840 train_time:59591ms step_avg:48.29ms
+step:1235/1840 train_time:59677ms step_avg:48.32ms
+step:1236/1840 train_time:59767ms step_avg:48.36ms
+step:1237/1840 train_time:59853ms step_avg:48.39ms
+step:1238/1840 train_time:59942ms step_avg:48.42ms
+step:1239/1840 train_time:60029ms step_avg:48.45ms
+step:1240/1840 train_time:60118ms step_avg:48.48ms
+step:1241/1840 train_time:60205ms step_avg:48.51ms
+step:1242/1840 train_time:60292ms step_avg:48.54ms
+step:1243/1840 train_time:60378ms step_avg:48.57ms
+step:1244/1840 train_time:60467ms step_avg:48.61ms
+step:1245/1840 train_time:60553ms step_avg:48.64ms
+step:1246/1840 train_time:60642ms step_avg:48.67ms
+step:1247/1840 train_time:60729ms step_avg:48.70ms
+step:1248/1840 train_time:60817ms step_avg:48.73ms
+step:1249/1840 train_time:60904ms step_avg:48.76ms
+step:1250/1840 train_time:60992ms step_avg:48.79ms
+step:1250/1840 val_loss:3.5338 train_time:61092ms step_avg:48.87ms
+step:1251/1840 train_time:61113ms step_avg:48.85ms
+step:1252/1840 train_time:61169ms step_avg:48.86ms
+step:1253/1840 train_time:61259ms step_avg:48.89ms
+step:1254/1840 train_time:61352ms step_avg:48.92ms
+step:1255/1840 train_time:61437ms step_avg:48.95ms
+step:1256/1840 train_time:61527ms step_avg:48.99ms
+step:1257/1840 train_time:61612ms step_avg:49.02ms
+step:1258/1840 train_time:61700ms step_avg:49.05ms
+step:1259/1840 train_time:61785ms step_avg:49.07ms
+step:1260/1840 train_time:61873ms step_avg:49.11ms
+step:1261/1840 train_time:61958ms step_avg:49.13ms
+step:1262/1840 train_time:62047ms step_avg:49.17ms
+step:1263/1840 train_time:62136ms step_avg:49.20ms
+step:1264/1840 train_time:62227ms step_avg:49.23ms
+step:1265/1840 train_time:62316ms step_avg:49.26ms
+step:1266/1840 train_time:62406ms step_avg:49.29ms
+step:1267/1840 train_time:62492ms step_avg:49.32ms
+step:1268/1840 train_time:62580ms step_avg:49.35ms
+step:1269/1840 train_time:62665ms step_avg:49.38ms
+step:1270/1840 train_time:62754ms step_avg:49.41ms
+step:1271/1840 train_time:62839ms step_avg:49.44ms
+step:1272/1840 train_time:62926ms step_avg:49.47ms
+step:1273/1840 train_time:63014ms step_avg:49.50ms
+step:1274/1840 train_time:63103ms step_avg:49.53ms
+step:1275/1840 train_time:63193ms step_avg:49.56ms
+step:1276/1840 train_time:63281ms step_avg:49.59ms
+step:1277/1840 train_time:63367ms step_avg:49.62ms
+step:1278/1840 train_time:63456ms step_avg:49.65ms
+step:1279/1840 train_time:63542ms step_avg:49.68ms
+step:1280/1840 train_time:63631ms step_avg:49.71ms
+step:1281/1840 train_time:63716ms step_avg:49.74ms
+step:1282/1840 train_time:63803ms step_avg:49.77ms
+step:1283/1840 train_time:63890ms step_avg:49.80ms
+step:1284/1840 train_time:63978ms step_avg:49.83ms
+step:1285/1840 train_time:64064ms step_avg:49.85ms
+step:1286/1840 train_time:64154ms step_avg:49.89ms
+step:1287/1840 train_time:64240ms step_avg:49.91ms
+step:1288/1840 train_time:64330ms step_avg:49.95ms
+step:1289/1840 train_time:64417ms step_avg:49.97ms
+step:1290/1840 train_time:64505ms step_avg:50.00ms
+step:1291/1840 train_time:64592ms step_avg:50.03ms
+step:1292/1840 train_time:64679ms step_avg:50.06ms
+step:1293/1840 train_time:64766ms step_avg:50.09ms
+step:1294/1840 train_time:64854ms step_avg:50.12ms
+step:1295/1840 train_time:64939ms step_avg:50.15ms
+step:1296/1840 train_time:65029ms step_avg:50.18ms
+step:1297/1840 train_time:65116ms step_avg:50.20ms
+step:1298/1840 train_time:65204ms step_avg:50.23ms
+step:1299/1840 train_time:65291ms step_avg:50.26ms
+step:1300/1840 train_time:65380ms step_avg:50.29ms
+step:1301/1840 train_time:65467ms step_avg:50.32ms
+step:1302/1840 train_time:65556ms step_avg:50.35ms
+step:1303/1840 train_time:65642ms step_avg:50.38ms
+step:1304/1840 train_time:65732ms step_avg:50.41ms
+step:1305/1840 train_time:65818ms step_avg:50.44ms
+step:1306/1840 train_time:65907ms step_avg:50.46ms
+step:1307/1840 train_time:65993ms step_avg:50.49ms
+step:1308/1840 train_time:66082ms step_avg:50.52ms
+step:1309/1840 train_time:66168ms step_avg:50.55ms
+step:1310/1840 train_time:66256ms step_avg:50.58ms
+step:1311/1840 train_time:66344ms step_avg:50.61ms
+step:1312/1840 train_time:66433ms step_avg:50.64ms
+step:1313/1840 train_time:66519ms step_avg:50.66ms
+step:1314/1840 train_time:66609ms step_avg:50.69ms
+step:1315/1840 train_time:66695ms step_avg:50.72ms
+step:1316/1840 train_time:66782ms step_avg:50.75ms
+step:1317/1840 train_time:66868ms step_avg:50.77ms
+step:1318/1840 train_time:66956ms step_avg:50.80ms
+step:1319/1840 train_time:67043ms step_avg:50.83ms
+step:1320/1840 train_time:67133ms step_avg:50.86ms
+step:1321/1840 train_time:67219ms step_avg:50.88ms
+step:1322/1840 train_time:67309ms step_avg:50.91ms
+step:1323/1840 train_time:67394ms step_avg:50.94ms
+step:1324/1840 train_time:67482ms step_avg:50.97ms
+step:1325/1840 train_time:67570ms step_avg:51.00ms
+step:1326/1840 train_time:67658ms step_avg:51.02ms
+step:1327/1840 train_time:67745ms step_avg:51.05ms
+step:1328/1840 train_time:67833ms step_avg:51.08ms
+step:1329/1840 train_time:67918ms step_avg:51.10ms
+step:1330/1840 train_time:68007ms step_avg:51.13ms
+step:1331/1840 train_time:68094ms step_avg:51.16ms
+step:1332/1840 train_time:68183ms step_avg:51.19ms
+step:1333/1840 train_time:68269ms step_avg:51.21ms
+step:1334/1840 train_time:68358ms step_avg:51.24ms
+step:1335/1840 train_time:68444ms step_avg:51.27ms
+step:1336/1840 train_time:68534ms step_avg:51.30ms
+step:1337/1840 train_time:68619ms step_avg:51.32ms
+step:1338/1840 train_time:68709ms step_avg:51.35ms
+step:1339/1840 train_time:68794ms step_avg:51.38ms
+step:1340/1840 train_time:68883ms step_avg:51.40ms
+step:1341/1840 train_time:68968ms step_avg:51.43ms
+step:1342/1840 train_time:69056ms step_avg:51.46ms
+step:1343/1840 train_time:69142ms step_avg:51.48ms
+step:1344/1840 train_time:69233ms step_avg:51.51ms
+step:1345/1840 train_time:69319ms step_avg:51.54ms
+step:1346/1840 train_time:69409ms step_avg:51.57ms
+step:1347/1840 train_time:69496ms step_avg:51.59ms
+step:1348/1840 train_time:69584ms step_avg:51.62ms
+step:1349/1840 train_time:69669ms step_avg:51.65ms
+step:1350/1840 train_time:69759ms step_avg:51.67ms
+step:1351/1840 train_time:69846ms step_avg:51.70ms
+step:1352/1840 train_time:69935ms step_avg:51.73ms
+step:1353/1840 train_time:70021ms step_avg:51.75ms
+step:1354/1840 train_time:70110ms step_avg:51.78ms
+step:1355/1840 train_time:70196ms step_avg:51.81ms
+step:1356/1840 train_time:70286ms step_avg:51.83ms
+step:1357/1840 train_time:70372ms step_avg:51.86ms
+step:1358/1840 train_time:70461ms step_avg:51.89ms
+step:1359/1840 train_time:70547ms step_avg:51.91ms
+step:1360/1840 train_time:70637ms step_avg:51.94ms
+step:1361/1840 train_time:70724ms step_avg:51.96ms
+step:1362/1840 train_time:70812ms step_avg:51.99ms
+step:1363/1840 train_time:70898ms step_avg:52.02ms
+step:1364/1840 train_time:70986ms step_avg:52.04ms
+step:1365/1840 train_time:71073ms step_avg:52.07ms
+step:1366/1840 train_time:71163ms step_avg:52.10ms
+step:1367/1840 train_time:71249ms step_avg:52.12ms
+step:1368/1840 train_time:71338ms step_avg:52.15ms
+step:1369/1840 train_time:71423ms step_avg:52.17ms
+step:1370/1840 train_time:71513ms step_avg:52.20ms
+step:1371/1840 train_time:71599ms step_avg:52.22ms
+step:1372/1840 train_time:71688ms step_avg:52.25ms
+step:1373/1840 train_time:71773ms step_avg:52.27ms
+step:1374/1840 train_time:71862ms step_avg:52.30ms
+step:1375/1840 train_time:71949ms step_avg:52.33ms
+step:1376/1840 train_time:72038ms step_avg:52.35ms
+step:1377/1840 train_time:72126ms step_avg:52.38ms
+step:1378/1840 train_time:72216ms step_avg:52.41ms
+step:1379/1840 train_time:72303ms step_avg:52.43ms
+step:1380/1840 train_time:72392ms step_avg:52.46ms
+step:1381/1840 train_time:72478ms step_avg:52.48ms
+step:1382/1840 train_time:72565ms step_avg:52.51ms
+step:1383/1840 train_time:72653ms step_avg:52.53ms
+step:1384/1840 train_time:72742ms step_avg:52.56ms
+step:1385/1840 train_time:72827ms step_avg:52.58ms
+step:1386/1840 train_time:72917ms step_avg:52.61ms
+step:1387/1840 train_time:73004ms step_avg:52.63ms
+step:1388/1840 train_time:73092ms step_avg:52.66ms
+step:1389/1840 train_time:73179ms step_avg:52.68ms
+step:1390/1840 train_time:73267ms step_avg:52.71ms
+step:1391/1840 train_time:73354ms step_avg:52.73ms
+step:1392/1840 train_time:73444ms step_avg:52.76ms
+step:1393/1840 train_time:73530ms step_avg:52.79ms
+step:1394/1840 train_time:73618ms step_avg:52.81ms
+step:1395/1840 train_time:73704ms step_avg:52.83ms
+step:1396/1840 train_time:73794ms step_avg:52.86ms
+step:1397/1840 train_time:73880ms step_avg:52.88ms
+step:1398/1840 train_time:73968ms step_avg:52.91ms
+step:1399/1840 train_time:74054ms step_avg:52.93ms
+step:1400/1840 train_time:74142ms step_avg:52.96ms
+step:1401/1840 train_time:74229ms step_avg:52.98ms
+step:1402/1840 train_time:74317ms step_avg:53.01ms
+step:1403/1840 train_time:74403ms step_avg:53.03ms
+step:1404/1840 train_time:74492ms step_avg:53.06ms
+step:1405/1840 train_time:74578ms step_avg:53.08ms
+step:1406/1840 train_time:74667ms step_avg:53.11ms
+step:1407/1840 train_time:74754ms step_avg:53.13ms
+step:1408/1840 train_time:74842ms step_avg:53.15ms
+step:1409/1840 train_time:74929ms step_avg:53.18ms
+step:1410/1840 train_time:75017ms step_avg:53.20ms
+step:1411/1840 train_time:75103ms step_avg:53.23ms
+step:1412/1840 train_time:75192ms step_avg:53.25ms
+step:1413/1840 train_time:75277ms step_avg:53.27ms
+step:1414/1840 train_time:75366ms step_avg:53.30ms
+step:1415/1840 train_time:75452ms step_avg:53.32ms
+step:1416/1840 train_time:75540ms step_avg:53.35ms
+step:1417/1840 train_time:75627ms step_avg:53.37ms
+step:1418/1840 train_time:75717ms step_avg:53.40ms
+step:1419/1840 train_time:75804ms step_avg:53.42ms
+step:1420/1840 train_time:75893ms step_avg:53.45ms
+step:1421/1840 train_time:75979ms step_avg:53.47ms
+step:1422/1840 train_time:76067ms step_avg:53.49ms
+step:1423/1840 train_time:76155ms step_avg:53.52ms
+step:1424/1840 train_time:76243ms step_avg:53.54ms
+step:1425/1840 train_time:76329ms step_avg:53.56ms
+step:1426/1840 train_time:76418ms step_avg:53.59ms
+step:1427/1840 train_time:76503ms step_avg:53.61ms
+step:1428/1840 train_time:76593ms step_avg:53.64ms
+step:1429/1840 train_time:76679ms step_avg:53.66ms
+step:1430/1840 train_time:76768ms step_avg:53.68ms
+step:1431/1840 train_time:76855ms step_avg:53.71ms
+step:1432/1840 train_time:76944ms step_avg:53.73ms
+step:1433/1840 train_time:77030ms step_avg:53.75ms
+step:1434/1840 train_time:77118ms step_avg:53.78ms
+step:1435/1840 train_time:77205ms step_avg:53.80ms
+step:1436/1840 train_time:77295ms step_avg:53.83ms
+step:1437/1840 train_time:77380ms step_avg:53.85ms
+step:1438/1840 train_time:77470ms step_avg:53.87ms
+step:1439/1840 train_time:77556ms step_avg:53.90ms
+step:1440/1840 train_time:77645ms step_avg:53.92ms
+step:1441/1840 train_time:77732ms step_avg:53.94ms
+step:1442/1840 train_time:77821ms step_avg:53.97ms
+step:1443/1840 train_time:77907ms step_avg:53.99ms
+step:1444/1840 train_time:77995ms step_avg:54.01ms
+step:1445/1840 train_time:78081ms step_avg:54.04ms
+step:1446/1840 train_time:78170ms step_avg:54.06ms
+step:1447/1840 train_time:78256ms step_avg:54.08ms
+step:1448/1840 train_time:78344ms step_avg:54.11ms
+step:1449/1840 train_time:78431ms step_avg:54.13ms
+step:1450/1840 train_time:78521ms step_avg:54.15ms
+step:1451/1840 train_time:78607ms step_avg:54.17ms
+step:1452/1840 train_time:78696ms step_avg:54.20ms
+step:1453/1840 train_time:78783ms step_avg:54.22ms
+step:1454/1840 train_time:78872ms step_avg:54.24ms
+step:1455/1840 train_time:78957ms step_avg:54.27ms
+step:1456/1840 train_time:79046ms step_avg:54.29ms
+step:1457/1840 train_time:79132ms step_avg:54.31ms
+step:1458/1840 train_time:79221ms step_avg:54.34ms
+step:1459/1840 train_time:79307ms step_avg:54.36ms
+step:1460/1840 train_time:79395ms step_avg:54.38ms
+step:1461/1840 train_time:79480ms step_avg:54.40ms
+step:1462/1840 train_time:79569ms step_avg:54.42ms
+step:1463/1840 train_time:79655ms step_avg:54.45ms
+step:1464/1840 train_time:79745ms step_avg:54.47ms
+step:1465/1840 train_time:79832ms step_avg:54.49ms
+step:1466/1840 train_time:79919ms step_avg:54.52ms
+step:1467/1840 train_time:80007ms step_avg:54.54ms
+step:1468/1840 train_time:80096ms step_avg:54.56ms
+step:1469/1840 train_time:80184ms step_avg:54.58ms
+step:1470/1840 train_time:80273ms step_avg:54.61ms
+step:1471/1840 train_time:80358ms step_avg:54.63ms
+step:1472/1840 train_time:80447ms step_avg:54.65ms
+step:1473/1840 train_time:80534ms step_avg:54.67ms
+step:1474/1840 train_time:80623ms step_avg:54.70ms
+step:1475/1840 train_time:80709ms step_avg:54.72ms
+step:1476/1840 train_time:80796ms step_avg:54.74ms
+step:1477/1840 train_time:80883ms step_avg:54.76ms
+step:1478/1840 train_time:80971ms step_avg:54.78ms
+step:1479/1840 train_time:81057ms step_avg:54.81ms
+step:1480/1840 train_time:81146ms step_avg:54.83ms
+step:1481/1840 train_time:81233ms step_avg:54.85ms
+step:1482/1840 train_time:81321ms step_avg:54.87ms
+step:1483/1840 train_time:81408ms step_avg:54.89ms
+step:1484/1840 train_time:81496ms step_avg:54.92ms
+step:1485/1840 train_time:81583ms step_avg:54.94ms
+step:1486/1840 train_time:81673ms step_avg:54.96ms
+step:1487/1840 train_time:81759ms step_avg:54.98ms
+step:1488/1840 train_time:81847ms step_avg:55.00ms
+step:1489/1840 train_time:81934ms step_avg:55.03ms
+step:1490/1840 train_time:82022ms step_avg:55.05ms
+step:1491/1840 train_time:82108ms step_avg:55.07ms
+step:1492/1840 train_time:82197ms step_avg:55.09ms
+step:1493/1840 train_time:82284ms step_avg:55.11ms
+step:1494/1840 train_time:82373ms step_avg:55.14ms
+step:1495/1840 train_time:82459ms step_avg:55.16ms
+step:1496/1840 train_time:82548ms step_avg:55.18ms
+step:1497/1840 train_time:82634ms step_avg:55.20ms
+step:1498/1840 train_time:82723ms step_avg:55.22ms
+step:1499/1840 train_time:82808ms step_avg:55.24ms
+step:1500/1840 train_time:82897ms step_avg:55.26ms
+step:1500/1840 val_loss:3.4025 train_time:82997ms step_avg:55.33ms
+step:1501/1840 train_time:83017ms step_avg:55.31ms
+step:1502/1840 train_time:83074ms step_avg:55.31ms
+step:1503/1840 train_time:83163ms step_avg:55.33ms
+step:1504/1840 train_time:83251ms step_avg:55.35ms
+step:1505/1840 train_time:83337ms step_avg:55.37ms
+step:1506/1840 train_time:83425ms step_avg:55.39ms
+step:1507/1840 train_time:83510ms step_avg:55.41ms
+step:1508/1840 train_time:83598ms step_avg:55.44ms
+step:1509/1840 train_time:83682ms step_avg:55.46ms
+step:1510/1840 train_time:83770ms step_avg:55.48ms
+step:1511/1840 train_time:83856ms step_avg:55.50ms
+step:1512/1840 train_time:83947ms step_avg:55.52ms
+step:1513/1840 train_time:84036ms step_avg:55.54ms
+step:1514/1840 train_time:84127ms step_avg:55.57ms
+step:1515/1840 train_time:84214ms step_avg:55.59ms
+step:1516/1840 train_time:84302ms step_avg:55.61ms
+step:1517/1840 train_time:84387ms step_avg:55.63ms
+step:1518/1840 train_time:84475ms step_avg:55.65ms
+step:1519/1840 train_time:84559ms step_avg:55.67ms
+step:1520/1840 train_time:84649ms step_avg:55.69ms
+step:1521/1840 train_time:84735ms step_avg:55.71ms
+step:1522/1840 train_time:84823ms step_avg:55.73ms
+step:1523/1840 train_time:84910ms step_avg:55.75ms
+step:1524/1840 train_time:84999ms step_avg:55.77ms
+step:1525/1840 train_time:85088ms step_avg:55.80ms
+step:1526/1840 train_time:85178ms step_avg:55.82ms
+step:1527/1840 train_time:85264ms step_avg:55.84ms
+step:1528/1840 train_time:85352ms step_avg:55.86ms
+step:1529/1840 train_time:85437ms step_avg:55.88ms
+step:1530/1840 train_time:85525ms step_avg:55.90ms
+step:1531/1840 train_time:85611ms step_avg:55.92ms
+step:1532/1840 train_time:85699ms step_avg:55.94ms
+step:1533/1840 train_time:85784ms step_avg:55.96ms
+step:1534/1840 train_time:85875ms step_avg:55.98ms
+step:1535/1840 train_time:85961ms step_avg:56.00ms
+step:1536/1840 train_time:86051ms step_avg:56.02ms
+step:1537/1840 train_time:86138ms step_avg:56.04ms
+step:1538/1840 train_time:86227ms step_avg:56.06ms
+step:1539/1840 train_time:86314ms step_avg:56.08ms
+step:1540/1840 train_time:86403ms step_avg:56.11ms
+step:1541/1840 train_time:86489ms step_avg:56.12ms
+step:1542/1840 train_time:86577ms step_avg:56.15ms
+step:1543/1840 train_time:86661ms step_avg:56.16ms
+step:1544/1840 train_time:86752ms step_avg:56.19ms
+step:1545/1840 train_time:86839ms step_avg:56.21ms
+step:1546/1840 train_time:86928ms step_avg:56.23ms
+step:1547/1840 train_time:87015ms step_avg:56.25ms
+step:1548/1840 train_time:87104ms step_avg:56.27ms
+step:1549/1840 train_time:87189ms step_avg:56.29ms
+step:1550/1840 train_time:87278ms step_avg:56.31ms
+step:1551/1840 train_time:87364ms step_avg:56.33ms
+step:1552/1840 train_time:87453ms step_avg:56.35ms
+step:1553/1840 train_time:87539ms step_avg:56.37ms
+step:1554/1840 train_time:87627ms step_avg:56.39ms
+step:1555/1840 train_time:87713ms step_avg:56.41ms
+step:1556/1840 train_time:87801ms step_avg:56.43ms
+step:1557/1840 train_time:87886ms step_avg:56.45ms
+step:1558/1840 train_time:87977ms step_avg:56.47ms
+step:1559/1840 train_time:88063ms step_avg:56.49ms
+step:1560/1840 train_time:88152ms step_avg:56.51ms
+step:1561/1840 train_time:88237ms step_avg:56.53ms
+step:1562/1840 train_time:88328ms step_avg:56.55ms
+step:1563/1840 train_time:88414ms step_avg:56.57ms
+step:1564/1840 train_time:88502ms step_avg:56.59ms
+step:1565/1840 train_time:88587ms step_avg:56.61ms
+step:1566/1840 train_time:88676ms step_avg:56.63ms
+step:1567/1840 train_time:88761ms step_avg:56.64ms
+step:1568/1840 train_time:88850ms step_avg:56.66ms
+step:1569/1840 train_time:88938ms step_avg:56.68ms
+step:1570/1840 train_time:89026ms step_avg:56.70ms
+step:1571/1840 train_time:89113ms step_avg:56.72ms
+step:1572/1840 train_time:89201ms step_avg:56.74ms
+step:1573/1840 train_time:89287ms step_avg:56.76ms
+step:1574/1840 train_time:89376ms step_avg:56.78ms
+step:1575/1840 train_time:89461ms step_avg:56.80ms
+step:1576/1840 train_time:89551ms step_avg:56.82ms
+step:1577/1840 train_time:89637ms step_avg:56.84ms
+step:1578/1840 train_time:89726ms step_avg:56.86ms
+step:1579/1840 train_time:89812ms step_avg:56.88ms
+step:1580/1840 train_time:89901ms step_avg:56.90ms
+step:1581/1840 train_time:89987ms step_avg:56.92ms
+step:1582/1840 train_time:90076ms step_avg:56.94ms
+step:1583/1840 train_time:90163ms step_avg:56.96ms
+step:1584/1840 train_time:90252ms step_avg:56.98ms
+step:1585/1840 train_time:90338ms step_avg:57.00ms
+step:1586/1840 train_time:90427ms step_avg:57.02ms
+step:1587/1840 train_time:90512ms step_avg:57.03ms
+step:1588/1840 train_time:90600ms step_avg:57.05ms
+step:1589/1840 train_time:90686ms step_avg:57.07ms
+step:1590/1840 train_time:90776ms step_avg:57.09ms
+step:1591/1840 train_time:90863ms step_avg:57.11ms
+step:1592/1840 train_time:90951ms step_avg:57.13ms
+step:1593/1840 train_time:91037ms step_avg:57.15ms
+step:1594/1840 train_time:91127ms step_avg:57.17ms
+step:1595/1840 train_time:91212ms step_avg:57.19ms
+step:1596/1840 train_time:91300ms step_avg:57.21ms
+step:1597/1840 train_time:91386ms step_avg:57.22ms
+step:1598/1840 train_time:91475ms step_avg:57.24ms
+step:1599/1840 train_time:91560ms step_avg:57.26ms
+step:1600/1840 train_time:91650ms step_avg:57.28ms
+step:1601/1840 train_time:91737ms step_avg:57.30ms
+step:1602/1840 train_time:91825ms step_avg:57.32ms
+step:1603/1840 train_time:91912ms step_avg:57.34ms
+step:1604/1840 train_time:92001ms step_avg:57.36ms
+step:1605/1840 train_time:92087ms step_avg:57.38ms
+step:1606/1840 train_time:92177ms step_avg:57.40ms
+step:1607/1840 train_time:92263ms step_avg:57.41ms
+step:1608/1840 train_time:92352ms step_avg:57.43ms
+step:1609/1840 train_time:92437ms step_avg:57.45ms
+step:1610/1840 train_time:92525ms step_avg:57.47ms
+step:1611/1840 train_time:92611ms step_avg:57.49ms
+step:1612/1840 train_time:92700ms step_avg:57.51ms
+step:1613/1840 train_time:92786ms step_avg:57.52ms
+step:1614/1840 train_time:92877ms step_avg:57.54ms
+step:1615/1840 train_time:92962ms step_avg:57.56ms
+step:1616/1840 train_time:93052ms step_avg:57.58ms
+step:1617/1840 train_time:93138ms step_avg:57.60ms
+step:1618/1840 train_time:93227ms step_avg:57.62ms
+step:1619/1840 train_time:93312ms step_avg:57.64ms
+step:1620/1840 train_time:93400ms step_avg:57.65ms
+step:1621/1840 train_time:93487ms step_avg:57.67ms
+step:1622/1840 train_time:93576ms step_avg:57.69ms
+step:1623/1840 train_time:93661ms step_avg:57.71ms
+step:1624/1840 train_time:93749ms step_avg:57.73ms
+step:1625/1840 train_time:93838ms step_avg:57.75ms
+step:1626/1840 train_time:93926ms step_avg:57.77ms
+step:1627/1840 train_time:94013ms step_avg:57.78ms
+step:1628/1840 train_time:94102ms step_avg:57.80ms
+step:1629/1840 train_time:94188ms step_avg:57.82ms
+step:1630/1840 train_time:94277ms step_avg:57.84ms
+step:1631/1840 train_time:94363ms step_avg:57.86ms
+step:1632/1840 train_time:94453ms step_avg:57.88ms
+step:1633/1840 train_time:94538ms step_avg:57.89ms
+step:1634/1840 train_time:94625ms step_avg:57.91ms
+step:1635/1840 train_time:94713ms step_avg:57.93ms
+step:1636/1840 train_time:94802ms step_avg:57.95ms
+step:1637/1840 train_time:94887ms step_avg:57.96ms
+step:1638/1840 train_time:94977ms step_avg:57.98ms
+step:1639/1840 train_time:95062ms step_avg:58.00ms
+step:1640/1840 train_time:95152ms step_avg:58.02ms
+step:1641/1840 train_time:95238ms step_avg:58.04ms
+step:1642/1840 train_time:95326ms step_avg:58.05ms
+step:1643/1840 train_time:95413ms step_avg:58.07ms
+step:1644/1840 train_time:95501ms step_avg:58.09ms
+step:1645/1840 train_time:95586ms step_avg:58.11ms
+step:1646/1840 train_time:95675ms step_avg:58.13ms
+step:1647/1840 train_time:95760ms step_avg:58.14ms
+step:1648/1840 train_time:95850ms step_avg:58.16ms
+step:1649/1840 train_time:95937ms step_avg:58.18ms
+step:1650/1840 train_time:96025ms step_avg:58.20ms
+step:1651/1840 train_time:96112ms step_avg:58.21ms
+step:1652/1840 train_time:96200ms step_avg:58.23ms
+step:1653/1840 train_time:96286ms step_avg:58.25ms
+step:1654/1840 train_time:96376ms step_avg:58.27ms
+step:1655/1840 train_time:96461ms step_avg:58.28ms
+step:1656/1840 train_time:96550ms step_avg:58.30ms
+step:1657/1840 train_time:96636ms step_avg:58.32ms
+step:1658/1840 train_time:96724ms step_avg:58.34ms
+step:1659/1840 train_time:96812ms step_avg:58.36ms
+step:1660/1840 train_time:96901ms step_avg:58.37ms
+step:1661/1840 train_time:96988ms step_avg:58.39ms
+step:1662/1840 train_time:97078ms step_avg:58.41ms
+step:1663/1840 train_time:97164ms step_avg:58.43ms
+step:1664/1840 train_time:97252ms step_avg:58.44ms
+step:1665/1840 train_time:97338ms step_avg:58.46ms
+step:1666/1840 train_time:97427ms step_avg:58.48ms
+step:1667/1840 train_time:97513ms step_avg:58.50ms
+step:1668/1840 train_time:97602ms step_avg:58.51ms
+step:1669/1840 train_time:97688ms step_avg:58.53ms
+step:1670/1840 train_time:97777ms step_avg:58.55ms
+step:1671/1840 train_time:97863ms step_avg:58.57ms
+step:1672/1840 train_time:97953ms step_avg:58.58ms
+step:1673/1840 train_time:98038ms step_avg:58.60ms
+step:1674/1840 train_time:98128ms step_avg:58.62ms
+step:1675/1840 train_time:98214ms step_avg:58.64ms
+step:1676/1840 train_time:98302ms step_avg:58.65ms
+step:1677/1840 train_time:98388ms step_avg:58.67ms
+step:1678/1840 train_time:98476ms step_avg:58.69ms
+step:1679/1840 train_time:98562ms step_avg:58.70ms
+step:1680/1840 train_time:98652ms step_avg:58.72ms
+step:1681/1840 train_time:98738ms step_avg:58.74ms
+step:1682/1840 train_time:98826ms step_avg:58.75ms
+step:1683/1840 train_time:98912ms step_avg:58.77ms
+step:1684/1840 train_time:99000ms step_avg:58.79ms
+step:1685/1840 train_time:99086ms step_avg:58.81ms
+step:1686/1840 train_time:99177ms step_avg:58.82ms
+step:1687/1840 train_time:99262ms step_avg:58.84ms
+step:1688/1840 train_time:99352ms step_avg:58.86ms
+step:1689/1840 train_time:99438ms step_avg:58.87ms
+step:1690/1840 train_time:99528ms step_avg:58.89ms
+step:1691/1840 train_time:99615ms step_avg:58.91ms
+step:1692/1840 train_time:99703ms step_avg:58.93ms
+step:1693/1840 train_time:99789ms step_avg:58.94ms
+step:1694/1840 train_time:99878ms step_avg:58.96ms
+step:1695/1840 train_time:99963ms step_avg:58.98ms
+step:1696/1840 train_time:100052ms step_avg:58.99ms
+step:1697/1840 train_time:100138ms step_avg:59.01ms
+step:1698/1840 train_time:100227ms step_avg:59.03ms
+step:1699/1840 train_time:100314ms step_avg:59.04ms
+step:1700/1840 train_time:100402ms step_avg:59.06ms
+step:1701/1840 train_time:100487ms step_avg:59.08ms
+step:1702/1840 train_time:100576ms step_avg:59.09ms
+step:1703/1840 train_time:100661ms step_avg:59.11ms
+step:1704/1840 train_time:100751ms step_avg:59.13ms
+step:1705/1840 train_time:100838ms step_avg:59.14ms
+step:1706/1840 train_time:100926ms step_avg:59.16ms
+step:1707/1840 train_time:101013ms step_avg:59.18ms
+step:1708/1840 train_time:101101ms step_avg:59.19ms
+step:1709/1840 train_time:101186ms step_avg:59.21ms
+step:1710/1840 train_time:101276ms step_avg:59.23ms
+step:1711/1840 train_time:101362ms step_avg:59.24ms
+step:1712/1840 train_time:101450ms step_avg:59.26ms
+step:1713/1840 train_time:101537ms step_avg:59.27ms
+step:1714/1840 train_time:101626ms step_avg:59.29ms
+step:1715/1840 train_time:101712ms step_avg:59.31ms
+step:1716/1840 train_time:101800ms step_avg:59.32ms
+step:1717/1840 train_time:101885ms step_avg:59.34ms
+step:1718/1840 train_time:101977ms step_avg:59.36ms
+step:1719/1840 train_time:102062ms step_avg:59.37ms
+step:1720/1840 train_time:102150ms step_avg:59.39ms
+step:1721/1840 train_time:102238ms step_avg:59.41ms
+step:1722/1840 train_time:102327ms step_avg:59.42ms
+step:1723/1840 train_time:102413ms step_avg:59.44ms
+step:1724/1840 train_time:102500ms step_avg:59.46ms
+step:1725/1840 train_time:102586ms step_avg:59.47ms
+step:1726/1840 train_time:102676ms step_avg:59.49ms
+step:1727/1840 train_time:102761ms step_avg:59.50ms
+step:1728/1840 train_time:102852ms step_avg:59.52ms
+step:1729/1840 train_time:102938ms step_avg:59.54ms
+step:1730/1840 train_time:103027ms step_avg:59.55ms
+step:1731/1840 train_time:103114ms step_avg:59.57ms
+step:1732/1840 train_time:103202ms step_avg:59.59ms
+step:1733/1840 train_time:103288ms step_avg:59.60ms
+step:1734/1840 train_time:103377ms step_avg:59.62ms
+step:1735/1840 train_time:103462ms step_avg:59.63ms
+step:1736/1840 train_time:103552ms step_avg:59.65ms
+step:1737/1840 train_time:103637ms step_avg:59.66ms
+step:1738/1840 train_time:103727ms step_avg:59.68ms
+step:1739/1840 train_time:103813ms step_avg:59.70ms
+step:1740/1840 train_time:103901ms step_avg:59.71ms
+step:1741/1840 train_time:103988ms step_avg:59.73ms
+step:1742/1840 train_time:104076ms step_avg:59.75ms
+step:1743/1840 train_time:104161ms step_avg:59.76ms
+step:1744/1840 train_time:104249ms step_avg:59.78ms
+step:1745/1840 train_time:104337ms step_avg:59.79ms
+step:1746/1840 train_time:104425ms step_avg:59.81ms
+step:1747/1840 train_time:104511ms step_avg:59.82ms
+step:1748/1840 train_time:104600ms step_avg:59.84ms
+step:1749/1840 train_time:104686ms step_avg:59.85ms
+step:1750/1840 train_time:104776ms step_avg:59.87ms
+step:1750/1840 val_loss:3.3044 train_time:104876ms step_avg:59.93ms
+step:1751/1840 train_time:104896ms step_avg:59.91ms
+step:1752/1840 train_time:104953ms step_avg:59.90ms
+step:1753/1840 train_time:105045ms step_avg:59.92ms
+step:1754/1840 train_time:105134ms step_avg:59.94ms
+step:1755/1840 train_time:105221ms step_avg:59.95ms
+step:1756/1840 train_time:105308ms step_avg:59.97ms
+step:1757/1840 train_time:105393ms step_avg:59.98ms
+step:1758/1840 train_time:105481ms step_avg:60.00ms
+step:1759/1840 train_time:105566ms step_avg:60.01ms
+step:1760/1840 train_time:105654ms step_avg:60.03ms
+step:1761/1840 train_time:105740ms step_avg:60.05ms
+step:1762/1840 train_time:105830ms step_avg:60.06ms
+step:1763/1840 train_time:105918ms step_avg:60.08ms
+step:1764/1840 train_time:106010ms step_avg:60.10ms
+step:1765/1840 train_time:106099ms step_avg:60.11ms
+step:1766/1840 train_time:106187ms step_avg:60.13ms
+step:1767/1840 train_time:106273ms step_avg:60.14ms
+step:1768/1840 train_time:106362ms step_avg:60.16ms
+step:1769/1840 train_time:106446ms step_avg:60.17ms
+step:1770/1840 train_time:106534ms step_avg:60.19ms
+step:1771/1840 train_time:106620ms step_avg:60.20ms
+step:1772/1840 train_time:106707ms step_avg:60.22ms
+step:1773/1840 train_time:106793ms step_avg:60.23ms
+step:1774/1840 train_time:106884ms step_avg:60.25ms
+step:1775/1840 train_time:106971ms step_avg:60.27ms
+step:1776/1840 train_time:107061ms step_avg:60.28ms
+step:1777/1840 train_time:107148ms step_avg:60.30ms
+step:1778/1840 train_time:107236ms step_avg:60.31ms
+step:1779/1840 train_time:107323ms step_avg:60.33ms
+step:1780/1840 train_time:107410ms step_avg:60.34ms
+step:1781/1840 train_time:107496ms step_avg:60.36ms
+step:1782/1840 train_time:107585ms step_avg:60.37ms
+step:1783/1840 train_time:107670ms step_avg:60.39ms
+step:1784/1840 train_time:107758ms step_avg:60.40ms
+step:1785/1840 train_time:107845ms step_avg:60.42ms
+step:1786/1840 train_time:107935ms step_avg:60.43ms
+step:1787/1840 train_time:108023ms step_avg:60.45ms
+step:1788/1840 train_time:108111ms step_avg:60.46ms
+step:1789/1840 train_time:108198ms step_avg:60.48ms
+step:1790/1840 train_time:108287ms step_avg:60.50ms
+step:1791/1840 train_time:108372ms step_avg:60.51ms
+step:1792/1840 train_time:108461ms step_avg:60.53ms
+step:1793/1840 train_time:108547ms step_avg:60.54ms
+step:1794/1840 train_time:108635ms step_avg:60.55ms
+step:1795/1840 train_time:108721ms step_avg:60.57ms
+step:1796/1840 train_time:108810ms step_avg:60.58ms
+step:1797/1840 train_time:108898ms step_avg:60.60ms
+step:1798/1840 train_time:108987ms step_avg:60.62ms
+step:1799/1840 train_time:109074ms step_avg:60.63ms
+step:1800/1840 train_time:109165ms step_avg:60.65ms
+step:1801/1840 train_time:109252ms step_avg:60.66ms
+step:1802/1840 train_time:109339ms step_avg:60.68ms
+step:1803/1840 train_time:109426ms step_avg:60.69ms
+step:1804/1840 train_time:109514ms step_avg:60.71ms
+step:1805/1840 train_time:109600ms step_avg:60.72ms
+step:1806/1840 train_time:109689ms step_avg:60.74ms
+step:1807/1840 train_time:109775ms step_avg:60.75ms
+step:1808/1840 train_time:109865ms step_avg:60.77ms
+step:1809/1840 train_time:109951ms step_avg:60.78ms
+step:1810/1840 train_time:110041ms step_avg:60.80ms
+step:1811/1840 train_time:110128ms step_avg:60.81ms
+step:1812/1840 train_time:110217ms step_avg:60.83ms
+step:1813/1840 train_time:110304ms step_avg:60.84ms
+step:1814/1840 train_time:110393ms step_avg:60.86ms
+step:1815/1840 train_time:110479ms step_avg:60.87ms
+step:1816/1840 train_time:110567ms step_avg:60.89ms
+step:1817/1840 train_time:110653ms step_avg:60.90ms
+step:1818/1840 train_time:110742ms step_avg:60.91ms
+step:1819/1840 train_time:110828ms step_avg:60.93ms
+step:1820/1840 train_time:110918ms step_avg:60.94ms
+step:1821/1840 train_time:111005ms step_avg:60.96ms
+step:1822/1840 train_time:111095ms step_avg:60.97ms
+step:1823/1840 train_time:111181ms step_avg:60.99ms
+step:1824/1840 train_time:111270ms step_avg:61.00ms
+step:1825/1840 train_time:111356ms step_avg:61.02ms
+step:1826/1840 train_time:111445ms step_avg:61.03ms
+step:1827/1840 train_time:111531ms step_avg:61.05ms
+step:1828/1840 train_time:111620ms step_avg:61.06ms
+step:1829/1840 train_time:111706ms step_avg:61.07ms
+step:1830/1840 train_time:111795ms step_avg:61.09ms
+step:1831/1840 train_time:111882ms step_avg:61.10ms
+step:1832/1840 train_time:111971ms step_avg:61.12ms
+step:1833/1840 train_time:112057ms step_avg:61.13ms
+step:1834/1840 train_time:112146ms step_avg:61.15ms
+step:1835/1840 train_time:112234ms step_avg:61.16ms
+step:1836/1840 train_time:112321ms step_avg:61.18ms
+step:1837/1840 train_time:112408ms step_avg:61.19ms
+step:1838/1840 train_time:112497ms step_avg:61.21ms
+step:1839/1840 train_time:112585ms step_avg:61.22ms
+step:1840/1840 train_time:112673ms step_avg:61.24ms
+step:1840/1840 val_loss:3.2795 train_time:112774ms step_avg:61.29ms
+peak memory allocated: 28507 MiB reserved: 44038 MiB

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/8c2cb70f-3121-4d38-b964-b0374a54dc86.txt
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/8c2cb70f-3121-4d38-b964-b0374a54dc86.txt
@@ -1,0 +1,3786 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+    """
+    Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+    Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+    bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+    float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+    """
+    assert p.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    wd_factor = wd_tensor.to(torch.float32)
+    lr_factor = lr_tensor.to(torch.float32)
+    p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    p_precise = p_precise_raw.view(torch.float32)
+    mask = (grad * p_precise) >= 0
+    p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+    p.copy_((p_precise_raw >> 16).to(torch.uint16))
+    mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        2. reduce scatter attn/mlp round 2 (16 mlp params)
+        3. wait on step 1, then compute update of 1 and schedule all gather
+        4. wait on step 2, then compute update of 2 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        5. wait for each all gather to complete and update params
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["mantissa"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn', 'mlp']
+        group_sizes = [16, 16]  # 10 attn + 6 mlp, then 16 mlp
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    def step(self):
+        self.step_p1()
+        self.step_p2()
+        self.step_p3()
+        
+    @torch.no_grad()
+    def step_p1(self):
+        """
+        Part 1: Launch distributed reduce_scatter operations for parameter groups.
+        """
+        rank = dist.get_rank()
+        self.group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            self.group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+    
+    @torch.no_grad()
+    def step_p2(self):
+        """
+        Part 2: Compute gradient updates and launch all_gather operations
+        Wait for all gather to complete for all parameter groups except final one
+        """
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = self.group_infos
+        
+        self.all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"].float()
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params], dtype=torch.float32)
+                
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            if "second_momentum_buffer" not in group:
+                group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1], dtype=torch.float32)
+                    if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if param_shape[-2] >= param_shape[-1] else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk, dtype=torch.bfloat16)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                if "mantissa" not in group:
+                    group["mantissa"] = torch.zeros_like(param_chunk, dtype=torch.uint16)
+                mantissa = group["mantissa"]
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx].view(torch.uint16),
+                        mantissa[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx]
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            self.all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete for all except final and copy results back into original parameter tensors.
+        for info in self.all_gather_infos[:-1]:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+    @torch.no_grad()
+    def step_p3(self):
+        """
+        Part 3: Wait for final all gather to complete and copy results back into original parameter tensors
+        """
+        info = self.all_gather_infos[-1]
+        info["gather_future"].wait()
+        stacked_params = info["stacked_params"]
+        orig_params = info["orig_params"]
+
+        unstacked_params = torch.unbind(stacked_params)
+        for i, p in enumerate(orig_params):
+            p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str], betas: list[list[float]], lr: float = 1e-3, eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for idx, label in enumerate(label_order):
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label], betas=betas[idx]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+        # tag the final param for optimizer pipelining, run all gather after muon copy
+        param_groups[-1]['params'][-1].is_final_param = True
+        
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        # 0-D CPU tensors to avoid recompilation in _update_step
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    def load_state_dict(self, state_dict):
+        """Override to preserve optimizer state dtypes (avoid BFloat16->Float32 cast that causes recompilation)."""
+        # Save original state dtypes before loading
+        original_dtypes = {}
+        for p, s in self.state.items():
+            original_dtypes[p] = {k: v.dtype for k, v in s.items() if isinstance(v, torch.Tensor)}
+        
+        # Call parent load_state_dict (which may cast dtypes to match param dtype)
+        super().load_state_dict(state_dict)
+        
+        # Restore original dtypes
+        for p, s in self.state.items():
+            if p in original_dtypes:
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor) and k in original_dtypes[p]:
+                        if v.dtype != original_dtypes[p][k]:
+                            s[k] = v.to(original_dtypes[p][k])
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-2]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step. step_size_t and eff_wd_t are 0-D CPU tensors to avoid recompilation."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)  # exp_avg = beta1 * exp_avg + (1 - beta1) * g_slice
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)  # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * g_slice^2
+        # compute step
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)  # update = (exp_avg / (sqrt(exp_avg_sq) + eps)) * step_size
+        # cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)  # update += eff_wd_t * p_slice * mask
+        p_slice.add_(other=update, alpha=-1.0)  # p_slice -= update
+
+    @torch.no_grad()
+    def step(self, muon_opt):
+        muon_opt.step_p1()
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        last_param = None
+        last_p_slice = None
+        for group in self.param_groups:      
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+                state["step"] += 1
+                t = state["step"]
+                
+                # Pre-compute changing values as 0-D CPU tensors to avoid recompilation.
+                # `.fill_(value)` is the same as "= value", but doesn't change the tensor object.
+                bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+                self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+                self._eff_wd_t.fill_(lr * lr * wd * getattr(param, "wd_mul", 1.0)) # `lr` included twice to serve as weight decay schedule.
+
+                DistAdam._update_step(p_slice, g_slice, state["exp_avg"], state["exp_avg_sq"],
+                                      beta1, beta2, eps, self._step_size_t, self._eff_wd_t)
+
+                if not is_small:
+                    if getattr(param, "is_final_param", False):
+                        last_param = param
+                        last_p_slice = p_slice
+                    else:
+                        all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+        self._reduce_scatter_futures.clear()
+
+        muon_opt.step_p2()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+        if last_param is not None:
+            last_all_gather_future = dist.all_gather_into_tensor(last_param, last_p_slice, async_op=True).get_future()
+        muon_opt.step_p3()
+        torch.futures.collect_all([last_all_gather_future]).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        adam_betas = {
+            'lm_head': [0.5, 0.95],
+            'smear_gate': [0.9, 0.99],
+            'attn_gate_bank': [0.9, 0.99],
+            've_gate_bank': [0.9, 0.99],
+            'skip_gate': [0.9, 0.99],
+            'x0_lambdas': [0.65, 0.95],
+            'scalars': [0.9, 0.99],
+            'embed': [0.5, 0.95],
+            'value_embed': [0.75, 0.95]
+        }
+        adam_labels = list(adam_betas.keys())
+        adam_beta_values = list(adam_betas.values())
+        muon_labels = ['attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, adam_beta_values, lr=0.008, eps=1e-10, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.muon_opt]
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * step_lr
+                
+        if self._is_active_step(self.adam_opt, step):
+            # adam will interleave calls to muon step
+            self.adam_opt.step(self.muon_opt)
+            self.model.zero_grad(set_to_none=True)
+            self.adam_opt.should_sync = False
+        else:
+            self.muon_opt.step()
+            self.muon_opt.zero_grad(set_to_none=True)
+            
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1800  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan  5 07:44:22 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   35C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   32C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   30C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   35C    P0            123W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   37C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   32C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   35C    P0            124W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   28C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     44681      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     44682      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     44683      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     44684      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     44685      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     44686      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     44687      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     44688      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 599, 600, 601, 1199, 1200, 1201, 1799, 1800, 1801] for warmup
+Resetting Model
+step:0/1840 val_loss:10.8297 train_time:0ms step_avg:0.03ms
+step:1/1840 train_time:63ms step_avg:63.26ms
+step:2/1840 train_time:84ms step_avg:42.01ms
+step:3/1840 train_time:108ms step_avg:35.91ms
+step:4/1840 train_time:142ms step_avg:35.42ms
+step:5/1840 train_time:173ms step_avg:34.69ms
+step:6/1840 train_time:264ms step_avg:43.95ms
+step:7/1840 train_time:280ms step_avg:40.07ms
+step:8/1840 train_time:409ms step_avg:51.15ms
+step:9/1840 train_time:441ms step_avg:48.99ms
+step:10/1840 train_time:475ms step_avg:47.48ms
+step:11/1840 train_time:507ms step_avg:46.05ms
+step:12/1840 train_time:541ms step_avg:45.06ms
+step:13/1840 train_time:573ms step_avg:44.06ms
+step:14/1840 train_time:607ms step_avg:43.35ms
+step:15/1840 train_time:639ms step_avg:42.60ms
+step:16/1840 train_time:673ms step_avg:42.07ms
+step:17/1840 train_time:705ms step_avg:41.47ms
+step:18/1840 train_time:739ms step_avg:41.08ms
+step:19/1840 train_time:771ms step_avg:40.59ms
+step:20/1840 train_time:805ms step_avg:40.27ms
+step:21/1840 train_time:838ms step_avg:39.89ms
+step:22/1840 train_time:872ms step_avg:39.62ms
+step:23/1840 train_time:903ms step_avg:39.28ms
+step:24/1840 train_time:938ms step_avg:39.07ms
+step:25/1840 train_time:970ms step_avg:38.78ms
+step:26/1840 train_time:1003ms step_avg:38.59ms
+step:27/1840 train_time:1036ms step_avg:38.36ms
+step:28/1840 train_time:1070ms step_avg:38.21ms
+step:29/1840 train_time:1102ms step_avg:37.99ms
+step:30/1840 train_time:1136ms step_avg:37.87ms
+step:31/1840 train_time:1168ms step_avg:37.67ms
+step:32/1840 train_time:1202ms step_avg:37.57ms
+step:33/1840 train_time:1234ms step_avg:37.40ms
+step:34/1840 train_time:1268ms step_avg:37.30ms
+step:35/1840 train_time:1302ms step_avg:37.19ms
+step:36/1840 train_time:1337ms step_avg:37.14ms
+step:37/1840 train_time:1369ms step_avg:37.01ms
+step:38/1840 train_time:1404ms step_avg:36.95ms
+step:39/1840 train_time:1437ms step_avg:36.83ms
+step:40/1840 train_time:1471ms step_avg:36.77ms
+step:41/1840 train_time:1503ms step_avg:36.67ms
+step:42/1840 train_time:1538ms step_avg:36.62ms
+step:43/1840 train_time:1570ms step_avg:36.51ms
+step:44/1840 train_time:1604ms step_avg:36.46ms
+step:45/1840 train_time:1637ms step_avg:36.37ms
+step:46/1840 train_time:1671ms step_avg:36.33ms
+step:47/1840 train_time:1703ms step_avg:36.24ms
+step:48/1840 train_time:1738ms step_avg:36.20ms
+step:49/1840 train_time:1770ms step_avg:36.12ms
+step:50/1840 train_time:1804ms step_avg:36.08ms
+step:51/1840 train_time:1837ms step_avg:36.01ms
+step:52/1840 train_time:1871ms step_avg:35.98ms
+step:53/1840 train_time:1903ms step_avg:35.90ms
+step:54/1840 train_time:1937ms step_avg:35.87ms
+step:55/1840 train_time:1969ms step_avg:35.79ms
+step:56/1840 train_time:2003ms step_avg:35.77ms
+step:57/1840 train_time:2035ms step_avg:35.70ms
+step:58/1840 train_time:2069ms step_avg:35.67ms
+step:59/1840 train_time:2101ms step_avg:35.61ms
+step:60/1840 train_time:2135ms step_avg:35.59ms
+step:61/1840 train_time:2167ms step_avg:35.53ms
+step:62/1840 train_time:2201ms step_avg:35.51ms
+step:63/1840 train_time:2234ms step_avg:35.46ms
+step:64/1840 train_time:2268ms step_avg:35.44ms
+step:65/1840 train_time:2300ms step_avg:35.39ms
+step:66/1840 train_time:2335ms step_avg:35.38ms
+step:67/1840 train_time:2367ms step_avg:35.33ms
+step:68/1840 train_time:2401ms step_avg:35.31ms
+step:69/1840 train_time:2434ms step_avg:35.27ms
+step:70/1840 train_time:2468ms step_avg:35.26ms
+step:71/1840 train_time:2500ms step_avg:35.22ms
+step:72/1840 train_time:2535ms step_avg:35.21ms
+step:73/1840 train_time:2567ms step_avg:35.16ms
+step:74/1840 train_time:2601ms step_avg:35.15ms
+step:75/1840 train_time:2633ms step_avg:35.11ms
+step:76/1840 train_time:2668ms step_avg:35.10ms
+step:77/1840 train_time:2700ms step_avg:35.06ms
+step:78/1840 train_time:2734ms step_avg:35.05ms
+step:79/1840 train_time:2766ms step_avg:35.02ms
+step:80/1840 train_time:2800ms step_avg:35.01ms
+step:81/1840 train_time:2832ms step_avg:34.97ms
+step:82/1840 train_time:2867ms step_avg:34.96ms
+step:83/1840 train_time:2899ms step_avg:34.93ms
+step:84/1840 train_time:2933ms step_avg:34.92ms
+step:85/1840 train_time:2965ms step_avg:34.89ms
+step:86/1840 train_time:3000ms step_avg:34.88ms
+step:87/1840 train_time:3032ms step_avg:34.85ms
+step:88/1840 train_time:3066ms step_avg:34.85ms
+step:89/1840 train_time:3098ms step_avg:34.81ms
+step:90/1840 train_time:3133ms step_avg:34.81ms
+step:91/1840 train_time:3165ms step_avg:34.78ms
+step:92/1840 train_time:3199ms step_avg:34.77ms
+step:93/1840 train_time:3231ms step_avg:34.74ms
+step:94/1840 train_time:3266ms step_avg:34.74ms
+step:95/1840 train_time:3298ms step_avg:34.71ms
+step:96/1840 train_time:3332ms step_avg:34.71ms
+step:97/1840 train_time:3364ms step_avg:34.68ms
+step:98/1840 train_time:3398ms step_avg:34.68ms
+step:99/1840 train_time:3431ms step_avg:34.65ms
+step:100/1840 train_time:3465ms step_avg:34.65ms
+step:101/1840 train_time:3497ms step_avg:34.62ms
+step:102/1840 train_time:3531ms step_avg:34.62ms
+step:103/1840 train_time:3563ms step_avg:34.60ms
+step:104/1840 train_time:3598ms step_avg:34.59ms
+step:105/1840 train_time:3630ms step_avg:34.57ms
+step:106/1840 train_time:3664ms step_avg:34.57ms
+step:107/1840 train_time:3697ms step_avg:34.55ms
+step:108/1840 train_time:3731ms step_avg:34.54ms
+step:109/1840 train_time:3763ms step_avg:34.52ms
+step:110/1840 train_time:3798ms step_avg:34.52ms
+step:111/1840 train_time:3830ms step_avg:34.50ms
+step:112/1840 train_time:3864ms step_avg:34.50ms
+step:113/1840 train_time:3896ms step_avg:34.48ms
+step:114/1840 train_time:3930ms step_avg:34.47ms
+step:115/1840 train_time:3962ms step_avg:34.46ms
+step:116/1840 train_time:3997ms step_avg:34.46ms
+step:117/1840 train_time:4029ms step_avg:34.44ms
+step:118/1840 train_time:4063ms step_avg:34.44ms
+step:119/1840 train_time:4096ms step_avg:34.42ms
+step:120/1840 train_time:4129ms step_avg:34.41ms
+step:121/1840 train_time:4161ms step_avg:34.39ms
+step:122/1840 train_time:4196ms step_avg:34.39ms
+step:123/1840 train_time:4228ms step_avg:34.37ms
+step:124/1840 train_time:4263ms step_avg:34.38ms
+step:125/1840 train_time:4295ms step_avg:34.36ms
+step:126/1840 train_time:4329ms step_avg:34.36ms
+step:127/1840 train_time:4361ms step_avg:34.34ms
+step:128/1840 train_time:4395ms step_avg:34.34ms
+step:129/1840 train_time:4427ms step_avg:34.32ms
+step:130/1840 train_time:4462ms step_avg:34.32ms
+step:131/1840 train_time:4494ms step_avg:34.30ms
+step:132/1840 train_time:4528ms step_avg:34.30ms
+step:133/1840 train_time:4560ms step_avg:34.29ms
+step:134/1840 train_time:4594ms step_avg:34.29ms
+step:135/1840 train_time:4627ms step_avg:34.27ms
+step:136/1840 train_time:4661ms step_avg:34.27ms
+step:137/1840 train_time:4693ms step_avg:34.25ms
+step:138/1840 train_time:4727ms step_avg:34.25ms
+step:139/1840 train_time:4759ms step_avg:34.24ms
+step:140/1840 train_time:4794ms step_avg:34.24ms
+step:141/1840 train_time:4826ms step_avg:34.22ms
+step:142/1840 train_time:4860ms step_avg:34.22ms
+step:143/1840 train_time:4892ms step_avg:34.21ms
+step:144/1840 train_time:4926ms step_avg:34.21ms
+step:145/1840 train_time:4959ms step_avg:34.20ms
+step:146/1840 train_time:4993ms step_avg:34.20ms
+step:147/1840 train_time:5025ms step_avg:34.18ms
+step:148/1840 train_time:5059ms step_avg:34.18ms
+step:149/1840 train_time:5091ms step_avg:34.17ms
+step:150/1840 train_time:5126ms step_avg:34.17ms
+step:151/1840 train_time:5158ms step_avg:34.16ms
+step:152/1840 train_time:5191ms step_avg:34.15ms
+step:153/1840 train_time:5223ms step_avg:34.14ms
+step:154/1840 train_time:5258ms step_avg:34.14ms
+step:155/1840 train_time:5289ms step_avg:34.13ms
+step:156/1840 train_time:5324ms step_avg:34.13ms
+step:157/1840 train_time:5356ms step_avg:34.12ms
+step:158/1840 train_time:5390ms step_avg:34.12ms
+step:159/1840 train_time:5422ms step_avg:34.10ms
+step:160/1840 train_time:5457ms step_avg:34.11ms
+step:161/1840 train_time:5489ms step_avg:34.09ms
+step:162/1840 train_time:5523ms step_avg:34.09ms
+step:163/1840 train_time:5555ms step_avg:34.08ms
+step:164/1840 train_time:5589ms step_avg:34.08ms
+step:165/1840 train_time:5621ms step_avg:34.07ms
+step:166/1840 train_time:5655ms step_avg:34.07ms
+step:167/1840 train_time:5687ms step_avg:34.06ms
+step:168/1840 train_time:5722ms step_avg:34.06ms
+step:169/1840 train_time:5754ms step_avg:34.05ms
+step:170/1840 train_time:5788ms step_avg:34.05ms
+step:171/1840 train_time:5820ms step_avg:34.04ms
+step:172/1840 train_time:5855ms step_avg:34.04ms
+step:173/1840 train_time:5887ms step_avg:34.03ms
+step:174/1840 train_time:5922ms step_avg:34.03ms
+step:175/1840 train_time:5954ms step_avg:34.02ms
+step:176/1840 train_time:5988ms step_avg:34.02ms
+step:177/1840 train_time:6020ms step_avg:34.01ms
+step:178/1840 train_time:6054ms step_avg:34.01ms
+step:179/1840 train_time:6086ms step_avg:34.00ms
+step:180/1840 train_time:6121ms step_avg:34.00ms
+step:181/1840 train_time:6153ms step_avg:33.99ms
+step:182/1840 train_time:6187ms step_avg:33.99ms
+step:183/1840 train_time:6219ms step_avg:33.98ms
+step:184/1840 train_time:6253ms step_avg:33.98ms
+step:185/1840 train_time:6285ms step_avg:33.97ms
+step:186/1840 train_time:6320ms step_avg:33.98ms
+step:187/1840 train_time:6352ms step_avg:33.97ms
+step:188/1840 train_time:6385ms step_avg:33.97ms
+step:189/1840 train_time:6417ms step_avg:33.95ms
+step:190/1840 train_time:6451ms step_avg:33.96ms
+step:191/1840 train_time:6484ms step_avg:33.95ms
+step:192/1840 train_time:6518ms step_avg:33.95ms
+step:193/1840 train_time:6550ms step_avg:33.94ms
+step:194/1840 train_time:6584ms step_avg:33.94ms
+step:195/1840 train_time:6616ms step_avg:33.93ms
+step:196/1840 train_time:6650ms step_avg:33.93ms
+step:197/1840 train_time:6682ms step_avg:33.92ms
+step:198/1840 train_time:6716ms step_avg:33.92ms
+step:199/1840 train_time:6748ms step_avg:33.91ms
+step:200/1840 train_time:6782ms step_avg:33.91ms
+step:201/1840 train_time:6815ms step_avg:33.90ms
+step:202/1840 train_time:6849ms step_avg:33.91ms
+step:203/1840 train_time:6881ms step_avg:33.90ms
+step:204/1840 train_time:6916ms step_avg:33.90ms
+step:205/1840 train_time:6948ms step_avg:33.89ms
+step:206/1840 train_time:6982ms step_avg:33.89ms
+step:207/1840 train_time:7014ms step_avg:33.88ms
+step:208/1840 train_time:7048ms step_avg:33.89ms
+step:209/1840 train_time:7080ms step_avg:33.88ms
+step:210/1840 train_time:7115ms step_avg:33.88ms
+step:211/1840 train_time:7147ms step_avg:33.87ms
+step:212/1840 train_time:7181ms step_avg:33.87ms
+step:213/1840 train_time:7214ms step_avg:33.87ms
+step:214/1840 train_time:7248ms step_avg:33.87ms
+step:215/1840 train_time:7280ms step_avg:33.86ms
+step:216/1840 train_time:7314ms step_avg:33.86ms
+step:217/1840 train_time:7347ms step_avg:33.85ms
+step:218/1840 train_time:7381ms step_avg:33.86ms
+step:219/1840 train_time:7413ms step_avg:33.85ms
+step:220/1840 train_time:7448ms step_avg:33.85ms
+step:221/1840 train_time:7480ms step_avg:33.84ms
+step:222/1840 train_time:7514ms step_avg:33.85ms
+step:223/1840 train_time:7546ms step_avg:33.84ms
+step:224/1840 train_time:7580ms step_avg:33.84ms
+step:225/1840 train_time:7612ms step_avg:33.83ms
+step:226/1840 train_time:7646ms step_avg:33.83ms
+step:227/1840 train_time:7678ms step_avg:33.82ms
+step:228/1840 train_time:7712ms step_avg:33.82ms
+step:229/1840 train_time:7744ms step_avg:33.81ms
+step:230/1840 train_time:7778ms step_avg:33.82ms
+step:231/1840 train_time:7810ms step_avg:33.81ms
+step:232/1840 train_time:7844ms step_avg:33.81ms
+step:233/1840 train_time:7876ms step_avg:33.80ms
+step:234/1840 train_time:7910ms step_avg:33.80ms
+step:235/1840 train_time:7942ms step_avg:33.80ms
+step:236/1840 train_time:7977ms step_avg:33.80ms
+step:237/1840 train_time:8009ms step_avg:33.79ms
+step:238/1840 train_time:8043ms step_avg:33.79ms
+step:239/1840 train_time:8075ms step_avg:33.79ms
+step:240/1840 train_time:8109ms step_avg:33.79ms
+step:241/1840 train_time:8141ms step_avg:33.78ms
+step:242/1840 train_time:8176ms step_avg:33.78ms
+step:243/1840 train_time:8208ms step_avg:33.78ms
+step:244/1840 train_time:8242ms step_avg:33.78ms
+step:245/1840 train_time:8274ms step_avg:33.77ms
+step:246/1840 train_time:8308ms step_avg:33.77ms
+step:247/1840 train_time:8340ms step_avg:33.77ms
+step:248/1840 train_time:8374ms step_avg:33.77ms
+step:249/1840 train_time:8406ms step_avg:33.76ms
+step:250/1840 train_time:8440ms step_avg:33.76ms
+step:250/1840 val_loss:4.6069 train_time:8482ms step_avg:33.93ms
+step:251/1840 train_time:8500ms step_avg:33.87ms
+step:252/1840 train_time:8522ms step_avg:33.82ms
+step:253/1840 train_time:8543ms step_avg:33.77ms
+step:254/1840 train_time:8577ms step_avg:33.77ms
+step:255/1840 train_time:8611ms step_avg:33.77ms
+step:256/1840 train_time:8645ms step_avg:33.77ms
+step:257/1840 train_time:8678ms step_avg:33.77ms
+step:258/1840 train_time:8712ms step_avg:33.77ms
+step:259/1840 train_time:8744ms step_avg:33.76ms
+step:260/1840 train_time:8778ms step_avg:33.76ms
+step:261/1840 train_time:8810ms step_avg:33.75ms
+step:262/1840 train_time:8844ms step_avg:33.76ms
+step:263/1840 train_time:8876ms step_avg:33.75ms
+step:264/1840 train_time:8910ms step_avg:33.75ms
+step:265/1840 train_time:8941ms step_avg:33.74ms
+step:266/1840 train_time:8976ms step_avg:33.74ms
+step:267/1840 train_time:9007ms step_avg:33.74ms
+step:268/1840 train_time:9041ms step_avg:33.74ms
+step:269/1840 train_time:9073ms step_avg:33.73ms
+step:270/1840 train_time:9107ms step_avg:33.73ms
+step:271/1840 train_time:9139ms step_avg:33.72ms
+step:272/1840 train_time:9173ms step_avg:33.72ms
+step:273/1840 train_time:9205ms step_avg:33.72ms
+step:274/1840 train_time:9239ms step_avg:33.72ms
+step:275/1840 train_time:9271ms step_avg:33.71ms
+step:276/1840 train_time:9305ms step_avg:33.71ms
+step:277/1840 train_time:9337ms step_avg:33.71ms
+step:278/1840 train_time:9371ms step_avg:33.71ms
+step:279/1840 train_time:9403ms step_avg:33.70ms
+step:280/1840 train_time:9438ms step_avg:33.71ms
+step:281/1840 train_time:9470ms step_avg:33.70ms
+step:282/1840 train_time:9505ms step_avg:33.71ms
+step:283/1840 train_time:9537ms step_avg:33.70ms
+step:284/1840 train_time:9572ms step_avg:33.70ms
+step:285/1840 train_time:9604ms step_avg:33.70ms
+step:286/1840 train_time:9639ms step_avg:33.70ms
+step:287/1840 train_time:9671ms step_avg:33.70ms
+step:288/1840 train_time:9706ms step_avg:33.70ms
+step:289/1840 train_time:9738ms step_avg:33.69ms
+step:290/1840 train_time:9772ms step_avg:33.70ms
+step:291/1840 train_time:9804ms step_avg:33.69ms
+step:292/1840 train_time:9838ms step_avg:33.69ms
+step:293/1840 train_time:9870ms step_avg:33.69ms
+step:294/1840 train_time:9904ms step_avg:33.69ms
+step:295/1840 train_time:9936ms step_avg:33.68ms
+step:296/1840 train_time:9970ms step_avg:33.68ms
+step:297/1840 train_time:10002ms step_avg:33.68ms
+step:298/1840 train_time:10036ms step_avg:33.68ms
+step:299/1840 train_time:10068ms step_avg:33.67ms
+step:300/1840 train_time:10102ms step_avg:33.67ms
+step:301/1840 train_time:10134ms step_avg:33.67ms
+step:302/1840 train_time:10169ms step_avg:33.67ms
+step:303/1840 train_time:10200ms step_avg:33.66ms
+step:304/1840 train_time:10234ms step_avg:33.67ms
+step:305/1840 train_time:10266ms step_avg:33.66ms
+step:306/1840 train_time:10300ms step_avg:33.66ms
+step:307/1840 train_time:10332ms step_avg:33.66ms
+step:308/1840 train_time:10366ms step_avg:33.66ms
+step:309/1840 train_time:10398ms step_avg:33.65ms
+step:310/1840 train_time:10433ms step_avg:33.66ms
+step:311/1840 train_time:10465ms step_avg:33.65ms
+step:312/1840 train_time:10499ms step_avg:33.65ms
+step:313/1840 train_time:10531ms step_avg:33.65ms
+step:314/1840 train_time:10566ms step_avg:33.65ms
+step:315/1840 train_time:10598ms step_avg:33.64ms
+step:316/1840 train_time:10633ms step_avg:33.65ms
+step:317/1840 train_time:10665ms step_avg:33.64ms
+step:318/1840 train_time:10699ms step_avg:33.64ms
+step:319/1840 train_time:10731ms step_avg:33.64ms
+step:320/1840 train_time:10766ms step_avg:33.64ms
+step:321/1840 train_time:10798ms step_avg:33.64ms
+step:322/1840 train_time:10832ms step_avg:33.64ms
+step:323/1840 train_time:10865ms step_avg:33.64ms
+step:324/1840 train_time:10899ms step_avg:33.64ms
+step:325/1840 train_time:10931ms step_avg:33.63ms
+step:326/1840 train_time:10965ms step_avg:33.63ms
+step:327/1840 train_time:10997ms step_avg:33.63ms
+step:328/1840 train_time:11031ms step_avg:33.63ms
+step:329/1840 train_time:11063ms step_avg:33.63ms
+step:330/1840 train_time:11097ms step_avg:33.63ms
+step:331/1840 train_time:11128ms step_avg:33.62ms
+step:332/1840 train_time:11162ms step_avg:33.62ms
+step:333/1840 train_time:11195ms step_avg:33.62ms
+step:334/1840 train_time:11229ms step_avg:33.62ms
+step:335/1840 train_time:11260ms step_avg:33.61ms
+step:336/1840 train_time:11295ms step_avg:33.61ms
+step:337/1840 train_time:11326ms step_avg:33.61ms
+step:338/1840 train_time:11360ms step_avg:33.61ms
+step:339/1840 train_time:11393ms step_avg:33.61ms
+step:340/1840 train_time:11427ms step_avg:33.61ms
+step:341/1840 train_time:11459ms step_avg:33.60ms
+step:342/1840 train_time:11493ms step_avg:33.61ms
+step:343/1840 train_time:11526ms step_avg:33.60ms
+step:344/1840 train_time:11560ms step_avg:33.60ms
+step:345/1840 train_time:11592ms step_avg:33.60ms
+step:346/1840 train_time:11627ms step_avg:33.60ms
+step:347/1840 train_time:11659ms step_avg:33.60ms
+step:348/1840 train_time:11693ms step_avg:33.60ms
+step:349/1840 train_time:11725ms step_avg:33.60ms
+step:350/1840 train_time:11760ms step_avg:33.60ms
+step:351/1840 train_time:11792ms step_avg:33.59ms
+step:352/1840 train_time:11826ms step_avg:33.60ms
+step:353/1840 train_time:11858ms step_avg:33.59ms
+step:354/1840 train_time:11893ms step_avg:33.60ms
+step:355/1840 train_time:11925ms step_avg:33.59ms
+step:356/1840 train_time:11959ms step_avg:33.59ms
+step:357/1840 train_time:11991ms step_avg:33.59ms
+step:358/1840 train_time:12025ms step_avg:33.59ms
+step:359/1840 train_time:12057ms step_avg:33.58ms
+step:360/1840 train_time:12091ms step_avg:33.59ms
+step:361/1840 train_time:12123ms step_avg:33.58ms
+step:362/1840 train_time:12157ms step_avg:33.58ms
+step:363/1840 train_time:12189ms step_avg:33.58ms
+step:364/1840 train_time:12223ms step_avg:33.58ms
+step:365/1840 train_time:12255ms step_avg:33.57ms
+step:366/1840 train_time:12289ms step_avg:33.58ms
+step:367/1840 train_time:12321ms step_avg:33.57ms
+step:368/1840 train_time:12355ms step_avg:33.57ms
+step:369/1840 train_time:12387ms step_avg:33.57ms
+step:370/1840 train_time:12421ms step_avg:33.57ms
+step:371/1840 train_time:12453ms step_avg:33.56ms
+step:372/1840 train_time:12487ms step_avg:33.57ms
+step:373/1840 train_time:12519ms step_avg:33.56ms
+step:374/1840 train_time:12553ms step_avg:33.56ms
+step:375/1840 train_time:12585ms step_avg:33.56ms
+step:376/1840 train_time:12620ms step_avg:33.56ms
+step:377/1840 train_time:12652ms step_avg:33.56ms
+step:378/1840 train_time:12686ms step_avg:33.56ms
+step:379/1840 train_time:12718ms step_avg:33.56ms
+step:380/1840 train_time:12752ms step_avg:33.56ms
+step:381/1840 train_time:12785ms step_avg:33.56ms
+step:382/1840 train_time:12819ms step_avg:33.56ms
+step:383/1840 train_time:12851ms step_avg:33.55ms
+step:384/1840 train_time:12885ms step_avg:33.56ms
+step:385/1840 train_time:12918ms step_avg:33.55ms
+step:386/1840 train_time:12951ms step_avg:33.55ms
+step:387/1840 train_time:12983ms step_avg:33.55ms
+step:388/1840 train_time:13018ms step_avg:33.55ms
+step:389/1840 train_time:13050ms step_avg:33.55ms
+step:390/1840 train_time:13084ms step_avg:33.55ms
+step:391/1840 train_time:13116ms step_avg:33.54ms
+step:392/1840 train_time:13150ms step_avg:33.55ms
+step:393/1840 train_time:13182ms step_avg:33.54ms
+step:394/1840 train_time:13216ms step_avg:33.54ms
+step:395/1840 train_time:13248ms step_avg:33.54ms
+step:396/1840 train_time:13282ms step_avg:33.54ms
+step:397/1840 train_time:13314ms step_avg:33.54ms
+step:398/1840 train_time:13348ms step_avg:33.54ms
+step:399/1840 train_time:13380ms step_avg:33.53ms
+step:400/1840 train_time:13414ms step_avg:33.53ms
+step:401/1840 train_time:13446ms step_avg:33.53ms
+step:402/1840 train_time:13480ms step_avg:33.53ms
+step:403/1840 train_time:13512ms step_avg:33.53ms
+step:404/1840 train_time:13546ms step_avg:33.53ms
+step:405/1840 train_time:13578ms step_avg:33.53ms
+step:406/1840 train_time:13613ms step_avg:33.53ms
+step:407/1840 train_time:13645ms step_avg:33.53ms
+step:408/1840 train_time:13679ms step_avg:33.53ms
+step:409/1840 train_time:13711ms step_avg:33.52ms
+step:410/1840 train_time:13745ms step_avg:33.52ms
+step:411/1840 train_time:13777ms step_avg:33.52ms
+step:412/1840 train_time:13811ms step_avg:33.52ms
+step:413/1840 train_time:13843ms step_avg:33.52ms
+step:414/1840 train_time:13878ms step_avg:33.52ms
+step:415/1840 train_time:13910ms step_avg:33.52ms
+step:416/1840 train_time:13944ms step_avg:33.52ms
+step:417/1840 train_time:13976ms step_avg:33.52ms
+step:418/1840 train_time:14011ms step_avg:33.52ms
+step:419/1840 train_time:14043ms step_avg:33.51ms
+step:420/1840 train_time:14077ms step_avg:33.52ms
+step:421/1840 train_time:14109ms step_avg:33.51ms
+step:422/1840 train_time:14143ms step_avg:33.51ms
+step:423/1840 train_time:14175ms step_avg:33.51ms
+step:424/1840 train_time:14210ms step_avg:33.51ms
+step:425/1840 train_time:14242ms step_avg:33.51ms
+step:426/1840 train_time:14276ms step_avg:33.51ms
+step:427/1840 train_time:14309ms step_avg:33.51ms
+step:428/1840 train_time:14342ms step_avg:33.51ms
+step:429/1840 train_time:14374ms step_avg:33.51ms
+step:430/1840 train_time:14409ms step_avg:33.51ms
+step:431/1840 train_time:14441ms step_avg:33.51ms
+step:432/1840 train_time:14475ms step_avg:33.51ms
+step:433/1840 train_time:14507ms step_avg:33.50ms
+step:434/1840 train_time:14541ms step_avg:33.51ms
+step:435/1840 train_time:14574ms step_avg:33.50ms
+step:436/1840 train_time:14608ms step_avg:33.50ms
+step:437/1840 train_time:14640ms step_avg:33.50ms
+step:438/1840 train_time:14674ms step_avg:33.50ms
+step:439/1840 train_time:14706ms step_avg:33.50ms
+step:440/1840 train_time:14740ms step_avg:33.50ms
+step:441/1840 train_time:14772ms step_avg:33.50ms
+step:442/1840 train_time:14807ms step_avg:33.50ms
+step:443/1840 train_time:14839ms step_avg:33.50ms
+step:444/1840 train_time:14873ms step_avg:33.50ms
+step:445/1840 train_time:14905ms step_avg:33.50ms
+step:446/1840 train_time:14940ms step_avg:33.50ms
+step:447/1840 train_time:14971ms step_avg:33.49ms
+step:448/1840 train_time:15006ms step_avg:33.50ms
+step:449/1840 train_time:15038ms step_avg:33.49ms
+step:450/1840 train_time:15071ms step_avg:33.49ms
+step:451/1840 train_time:15104ms step_avg:33.49ms
+step:452/1840 train_time:15138ms step_avg:33.49ms
+step:453/1840 train_time:15169ms step_avg:33.49ms
+step:454/1840 train_time:15204ms step_avg:33.49ms
+step:455/1840 train_time:15236ms step_avg:33.48ms
+step:456/1840 train_time:15270ms step_avg:33.49ms
+step:457/1840 train_time:15302ms step_avg:33.48ms
+step:458/1840 train_time:15336ms step_avg:33.48ms
+step:459/1840 train_time:15368ms step_avg:33.48ms
+step:460/1840 train_time:15402ms step_avg:33.48ms
+step:461/1840 train_time:15434ms step_avg:33.48ms
+step:462/1840 train_time:15468ms step_avg:33.48ms
+step:463/1840 train_time:15500ms step_avg:33.48ms
+step:464/1840 train_time:15535ms step_avg:33.48ms
+step:465/1840 train_time:15567ms step_avg:33.48ms
+step:466/1840 train_time:15601ms step_avg:33.48ms
+step:467/1840 train_time:15633ms step_avg:33.48ms
+step:468/1840 train_time:15667ms step_avg:33.48ms
+step:469/1840 train_time:15699ms step_avg:33.47ms
+step:470/1840 train_time:15733ms step_avg:33.47ms
+step:471/1840 train_time:15765ms step_avg:33.47ms
+step:472/1840 train_time:15800ms step_avg:33.47ms
+step:473/1840 train_time:15832ms step_avg:33.47ms
+step:474/1840 train_time:15866ms step_avg:33.47ms
+step:475/1840 train_time:15898ms step_avg:33.47ms
+step:476/1840 train_time:15932ms step_avg:33.47ms
+step:477/1840 train_time:15964ms step_avg:33.47ms
+step:478/1840 train_time:15999ms step_avg:33.47ms
+step:479/1840 train_time:16031ms step_avg:33.47ms
+step:480/1840 train_time:16065ms step_avg:33.47ms
+step:481/1840 train_time:16097ms step_avg:33.47ms
+step:482/1840 train_time:16131ms step_avg:33.47ms
+step:483/1840 train_time:16163ms step_avg:33.46ms
+step:484/1840 train_time:16198ms step_avg:33.47ms
+step:485/1840 train_time:16230ms step_avg:33.46ms
+step:486/1840 train_time:16264ms step_avg:33.46ms
+step:487/1840 train_time:16296ms step_avg:33.46ms
+step:488/1840 train_time:16330ms step_avg:33.46ms
+step:489/1840 train_time:16363ms step_avg:33.46ms
+step:490/1840 train_time:16396ms step_avg:33.46ms
+step:491/1840 train_time:16429ms step_avg:33.46ms
+step:492/1840 train_time:16463ms step_avg:33.46ms
+step:493/1840 train_time:16495ms step_avg:33.46ms
+step:494/1840 train_time:16529ms step_avg:33.46ms
+step:495/1840 train_time:16561ms step_avg:33.46ms
+step:496/1840 train_time:16595ms step_avg:33.46ms
+step:497/1840 train_time:16627ms step_avg:33.46ms
+step:498/1840 train_time:16661ms step_avg:33.46ms
+step:499/1840 train_time:16694ms step_avg:33.45ms
+step:500/1840 train_time:16728ms step_avg:33.46ms
+step:500/1840 val_loss:4.2844 train_time:16770ms step_avg:33.54ms
+step:501/1840 train_time:16790ms step_avg:33.51ms
+step:502/1840 train_time:16808ms step_avg:33.48ms
+step:503/1840 train_time:16829ms step_avg:33.46ms
+step:504/1840 train_time:16864ms step_avg:33.46ms
+step:505/1840 train_time:16897ms step_avg:33.46ms
+step:506/1840 train_time:16932ms step_avg:33.46ms
+step:507/1840 train_time:16964ms step_avg:33.46ms
+step:508/1840 train_time:16998ms step_avg:33.46ms
+step:509/1840 train_time:17030ms step_avg:33.46ms
+step:510/1840 train_time:17065ms step_avg:33.46ms
+step:511/1840 train_time:17097ms step_avg:33.46ms
+step:512/1840 train_time:17131ms step_avg:33.46ms
+step:513/1840 train_time:17163ms step_avg:33.46ms
+step:514/1840 train_time:17197ms step_avg:33.46ms
+step:515/1840 train_time:17228ms step_avg:33.45ms
+step:516/1840 train_time:17262ms step_avg:33.45ms
+step:517/1840 train_time:17294ms step_avg:33.45ms
+step:518/1840 train_time:17328ms step_avg:33.45ms
+step:519/1840 train_time:17360ms step_avg:33.45ms
+step:520/1840 train_time:17394ms step_avg:33.45ms
+step:521/1840 train_time:17426ms step_avg:33.45ms
+step:522/1840 train_time:17460ms step_avg:33.45ms
+step:523/1840 train_time:17492ms step_avg:33.45ms
+step:524/1840 train_time:17526ms step_avg:33.45ms
+step:525/1840 train_time:17559ms step_avg:33.44ms
+step:526/1840 train_time:17592ms step_avg:33.45ms
+step:527/1840 train_time:17624ms step_avg:33.44ms
+step:528/1840 train_time:17659ms step_avg:33.45ms
+step:529/1840 train_time:17691ms step_avg:33.44ms
+step:530/1840 train_time:17726ms step_avg:33.44ms
+step:531/1840 train_time:17758ms step_avg:33.44ms
+step:532/1840 train_time:17792ms step_avg:33.44ms
+step:533/1840 train_time:17825ms step_avg:33.44ms
+step:534/1840 train_time:17859ms step_avg:33.44ms
+step:535/1840 train_time:17891ms step_avg:33.44ms
+step:536/1840 train_time:17926ms step_avg:33.44ms
+step:537/1840 train_time:17958ms step_avg:33.44ms
+step:538/1840 train_time:17992ms step_avg:33.44ms
+step:539/1840 train_time:18025ms step_avg:33.44ms
+step:540/1840 train_time:18059ms step_avg:33.44ms
+step:541/1840 train_time:18091ms step_avg:33.44ms
+step:542/1840 train_time:18125ms step_avg:33.44ms
+step:543/1840 train_time:18158ms step_avg:33.44ms
+step:544/1840 train_time:18192ms step_avg:33.44ms
+step:545/1840 train_time:18224ms step_avg:33.44ms
+step:546/1840 train_time:18259ms step_avg:33.44ms
+step:547/1840 train_time:18291ms step_avg:33.44ms
+step:548/1840 train_time:18325ms step_avg:33.44ms
+step:549/1840 train_time:18357ms step_avg:33.44ms
+step:550/1840 train_time:18391ms step_avg:33.44ms
+step:551/1840 train_time:18423ms step_avg:33.44ms
+step:552/1840 train_time:18457ms step_avg:33.44ms
+step:553/1840 train_time:18489ms step_avg:33.43ms
+step:554/1840 train_time:18523ms step_avg:33.43ms
+step:555/1840 train_time:18555ms step_avg:33.43ms
+step:556/1840 train_time:18589ms step_avg:33.43ms
+step:557/1840 train_time:18621ms step_avg:33.43ms
+step:558/1840 train_time:18656ms step_avg:33.43ms
+step:559/1840 train_time:18688ms step_avg:33.43ms
+step:560/1840 train_time:18722ms step_avg:33.43ms
+step:561/1840 train_time:18754ms step_avg:33.43ms
+step:562/1840 train_time:18789ms step_avg:33.43ms
+step:563/1840 train_time:18821ms step_avg:33.43ms
+step:564/1840 train_time:18855ms step_avg:33.43ms
+step:565/1840 train_time:18887ms step_avg:33.43ms
+step:566/1840 train_time:18922ms step_avg:33.43ms
+step:567/1840 train_time:18954ms step_avg:33.43ms
+step:568/1840 train_time:18989ms step_avg:33.43ms
+step:569/1840 train_time:19021ms step_avg:33.43ms
+step:570/1840 train_time:19055ms step_avg:33.43ms
+step:571/1840 train_time:19087ms step_avg:33.43ms
+step:572/1840 train_time:19121ms step_avg:33.43ms
+step:573/1840 train_time:19153ms step_avg:33.43ms
+step:574/1840 train_time:19187ms step_avg:33.43ms
+step:575/1840 train_time:19219ms step_avg:33.42ms
+step:576/1840 train_time:19253ms step_avg:33.43ms
+step:577/1840 train_time:19286ms step_avg:33.42ms
+step:578/1840 train_time:19319ms step_avg:33.42ms
+step:579/1840 train_time:19351ms step_avg:33.42ms
+step:580/1840 train_time:19386ms step_avg:33.42ms
+step:581/1840 train_time:19418ms step_avg:33.42ms
+step:582/1840 train_time:19452ms step_avg:33.42ms
+step:583/1840 train_time:19484ms step_avg:33.42ms
+step:584/1840 train_time:19518ms step_avg:33.42ms
+step:585/1840 train_time:19550ms step_avg:33.42ms
+step:586/1840 train_time:19584ms step_avg:33.42ms
+step:587/1840 train_time:19616ms step_avg:33.42ms
+step:588/1840 train_time:19650ms step_avg:33.42ms
+step:589/1840 train_time:19682ms step_avg:33.42ms
+step:590/1840 train_time:19716ms step_avg:33.42ms
+step:591/1840 train_time:19748ms step_avg:33.41ms
+step:592/1840 train_time:19783ms step_avg:33.42ms
+step:593/1840 train_time:19815ms step_avg:33.41ms
+step:594/1840 train_time:19849ms step_avg:33.42ms
+step:595/1840 train_time:19881ms step_avg:33.41ms
+step:596/1840 train_time:19916ms step_avg:33.42ms
+step:597/1840 train_time:19949ms step_avg:33.41ms
+step:598/1840 train_time:19983ms step_avg:33.42ms
+step:599/1840 train_time:20015ms step_avg:33.41ms
+step:600/1840 train_time:20049ms step_avg:33.41ms
+step:601/1840 train_time:20084ms step_avg:33.42ms
+step:602/1840 train_time:20142ms step_avg:33.46ms
+step:603/1840 train_time:20202ms step_avg:33.50ms
+step:604/1840 train_time:20264ms step_avg:33.55ms
+step:605/1840 train_time:20324ms step_avg:33.59ms
+step:606/1840 train_time:20386ms step_avg:33.64ms
+step:607/1840 train_time:20446ms step_avg:33.68ms
+step:608/1840 train_time:20507ms step_avg:33.73ms
+step:609/1840 train_time:20567ms step_avg:33.77ms
+step:610/1840 train_time:20629ms step_avg:33.82ms
+step:611/1840 train_time:20689ms step_avg:33.86ms
+step:612/1840 train_time:20751ms step_avg:33.91ms
+step:613/1840 train_time:20810ms step_avg:33.95ms
+step:614/1840 train_time:20873ms step_avg:34.00ms
+step:615/1840 train_time:20933ms step_avg:34.04ms
+step:616/1840 train_time:20996ms step_avg:34.08ms
+step:617/1840 train_time:21054ms step_avg:34.12ms
+step:618/1840 train_time:21117ms step_avg:34.17ms
+step:619/1840 train_time:21176ms step_avg:34.21ms
+step:620/1840 train_time:21238ms step_avg:34.26ms
+step:621/1840 train_time:21299ms step_avg:34.30ms
+step:622/1840 train_time:21362ms step_avg:34.34ms
+step:623/1840 train_time:21421ms step_avg:34.38ms
+step:624/1840 train_time:21483ms step_avg:34.43ms
+step:625/1840 train_time:21543ms step_avg:34.47ms
+step:626/1840 train_time:21606ms step_avg:34.51ms
+step:627/1840 train_time:21667ms step_avg:34.56ms
+step:628/1840 train_time:21729ms step_avg:34.60ms
+step:629/1840 train_time:21788ms step_avg:34.64ms
+step:630/1840 train_time:21850ms step_avg:34.68ms
+step:631/1840 train_time:21911ms step_avg:34.72ms
+step:632/1840 train_time:21972ms step_avg:34.77ms
+step:633/1840 train_time:22031ms step_avg:34.80ms
+step:634/1840 train_time:22093ms step_avg:34.85ms
+step:635/1840 train_time:22153ms step_avg:34.89ms
+step:636/1840 train_time:22215ms step_avg:34.93ms
+step:637/1840 train_time:22275ms step_avg:34.97ms
+step:638/1840 train_time:22338ms step_avg:35.01ms
+step:639/1840 train_time:22398ms step_avg:35.05ms
+step:640/1840 train_time:22460ms step_avg:35.09ms
+step:641/1840 train_time:22520ms step_avg:35.13ms
+step:642/1840 train_time:22583ms step_avg:35.18ms
+step:643/1840 train_time:22643ms step_avg:35.21ms
+step:644/1840 train_time:22705ms step_avg:35.26ms
+step:645/1840 train_time:22765ms step_avg:35.29ms
+step:646/1840 train_time:22828ms step_avg:35.34ms
+step:647/1840 train_time:22888ms step_avg:35.38ms
+step:648/1840 train_time:22950ms step_avg:35.42ms
+step:649/1840 train_time:23010ms step_avg:35.45ms
+step:650/1840 train_time:23073ms step_avg:35.50ms
+step:651/1840 train_time:23133ms step_avg:35.53ms
+step:652/1840 train_time:23194ms step_avg:35.57ms
+step:653/1840 train_time:23254ms step_avg:35.61ms
+step:654/1840 train_time:23317ms step_avg:35.65ms
+step:655/1840 train_time:23377ms step_avg:35.69ms
+step:656/1840 train_time:23440ms step_avg:35.73ms
+step:657/1840 train_time:23499ms step_avg:35.77ms
+step:658/1840 train_time:23562ms step_avg:35.81ms
+step:659/1840 train_time:23622ms step_avg:35.85ms
+step:660/1840 train_time:23684ms step_avg:35.88ms
+step:661/1840 train_time:23744ms step_avg:35.92ms
+step:662/1840 train_time:23806ms step_avg:35.96ms
+step:663/1840 train_time:23866ms step_avg:36.00ms
+step:664/1840 train_time:23929ms step_avg:36.04ms
+step:665/1840 train_time:23989ms step_avg:36.07ms
+step:666/1840 train_time:24051ms step_avg:36.11ms
+step:667/1840 train_time:24110ms step_avg:36.15ms
+step:668/1840 train_time:24173ms step_avg:36.19ms
+step:669/1840 train_time:24233ms step_avg:36.22ms
+step:670/1840 train_time:24295ms step_avg:36.26ms
+step:671/1840 train_time:24354ms step_avg:36.30ms
+step:672/1840 train_time:24417ms step_avg:36.33ms
+step:673/1840 train_time:24477ms step_avg:36.37ms
+step:674/1840 train_time:24540ms step_avg:36.41ms
+step:675/1840 train_time:24599ms step_avg:36.44ms
+step:676/1840 train_time:24661ms step_avg:36.48ms
+step:677/1840 train_time:24721ms step_avg:36.52ms
+step:678/1840 train_time:24784ms step_avg:36.55ms
+step:679/1840 train_time:24844ms step_avg:36.59ms
+step:680/1840 train_time:24906ms step_avg:36.63ms
+step:681/1840 train_time:24966ms step_avg:36.66ms
+step:682/1840 train_time:25028ms step_avg:36.70ms
+step:683/1840 train_time:25088ms step_avg:36.73ms
+step:684/1840 train_time:25150ms step_avg:36.77ms
+step:685/1840 train_time:25211ms step_avg:36.80ms
+step:686/1840 train_time:25272ms step_avg:36.84ms
+step:687/1840 train_time:25332ms step_avg:36.87ms
+step:688/1840 train_time:25395ms step_avg:36.91ms
+step:689/1840 train_time:25454ms step_avg:36.94ms
+step:690/1840 train_time:25516ms step_avg:36.98ms
+step:691/1840 train_time:25576ms step_avg:37.01ms
+step:692/1840 train_time:25638ms step_avg:37.05ms
+step:693/1840 train_time:25698ms step_avg:37.08ms
+step:694/1840 train_time:25761ms step_avg:37.12ms
+step:695/1840 train_time:25821ms step_avg:37.15ms
+step:696/1840 train_time:25884ms step_avg:37.19ms
+step:697/1840 train_time:25944ms step_avg:37.22ms
+step:698/1840 train_time:26007ms step_avg:37.26ms
+step:699/1840 train_time:26067ms step_avg:37.29ms
+step:700/1840 train_time:26130ms step_avg:37.33ms
+step:701/1840 train_time:26190ms step_avg:37.36ms
+step:702/1840 train_time:26252ms step_avg:37.40ms
+step:703/1840 train_time:26311ms step_avg:37.43ms
+step:704/1840 train_time:26373ms step_avg:37.46ms
+step:705/1840 train_time:26432ms step_avg:37.49ms
+step:706/1840 train_time:26495ms step_avg:37.53ms
+step:707/1840 train_time:26555ms step_avg:37.56ms
+step:708/1840 train_time:26617ms step_avg:37.59ms
+step:709/1840 train_time:26676ms step_avg:37.63ms
+step:710/1840 train_time:26739ms step_avg:37.66ms
+step:711/1840 train_time:26799ms step_avg:37.69ms
+step:712/1840 train_time:26861ms step_avg:37.73ms
+step:713/1840 train_time:26921ms step_avg:37.76ms
+step:714/1840 train_time:26983ms step_avg:37.79ms
+step:715/1840 train_time:27043ms step_avg:37.82ms
+step:716/1840 train_time:27107ms step_avg:37.86ms
+step:717/1840 train_time:27167ms step_avg:37.89ms
+step:718/1840 train_time:27230ms step_avg:37.92ms
+step:719/1840 train_time:27289ms step_avg:37.95ms
+step:720/1840 train_time:27351ms step_avg:37.99ms
+step:721/1840 train_time:27411ms step_avg:38.02ms
+step:722/1840 train_time:27474ms step_avg:38.05ms
+step:723/1840 train_time:27533ms step_avg:38.08ms
+step:724/1840 train_time:27595ms step_avg:38.12ms
+step:725/1840 train_time:27655ms step_avg:38.14ms
+step:726/1840 train_time:27718ms step_avg:38.18ms
+step:727/1840 train_time:27777ms step_avg:38.21ms
+step:728/1840 train_time:27840ms step_avg:38.24ms
+step:729/1840 train_time:27900ms step_avg:38.27ms
+step:730/1840 train_time:27963ms step_avg:38.31ms
+step:731/1840 train_time:28023ms step_avg:38.34ms
+step:732/1840 train_time:28086ms step_avg:38.37ms
+step:733/1840 train_time:28146ms step_avg:38.40ms
+step:734/1840 train_time:28208ms step_avg:38.43ms
+step:735/1840 train_time:28268ms step_avg:38.46ms
+step:736/1840 train_time:28330ms step_avg:38.49ms
+step:737/1840 train_time:28390ms step_avg:38.52ms
+step:738/1840 train_time:28452ms step_avg:38.55ms
+step:739/1840 train_time:28511ms step_avg:38.58ms
+step:740/1840 train_time:28574ms step_avg:38.61ms
+step:741/1840 train_time:28633ms step_avg:38.64ms
+step:742/1840 train_time:28697ms step_avg:38.67ms
+step:743/1840 train_time:28756ms step_avg:38.70ms
+step:744/1840 train_time:28819ms step_avg:38.74ms
+step:745/1840 train_time:28878ms step_avg:38.76ms
+step:746/1840 train_time:28941ms step_avg:38.79ms
+step:747/1840 train_time:29001ms step_avg:38.82ms
+step:748/1840 train_time:29064ms step_avg:38.86ms
+step:749/1840 train_time:29123ms step_avg:38.88ms
+step:750/1840 train_time:29186ms step_avg:38.91ms
+step:750/1840 val_loss:4.0142 train_time:29258ms step_avg:39.01ms
+step:751/1840 train_time:29277ms step_avg:38.98ms
+step:752/1840 train_time:29310ms step_avg:38.98ms
+step:753/1840 train_time:29373ms step_avg:39.01ms
+step:754/1840 train_time:29435ms step_avg:39.04ms
+step:755/1840 train_time:29495ms step_avg:39.07ms
+step:756/1840 train_time:29557ms step_avg:39.10ms
+step:757/1840 train_time:29616ms step_avg:39.12ms
+step:758/1840 train_time:29678ms step_avg:39.15ms
+step:759/1840 train_time:29736ms step_avg:39.18ms
+step:760/1840 train_time:29798ms step_avg:39.21ms
+step:761/1840 train_time:29857ms step_avg:39.23ms
+step:762/1840 train_time:29919ms step_avg:39.26ms
+step:763/1840 train_time:29978ms step_avg:39.29ms
+step:764/1840 train_time:30040ms step_avg:39.32ms
+step:765/1840 train_time:30100ms step_avg:39.35ms
+step:766/1840 train_time:30162ms step_avg:39.38ms
+step:767/1840 train_time:30226ms step_avg:39.41ms
+step:768/1840 train_time:30290ms step_avg:39.44ms
+step:769/1840 train_time:30351ms step_avg:39.47ms
+step:770/1840 train_time:30414ms step_avg:39.50ms
+step:771/1840 train_time:30474ms step_avg:39.53ms
+step:772/1840 train_time:30537ms step_avg:39.56ms
+step:773/1840 train_time:30596ms step_avg:39.58ms
+step:774/1840 train_time:30658ms step_avg:39.61ms
+step:775/1840 train_time:30718ms step_avg:39.64ms
+step:776/1840 train_time:30780ms step_avg:39.66ms
+step:777/1840 train_time:30838ms step_avg:39.69ms
+step:778/1840 train_time:30900ms step_avg:39.72ms
+step:779/1840 train_time:30959ms step_avg:39.74ms
+step:780/1840 train_time:31021ms step_avg:39.77ms
+step:781/1840 train_time:31081ms step_avg:39.80ms
+step:782/1840 train_time:31143ms step_avg:39.82ms
+step:783/1840 train_time:31204ms step_avg:39.85ms
+step:784/1840 train_time:31268ms step_avg:39.88ms
+step:785/1840 train_time:31328ms step_avg:39.91ms
+step:786/1840 train_time:31391ms step_avg:39.94ms
+step:787/1840 train_time:31451ms step_avg:39.96ms
+step:788/1840 train_time:31513ms step_avg:39.99ms
+step:789/1840 train_time:31573ms step_avg:40.02ms
+step:790/1840 train_time:31635ms step_avg:40.04ms
+step:791/1840 train_time:31695ms step_avg:40.07ms
+step:792/1840 train_time:31757ms step_avg:40.10ms
+step:793/1840 train_time:31817ms step_avg:40.12ms
+step:794/1840 train_time:31878ms step_avg:40.15ms
+step:795/1840 train_time:31938ms step_avg:40.17ms
+step:796/1840 train_time:31999ms step_avg:40.20ms
+step:797/1840 train_time:32059ms step_avg:40.22ms
+step:798/1840 train_time:32121ms step_avg:40.25ms
+step:799/1840 train_time:32181ms step_avg:40.28ms
+step:800/1840 train_time:32244ms step_avg:40.31ms
+step:801/1840 train_time:32304ms step_avg:40.33ms
+step:802/1840 train_time:32367ms step_avg:40.36ms
+step:803/1840 train_time:32428ms step_avg:40.38ms
+step:804/1840 train_time:32490ms step_avg:40.41ms
+step:805/1840 train_time:32549ms step_avg:40.43ms
+step:806/1840 train_time:32612ms step_avg:40.46ms
+step:807/1840 train_time:32671ms step_avg:40.48ms
+step:808/1840 train_time:32734ms step_avg:40.51ms
+step:809/1840 train_time:32793ms step_avg:40.54ms
+step:810/1840 train_time:32855ms step_avg:40.56ms
+step:811/1840 train_time:32915ms step_avg:40.59ms
+step:812/1840 train_time:32978ms step_avg:40.61ms
+step:813/1840 train_time:33037ms step_avg:40.64ms
+step:814/1840 train_time:33100ms step_avg:40.66ms
+step:815/1840 train_time:33159ms step_avg:40.69ms
+step:816/1840 train_time:33222ms step_avg:40.71ms
+step:817/1840 train_time:33282ms step_avg:40.74ms
+step:818/1840 train_time:33345ms step_avg:40.76ms
+step:819/1840 train_time:33405ms step_avg:40.79ms
+step:820/1840 train_time:33467ms step_avg:40.81ms
+step:821/1840 train_time:33528ms step_avg:40.84ms
+step:822/1840 train_time:33590ms step_avg:40.86ms
+step:823/1840 train_time:33650ms step_avg:40.89ms
+step:824/1840 train_time:33712ms step_avg:40.91ms
+step:825/1840 train_time:33772ms step_avg:40.94ms
+step:826/1840 train_time:33835ms step_avg:40.96ms
+step:827/1840 train_time:33894ms step_avg:40.98ms
+step:828/1840 train_time:33956ms step_avg:41.01ms
+step:829/1840 train_time:34016ms step_avg:41.03ms
+step:830/1840 train_time:34078ms step_avg:41.06ms
+step:831/1840 train_time:34139ms step_avg:41.08ms
+step:832/1840 train_time:34202ms step_avg:41.11ms
+step:833/1840 train_time:34261ms step_avg:41.13ms
+step:834/1840 train_time:34324ms step_avg:41.16ms
+step:835/1840 train_time:34384ms step_avg:41.18ms
+step:836/1840 train_time:34446ms step_avg:41.20ms
+step:837/1840 train_time:34505ms step_avg:41.22ms
+step:838/1840 train_time:34567ms step_avg:41.25ms
+step:839/1840 train_time:34628ms step_avg:41.27ms
+step:840/1840 train_time:34690ms step_avg:41.30ms
+step:841/1840 train_time:34750ms step_avg:41.32ms
+step:842/1840 train_time:34812ms step_avg:41.34ms
+step:843/1840 train_time:34872ms step_avg:41.37ms
+step:844/1840 train_time:34934ms step_avg:41.39ms
+step:845/1840 train_time:34993ms step_avg:41.41ms
+step:846/1840 train_time:35055ms step_avg:41.44ms
+step:847/1840 train_time:35115ms step_avg:41.46ms
+step:848/1840 train_time:35178ms step_avg:41.48ms
+step:849/1840 train_time:35239ms step_avg:41.51ms
+step:850/1840 train_time:35302ms step_avg:41.53ms
+step:851/1840 train_time:35362ms step_avg:41.55ms
+step:852/1840 train_time:35423ms step_avg:41.58ms
+step:853/1840 train_time:35484ms step_avg:41.60ms
+step:854/1840 train_time:35545ms step_avg:41.62ms
+step:855/1840 train_time:35605ms step_avg:41.64ms
+step:856/1840 train_time:35668ms step_avg:41.67ms
+step:857/1840 train_time:35728ms step_avg:41.69ms
+step:858/1840 train_time:35791ms step_avg:41.71ms
+step:859/1840 train_time:35850ms step_avg:41.74ms
+step:860/1840 train_time:35913ms step_avg:41.76ms
+step:861/1840 train_time:35973ms step_avg:41.78ms
+step:862/1840 train_time:36036ms step_avg:41.80ms
+step:863/1840 train_time:36095ms step_avg:41.83ms
+step:864/1840 train_time:36157ms step_avg:41.85ms
+step:865/1840 train_time:36217ms step_avg:41.87ms
+step:866/1840 train_time:36280ms step_avg:41.89ms
+step:867/1840 train_time:36340ms step_avg:41.91ms
+step:868/1840 train_time:36402ms step_avg:41.94ms
+step:869/1840 train_time:36461ms step_avg:41.96ms
+step:870/1840 train_time:36524ms step_avg:41.98ms
+step:871/1840 train_time:36584ms step_avg:42.00ms
+step:872/1840 train_time:36646ms step_avg:42.03ms
+step:873/1840 train_time:36705ms step_avg:42.04ms
+step:874/1840 train_time:36768ms step_avg:42.07ms
+step:875/1840 train_time:36828ms step_avg:42.09ms
+step:876/1840 train_time:36891ms step_avg:42.11ms
+step:877/1840 train_time:36950ms step_avg:42.13ms
+step:878/1840 train_time:37013ms step_avg:42.16ms
+step:879/1840 train_time:37073ms step_avg:42.18ms
+step:880/1840 train_time:37134ms step_avg:42.20ms
+step:881/1840 train_time:37194ms step_avg:42.22ms
+step:882/1840 train_time:37257ms step_avg:42.24ms
+step:883/1840 train_time:37317ms step_avg:42.26ms
+step:884/1840 train_time:37379ms step_avg:42.28ms
+step:885/1840 train_time:37440ms step_avg:42.30ms
+step:886/1840 train_time:37503ms step_avg:42.33ms
+step:887/1840 train_time:37562ms step_avg:42.35ms
+step:888/1840 train_time:37624ms step_avg:42.37ms
+step:889/1840 train_time:37684ms step_avg:42.39ms
+step:890/1840 train_time:37746ms step_avg:42.41ms
+step:891/1840 train_time:37805ms step_avg:42.43ms
+step:892/1840 train_time:37869ms step_avg:42.45ms
+step:893/1840 train_time:37929ms step_avg:42.47ms
+step:894/1840 train_time:37992ms step_avg:42.50ms
+step:895/1840 train_time:38051ms step_avg:42.52ms
+step:896/1840 train_time:38113ms step_avg:42.54ms
+step:897/1840 train_time:38174ms step_avg:42.56ms
+step:898/1840 train_time:38236ms step_avg:42.58ms
+step:899/1840 train_time:38296ms step_avg:42.60ms
+step:900/1840 train_time:38359ms step_avg:42.62ms
+step:901/1840 train_time:38418ms step_avg:42.64ms
+step:902/1840 train_time:38481ms step_avg:42.66ms
+step:903/1840 train_time:38540ms step_avg:42.68ms
+step:904/1840 train_time:38602ms step_avg:42.70ms
+step:905/1840 train_time:38662ms step_avg:42.72ms
+step:906/1840 train_time:38726ms step_avg:42.74ms
+step:907/1840 train_time:38785ms step_avg:42.76ms
+step:908/1840 train_time:38848ms step_avg:42.78ms
+step:909/1840 train_time:38908ms step_avg:42.80ms
+step:910/1840 train_time:38970ms step_avg:42.82ms
+step:911/1840 train_time:39030ms step_avg:42.84ms
+step:912/1840 train_time:39092ms step_avg:42.86ms
+step:913/1840 train_time:39152ms step_avg:42.88ms
+step:914/1840 train_time:39215ms step_avg:42.90ms
+step:915/1840 train_time:39275ms step_avg:42.92ms
+step:916/1840 train_time:39337ms step_avg:42.94ms
+step:917/1840 train_time:39398ms step_avg:42.96ms
+step:918/1840 train_time:39460ms step_avg:42.98ms
+step:919/1840 train_time:39521ms step_avg:43.00ms
+step:920/1840 train_time:39583ms step_avg:43.02ms
+step:921/1840 train_time:39642ms step_avg:43.04ms
+step:922/1840 train_time:39705ms step_avg:43.06ms
+step:923/1840 train_time:39764ms step_avg:43.08ms
+step:924/1840 train_time:39827ms step_avg:43.10ms
+step:925/1840 train_time:39886ms step_avg:43.12ms
+step:926/1840 train_time:39948ms step_avg:43.14ms
+step:927/1840 train_time:40008ms step_avg:43.16ms
+step:928/1840 train_time:40070ms step_avg:43.18ms
+step:929/1840 train_time:40131ms step_avg:43.20ms
+step:930/1840 train_time:40193ms step_avg:43.22ms
+step:931/1840 train_time:40253ms step_avg:43.24ms
+step:932/1840 train_time:40316ms step_avg:43.26ms
+step:933/1840 train_time:40375ms step_avg:43.27ms
+step:934/1840 train_time:40439ms step_avg:43.30ms
+step:935/1840 train_time:40499ms step_avg:43.31ms
+step:936/1840 train_time:40561ms step_avg:43.33ms
+step:937/1840 train_time:40621ms step_avg:43.35ms
+step:938/1840 train_time:40682ms step_avg:43.37ms
+step:939/1840 train_time:40743ms step_avg:43.39ms
+step:940/1840 train_time:40804ms step_avg:43.41ms
+step:941/1840 train_time:40865ms step_avg:43.43ms
+step:942/1840 train_time:40926ms step_avg:43.45ms
+step:943/1840 train_time:40986ms step_avg:43.46ms
+step:944/1840 train_time:41050ms step_avg:43.48ms
+step:945/1840 train_time:41109ms step_avg:43.50ms
+step:946/1840 train_time:41172ms step_avg:43.52ms
+step:947/1840 train_time:41231ms step_avg:43.54ms
+step:948/1840 train_time:41293ms step_avg:43.56ms
+step:949/1840 train_time:41353ms step_avg:43.58ms
+step:950/1840 train_time:41416ms step_avg:43.60ms
+step:951/1840 train_time:41476ms step_avg:43.61ms
+step:952/1840 train_time:41538ms step_avg:43.63ms
+step:953/1840 train_time:41599ms step_avg:43.65ms
+step:954/1840 train_time:41662ms step_avg:43.67ms
+step:955/1840 train_time:41722ms step_avg:43.69ms
+step:956/1840 train_time:41784ms step_avg:43.71ms
+step:957/1840 train_time:41843ms step_avg:43.72ms
+step:958/1840 train_time:41906ms step_avg:43.74ms
+step:959/1840 train_time:41965ms step_avg:43.76ms
+step:960/1840 train_time:42028ms step_avg:43.78ms
+step:961/1840 train_time:42088ms step_avg:43.80ms
+step:962/1840 train_time:42151ms step_avg:43.82ms
+step:963/1840 train_time:42210ms step_avg:43.83ms
+step:964/1840 train_time:42272ms step_avg:43.85ms
+step:965/1840 train_time:42333ms step_avg:43.87ms
+step:966/1840 train_time:42395ms step_avg:43.89ms
+step:967/1840 train_time:42454ms step_avg:43.90ms
+step:968/1840 train_time:42516ms step_avg:43.92ms
+step:969/1840 train_time:42576ms step_avg:43.94ms
+step:970/1840 train_time:42638ms step_avg:43.96ms
+step:971/1840 train_time:42698ms step_avg:43.97ms
+step:972/1840 train_time:42760ms step_avg:43.99ms
+step:973/1840 train_time:42821ms step_avg:44.01ms
+step:974/1840 train_time:42883ms step_avg:44.03ms
+step:975/1840 train_time:42944ms step_avg:44.04ms
+step:976/1840 train_time:43006ms step_avg:44.06ms
+step:977/1840 train_time:43065ms step_avg:44.08ms
+step:978/1840 train_time:43128ms step_avg:44.10ms
+step:979/1840 train_time:43188ms step_avg:44.11ms
+step:980/1840 train_time:43252ms step_avg:44.13ms
+step:981/1840 train_time:43312ms step_avg:44.15ms
+step:982/1840 train_time:43375ms step_avg:44.17ms
+step:983/1840 train_time:43435ms step_avg:44.19ms
+step:984/1840 train_time:43497ms step_avg:44.20ms
+step:985/1840 train_time:43557ms step_avg:44.22ms
+step:986/1840 train_time:43619ms step_avg:44.24ms
+step:987/1840 train_time:43679ms step_avg:44.25ms
+step:988/1840 train_time:43741ms step_avg:44.27ms
+step:989/1840 train_time:43801ms step_avg:44.29ms
+step:990/1840 train_time:43863ms step_avg:44.31ms
+step:991/1840 train_time:43924ms step_avg:44.32ms
+step:992/1840 train_time:43985ms step_avg:44.34ms
+step:993/1840 train_time:44046ms step_avg:44.36ms
+step:994/1840 train_time:44108ms step_avg:44.37ms
+step:995/1840 train_time:44168ms step_avg:44.39ms
+step:996/1840 train_time:44231ms step_avg:44.41ms
+step:997/1840 train_time:44291ms step_avg:44.42ms
+step:998/1840 train_time:44352ms step_avg:44.44ms
+step:999/1840 train_time:44414ms step_avg:44.46ms
+step:1000/1840 train_time:44476ms step_avg:44.48ms
+step:1000/1840 val_loss:3.7707 train_time:44547ms step_avg:44.55ms
+step:1001/1840 train_time:44566ms step_avg:44.52ms
+step:1002/1840 train_time:44599ms step_avg:44.51ms
+step:1003/1840 train_time:44659ms step_avg:44.53ms
+step:1004/1840 train_time:44722ms step_avg:44.54ms
+step:1005/1840 train_time:44782ms step_avg:44.56ms
+step:1006/1840 train_time:44845ms step_avg:44.58ms
+step:1007/1840 train_time:44904ms step_avg:44.59ms
+step:1008/1840 train_time:44966ms step_avg:44.61ms
+step:1009/1840 train_time:45025ms step_avg:44.62ms
+step:1010/1840 train_time:45086ms step_avg:44.64ms
+step:1011/1840 train_time:45145ms step_avg:44.65ms
+step:1012/1840 train_time:45207ms step_avg:44.67ms
+step:1013/1840 train_time:45266ms step_avg:44.68ms
+step:1014/1840 train_time:45327ms step_avg:44.70ms
+step:1015/1840 train_time:45386ms step_avg:44.72ms
+step:1016/1840 train_time:45448ms step_avg:44.73ms
+step:1017/1840 train_time:45509ms step_avg:44.75ms
+step:1018/1840 train_time:45572ms step_avg:44.77ms
+step:1019/1840 train_time:45634ms step_avg:44.78ms
+step:1020/1840 train_time:45698ms step_avg:44.80ms
+step:1021/1840 train_time:45757ms step_avg:44.82ms
+step:1022/1840 train_time:45819ms step_avg:44.83ms
+step:1023/1840 train_time:45878ms step_avg:44.85ms
+step:1024/1840 train_time:45940ms step_avg:44.86ms
+step:1025/1840 train_time:45999ms step_avg:44.88ms
+step:1026/1840 train_time:46061ms step_avg:44.89ms
+step:1027/1840 train_time:46120ms step_avg:44.91ms
+step:1028/1840 train_time:46182ms step_avg:44.92ms
+step:1029/1840 train_time:46241ms step_avg:44.94ms
+step:1030/1840 train_time:46303ms step_avg:44.95ms
+step:1031/1840 train_time:46363ms step_avg:44.97ms
+step:1032/1840 train_time:46425ms step_avg:44.99ms
+step:1033/1840 train_time:46484ms step_avg:45.00ms
+step:1034/1840 train_time:46548ms step_avg:45.02ms
+step:1035/1840 train_time:46608ms step_avg:45.03ms
+step:1036/1840 train_time:46671ms step_avg:45.05ms
+step:1037/1840 train_time:46732ms step_avg:45.06ms
+step:1038/1840 train_time:46794ms step_avg:45.08ms
+step:1039/1840 train_time:46854ms step_avg:45.09ms
+step:1040/1840 train_time:46916ms step_avg:45.11ms
+step:1041/1840 train_time:46976ms step_avg:45.13ms
+step:1042/1840 train_time:47037ms step_avg:45.14ms
+step:1043/1840 train_time:47096ms step_avg:45.15ms
+step:1044/1840 train_time:47159ms step_avg:45.17ms
+step:1045/1840 train_time:47218ms step_avg:45.18ms
+step:1046/1840 train_time:47280ms step_avg:45.20ms
+step:1047/1840 train_time:47340ms step_avg:45.21ms
+step:1048/1840 train_time:47402ms step_avg:45.23ms
+step:1049/1840 train_time:47462ms step_avg:45.24ms
+step:1050/1840 train_time:47525ms step_avg:45.26ms
+step:1051/1840 train_time:47586ms step_avg:45.28ms
+step:1052/1840 train_time:47648ms step_avg:45.29ms
+step:1053/1840 train_time:47708ms step_avg:45.31ms
+step:1054/1840 train_time:47771ms step_avg:45.32ms
+step:1055/1840 train_time:47831ms step_avg:45.34ms
+step:1056/1840 train_time:47893ms step_avg:45.35ms
+step:1057/1840 train_time:47953ms step_avg:45.37ms
+step:1058/1840 train_time:48015ms step_avg:45.38ms
+step:1059/1840 train_time:48075ms step_avg:45.40ms
+step:1060/1840 train_time:48137ms step_avg:45.41ms
+step:1061/1840 train_time:48197ms step_avg:45.43ms
+step:1062/1840 train_time:48259ms step_avg:45.44ms
+step:1063/1840 train_time:48318ms step_avg:45.45ms
+step:1064/1840 train_time:48380ms step_avg:45.47ms
+step:1065/1840 train_time:48440ms step_avg:45.48ms
+step:1066/1840 train_time:48503ms step_avg:45.50ms
+step:1067/1840 train_time:48563ms step_avg:45.51ms
+step:1068/1840 train_time:48627ms step_avg:45.53ms
+step:1069/1840 train_time:48686ms step_avg:45.54ms
+step:1070/1840 train_time:48749ms step_avg:45.56ms
+step:1071/1840 train_time:48809ms step_avg:45.57ms
+step:1072/1840 train_time:48872ms step_avg:45.59ms
+step:1073/1840 train_time:48932ms step_avg:45.60ms
+step:1074/1840 train_time:48994ms step_avg:45.62ms
+step:1075/1840 train_time:49053ms step_avg:45.63ms
+step:1076/1840 train_time:49116ms step_avg:45.65ms
+step:1077/1840 train_time:49176ms step_avg:45.66ms
+step:1078/1840 train_time:49238ms step_avg:45.68ms
+step:1079/1840 train_time:49297ms step_avg:45.69ms
+step:1080/1840 train_time:49359ms step_avg:45.70ms
+step:1081/1840 train_time:49419ms step_avg:45.72ms
+step:1082/1840 train_time:49482ms step_avg:45.73ms
+step:1083/1840 train_time:49541ms step_avg:45.74ms
+step:1084/1840 train_time:49604ms step_avg:45.76ms
+step:1085/1840 train_time:49665ms step_avg:45.77ms
+step:1086/1840 train_time:49727ms step_avg:45.79ms
+step:1087/1840 train_time:49786ms step_avg:45.80ms
+step:1088/1840 train_time:49849ms step_avg:45.82ms
+step:1089/1840 train_time:49909ms step_avg:45.83ms
+step:1090/1840 train_time:49972ms step_avg:45.85ms
+step:1091/1840 train_time:50032ms step_avg:45.86ms
+step:1092/1840 train_time:50094ms step_avg:45.87ms
+step:1093/1840 train_time:50155ms step_avg:45.89ms
+step:1094/1840 train_time:50217ms step_avg:45.90ms
+step:1095/1840 train_time:50277ms step_avg:45.91ms
+step:1096/1840 train_time:50338ms step_avg:45.93ms
+step:1097/1840 train_time:50398ms step_avg:45.94ms
+step:1098/1840 train_time:50461ms step_avg:45.96ms
+step:1099/1840 train_time:50521ms step_avg:45.97ms
+step:1100/1840 train_time:50583ms step_avg:45.98ms
+step:1101/1840 train_time:50643ms step_avg:46.00ms
+step:1102/1840 train_time:50705ms step_avg:46.01ms
+step:1103/1840 train_time:50765ms step_avg:46.02ms
+step:1104/1840 train_time:50827ms step_avg:46.04ms
+step:1105/1840 train_time:50887ms step_avg:46.05ms
+step:1106/1840 train_time:50951ms step_avg:46.07ms
+step:1107/1840 train_time:51011ms step_avg:46.08ms
+step:1108/1840 train_time:51073ms step_avg:46.10ms
+step:1109/1840 train_time:51133ms step_avg:46.11ms
+step:1110/1840 train_time:51195ms step_avg:46.12ms
+step:1111/1840 train_time:51255ms step_avg:46.13ms
+step:1112/1840 train_time:51317ms step_avg:46.15ms
+step:1113/1840 train_time:51377ms step_avg:46.16ms
+step:1114/1840 train_time:51439ms step_avg:46.17ms
+step:1115/1840 train_time:51498ms step_avg:46.19ms
+step:1116/1840 train_time:51561ms step_avg:46.20ms
+step:1117/1840 train_time:51620ms step_avg:46.21ms
+step:1118/1840 train_time:51682ms step_avg:46.23ms
+step:1119/1840 train_time:51742ms step_avg:46.24ms
+step:1120/1840 train_time:51805ms step_avg:46.25ms
+step:1121/1840 train_time:51866ms step_avg:46.27ms
+step:1122/1840 train_time:51929ms step_avg:46.28ms
+step:1123/1840 train_time:51989ms step_avg:46.29ms
+step:1124/1840 train_time:52051ms step_avg:46.31ms
+step:1125/1840 train_time:52111ms step_avg:46.32ms
+step:1126/1840 train_time:52173ms step_avg:46.34ms
+step:1127/1840 train_time:52234ms step_avg:46.35ms
+step:1128/1840 train_time:52296ms step_avg:46.36ms
+step:1129/1840 train_time:52357ms step_avg:46.37ms
+step:1130/1840 train_time:52419ms step_avg:46.39ms
+step:1131/1840 train_time:52478ms step_avg:46.40ms
+step:1132/1840 train_time:52540ms step_avg:46.41ms
+step:1133/1840 train_time:52600ms step_avg:46.43ms
+step:1134/1840 train_time:52662ms step_avg:46.44ms
+step:1135/1840 train_time:52722ms step_avg:46.45ms
+step:1136/1840 train_time:52784ms step_avg:46.46ms
+step:1137/1840 train_time:52844ms step_avg:46.48ms
+step:1138/1840 train_time:52906ms step_avg:46.49ms
+step:1139/1840 train_time:52966ms step_avg:46.50ms
+step:1140/1840 train_time:53029ms step_avg:46.52ms
+step:1141/1840 train_time:53089ms step_avg:46.53ms
+step:1142/1840 train_time:53151ms step_avg:46.54ms
+step:1143/1840 train_time:53211ms step_avg:46.55ms
+step:1144/1840 train_time:53273ms step_avg:46.57ms
+step:1145/1840 train_time:53333ms step_avg:46.58ms
+step:1146/1840 train_time:53396ms step_avg:46.59ms
+step:1147/1840 train_time:53457ms step_avg:46.61ms
+step:1148/1840 train_time:53520ms step_avg:46.62ms
+step:1149/1840 train_time:53579ms step_avg:46.63ms
+step:1150/1840 train_time:53641ms step_avg:46.64ms
+step:1151/1840 train_time:53701ms step_avg:46.66ms
+step:1152/1840 train_time:53764ms step_avg:46.67ms
+step:1153/1840 train_time:53823ms step_avg:46.68ms
+step:1154/1840 train_time:53886ms step_avg:46.70ms
+step:1155/1840 train_time:53946ms step_avg:46.71ms
+step:1156/1840 train_time:54008ms step_avg:46.72ms
+step:1157/1840 train_time:54068ms step_avg:46.73ms
+step:1158/1840 train_time:54131ms step_avg:46.74ms
+step:1159/1840 train_time:54190ms step_avg:46.76ms
+step:1160/1840 train_time:54252ms step_avg:46.77ms
+step:1161/1840 train_time:54312ms step_avg:46.78ms
+step:1162/1840 train_time:54375ms step_avg:46.79ms
+step:1163/1840 train_time:54436ms step_avg:46.81ms
+step:1164/1840 train_time:54498ms step_avg:46.82ms
+step:1165/1840 train_time:54558ms step_avg:46.83ms
+step:1166/1840 train_time:54620ms step_avg:46.84ms
+step:1167/1840 train_time:54680ms step_avg:46.85ms
+step:1168/1840 train_time:54742ms step_avg:46.87ms
+step:1169/1840 train_time:54802ms step_avg:46.88ms
+step:1170/1840 train_time:54865ms step_avg:46.89ms
+step:1171/1840 train_time:54924ms step_avg:46.90ms
+step:1172/1840 train_time:54987ms step_avg:46.92ms
+step:1173/1840 train_time:55046ms step_avg:46.93ms
+step:1174/1840 train_time:55109ms step_avg:46.94ms
+step:1175/1840 train_time:55170ms step_avg:46.95ms
+step:1176/1840 train_time:55233ms step_avg:46.97ms
+step:1177/1840 train_time:55292ms step_avg:46.98ms
+step:1178/1840 train_time:55354ms step_avg:46.99ms
+step:1179/1840 train_time:55415ms step_avg:47.00ms
+step:1180/1840 train_time:55477ms step_avg:47.01ms
+step:1181/1840 train_time:55537ms step_avg:47.03ms
+step:1182/1840 train_time:55598ms step_avg:47.04ms
+step:1183/1840 train_time:55658ms step_avg:47.05ms
+step:1184/1840 train_time:55721ms step_avg:47.06ms
+step:1185/1840 train_time:55780ms step_avg:47.07ms
+step:1186/1840 train_time:55842ms step_avg:47.08ms
+step:1187/1840 train_time:55902ms step_avg:47.10ms
+step:1188/1840 train_time:55965ms step_avg:47.11ms
+step:1189/1840 train_time:56025ms step_avg:47.12ms
+step:1190/1840 train_time:56087ms step_avg:47.13ms
+step:1191/1840 train_time:56147ms step_avg:47.14ms
+step:1192/1840 train_time:56209ms step_avg:47.16ms
+step:1193/1840 train_time:56269ms step_avg:47.17ms
+step:1194/1840 train_time:56331ms step_avg:47.18ms
+step:1195/1840 train_time:56391ms step_avg:47.19ms
+step:1196/1840 train_time:56454ms step_avg:47.20ms
+step:1197/1840 train_time:56515ms step_avg:47.21ms
+step:1198/1840 train_time:56577ms step_avg:47.23ms
+step:1199/1840 train_time:56637ms step_avg:47.24ms
+step:1200/1840 train_time:56699ms step_avg:47.25ms
+step:1201/1840 train_time:56761ms step_avg:47.26ms
+step:1202/1840 train_time:56847ms step_avg:47.29ms
+step:1203/1840 train_time:56933ms step_avg:47.33ms
+step:1204/1840 train_time:57023ms step_avg:47.36ms
+step:1205/1840 train_time:57109ms step_avg:47.39ms
+step:1206/1840 train_time:57201ms step_avg:47.43ms
+step:1207/1840 train_time:57288ms step_avg:47.46ms
+step:1208/1840 train_time:57379ms step_avg:47.50ms
+step:1209/1840 train_time:57466ms step_avg:47.53ms
+step:1210/1840 train_time:57554ms step_avg:47.57ms
+step:1211/1840 train_time:57641ms step_avg:47.60ms
+step:1212/1840 train_time:57728ms step_avg:47.63ms
+step:1213/1840 train_time:57816ms step_avg:47.66ms
+step:1214/1840 train_time:57906ms step_avg:47.70ms
+step:1215/1840 train_time:57991ms step_avg:47.73ms
+step:1216/1840 train_time:58080ms step_avg:47.76ms
+step:1217/1840 train_time:58167ms step_avg:47.80ms
+step:1218/1840 train_time:58258ms step_avg:47.83ms
+step:1219/1840 train_time:58344ms step_avg:47.86ms
+step:1220/1840 train_time:58432ms step_avg:47.90ms
+step:1221/1840 train_time:58520ms step_avg:47.93ms
+step:1222/1840 train_time:58608ms step_avg:47.96ms
+step:1223/1840 train_time:58694ms step_avg:47.99ms
+step:1224/1840 train_time:58783ms step_avg:48.03ms
+step:1225/1840 train_time:58869ms step_avg:48.06ms
+step:1226/1840 train_time:58958ms step_avg:48.09ms
+step:1227/1840 train_time:59045ms step_avg:48.12ms
+step:1228/1840 train_time:59131ms step_avg:48.15ms
+step:1229/1840 train_time:59218ms step_avg:48.18ms
+step:1230/1840 train_time:59308ms step_avg:48.22ms
+step:1231/1840 train_time:59396ms step_avg:48.25ms
+step:1232/1840 train_time:59486ms step_avg:48.28ms
+step:1233/1840 train_time:59572ms step_avg:48.31ms
+step:1234/1840 train_time:59661ms step_avg:48.35ms
+step:1235/1840 train_time:59747ms step_avg:48.38ms
+step:1236/1840 train_time:59835ms step_avg:48.41ms
+step:1237/1840 train_time:59922ms step_avg:48.44ms
+step:1238/1840 train_time:60010ms step_avg:48.47ms
+step:1239/1840 train_time:60096ms step_avg:48.50ms
+step:1240/1840 train_time:60185ms step_avg:48.54ms
+step:1241/1840 train_time:60271ms step_avg:48.57ms
+step:1242/1840 train_time:60360ms step_avg:48.60ms
+step:1243/1840 train_time:60447ms step_avg:48.63ms
+step:1244/1840 train_time:60535ms step_avg:48.66ms
+step:1245/1840 train_time:60622ms step_avg:48.69ms
+step:1246/1840 train_time:60710ms step_avg:48.72ms
+step:1247/1840 train_time:60796ms step_avg:48.75ms
+step:1248/1840 train_time:60886ms step_avg:48.79ms
+step:1249/1840 train_time:60971ms step_avg:48.82ms
+step:1250/1840 train_time:61060ms step_avg:48.85ms
+step:1250/1840 val_loss:3.5329 train_time:61160ms step_avg:48.93ms
+step:1251/1840 train_time:61179ms step_avg:48.90ms
+step:1252/1840 train_time:61237ms step_avg:48.91ms
+step:1253/1840 train_time:61327ms step_avg:48.94ms
+step:1254/1840 train_time:61417ms step_avg:48.98ms
+step:1255/1840 train_time:61503ms step_avg:49.01ms
+step:1256/1840 train_time:61591ms step_avg:49.04ms
+step:1257/1840 train_time:61675ms step_avg:49.07ms
+step:1258/1840 train_time:61763ms step_avg:49.10ms
+step:1259/1840 train_time:61849ms step_avg:49.13ms
+step:1260/1840 train_time:61937ms step_avg:49.16ms
+step:1261/1840 train_time:62022ms step_avg:49.19ms
+step:1262/1840 train_time:62112ms step_avg:49.22ms
+step:1263/1840 train_time:62199ms step_avg:49.25ms
+step:1264/1840 train_time:62293ms step_avg:49.28ms
+step:1265/1840 train_time:62380ms step_avg:49.31ms
+step:1266/1840 train_time:62470ms step_avg:49.34ms
+step:1267/1840 train_time:62556ms step_avg:49.37ms
+step:1268/1840 train_time:62644ms step_avg:49.40ms
+step:1269/1840 train_time:62730ms step_avg:49.43ms
+step:1270/1840 train_time:62817ms step_avg:49.46ms
+step:1271/1840 train_time:62902ms step_avg:49.49ms
+step:1272/1840 train_time:62991ms step_avg:49.52ms
+step:1273/1840 train_time:63078ms step_avg:49.55ms
+step:1274/1840 train_time:63167ms step_avg:49.58ms
+step:1275/1840 train_time:63256ms step_avg:49.61ms
+step:1276/1840 train_time:63345ms step_avg:49.64ms
+step:1277/1840 train_time:63431ms step_avg:49.67ms
+step:1278/1840 train_time:63519ms step_avg:49.70ms
+step:1279/1840 train_time:63605ms step_avg:49.73ms
+step:1280/1840 train_time:63694ms step_avg:49.76ms
+step:1281/1840 train_time:63779ms step_avg:49.79ms
+step:1282/1840 train_time:63868ms step_avg:49.82ms
+step:1283/1840 train_time:63955ms step_avg:49.85ms
+step:1284/1840 train_time:64043ms step_avg:49.88ms
+step:1285/1840 train_time:64130ms step_avg:49.91ms
+step:1286/1840 train_time:64220ms step_avg:49.94ms
+step:1287/1840 train_time:64308ms step_avg:49.97ms
+step:1288/1840 train_time:64398ms step_avg:50.00ms
+step:1289/1840 train_time:64484ms step_avg:50.03ms
+step:1290/1840 train_time:64572ms step_avg:50.06ms
+step:1291/1840 train_time:64658ms step_avg:50.08ms
+step:1292/1840 train_time:64747ms step_avg:50.11ms
+step:1293/1840 train_time:64833ms step_avg:50.14ms
+step:1294/1840 train_time:64920ms step_avg:50.17ms
+step:1295/1840 train_time:65008ms step_avg:50.20ms
+step:1296/1840 train_time:65097ms step_avg:50.23ms
+step:1297/1840 train_time:65183ms step_avg:50.26ms
+step:1298/1840 train_time:65273ms step_avg:50.29ms
+step:1299/1840 train_time:65358ms step_avg:50.31ms
+step:1300/1840 train_time:65447ms step_avg:50.34ms
+step:1301/1840 train_time:65534ms step_avg:50.37ms
+step:1302/1840 train_time:65622ms step_avg:50.40ms
+step:1303/1840 train_time:65708ms step_avg:50.43ms
+step:1304/1840 train_time:65795ms step_avg:50.46ms
+step:1305/1840 train_time:65882ms step_avg:50.48ms
+step:1306/1840 train_time:65972ms step_avg:50.51ms
+step:1307/1840 train_time:66058ms step_avg:50.54ms
+step:1308/1840 train_time:66147ms step_avg:50.57ms
+step:1309/1840 train_time:66234ms step_avg:50.60ms
+step:1310/1840 train_time:66323ms step_avg:50.63ms
+step:1311/1840 train_time:66409ms step_avg:50.66ms
+step:1312/1840 train_time:66496ms step_avg:50.68ms
+step:1313/1840 train_time:66583ms step_avg:50.71ms
+step:1314/1840 train_time:66672ms step_avg:50.74ms
+step:1315/1840 train_time:66758ms step_avg:50.77ms
+step:1316/1840 train_time:66847ms step_avg:50.80ms
+step:1317/1840 train_time:66932ms step_avg:50.82ms
+step:1318/1840 train_time:67021ms step_avg:50.85ms
+step:1319/1840 train_time:67107ms step_avg:50.88ms
+step:1320/1840 train_time:67196ms step_avg:50.91ms
+step:1321/1840 train_time:67283ms step_avg:50.93ms
+step:1322/1840 train_time:67372ms step_avg:50.96ms
+step:1323/1840 train_time:67458ms step_avg:50.99ms
+step:1324/1840 train_time:67547ms step_avg:51.02ms
+step:1325/1840 train_time:67634ms step_avg:51.04ms
+step:1326/1840 train_time:67723ms step_avg:51.07ms
+step:1327/1840 train_time:67808ms step_avg:51.10ms
+step:1328/1840 train_time:67896ms step_avg:51.13ms
+step:1329/1840 train_time:67982ms step_avg:51.15ms
+step:1330/1840 train_time:68072ms step_avg:51.18ms
+step:1331/1840 train_time:68158ms step_avg:51.21ms
+step:1332/1840 train_time:68249ms step_avg:51.24ms
+step:1333/1840 train_time:68335ms step_avg:51.26ms
+step:1334/1840 train_time:68423ms step_avg:51.29ms
+step:1335/1840 train_time:68509ms step_avg:51.32ms
+step:1336/1840 train_time:68597ms step_avg:51.35ms
+step:1337/1840 train_time:68683ms step_avg:51.37ms
+step:1338/1840 train_time:68774ms step_avg:51.40ms
+step:1339/1840 train_time:68859ms step_avg:51.43ms
+step:1340/1840 train_time:68948ms step_avg:51.45ms
+step:1341/1840 train_time:69035ms step_avg:51.48ms
+step:1342/1840 train_time:69124ms step_avg:51.51ms
+step:1343/1840 train_time:69210ms step_avg:51.53ms
+step:1344/1840 train_time:69298ms step_avg:51.56ms
+step:1345/1840 train_time:69384ms step_avg:51.59ms
+step:1346/1840 train_time:69474ms step_avg:51.62ms
+step:1347/1840 train_time:69559ms step_avg:51.64ms
+step:1348/1840 train_time:69649ms step_avg:51.67ms
+step:1349/1840 train_time:69735ms step_avg:51.69ms
+step:1350/1840 train_time:69824ms step_avg:51.72ms
+step:1351/1840 train_time:69910ms step_avg:51.75ms
+step:1352/1840 train_time:69998ms step_avg:51.77ms
+step:1353/1840 train_time:70084ms step_avg:51.80ms
+step:1354/1840 train_time:70173ms step_avg:51.83ms
+step:1355/1840 train_time:70259ms step_avg:51.85ms
+step:1356/1840 train_time:70348ms step_avg:51.88ms
+step:1357/1840 train_time:70435ms step_avg:51.90ms
+step:1358/1840 train_time:70524ms step_avg:51.93ms
+step:1359/1840 train_time:70610ms step_avg:51.96ms
+step:1360/1840 train_time:70698ms step_avg:51.98ms
+step:1361/1840 train_time:70784ms step_avg:52.01ms
+step:1362/1840 train_time:70873ms step_avg:52.04ms
+step:1363/1840 train_time:70958ms step_avg:52.06ms
+step:1364/1840 train_time:71048ms step_avg:52.09ms
+step:1365/1840 train_time:71134ms step_avg:52.11ms
+step:1366/1840 train_time:71222ms step_avg:52.14ms
+step:1367/1840 train_time:71309ms step_avg:52.16ms
+step:1368/1840 train_time:71397ms step_avg:52.19ms
+step:1369/1840 train_time:71484ms step_avg:52.22ms
+step:1370/1840 train_time:71573ms step_avg:52.24ms
+step:1371/1840 train_time:71658ms step_avg:52.27ms
+step:1372/1840 train_time:71747ms step_avg:52.29ms
+step:1373/1840 train_time:71833ms step_avg:52.32ms
+step:1374/1840 train_time:71920ms step_avg:52.34ms
+step:1375/1840 train_time:72008ms step_avg:52.37ms
+step:1376/1840 train_time:72096ms step_avg:52.40ms
+step:1377/1840 train_time:72182ms step_avg:52.42ms
+step:1378/1840 train_time:72272ms step_avg:52.45ms
+step:1379/1840 train_time:72357ms step_avg:52.47ms
+step:1380/1840 train_time:72447ms step_avg:52.50ms
+step:1381/1840 train_time:72534ms step_avg:52.52ms
+step:1382/1840 train_time:72622ms step_avg:52.55ms
+step:1383/1840 train_time:72709ms step_avg:52.57ms
+step:1384/1840 train_time:72797ms step_avg:52.60ms
+step:1385/1840 train_time:72884ms step_avg:52.62ms
+step:1386/1840 train_time:72973ms step_avg:52.65ms
+step:1387/1840 train_time:73060ms step_avg:52.67ms
+step:1388/1840 train_time:73151ms step_avg:52.70ms
+step:1389/1840 train_time:73237ms step_avg:52.73ms
+step:1390/1840 train_time:73325ms step_avg:52.75ms
+step:1391/1840 train_time:73412ms step_avg:52.78ms
+step:1392/1840 train_time:73500ms step_avg:52.80ms
+step:1393/1840 train_time:73588ms step_avg:52.83ms
+step:1394/1840 train_time:73675ms step_avg:52.85ms
+step:1395/1840 train_time:73761ms step_avg:52.88ms
+step:1396/1840 train_time:73850ms step_avg:52.90ms
+step:1397/1840 train_time:73936ms step_avg:52.92ms
+step:1398/1840 train_time:74024ms step_avg:52.95ms
+step:1399/1840 train_time:74111ms step_avg:52.97ms
+step:1400/1840 train_time:74199ms step_avg:53.00ms
+step:1401/1840 train_time:74286ms step_avg:53.02ms
+step:1402/1840 train_time:74374ms step_avg:53.05ms
+step:1403/1840 train_time:74459ms step_avg:53.07ms
+step:1404/1840 train_time:74549ms step_avg:53.10ms
+step:1405/1840 train_time:74635ms step_avg:53.12ms
+step:1406/1840 train_time:74725ms step_avg:53.15ms
+step:1407/1840 train_time:74810ms step_avg:53.17ms
+step:1408/1840 train_time:74899ms step_avg:53.19ms
+step:1409/1840 train_time:74985ms step_avg:53.22ms
+step:1410/1840 train_time:75076ms step_avg:53.25ms
+step:1411/1840 train_time:75161ms step_avg:53.27ms
+step:1412/1840 train_time:75252ms step_avg:53.29ms
+step:1413/1840 train_time:75337ms step_avg:53.32ms
+step:1414/1840 train_time:75426ms step_avg:53.34ms
+step:1415/1840 train_time:75511ms step_avg:53.36ms
+step:1416/1840 train_time:75598ms step_avg:53.39ms
+step:1417/1840 train_time:75685ms step_avg:53.41ms
+step:1418/1840 train_time:75774ms step_avg:53.44ms
+step:1419/1840 train_time:75859ms step_avg:53.46ms
+step:1420/1840 train_time:75949ms step_avg:53.48ms
+step:1421/1840 train_time:76036ms step_avg:53.51ms
+step:1422/1840 train_time:76124ms step_avg:53.53ms
+step:1423/1840 train_time:76212ms step_avg:53.56ms
+step:1424/1840 train_time:76299ms step_avg:53.58ms
+step:1425/1840 train_time:76385ms step_avg:53.60ms
+step:1426/1840 train_time:76474ms step_avg:53.63ms
+step:1427/1840 train_time:76559ms step_avg:53.65ms
+step:1428/1840 train_time:76649ms step_avg:53.68ms
+step:1429/1840 train_time:76736ms step_avg:53.70ms
+step:1430/1840 train_time:76824ms step_avg:53.72ms
+step:1431/1840 train_time:76910ms step_avg:53.75ms
+step:1432/1840 train_time:76998ms step_avg:53.77ms
+step:1433/1840 train_time:77084ms step_avg:53.79ms
+step:1434/1840 train_time:77174ms step_avg:53.82ms
+step:1435/1840 train_time:77259ms step_avg:53.84ms
+step:1436/1840 train_time:77347ms step_avg:53.86ms
+step:1437/1840 train_time:77433ms step_avg:53.89ms
+step:1438/1840 train_time:77522ms step_avg:53.91ms
+step:1439/1840 train_time:77608ms step_avg:53.93ms
+step:1440/1840 train_time:77696ms step_avg:53.96ms
+step:1441/1840 train_time:77782ms step_avg:53.98ms
+step:1442/1840 train_time:77872ms step_avg:54.00ms
+step:1443/1840 train_time:77958ms step_avg:54.02ms
+step:1444/1840 train_time:78046ms step_avg:54.05ms
+step:1445/1840 train_time:78133ms step_avg:54.07ms
+step:1446/1840 train_time:78222ms step_avg:54.10ms
+step:1447/1840 train_time:78307ms step_avg:54.12ms
+step:1448/1840 train_time:78396ms step_avg:54.14ms
+step:1449/1840 train_time:78481ms step_avg:54.16ms
+step:1450/1840 train_time:78571ms step_avg:54.19ms
+step:1451/1840 train_time:78657ms step_avg:54.21ms
+step:1452/1840 train_time:78746ms step_avg:54.23ms
+step:1453/1840 train_time:78832ms step_avg:54.25ms
+step:1454/1840 train_time:78920ms step_avg:54.28ms
+step:1455/1840 train_time:79008ms step_avg:54.30ms
+step:1456/1840 train_time:79097ms step_avg:54.32ms
+step:1457/1840 train_time:79183ms step_avg:54.35ms
+step:1458/1840 train_time:79272ms step_avg:54.37ms
+step:1459/1840 train_time:79358ms step_avg:54.39ms
+step:1460/1840 train_time:79446ms step_avg:54.42ms
+step:1461/1840 train_time:79532ms step_avg:54.44ms
+step:1462/1840 train_time:79620ms step_avg:54.46ms
+step:1463/1840 train_time:79707ms step_avg:54.48ms
+step:1464/1840 train_time:79796ms step_avg:54.51ms
+step:1465/1840 train_time:79882ms step_avg:54.53ms
+step:1466/1840 train_time:79971ms step_avg:54.55ms
+step:1467/1840 train_time:80057ms step_avg:54.57ms
+step:1468/1840 train_time:80147ms step_avg:54.60ms
+step:1469/1840 train_time:80233ms step_avg:54.62ms
+step:1470/1840 train_time:80320ms step_avg:54.64ms
+step:1471/1840 train_time:80408ms step_avg:54.66ms
+step:1472/1840 train_time:80496ms step_avg:54.68ms
+step:1473/1840 train_time:80583ms step_avg:54.71ms
+step:1474/1840 train_time:80671ms step_avg:54.73ms
+step:1475/1840 train_time:80757ms step_avg:54.75ms
+step:1476/1840 train_time:80846ms step_avg:54.77ms
+step:1477/1840 train_time:80934ms step_avg:54.80ms
+step:1478/1840 train_time:81022ms step_avg:54.82ms
+step:1479/1840 train_time:81108ms step_avg:54.84ms
+step:1480/1840 train_time:81196ms step_avg:54.86ms
+step:1481/1840 train_time:81282ms step_avg:54.88ms
+step:1482/1840 train_time:81371ms step_avg:54.91ms
+step:1483/1840 train_time:81457ms step_avg:54.93ms
+step:1484/1840 train_time:81546ms step_avg:54.95ms
+step:1485/1840 train_time:81632ms step_avg:54.97ms
+step:1486/1840 train_time:81720ms step_avg:54.99ms
+step:1487/1840 train_time:81807ms step_avg:55.02ms
+step:1488/1840 train_time:81897ms step_avg:55.04ms
+step:1489/1840 train_time:81983ms step_avg:55.06ms
+step:1490/1840 train_time:82072ms step_avg:55.08ms
+step:1491/1840 train_time:82158ms step_avg:55.10ms
+step:1492/1840 train_time:82248ms step_avg:55.13ms
+step:1493/1840 train_time:82334ms step_avg:55.15ms
+step:1494/1840 train_time:82422ms step_avg:55.17ms
+step:1495/1840 train_time:82508ms step_avg:55.19ms
+step:1496/1840 train_time:82596ms step_avg:55.21ms
+step:1497/1840 train_time:82681ms step_avg:55.23ms
+step:1498/1840 train_time:82771ms step_avg:55.25ms
+step:1499/1840 train_time:82857ms step_avg:55.27ms
+step:1500/1840 train_time:82946ms step_avg:55.30ms
+step:1500/1840 val_loss:3.4001 train_time:83046ms step_avg:55.36ms
+step:1501/1840 train_time:83065ms step_avg:55.34ms
+step:1502/1840 train_time:83124ms step_avg:55.34ms
+step:1503/1840 train_time:83212ms step_avg:55.36ms
+step:1504/1840 train_time:83302ms step_avg:55.39ms
+step:1505/1840 train_time:83389ms step_avg:55.41ms
+step:1506/1840 train_time:83478ms step_avg:55.43ms
+step:1507/1840 train_time:83562ms step_avg:55.45ms
+step:1508/1840 train_time:83649ms step_avg:55.47ms
+step:1509/1840 train_time:83734ms step_avg:55.49ms
+step:1510/1840 train_time:83823ms step_avg:55.51ms
+step:1511/1840 train_time:83908ms step_avg:55.53ms
+step:1512/1840 train_time:83997ms step_avg:55.55ms
+step:1513/1840 train_time:84084ms step_avg:55.57ms
+step:1514/1840 train_time:84178ms step_avg:55.60ms
+step:1515/1840 train_time:84264ms step_avg:55.62ms
+step:1516/1840 train_time:84355ms step_avg:55.64ms
+step:1517/1840 train_time:84442ms step_avg:55.66ms
+step:1518/1840 train_time:84530ms step_avg:55.68ms
+step:1519/1840 train_time:84614ms step_avg:55.70ms
+step:1520/1840 train_time:84702ms step_avg:55.72ms
+step:1521/1840 train_time:84787ms step_avg:55.74ms
+step:1522/1840 train_time:84876ms step_avg:55.77ms
+step:1523/1840 train_time:84962ms step_avg:55.79ms
+step:1524/1840 train_time:85053ms step_avg:55.81ms
+step:1525/1840 train_time:85142ms step_avg:55.83ms
+step:1526/1840 train_time:85229ms step_avg:55.85ms
+step:1527/1840 train_time:85317ms step_avg:55.87ms
+step:1528/1840 train_time:85405ms step_avg:55.89ms
+step:1529/1840 train_time:85490ms step_avg:55.91ms
+step:1530/1840 train_time:85579ms step_avg:55.93ms
+step:1531/1840 train_time:85664ms step_avg:55.95ms
+step:1532/1840 train_time:85753ms step_avg:55.97ms
+step:1533/1840 train_time:85840ms step_avg:55.99ms
+step:1534/1840 train_time:85928ms step_avg:56.02ms
+step:1535/1840 train_time:86015ms step_avg:56.04ms
+step:1536/1840 train_time:86104ms step_avg:56.06ms
+step:1537/1840 train_time:86192ms step_avg:56.08ms
+step:1538/1840 train_time:86282ms step_avg:56.10ms
+step:1539/1840 train_time:86368ms step_avg:56.12ms
+step:1540/1840 train_time:86457ms step_avg:56.14ms
+step:1541/1840 train_time:86543ms step_avg:56.16ms
+step:1542/1840 train_time:86631ms step_avg:56.18ms
+step:1543/1840 train_time:86716ms step_avg:56.20ms
+step:1544/1840 train_time:86804ms step_avg:56.22ms
+step:1545/1840 train_time:86890ms step_avg:56.24ms
+step:1546/1840 train_time:86980ms step_avg:56.26ms
+step:1547/1840 train_time:87065ms step_avg:56.28ms
+step:1548/1840 train_time:87156ms step_avg:56.30ms
+step:1549/1840 train_time:87243ms step_avg:56.32ms
+step:1550/1840 train_time:87333ms step_avg:56.34ms
+step:1551/1840 train_time:87418ms step_avg:56.36ms
+step:1552/1840 train_time:87505ms step_avg:56.38ms
+step:1553/1840 train_time:87592ms step_avg:56.40ms
+step:1554/1840 train_time:87681ms step_avg:56.42ms
+step:1555/1840 train_time:87765ms step_avg:56.44ms
+step:1556/1840 train_time:87854ms step_avg:56.46ms
+step:1557/1840 train_time:87940ms step_avg:56.48ms
+step:1558/1840 train_time:88028ms step_avg:56.50ms
+step:1559/1840 train_time:88115ms step_avg:56.52ms
+step:1560/1840 train_time:88205ms step_avg:56.54ms
+step:1561/1840 train_time:88291ms step_avg:56.56ms
+step:1562/1840 train_time:88382ms step_avg:56.58ms
+step:1563/1840 train_time:88467ms step_avg:56.60ms
+step:1564/1840 train_time:88555ms step_avg:56.62ms
+step:1565/1840 train_time:88642ms step_avg:56.64ms
+step:1566/1840 train_time:88730ms step_avg:56.66ms
+step:1567/1840 train_time:88814ms step_avg:56.68ms
+step:1568/1840 train_time:88902ms step_avg:56.70ms
+step:1569/1840 train_time:88988ms step_avg:56.72ms
+step:1570/1840 train_time:89079ms step_avg:56.74ms
+step:1571/1840 train_time:89166ms step_avg:56.76ms
+step:1572/1840 train_time:89256ms step_avg:56.78ms
+step:1573/1840 train_time:89342ms step_avg:56.80ms
+step:1574/1840 train_time:89431ms step_avg:56.82ms
+step:1575/1840 train_time:89517ms step_avg:56.84ms
+step:1576/1840 train_time:89605ms step_avg:56.86ms
+step:1577/1840 train_time:89690ms step_avg:56.87ms
+step:1578/1840 train_time:89779ms step_avg:56.89ms
+step:1579/1840 train_time:89864ms step_avg:56.91ms
+step:1580/1840 train_time:89954ms step_avg:56.93ms
+step:1581/1840 train_time:90040ms step_avg:56.95ms
+step:1582/1840 train_time:90128ms step_avg:56.97ms
+step:1583/1840 train_time:90215ms step_avg:56.99ms
+step:1584/1840 train_time:90303ms step_avg:57.01ms
+step:1585/1840 train_time:90388ms step_avg:57.03ms
+step:1586/1840 train_time:90479ms step_avg:57.05ms
+step:1587/1840 train_time:90564ms step_avg:57.07ms
+step:1588/1840 train_time:90652ms step_avg:57.09ms
+step:1589/1840 train_time:90738ms step_avg:57.10ms
+step:1590/1840 train_time:90826ms step_avg:57.12ms
+step:1591/1840 train_time:90913ms step_avg:57.14ms
+step:1592/1840 train_time:91002ms step_avg:57.16ms
+step:1593/1840 train_time:91087ms step_avg:57.18ms
+step:1594/1840 train_time:91179ms step_avg:57.20ms
+step:1595/1840 train_time:91265ms step_avg:57.22ms
+step:1596/1840 train_time:91353ms step_avg:57.24ms
+step:1597/1840 train_time:91440ms step_avg:57.26ms
+step:1598/1840 train_time:91528ms step_avg:57.28ms
+step:1599/1840 train_time:91614ms step_avg:57.29ms
+step:1600/1840 train_time:91703ms step_avg:57.31ms
+step:1601/1840 train_time:91788ms step_avg:57.33ms
+step:1602/1840 train_time:91878ms step_avg:57.35ms
+step:1603/1840 train_time:91964ms step_avg:57.37ms
+step:1604/1840 train_time:92052ms step_avg:57.39ms
+step:1605/1840 train_time:92139ms step_avg:57.41ms
+step:1606/1840 train_time:92227ms step_avg:57.43ms
+step:1607/1840 train_time:92314ms step_avg:57.45ms
+step:1608/1840 train_time:92403ms step_avg:57.46ms
+step:1609/1840 train_time:92488ms step_avg:57.48ms
+step:1610/1840 train_time:92578ms step_avg:57.50ms
+step:1611/1840 train_time:92663ms step_avg:57.52ms
+step:1612/1840 train_time:92753ms step_avg:57.54ms
+step:1613/1840 train_time:92840ms step_avg:57.56ms
+step:1614/1840 train_time:92928ms step_avg:57.58ms
+step:1615/1840 train_time:93014ms step_avg:57.59ms
+step:1616/1840 train_time:93102ms step_avg:57.61ms
+step:1617/1840 train_time:93188ms step_avg:57.63ms
+step:1618/1840 train_time:93277ms step_avg:57.65ms
+step:1619/1840 train_time:93363ms step_avg:57.67ms
+step:1620/1840 train_time:93451ms step_avg:57.69ms
+step:1621/1840 train_time:93537ms step_avg:57.70ms
+step:1622/1840 train_time:93624ms step_avg:57.72ms
+step:1623/1840 train_time:93712ms step_avg:57.74ms
+step:1624/1840 train_time:93800ms step_avg:57.76ms
+step:1625/1840 train_time:93886ms step_avg:57.78ms
+step:1626/1840 train_time:93976ms step_avg:57.80ms
+step:1627/1840 train_time:94063ms step_avg:57.81ms
+step:1628/1840 train_time:94153ms step_avg:57.83ms
+step:1629/1840 train_time:94240ms step_avg:57.85ms
+step:1630/1840 train_time:94328ms step_avg:57.87ms
+step:1631/1840 train_time:94414ms step_avg:57.89ms
+step:1632/1840 train_time:94502ms step_avg:57.91ms
+step:1633/1840 train_time:94588ms step_avg:57.92ms
+step:1634/1840 train_time:94678ms step_avg:57.94ms
+step:1635/1840 train_time:94763ms step_avg:57.96ms
+step:1636/1840 train_time:94852ms step_avg:57.98ms
+step:1637/1840 train_time:94938ms step_avg:58.00ms
+step:1638/1840 train_time:95026ms step_avg:58.01ms
+step:1639/1840 train_time:95114ms step_avg:58.03ms
+step:1640/1840 train_time:95203ms step_avg:58.05ms
+step:1641/1840 train_time:95288ms step_avg:58.07ms
+step:1642/1840 train_time:95378ms step_avg:58.09ms
+step:1643/1840 train_time:95464ms step_avg:58.10ms
+step:1644/1840 train_time:95554ms step_avg:58.12ms
+step:1645/1840 train_time:95641ms step_avg:58.14ms
+step:1646/1840 train_time:95729ms step_avg:58.16ms
+step:1647/1840 train_time:95813ms step_avg:58.17ms
+step:1648/1840 train_time:95902ms step_avg:58.19ms
+step:1649/1840 train_time:95988ms step_avg:58.21ms
+step:1650/1840 train_time:96080ms step_avg:58.23ms
+step:1651/1840 train_time:96166ms step_avg:58.25ms
+step:1652/1840 train_time:96255ms step_avg:58.27ms
+step:1653/1840 train_time:96343ms step_avg:58.28ms
+step:1654/1840 train_time:96432ms step_avg:58.30ms
+step:1655/1840 train_time:96518ms step_avg:58.32ms
+step:1656/1840 train_time:96606ms step_avg:58.34ms
+step:1657/1840 train_time:96691ms step_avg:58.35ms
+step:1658/1840 train_time:96780ms step_avg:58.37ms
+step:1659/1840 train_time:96866ms step_avg:58.39ms
+step:1660/1840 train_time:96955ms step_avg:58.41ms
+step:1661/1840 train_time:97043ms step_avg:58.42ms
+step:1662/1840 train_time:97132ms step_avg:58.44ms
+step:1663/1840 train_time:97218ms step_avg:58.46ms
+step:1664/1840 train_time:97306ms step_avg:58.48ms
+step:1665/1840 train_time:97392ms step_avg:58.49ms
+step:1666/1840 train_time:97483ms step_avg:58.51ms
+step:1667/1840 train_time:97568ms step_avg:58.53ms
+step:1668/1840 train_time:97657ms step_avg:58.55ms
+step:1669/1840 train_time:97743ms step_avg:58.56ms
+step:1670/1840 train_time:97832ms step_avg:58.58ms
+step:1671/1840 train_time:97919ms step_avg:58.60ms
+step:1672/1840 train_time:98007ms step_avg:58.62ms
+step:1673/1840 train_time:98092ms step_avg:58.63ms
+step:1674/1840 train_time:98182ms step_avg:58.65ms
+step:1675/1840 train_time:98268ms step_avg:58.67ms
+step:1676/1840 train_time:98357ms step_avg:58.69ms
+step:1677/1840 train_time:98443ms step_avg:58.70ms
+step:1678/1840 train_time:98532ms step_avg:58.72ms
+step:1679/1840 train_time:98617ms step_avg:58.74ms
+step:1680/1840 train_time:98705ms step_avg:58.75ms
+step:1681/1840 train_time:98791ms step_avg:58.77ms
+step:1682/1840 train_time:98881ms step_avg:58.79ms
+step:1683/1840 train_time:98966ms step_avg:58.80ms
+step:1684/1840 train_time:99056ms step_avg:58.82ms
+step:1685/1840 train_time:99143ms step_avg:58.84ms
+step:1686/1840 train_time:99231ms step_avg:58.86ms
+step:1687/1840 train_time:99317ms step_avg:58.87ms
+step:1688/1840 train_time:99405ms step_avg:58.89ms
+step:1689/1840 train_time:99492ms step_avg:58.91ms
+step:1690/1840 train_time:99580ms step_avg:58.92ms
+step:1691/1840 train_time:99665ms step_avg:58.94ms
+step:1692/1840 train_time:99755ms step_avg:58.96ms
+step:1693/1840 train_time:99841ms step_avg:58.97ms
+step:1694/1840 train_time:99930ms step_avg:58.99ms
+step:1695/1840 train_time:100015ms step_avg:59.01ms
+step:1696/1840 train_time:100103ms step_avg:59.02ms
+step:1697/1840 train_time:100190ms step_avg:59.04ms
+step:1698/1840 train_time:100280ms step_avg:59.06ms
+step:1699/1840 train_time:100366ms step_avg:59.07ms
+step:1700/1840 train_time:100454ms step_avg:59.09ms
+step:1701/1840 train_time:100540ms step_avg:59.11ms
+step:1702/1840 train_time:100628ms step_avg:59.12ms
+step:1703/1840 train_time:100715ms step_avg:59.14ms
+step:1704/1840 train_time:100803ms step_avg:59.16ms
+step:1705/1840 train_time:100888ms step_avg:59.17ms
+step:1706/1840 train_time:100978ms step_avg:59.19ms
+step:1707/1840 train_time:101063ms step_avg:59.21ms
+step:1708/1840 train_time:101154ms step_avg:59.22ms
+step:1709/1840 train_time:101240ms step_avg:59.24ms
+step:1710/1840 train_time:101329ms step_avg:59.26ms
+step:1711/1840 train_time:101415ms step_avg:59.27ms
+step:1712/1840 train_time:101504ms step_avg:59.29ms
+step:1713/1840 train_time:101589ms step_avg:59.30ms
+step:1714/1840 train_time:101679ms step_avg:59.32ms
+step:1715/1840 train_time:101766ms step_avg:59.34ms
+step:1716/1840 train_time:101854ms step_avg:59.36ms
+step:1717/1840 train_time:101940ms step_avg:59.37ms
+step:1718/1840 train_time:102029ms step_avg:59.39ms
+step:1719/1840 train_time:102115ms step_avg:59.40ms
+step:1720/1840 train_time:102203ms step_avg:59.42ms
+step:1721/1840 train_time:102290ms step_avg:59.44ms
+step:1722/1840 train_time:102381ms step_avg:59.45ms
+step:1723/1840 train_time:102467ms step_avg:59.47ms
+step:1724/1840 train_time:102555ms step_avg:59.49ms
+step:1725/1840 train_time:102642ms step_avg:59.50ms
+step:1726/1840 train_time:102731ms step_avg:59.52ms
+step:1727/1840 train_time:102815ms step_avg:59.53ms
+step:1728/1840 train_time:102903ms step_avg:59.55ms
+step:1729/1840 train_time:102989ms step_avg:59.57ms
+step:1730/1840 train_time:103079ms step_avg:59.58ms
+step:1731/1840 train_time:103167ms step_avg:59.60ms
+step:1732/1840 train_time:103258ms step_avg:59.62ms
+step:1733/1840 train_time:103344ms step_avg:59.63ms
+step:1734/1840 train_time:103432ms step_avg:59.65ms
+step:1735/1840 train_time:103518ms step_avg:59.66ms
+step:1736/1840 train_time:103606ms step_avg:59.68ms
+step:1737/1840 train_time:103691ms step_avg:59.70ms
+step:1738/1840 train_time:103782ms step_avg:59.71ms
+step:1739/1840 train_time:103868ms step_avg:59.73ms
+step:1740/1840 train_time:103957ms step_avg:59.75ms
+step:1741/1840 train_time:104042ms step_avg:59.76ms
+step:1742/1840 train_time:104131ms step_avg:59.78ms
+step:1743/1840 train_time:104218ms step_avg:59.79ms
+step:1744/1840 train_time:104305ms step_avg:59.81ms
+step:1745/1840 train_time:104392ms step_avg:59.82ms
+step:1746/1840 train_time:104482ms step_avg:59.84ms
+step:1747/1840 train_time:104567ms step_avg:59.86ms
+step:1748/1840 train_time:104657ms step_avg:59.87ms
+step:1749/1840 train_time:104743ms step_avg:59.89ms
+step:1750/1840 train_time:104832ms step_avg:59.90ms
+step:1750/1840 val_loss:3.3025 train_time:104932ms step_avg:59.96ms
+step:1751/1840 train_time:104951ms step_avg:59.94ms
+step:1752/1840 train_time:105008ms step_avg:59.94ms
+step:1753/1840 train_time:105095ms step_avg:59.95ms
+step:1754/1840 train_time:105190ms step_avg:59.97ms
+step:1755/1840 train_time:105279ms step_avg:59.99ms
+step:1756/1840 train_time:105368ms step_avg:60.00ms
+step:1757/1840 train_time:105454ms step_avg:60.02ms
+step:1758/1840 train_time:105542ms step_avg:60.04ms
+step:1759/1840 train_time:105628ms step_avg:60.05ms
+step:1760/1840 train_time:105716ms step_avg:60.07ms
+step:1761/1840 train_time:105801ms step_avg:60.08ms
+step:1762/1840 train_time:105891ms step_avg:60.10ms
+step:1763/1840 train_time:105979ms step_avg:60.11ms
+step:1764/1840 train_time:106070ms step_avg:60.13ms
+step:1765/1840 train_time:106159ms step_avg:60.15ms
+step:1766/1840 train_time:106248ms step_avg:60.16ms
+step:1767/1840 train_time:106334ms step_avg:60.18ms
+step:1768/1840 train_time:106423ms step_avg:60.19ms
+step:1769/1840 train_time:106509ms step_avg:60.21ms
+step:1770/1840 train_time:106596ms step_avg:60.22ms
+step:1771/1840 train_time:106682ms step_avg:60.24ms
+step:1772/1840 train_time:106770ms step_avg:60.25ms
+step:1773/1840 train_time:106856ms step_avg:60.27ms
+step:1774/1840 train_time:106946ms step_avg:60.29ms
+step:1775/1840 train_time:107034ms step_avg:60.30ms
+step:1776/1840 train_time:107124ms step_avg:60.32ms
+step:1777/1840 train_time:107210ms step_avg:60.33ms
+step:1778/1840 train_time:107299ms step_avg:60.35ms
+step:1779/1840 train_time:107384ms step_avg:60.36ms
+step:1780/1840 train_time:107472ms step_avg:60.38ms
+step:1781/1840 train_time:107557ms step_avg:60.39ms
+step:1782/1840 train_time:107646ms step_avg:60.41ms
+step:1783/1840 train_time:107732ms step_avg:60.42ms
+step:1784/1840 train_time:107820ms step_avg:60.44ms
+step:1785/1840 train_time:107908ms step_avg:60.45ms
+step:1786/1840 train_time:107998ms step_avg:60.47ms
+step:1787/1840 train_time:108087ms step_avg:60.48ms
+step:1788/1840 train_time:108176ms step_avg:60.50ms
+step:1789/1840 train_time:108262ms step_avg:60.52ms
+step:1790/1840 train_time:108350ms step_avg:60.53ms
+step:1791/1840 train_time:108436ms step_avg:60.55ms
+step:1792/1840 train_time:108524ms step_avg:60.56ms
+step:1793/1840 train_time:108609ms step_avg:60.57ms
+step:1794/1840 train_time:108699ms step_avg:60.59ms
+step:1795/1840 train_time:108786ms step_avg:60.60ms
+step:1796/1840 train_time:108874ms step_avg:60.62ms
+step:1797/1840 train_time:108962ms step_avg:60.64ms
+step:1798/1840 train_time:109050ms step_avg:60.65ms
+step:1799/1840 train_time:109138ms step_avg:60.67ms
+step:1800/1840 train_time:109228ms step_avg:60.68ms
+step:1801/1840 train_time:109316ms step_avg:60.70ms
+step:1802/1840 train_time:109404ms step_avg:60.71ms
+step:1803/1840 train_time:109489ms step_avg:60.73ms
+step:1804/1840 train_time:109578ms step_avg:60.74ms
+step:1805/1840 train_time:109665ms step_avg:60.76ms
+step:1806/1840 train_time:109753ms step_avg:60.77ms
+step:1807/1840 train_time:109839ms step_avg:60.79ms
+step:1808/1840 train_time:109929ms step_avg:60.80ms
+step:1809/1840 train_time:110015ms step_avg:60.82ms
+step:1810/1840 train_time:110106ms step_avg:60.83ms
+step:1811/1840 train_time:110192ms step_avg:60.85ms
+step:1812/1840 train_time:110282ms step_avg:60.86ms
+step:1813/1840 train_time:110369ms step_avg:60.88ms
+step:1814/1840 train_time:110457ms step_avg:60.89ms
+step:1815/1840 train_time:110541ms step_avg:60.90ms
+step:1816/1840 train_time:110630ms step_avg:60.92ms
+step:1817/1840 train_time:110716ms step_avg:60.93ms
+step:1818/1840 train_time:110806ms step_avg:60.95ms
+step:1819/1840 train_time:110892ms step_avg:60.96ms
+step:1820/1840 train_time:110981ms step_avg:60.98ms
+step:1821/1840 train_time:111068ms step_avg:60.99ms
+step:1822/1840 train_time:111157ms step_avg:61.01ms
+step:1823/1840 train_time:111243ms step_avg:61.02ms
+step:1824/1840 train_time:111332ms step_avg:61.04ms
+step:1825/1840 train_time:111419ms step_avg:61.05ms
+step:1826/1840 train_time:111507ms step_avg:61.07ms
+step:1827/1840 train_time:111593ms step_avg:61.08ms
+step:1828/1840 train_time:111681ms step_avg:61.09ms
+step:1829/1840 train_time:111769ms step_avg:61.11ms
+step:1830/1840 train_time:111858ms step_avg:61.12ms
+step:1831/1840 train_time:111945ms step_avg:61.14ms
+step:1832/1840 train_time:112033ms step_avg:61.15ms
+step:1833/1840 train_time:112119ms step_avg:61.17ms
+step:1834/1840 train_time:112209ms step_avg:61.18ms
+step:1835/1840 train_time:112296ms step_avg:61.20ms
+step:1836/1840 train_time:112386ms step_avg:61.21ms
+step:1837/1840 train_time:112473ms step_avg:61.23ms
+step:1838/1840 train_time:112562ms step_avg:61.24ms
+step:1839/1840 train_time:112647ms step_avg:61.25ms
+step:1840/1840 train_time:112736ms step_avg:61.27ms
+step:1840/1840 val_loss:3.2776 train_time:112837ms step_avg:61.32ms
+peak memory allocated: 28507 MiB reserved: 43618 MiB

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/README.md
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/README.md
@@ -1,0 +1,37 @@
+## New Record: Mixed Precision Interweaved Optimizer (-1.0s)
+
+Updates in PR:
+* Update MLP and ATTN weights from float32 to bfloat16
+* Add a mantissa buffer to Muon such that parameter updates can be tracked in float32 even though weights are in bfloat16. Following work of YouJiacheng on Medium track record 7.
+* Enable Adam beta values to be specified on a module level, and slightly adjust these
+* Interleave Muon with Adam. Heavily based on the ideas of Chris McCormick here: https://github.com/KellerJordan/modded-nanogpt/discussions/170.
+* Add 15 steps (not strictly necessary based on loss)
+
+Without the mantissa tracking the bfloat16 update is substantially detrimental to loss. 
+
+I observed that the lm_head/embed slightly benefits from a very low beta1 term in Adam (0.5), whereas standard convention is closer to 0.9 for Adam parameters. I hypothesis that this is driven by the asymmetrical gradient distribution caused by the nature of low frequency tokens. Consider a parameter with a very large gradient signal once every 100 steps. A small beta1 causes the parameter to take a massive step in the direction of the large gradient, and then quickly fall back to whatever the weak gradient signal is when the parameter is not the target. A large beta1 causes the parameter to continue moving in whatever direction activated it for 100+ steps, even after the signal is long gone and the network has a new topology. It may be worth exploring different beta1 values for different tokens as a function of token frequency. I find it quite unlikely that a token that occurs once every 1 million tokens should have the same beta as a token that occurs once every 100 tokens.
+
+Muon.step() is separated into 3 modular components, such that when Adam.step() is called Adam can selectively interweave Muon components. Adam first immediately calls the muon reduce scatter, then Adam kicks off every all gather except for the last value embed, then muon runs polar express and kicks off its all gathers and completes its first all gather and parameter copy, then Adam kicks off its last all gather, then Muon runs its final parameter copy, then Adam finishes its last all gather. This enables close to zero communication downtime.
+
+
+## Timing and Validation
+```
+import scipy.stats
+import torch
+
+losses = [3.2795, 3.2789, 3.2776, 3.2763, 3.2785, 3.278, 3.2774, 3.2777, 3.2802, 3.2767]
+times = [112.774,112.798,112.837,112.767,112.805,112.802,112.822,112.755,112.932,112.953]
+
+print("p=%.4f" % scipy.stats.ttest_1samp(losses, 3.28, alternative="less").pvalue)
+# p=0.0004
+
+print("losses:", torch.std_mean(torch.tensor(losses)))
+# losses: (tensor(0.0012), tensor(3.2781))
+
+print("time:", torch.std_mean(torch.tensor(times)))
+# time: (tensor(0.0671), tensor(112.8245))
+```
+
+retiming prior record: 113.895 [113.818, 113.896, 113.97]
+
+If no changes, will merge at 112.7s to be consistent with 1.0s improvement.

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/README.md
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/README.md
@@ -11,7 +11,15 @@ Without the mantissa tracking the bfloat16 update is substantially detrimental t
 
 I observed that the lm_head/embed slightly benefits from a very low beta1 term in Adam (0.5), whereas standard convention is closer to 0.9 for Adam parameters. I hypothesis that this is driven by the asymmetrical gradient distribution caused by the nature of low frequency tokens. Consider a parameter with a very large gradient signal once every 100 steps. A small beta1 causes the parameter to take a massive step in the direction of the large gradient, and then quickly fall back to whatever the weak gradient signal is when the parameter is not the target. A large beta1 causes the parameter to continue moving in whatever direction activated it for 100+ steps, even after the signal is long gone and the network has a new topology. It may be worth exploring different beta1 values for different tokens as a function of token frequency. I find it quite unlikely that a token that occurs once every 1 million tokens should have the same beta as a token that occurs once every 100 tokens.
 
-Muon.step() is separated into 3 modular components, such that when Adam.step() is called Adam can selectively interweave Muon components. Adam first immediately calls the muon reduce scatter, then Adam kicks off every all gather except for the last value embed, then muon runs polar express and kicks off its all gathers and completes its first all gather and parameter copy, then Adam kicks off its last all gather, then Muon runs its final parameter copy, then Adam finishes its last all gather. This enables close to zero communication downtime.
+Muon.step() is separated into 3 modular components, such that when Adam.step() is called Adam can selectively interweave Muon components. 
+* Adam first immediately calls the muon reduce scatter
+* Adam kicks off every all gather except for the last value embed
+* muon runs polar express and kicks off its all gathers and completes its first all gather and parameter copy
+* Adam kicks off its last all gather
+* Muon runs its final parameter copy
+* Adam finishes its last all gather.
+
+This enables close to zero communication downtime.
 
 <img width="1434" height="377" alt="image" src="https://github.com/user-attachments/assets/05eee60f-ffd4-4327-b437-47310d121c17" />
 

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/README.md
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/README.md
@@ -13,6 +13,11 @@ I observed that the lm_head/embed slightly benefits from a very low beta1 term i
 
 Muon.step() is separated into 3 modular components, such that when Adam.step() is called Adam can selectively interweave Muon components. Adam first immediately calls the muon reduce scatter, then Adam kicks off every all gather except for the last value embed, then muon runs polar express and kicks off its all gathers and completes its first all gather and parameter copy, then Adam kicks off its last all gather, then Muon runs its final parameter copy, then Adam finishes its last all gather. This enables close to zero communication downtime.
 
+<img width="1434" height="377" alt="image" src="https://github.com/user-attachments/assets/05eee60f-ffd4-4327-b437-47310d121c17" />
+
+Whereas before:
+<img width="998" height="310" alt="image" src="https://github.com/user-attachments/assets/85a0b4a9-0ad6-4933-a669-1d0f231e3674" />
+
 
 ## Timing and Validation
 ```

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/aabc069a-0491-4aaf-b562-e41bf232f39c.txt
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/aabc069a-0491-4aaf-b562-e41bf232f39c.txt
@@ -1,0 +1,3786 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+    """
+    Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+    Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+    bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+    float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+    """
+    assert p.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    wd_factor = wd_tensor.to(torch.float32)
+    lr_factor = lr_tensor.to(torch.float32)
+    p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    p_precise = p_precise_raw.view(torch.float32)
+    mask = (grad * p_precise) >= 0
+    p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+    p.copy_((p_precise_raw >> 16).to(torch.uint16))
+    mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        2. reduce scatter attn/mlp round 2 (16 mlp params)
+        3. wait on step 1, then compute update of 1 and schedule all gather
+        4. wait on step 2, then compute update of 2 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        5. wait for each all gather to complete and update params
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["mantissa"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn', 'mlp']
+        group_sizes = [16, 16]  # 10 attn + 6 mlp, then 16 mlp
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    def step(self):
+        self.step_p1()
+        self.step_p2()
+        self.step_p3()
+        
+    @torch.no_grad()
+    def step_p1(self):
+        """
+        Part 1: Launch distributed reduce_scatter operations for parameter groups.
+        """
+        rank = dist.get_rank()
+        self.group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            self.group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+    
+    @torch.no_grad()
+    def step_p2(self):
+        """
+        Part 2: Compute gradient updates and launch all_gather operations
+        Wait for all gather to complete for all parameter groups except final one
+        """
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = self.group_infos
+        
+        self.all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"].float()
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params], dtype=torch.float32)
+                
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            if "second_momentum_buffer" not in group:
+                group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1], dtype=torch.float32)
+                    if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if param_shape[-2] >= param_shape[-1] else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk, dtype=torch.bfloat16)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                if "mantissa" not in group:
+                    group["mantissa"] = torch.zeros_like(param_chunk, dtype=torch.uint16)
+                mantissa = group["mantissa"]
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx].view(torch.uint16),
+                        mantissa[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx]
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            self.all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete for all except final and copy results back into original parameter tensors.
+        for info in self.all_gather_infos[:-1]:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+    @torch.no_grad()
+    def step_p3(self):
+        """
+        Part 3: Wait for final all gather to complete and copy results back into original parameter tensors
+        """
+        info = self.all_gather_infos[-1]
+        info["gather_future"].wait()
+        stacked_params = info["stacked_params"]
+        orig_params = info["orig_params"]
+
+        unstacked_params = torch.unbind(stacked_params)
+        for i, p in enumerate(orig_params):
+            p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str], betas: list[list[float]], lr: float = 1e-3, eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for idx, label in enumerate(label_order):
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label], betas=betas[idx]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+        # tag the final param for optimizer pipelining, run all gather after muon copy
+        param_groups[-1]['params'][-1].is_final_param = True
+        
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        # 0-D CPU tensors to avoid recompilation in _update_step
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    def load_state_dict(self, state_dict):
+        """Override to preserve optimizer state dtypes (avoid BFloat16->Float32 cast that causes recompilation)."""
+        # Save original state dtypes before loading
+        original_dtypes = {}
+        for p, s in self.state.items():
+            original_dtypes[p] = {k: v.dtype for k, v in s.items() if isinstance(v, torch.Tensor)}
+        
+        # Call parent load_state_dict (which may cast dtypes to match param dtype)
+        super().load_state_dict(state_dict)
+        
+        # Restore original dtypes
+        for p, s in self.state.items():
+            if p in original_dtypes:
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor) and k in original_dtypes[p]:
+                        if v.dtype != original_dtypes[p][k]:
+                            s[k] = v.to(original_dtypes[p][k])
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-2]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step. step_size_t and eff_wd_t are 0-D CPU tensors to avoid recompilation."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)  # exp_avg = beta1 * exp_avg + (1 - beta1) * g_slice
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)  # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * g_slice^2
+        # compute step
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)  # update = (exp_avg / (sqrt(exp_avg_sq) + eps)) * step_size
+        # cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)  # update += eff_wd_t * p_slice * mask
+        p_slice.add_(other=update, alpha=-1.0)  # p_slice -= update
+
+    @torch.no_grad()
+    def step(self, muon_opt):
+        muon_opt.step_p1()
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        last_param = None
+        last_p_slice = None
+        for group in self.param_groups:      
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+                state["step"] += 1
+                t = state["step"]
+                
+                # Pre-compute changing values as 0-D CPU tensors to avoid recompilation.
+                # `.fill_(value)` is the same as "= value", but doesn't change the tensor object.
+                bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+                self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+                self._eff_wd_t.fill_(lr * lr * wd * getattr(param, "wd_mul", 1.0)) # `lr` included twice to serve as weight decay schedule.
+
+                DistAdam._update_step(p_slice, g_slice, state["exp_avg"], state["exp_avg_sq"],
+                                      beta1, beta2, eps, self._step_size_t, self._eff_wd_t)
+
+                if not is_small:
+                    if getattr(param, "is_final_param", False):
+                        last_param = param
+                        last_p_slice = p_slice
+                    else:
+                        all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+        self._reduce_scatter_futures.clear()
+
+        muon_opt.step_p2()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+        if last_param is not None:
+            last_all_gather_future = dist.all_gather_into_tensor(last_param, last_p_slice, async_op=True).get_future()
+        muon_opt.step_p3()
+        torch.futures.collect_all([last_all_gather_future]).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        adam_betas = {
+            'lm_head': [0.5, 0.95],
+            'smear_gate': [0.9, 0.99],
+            'attn_gate_bank': [0.9, 0.99],
+            've_gate_bank': [0.9, 0.99],
+            'skip_gate': [0.9, 0.99],
+            'x0_lambdas': [0.65, 0.95],
+            'scalars': [0.9, 0.99],
+            'embed': [0.5, 0.95],
+            'value_embed': [0.75, 0.95]
+        }
+        adam_labels = list(adam_betas.keys())
+        adam_beta_values = list(adam_betas.values())
+        muon_labels = ['attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, adam_beta_values, lr=0.008, eps=1e-10, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.muon_opt]
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * step_lr
+                
+        if self._is_active_step(self.adam_opt, step):
+            # adam will interleave calls to muon step
+            self.adam_opt.step(self.muon_opt)
+            self.model.zero_grad(set_to_none=True)
+            self.adam_opt.should_sync = False
+        else:
+            self.muon_opt.step()
+            self.muon_opt.zero_grad(set_to_none=True)
+            
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1800  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan  5 08:06:31 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   42C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            129W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   44C    P0            133W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     56437      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     56438      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     56439      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     56440      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     56441      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     56442      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     56443      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     56444      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 599, 600, 601, 1199, 1200, 1201, 1799, 1800, 1801] for warmup
+Resetting Model
+step:0/1840 val_loss:10.8279 train_time:0ms step_avg:0.03ms
+step:1/1840 train_time:71ms step_avg:70.50ms
+step:2/1840 train_time:92ms step_avg:45.84ms
+step:3/1840 train_time:110ms step_avg:36.66ms
+step:4/1840 train_time:141ms step_avg:35.37ms
+step:5/1840 train_time:173ms step_avg:34.66ms
+step:6/1840 train_time:263ms step_avg:43.81ms
+step:7/1840 train_time:280ms step_avg:39.94ms
+step:8/1840 train_time:303ms step_avg:37.83ms
+step:9/1840 train_time:335ms step_avg:37.17ms
+step:10/1840 train_time:369ms step_avg:36.85ms
+step:11/1840 train_time:400ms step_avg:36.40ms
+step:12/1840 train_time:435ms step_avg:36.23ms
+step:13/1840 train_time:467ms step_avg:35.90ms
+step:14/1840 train_time:501ms step_avg:35.78ms
+step:15/1840 train_time:533ms step_avg:35.55ms
+step:16/1840 train_time:567ms step_avg:35.46ms
+step:17/1840 train_time:599ms step_avg:35.25ms
+step:18/1840 train_time:633ms step_avg:35.19ms
+step:19/1840 train_time:666ms step_avg:35.05ms
+step:20/1840 train_time:700ms step_avg:35.00ms
+step:21/1840 train_time:732ms step_avg:34.87ms
+step:22/1840 train_time:766ms step_avg:34.84ms
+step:23/1840 train_time:798ms step_avg:34.71ms
+step:24/1840 train_time:833ms step_avg:34.70ms
+step:25/1840 train_time:865ms step_avg:34.59ms
+step:26/1840 train_time:899ms step_avg:34.57ms
+step:27/1840 train_time:931ms step_avg:34.48ms
+step:28/1840 train_time:965ms step_avg:34.47ms
+step:29/1840 train_time:997ms step_avg:34.39ms
+step:30/1840 train_time:1031ms step_avg:34.38ms
+step:31/1840 train_time:1064ms step_avg:34.31ms
+step:32/1840 train_time:1098ms step_avg:34.30ms
+step:33/1840 train_time:1130ms step_avg:34.26ms
+step:34/1840 train_time:1166ms step_avg:34.30ms
+step:35/1840 train_time:1199ms step_avg:34.27ms
+step:36/1840 train_time:1234ms step_avg:34.29ms
+step:37/1840 train_time:1267ms step_avg:34.24ms
+step:38/1840 train_time:1301ms step_avg:34.24ms
+step:39/1840 train_time:1333ms step_avg:34.19ms
+step:40/1840 train_time:1368ms step_avg:34.20ms
+step:41/1840 train_time:1400ms step_avg:34.15ms
+step:42/1840 train_time:1435ms step_avg:34.16ms
+step:43/1840 train_time:1467ms step_avg:34.12ms
+step:44/1840 train_time:1501ms step_avg:34.12ms
+step:45/1840 train_time:1533ms step_avg:34.07ms
+step:46/1840 train_time:1568ms step_avg:34.08ms
+step:47/1840 train_time:1600ms step_avg:34.04ms
+step:48/1840 train_time:1634ms step_avg:34.05ms
+step:49/1840 train_time:1667ms step_avg:34.02ms
+step:50/1840 train_time:1701ms step_avg:34.02ms
+step:51/1840 train_time:1733ms step_avg:33.98ms
+step:52/1840 train_time:1768ms step_avg:34.00ms
+step:53/1840 train_time:1800ms step_avg:33.96ms
+step:54/1840 train_time:1834ms step_avg:33.97ms
+step:55/1840 train_time:1867ms step_avg:33.94ms
+step:56/1840 train_time:1901ms step_avg:33.94ms
+step:57/1840 train_time:1933ms step_avg:33.91ms
+step:58/1840 train_time:1967ms step_avg:33.92ms
+step:59/1840 train_time:1999ms step_avg:33.89ms
+step:60/1840 train_time:2033ms step_avg:33.89ms
+step:61/1840 train_time:2066ms step_avg:33.87ms
+step:62/1840 train_time:2100ms step_avg:33.87ms
+step:63/1840 train_time:2132ms step_avg:33.84ms
+step:64/1840 train_time:2167ms step_avg:33.85ms
+step:65/1840 train_time:2199ms step_avg:33.83ms
+step:66/1840 train_time:2233ms step_avg:33.84ms
+step:67/1840 train_time:2266ms step_avg:33.81ms
+step:68/1840 train_time:2300ms step_avg:33.82ms
+step:69/1840 train_time:2332ms step_avg:33.80ms
+step:70/1840 train_time:2367ms step_avg:33.81ms
+step:71/1840 train_time:2399ms step_avg:33.79ms
+step:72/1840 train_time:2433ms step_avg:33.79ms
+step:73/1840 train_time:2466ms step_avg:33.77ms
+step:74/1840 train_time:2500ms step_avg:33.78ms
+step:75/1840 train_time:2532ms step_avg:33.76ms
+step:76/1840 train_time:2566ms step_avg:33.76ms
+step:77/1840 train_time:2598ms step_avg:33.74ms
+step:78/1840 train_time:2632ms step_avg:33.75ms
+step:79/1840 train_time:2665ms step_avg:33.73ms
+step:80/1840 train_time:2699ms step_avg:33.74ms
+step:81/1840 train_time:2731ms step_avg:33.72ms
+step:82/1840 train_time:2766ms step_avg:33.73ms
+step:83/1840 train_time:2798ms step_avg:33.71ms
+step:84/1840 train_time:2832ms step_avg:33.71ms
+step:85/1840 train_time:2864ms step_avg:33.69ms
+step:86/1840 train_time:2898ms step_avg:33.70ms
+step:87/1840 train_time:2930ms step_avg:33.68ms
+step:88/1840 train_time:2965ms step_avg:33.69ms
+step:89/1840 train_time:2997ms step_avg:33.67ms
+step:90/1840 train_time:3031ms step_avg:33.67ms
+step:91/1840 train_time:3063ms step_avg:33.66ms
+step:92/1840 train_time:3098ms step_avg:33.67ms
+step:93/1840 train_time:3130ms step_avg:33.65ms
+step:94/1840 train_time:3164ms step_avg:33.66ms
+step:95/1840 train_time:3196ms step_avg:33.64ms
+step:96/1840 train_time:3230ms step_avg:33.65ms
+step:97/1840 train_time:3263ms step_avg:33.64ms
+step:98/1840 train_time:3297ms step_avg:33.64ms
+step:99/1840 train_time:3329ms step_avg:33.63ms
+step:100/1840 train_time:3364ms step_avg:33.64ms
+step:101/1840 train_time:3396ms step_avg:33.63ms
+step:102/1840 train_time:3431ms step_avg:33.63ms
+step:103/1840 train_time:3463ms step_avg:33.62ms
+step:104/1840 train_time:3497ms step_avg:33.62ms
+step:105/1840 train_time:3529ms step_avg:33.61ms
+step:106/1840 train_time:3564ms step_avg:33.62ms
+step:107/1840 train_time:3596ms step_avg:33.61ms
+step:108/1840 train_time:3630ms step_avg:33.61ms
+step:109/1840 train_time:3662ms step_avg:33.60ms
+step:110/1840 train_time:3696ms step_avg:33.60ms
+step:111/1840 train_time:3728ms step_avg:33.59ms
+step:112/1840 train_time:3763ms step_avg:33.59ms
+step:113/1840 train_time:3795ms step_avg:33.59ms
+step:114/1840 train_time:3830ms step_avg:33.59ms
+step:115/1840 train_time:3862ms step_avg:33.58ms
+step:116/1840 train_time:3896ms step_avg:33.59ms
+step:117/1840 train_time:3928ms step_avg:33.58ms
+step:118/1840 train_time:3963ms step_avg:33.58ms
+step:119/1840 train_time:3995ms step_avg:33.57ms
+step:120/1840 train_time:4029ms step_avg:33.58ms
+step:121/1840 train_time:4061ms step_avg:33.57ms
+step:122/1840 train_time:4096ms step_avg:33.57ms
+step:123/1840 train_time:4128ms step_avg:33.56ms
+step:124/1840 train_time:4162ms step_avg:33.57ms
+step:125/1840 train_time:4195ms step_avg:33.56ms
+step:126/1840 train_time:4229ms step_avg:33.56ms
+step:127/1840 train_time:4262ms step_avg:33.56ms
+step:128/1840 train_time:4296ms step_avg:33.56ms
+step:129/1840 train_time:4328ms step_avg:33.55ms
+step:130/1840 train_time:4363ms step_avg:33.56ms
+step:131/1840 train_time:4395ms step_avg:33.55ms
+step:132/1840 train_time:4429ms step_avg:33.56ms
+step:133/1840 train_time:4462ms step_avg:33.55ms
+step:134/1840 train_time:4496ms step_avg:33.55ms
+step:135/1840 train_time:4528ms step_avg:33.54ms
+step:136/1840 train_time:4563ms step_avg:33.55ms
+step:137/1840 train_time:4595ms step_avg:33.54ms
+step:138/1840 train_time:4629ms step_avg:33.54ms
+step:139/1840 train_time:4661ms step_avg:33.53ms
+step:140/1840 train_time:4695ms step_avg:33.54ms
+step:141/1840 train_time:4727ms step_avg:33.53ms
+step:142/1840 train_time:4762ms step_avg:33.53ms
+step:143/1840 train_time:4794ms step_avg:33.52ms
+step:144/1840 train_time:4828ms step_avg:33.53ms
+step:145/1840 train_time:4860ms step_avg:33.52ms
+step:146/1840 train_time:4895ms step_avg:33.52ms
+step:147/1840 train_time:4927ms step_avg:33.52ms
+step:148/1840 train_time:4961ms step_avg:33.52ms
+step:149/1840 train_time:4994ms step_avg:33.52ms
+step:150/1840 train_time:5028ms step_avg:33.52ms
+step:151/1840 train_time:5061ms step_avg:33.51ms
+step:152/1840 train_time:5095ms step_avg:33.52ms
+step:153/1840 train_time:5127ms step_avg:33.51ms
+step:154/1840 train_time:5162ms step_avg:33.52ms
+step:155/1840 train_time:5194ms step_avg:33.51ms
+step:156/1840 train_time:5228ms step_avg:33.51ms
+step:157/1840 train_time:5260ms step_avg:33.51ms
+step:158/1840 train_time:5295ms step_avg:33.51ms
+step:159/1840 train_time:5327ms step_avg:33.50ms
+step:160/1840 train_time:5361ms step_avg:33.51ms
+step:161/1840 train_time:5394ms step_avg:33.50ms
+step:162/1840 train_time:5428ms step_avg:33.51ms
+step:163/1840 train_time:5460ms step_avg:33.50ms
+step:164/1840 train_time:5495ms step_avg:33.50ms
+step:165/1840 train_time:5527ms step_avg:33.50ms
+step:166/1840 train_time:5561ms step_avg:33.50ms
+step:167/1840 train_time:5593ms step_avg:33.49ms
+step:168/1840 train_time:5627ms step_avg:33.50ms
+step:169/1840 train_time:5660ms step_avg:33.49ms
+step:170/1840 train_time:5694ms step_avg:33.50ms
+step:171/1840 train_time:5726ms step_avg:33.49ms
+step:172/1840 train_time:5761ms step_avg:33.49ms
+step:173/1840 train_time:5793ms step_avg:33.48ms
+step:174/1840 train_time:5827ms step_avg:33.49ms
+step:175/1840 train_time:5860ms step_avg:33.48ms
+step:176/1840 train_time:5894ms step_avg:33.49ms
+step:177/1840 train_time:5926ms step_avg:33.48ms
+step:178/1840 train_time:5960ms step_avg:33.48ms
+step:179/1840 train_time:5992ms step_avg:33.48ms
+step:180/1840 train_time:6027ms step_avg:33.48ms
+step:181/1840 train_time:6059ms step_avg:33.47ms
+step:182/1840 train_time:6093ms step_avg:33.48ms
+step:183/1840 train_time:6126ms step_avg:33.47ms
+step:184/1840 train_time:6160ms step_avg:33.48ms
+step:185/1840 train_time:6191ms step_avg:33.47ms
+step:186/1840 train_time:6226ms step_avg:33.47ms
+step:187/1840 train_time:6258ms step_avg:33.46ms
+step:188/1840 train_time:6292ms step_avg:33.47ms
+step:189/1840 train_time:6324ms step_avg:33.46ms
+step:190/1840 train_time:6358ms step_avg:33.46ms
+step:191/1840 train_time:6390ms step_avg:33.46ms
+step:192/1840 train_time:6425ms step_avg:33.46ms
+step:193/1840 train_time:6457ms step_avg:33.45ms
+step:194/1840 train_time:6491ms step_avg:33.46ms
+step:195/1840 train_time:6524ms step_avg:33.45ms
+step:196/1840 train_time:6558ms step_avg:33.46ms
+step:197/1840 train_time:6590ms step_avg:33.45ms
+step:198/1840 train_time:6624ms step_avg:33.46ms
+step:199/1840 train_time:6656ms step_avg:33.45ms
+step:200/1840 train_time:6691ms step_avg:33.45ms
+step:201/1840 train_time:6723ms step_avg:33.45ms
+step:202/1840 train_time:6757ms step_avg:33.45ms
+step:203/1840 train_time:6789ms step_avg:33.45ms
+step:204/1840 train_time:6824ms step_avg:33.45ms
+step:205/1840 train_time:6856ms step_avg:33.44ms
+step:206/1840 train_time:6890ms step_avg:33.44ms
+step:207/1840 train_time:6921ms step_avg:33.44ms
+step:208/1840 train_time:6956ms step_avg:33.44ms
+step:209/1840 train_time:6988ms step_avg:33.43ms
+step:210/1840 train_time:7022ms step_avg:33.44ms
+step:211/1840 train_time:7055ms step_avg:33.43ms
+step:212/1840 train_time:7089ms step_avg:33.44ms
+step:213/1840 train_time:7121ms step_avg:33.43ms
+step:214/1840 train_time:7155ms step_avg:33.44ms
+step:215/1840 train_time:7187ms step_avg:33.43ms
+step:216/1840 train_time:7221ms step_avg:33.43ms
+step:217/1840 train_time:7254ms step_avg:33.43ms
+step:218/1840 train_time:7288ms step_avg:33.43ms
+step:219/1840 train_time:7320ms step_avg:33.43ms
+step:220/1840 train_time:7355ms step_avg:33.43ms
+step:221/1840 train_time:7387ms step_avg:33.42ms
+step:222/1840 train_time:7421ms step_avg:33.43ms
+step:223/1840 train_time:7453ms step_avg:33.42ms
+step:224/1840 train_time:7487ms step_avg:33.43ms
+step:225/1840 train_time:7519ms step_avg:33.42ms
+step:226/1840 train_time:7553ms step_avg:33.42ms
+step:227/1840 train_time:7586ms step_avg:33.42ms
+step:228/1840 train_time:7620ms step_avg:33.42ms
+step:229/1840 train_time:7652ms step_avg:33.42ms
+step:230/1840 train_time:7686ms step_avg:33.42ms
+step:231/1840 train_time:7718ms step_avg:33.41ms
+step:232/1840 train_time:7753ms step_avg:33.42ms
+step:233/1840 train_time:7785ms step_avg:33.41ms
+step:234/1840 train_time:7819ms step_avg:33.42ms
+step:235/1840 train_time:7851ms step_avg:33.41ms
+step:236/1840 train_time:7886ms step_avg:33.41ms
+step:237/1840 train_time:7917ms step_avg:33.41ms
+step:238/1840 train_time:7952ms step_avg:33.41ms
+step:239/1840 train_time:7983ms step_avg:33.40ms
+step:240/1840 train_time:8018ms step_avg:33.41ms
+step:241/1840 train_time:8050ms step_avg:33.40ms
+step:242/1840 train_time:8084ms step_avg:33.40ms
+step:243/1840 train_time:8116ms step_avg:33.40ms
+step:244/1840 train_time:8151ms step_avg:33.40ms
+step:245/1840 train_time:8183ms step_avg:33.40ms
+step:246/1840 train_time:8217ms step_avg:33.40ms
+step:247/1840 train_time:8249ms step_avg:33.40ms
+step:248/1840 train_time:8283ms step_avg:33.40ms
+step:249/1840 train_time:8315ms step_avg:33.39ms
+step:250/1840 train_time:8350ms step_avg:33.40ms
+step:250/1840 val_loss:4.6176 train_time:8392ms step_avg:33.57ms
+step:251/1840 train_time:8410ms step_avg:33.51ms
+step:252/1840 train_time:8428ms step_avg:33.45ms
+step:253/1840 train_time:8449ms step_avg:33.40ms
+step:254/1840 train_time:8484ms step_avg:33.40ms
+step:255/1840 train_time:8516ms step_avg:33.40ms
+step:256/1840 train_time:8551ms step_avg:33.40ms
+step:257/1840 train_time:8583ms step_avg:33.40ms
+step:258/1840 train_time:8617ms step_avg:33.40ms
+step:259/1840 train_time:8649ms step_avg:33.39ms
+step:260/1840 train_time:8683ms step_avg:33.40ms
+step:261/1840 train_time:8715ms step_avg:33.39ms
+step:262/1840 train_time:8749ms step_avg:33.39ms
+step:263/1840 train_time:8781ms step_avg:33.39ms
+step:264/1840 train_time:8815ms step_avg:33.39ms
+step:265/1840 train_time:8847ms step_avg:33.39ms
+step:266/1840 train_time:8881ms step_avg:33.39ms
+step:267/1840 train_time:8913ms step_avg:33.38ms
+step:268/1840 train_time:8947ms step_avg:33.39ms
+step:269/1840 train_time:8979ms step_avg:33.38ms
+step:270/1840 train_time:9013ms step_avg:33.38ms
+step:271/1840 train_time:9045ms step_avg:33.38ms
+step:272/1840 train_time:9079ms step_avg:33.38ms
+step:273/1840 train_time:9111ms step_avg:33.37ms
+step:274/1840 train_time:9145ms step_avg:33.38ms
+step:275/1840 train_time:9177ms step_avg:33.37ms
+step:276/1840 train_time:9211ms step_avg:33.37ms
+step:277/1840 train_time:9243ms step_avg:33.37ms
+step:278/1840 train_time:9277ms step_avg:33.37ms
+step:279/1840 train_time:9309ms step_avg:33.37ms
+step:280/1840 train_time:9344ms step_avg:33.37ms
+step:281/1840 train_time:9377ms step_avg:33.37ms
+step:282/1840 train_time:9412ms step_avg:33.37ms
+step:283/1840 train_time:9444ms step_avg:33.37ms
+step:284/1840 train_time:9478ms step_avg:33.37ms
+step:285/1840 train_time:9510ms step_avg:33.37ms
+step:286/1840 train_time:9545ms step_avg:33.37ms
+step:287/1840 train_time:9577ms step_avg:33.37ms
+step:288/1840 train_time:9611ms step_avg:33.37ms
+step:289/1840 train_time:9643ms step_avg:33.37ms
+step:290/1840 train_time:9677ms step_avg:33.37ms
+step:291/1840 train_time:9709ms step_avg:33.37ms
+step:292/1840 train_time:9743ms step_avg:33.37ms
+step:293/1840 train_time:9776ms step_avg:33.36ms
+step:294/1840 train_time:9810ms step_avg:33.37ms
+step:295/1840 train_time:9842ms step_avg:33.36ms
+step:296/1840 train_time:9876ms step_avg:33.36ms
+step:297/1840 train_time:9908ms step_avg:33.36ms
+step:298/1840 train_time:9942ms step_avg:33.36ms
+step:299/1840 train_time:9974ms step_avg:33.36ms
+step:300/1840 train_time:10008ms step_avg:33.36ms
+step:301/1840 train_time:10040ms step_avg:33.36ms
+step:302/1840 train_time:10074ms step_avg:33.36ms
+step:303/1840 train_time:10106ms step_avg:33.35ms
+step:304/1840 train_time:10141ms step_avg:33.36ms
+step:305/1840 train_time:10172ms step_avg:33.35ms
+step:306/1840 train_time:10207ms step_avg:33.35ms
+step:307/1840 train_time:10239ms step_avg:33.35ms
+step:308/1840 train_time:10273ms step_avg:33.35ms
+step:309/1840 train_time:10305ms step_avg:33.35ms
+step:310/1840 train_time:10339ms step_avg:33.35ms
+step:311/1840 train_time:10371ms step_avg:33.35ms
+step:312/1840 train_time:10406ms step_avg:33.35ms
+step:313/1840 train_time:10438ms step_avg:33.35ms
+step:314/1840 train_time:10473ms step_avg:33.35ms
+step:315/1840 train_time:10505ms step_avg:33.35ms
+step:316/1840 train_time:10539ms step_avg:33.35ms
+step:317/1840 train_time:10572ms step_avg:33.35ms
+step:318/1840 train_time:10606ms step_avg:33.35ms
+step:319/1840 train_time:10639ms step_avg:33.35ms
+step:320/1840 train_time:10673ms step_avg:33.35ms
+step:321/1840 train_time:10705ms step_avg:33.35ms
+step:322/1840 train_time:10739ms step_avg:33.35ms
+step:323/1840 train_time:10771ms step_avg:33.35ms
+step:324/1840 train_time:10805ms step_avg:33.35ms
+step:325/1840 train_time:10838ms step_avg:33.35ms
+step:326/1840 train_time:10872ms step_avg:33.35ms
+step:327/1840 train_time:10904ms step_avg:33.35ms
+step:328/1840 train_time:10938ms step_avg:33.35ms
+step:329/1840 train_time:10970ms step_avg:33.34ms
+step:330/1840 train_time:11004ms step_avg:33.35ms
+step:331/1840 train_time:11036ms step_avg:33.34ms
+step:332/1840 train_time:11071ms step_avg:33.35ms
+step:333/1840 train_time:11103ms step_avg:33.34ms
+step:334/1840 train_time:11137ms step_avg:33.34ms
+step:335/1840 train_time:11169ms step_avg:33.34ms
+step:336/1840 train_time:11203ms step_avg:33.34ms
+step:337/1840 train_time:11235ms step_avg:33.34ms
+step:338/1840 train_time:11269ms step_avg:33.34ms
+step:339/1840 train_time:11301ms step_avg:33.34ms
+step:340/1840 train_time:11335ms step_avg:33.34ms
+step:341/1840 train_time:11368ms step_avg:33.34ms
+step:342/1840 train_time:11402ms step_avg:33.34ms
+step:343/1840 train_time:11434ms step_avg:33.34ms
+step:344/1840 train_time:11468ms step_avg:33.34ms
+step:345/1840 train_time:11500ms step_avg:33.33ms
+step:346/1840 train_time:11535ms step_avg:33.34ms
+step:347/1840 train_time:11567ms step_avg:33.33ms
+step:348/1840 train_time:11602ms step_avg:33.34ms
+step:349/1840 train_time:11634ms step_avg:33.33ms
+step:350/1840 train_time:11668ms step_avg:33.34ms
+step:351/1840 train_time:11700ms step_avg:33.33ms
+step:352/1840 train_time:11734ms step_avg:33.34ms
+step:353/1840 train_time:11767ms step_avg:33.33ms
+step:354/1840 train_time:11801ms step_avg:33.34ms
+step:355/1840 train_time:11833ms step_avg:33.33ms
+step:356/1840 train_time:11867ms step_avg:33.34ms
+step:357/1840 train_time:11900ms step_avg:33.33ms
+step:358/1840 train_time:11934ms step_avg:33.33ms
+step:359/1840 train_time:11966ms step_avg:33.33ms
+step:360/1840 train_time:12000ms step_avg:33.33ms
+step:361/1840 train_time:12032ms step_avg:33.33ms
+step:362/1840 train_time:12067ms step_avg:33.33ms
+step:363/1840 train_time:12099ms step_avg:33.33ms
+step:364/1840 train_time:12133ms step_avg:33.33ms
+step:365/1840 train_time:12165ms step_avg:33.33ms
+step:366/1840 train_time:12200ms step_avg:33.33ms
+step:367/1840 train_time:12232ms step_avg:33.33ms
+step:368/1840 train_time:12266ms step_avg:33.33ms
+step:369/1840 train_time:12298ms step_avg:33.33ms
+step:370/1840 train_time:12332ms step_avg:33.33ms
+step:371/1840 train_time:12364ms step_avg:33.33ms
+step:372/1840 train_time:12398ms step_avg:33.33ms
+step:373/1840 train_time:12430ms step_avg:33.33ms
+step:374/1840 train_time:12465ms step_avg:33.33ms
+step:375/1840 train_time:12497ms step_avg:33.33ms
+step:376/1840 train_time:12531ms step_avg:33.33ms
+step:377/1840 train_time:12563ms step_avg:33.32ms
+step:378/1840 train_time:12598ms step_avg:33.33ms
+step:379/1840 train_time:12629ms step_avg:33.32ms
+step:380/1840 train_time:12664ms step_avg:33.33ms
+step:381/1840 train_time:12696ms step_avg:33.32ms
+step:382/1840 train_time:12730ms step_avg:33.32ms
+step:383/1840 train_time:12762ms step_avg:33.32ms
+step:384/1840 train_time:12796ms step_avg:33.32ms
+step:385/1840 train_time:12828ms step_avg:33.32ms
+step:386/1840 train_time:12862ms step_avg:33.32ms
+step:387/1840 train_time:12894ms step_avg:33.32ms
+step:388/1840 train_time:12928ms step_avg:33.32ms
+step:389/1840 train_time:12961ms step_avg:33.32ms
+step:390/1840 train_time:12995ms step_avg:33.32ms
+step:391/1840 train_time:13027ms step_avg:33.32ms
+step:392/1840 train_time:13061ms step_avg:33.32ms
+step:393/1840 train_time:13093ms step_avg:33.32ms
+step:394/1840 train_time:13128ms step_avg:33.32ms
+step:395/1840 train_time:13160ms step_avg:33.32ms
+step:396/1840 train_time:13194ms step_avg:33.32ms
+step:397/1840 train_time:13226ms step_avg:33.31ms
+step:398/1840 train_time:13260ms step_avg:33.32ms
+step:399/1840 train_time:13292ms step_avg:33.31ms
+step:400/1840 train_time:13327ms step_avg:33.32ms
+step:401/1840 train_time:13359ms step_avg:33.31ms
+step:402/1840 train_time:13393ms step_avg:33.32ms
+step:403/1840 train_time:13425ms step_avg:33.31ms
+step:404/1840 train_time:13460ms step_avg:33.32ms
+step:405/1840 train_time:13492ms step_avg:33.31ms
+step:406/1840 train_time:13526ms step_avg:33.32ms
+step:407/1840 train_time:13558ms step_avg:33.31ms
+step:408/1840 train_time:13593ms step_avg:33.32ms
+step:409/1840 train_time:13625ms step_avg:33.31ms
+step:410/1840 train_time:13659ms step_avg:33.32ms
+step:411/1840 train_time:13691ms step_avg:33.31ms
+step:412/1840 train_time:13726ms step_avg:33.31ms
+step:413/1840 train_time:13758ms step_avg:33.31ms
+step:414/1840 train_time:13792ms step_avg:33.31ms
+step:415/1840 train_time:13825ms step_avg:33.31ms
+step:416/1840 train_time:13859ms step_avg:33.31ms
+step:417/1840 train_time:13891ms step_avg:33.31ms
+step:418/1840 train_time:13925ms step_avg:33.31ms
+step:419/1840 train_time:13958ms step_avg:33.31ms
+step:420/1840 train_time:13992ms step_avg:33.31ms
+step:421/1840 train_time:14023ms step_avg:33.31ms
+step:422/1840 train_time:14058ms step_avg:33.31ms
+step:423/1840 train_time:14090ms step_avg:33.31ms
+step:424/1840 train_time:14124ms step_avg:33.31ms
+step:425/1840 train_time:14156ms step_avg:33.31ms
+step:426/1840 train_time:14190ms step_avg:33.31ms
+step:427/1840 train_time:14222ms step_avg:33.31ms
+step:428/1840 train_time:14257ms step_avg:33.31ms
+step:429/1840 train_time:14289ms step_avg:33.31ms
+step:430/1840 train_time:14323ms step_avg:33.31ms
+step:431/1840 train_time:14355ms step_avg:33.31ms
+step:432/1840 train_time:14389ms step_avg:33.31ms
+step:433/1840 train_time:14421ms step_avg:33.31ms
+step:434/1840 train_time:14455ms step_avg:33.31ms
+step:435/1840 train_time:14487ms step_avg:33.30ms
+step:436/1840 train_time:14522ms step_avg:33.31ms
+step:437/1840 train_time:14554ms step_avg:33.30ms
+step:438/1840 train_time:14589ms step_avg:33.31ms
+step:439/1840 train_time:14621ms step_avg:33.30ms
+step:440/1840 train_time:14655ms step_avg:33.31ms
+step:441/1840 train_time:14687ms step_avg:33.30ms
+step:442/1840 train_time:14722ms step_avg:33.31ms
+step:443/1840 train_time:14754ms step_avg:33.30ms
+step:444/1840 train_time:14788ms step_avg:33.31ms
+step:445/1840 train_time:14820ms step_avg:33.30ms
+step:446/1840 train_time:14854ms step_avg:33.31ms
+step:447/1840 train_time:14886ms step_avg:33.30ms
+step:448/1840 train_time:14920ms step_avg:33.30ms
+step:449/1840 train_time:14953ms step_avg:33.30ms
+step:450/1840 train_time:14987ms step_avg:33.30ms
+step:451/1840 train_time:15019ms step_avg:33.30ms
+step:452/1840 train_time:15054ms step_avg:33.30ms
+step:453/1840 train_time:15086ms step_avg:33.30ms
+step:454/1840 train_time:15120ms step_avg:33.30ms
+step:455/1840 train_time:15152ms step_avg:33.30ms
+step:456/1840 train_time:15187ms step_avg:33.30ms
+step:457/1840 train_time:15219ms step_avg:33.30ms
+step:458/1840 train_time:15253ms step_avg:33.30ms
+step:459/1840 train_time:15285ms step_avg:33.30ms
+step:460/1840 train_time:15320ms step_avg:33.30ms
+step:461/1840 train_time:15352ms step_avg:33.30ms
+step:462/1840 train_time:15386ms step_avg:33.30ms
+step:463/1840 train_time:15418ms step_avg:33.30ms
+step:464/1840 train_time:15452ms step_avg:33.30ms
+step:465/1840 train_time:15484ms step_avg:33.30ms
+step:466/1840 train_time:15518ms step_avg:33.30ms
+step:467/1840 train_time:15550ms step_avg:33.30ms
+step:468/1840 train_time:15584ms step_avg:33.30ms
+step:469/1840 train_time:15616ms step_avg:33.30ms
+step:470/1840 train_time:15651ms step_avg:33.30ms
+step:471/1840 train_time:15683ms step_avg:33.30ms
+step:472/1840 train_time:15718ms step_avg:33.30ms
+step:473/1840 train_time:15750ms step_avg:33.30ms
+step:474/1840 train_time:15784ms step_avg:33.30ms
+step:475/1840 train_time:15816ms step_avg:33.30ms
+step:476/1840 train_time:15850ms step_avg:33.30ms
+step:477/1840 train_time:15882ms step_avg:33.30ms
+step:478/1840 train_time:15917ms step_avg:33.30ms
+step:479/1840 train_time:15949ms step_avg:33.30ms
+step:480/1840 train_time:15983ms step_avg:33.30ms
+step:481/1840 train_time:16015ms step_avg:33.30ms
+step:482/1840 train_time:16050ms step_avg:33.30ms
+step:483/1840 train_time:16081ms step_avg:33.29ms
+step:484/1840 train_time:16116ms step_avg:33.30ms
+step:485/1840 train_time:16148ms step_avg:33.30ms
+step:486/1840 train_time:16182ms step_avg:33.30ms
+step:487/1840 train_time:16214ms step_avg:33.29ms
+step:488/1840 train_time:16249ms step_avg:33.30ms
+step:489/1840 train_time:16281ms step_avg:33.29ms
+step:490/1840 train_time:16315ms step_avg:33.30ms
+step:491/1840 train_time:16347ms step_avg:33.29ms
+step:492/1840 train_time:16381ms step_avg:33.30ms
+step:493/1840 train_time:16413ms step_avg:33.29ms
+step:494/1840 train_time:16448ms step_avg:33.30ms
+step:495/1840 train_time:16480ms step_avg:33.29ms
+step:496/1840 train_time:16514ms step_avg:33.30ms
+step:497/1840 train_time:16547ms step_avg:33.29ms
+step:498/1840 train_time:16581ms step_avg:33.30ms
+step:499/1840 train_time:16613ms step_avg:33.29ms
+step:500/1840 train_time:16648ms step_avg:33.30ms
+step:500/1840 val_loss:4.2953 train_time:16690ms step_avg:33.38ms
+step:501/1840 train_time:16709ms step_avg:33.35ms
+step:502/1840 train_time:16727ms step_avg:33.32ms
+step:503/1840 train_time:16750ms step_avg:33.30ms
+step:504/1840 train_time:16784ms step_avg:33.30ms
+step:505/1840 train_time:16816ms step_avg:33.30ms
+step:506/1840 train_time:16851ms step_avg:33.30ms
+step:507/1840 train_time:16882ms step_avg:33.30ms
+step:508/1840 train_time:16916ms step_avg:33.30ms
+step:509/1840 train_time:16948ms step_avg:33.30ms
+step:510/1840 train_time:16982ms step_avg:33.30ms
+step:511/1840 train_time:17015ms step_avg:33.30ms
+step:512/1840 train_time:17049ms step_avg:33.30ms
+step:513/1840 train_time:17081ms step_avg:33.30ms
+step:514/1840 train_time:17115ms step_avg:33.30ms
+step:515/1840 train_time:17146ms step_avg:33.29ms
+step:516/1840 train_time:17180ms step_avg:33.30ms
+step:517/1840 train_time:17212ms step_avg:33.29ms
+step:518/1840 train_time:17247ms step_avg:33.29ms
+step:519/1840 train_time:17278ms step_avg:33.29ms
+step:520/1840 train_time:17312ms step_avg:33.29ms
+step:521/1840 train_time:17344ms step_avg:33.29ms
+step:522/1840 train_time:17378ms step_avg:33.29ms
+step:523/1840 train_time:17410ms step_avg:33.29ms
+step:524/1840 train_time:17444ms step_avg:33.29ms
+step:525/1840 train_time:17476ms step_avg:33.29ms
+step:526/1840 train_time:17510ms step_avg:33.29ms
+step:527/1840 train_time:17543ms step_avg:33.29ms
+step:528/1840 train_time:17577ms step_avg:33.29ms
+step:529/1840 train_time:17609ms step_avg:33.29ms
+step:530/1840 train_time:17644ms step_avg:33.29ms
+step:531/1840 train_time:17677ms step_avg:33.29ms
+step:532/1840 train_time:17712ms step_avg:33.29ms
+step:533/1840 train_time:17744ms step_avg:33.29ms
+step:534/1840 train_time:17778ms step_avg:33.29ms
+step:535/1840 train_time:17811ms step_avg:33.29ms
+step:536/1840 train_time:17845ms step_avg:33.29ms
+step:537/1840 train_time:17878ms step_avg:33.29ms
+step:538/1840 train_time:17912ms step_avg:33.29ms
+step:539/1840 train_time:17944ms step_avg:33.29ms
+step:540/1840 train_time:17978ms step_avg:33.29ms
+step:541/1840 train_time:18010ms step_avg:33.29ms
+step:542/1840 train_time:18044ms step_avg:33.29ms
+step:543/1840 train_time:18076ms step_avg:33.29ms
+step:544/1840 train_time:18110ms step_avg:33.29ms
+step:545/1840 train_time:18142ms step_avg:33.29ms
+step:546/1840 train_time:18176ms step_avg:33.29ms
+step:547/1840 train_time:18208ms step_avg:33.29ms
+step:548/1840 train_time:18243ms step_avg:33.29ms
+step:549/1840 train_time:18275ms step_avg:33.29ms
+step:550/1840 train_time:18309ms step_avg:33.29ms
+step:551/1840 train_time:18341ms step_avg:33.29ms
+step:552/1840 train_time:18375ms step_avg:33.29ms
+step:553/1840 train_time:18407ms step_avg:33.29ms
+step:554/1840 train_time:18442ms step_avg:33.29ms
+step:555/1840 train_time:18474ms step_avg:33.29ms
+step:556/1840 train_time:18508ms step_avg:33.29ms
+step:557/1840 train_time:18540ms step_avg:33.29ms
+step:558/1840 train_time:18574ms step_avg:33.29ms
+step:559/1840 train_time:18607ms step_avg:33.29ms
+step:560/1840 train_time:18641ms step_avg:33.29ms
+step:561/1840 train_time:18673ms step_avg:33.29ms
+step:562/1840 train_time:18708ms step_avg:33.29ms
+step:563/1840 train_time:18740ms step_avg:33.29ms
+step:564/1840 train_time:18774ms step_avg:33.29ms
+step:565/1840 train_time:18806ms step_avg:33.29ms
+step:566/1840 train_time:18841ms step_avg:33.29ms
+step:567/1840 train_time:18873ms step_avg:33.29ms
+step:568/1840 train_time:18907ms step_avg:33.29ms
+step:569/1840 train_time:18940ms step_avg:33.29ms
+step:570/1840 train_time:18974ms step_avg:33.29ms
+step:571/1840 train_time:19006ms step_avg:33.29ms
+step:572/1840 train_time:19040ms step_avg:33.29ms
+step:573/1840 train_time:19072ms step_avg:33.28ms
+step:574/1840 train_time:19106ms step_avg:33.29ms
+step:575/1840 train_time:19138ms step_avg:33.28ms
+step:576/1840 train_time:19172ms step_avg:33.29ms
+step:577/1840 train_time:19204ms step_avg:33.28ms
+step:578/1840 train_time:19238ms step_avg:33.28ms
+step:579/1840 train_time:19270ms step_avg:33.28ms
+step:580/1840 train_time:19305ms step_avg:33.28ms
+step:581/1840 train_time:19337ms step_avg:33.28ms
+step:582/1840 train_time:19371ms step_avg:33.28ms
+step:583/1840 train_time:19403ms step_avg:33.28ms
+step:584/1840 train_time:19437ms step_avg:33.28ms
+step:585/1840 train_time:19469ms step_avg:33.28ms
+step:586/1840 train_time:19503ms step_avg:33.28ms
+step:587/1840 train_time:19535ms step_avg:33.28ms
+step:588/1840 train_time:19570ms step_avg:33.28ms
+step:589/1840 train_time:19602ms step_avg:33.28ms
+step:590/1840 train_time:19637ms step_avg:33.28ms
+step:591/1840 train_time:19669ms step_avg:33.28ms
+step:592/1840 train_time:19704ms step_avg:33.28ms
+step:593/1840 train_time:19736ms step_avg:33.28ms
+step:594/1840 train_time:19770ms step_avg:33.28ms
+step:595/1840 train_time:19803ms step_avg:33.28ms
+step:596/1840 train_time:19837ms step_avg:33.28ms
+step:597/1840 train_time:19869ms step_avg:33.28ms
+step:598/1840 train_time:19904ms step_avg:33.28ms
+step:599/1840 train_time:19936ms step_avg:33.28ms
+step:600/1840 train_time:19971ms step_avg:33.28ms
+step:601/1840 train_time:20005ms step_avg:33.29ms
+step:602/1840 train_time:20063ms step_avg:33.33ms
+step:603/1840 train_time:20123ms step_avg:33.37ms
+step:604/1840 train_time:20185ms step_avg:33.42ms
+step:605/1840 train_time:20244ms step_avg:33.46ms
+step:606/1840 train_time:20307ms step_avg:33.51ms
+step:607/1840 train_time:20366ms step_avg:33.55ms
+step:608/1840 train_time:20429ms step_avg:33.60ms
+step:609/1840 train_time:20489ms step_avg:33.64ms
+step:610/1840 train_time:20551ms step_avg:33.69ms
+step:611/1840 train_time:20610ms step_avg:33.73ms
+step:612/1840 train_time:20672ms step_avg:33.78ms
+step:613/1840 train_time:20733ms step_avg:33.82ms
+step:614/1840 train_time:20794ms step_avg:33.87ms
+step:615/1840 train_time:20854ms step_avg:33.91ms
+step:616/1840 train_time:20916ms step_avg:33.95ms
+step:617/1840 train_time:20975ms step_avg:34.00ms
+step:618/1840 train_time:21038ms step_avg:34.04ms
+step:619/1840 train_time:21097ms step_avg:34.08ms
+step:620/1840 train_time:21160ms step_avg:34.13ms
+step:621/1840 train_time:21219ms step_avg:34.17ms
+step:622/1840 train_time:21280ms step_avg:34.21ms
+step:623/1840 train_time:21340ms step_avg:34.25ms
+step:624/1840 train_time:21402ms step_avg:34.30ms
+step:625/1840 train_time:21462ms step_avg:34.34ms
+step:626/1840 train_time:21525ms step_avg:34.38ms
+step:627/1840 train_time:21585ms step_avg:34.43ms
+step:628/1840 train_time:21648ms step_avg:34.47ms
+step:629/1840 train_time:21709ms step_avg:34.51ms
+step:630/1840 train_time:21772ms step_avg:34.56ms
+step:631/1840 train_time:21832ms step_avg:34.60ms
+step:632/1840 train_time:21894ms step_avg:34.64ms
+step:633/1840 train_time:21954ms step_avg:34.68ms
+step:634/1840 train_time:22016ms step_avg:34.73ms
+step:635/1840 train_time:22076ms step_avg:34.77ms
+step:636/1840 train_time:22138ms step_avg:34.81ms
+step:637/1840 train_time:22198ms step_avg:34.85ms
+step:638/1840 train_time:22259ms step_avg:34.89ms
+step:639/1840 train_time:22318ms step_avg:34.93ms
+step:640/1840 train_time:22380ms step_avg:34.97ms
+step:641/1840 train_time:22440ms step_avg:35.01ms
+step:642/1840 train_time:22502ms step_avg:35.05ms
+step:643/1840 train_time:22562ms step_avg:35.09ms
+step:644/1840 train_time:22625ms step_avg:35.13ms
+step:645/1840 train_time:22685ms step_avg:35.17ms
+step:646/1840 train_time:22748ms step_avg:35.21ms
+step:647/1840 train_time:22809ms step_avg:35.25ms
+step:648/1840 train_time:22872ms step_avg:35.30ms
+step:649/1840 train_time:22932ms step_avg:35.33ms
+step:650/1840 train_time:22995ms step_avg:35.38ms
+step:651/1840 train_time:23055ms step_avg:35.41ms
+step:652/1840 train_time:23117ms step_avg:35.46ms
+step:653/1840 train_time:23176ms step_avg:35.49ms
+step:654/1840 train_time:23238ms step_avg:35.53ms
+step:655/1840 train_time:23297ms step_avg:35.57ms
+step:656/1840 train_time:23360ms step_avg:35.61ms
+step:657/1840 train_time:23419ms step_avg:35.65ms
+step:658/1840 train_time:23482ms step_avg:35.69ms
+step:659/1840 train_time:23542ms step_avg:35.72ms
+step:660/1840 train_time:23605ms step_avg:35.77ms
+step:661/1840 train_time:23665ms step_avg:35.80ms
+step:662/1840 train_time:23728ms step_avg:35.84ms
+step:663/1840 train_time:23789ms step_avg:35.88ms
+step:664/1840 train_time:23852ms step_avg:35.92ms
+step:665/1840 train_time:23913ms step_avg:35.96ms
+step:666/1840 train_time:23975ms step_avg:36.00ms
+step:667/1840 train_time:24034ms step_avg:36.03ms
+step:668/1840 train_time:24096ms step_avg:36.07ms
+step:669/1840 train_time:24156ms step_avg:36.11ms
+step:670/1840 train_time:24219ms step_avg:36.15ms
+step:671/1840 train_time:24278ms step_avg:36.18ms
+step:672/1840 train_time:24340ms step_avg:36.22ms
+step:673/1840 train_time:24399ms step_avg:36.25ms
+step:674/1840 train_time:24461ms step_avg:36.29ms
+step:675/1840 train_time:24520ms step_avg:36.33ms
+step:676/1840 train_time:24583ms step_avg:36.37ms
+step:677/1840 train_time:24643ms step_avg:36.40ms
+step:678/1840 train_time:24706ms step_avg:36.44ms
+step:679/1840 train_time:24766ms step_avg:36.47ms
+step:680/1840 train_time:24829ms step_avg:36.51ms
+step:681/1840 train_time:24889ms step_avg:36.55ms
+step:682/1840 train_time:24952ms step_avg:36.59ms
+step:683/1840 train_time:25012ms step_avg:36.62ms
+step:684/1840 train_time:25074ms step_avg:36.66ms
+step:685/1840 train_time:25134ms step_avg:36.69ms
+step:686/1840 train_time:25196ms step_avg:36.73ms
+step:687/1840 train_time:25255ms step_avg:36.76ms
+step:688/1840 train_time:25318ms step_avg:36.80ms
+step:689/1840 train_time:25377ms step_avg:36.83ms
+step:690/1840 train_time:25439ms step_avg:36.87ms
+step:691/1840 train_time:25499ms step_avg:36.90ms
+step:692/1840 train_time:25561ms step_avg:36.94ms
+step:693/1840 train_time:25620ms step_avg:36.97ms
+step:694/1840 train_time:25683ms step_avg:37.01ms
+step:695/1840 train_time:25744ms step_avg:37.04ms
+step:696/1840 train_time:25806ms step_avg:37.08ms
+step:697/1840 train_time:25867ms step_avg:37.11ms
+step:698/1840 train_time:25931ms step_avg:37.15ms
+step:699/1840 train_time:25991ms step_avg:37.18ms
+step:700/1840 train_time:26053ms step_avg:37.22ms
+step:701/1840 train_time:26113ms step_avg:37.25ms
+step:702/1840 train_time:26176ms step_avg:37.29ms
+step:703/1840 train_time:26236ms step_avg:37.32ms
+step:704/1840 train_time:26297ms step_avg:37.35ms
+step:705/1840 train_time:26356ms step_avg:37.38ms
+step:706/1840 train_time:26418ms step_avg:37.42ms
+step:707/1840 train_time:26478ms step_avg:37.45ms
+step:708/1840 train_time:26540ms step_avg:37.49ms
+step:709/1840 train_time:26599ms step_avg:37.52ms
+step:710/1840 train_time:26662ms step_avg:37.55ms
+step:711/1840 train_time:26722ms step_avg:37.58ms
+step:712/1840 train_time:26785ms step_avg:37.62ms
+step:713/1840 train_time:26845ms step_avg:37.65ms
+step:714/1840 train_time:26907ms step_avg:37.69ms
+step:715/1840 train_time:26967ms step_avg:37.72ms
+step:716/1840 train_time:27031ms step_avg:37.75ms
+step:717/1840 train_time:27092ms step_avg:37.79ms
+step:718/1840 train_time:27154ms step_avg:37.82ms
+step:719/1840 train_time:27214ms step_avg:37.85ms
+step:720/1840 train_time:27276ms step_avg:37.88ms
+step:721/1840 train_time:27336ms step_avg:37.91ms
+step:722/1840 train_time:27398ms step_avg:37.95ms
+step:723/1840 train_time:27458ms step_avg:37.98ms
+step:724/1840 train_time:27519ms step_avg:38.01ms
+step:725/1840 train_time:27578ms step_avg:38.04ms
+step:726/1840 train_time:27641ms step_avg:38.07ms
+step:727/1840 train_time:27700ms step_avg:38.10ms
+step:728/1840 train_time:27764ms step_avg:38.14ms
+step:729/1840 train_time:27824ms step_avg:38.17ms
+step:730/1840 train_time:27887ms step_avg:38.20ms
+step:731/1840 train_time:27947ms step_avg:38.23ms
+step:732/1840 train_time:28011ms step_avg:38.27ms
+step:733/1840 train_time:28071ms step_avg:38.30ms
+step:734/1840 train_time:28133ms step_avg:38.33ms
+step:735/1840 train_time:28193ms step_avg:38.36ms
+step:736/1840 train_time:28254ms step_avg:38.39ms
+step:737/1840 train_time:28315ms step_avg:38.42ms
+step:738/1840 train_time:28377ms step_avg:38.45ms
+step:739/1840 train_time:28436ms step_avg:38.48ms
+step:740/1840 train_time:28498ms step_avg:38.51ms
+step:741/1840 train_time:28558ms step_avg:38.54ms
+step:742/1840 train_time:28621ms step_avg:38.57ms
+step:743/1840 train_time:28680ms step_avg:38.60ms
+step:744/1840 train_time:28743ms step_avg:38.63ms
+step:745/1840 train_time:28802ms step_avg:38.66ms
+step:746/1840 train_time:28865ms step_avg:38.69ms
+step:747/1840 train_time:28925ms step_avg:38.72ms
+step:748/1840 train_time:28988ms step_avg:38.75ms
+step:749/1840 train_time:29048ms step_avg:38.78ms
+step:750/1840 train_time:29111ms step_avg:38.81ms
+step:750/1840 val_loss:4.0304 train_time:29182ms step_avg:38.91ms
+step:751/1840 train_time:29200ms step_avg:38.88ms
+step:752/1840 train_time:29232ms step_avg:38.87ms
+step:753/1840 train_time:29295ms step_avg:38.90ms
+step:754/1840 train_time:29358ms step_avg:38.94ms
+step:755/1840 train_time:29417ms step_avg:38.96ms
+step:756/1840 train_time:29479ms step_avg:38.99ms
+step:757/1840 train_time:29539ms step_avg:39.02ms
+step:758/1840 train_time:29601ms step_avg:39.05ms
+step:759/1840 train_time:29661ms step_avg:39.08ms
+step:760/1840 train_time:29723ms step_avg:39.11ms
+step:761/1840 train_time:29783ms step_avg:39.14ms
+step:762/1840 train_time:29845ms step_avg:39.17ms
+step:763/1840 train_time:29905ms step_avg:39.19ms
+step:764/1840 train_time:29967ms step_avg:39.22ms
+step:765/1840 train_time:30026ms step_avg:39.25ms
+step:766/1840 train_time:30088ms step_avg:39.28ms
+step:767/1840 train_time:30150ms step_avg:39.31ms
+step:768/1840 train_time:30213ms step_avg:39.34ms
+step:769/1840 train_time:30274ms step_avg:39.37ms
+step:770/1840 train_time:30336ms step_avg:39.40ms
+step:771/1840 train_time:30396ms step_avg:39.42ms
+step:772/1840 train_time:30457ms step_avg:39.45ms
+step:773/1840 train_time:30517ms step_avg:39.48ms
+step:774/1840 train_time:30579ms step_avg:39.51ms
+step:775/1840 train_time:30638ms step_avg:39.53ms
+step:776/1840 train_time:30701ms step_avg:39.56ms
+step:777/1840 train_time:30761ms step_avg:39.59ms
+step:778/1840 train_time:30824ms step_avg:39.62ms
+step:779/1840 train_time:30883ms step_avg:39.64ms
+step:780/1840 train_time:30946ms step_avg:39.67ms
+step:781/1840 train_time:31005ms step_avg:39.70ms
+step:782/1840 train_time:31068ms step_avg:39.73ms
+step:783/1840 train_time:31129ms step_avg:39.76ms
+step:784/1840 train_time:31192ms step_avg:39.79ms
+step:785/1840 train_time:31251ms step_avg:39.81ms
+step:786/1840 train_time:31313ms step_avg:39.84ms
+step:787/1840 train_time:31373ms step_avg:39.86ms
+step:788/1840 train_time:31435ms step_avg:39.89ms
+step:789/1840 train_time:31495ms step_avg:39.92ms
+step:790/1840 train_time:31557ms step_avg:39.95ms
+step:791/1840 train_time:31616ms step_avg:39.97ms
+step:792/1840 train_time:31679ms step_avg:40.00ms
+step:793/1840 train_time:31738ms step_avg:40.02ms
+step:794/1840 train_time:31800ms step_avg:40.05ms
+step:795/1840 train_time:31860ms step_avg:40.08ms
+step:796/1840 train_time:31921ms step_avg:40.10ms
+step:797/1840 train_time:31982ms step_avg:40.13ms
+step:798/1840 train_time:32044ms step_avg:40.16ms
+step:799/1840 train_time:32104ms step_avg:40.18ms
+step:800/1840 train_time:32169ms step_avg:40.21ms
+step:801/1840 train_time:32229ms step_avg:40.24ms
+step:802/1840 train_time:32291ms step_avg:40.26ms
+step:803/1840 train_time:32352ms step_avg:40.29ms
+step:804/1840 train_time:32414ms step_avg:40.32ms
+step:805/1840 train_time:32473ms step_avg:40.34ms
+step:806/1840 train_time:32535ms step_avg:40.37ms
+step:807/1840 train_time:32596ms step_avg:40.39ms
+step:808/1840 train_time:32658ms step_avg:40.42ms
+step:809/1840 train_time:32717ms step_avg:40.44ms
+step:810/1840 train_time:32779ms step_avg:40.47ms
+step:811/1840 train_time:32838ms step_avg:40.49ms
+step:812/1840 train_time:32900ms step_avg:40.52ms
+step:813/1840 train_time:32960ms step_avg:40.54ms
+step:814/1840 train_time:33022ms step_avg:40.57ms
+step:815/1840 train_time:33084ms step_avg:40.59ms
+step:816/1840 train_time:33147ms step_avg:40.62ms
+step:817/1840 train_time:33207ms step_avg:40.64ms
+step:818/1840 train_time:33270ms step_avg:40.67ms
+step:819/1840 train_time:33331ms step_avg:40.70ms
+step:820/1840 train_time:33392ms step_avg:40.72ms
+step:821/1840 train_time:33453ms step_avg:40.75ms
+step:822/1840 train_time:33514ms step_avg:40.77ms
+step:823/1840 train_time:33575ms step_avg:40.80ms
+step:824/1840 train_time:33637ms step_avg:40.82ms
+step:825/1840 train_time:33697ms step_avg:40.84ms
+step:826/1840 train_time:33758ms step_avg:40.87ms
+step:827/1840 train_time:33818ms step_avg:40.89ms
+step:828/1840 train_time:33880ms step_avg:40.92ms
+step:829/1840 train_time:33939ms step_avg:40.94ms
+step:830/1840 train_time:34002ms step_avg:40.97ms
+step:831/1840 train_time:34062ms step_avg:40.99ms
+step:832/1840 train_time:34124ms step_avg:41.01ms
+step:833/1840 train_time:34185ms step_avg:41.04ms
+step:834/1840 train_time:34250ms step_avg:41.07ms
+step:835/1840 train_time:34310ms step_avg:41.09ms
+step:836/1840 train_time:34372ms step_avg:41.12ms
+step:837/1840 train_time:34432ms step_avg:41.14ms
+step:838/1840 train_time:34495ms step_avg:41.16ms
+step:839/1840 train_time:34555ms step_avg:41.19ms
+step:840/1840 train_time:34617ms step_avg:41.21ms
+step:841/1840 train_time:34676ms step_avg:41.23ms
+step:842/1840 train_time:34737ms step_avg:41.26ms
+step:843/1840 train_time:34796ms step_avg:41.28ms
+step:844/1840 train_time:34859ms step_avg:41.30ms
+step:845/1840 train_time:34919ms step_avg:41.32ms
+step:846/1840 train_time:34982ms step_avg:41.35ms
+step:847/1840 train_time:35041ms step_avg:41.37ms
+step:848/1840 train_time:35103ms step_avg:41.40ms
+step:849/1840 train_time:35163ms step_avg:41.42ms
+step:850/1840 train_time:35227ms step_avg:41.44ms
+step:851/1840 train_time:35287ms step_avg:41.47ms
+step:852/1840 train_time:35351ms step_avg:41.49ms
+step:853/1840 train_time:35411ms step_avg:41.51ms
+step:854/1840 train_time:35473ms step_avg:41.54ms
+step:855/1840 train_time:35532ms step_avg:41.56ms
+step:856/1840 train_time:35594ms step_avg:41.58ms
+step:857/1840 train_time:35654ms step_avg:41.60ms
+step:858/1840 train_time:35717ms step_avg:41.63ms
+step:859/1840 train_time:35776ms step_avg:41.65ms
+step:860/1840 train_time:35838ms step_avg:41.67ms
+step:861/1840 train_time:35898ms step_avg:41.69ms
+step:862/1840 train_time:35960ms step_avg:41.72ms
+step:863/1840 train_time:36020ms step_avg:41.74ms
+step:864/1840 train_time:36082ms step_avg:41.76ms
+step:865/1840 train_time:36142ms step_avg:41.78ms
+step:866/1840 train_time:36204ms step_avg:41.81ms
+step:867/1840 train_time:36266ms step_avg:41.83ms
+step:868/1840 train_time:36329ms step_avg:41.85ms
+step:869/1840 train_time:36390ms step_avg:41.88ms
+step:870/1840 train_time:36453ms step_avg:41.90ms
+step:871/1840 train_time:36512ms step_avg:41.92ms
+step:872/1840 train_time:36574ms step_avg:41.94ms
+step:873/1840 train_time:36634ms step_avg:41.96ms
+step:874/1840 train_time:36696ms step_avg:41.99ms
+step:875/1840 train_time:36755ms step_avg:42.01ms
+step:876/1840 train_time:36817ms step_avg:42.03ms
+step:877/1840 train_time:36876ms step_avg:42.05ms
+step:878/1840 train_time:36938ms step_avg:42.07ms
+step:879/1840 train_time:36998ms step_avg:42.09ms
+step:880/1840 train_time:37060ms step_avg:42.11ms
+step:881/1840 train_time:37119ms step_avg:42.13ms
+step:882/1840 train_time:37183ms step_avg:42.16ms
+step:883/1840 train_time:37243ms step_avg:42.18ms
+step:884/1840 train_time:37307ms step_avg:42.20ms
+step:885/1840 train_time:37368ms step_avg:42.22ms
+step:886/1840 train_time:37431ms step_avg:42.25ms
+step:887/1840 train_time:37490ms step_avg:42.27ms
+step:888/1840 train_time:37553ms step_avg:42.29ms
+step:889/1840 train_time:37612ms step_avg:42.31ms
+step:890/1840 train_time:37675ms step_avg:42.33ms
+step:891/1840 train_time:37734ms step_avg:42.35ms
+step:892/1840 train_time:37796ms step_avg:42.37ms
+step:893/1840 train_time:37856ms step_avg:42.39ms
+step:894/1840 train_time:37918ms step_avg:42.41ms
+step:895/1840 train_time:37978ms step_avg:42.43ms
+step:896/1840 train_time:38040ms step_avg:42.46ms
+step:897/1840 train_time:38100ms step_avg:42.47ms
+step:898/1840 train_time:38162ms step_avg:42.50ms
+step:899/1840 train_time:38223ms step_avg:42.52ms
+step:900/1840 train_time:38286ms step_avg:42.54ms
+step:901/1840 train_time:38347ms step_avg:42.56ms
+step:902/1840 train_time:38409ms step_avg:42.58ms
+step:903/1840 train_time:38470ms step_avg:42.60ms
+step:904/1840 train_time:38531ms step_avg:42.62ms
+step:905/1840 train_time:38591ms step_avg:42.64ms
+step:906/1840 train_time:38654ms step_avg:42.66ms
+step:907/1840 train_time:38714ms step_avg:42.68ms
+step:908/1840 train_time:38776ms step_avg:42.71ms
+step:909/1840 train_time:38835ms step_avg:42.72ms
+step:910/1840 train_time:38898ms step_avg:42.74ms
+step:911/1840 train_time:38956ms step_avg:42.76ms
+step:912/1840 train_time:39018ms step_avg:42.78ms
+step:913/1840 train_time:39078ms step_avg:42.80ms
+step:914/1840 train_time:39140ms step_avg:42.82ms
+step:915/1840 train_time:39200ms step_avg:42.84ms
+step:916/1840 train_time:39263ms step_avg:42.86ms
+step:917/1840 train_time:39323ms step_avg:42.88ms
+step:918/1840 train_time:39386ms step_avg:42.90ms
+step:919/1840 train_time:39448ms step_avg:42.92ms
+step:920/1840 train_time:39511ms step_avg:42.95ms
+step:921/1840 train_time:39570ms step_avg:42.96ms
+step:922/1840 train_time:39633ms step_avg:42.99ms
+step:923/1840 train_time:39693ms step_avg:43.00ms
+step:924/1840 train_time:39755ms step_avg:43.02ms
+step:925/1840 train_time:39814ms step_avg:43.04ms
+step:926/1840 train_time:39877ms step_avg:43.06ms
+step:927/1840 train_time:39936ms step_avg:43.08ms
+step:928/1840 train_time:39998ms step_avg:43.10ms
+step:929/1840 train_time:40057ms step_avg:43.12ms
+step:930/1840 train_time:40119ms step_avg:43.14ms
+step:931/1840 train_time:40179ms step_avg:43.16ms
+step:932/1840 train_time:40242ms step_avg:43.18ms
+step:933/1840 train_time:40302ms step_avg:43.20ms
+step:934/1840 train_time:40365ms step_avg:43.22ms
+step:935/1840 train_time:40426ms step_avg:43.24ms
+step:936/1840 train_time:40490ms step_avg:43.26ms
+step:937/1840 train_time:40549ms step_avg:43.28ms
+step:938/1840 train_time:40612ms step_avg:43.30ms
+step:939/1840 train_time:40672ms step_avg:43.31ms
+step:940/1840 train_time:40734ms step_avg:43.33ms
+step:941/1840 train_time:40794ms step_avg:43.35ms
+step:942/1840 train_time:40857ms step_avg:43.37ms
+step:943/1840 train_time:40916ms step_avg:43.39ms
+step:944/1840 train_time:40977ms step_avg:43.41ms
+step:945/1840 train_time:41037ms step_avg:43.42ms
+step:946/1840 train_time:41099ms step_avg:43.45ms
+step:947/1840 train_time:41159ms step_avg:43.46ms
+step:948/1840 train_time:41221ms step_avg:43.48ms
+step:949/1840 train_time:41282ms step_avg:43.50ms
+step:950/1840 train_time:41344ms step_avg:43.52ms
+step:951/1840 train_time:41405ms step_avg:43.54ms
+step:952/1840 train_time:41467ms step_avg:43.56ms
+step:953/1840 train_time:41527ms step_avg:43.57ms
+step:954/1840 train_time:41590ms step_avg:43.60ms
+step:955/1840 train_time:41650ms step_avg:43.61ms
+step:956/1840 train_time:41711ms step_avg:43.63ms
+step:957/1840 train_time:41772ms step_avg:43.65ms
+step:958/1840 train_time:41834ms step_avg:43.67ms
+step:959/1840 train_time:41894ms step_avg:43.69ms
+step:960/1840 train_time:41956ms step_avg:43.70ms
+step:961/1840 train_time:42015ms step_avg:43.72ms
+step:962/1840 train_time:42078ms step_avg:43.74ms
+step:963/1840 train_time:42136ms step_avg:43.76ms
+step:964/1840 train_time:42199ms step_avg:43.77ms
+step:965/1840 train_time:42258ms step_avg:43.79ms
+step:966/1840 train_time:42321ms step_avg:43.81ms
+step:967/1840 train_time:42382ms step_avg:43.83ms
+step:968/1840 train_time:42445ms step_avg:43.85ms
+step:969/1840 train_time:42505ms step_avg:43.87ms
+step:970/1840 train_time:42569ms step_avg:43.89ms
+step:971/1840 train_time:42629ms step_avg:43.90ms
+step:972/1840 train_time:42691ms step_avg:43.92ms
+step:973/1840 train_time:42751ms step_avg:43.94ms
+step:974/1840 train_time:42812ms step_avg:43.96ms
+step:975/1840 train_time:42872ms step_avg:43.97ms
+step:976/1840 train_time:42935ms step_avg:43.99ms
+step:977/1840 train_time:42994ms step_avg:44.01ms
+step:978/1840 train_time:43057ms step_avg:44.03ms
+step:979/1840 train_time:43117ms step_avg:44.04ms
+step:980/1840 train_time:43178ms step_avg:44.06ms
+step:981/1840 train_time:43237ms step_avg:44.07ms
+step:982/1840 train_time:43300ms step_avg:44.09ms
+step:983/1840 train_time:43359ms step_avg:44.11ms
+step:984/1840 train_time:43422ms step_avg:44.13ms
+step:985/1840 train_time:43483ms step_avg:44.14ms
+step:986/1840 train_time:43545ms step_avg:44.16ms
+step:987/1840 train_time:43606ms step_avg:44.18ms
+step:988/1840 train_time:43670ms step_avg:44.20ms
+step:989/1840 train_time:43730ms step_avg:44.22ms
+step:990/1840 train_time:43791ms step_avg:44.23ms
+step:991/1840 train_time:43851ms step_avg:44.25ms
+step:992/1840 train_time:43913ms step_avg:44.27ms
+step:993/1840 train_time:43973ms step_avg:44.28ms
+step:994/1840 train_time:44035ms step_avg:44.30ms
+step:995/1840 train_time:44095ms step_avg:44.32ms
+step:996/1840 train_time:44157ms step_avg:44.33ms
+step:997/1840 train_time:44216ms step_avg:44.35ms
+step:998/1840 train_time:44278ms step_avg:44.37ms
+step:999/1840 train_time:44337ms step_avg:44.38ms
+step:1000/1840 train_time:44400ms step_avg:44.40ms
+step:1000/1840 val_loss:3.7764 train_time:44473ms step_avg:44.47ms
+step:1001/1840 train_time:44492ms step_avg:44.45ms
+step:1002/1840 train_time:44525ms step_avg:44.44ms
+step:1003/1840 train_time:44588ms step_avg:44.45ms
+step:1004/1840 train_time:44649ms step_avg:44.47ms
+step:1005/1840 train_time:44709ms step_avg:44.49ms
+step:1006/1840 train_time:44770ms step_avg:44.50ms
+step:1007/1840 train_time:44830ms step_avg:44.52ms
+step:1008/1840 train_time:44892ms step_avg:44.54ms
+step:1009/1840 train_time:44951ms step_avg:44.55ms
+step:1010/1840 train_time:45013ms step_avg:44.57ms
+step:1011/1840 train_time:45073ms step_avg:44.58ms
+step:1012/1840 train_time:45134ms step_avg:44.60ms
+step:1013/1840 train_time:45194ms step_avg:44.61ms
+step:1014/1840 train_time:45256ms step_avg:44.63ms
+step:1015/1840 train_time:45317ms step_avg:44.65ms
+step:1016/1840 train_time:45379ms step_avg:44.66ms
+step:1017/1840 train_time:45439ms step_avg:44.68ms
+step:1018/1840 train_time:45503ms step_avg:44.70ms
+step:1019/1840 train_time:45563ms step_avg:44.71ms
+step:1020/1840 train_time:45626ms step_avg:44.73ms
+step:1021/1840 train_time:45686ms step_avg:44.75ms
+step:1022/1840 train_time:45748ms step_avg:44.76ms
+step:1023/1840 train_time:45808ms step_avg:44.78ms
+step:1024/1840 train_time:45869ms step_avg:44.79ms
+step:1025/1840 train_time:45929ms step_avg:44.81ms
+step:1026/1840 train_time:45991ms step_avg:44.83ms
+step:1027/1840 train_time:46050ms step_avg:44.84ms
+step:1028/1840 train_time:46112ms step_avg:44.86ms
+step:1029/1840 train_time:46171ms step_avg:44.87ms
+step:1030/1840 train_time:46234ms step_avg:44.89ms
+step:1031/1840 train_time:46293ms step_avg:44.90ms
+step:1032/1840 train_time:46355ms step_avg:44.92ms
+step:1033/1840 train_time:46415ms step_avg:44.93ms
+step:1034/1840 train_time:46478ms step_avg:44.95ms
+step:1035/1840 train_time:46540ms step_avg:44.97ms
+step:1036/1840 train_time:46604ms step_avg:44.98ms
+step:1037/1840 train_time:46664ms step_avg:45.00ms
+step:1038/1840 train_time:46726ms step_avg:45.02ms
+step:1039/1840 train_time:46786ms step_avg:45.03ms
+step:1040/1840 train_time:46847ms step_avg:45.05ms
+step:1041/1840 train_time:46908ms step_avg:45.06ms
+step:1042/1840 train_time:46970ms step_avg:45.08ms
+step:1043/1840 train_time:47029ms step_avg:45.09ms
+step:1044/1840 train_time:47091ms step_avg:45.11ms
+step:1045/1840 train_time:47150ms step_avg:45.12ms
+step:1046/1840 train_time:47213ms step_avg:45.14ms
+step:1047/1840 train_time:47272ms step_avg:45.15ms
+step:1048/1840 train_time:47333ms step_avg:45.17ms
+step:1049/1840 train_time:47393ms step_avg:45.18ms
+step:1050/1840 train_time:47456ms step_avg:45.20ms
+step:1051/1840 train_time:47517ms step_avg:45.21ms
+step:1052/1840 train_time:47580ms step_avg:45.23ms
+step:1053/1840 train_time:47640ms step_avg:45.24ms
+step:1054/1840 train_time:47704ms step_avg:45.26ms
+step:1055/1840 train_time:47764ms step_avg:45.27ms
+step:1056/1840 train_time:47826ms step_avg:45.29ms
+step:1057/1840 train_time:47886ms step_avg:45.30ms
+step:1058/1840 train_time:47947ms step_avg:45.32ms
+step:1059/1840 train_time:48007ms step_avg:45.33ms
+step:1060/1840 train_time:48068ms step_avg:45.35ms
+step:1061/1840 train_time:48128ms step_avg:45.36ms
+step:1062/1840 train_time:48190ms step_avg:45.38ms
+step:1063/1840 train_time:48250ms step_avg:45.39ms
+step:1064/1840 train_time:48312ms step_avg:45.41ms
+step:1065/1840 train_time:48371ms step_avg:45.42ms
+step:1066/1840 train_time:48433ms step_avg:45.43ms
+step:1067/1840 train_time:48494ms step_avg:45.45ms
+step:1068/1840 train_time:48557ms step_avg:45.47ms
+step:1069/1840 train_time:48617ms step_avg:45.48ms
+step:1070/1840 train_time:48680ms step_avg:45.50ms
+step:1071/1840 train_time:48740ms step_avg:45.51ms
+step:1072/1840 train_time:48803ms step_avg:45.53ms
+step:1073/1840 train_time:48863ms step_avg:45.54ms
+step:1074/1840 train_time:48925ms step_avg:45.55ms
+step:1075/1840 train_time:48984ms step_avg:45.57ms
+step:1076/1840 train_time:49046ms step_avg:45.58ms
+step:1077/1840 train_time:49106ms step_avg:45.60ms
+step:1078/1840 train_time:49169ms step_avg:45.61ms
+step:1079/1840 train_time:49228ms step_avg:45.62ms
+step:1080/1840 train_time:49290ms step_avg:45.64ms
+step:1081/1840 train_time:49350ms step_avg:45.65ms
+step:1082/1840 train_time:49413ms step_avg:45.67ms
+step:1083/1840 train_time:49472ms step_avg:45.68ms
+step:1084/1840 train_time:49534ms step_avg:45.70ms
+step:1085/1840 train_time:49594ms step_avg:45.71ms
+step:1086/1840 train_time:49657ms step_avg:45.73ms
+step:1087/1840 train_time:49717ms step_avg:45.74ms
+step:1088/1840 train_time:49780ms step_avg:45.75ms
+step:1089/1840 train_time:49841ms step_avg:45.77ms
+step:1090/1840 train_time:49905ms step_avg:45.78ms
+step:1091/1840 train_time:49965ms step_avg:45.80ms
+step:1092/1840 train_time:50027ms step_avg:45.81ms
+step:1093/1840 train_time:50086ms step_avg:45.82ms
+step:1094/1840 train_time:50149ms step_avg:45.84ms
+step:1095/1840 train_time:50209ms step_avg:45.85ms
+step:1096/1840 train_time:50271ms step_avg:45.87ms
+step:1097/1840 train_time:50331ms step_avg:45.88ms
+step:1098/1840 train_time:50393ms step_avg:45.90ms
+step:1099/1840 train_time:50453ms step_avg:45.91ms
+step:1100/1840 train_time:50515ms step_avg:45.92ms
+step:1101/1840 train_time:50575ms step_avg:45.94ms
+step:1102/1840 train_time:50637ms step_avg:45.95ms
+step:1103/1840 train_time:50697ms step_avg:45.96ms
+step:1104/1840 train_time:50759ms step_avg:45.98ms
+step:1105/1840 train_time:50820ms step_avg:45.99ms
+step:1106/1840 train_time:50884ms step_avg:46.01ms
+step:1107/1840 train_time:50944ms step_avg:46.02ms
+step:1108/1840 train_time:51006ms step_avg:46.03ms
+step:1109/1840 train_time:51067ms step_avg:46.05ms
+step:1110/1840 train_time:51128ms step_avg:46.06ms
+step:1111/1840 train_time:51188ms step_avg:46.07ms
+step:1112/1840 train_time:51249ms step_avg:46.09ms
+step:1113/1840 train_time:51309ms step_avg:46.10ms
+step:1114/1840 train_time:51371ms step_avg:46.11ms
+step:1115/1840 train_time:51430ms step_avg:46.13ms
+step:1116/1840 train_time:51493ms step_avg:46.14ms
+step:1117/1840 train_time:51552ms step_avg:46.15ms
+step:1118/1840 train_time:51614ms step_avg:46.17ms
+step:1119/1840 train_time:51674ms step_avg:46.18ms
+step:1120/1840 train_time:51737ms step_avg:46.19ms
+step:1121/1840 train_time:51797ms step_avg:46.21ms
+step:1122/1840 train_time:51861ms step_avg:46.22ms
+step:1123/1840 train_time:51922ms step_avg:46.23ms
+step:1124/1840 train_time:51985ms step_avg:46.25ms
+step:1125/1840 train_time:52045ms step_avg:46.26ms
+step:1126/1840 train_time:52107ms step_avg:46.28ms
+step:1127/1840 train_time:52167ms step_avg:46.29ms
+step:1128/1840 train_time:52228ms step_avg:46.30ms
+step:1129/1840 train_time:52288ms step_avg:46.31ms
+step:1130/1840 train_time:52351ms step_avg:46.33ms
+step:1131/1840 train_time:52410ms step_avg:46.34ms
+step:1132/1840 train_time:52472ms step_avg:46.35ms
+step:1133/1840 train_time:52531ms step_avg:46.36ms
+step:1134/1840 train_time:52594ms step_avg:46.38ms
+step:1135/1840 train_time:52653ms step_avg:46.39ms
+step:1136/1840 train_time:52716ms step_avg:46.40ms
+step:1137/1840 train_time:52776ms step_avg:46.42ms
+step:1138/1840 train_time:52839ms step_avg:46.43ms
+step:1139/1840 train_time:52899ms step_avg:46.44ms
+step:1140/1840 train_time:52963ms step_avg:46.46ms
+step:1141/1840 train_time:53023ms step_avg:46.47ms
+step:1142/1840 train_time:53086ms step_avg:46.49ms
+step:1143/1840 train_time:53146ms step_avg:46.50ms
+step:1144/1840 train_time:53208ms step_avg:46.51ms
+step:1145/1840 train_time:53267ms step_avg:46.52ms
+step:1146/1840 train_time:53329ms step_avg:46.54ms
+step:1147/1840 train_time:53389ms step_avg:46.55ms
+step:1148/1840 train_time:53452ms step_avg:46.56ms
+step:1149/1840 train_time:53512ms step_avg:46.57ms
+step:1150/1840 train_time:53574ms step_avg:46.59ms
+step:1151/1840 train_time:53633ms step_avg:46.60ms
+step:1152/1840 train_time:53695ms step_avg:46.61ms
+step:1153/1840 train_time:53755ms step_avg:46.62ms
+step:1154/1840 train_time:53817ms step_avg:46.64ms
+step:1155/1840 train_time:53877ms step_avg:46.65ms
+step:1156/1840 train_time:53941ms step_avg:46.66ms
+step:1157/1840 train_time:54000ms step_avg:46.67ms
+step:1158/1840 train_time:54064ms step_avg:46.69ms
+step:1159/1840 train_time:54125ms step_avg:46.70ms
+step:1160/1840 train_time:54187ms step_avg:46.71ms
+step:1161/1840 train_time:54247ms step_avg:46.72ms
+step:1162/1840 train_time:54308ms step_avg:46.74ms
+step:1163/1840 train_time:54367ms step_avg:46.75ms
+step:1164/1840 train_time:54430ms step_avg:46.76ms
+step:1165/1840 train_time:54489ms step_avg:46.77ms
+step:1166/1840 train_time:54552ms step_avg:46.79ms
+step:1167/1840 train_time:54612ms step_avg:46.80ms
+step:1168/1840 train_time:54674ms step_avg:46.81ms
+step:1169/1840 train_time:54734ms step_avg:46.82ms
+step:1170/1840 train_time:54796ms step_avg:46.83ms
+step:1171/1840 train_time:54855ms step_avg:46.84ms
+step:1172/1840 train_time:54918ms step_avg:46.86ms
+step:1173/1840 train_time:54978ms step_avg:46.87ms
+step:1174/1840 train_time:55041ms step_avg:46.88ms
+step:1175/1840 train_time:55104ms step_avg:46.90ms
+step:1176/1840 train_time:55166ms step_avg:46.91ms
+step:1177/1840 train_time:55226ms step_avg:46.92ms
+step:1178/1840 train_time:55288ms step_avg:46.93ms
+step:1179/1840 train_time:55347ms step_avg:46.94ms
+step:1180/1840 train_time:55409ms step_avg:46.96ms
+step:1181/1840 train_time:55469ms step_avg:46.97ms
+step:1182/1840 train_time:55531ms step_avg:46.98ms
+step:1183/1840 train_time:55590ms step_avg:46.99ms
+step:1184/1840 train_time:55652ms step_avg:47.00ms
+step:1185/1840 train_time:55712ms step_avg:47.01ms
+step:1186/1840 train_time:55774ms step_avg:47.03ms
+step:1187/1840 train_time:55834ms step_avg:47.04ms
+step:1188/1840 train_time:55897ms step_avg:47.05ms
+step:1189/1840 train_time:55957ms step_avg:47.06ms
+step:1190/1840 train_time:56020ms step_avg:47.08ms
+step:1191/1840 train_time:56080ms step_avg:47.09ms
+step:1192/1840 train_time:56143ms step_avg:47.10ms
+step:1193/1840 train_time:56203ms step_avg:47.11ms
+step:1194/1840 train_time:56265ms step_avg:47.12ms
+step:1195/1840 train_time:56325ms step_avg:47.13ms
+step:1196/1840 train_time:56387ms step_avg:47.15ms
+step:1197/1840 train_time:56447ms step_avg:47.16ms
+step:1198/1840 train_time:56508ms step_avg:47.17ms
+step:1199/1840 train_time:56568ms step_avg:47.18ms
+step:1200/1840 train_time:56631ms step_avg:47.19ms
+step:1201/1840 train_time:56692ms step_avg:47.20ms
+step:1202/1840 train_time:56776ms step_avg:47.23ms
+step:1203/1840 train_time:56863ms step_avg:47.27ms
+step:1204/1840 train_time:56951ms step_avg:47.30ms
+step:1205/1840 train_time:57038ms step_avg:47.33ms
+step:1206/1840 train_time:57129ms step_avg:47.37ms
+step:1207/1840 train_time:57215ms step_avg:47.40ms
+step:1208/1840 train_time:57304ms step_avg:47.44ms
+step:1209/1840 train_time:57392ms step_avg:47.47ms
+step:1210/1840 train_time:57483ms step_avg:47.51ms
+step:1211/1840 train_time:57572ms step_avg:47.54ms
+step:1212/1840 train_time:57661ms step_avg:47.57ms
+step:1213/1840 train_time:57747ms step_avg:47.61ms
+step:1214/1840 train_time:57835ms step_avg:47.64ms
+step:1215/1840 train_time:57919ms step_avg:47.67ms
+step:1216/1840 train_time:58008ms step_avg:47.70ms
+step:1217/1840 train_time:58094ms step_avg:47.74ms
+step:1218/1840 train_time:58183ms step_avg:47.77ms
+step:1219/1840 train_time:58271ms step_avg:47.80ms
+step:1220/1840 train_time:58360ms step_avg:47.84ms
+step:1221/1840 train_time:58448ms step_avg:47.87ms
+step:1222/1840 train_time:58537ms step_avg:47.90ms
+step:1223/1840 train_time:58623ms step_avg:47.93ms
+step:1224/1840 train_time:58712ms step_avg:47.97ms
+step:1225/1840 train_time:58797ms step_avg:48.00ms
+step:1226/1840 train_time:58887ms step_avg:48.03ms
+step:1227/1840 train_time:58974ms step_avg:48.06ms
+step:1228/1840 train_time:59061ms step_avg:48.10ms
+step:1229/1840 train_time:59148ms step_avg:48.13ms
+step:1230/1840 train_time:59238ms step_avg:48.16ms
+step:1231/1840 train_time:59324ms step_avg:48.19ms
+step:1232/1840 train_time:59414ms step_avg:48.23ms
+step:1233/1840 train_time:59499ms step_avg:48.26ms
+step:1234/1840 train_time:59588ms step_avg:48.29ms
+step:1235/1840 train_time:59675ms step_avg:48.32ms
+step:1236/1840 train_time:59764ms step_avg:48.35ms
+step:1237/1840 train_time:59850ms step_avg:48.38ms
+step:1238/1840 train_time:59939ms step_avg:48.42ms
+step:1239/1840 train_time:60025ms step_avg:48.45ms
+step:1240/1840 train_time:60114ms step_avg:48.48ms
+step:1241/1840 train_time:60200ms step_avg:48.51ms
+step:1242/1840 train_time:60289ms step_avg:48.54ms
+step:1243/1840 train_time:60377ms step_avg:48.57ms
+step:1244/1840 train_time:60466ms step_avg:48.61ms
+step:1245/1840 train_time:60552ms step_avg:48.64ms
+step:1246/1840 train_time:60641ms step_avg:48.67ms
+step:1247/1840 train_time:60727ms step_avg:48.70ms
+step:1248/1840 train_time:60816ms step_avg:48.73ms
+step:1249/1840 train_time:60901ms step_avg:48.76ms
+step:1250/1840 train_time:60989ms step_avg:48.79ms
+step:1250/1840 val_loss:3.5357 train_time:61090ms step_avg:48.87ms
+step:1251/1840 train_time:61109ms step_avg:48.85ms
+step:1252/1840 train_time:61165ms step_avg:48.85ms
+step:1253/1840 train_time:61252ms step_avg:48.88ms
+step:1254/1840 train_time:61344ms step_avg:48.92ms
+step:1255/1840 train_time:61434ms step_avg:48.95ms
+step:1256/1840 train_time:61525ms step_avg:48.99ms
+step:1257/1840 train_time:61611ms step_avg:49.01ms
+step:1258/1840 train_time:61700ms step_avg:49.05ms
+step:1259/1840 train_time:61786ms step_avg:49.08ms
+step:1260/1840 train_time:61873ms step_avg:49.11ms
+step:1261/1840 train_time:61958ms step_avg:49.13ms
+step:1262/1840 train_time:62051ms step_avg:49.17ms
+step:1263/1840 train_time:62138ms step_avg:49.20ms
+step:1264/1840 train_time:62226ms step_avg:49.23ms
+step:1265/1840 train_time:62313ms step_avg:49.26ms
+step:1266/1840 train_time:62404ms step_avg:49.29ms
+step:1267/1840 train_time:62492ms step_avg:49.32ms
+step:1268/1840 train_time:62582ms step_avg:49.35ms
+step:1269/1840 train_time:62667ms step_avg:49.38ms
+step:1270/1840 train_time:62755ms step_avg:49.41ms
+step:1271/1840 train_time:62841ms step_avg:49.44ms
+step:1272/1840 train_time:62930ms step_avg:49.47ms
+step:1273/1840 train_time:63018ms step_avg:49.50ms
+step:1274/1840 train_time:63107ms step_avg:49.53ms
+step:1275/1840 train_time:63192ms step_avg:49.56ms
+step:1276/1840 train_time:63281ms step_avg:49.59ms
+step:1277/1840 train_time:63368ms step_avg:49.62ms
+step:1278/1840 train_time:63458ms step_avg:49.65ms
+step:1279/1840 train_time:63544ms step_avg:49.68ms
+step:1280/1840 train_time:63633ms step_avg:49.71ms
+step:1281/1840 train_time:63719ms step_avg:49.74ms
+step:1282/1840 train_time:63807ms step_avg:49.77ms
+step:1283/1840 train_time:63892ms step_avg:49.80ms
+step:1284/1840 train_time:63981ms step_avg:49.83ms
+step:1285/1840 train_time:64069ms step_avg:49.86ms
+step:1286/1840 train_time:64157ms step_avg:49.89ms
+step:1287/1840 train_time:64244ms step_avg:49.92ms
+step:1288/1840 train_time:64332ms step_avg:49.95ms
+step:1289/1840 train_time:64419ms step_avg:49.98ms
+step:1290/1840 train_time:64508ms step_avg:50.01ms
+step:1291/1840 train_time:64593ms step_avg:50.03ms
+step:1292/1840 train_time:64682ms step_avg:50.06ms
+step:1293/1840 train_time:64768ms step_avg:50.09ms
+step:1294/1840 train_time:64857ms step_avg:50.12ms
+step:1295/1840 train_time:64943ms step_avg:50.15ms
+step:1296/1840 train_time:65031ms step_avg:50.18ms
+step:1297/1840 train_time:65117ms step_avg:50.21ms
+step:1298/1840 train_time:65206ms step_avg:50.24ms
+step:1299/1840 train_time:65292ms step_avg:50.26ms
+step:1300/1840 train_time:65380ms step_avg:50.29ms
+step:1301/1840 train_time:65467ms step_avg:50.32ms
+step:1302/1840 train_time:65556ms step_avg:50.35ms
+step:1303/1840 train_time:65642ms step_avg:50.38ms
+step:1304/1840 train_time:65730ms step_avg:50.41ms
+step:1305/1840 train_time:65817ms step_avg:50.43ms
+step:1306/1840 train_time:65905ms step_avg:50.46ms
+step:1307/1840 train_time:65992ms step_avg:50.49ms
+step:1308/1840 train_time:66080ms step_avg:50.52ms
+step:1309/1840 train_time:66166ms step_avg:50.55ms
+step:1310/1840 train_time:66255ms step_avg:50.58ms
+step:1311/1840 train_time:66341ms step_avg:50.60ms
+step:1312/1840 train_time:66431ms step_avg:50.63ms
+step:1313/1840 train_time:66517ms step_avg:50.66ms
+step:1314/1840 train_time:66606ms step_avg:50.69ms
+step:1315/1840 train_time:66692ms step_avg:50.72ms
+step:1316/1840 train_time:66780ms step_avg:50.74ms
+step:1317/1840 train_time:66866ms step_avg:50.77ms
+step:1318/1840 train_time:66954ms step_avg:50.80ms
+step:1319/1840 train_time:67039ms step_avg:50.83ms
+step:1320/1840 train_time:67129ms step_avg:50.86ms
+step:1321/1840 train_time:67215ms step_avg:50.88ms
+step:1322/1840 train_time:67303ms step_avg:50.91ms
+step:1323/1840 train_time:67391ms step_avg:50.94ms
+step:1324/1840 train_time:67479ms step_avg:50.97ms
+step:1325/1840 train_time:67564ms step_avg:50.99ms
+step:1326/1840 train_time:67652ms step_avg:51.02ms
+step:1327/1840 train_time:67739ms step_avg:51.05ms
+step:1328/1840 train_time:67828ms step_avg:51.08ms
+step:1329/1840 train_time:67915ms step_avg:51.10ms
+step:1330/1840 train_time:68003ms step_avg:51.13ms
+step:1331/1840 train_time:68091ms step_avg:51.16ms
+step:1332/1840 train_time:68179ms step_avg:51.19ms
+step:1333/1840 train_time:68265ms step_avg:51.21ms
+step:1334/1840 train_time:68354ms step_avg:51.24ms
+step:1335/1840 train_time:68441ms step_avg:51.27ms
+step:1336/1840 train_time:68529ms step_avg:51.29ms
+step:1337/1840 train_time:68614ms step_avg:51.32ms
+step:1338/1840 train_time:68703ms step_avg:51.35ms
+step:1339/1840 train_time:68790ms step_avg:51.37ms
+step:1340/1840 train_time:68878ms step_avg:51.40ms
+step:1341/1840 train_time:68963ms step_avg:51.43ms
+step:1342/1840 train_time:69053ms step_avg:51.46ms
+step:1343/1840 train_time:69139ms step_avg:51.48ms
+step:1344/1840 train_time:69228ms step_avg:51.51ms
+step:1345/1840 train_time:69313ms step_avg:51.53ms
+step:1346/1840 train_time:69403ms step_avg:51.56ms
+step:1347/1840 train_time:69490ms step_avg:51.59ms
+step:1348/1840 train_time:69578ms step_avg:51.62ms
+step:1349/1840 train_time:69663ms step_avg:51.64ms
+step:1350/1840 train_time:69752ms step_avg:51.67ms
+step:1351/1840 train_time:69838ms step_avg:51.69ms
+step:1352/1840 train_time:69928ms step_avg:51.72ms
+step:1353/1840 train_time:70013ms step_avg:51.75ms
+step:1354/1840 train_time:70102ms step_avg:51.77ms
+step:1355/1840 train_time:70190ms step_avg:51.80ms
+step:1356/1840 train_time:70278ms step_avg:51.83ms
+step:1357/1840 train_time:70364ms step_avg:51.85ms
+step:1358/1840 train_time:70453ms step_avg:51.88ms
+step:1359/1840 train_time:70540ms step_avg:51.91ms
+step:1360/1840 train_time:70628ms step_avg:51.93ms
+step:1361/1840 train_time:70714ms step_avg:51.96ms
+step:1362/1840 train_time:70802ms step_avg:51.98ms
+step:1363/1840 train_time:70889ms step_avg:52.01ms
+step:1364/1840 train_time:70978ms step_avg:52.04ms
+step:1365/1840 train_time:71065ms step_avg:52.06ms
+step:1366/1840 train_time:71153ms step_avg:52.09ms
+step:1367/1840 train_time:71239ms step_avg:52.11ms
+step:1368/1840 train_time:71329ms step_avg:52.14ms
+step:1369/1840 train_time:71414ms step_avg:52.17ms
+step:1370/1840 train_time:71503ms step_avg:52.19ms
+step:1371/1840 train_time:71591ms step_avg:52.22ms
+step:1372/1840 train_time:71679ms step_avg:52.24ms
+step:1373/1840 train_time:71764ms step_avg:52.27ms
+step:1374/1840 train_time:71853ms step_avg:52.29ms
+step:1375/1840 train_time:71940ms step_avg:52.32ms
+step:1376/1840 train_time:72029ms step_avg:52.35ms
+step:1377/1840 train_time:72115ms step_avg:52.37ms
+step:1378/1840 train_time:72203ms step_avg:52.40ms
+step:1379/1840 train_time:72291ms step_avg:52.42ms
+step:1380/1840 train_time:72379ms step_avg:52.45ms
+step:1381/1840 train_time:72464ms step_avg:52.47ms
+step:1382/1840 train_time:72553ms step_avg:52.50ms
+step:1383/1840 train_time:72640ms step_avg:52.52ms
+step:1384/1840 train_time:72728ms step_avg:52.55ms
+step:1385/1840 train_time:72814ms step_avg:52.57ms
+step:1386/1840 train_time:72902ms step_avg:52.60ms
+step:1387/1840 train_time:72990ms step_avg:52.62ms
+step:1388/1840 train_time:73079ms step_avg:52.65ms
+step:1389/1840 train_time:73165ms step_avg:52.67ms
+step:1390/1840 train_time:73254ms step_avg:52.70ms
+step:1391/1840 train_time:73342ms step_avg:52.73ms
+step:1392/1840 train_time:73430ms step_avg:52.75ms
+step:1393/1840 train_time:73516ms step_avg:52.78ms
+step:1394/1840 train_time:73604ms step_avg:52.80ms
+step:1395/1840 train_time:73691ms step_avg:52.83ms
+step:1396/1840 train_time:73779ms step_avg:52.85ms
+step:1397/1840 train_time:73865ms step_avg:52.87ms
+step:1398/1840 train_time:73954ms step_avg:52.90ms
+step:1399/1840 train_time:74041ms step_avg:52.92ms
+step:1400/1840 train_time:74129ms step_avg:52.95ms
+step:1401/1840 train_time:74215ms step_avg:52.97ms
+step:1402/1840 train_time:74303ms step_avg:53.00ms
+step:1403/1840 train_time:74390ms step_avg:53.02ms
+step:1404/1840 train_time:74478ms step_avg:53.05ms
+step:1405/1840 train_time:74564ms step_avg:53.07ms
+step:1406/1840 train_time:74654ms step_avg:53.10ms
+step:1407/1840 train_time:74740ms step_avg:53.12ms
+step:1408/1840 train_time:74828ms step_avg:53.14ms
+step:1409/1840 train_time:74915ms step_avg:53.17ms
+step:1410/1840 train_time:75004ms step_avg:53.19ms
+step:1411/1840 train_time:75090ms step_avg:53.22ms
+step:1412/1840 train_time:75178ms step_avg:53.24ms
+step:1413/1840 train_time:75265ms step_avg:53.27ms
+step:1414/1840 train_time:75354ms step_avg:53.29ms
+step:1415/1840 train_time:75441ms step_avg:53.32ms
+step:1416/1840 train_time:75530ms step_avg:53.34ms
+step:1417/1840 train_time:75615ms step_avg:53.36ms
+step:1418/1840 train_time:75703ms step_avg:53.39ms
+step:1419/1840 train_time:75791ms step_avg:53.41ms
+step:1420/1840 train_time:75879ms step_avg:53.44ms
+step:1421/1840 train_time:75965ms step_avg:53.46ms
+step:1422/1840 train_time:76054ms step_avg:53.48ms
+step:1423/1840 train_time:76140ms step_avg:53.51ms
+step:1424/1840 train_time:76230ms step_avg:53.53ms
+step:1425/1840 train_time:76316ms step_avg:53.56ms
+step:1426/1840 train_time:76404ms step_avg:53.58ms
+step:1427/1840 train_time:76490ms step_avg:53.60ms
+step:1428/1840 train_time:76579ms step_avg:53.63ms
+step:1429/1840 train_time:76665ms step_avg:53.65ms
+step:1430/1840 train_time:76754ms step_avg:53.67ms
+step:1431/1840 train_time:76840ms step_avg:53.70ms
+step:1432/1840 train_time:76929ms step_avg:53.72ms
+step:1433/1840 train_time:77015ms step_avg:53.74ms
+step:1434/1840 train_time:77103ms step_avg:53.77ms
+step:1435/1840 train_time:77190ms step_avg:53.79ms
+step:1436/1840 train_time:77279ms step_avg:53.82ms
+step:1437/1840 train_time:77364ms step_avg:53.84ms
+step:1438/1840 train_time:77453ms step_avg:53.86ms
+step:1439/1840 train_time:77540ms step_avg:53.88ms
+step:1440/1840 train_time:77629ms step_avg:53.91ms
+step:1441/1840 train_time:77715ms step_avg:53.93ms
+step:1442/1840 train_time:77803ms step_avg:53.95ms
+step:1443/1840 train_time:77891ms step_avg:53.98ms
+step:1444/1840 train_time:77979ms step_avg:54.00ms
+step:1445/1840 train_time:78065ms step_avg:54.02ms
+step:1446/1840 train_time:78154ms step_avg:54.05ms
+step:1447/1840 train_time:78241ms step_avg:54.07ms
+step:1448/1840 train_time:78329ms step_avg:54.09ms
+step:1449/1840 train_time:78414ms step_avg:54.12ms
+step:1450/1840 train_time:78503ms step_avg:54.14ms
+step:1451/1840 train_time:78590ms step_avg:54.16ms
+step:1452/1840 train_time:78678ms step_avg:54.19ms
+step:1453/1840 train_time:78765ms step_avg:54.21ms
+step:1454/1840 train_time:78854ms step_avg:54.23ms
+step:1455/1840 train_time:78940ms step_avg:54.25ms
+step:1456/1840 train_time:79029ms step_avg:54.28ms
+step:1457/1840 train_time:79115ms step_avg:54.30ms
+step:1458/1840 train_time:79203ms step_avg:54.32ms
+step:1459/1840 train_time:79291ms step_avg:54.35ms
+step:1460/1840 train_time:79379ms step_avg:54.37ms
+step:1461/1840 train_time:79465ms step_avg:54.39ms
+step:1462/1840 train_time:79555ms step_avg:54.41ms
+step:1463/1840 train_time:79642ms step_avg:54.44ms
+step:1464/1840 train_time:79731ms step_avg:54.46ms
+step:1465/1840 train_time:79817ms step_avg:54.48ms
+step:1466/1840 train_time:79905ms step_avg:54.51ms
+step:1467/1840 train_time:79992ms step_avg:54.53ms
+step:1468/1840 train_time:80080ms step_avg:54.55ms
+step:1469/1840 train_time:80167ms step_avg:54.57ms
+step:1470/1840 train_time:80256ms step_avg:54.60ms
+step:1471/1840 train_time:80341ms step_avg:54.62ms
+step:1472/1840 train_time:80430ms step_avg:54.64ms
+step:1473/1840 train_time:80517ms step_avg:54.66ms
+step:1474/1840 train_time:80605ms step_avg:54.68ms
+step:1475/1840 train_time:80691ms step_avg:54.71ms
+step:1476/1840 train_time:80781ms step_avg:54.73ms
+step:1477/1840 train_time:80867ms step_avg:54.75ms
+step:1478/1840 train_time:80956ms step_avg:54.77ms
+step:1479/1840 train_time:81043ms step_avg:54.80ms
+step:1480/1840 train_time:81131ms step_avg:54.82ms
+step:1481/1840 train_time:81217ms step_avg:54.84ms
+step:1482/1840 train_time:81305ms step_avg:54.86ms
+step:1483/1840 train_time:81392ms step_avg:54.88ms
+step:1484/1840 train_time:81481ms step_avg:54.91ms
+step:1485/1840 train_time:81567ms step_avg:54.93ms
+step:1486/1840 train_time:81655ms step_avg:54.95ms
+step:1487/1840 train_time:81741ms step_avg:54.97ms
+step:1488/1840 train_time:81831ms step_avg:54.99ms
+step:1489/1840 train_time:81915ms step_avg:55.01ms
+step:1490/1840 train_time:82004ms step_avg:55.04ms
+step:1491/1840 train_time:82090ms step_avg:55.06ms
+step:1492/1840 train_time:82179ms step_avg:55.08ms
+step:1493/1840 train_time:82266ms step_avg:55.10ms
+step:1494/1840 train_time:82354ms step_avg:55.12ms
+step:1495/1840 train_time:82439ms step_avg:55.14ms
+step:1496/1840 train_time:82529ms step_avg:55.17ms
+step:1497/1840 train_time:82615ms step_avg:55.19ms
+step:1498/1840 train_time:82705ms step_avg:55.21ms
+step:1499/1840 train_time:82791ms step_avg:55.23ms
+step:1500/1840 train_time:82879ms step_avg:55.25ms
+step:1500/1840 val_loss:3.4024 train_time:82978ms step_avg:55.32ms
+step:1501/1840 train_time:82997ms step_avg:55.29ms
+step:1502/1840 train_time:83053ms step_avg:55.29ms
+step:1503/1840 train_time:83141ms step_avg:55.32ms
+step:1504/1840 train_time:83231ms step_avg:55.34ms
+step:1505/1840 train_time:83316ms step_avg:55.36ms
+step:1506/1840 train_time:83404ms step_avg:55.38ms
+step:1507/1840 train_time:83489ms step_avg:55.40ms
+step:1508/1840 train_time:83576ms step_avg:55.42ms
+step:1509/1840 train_time:83662ms step_avg:55.44ms
+step:1510/1840 train_time:83750ms step_avg:55.46ms
+step:1511/1840 train_time:83835ms step_avg:55.48ms
+step:1512/1840 train_time:83927ms step_avg:55.51ms
+step:1513/1840 train_time:84015ms step_avg:55.53ms
+step:1514/1840 train_time:84107ms step_avg:55.55ms
+step:1515/1840 train_time:84195ms step_avg:55.57ms
+step:1516/1840 train_time:84284ms step_avg:55.60ms
+step:1517/1840 train_time:84371ms step_avg:55.62ms
+step:1518/1840 train_time:84457ms step_avg:55.64ms
+step:1519/1840 train_time:84543ms step_avg:55.66ms
+step:1520/1840 train_time:84631ms step_avg:55.68ms
+step:1521/1840 train_time:84717ms step_avg:55.70ms
+step:1522/1840 train_time:84805ms step_avg:55.72ms
+step:1523/1840 train_time:84892ms step_avg:55.74ms
+step:1524/1840 train_time:84982ms step_avg:55.76ms
+step:1525/1840 train_time:85071ms step_avg:55.78ms
+step:1526/1840 train_time:85160ms step_avg:55.81ms
+step:1527/1840 train_time:85247ms step_avg:55.83ms
+step:1528/1840 train_time:85334ms step_avg:55.85ms
+step:1529/1840 train_time:85420ms step_avg:55.87ms
+step:1530/1840 train_time:85508ms step_avg:55.89ms
+step:1531/1840 train_time:85594ms step_avg:55.91ms
+step:1532/1840 train_time:85683ms step_avg:55.93ms
+step:1533/1840 train_time:85769ms step_avg:55.95ms
+step:1534/1840 train_time:85857ms step_avg:55.97ms
+step:1535/1840 train_time:85945ms step_avg:55.99ms
+step:1536/1840 train_time:86035ms step_avg:56.01ms
+step:1537/1840 train_time:86122ms step_avg:56.03ms
+step:1538/1840 train_time:86212ms step_avg:56.05ms
+step:1539/1840 train_time:86296ms step_avg:56.07ms
+step:1540/1840 train_time:86386ms step_avg:56.09ms
+step:1541/1840 train_time:86472ms step_avg:56.11ms
+step:1542/1840 train_time:86561ms step_avg:56.14ms
+step:1543/1840 train_time:86646ms step_avg:56.15ms
+step:1544/1840 train_time:86734ms step_avg:56.17ms
+step:1545/1840 train_time:86821ms step_avg:56.19ms
+step:1546/1840 train_time:86911ms step_avg:56.22ms
+step:1547/1840 train_time:86998ms step_avg:56.24ms
+step:1548/1840 train_time:87087ms step_avg:56.26ms
+step:1549/1840 train_time:87174ms step_avg:56.28ms
+step:1550/1840 train_time:87262ms step_avg:56.30ms
+step:1551/1840 train_time:87347ms step_avg:56.32ms
+step:1552/1840 train_time:87435ms step_avg:56.34ms
+step:1553/1840 train_time:87521ms step_avg:56.36ms
+step:1554/1840 train_time:87611ms step_avg:56.38ms
+step:1555/1840 train_time:87696ms step_avg:56.40ms
+step:1556/1840 train_time:87785ms step_avg:56.42ms
+step:1557/1840 train_time:87872ms step_avg:56.44ms
+step:1558/1840 train_time:87961ms step_avg:56.46ms
+step:1559/1840 train_time:88047ms step_avg:56.48ms
+step:1560/1840 train_time:88136ms step_avg:56.50ms
+step:1561/1840 train_time:88222ms step_avg:56.52ms
+step:1562/1840 train_time:88311ms step_avg:56.54ms
+step:1563/1840 train_time:88396ms step_avg:56.56ms
+step:1564/1840 train_time:88484ms step_avg:56.58ms
+step:1565/1840 train_time:88572ms step_avg:56.60ms
+step:1566/1840 train_time:88660ms step_avg:56.62ms
+step:1567/1840 train_time:88746ms step_avg:56.63ms
+step:1568/1840 train_time:88834ms step_avg:56.65ms
+step:1569/1840 train_time:88921ms step_avg:56.67ms
+step:1570/1840 train_time:89010ms step_avg:56.69ms
+step:1571/1840 train_time:89096ms step_avg:56.71ms
+step:1572/1840 train_time:89185ms step_avg:56.73ms
+step:1573/1840 train_time:89272ms step_avg:56.75ms
+step:1574/1840 train_time:89360ms step_avg:56.77ms
+step:1575/1840 train_time:89446ms step_avg:56.79ms
+step:1576/1840 train_time:89535ms step_avg:56.81ms
+step:1577/1840 train_time:89620ms step_avg:56.83ms
+step:1578/1840 train_time:89709ms step_avg:56.85ms
+step:1579/1840 train_time:89795ms step_avg:56.87ms
+step:1580/1840 train_time:89884ms step_avg:56.89ms
+step:1581/1840 train_time:89972ms step_avg:56.91ms
+step:1582/1840 train_time:90061ms step_avg:56.93ms
+step:1583/1840 train_time:90148ms step_avg:56.95ms
+step:1584/1840 train_time:90236ms step_avg:56.97ms
+step:1585/1840 train_time:90320ms step_avg:56.98ms
+step:1586/1840 train_time:90410ms step_avg:57.01ms
+step:1587/1840 train_time:90496ms step_avg:57.02ms
+step:1588/1840 train_time:90585ms step_avg:57.04ms
+step:1589/1840 train_time:90671ms step_avg:57.06ms
+step:1590/1840 train_time:90759ms step_avg:57.08ms
+step:1591/1840 train_time:90845ms step_avg:57.10ms
+step:1592/1840 train_time:90935ms step_avg:57.12ms
+step:1593/1840 train_time:91022ms step_avg:57.14ms
+step:1594/1840 train_time:91113ms step_avg:57.16ms
+step:1595/1840 train_time:91197ms step_avg:57.18ms
+step:1596/1840 train_time:91286ms step_avg:57.20ms
+step:1597/1840 train_time:91373ms step_avg:57.22ms
+step:1598/1840 train_time:91462ms step_avg:57.24ms
+step:1599/1840 train_time:91548ms step_avg:57.25ms
+step:1600/1840 train_time:91635ms step_avg:57.27ms
+step:1601/1840 train_time:91721ms step_avg:57.29ms
+step:1602/1840 train_time:91810ms step_avg:57.31ms
+step:1603/1840 train_time:91896ms step_avg:57.33ms
+step:1604/1840 train_time:91986ms step_avg:57.35ms
+step:1605/1840 train_time:92073ms step_avg:57.37ms
+step:1606/1840 train_time:92162ms step_avg:57.39ms
+step:1607/1840 train_time:92248ms step_avg:57.40ms
+step:1608/1840 train_time:92337ms step_avg:57.42ms
+step:1609/1840 train_time:92424ms step_avg:57.44ms
+step:1610/1840 train_time:92512ms step_avg:57.46ms
+step:1611/1840 train_time:92597ms step_avg:57.48ms
+step:1612/1840 train_time:92686ms step_avg:57.50ms
+step:1613/1840 train_time:92773ms step_avg:57.52ms
+step:1614/1840 train_time:92861ms step_avg:57.53ms
+step:1615/1840 train_time:92947ms step_avg:57.55ms
+step:1616/1840 train_time:93036ms step_avg:57.57ms
+step:1617/1840 train_time:93123ms step_avg:57.59ms
+step:1618/1840 train_time:93212ms step_avg:57.61ms
+step:1619/1840 train_time:93297ms step_avg:57.63ms
+step:1620/1840 train_time:93386ms step_avg:57.65ms
+step:1621/1840 train_time:93473ms step_avg:57.66ms
+step:1622/1840 train_time:93561ms step_avg:57.68ms
+step:1623/1840 train_time:93647ms step_avg:57.70ms
+step:1624/1840 train_time:93736ms step_avg:57.72ms
+step:1625/1840 train_time:93822ms step_avg:57.74ms
+step:1626/1840 train_time:93912ms step_avg:57.76ms
+step:1627/1840 train_time:93997ms step_avg:57.77ms
+step:1628/1840 train_time:94086ms step_avg:57.79ms
+step:1629/1840 train_time:94173ms step_avg:57.81ms
+step:1630/1840 train_time:94262ms step_avg:57.83ms
+step:1631/1840 train_time:94350ms step_avg:57.85ms
+step:1632/1840 train_time:94438ms step_avg:57.87ms
+step:1633/1840 train_time:94524ms step_avg:57.88ms
+step:1634/1840 train_time:94612ms step_avg:57.90ms
+step:1635/1840 train_time:94699ms step_avg:57.92ms
+step:1636/1840 train_time:94788ms step_avg:57.94ms
+step:1637/1840 train_time:94873ms step_avg:57.96ms
+step:1638/1840 train_time:94962ms step_avg:57.97ms
+step:1639/1840 train_time:95048ms step_avg:57.99ms
+step:1640/1840 train_time:95137ms step_avg:58.01ms
+step:1641/1840 train_time:95223ms step_avg:58.03ms
+step:1642/1840 train_time:95312ms step_avg:58.05ms
+step:1643/1840 train_time:95397ms step_avg:58.06ms
+step:1644/1840 train_time:95487ms step_avg:58.08ms
+step:1645/1840 train_time:95573ms step_avg:58.10ms
+step:1646/1840 train_time:95662ms step_avg:58.12ms
+step:1647/1840 train_time:95748ms step_avg:58.13ms
+step:1648/1840 train_time:95837ms step_avg:58.15ms
+step:1649/1840 train_time:95923ms step_avg:58.17ms
+step:1650/1840 train_time:96012ms step_avg:58.19ms
+step:1651/1840 train_time:96099ms step_avg:58.21ms
+step:1652/1840 train_time:96188ms step_avg:58.23ms
+step:1653/1840 train_time:96275ms step_avg:58.24ms
+step:1654/1840 train_time:96363ms step_avg:58.26ms
+step:1655/1840 train_time:96450ms step_avg:58.28ms
+step:1656/1840 train_time:96539ms step_avg:58.30ms
+step:1657/1840 train_time:96625ms step_avg:58.31ms
+step:1658/1840 train_time:96713ms step_avg:58.33ms
+step:1659/1840 train_time:96798ms step_avg:58.35ms
+step:1660/1840 train_time:96887ms step_avg:58.37ms
+step:1661/1840 train_time:96973ms step_avg:58.38ms
+step:1662/1840 train_time:97062ms step_avg:58.40ms
+step:1663/1840 train_time:97149ms step_avg:58.42ms
+step:1664/1840 train_time:97237ms step_avg:58.44ms
+step:1665/1840 train_time:97322ms step_avg:58.45ms
+step:1666/1840 train_time:97412ms step_avg:58.47ms
+step:1667/1840 train_time:97498ms step_avg:58.49ms
+step:1668/1840 train_time:97588ms step_avg:58.51ms
+step:1669/1840 train_time:97674ms step_avg:58.52ms
+step:1670/1840 train_time:97764ms step_avg:58.54ms
+step:1671/1840 train_time:97850ms step_avg:58.56ms
+step:1672/1840 train_time:97938ms step_avg:58.58ms
+step:1673/1840 train_time:98024ms step_avg:58.59ms
+step:1674/1840 train_time:98113ms step_avg:58.61ms
+step:1675/1840 train_time:98198ms step_avg:58.63ms
+step:1676/1840 train_time:98286ms step_avg:58.64ms
+step:1677/1840 train_time:98373ms step_avg:58.66ms
+step:1678/1840 train_time:98462ms step_avg:58.68ms
+step:1679/1840 train_time:98549ms step_avg:58.70ms
+step:1680/1840 train_time:98639ms step_avg:58.71ms
+step:1681/1840 train_time:98725ms step_avg:58.73ms
+step:1682/1840 train_time:98813ms step_avg:58.75ms
+step:1683/1840 train_time:98899ms step_avg:58.76ms
+step:1684/1840 train_time:98989ms step_avg:58.78ms
+step:1685/1840 train_time:99075ms step_avg:58.80ms
+step:1686/1840 train_time:99163ms step_avg:58.82ms
+step:1687/1840 train_time:99250ms step_avg:58.83ms
+step:1688/1840 train_time:99339ms step_avg:58.85ms
+step:1689/1840 train_time:99425ms step_avg:58.87ms
+step:1690/1840 train_time:99513ms step_avg:58.88ms
+step:1691/1840 train_time:99600ms step_avg:58.90ms
+step:1692/1840 train_time:99690ms step_avg:58.92ms
+step:1693/1840 train_time:99775ms step_avg:58.93ms
+step:1694/1840 train_time:99864ms step_avg:58.95ms
+step:1695/1840 train_time:99950ms step_avg:58.97ms
+step:1696/1840 train_time:100039ms step_avg:58.99ms
+step:1697/1840 train_time:100125ms step_avg:59.00ms
+step:1698/1840 train_time:100213ms step_avg:59.02ms
+step:1699/1840 train_time:100299ms step_avg:59.03ms
+step:1700/1840 train_time:100388ms step_avg:59.05ms
+step:1701/1840 train_time:100474ms step_avg:59.07ms
+step:1702/1840 train_time:100562ms step_avg:59.08ms
+step:1703/1840 train_time:100648ms step_avg:59.10ms
+step:1704/1840 train_time:100737ms step_avg:59.12ms
+step:1705/1840 train_time:100823ms step_avg:59.13ms
+step:1706/1840 train_time:100912ms step_avg:59.15ms
+step:1707/1840 train_time:100998ms step_avg:59.17ms
+step:1708/1840 train_time:101086ms step_avg:59.18ms
+step:1709/1840 train_time:101172ms step_avg:59.20ms
+step:1710/1840 train_time:101261ms step_avg:59.22ms
+step:1711/1840 train_time:101348ms step_avg:59.23ms
+step:1712/1840 train_time:101436ms step_avg:59.25ms
+step:1713/1840 train_time:101522ms step_avg:59.27ms
+step:1714/1840 train_time:101611ms step_avg:59.28ms
+step:1715/1840 train_time:101696ms step_avg:59.30ms
+step:1716/1840 train_time:101785ms step_avg:59.32ms
+step:1717/1840 train_time:101872ms step_avg:59.33ms
+step:1718/1840 train_time:101961ms step_avg:59.35ms
+step:1719/1840 train_time:102047ms step_avg:59.36ms
+step:1720/1840 train_time:102136ms step_avg:59.38ms
+step:1721/1840 train_time:102222ms step_avg:59.40ms
+step:1722/1840 train_time:102311ms step_avg:59.41ms
+step:1723/1840 train_time:102398ms step_avg:59.43ms
+step:1724/1840 train_time:102487ms step_avg:59.45ms
+step:1725/1840 train_time:102574ms step_avg:59.46ms
+step:1726/1840 train_time:102662ms step_avg:59.48ms
+step:1727/1840 train_time:102749ms step_avg:59.50ms
+step:1728/1840 train_time:102838ms step_avg:59.51ms
+step:1729/1840 train_time:102923ms step_avg:59.53ms
+step:1730/1840 train_time:103012ms step_avg:59.54ms
+step:1731/1840 train_time:103097ms step_avg:59.56ms
+step:1732/1840 train_time:103186ms step_avg:59.58ms
+step:1733/1840 train_time:103273ms step_avg:59.59ms
+step:1734/1840 train_time:103361ms step_avg:59.61ms
+step:1735/1840 train_time:103448ms step_avg:59.62ms
+step:1736/1840 train_time:103537ms step_avg:59.64ms
+step:1737/1840 train_time:103623ms step_avg:59.66ms
+step:1738/1840 train_time:103712ms step_avg:59.67ms
+step:1739/1840 train_time:103797ms step_avg:59.69ms
+step:1740/1840 train_time:103886ms step_avg:59.70ms
+step:1741/1840 train_time:103972ms step_avg:59.72ms
+step:1742/1840 train_time:104060ms step_avg:59.74ms
+step:1743/1840 train_time:104147ms step_avg:59.75ms
+step:1744/1840 train_time:104235ms step_avg:59.77ms
+step:1745/1840 train_time:104322ms step_avg:59.78ms
+step:1746/1840 train_time:104412ms step_avg:59.80ms
+step:1747/1840 train_time:104498ms step_avg:59.82ms
+step:1748/1840 train_time:104586ms step_avg:59.83ms
+step:1749/1840 train_time:104673ms step_avg:59.85ms
+step:1750/1840 train_time:104762ms step_avg:59.86ms
+step:1750/1840 val_loss:3.3030 train_time:104862ms step_avg:59.92ms
+step:1751/1840 train_time:104881ms step_avg:59.90ms
+step:1752/1840 train_time:104938ms step_avg:59.90ms
+step:1753/1840 train_time:105027ms step_avg:59.91ms
+step:1754/1840 train_time:105118ms step_avg:59.93ms
+step:1755/1840 train_time:105203ms step_avg:59.94ms
+step:1756/1840 train_time:105290ms step_avg:59.96ms
+step:1757/1840 train_time:105374ms step_avg:59.97ms
+step:1758/1840 train_time:105463ms step_avg:59.99ms
+step:1759/1840 train_time:105548ms step_avg:60.00ms
+step:1760/1840 train_time:105636ms step_avg:60.02ms
+step:1761/1840 train_time:105723ms step_avg:60.04ms
+step:1762/1840 train_time:105813ms step_avg:60.05ms
+step:1763/1840 train_time:105904ms step_avg:60.07ms
+step:1764/1840 train_time:105995ms step_avg:60.09ms
+step:1765/1840 train_time:106082ms step_avg:60.10ms
+step:1766/1840 train_time:106170ms step_avg:60.12ms
+step:1767/1840 train_time:106255ms step_avg:60.13ms
+step:1768/1840 train_time:106343ms step_avg:60.15ms
+step:1769/1840 train_time:106428ms step_avg:60.16ms
+step:1770/1840 train_time:106516ms step_avg:60.18ms
+step:1771/1840 train_time:106602ms step_avg:60.19ms
+step:1772/1840 train_time:106690ms step_avg:60.21ms
+step:1773/1840 train_time:106777ms step_avg:60.22ms
+step:1774/1840 train_time:106866ms step_avg:60.24ms
+step:1775/1840 train_time:106954ms step_avg:60.26ms
+step:1776/1840 train_time:107044ms step_avg:60.27ms
+step:1777/1840 train_time:107130ms step_avg:60.29ms
+step:1778/1840 train_time:107218ms step_avg:60.30ms
+step:1779/1840 train_time:107304ms step_avg:60.32ms
+step:1780/1840 train_time:107393ms step_avg:60.33ms
+step:1781/1840 train_time:107477ms step_avg:60.35ms
+step:1782/1840 train_time:107565ms step_avg:60.36ms
+step:1783/1840 train_time:107651ms step_avg:60.38ms
+step:1784/1840 train_time:107740ms step_avg:60.39ms
+step:1785/1840 train_time:107826ms step_avg:60.41ms
+step:1786/1840 train_time:107918ms step_avg:60.42ms
+step:1787/1840 train_time:108006ms step_avg:60.44ms
+step:1788/1840 train_time:108094ms step_avg:60.46ms
+step:1789/1840 train_time:108180ms step_avg:60.47ms
+step:1790/1840 train_time:108267ms step_avg:60.48ms
+step:1791/1840 train_time:108353ms step_avg:60.50ms
+step:1792/1840 train_time:108442ms step_avg:60.51ms
+step:1793/1840 train_time:108527ms step_avg:60.53ms
+step:1794/1840 train_time:108616ms step_avg:60.54ms
+step:1795/1840 train_time:108703ms step_avg:60.56ms
+step:1796/1840 train_time:108792ms step_avg:60.57ms
+step:1797/1840 train_time:108880ms step_avg:60.59ms
+step:1798/1840 train_time:108969ms step_avg:60.61ms
+step:1799/1840 train_time:109056ms step_avg:60.62ms
+step:1800/1840 train_time:109145ms step_avg:60.64ms
+step:1801/1840 train_time:109233ms step_avg:60.65ms
+step:1802/1840 train_time:109321ms step_avg:60.67ms
+step:1803/1840 train_time:109407ms step_avg:60.68ms
+step:1804/1840 train_time:109496ms step_avg:60.70ms
+step:1805/1840 train_time:109584ms step_avg:60.71ms
+step:1806/1840 train_time:109672ms step_avg:60.73ms
+step:1807/1840 train_time:109757ms step_avg:60.74ms
+step:1808/1840 train_time:109847ms step_avg:60.76ms
+step:1809/1840 train_time:109934ms step_avg:60.77ms
+step:1810/1840 train_time:110024ms step_avg:60.79ms
+step:1811/1840 train_time:110111ms step_avg:60.80ms
+step:1812/1840 train_time:110198ms step_avg:60.82ms
+step:1813/1840 train_time:110285ms step_avg:60.83ms
+step:1814/1840 train_time:110374ms step_avg:60.85ms
+step:1815/1840 train_time:110460ms step_avg:60.86ms
+step:1816/1840 train_time:110549ms step_avg:60.87ms
+step:1817/1840 train_time:110635ms step_avg:60.89ms
+step:1818/1840 train_time:110724ms step_avg:60.90ms
+step:1819/1840 train_time:110811ms step_avg:60.92ms
+step:1820/1840 train_time:110900ms step_avg:60.93ms
+step:1821/1840 train_time:110986ms step_avg:60.95ms
+step:1822/1840 train_time:111076ms step_avg:60.96ms
+step:1823/1840 train_time:111163ms step_avg:60.98ms
+step:1824/1840 train_time:111251ms step_avg:60.99ms
+step:1825/1840 train_time:111337ms step_avg:61.01ms
+step:1826/1840 train_time:111426ms step_avg:61.02ms
+step:1827/1840 train_time:111512ms step_avg:61.04ms
+step:1828/1840 train_time:111602ms step_avg:61.05ms
+step:1829/1840 train_time:111687ms step_avg:61.06ms
+step:1830/1840 train_time:111777ms step_avg:61.08ms
+step:1831/1840 train_time:111864ms step_avg:61.09ms
+step:1832/1840 train_time:111952ms step_avg:61.11ms
+step:1833/1840 train_time:112039ms step_avg:61.12ms
+step:1834/1840 train_time:112128ms step_avg:61.14ms
+step:1835/1840 train_time:112216ms step_avg:61.15ms
+step:1836/1840 train_time:112305ms step_avg:61.17ms
+step:1837/1840 train_time:112390ms step_avg:61.18ms
+step:1838/1840 train_time:112478ms step_avg:61.20ms
+step:1839/1840 train_time:112565ms step_avg:61.21ms
+step:1840/1840 train_time:112654ms step_avg:61.22ms
+step:1840/1840 val_loss:3.2777 train_time:112755ms step_avg:61.28ms
+peak memory allocated: 28379 MiB reserved: 39958 MiB

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/bc60aae2-2dfa-422d-8e55-bf9ed29eacae.txt
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/bc60aae2-2dfa-422d-8e55-bf9ed29eacae.txt
@@ -1,0 +1,3786 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+    """
+    Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+    Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+    bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+    float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+    """
+    assert p.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    wd_factor = wd_tensor.to(torch.float32)
+    lr_factor = lr_tensor.to(torch.float32)
+    p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    p_precise = p_precise_raw.view(torch.float32)
+    mask = (grad * p_precise) >= 0
+    p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+    p.copy_((p_precise_raw >> 16).to(torch.uint16))
+    mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        2. reduce scatter attn/mlp round 2 (16 mlp params)
+        3. wait on step 1, then compute update of 1 and schedule all gather
+        4. wait on step 2, then compute update of 2 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        5. wait for each all gather to complete and update params
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["mantissa"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn', 'mlp']
+        group_sizes = [16, 16]  # 10 attn + 6 mlp, then 16 mlp
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    def step(self):
+        self.step_p1()
+        self.step_p2()
+        self.step_p3()
+        
+    @torch.no_grad()
+    def step_p1(self):
+        """
+        Part 1: Launch distributed reduce_scatter operations for parameter groups.
+        """
+        rank = dist.get_rank()
+        self.group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            self.group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+    
+    @torch.no_grad()
+    def step_p2(self):
+        """
+        Part 2: Compute gradient updates and launch all_gather operations
+        Wait for all gather to complete for all parameter groups except final one
+        """
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = self.group_infos
+        
+        self.all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"].float()
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params], dtype=torch.float32)
+                
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            if "second_momentum_buffer" not in group:
+                group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1], dtype=torch.float32)
+                    if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if param_shape[-2] >= param_shape[-1] else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk, dtype=torch.bfloat16)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                if "mantissa" not in group:
+                    group["mantissa"] = torch.zeros_like(param_chunk, dtype=torch.uint16)
+                mantissa = group["mantissa"]
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx].view(torch.uint16),
+                        mantissa[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx]
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            self.all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete for all except final and copy results back into original parameter tensors.
+        for info in self.all_gather_infos[:-1]:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+    @torch.no_grad()
+    def step_p3(self):
+        """
+        Part 3: Wait for final all gather to complete and copy results back into original parameter tensors
+        """
+        info = self.all_gather_infos[-1]
+        info["gather_future"].wait()
+        stacked_params = info["stacked_params"]
+        orig_params = info["orig_params"]
+
+        unstacked_params = torch.unbind(stacked_params)
+        for i, p in enumerate(orig_params):
+            p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str], betas: list[list[float]], lr: float = 1e-3, eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for idx, label in enumerate(label_order):
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label], betas=betas[idx]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+        # tag the final param for optimizer pipelining, run all gather after muon copy
+        param_groups[-1]['params'][-1].is_final_param = True
+        
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        # 0-D CPU tensors to avoid recompilation in _update_step
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    def load_state_dict(self, state_dict):
+        """Override to preserve optimizer state dtypes (avoid BFloat16->Float32 cast that causes recompilation)."""
+        # Save original state dtypes before loading
+        original_dtypes = {}
+        for p, s in self.state.items():
+            original_dtypes[p] = {k: v.dtype for k, v in s.items() if isinstance(v, torch.Tensor)}
+        
+        # Call parent load_state_dict (which may cast dtypes to match param dtype)
+        super().load_state_dict(state_dict)
+        
+        # Restore original dtypes
+        for p, s in self.state.items():
+            if p in original_dtypes:
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor) and k in original_dtypes[p]:
+                        if v.dtype != original_dtypes[p][k]:
+                            s[k] = v.to(original_dtypes[p][k])
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-2]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step. step_size_t and eff_wd_t are 0-D CPU tensors to avoid recompilation."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)  # exp_avg = beta1 * exp_avg + (1 - beta1) * g_slice
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)  # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * g_slice^2
+        # compute step
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)  # update = (exp_avg / (sqrt(exp_avg_sq) + eps)) * step_size
+        # cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)  # update += eff_wd_t * p_slice * mask
+        p_slice.add_(other=update, alpha=-1.0)  # p_slice -= update
+
+    @torch.no_grad()
+    def step(self, muon_opt):
+        muon_opt.step_p1()
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        last_param = None
+        last_p_slice = None
+        for group in self.param_groups:      
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+                state["step"] += 1
+                t = state["step"]
+                
+                # Pre-compute changing values as 0-D CPU tensors to avoid recompilation.
+                # `.fill_(value)` is the same as "= value", but doesn't change the tensor object.
+                bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+                self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+                self._eff_wd_t.fill_(lr * lr * wd * getattr(param, "wd_mul", 1.0)) # `lr` included twice to serve as weight decay schedule.
+
+                DistAdam._update_step(p_slice, g_slice, state["exp_avg"], state["exp_avg_sq"],
+                                      beta1, beta2, eps, self._step_size_t, self._eff_wd_t)
+
+                if not is_small:
+                    if getattr(param, "is_final_param", False):
+                        last_param = param
+                        last_p_slice = p_slice
+                    else:
+                        all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+        self._reduce_scatter_futures.clear()
+
+        muon_opt.step_p2()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+        if last_param is not None:
+            last_all_gather_future = dist.all_gather_into_tensor(last_param, last_p_slice, async_op=True).get_future()
+        muon_opt.step_p3()
+        torch.futures.collect_all([last_all_gather_future]).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        adam_betas = {
+            'lm_head': [0.5, 0.95],
+            'smear_gate': [0.9, 0.99],
+            'attn_gate_bank': [0.9, 0.99],
+            've_gate_bank': [0.9, 0.99],
+            'skip_gate': [0.9, 0.99],
+            'x0_lambdas': [0.65, 0.95],
+            'scalars': [0.9, 0.99],
+            'embed': [0.5, 0.95],
+            'value_embed': [0.75, 0.95]
+        }
+        adam_labels = list(adam_betas.keys())
+        adam_beta_values = list(adam_betas.values())
+        muon_labels = ['attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, adam_beta_values, lr=0.008, eps=1e-10, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.muon_opt]
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * step_lr
+                
+        if self._is_active_step(self.adam_opt, step):
+            # adam will interleave calls to muon step
+            self.adam_opt.step(self.muon_opt)
+            self.model.zero_grad(set_to_none=True)
+            self.adam_opt.should_sync = False
+        else:
+            self.muon_opt.step()
+            self.muon_opt.zero_grad(set_to_none=True)
+            
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1800  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan  5 07:51:46 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   42C    P0            128W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   43C    P0            133W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     48608      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     48609      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     48610      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     48611      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     48612      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     48613      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     48614      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     48615      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 599, 600, 601, 1199, 1200, 1201, 1799, 1800, 1801] for warmup
+Resetting Model
+step:0/1840 val_loss:10.8327 train_time:0ms step_avg:0.04ms
+step:1/1840 train_time:84ms step_avg:83.95ms
+step:2/1840 train_time:106ms step_avg:53.20ms
+step:3/1840 train_time:126ms step_avg:41.88ms
+step:4/1840 train_time:155ms step_avg:38.63ms
+step:5/1840 train_time:187ms step_avg:37.30ms
+step:6/1840 train_time:274ms step_avg:45.60ms
+step:7/1840 train_time:291ms step_avg:41.64ms
+step:8/1840 train_time:315ms step_avg:39.35ms
+step:9/1840 train_time:347ms step_avg:38.51ms
+step:10/1840 train_time:381ms step_avg:38.06ms
+step:11/1840 train_time:413ms step_avg:37.52ms
+step:12/1840 train_time:447ms step_avg:37.24ms
+step:13/1840 train_time:479ms step_avg:36.83ms
+step:14/1840 train_time:513ms step_avg:36.64ms
+step:15/1840 train_time:545ms step_avg:36.34ms
+step:16/1840 train_time:579ms step_avg:36.19ms
+step:17/1840 train_time:611ms step_avg:35.95ms
+step:18/1840 train_time:645ms step_avg:35.85ms
+step:19/1840 train_time:677ms step_avg:35.64ms
+step:20/1840 train_time:711ms step_avg:35.56ms
+step:21/1840 train_time:743ms step_avg:35.39ms
+step:22/1840 train_time:777ms step_avg:35.34ms
+step:23/1840 train_time:809ms step_avg:35.19ms
+step:24/1840 train_time:844ms step_avg:35.15ms
+step:25/1840 train_time:875ms step_avg:35.02ms
+step:26/1840 train_time:909ms step_avg:34.98ms
+step:27/1840 train_time:941ms step_avg:34.87ms
+step:28/1840 train_time:976ms step_avg:34.86ms
+step:29/1840 train_time:1008ms step_avg:34.76ms
+step:30/1840 train_time:1043ms step_avg:34.76ms
+step:31/1840 train_time:1075ms step_avg:34.67ms
+step:32/1840 train_time:1109ms step_avg:34.65ms
+step:33/1840 train_time:1141ms step_avg:34.59ms
+step:34/1840 train_time:1177ms step_avg:34.61ms
+step:35/1840 train_time:1210ms step_avg:34.56ms
+step:36/1840 train_time:1244ms step_avg:34.56ms
+step:37/1840 train_time:1277ms step_avg:34.50ms
+step:38/1840 train_time:1311ms step_avg:34.50ms
+step:39/1840 train_time:1343ms step_avg:34.44ms
+step:40/1840 train_time:1378ms step_avg:34.45ms
+step:41/1840 train_time:1410ms step_avg:34.39ms
+step:42/1840 train_time:1444ms step_avg:34.39ms
+step:43/1840 train_time:1477ms step_avg:34.34ms
+step:44/1840 train_time:1511ms step_avg:34.33ms
+step:45/1840 train_time:1543ms step_avg:34.29ms
+step:46/1840 train_time:1578ms step_avg:34.30ms
+step:47/1840 train_time:1610ms step_avg:34.25ms
+step:48/1840 train_time:1644ms step_avg:34.25ms
+step:49/1840 train_time:1676ms step_avg:34.20ms
+step:50/1840 train_time:1710ms step_avg:34.20ms
+step:51/1840 train_time:1742ms step_avg:34.16ms
+step:52/1840 train_time:1776ms step_avg:34.16ms
+step:53/1840 train_time:1808ms step_avg:34.12ms
+step:54/1840 train_time:1842ms step_avg:34.12ms
+step:55/1840 train_time:1874ms step_avg:34.08ms
+step:56/1840 train_time:1909ms step_avg:34.08ms
+step:57/1840 train_time:1941ms step_avg:34.05ms
+step:58/1840 train_time:1975ms step_avg:34.05ms
+step:59/1840 train_time:2007ms step_avg:34.02ms
+step:60/1840 train_time:2041ms step_avg:34.02ms
+step:61/1840 train_time:2074ms step_avg:33.99ms
+step:62/1840 train_time:2108ms step_avg:34.00ms
+step:63/1840 train_time:2140ms step_avg:33.97ms
+step:64/1840 train_time:2175ms step_avg:33.98ms
+step:65/1840 train_time:2207ms step_avg:33.95ms
+step:66/1840 train_time:2242ms step_avg:33.97ms
+step:67/1840 train_time:2275ms step_avg:33.95ms
+step:68/1840 train_time:2309ms step_avg:33.96ms
+step:69/1840 train_time:2342ms step_avg:33.94ms
+step:70/1840 train_time:2376ms step_avg:33.94ms
+step:71/1840 train_time:2408ms step_avg:33.92ms
+step:72/1840 train_time:2443ms step_avg:33.93ms
+step:73/1840 train_time:2475ms step_avg:33.91ms
+step:74/1840 train_time:2509ms step_avg:33.91ms
+step:75/1840 train_time:2542ms step_avg:33.89ms
+step:76/1840 train_time:2576ms step_avg:33.90ms
+step:77/1840 train_time:2608ms step_avg:33.87ms
+step:78/1840 train_time:2642ms step_avg:33.88ms
+step:79/1840 train_time:2675ms step_avg:33.86ms
+step:80/1840 train_time:2709ms step_avg:33.86ms
+step:81/1840 train_time:2741ms step_avg:33.84ms
+step:82/1840 train_time:2775ms step_avg:33.85ms
+step:83/1840 train_time:2807ms step_avg:33.82ms
+step:84/1840 train_time:2842ms step_avg:33.83ms
+step:85/1840 train_time:2874ms step_avg:33.81ms
+step:86/1840 train_time:2908ms step_avg:33.82ms
+step:87/1840 train_time:2940ms step_avg:33.80ms
+step:88/1840 train_time:2975ms step_avg:33.80ms
+step:89/1840 train_time:3007ms step_avg:33.78ms
+step:90/1840 train_time:3041ms step_avg:33.79ms
+step:91/1840 train_time:3073ms step_avg:33.77ms
+step:92/1840 train_time:3107ms step_avg:33.77ms
+step:93/1840 train_time:3140ms step_avg:33.76ms
+step:94/1840 train_time:3174ms step_avg:33.77ms
+step:95/1840 train_time:3206ms step_avg:33.75ms
+step:96/1840 train_time:3241ms step_avg:33.76ms
+step:97/1840 train_time:3273ms step_avg:33.74ms
+step:98/1840 train_time:3307ms step_avg:33.75ms
+step:99/1840 train_time:3340ms step_avg:33.73ms
+step:100/1840 train_time:3374ms step_avg:33.74ms
+step:101/1840 train_time:3406ms step_avg:33.73ms
+step:102/1840 train_time:3441ms step_avg:33.73ms
+step:103/1840 train_time:3473ms step_avg:33.72ms
+step:104/1840 train_time:3508ms step_avg:33.73ms
+step:105/1840 train_time:3540ms step_avg:33.71ms
+step:106/1840 train_time:3574ms step_avg:33.72ms
+step:107/1840 train_time:3606ms step_avg:33.70ms
+step:108/1840 train_time:3641ms step_avg:33.72ms
+step:109/1840 train_time:3674ms step_avg:33.70ms
+step:110/1840 train_time:3708ms step_avg:33.71ms
+step:111/1840 train_time:3740ms step_avg:33.69ms
+step:112/1840 train_time:3774ms step_avg:33.70ms
+step:113/1840 train_time:3806ms step_avg:33.68ms
+step:114/1840 train_time:3840ms step_avg:33.69ms
+step:115/1840 train_time:3872ms step_avg:33.67ms
+step:116/1840 train_time:3906ms step_avg:33.68ms
+step:117/1840 train_time:3939ms step_avg:33.66ms
+step:118/1840 train_time:3973ms step_avg:33.67ms
+step:119/1840 train_time:4005ms step_avg:33.65ms
+step:120/1840 train_time:4039ms step_avg:33.66ms
+step:121/1840 train_time:4072ms step_avg:33.65ms
+step:122/1840 train_time:4106ms step_avg:33.65ms
+step:123/1840 train_time:4138ms step_avg:33.64ms
+step:124/1840 train_time:4172ms step_avg:33.64ms
+step:125/1840 train_time:4205ms step_avg:33.64ms
+step:126/1840 train_time:4239ms step_avg:33.64ms
+step:127/1840 train_time:4271ms step_avg:33.63ms
+step:128/1840 train_time:4306ms step_avg:33.64ms
+step:129/1840 train_time:4338ms step_avg:33.63ms
+step:130/1840 train_time:4372ms step_avg:33.63ms
+step:131/1840 train_time:4404ms step_avg:33.62ms
+step:132/1840 train_time:4439ms step_avg:33.63ms
+step:133/1840 train_time:4471ms step_avg:33.62ms
+step:134/1840 train_time:4505ms step_avg:33.62ms
+step:135/1840 train_time:4538ms step_avg:33.61ms
+step:136/1840 train_time:4572ms step_avg:33.62ms
+step:137/1840 train_time:4604ms step_avg:33.61ms
+step:138/1840 train_time:4638ms step_avg:33.61ms
+step:139/1840 train_time:4671ms step_avg:33.60ms
+step:140/1840 train_time:4705ms step_avg:33.61ms
+step:141/1840 train_time:4737ms step_avg:33.60ms
+step:142/1840 train_time:4772ms step_avg:33.60ms
+step:143/1840 train_time:4804ms step_avg:33.59ms
+step:144/1840 train_time:4838ms step_avg:33.60ms
+step:145/1840 train_time:4870ms step_avg:33.59ms
+step:146/1840 train_time:4904ms step_avg:33.59ms
+step:147/1840 train_time:4936ms step_avg:33.58ms
+step:148/1840 train_time:4970ms step_avg:33.58ms
+step:149/1840 train_time:5003ms step_avg:33.57ms
+step:150/1840 train_time:5037ms step_avg:33.58ms
+step:151/1840 train_time:5069ms step_avg:33.57ms
+step:152/1840 train_time:5103ms step_avg:33.57ms
+step:153/1840 train_time:5135ms step_avg:33.56ms
+step:154/1840 train_time:5169ms step_avg:33.57ms
+step:155/1840 train_time:5202ms step_avg:33.56ms
+step:156/1840 train_time:5236ms step_avg:33.56ms
+step:157/1840 train_time:5268ms step_avg:33.55ms
+step:158/1840 train_time:5302ms step_avg:33.56ms
+step:159/1840 train_time:5334ms step_avg:33.55ms
+step:160/1840 train_time:5369ms step_avg:33.55ms
+step:161/1840 train_time:5401ms step_avg:33.54ms
+step:162/1840 train_time:5435ms step_avg:33.55ms
+step:163/1840 train_time:5467ms step_avg:33.54ms
+step:164/1840 train_time:5502ms step_avg:33.55ms
+step:165/1840 train_time:5534ms step_avg:33.54ms
+step:166/1840 train_time:5568ms step_avg:33.54ms
+step:167/1840 train_time:5600ms step_avg:33.53ms
+step:168/1840 train_time:5635ms step_avg:33.54ms
+step:169/1840 train_time:5667ms step_avg:33.53ms
+step:170/1840 train_time:5701ms step_avg:33.54ms
+step:171/1840 train_time:5733ms step_avg:33.53ms
+step:172/1840 train_time:5768ms step_avg:33.53ms
+step:173/1840 train_time:5800ms step_avg:33.53ms
+step:174/1840 train_time:5834ms step_avg:33.53ms
+step:175/1840 train_time:5866ms step_avg:33.52ms
+step:176/1840 train_time:5900ms step_avg:33.52ms
+step:177/1840 train_time:5932ms step_avg:33.52ms
+step:178/1840 train_time:5967ms step_avg:33.52ms
+step:179/1840 train_time:5999ms step_avg:33.51ms
+step:180/1840 train_time:6033ms step_avg:33.52ms
+step:181/1840 train_time:6065ms step_avg:33.51ms
+step:182/1840 train_time:6099ms step_avg:33.51ms
+step:183/1840 train_time:6131ms step_avg:33.50ms
+step:184/1840 train_time:6165ms step_avg:33.51ms
+step:185/1840 train_time:6197ms step_avg:33.50ms
+step:186/1840 train_time:6232ms step_avg:33.50ms
+step:187/1840 train_time:6264ms step_avg:33.50ms
+step:188/1840 train_time:6298ms step_avg:33.50ms
+step:189/1840 train_time:6330ms step_avg:33.49ms
+step:190/1840 train_time:6364ms step_avg:33.49ms
+step:191/1840 train_time:6396ms step_avg:33.49ms
+step:192/1840 train_time:6430ms step_avg:33.49ms
+step:193/1840 train_time:6463ms step_avg:33.49ms
+step:194/1840 train_time:6497ms step_avg:33.49ms
+step:195/1840 train_time:6529ms step_avg:33.48ms
+step:196/1840 train_time:6564ms step_avg:33.49ms
+step:197/1840 train_time:6596ms step_avg:33.48ms
+step:198/1840 train_time:6630ms step_avg:33.48ms
+step:199/1840 train_time:6662ms step_avg:33.48ms
+step:200/1840 train_time:6696ms step_avg:33.48ms
+step:201/1840 train_time:6728ms step_avg:33.47ms
+step:202/1840 train_time:6763ms step_avg:33.48ms
+step:203/1840 train_time:6795ms step_avg:33.47ms
+step:204/1840 train_time:6829ms step_avg:33.48ms
+step:205/1840 train_time:6861ms step_avg:33.47ms
+step:206/1840 train_time:6896ms step_avg:33.48ms
+step:207/1840 train_time:6928ms step_avg:33.47ms
+step:208/1840 train_time:6963ms step_avg:33.48ms
+step:209/1840 train_time:6994ms step_avg:33.47ms
+step:210/1840 train_time:7028ms step_avg:33.47ms
+step:211/1840 train_time:7060ms step_avg:33.46ms
+step:212/1840 train_time:7094ms step_avg:33.46ms
+step:213/1840 train_time:7126ms step_avg:33.46ms
+step:214/1840 train_time:7161ms step_avg:33.46ms
+step:215/1840 train_time:7193ms step_avg:33.46ms
+step:216/1840 train_time:7227ms step_avg:33.46ms
+step:217/1840 train_time:7260ms step_avg:33.45ms
+step:218/1840 train_time:7294ms step_avg:33.46ms
+step:219/1840 train_time:7326ms step_avg:33.45ms
+step:220/1840 train_time:7360ms step_avg:33.46ms
+step:221/1840 train_time:7393ms step_avg:33.45ms
+step:222/1840 train_time:7427ms step_avg:33.46ms
+step:223/1840 train_time:7459ms step_avg:33.45ms
+step:224/1840 train_time:7493ms step_avg:33.45ms
+step:225/1840 train_time:7526ms step_avg:33.45ms
+step:226/1840 train_time:7560ms step_avg:33.45ms
+step:227/1840 train_time:7592ms step_avg:33.44ms
+step:228/1840 train_time:7626ms step_avg:33.45ms
+step:229/1840 train_time:7658ms step_avg:33.44ms
+step:230/1840 train_time:7692ms step_avg:33.44ms
+step:231/1840 train_time:7724ms step_avg:33.44ms
+step:232/1840 train_time:7759ms step_avg:33.45ms
+step:233/1840 train_time:7791ms step_avg:33.44ms
+step:234/1840 train_time:7825ms step_avg:33.44ms
+step:235/1840 train_time:7858ms step_avg:33.44ms
+step:236/1840 train_time:7892ms step_avg:33.44ms
+step:237/1840 train_time:7924ms step_avg:33.43ms
+step:238/1840 train_time:7958ms step_avg:33.44ms
+step:239/1840 train_time:7990ms step_avg:33.43ms
+step:240/1840 train_time:8025ms step_avg:33.44ms
+step:241/1840 train_time:8057ms step_avg:33.43ms
+step:242/1840 train_time:8091ms step_avg:33.43ms
+step:243/1840 train_time:8123ms step_avg:33.43ms
+step:244/1840 train_time:8158ms step_avg:33.43ms
+step:245/1840 train_time:8189ms step_avg:33.43ms
+step:246/1840 train_time:8224ms step_avg:33.43ms
+step:247/1840 train_time:8256ms step_avg:33.43ms
+step:248/1840 train_time:8290ms step_avg:33.43ms
+step:249/1840 train_time:8322ms step_avg:33.42ms
+step:250/1840 train_time:8356ms step_avg:33.42ms
+step:250/1840 val_loss:4.6048 train_time:8398ms step_avg:33.59ms
+step:251/1840 train_time:8418ms step_avg:33.54ms
+step:252/1840 train_time:8437ms step_avg:33.48ms
+step:253/1840 train_time:8456ms step_avg:33.42ms
+step:254/1840 train_time:8491ms step_avg:33.43ms
+step:255/1840 train_time:8525ms step_avg:33.43ms
+step:256/1840 train_time:8561ms step_avg:33.44ms
+step:257/1840 train_time:8593ms step_avg:33.44ms
+step:258/1840 train_time:8627ms step_avg:33.44ms
+step:259/1840 train_time:8659ms step_avg:33.43ms
+step:260/1840 train_time:8693ms step_avg:33.43ms
+step:261/1840 train_time:8725ms step_avg:33.43ms
+step:262/1840 train_time:8759ms step_avg:33.43ms
+step:263/1840 train_time:8791ms step_avg:33.42ms
+step:264/1840 train_time:8825ms step_avg:33.43ms
+step:265/1840 train_time:8857ms step_avg:33.42ms
+step:266/1840 train_time:8891ms step_avg:33.42ms
+step:267/1840 train_time:8923ms step_avg:33.42ms
+step:268/1840 train_time:8956ms step_avg:33.42ms
+step:269/1840 train_time:8988ms step_avg:33.41ms
+step:270/1840 train_time:9022ms step_avg:33.42ms
+step:271/1840 train_time:9054ms step_avg:33.41ms
+step:272/1840 train_time:9088ms step_avg:33.41ms
+step:273/1840 train_time:9120ms step_avg:33.41ms
+step:274/1840 train_time:9154ms step_avg:33.41ms
+step:275/1840 train_time:9186ms step_avg:33.40ms
+step:276/1840 train_time:9220ms step_avg:33.41ms
+step:277/1840 train_time:9252ms step_avg:33.40ms
+step:278/1840 train_time:9286ms step_avg:33.40ms
+step:279/1840 train_time:9318ms step_avg:33.40ms
+step:280/1840 train_time:9353ms step_avg:33.40ms
+step:281/1840 train_time:9386ms step_avg:33.40ms
+step:282/1840 train_time:9420ms step_avg:33.40ms
+step:283/1840 train_time:9452ms step_avg:33.40ms
+step:284/1840 train_time:9487ms step_avg:33.40ms
+step:285/1840 train_time:9520ms step_avg:33.40ms
+step:286/1840 train_time:9554ms step_avg:33.41ms
+step:287/1840 train_time:9586ms step_avg:33.40ms
+step:288/1840 train_time:9620ms step_avg:33.40ms
+step:289/1840 train_time:9652ms step_avg:33.40ms
+step:290/1840 train_time:9686ms step_avg:33.40ms
+step:291/1840 train_time:9719ms step_avg:33.40ms
+step:292/1840 train_time:9753ms step_avg:33.40ms
+step:293/1840 train_time:9785ms step_avg:33.40ms
+step:294/1840 train_time:9819ms step_avg:33.40ms
+step:295/1840 train_time:9851ms step_avg:33.39ms
+step:296/1840 train_time:9885ms step_avg:33.40ms
+step:297/1840 train_time:9917ms step_avg:33.39ms
+step:298/1840 train_time:9951ms step_avg:33.39ms
+step:299/1840 train_time:9983ms step_avg:33.39ms
+step:300/1840 train_time:10017ms step_avg:33.39ms
+step:301/1840 train_time:10049ms step_avg:33.38ms
+step:302/1840 train_time:10083ms step_avg:33.39ms
+step:303/1840 train_time:10115ms step_avg:33.38ms
+step:304/1840 train_time:10149ms step_avg:33.38ms
+step:305/1840 train_time:10181ms step_avg:33.38ms
+step:306/1840 train_time:10215ms step_avg:33.38ms
+step:307/1840 train_time:10247ms step_avg:33.38ms
+step:308/1840 train_time:10281ms step_avg:33.38ms
+step:309/1840 train_time:10313ms step_avg:33.38ms
+step:310/1840 train_time:10348ms step_avg:33.38ms
+step:311/1840 train_time:10380ms step_avg:33.38ms
+step:312/1840 train_time:10414ms step_avg:33.38ms
+step:313/1840 train_time:10446ms step_avg:33.37ms
+step:314/1840 train_time:10481ms step_avg:33.38ms
+step:315/1840 train_time:10513ms step_avg:33.37ms
+step:316/1840 train_time:10547ms step_avg:33.38ms
+step:317/1840 train_time:10579ms step_avg:33.37ms
+step:318/1840 train_time:10613ms step_avg:33.37ms
+step:319/1840 train_time:10646ms step_avg:33.37ms
+step:320/1840 train_time:10680ms step_avg:33.38ms
+step:321/1840 train_time:10712ms step_avg:33.37ms
+step:322/1840 train_time:10747ms step_avg:33.37ms
+step:323/1840 train_time:10779ms step_avg:33.37ms
+step:324/1840 train_time:10813ms step_avg:33.37ms
+step:325/1840 train_time:10845ms step_avg:33.37ms
+step:326/1840 train_time:10879ms step_avg:33.37ms
+step:327/1840 train_time:10911ms step_avg:33.37ms
+step:328/1840 train_time:10945ms step_avg:33.37ms
+step:329/1840 train_time:10977ms step_avg:33.37ms
+step:330/1840 train_time:11011ms step_avg:33.37ms
+step:331/1840 train_time:11043ms step_avg:33.36ms
+step:332/1840 train_time:11078ms step_avg:33.37ms
+step:333/1840 train_time:11110ms step_avg:33.36ms
+step:334/1840 train_time:11144ms step_avg:33.36ms
+step:335/1840 train_time:11176ms step_avg:33.36ms
+step:336/1840 train_time:11210ms step_avg:33.36ms
+step:337/1840 train_time:11242ms step_avg:33.36ms
+step:338/1840 train_time:11276ms step_avg:33.36ms
+step:339/1840 train_time:11308ms step_avg:33.36ms
+step:340/1840 train_time:11343ms step_avg:33.36ms
+step:341/1840 train_time:11375ms step_avg:33.36ms
+step:342/1840 train_time:11409ms step_avg:33.36ms
+step:343/1840 train_time:11441ms step_avg:33.36ms
+step:344/1840 train_time:11475ms step_avg:33.36ms
+step:345/1840 train_time:11508ms step_avg:33.36ms
+step:346/1840 train_time:11542ms step_avg:33.36ms
+step:347/1840 train_time:11574ms step_avg:33.35ms
+step:348/1840 train_time:11608ms step_avg:33.36ms
+step:349/1840 train_time:11640ms step_avg:33.35ms
+step:350/1840 train_time:11674ms step_avg:33.36ms
+step:351/1840 train_time:11706ms step_avg:33.35ms
+step:352/1840 train_time:11741ms step_avg:33.35ms
+step:353/1840 train_time:11772ms step_avg:33.35ms
+step:354/1840 train_time:11807ms step_avg:33.35ms
+step:355/1840 train_time:11839ms step_avg:33.35ms
+step:356/1840 train_time:11873ms step_avg:33.35ms
+step:357/1840 train_time:11905ms step_avg:33.35ms
+step:358/1840 train_time:11939ms step_avg:33.35ms
+step:359/1840 train_time:11970ms step_avg:33.34ms
+step:360/1840 train_time:12005ms step_avg:33.35ms
+step:361/1840 train_time:12037ms step_avg:33.34ms
+step:362/1840 train_time:12071ms step_avg:33.35ms
+step:363/1840 train_time:12103ms step_avg:33.34ms
+step:364/1840 train_time:12137ms step_avg:33.34ms
+step:365/1840 train_time:12169ms step_avg:33.34ms
+step:366/1840 train_time:12204ms step_avg:33.34ms
+step:367/1840 train_time:12235ms step_avg:33.34ms
+step:368/1840 train_time:12269ms step_avg:33.34ms
+step:369/1840 train_time:12302ms step_avg:33.34ms
+step:370/1840 train_time:12336ms step_avg:33.34ms
+step:371/1840 train_time:12368ms step_avg:33.34ms
+step:372/1840 train_time:12402ms step_avg:33.34ms
+step:373/1840 train_time:12434ms step_avg:33.34ms
+step:374/1840 train_time:12468ms step_avg:33.34ms
+step:375/1840 train_time:12500ms step_avg:33.33ms
+step:376/1840 train_time:12535ms step_avg:33.34ms
+step:377/1840 train_time:12567ms step_avg:33.34ms
+step:378/1840 train_time:12602ms step_avg:33.34ms
+step:379/1840 train_time:12633ms step_avg:33.33ms
+step:380/1840 train_time:12668ms step_avg:33.34ms
+step:381/1840 train_time:12700ms step_avg:33.33ms
+step:382/1840 train_time:12734ms step_avg:33.33ms
+step:383/1840 train_time:12766ms step_avg:33.33ms
+step:384/1840 train_time:12801ms step_avg:33.33ms
+step:385/1840 train_time:12832ms step_avg:33.33ms
+step:386/1840 train_time:12867ms step_avg:33.33ms
+step:387/1840 train_time:12899ms step_avg:33.33ms
+step:388/1840 train_time:12933ms step_avg:33.33ms
+step:389/1840 train_time:12965ms step_avg:33.33ms
+step:390/1840 train_time:12999ms step_avg:33.33ms
+step:391/1840 train_time:13031ms step_avg:33.33ms
+step:392/1840 train_time:13066ms step_avg:33.33ms
+step:393/1840 train_time:13098ms step_avg:33.33ms
+step:394/1840 train_time:13133ms step_avg:33.33ms
+step:395/1840 train_time:13165ms step_avg:33.33ms
+step:396/1840 train_time:13199ms step_avg:33.33ms
+step:397/1840 train_time:13231ms step_avg:33.33ms
+step:398/1840 train_time:13265ms step_avg:33.33ms
+step:399/1840 train_time:13297ms step_avg:33.33ms
+step:400/1840 train_time:13331ms step_avg:33.33ms
+step:401/1840 train_time:13364ms step_avg:33.33ms
+step:402/1840 train_time:13398ms step_avg:33.33ms
+step:403/1840 train_time:13430ms step_avg:33.32ms
+step:404/1840 train_time:13465ms step_avg:33.33ms
+step:405/1840 train_time:13497ms step_avg:33.33ms
+step:406/1840 train_time:13531ms step_avg:33.33ms
+step:407/1840 train_time:13563ms step_avg:33.32ms
+step:408/1840 train_time:13597ms step_avg:33.33ms
+step:409/1840 train_time:13629ms step_avg:33.32ms
+step:410/1840 train_time:13664ms step_avg:33.33ms
+step:411/1840 train_time:13696ms step_avg:33.32ms
+step:412/1840 train_time:13730ms step_avg:33.33ms
+step:413/1840 train_time:13763ms step_avg:33.32ms
+step:414/1840 train_time:13797ms step_avg:33.33ms
+step:415/1840 train_time:13829ms step_avg:33.32ms
+step:416/1840 train_time:13864ms step_avg:33.33ms
+step:417/1840 train_time:13896ms step_avg:33.32ms
+step:418/1840 train_time:13930ms step_avg:33.33ms
+step:419/1840 train_time:13962ms step_avg:33.32ms
+step:420/1840 train_time:13996ms step_avg:33.32ms
+step:421/1840 train_time:14028ms step_avg:33.32ms
+step:422/1840 train_time:14062ms step_avg:33.32ms
+step:423/1840 train_time:14094ms step_avg:33.32ms
+step:424/1840 train_time:14129ms step_avg:33.32ms
+step:425/1840 train_time:14161ms step_avg:33.32ms
+step:426/1840 train_time:14195ms step_avg:33.32ms
+step:427/1840 train_time:14227ms step_avg:33.32ms
+step:428/1840 train_time:14262ms step_avg:33.32ms
+step:429/1840 train_time:14294ms step_avg:33.32ms
+step:430/1840 train_time:14328ms step_avg:33.32ms
+step:431/1840 train_time:14360ms step_avg:33.32ms
+step:432/1840 train_time:14394ms step_avg:33.32ms
+step:433/1840 train_time:14426ms step_avg:33.32ms
+step:434/1840 train_time:14460ms step_avg:33.32ms
+step:435/1840 train_time:14492ms step_avg:33.31ms
+step:436/1840 train_time:14526ms step_avg:33.32ms
+step:437/1840 train_time:14558ms step_avg:33.31ms
+step:438/1840 train_time:14593ms step_avg:33.32ms
+step:439/1840 train_time:14625ms step_avg:33.31ms
+step:440/1840 train_time:14660ms step_avg:33.32ms
+step:441/1840 train_time:14692ms step_avg:33.31ms
+step:442/1840 train_time:14726ms step_avg:33.32ms
+step:443/1840 train_time:14758ms step_avg:33.31ms
+step:444/1840 train_time:14792ms step_avg:33.32ms
+step:445/1840 train_time:14824ms step_avg:33.31ms
+step:446/1840 train_time:14858ms step_avg:33.32ms
+step:447/1840 train_time:14891ms step_avg:33.31ms
+step:448/1840 train_time:14925ms step_avg:33.32ms
+step:449/1840 train_time:14958ms step_avg:33.31ms
+step:450/1840 train_time:14992ms step_avg:33.31ms
+step:451/1840 train_time:15024ms step_avg:33.31ms
+step:452/1840 train_time:15058ms step_avg:33.31ms
+step:453/1840 train_time:15090ms step_avg:33.31ms
+step:454/1840 train_time:15124ms step_avg:33.31ms
+step:455/1840 train_time:15156ms step_avg:33.31ms
+step:456/1840 train_time:15190ms step_avg:33.31ms
+step:457/1840 train_time:15223ms step_avg:33.31ms
+step:458/1840 train_time:15257ms step_avg:33.31ms
+step:459/1840 train_time:15289ms step_avg:33.31ms
+step:460/1840 train_time:15323ms step_avg:33.31ms
+step:461/1840 train_time:15355ms step_avg:33.31ms
+step:462/1840 train_time:15389ms step_avg:33.31ms
+step:463/1840 train_time:15421ms step_avg:33.31ms
+step:464/1840 train_time:15455ms step_avg:33.31ms
+step:465/1840 train_time:15487ms step_avg:33.31ms
+step:466/1840 train_time:15522ms step_avg:33.31ms
+step:467/1840 train_time:15553ms step_avg:33.30ms
+step:468/1840 train_time:15588ms step_avg:33.31ms
+step:469/1840 train_time:15620ms step_avg:33.30ms
+step:470/1840 train_time:15654ms step_avg:33.31ms
+step:471/1840 train_time:15686ms step_avg:33.30ms
+step:472/1840 train_time:15721ms step_avg:33.31ms
+step:473/1840 train_time:15753ms step_avg:33.30ms
+step:474/1840 train_time:15787ms step_avg:33.31ms
+step:475/1840 train_time:15819ms step_avg:33.30ms
+step:476/1840 train_time:15853ms step_avg:33.30ms
+step:477/1840 train_time:15885ms step_avg:33.30ms
+step:478/1840 train_time:15920ms step_avg:33.30ms
+step:479/1840 train_time:15952ms step_avg:33.30ms
+step:480/1840 train_time:15986ms step_avg:33.30ms
+step:481/1840 train_time:16018ms step_avg:33.30ms
+step:482/1840 train_time:16052ms step_avg:33.30ms
+step:483/1840 train_time:16084ms step_avg:33.30ms
+step:484/1840 train_time:16119ms step_avg:33.30ms
+step:485/1840 train_time:16151ms step_avg:33.30ms
+step:486/1840 train_time:16185ms step_avg:33.30ms
+step:487/1840 train_time:16217ms step_avg:33.30ms
+step:488/1840 train_time:16252ms step_avg:33.30ms
+step:489/1840 train_time:16283ms step_avg:33.30ms
+step:490/1840 train_time:16318ms step_avg:33.30ms
+step:491/1840 train_time:16350ms step_avg:33.30ms
+step:492/1840 train_time:16384ms step_avg:33.30ms
+step:493/1840 train_time:16416ms step_avg:33.30ms
+step:494/1840 train_time:16450ms step_avg:33.30ms
+step:495/1840 train_time:16483ms step_avg:33.30ms
+step:496/1840 train_time:16517ms step_avg:33.30ms
+step:497/1840 train_time:16549ms step_avg:33.30ms
+step:498/1840 train_time:16583ms step_avg:33.30ms
+step:499/1840 train_time:16615ms step_avg:33.30ms
+step:500/1840 train_time:16649ms step_avg:33.30ms
+step:500/1840 val_loss:4.2909 train_time:16691ms step_avg:33.38ms
+step:501/1840 train_time:16715ms step_avg:33.36ms
+step:502/1840 train_time:16735ms step_avg:33.34ms
+step:503/1840 train_time:16752ms step_avg:33.30ms
+step:504/1840 train_time:16786ms step_avg:33.30ms
+step:505/1840 train_time:16819ms step_avg:33.30ms
+step:506/1840 train_time:16854ms step_avg:33.31ms
+step:507/1840 train_time:16887ms step_avg:33.31ms
+step:508/1840 train_time:16921ms step_avg:33.31ms
+step:509/1840 train_time:16954ms step_avg:33.31ms
+step:510/1840 train_time:16988ms step_avg:33.31ms
+step:511/1840 train_time:17020ms step_avg:33.31ms
+step:512/1840 train_time:17054ms step_avg:33.31ms
+step:513/1840 train_time:17086ms step_avg:33.31ms
+step:514/1840 train_time:17120ms step_avg:33.31ms
+step:515/1840 train_time:17152ms step_avg:33.30ms
+step:516/1840 train_time:17186ms step_avg:33.31ms
+step:517/1840 train_time:17218ms step_avg:33.30ms
+step:518/1840 train_time:17252ms step_avg:33.30ms
+step:519/1840 train_time:17284ms step_avg:33.30ms
+step:520/1840 train_time:17318ms step_avg:33.30ms
+step:521/1840 train_time:17349ms step_avg:33.30ms
+step:522/1840 train_time:17383ms step_avg:33.30ms
+step:523/1840 train_time:17415ms step_avg:33.30ms
+step:524/1840 train_time:17449ms step_avg:33.30ms
+step:525/1840 train_time:17481ms step_avg:33.30ms
+step:526/1840 train_time:17515ms step_avg:33.30ms
+step:527/1840 train_time:17547ms step_avg:33.30ms
+step:528/1840 train_time:17581ms step_avg:33.30ms
+step:529/1840 train_time:17614ms step_avg:33.30ms
+step:530/1840 train_time:17648ms step_avg:33.30ms
+step:531/1840 train_time:17681ms step_avg:33.30ms
+step:532/1840 train_time:17715ms step_avg:33.30ms
+step:533/1840 train_time:17748ms step_avg:33.30ms
+step:534/1840 train_time:17782ms step_avg:33.30ms
+step:535/1840 train_time:17815ms step_avg:33.30ms
+step:536/1840 train_time:17850ms step_avg:33.30ms
+step:537/1840 train_time:17882ms step_avg:33.30ms
+step:538/1840 train_time:17916ms step_avg:33.30ms
+step:539/1840 train_time:17949ms step_avg:33.30ms
+step:540/1840 train_time:17982ms step_avg:33.30ms
+step:541/1840 train_time:18015ms step_avg:33.30ms
+step:542/1840 train_time:18049ms step_avg:33.30ms
+step:543/1840 train_time:18081ms step_avg:33.30ms
+step:544/1840 train_time:18115ms step_avg:33.30ms
+step:545/1840 train_time:18148ms step_avg:33.30ms
+step:546/1840 train_time:18181ms step_avg:33.30ms
+step:547/1840 train_time:18214ms step_avg:33.30ms
+step:548/1840 train_time:18248ms step_avg:33.30ms
+step:549/1840 train_time:18280ms step_avg:33.30ms
+step:550/1840 train_time:18314ms step_avg:33.30ms
+step:551/1840 train_time:18346ms step_avg:33.30ms
+step:552/1840 train_time:18380ms step_avg:33.30ms
+step:553/1840 train_time:18412ms step_avg:33.29ms
+step:554/1840 train_time:18446ms step_avg:33.30ms
+step:555/1840 train_time:18478ms step_avg:33.29ms
+step:556/1840 train_time:18513ms step_avg:33.30ms
+step:557/1840 train_time:18545ms step_avg:33.29ms
+step:558/1840 train_time:18579ms step_avg:33.30ms
+step:559/1840 train_time:18611ms step_avg:33.29ms
+step:560/1840 train_time:18645ms step_avg:33.29ms
+step:561/1840 train_time:18677ms step_avg:33.29ms
+step:562/1840 train_time:18712ms step_avg:33.29ms
+step:563/1840 train_time:18744ms step_avg:33.29ms
+step:564/1840 train_time:18778ms step_avg:33.30ms
+step:565/1840 train_time:18811ms step_avg:33.29ms
+step:566/1840 train_time:18845ms step_avg:33.29ms
+step:567/1840 train_time:18878ms step_avg:33.29ms
+step:568/1840 train_time:18912ms step_avg:33.30ms
+step:569/1840 train_time:18944ms step_avg:33.29ms
+step:570/1840 train_time:18978ms step_avg:33.29ms
+step:571/1840 train_time:19010ms step_avg:33.29ms
+step:572/1840 train_time:19044ms step_avg:33.29ms
+step:573/1840 train_time:19077ms step_avg:33.29ms
+step:574/1840 train_time:19111ms step_avg:33.29ms
+step:575/1840 train_time:19142ms step_avg:33.29ms
+step:576/1840 train_time:19177ms step_avg:33.29ms
+step:577/1840 train_time:19209ms step_avg:33.29ms
+step:578/1840 train_time:19243ms step_avg:33.29ms
+step:579/1840 train_time:19275ms step_avg:33.29ms
+step:580/1840 train_time:19309ms step_avg:33.29ms
+step:581/1840 train_time:19341ms step_avg:33.29ms
+step:582/1840 train_time:19375ms step_avg:33.29ms
+step:583/1840 train_time:19407ms step_avg:33.29ms
+step:584/1840 train_time:19441ms step_avg:33.29ms
+step:585/1840 train_time:19474ms step_avg:33.29ms
+step:586/1840 train_time:19508ms step_avg:33.29ms
+step:587/1840 train_time:19540ms step_avg:33.29ms
+step:588/1840 train_time:19574ms step_avg:33.29ms
+step:589/1840 train_time:19606ms step_avg:33.29ms
+step:590/1840 train_time:19640ms step_avg:33.29ms
+step:591/1840 train_time:19673ms step_avg:33.29ms
+step:592/1840 train_time:19707ms step_avg:33.29ms
+step:593/1840 train_time:19739ms step_avg:33.29ms
+step:594/1840 train_time:19773ms step_avg:33.29ms
+step:595/1840 train_time:19806ms step_avg:33.29ms
+step:596/1840 train_time:19840ms step_avg:33.29ms
+step:597/1840 train_time:19872ms step_avg:33.29ms
+step:598/1840 train_time:19906ms step_avg:33.29ms
+step:599/1840 train_time:19939ms step_avg:33.29ms
+step:600/1840 train_time:19973ms step_avg:33.29ms
+step:601/1840 train_time:20007ms step_avg:33.29ms
+step:602/1840 train_time:20065ms step_avg:33.33ms
+step:603/1840 train_time:20124ms step_avg:33.37ms
+step:604/1840 train_time:20187ms step_avg:33.42ms
+step:605/1840 train_time:20247ms step_avg:33.47ms
+step:606/1840 train_time:20309ms step_avg:33.51ms
+step:607/1840 train_time:20368ms step_avg:33.56ms
+step:608/1840 train_time:20431ms step_avg:33.60ms
+step:609/1840 train_time:20490ms step_avg:33.65ms
+step:610/1840 train_time:20553ms step_avg:33.69ms
+step:611/1840 train_time:20614ms step_avg:33.74ms
+step:612/1840 train_time:20676ms step_avg:33.78ms
+step:613/1840 train_time:20736ms step_avg:33.83ms
+step:614/1840 train_time:20798ms step_avg:33.87ms
+step:615/1840 train_time:20858ms step_avg:33.92ms
+step:616/1840 train_time:20921ms step_avg:33.96ms
+step:617/1840 train_time:20981ms step_avg:34.00ms
+step:618/1840 train_time:21043ms step_avg:34.05ms
+step:619/1840 train_time:21102ms step_avg:34.09ms
+step:620/1840 train_time:21164ms step_avg:34.14ms
+step:621/1840 train_time:21224ms step_avg:34.18ms
+step:622/1840 train_time:21286ms step_avg:34.22ms
+step:623/1840 train_time:21346ms step_avg:34.26ms
+step:624/1840 train_time:21407ms step_avg:34.31ms
+step:625/1840 train_time:21467ms step_avg:34.35ms
+step:626/1840 train_time:21529ms step_avg:34.39ms
+step:627/1840 train_time:21589ms step_avg:34.43ms
+step:628/1840 train_time:21651ms step_avg:34.48ms
+step:629/1840 train_time:21711ms step_avg:34.52ms
+step:630/1840 train_time:21775ms step_avg:34.56ms
+step:631/1840 train_time:21835ms step_avg:34.60ms
+step:632/1840 train_time:21898ms step_avg:34.65ms
+step:633/1840 train_time:21958ms step_avg:34.69ms
+step:634/1840 train_time:22020ms step_avg:34.73ms
+step:635/1840 train_time:22080ms step_avg:34.77ms
+step:636/1840 train_time:22142ms step_avg:34.81ms
+step:637/1840 train_time:22202ms step_avg:34.85ms
+step:638/1840 train_time:22264ms step_avg:34.90ms
+step:639/1840 train_time:22324ms step_avg:34.94ms
+step:640/1840 train_time:22387ms step_avg:34.98ms
+step:641/1840 train_time:22446ms step_avg:35.02ms
+step:642/1840 train_time:22508ms step_avg:35.06ms
+step:643/1840 train_time:22567ms step_avg:35.10ms
+step:644/1840 train_time:22629ms step_avg:35.14ms
+step:645/1840 train_time:22689ms step_avg:35.18ms
+step:646/1840 train_time:22752ms step_avg:35.22ms
+step:647/1840 train_time:22813ms step_avg:35.26ms
+step:648/1840 train_time:22876ms step_avg:35.30ms
+step:649/1840 train_time:22936ms step_avg:35.34ms
+step:650/1840 train_time:22999ms step_avg:35.38ms
+step:651/1840 train_time:23059ms step_avg:35.42ms
+step:652/1840 train_time:23121ms step_avg:35.46ms
+step:653/1840 train_time:23181ms step_avg:35.50ms
+step:654/1840 train_time:23242ms step_avg:35.54ms
+step:655/1840 train_time:23303ms step_avg:35.58ms
+step:656/1840 train_time:23364ms step_avg:35.62ms
+step:657/1840 train_time:23425ms step_avg:35.65ms
+step:658/1840 train_time:23486ms step_avg:35.69ms
+step:659/1840 train_time:23547ms step_avg:35.73ms
+step:660/1840 train_time:23609ms step_avg:35.77ms
+step:661/1840 train_time:23668ms step_avg:35.81ms
+step:662/1840 train_time:23730ms step_avg:35.85ms
+step:663/1840 train_time:23791ms step_avg:35.88ms
+step:664/1840 train_time:23855ms step_avg:35.93ms
+step:665/1840 train_time:23915ms step_avg:35.96ms
+step:666/1840 train_time:23979ms step_avg:36.00ms
+step:667/1840 train_time:24039ms step_avg:36.04ms
+step:668/1840 train_time:24101ms step_avg:36.08ms
+step:669/1840 train_time:24162ms step_avg:36.12ms
+step:670/1840 train_time:24224ms step_avg:36.15ms
+step:671/1840 train_time:24283ms step_avg:36.19ms
+step:672/1840 train_time:24345ms step_avg:36.23ms
+step:673/1840 train_time:24404ms step_avg:36.26ms
+step:674/1840 train_time:24466ms step_avg:36.30ms
+step:675/1840 train_time:24526ms step_avg:36.33ms
+step:676/1840 train_time:24589ms step_avg:36.37ms
+step:677/1840 train_time:24648ms step_avg:36.41ms
+step:678/1840 train_time:24710ms step_avg:36.45ms
+step:679/1840 train_time:24770ms step_avg:36.48ms
+step:680/1840 train_time:24833ms step_avg:36.52ms
+step:681/1840 train_time:24893ms step_avg:36.55ms
+step:682/1840 train_time:24956ms step_avg:36.59ms
+step:683/1840 train_time:25016ms step_avg:36.63ms
+step:684/1840 train_time:25078ms step_avg:36.66ms
+step:685/1840 train_time:25139ms step_avg:36.70ms
+step:686/1840 train_time:25201ms step_avg:36.74ms
+step:687/1840 train_time:25262ms step_avg:36.77ms
+step:688/1840 train_time:25324ms step_avg:36.81ms
+step:689/1840 train_time:25384ms step_avg:36.84ms
+step:690/1840 train_time:25445ms step_avg:36.88ms
+step:691/1840 train_time:25505ms step_avg:36.91ms
+step:692/1840 train_time:25566ms step_avg:36.95ms
+step:693/1840 train_time:25626ms step_avg:36.98ms
+step:694/1840 train_time:25689ms step_avg:37.02ms
+step:695/1840 train_time:25749ms step_avg:37.05ms
+step:696/1840 train_time:25811ms step_avg:37.08ms
+step:697/1840 train_time:25871ms step_avg:37.12ms
+step:698/1840 train_time:25934ms step_avg:37.16ms
+step:699/1840 train_time:25995ms step_avg:37.19ms
+step:700/1840 train_time:26057ms step_avg:37.22ms
+step:701/1840 train_time:26117ms step_avg:37.26ms
+step:702/1840 train_time:26180ms step_avg:37.29ms
+step:703/1840 train_time:26241ms step_avg:37.33ms
+step:704/1840 train_time:26303ms step_avg:37.36ms
+step:705/1840 train_time:26363ms step_avg:37.39ms
+step:706/1840 train_time:26425ms step_avg:37.43ms
+step:707/1840 train_time:26484ms step_avg:37.46ms
+step:708/1840 train_time:26546ms step_avg:37.49ms
+step:709/1840 train_time:26605ms step_avg:37.53ms
+step:710/1840 train_time:26668ms step_avg:37.56ms
+step:711/1840 train_time:26728ms step_avg:37.59ms
+step:712/1840 train_time:26790ms step_avg:37.63ms
+step:713/1840 train_time:26849ms step_avg:37.66ms
+step:714/1840 train_time:26913ms step_avg:37.69ms
+step:715/1840 train_time:26974ms step_avg:37.73ms
+step:716/1840 train_time:27036ms step_avg:37.76ms
+step:717/1840 train_time:27096ms step_avg:37.79ms
+step:718/1840 train_time:27160ms step_avg:37.83ms
+step:719/1840 train_time:27220ms step_avg:37.86ms
+step:720/1840 train_time:27282ms step_avg:37.89ms
+step:721/1840 train_time:27343ms step_avg:37.92ms
+step:722/1840 train_time:27404ms step_avg:37.96ms
+step:723/1840 train_time:27464ms step_avg:37.99ms
+step:724/1840 train_time:27526ms step_avg:38.02ms
+step:725/1840 train_time:27586ms step_avg:38.05ms
+step:726/1840 train_time:27648ms step_avg:38.08ms
+step:727/1840 train_time:27708ms step_avg:38.11ms
+step:728/1840 train_time:27770ms step_avg:38.15ms
+step:729/1840 train_time:27830ms step_avg:38.18ms
+step:730/1840 train_time:27893ms step_avg:38.21ms
+step:731/1840 train_time:27954ms step_avg:38.24ms
+step:732/1840 train_time:28016ms step_avg:38.27ms
+step:733/1840 train_time:28077ms step_avg:38.30ms
+step:734/1840 train_time:28139ms step_avg:38.34ms
+step:735/1840 train_time:28199ms step_avg:38.37ms
+step:736/1840 train_time:28261ms step_avg:38.40ms
+step:737/1840 train_time:28321ms step_avg:38.43ms
+step:738/1840 train_time:28383ms step_avg:38.46ms
+step:739/1840 train_time:28443ms step_avg:38.49ms
+step:740/1840 train_time:28505ms step_avg:38.52ms
+step:741/1840 train_time:28565ms step_avg:38.55ms
+step:742/1840 train_time:28627ms step_avg:38.58ms
+step:743/1840 train_time:28687ms step_avg:38.61ms
+step:744/1840 train_time:28750ms step_avg:38.64ms
+step:745/1840 train_time:28809ms step_avg:38.67ms
+step:746/1840 train_time:28871ms step_avg:38.70ms
+step:747/1840 train_time:28931ms step_avg:38.73ms
+step:748/1840 train_time:28996ms step_avg:38.76ms
+step:749/1840 train_time:29056ms step_avg:38.79ms
+step:750/1840 train_time:29118ms step_avg:38.82ms
+step:750/1840 val_loss:4.0231 train_time:29189ms step_avg:38.92ms
+step:751/1840 train_time:29212ms step_avg:38.90ms
+step:752/1840 train_time:29241ms step_avg:38.88ms
+step:753/1840 train_time:29302ms step_avg:38.91ms
+step:754/1840 train_time:29366ms step_avg:38.95ms
+step:755/1840 train_time:29427ms step_avg:38.98ms
+step:756/1840 train_time:29489ms step_avg:39.01ms
+step:757/1840 train_time:29549ms step_avg:39.03ms
+step:758/1840 train_time:29610ms step_avg:39.06ms
+step:759/1840 train_time:29669ms step_avg:39.09ms
+step:760/1840 train_time:29730ms step_avg:39.12ms
+step:761/1840 train_time:29790ms step_avg:39.15ms
+step:762/1840 train_time:29852ms step_avg:39.18ms
+step:763/1840 train_time:29912ms step_avg:39.20ms
+step:764/1840 train_time:29974ms step_avg:39.23ms
+step:765/1840 train_time:30033ms step_avg:39.26ms
+step:766/1840 train_time:30095ms step_avg:39.29ms
+step:767/1840 train_time:30155ms step_avg:39.32ms
+step:768/1840 train_time:30219ms step_avg:39.35ms
+step:769/1840 train_time:30280ms step_avg:39.38ms
+step:770/1840 train_time:30342ms step_avg:39.40ms
+step:771/1840 train_time:30402ms step_avg:39.43ms
+step:772/1840 train_time:30466ms step_avg:39.46ms
+step:773/1840 train_time:30525ms step_avg:39.49ms
+step:774/1840 train_time:30587ms step_avg:39.52ms
+step:775/1840 train_time:30647ms step_avg:39.54ms
+step:776/1840 train_time:30710ms step_avg:39.57ms
+step:777/1840 train_time:30768ms step_avg:39.60ms
+step:778/1840 train_time:30831ms step_avg:39.63ms
+step:779/1840 train_time:30890ms step_avg:39.65ms
+step:780/1840 train_time:30952ms step_avg:39.68ms
+step:781/1840 train_time:31013ms step_avg:39.71ms
+step:782/1840 train_time:31075ms step_avg:39.74ms
+step:783/1840 train_time:31135ms step_avg:39.76ms
+step:784/1840 train_time:31198ms step_avg:39.79ms
+step:785/1840 train_time:31258ms step_avg:39.82ms
+step:786/1840 train_time:31321ms step_avg:39.85ms
+step:787/1840 train_time:31381ms step_avg:39.87ms
+step:788/1840 train_time:31443ms step_avg:39.90ms
+step:789/1840 train_time:31503ms step_avg:39.93ms
+step:790/1840 train_time:31565ms step_avg:39.96ms
+step:791/1840 train_time:31625ms step_avg:39.98ms
+step:792/1840 train_time:31688ms step_avg:40.01ms
+step:793/1840 train_time:31748ms step_avg:40.04ms
+step:794/1840 train_time:31810ms step_avg:40.06ms
+step:795/1840 train_time:31870ms step_avg:40.09ms
+step:796/1840 train_time:31932ms step_avg:40.12ms
+step:797/1840 train_time:31991ms step_avg:40.14ms
+step:798/1840 train_time:32054ms step_avg:40.17ms
+step:799/1840 train_time:32115ms step_avg:40.19ms
+step:800/1840 train_time:32177ms step_avg:40.22ms
+step:801/1840 train_time:32237ms step_avg:40.25ms
+step:802/1840 train_time:32299ms step_avg:40.27ms
+step:803/1840 train_time:32359ms step_avg:40.30ms
+step:804/1840 train_time:32421ms step_avg:40.32ms
+step:805/1840 train_time:32481ms step_avg:40.35ms
+step:806/1840 train_time:32543ms step_avg:40.38ms
+step:807/1840 train_time:32604ms step_avg:40.40ms
+step:808/1840 train_time:32667ms step_avg:40.43ms
+step:809/1840 train_time:32728ms step_avg:40.45ms
+step:810/1840 train_time:32790ms step_avg:40.48ms
+step:811/1840 train_time:32850ms step_avg:40.51ms
+step:812/1840 train_time:32911ms step_avg:40.53ms
+step:813/1840 train_time:32971ms step_avg:40.55ms
+step:814/1840 train_time:33034ms step_avg:40.58ms
+step:815/1840 train_time:33094ms step_avg:40.61ms
+step:816/1840 train_time:33157ms step_avg:40.63ms
+step:817/1840 train_time:33216ms step_avg:40.66ms
+step:818/1840 train_time:33279ms step_avg:40.68ms
+step:819/1840 train_time:33338ms step_avg:40.71ms
+step:820/1840 train_time:33400ms step_avg:40.73ms
+step:821/1840 train_time:33460ms step_avg:40.76ms
+step:822/1840 train_time:33522ms step_avg:40.78ms
+step:823/1840 train_time:33582ms step_avg:40.80ms
+step:824/1840 train_time:33644ms step_avg:40.83ms
+step:825/1840 train_time:33704ms step_avg:40.85ms
+step:826/1840 train_time:33767ms step_avg:40.88ms
+step:827/1840 train_time:33827ms step_avg:40.90ms
+step:828/1840 train_time:33890ms step_avg:40.93ms
+step:829/1840 train_time:33950ms step_avg:40.95ms
+step:830/1840 train_time:34012ms step_avg:40.98ms
+step:831/1840 train_time:34073ms step_avg:41.00ms
+step:832/1840 train_time:34135ms step_avg:41.03ms
+step:833/1840 train_time:34195ms step_avg:41.05ms
+step:834/1840 train_time:34258ms step_avg:41.08ms
+step:835/1840 train_time:34317ms step_avg:41.10ms
+step:836/1840 train_time:34379ms step_avg:41.12ms
+step:837/1840 train_time:34439ms step_avg:41.15ms
+step:838/1840 train_time:34500ms step_avg:41.17ms
+step:839/1840 train_time:34559ms step_avg:41.19ms
+step:840/1840 train_time:34622ms step_avg:41.22ms
+step:841/1840 train_time:34682ms step_avg:41.24ms
+step:842/1840 train_time:34744ms step_avg:41.26ms
+step:843/1840 train_time:34805ms step_avg:41.29ms
+step:844/1840 train_time:34867ms step_avg:41.31ms
+step:845/1840 train_time:34928ms step_avg:41.33ms
+step:846/1840 train_time:34990ms step_avg:41.36ms
+step:847/1840 train_time:35051ms step_avg:41.38ms
+step:848/1840 train_time:35114ms step_avg:41.41ms
+step:849/1840 train_time:35174ms step_avg:41.43ms
+step:850/1840 train_time:35236ms step_avg:41.45ms
+step:851/1840 train_time:35296ms step_avg:41.48ms
+step:852/1840 train_time:35358ms step_avg:41.50ms
+step:853/1840 train_time:35417ms step_avg:41.52ms
+step:854/1840 train_time:35480ms step_avg:41.55ms
+step:855/1840 train_time:35539ms step_avg:41.57ms
+step:856/1840 train_time:35601ms step_avg:41.59ms
+step:857/1840 train_time:35661ms step_avg:41.61ms
+step:858/1840 train_time:35723ms step_avg:41.64ms
+step:859/1840 train_time:35783ms step_avg:41.66ms
+step:860/1840 train_time:35846ms step_avg:41.68ms
+step:861/1840 train_time:35906ms step_avg:41.70ms
+step:862/1840 train_time:35969ms step_avg:41.73ms
+step:863/1840 train_time:36030ms step_avg:41.75ms
+step:864/1840 train_time:36092ms step_avg:41.77ms
+step:865/1840 train_time:36152ms step_avg:41.79ms
+step:866/1840 train_time:36215ms step_avg:41.82ms
+step:867/1840 train_time:36275ms step_avg:41.84ms
+step:868/1840 train_time:36337ms step_avg:41.86ms
+step:869/1840 train_time:36397ms step_avg:41.88ms
+step:870/1840 train_time:36459ms step_avg:41.91ms
+step:871/1840 train_time:36518ms step_avg:41.93ms
+step:872/1840 train_time:36581ms step_avg:41.95ms
+step:873/1840 train_time:36640ms step_avg:41.97ms
+step:874/1840 train_time:36702ms step_avg:41.99ms
+step:875/1840 train_time:36762ms step_avg:42.01ms
+step:876/1840 train_time:36825ms step_avg:42.04ms
+step:877/1840 train_time:36884ms step_avg:42.06ms
+step:878/1840 train_time:36946ms step_avg:42.08ms
+step:879/1840 train_time:37007ms step_avg:42.10ms
+step:880/1840 train_time:37070ms step_avg:42.13ms
+step:881/1840 train_time:37130ms step_avg:42.15ms
+step:882/1840 train_time:37192ms step_avg:42.17ms
+step:883/1840 train_time:37253ms step_avg:42.19ms
+step:884/1840 train_time:37315ms step_avg:42.21ms
+step:885/1840 train_time:37374ms step_avg:42.23ms
+step:886/1840 train_time:37437ms step_avg:42.25ms
+step:887/1840 train_time:37497ms step_avg:42.27ms
+step:888/1840 train_time:37560ms step_avg:42.30ms
+step:889/1840 train_time:37619ms step_avg:42.32ms
+step:890/1840 train_time:37680ms step_avg:42.34ms
+step:891/1840 train_time:37740ms step_avg:42.36ms
+step:892/1840 train_time:37803ms step_avg:42.38ms
+step:893/1840 train_time:37862ms step_avg:42.40ms
+step:894/1840 train_time:37925ms step_avg:42.42ms
+step:895/1840 train_time:37986ms step_avg:42.44ms
+step:896/1840 train_time:38049ms step_avg:42.47ms
+step:897/1840 train_time:38110ms step_avg:42.49ms
+step:898/1840 train_time:38173ms step_avg:42.51ms
+step:899/1840 train_time:38232ms step_avg:42.53ms
+step:900/1840 train_time:38295ms step_avg:42.55ms
+step:901/1840 train_time:38354ms step_avg:42.57ms
+step:902/1840 train_time:38416ms step_avg:42.59ms
+step:903/1840 train_time:38476ms step_avg:42.61ms
+step:904/1840 train_time:38539ms step_avg:42.63ms
+step:905/1840 train_time:38598ms step_avg:42.65ms
+step:906/1840 train_time:38661ms step_avg:42.67ms
+step:907/1840 train_time:38720ms step_avg:42.69ms
+step:908/1840 train_time:38783ms step_avg:42.71ms
+step:909/1840 train_time:38842ms step_avg:42.73ms
+step:910/1840 train_time:38904ms step_avg:42.75ms
+step:911/1840 train_time:38964ms step_avg:42.77ms
+step:912/1840 train_time:39028ms step_avg:42.79ms
+step:913/1840 train_time:39089ms step_avg:42.81ms
+step:914/1840 train_time:39152ms step_avg:42.84ms
+step:915/1840 train_time:39212ms step_avg:42.85ms
+step:916/1840 train_time:39275ms step_avg:42.88ms
+step:917/1840 train_time:39334ms step_avg:42.89ms
+step:918/1840 train_time:39396ms step_avg:42.92ms
+step:919/1840 train_time:39456ms step_avg:42.93ms
+step:920/1840 train_time:39518ms step_avg:42.95ms
+step:921/1840 train_time:39577ms step_avg:42.97ms
+step:922/1840 train_time:39640ms step_avg:42.99ms
+step:923/1840 train_time:39700ms step_avg:43.01ms
+step:924/1840 train_time:39762ms step_avg:43.03ms
+step:925/1840 train_time:39822ms step_avg:43.05ms
+step:926/1840 train_time:39884ms step_avg:43.07ms
+step:927/1840 train_time:39943ms step_avg:43.09ms
+step:928/1840 train_time:40006ms step_avg:43.11ms
+step:929/1840 train_time:40065ms step_avg:43.13ms
+step:930/1840 train_time:40129ms step_avg:43.15ms
+step:931/1840 train_time:40190ms step_avg:43.17ms
+step:932/1840 train_time:40252ms step_avg:43.19ms
+step:933/1840 train_time:40312ms step_avg:43.21ms
+step:934/1840 train_time:40375ms step_avg:43.23ms
+step:935/1840 train_time:40435ms step_avg:43.25ms
+step:936/1840 train_time:40496ms step_avg:43.27ms
+step:937/1840 train_time:40557ms step_avg:43.28ms
+step:938/1840 train_time:40619ms step_avg:43.30ms
+step:939/1840 train_time:40679ms step_avg:43.32ms
+step:940/1840 train_time:40740ms step_avg:43.34ms
+step:941/1840 train_time:40800ms step_avg:43.36ms
+step:942/1840 train_time:40862ms step_avg:43.38ms
+step:943/1840 train_time:40922ms step_avg:43.40ms
+step:944/1840 train_time:40986ms step_avg:43.42ms
+step:945/1840 train_time:41047ms step_avg:43.44ms
+step:946/1840 train_time:41109ms step_avg:43.46ms
+step:947/1840 train_time:41169ms step_avg:43.47ms
+step:948/1840 train_time:41232ms step_avg:43.49ms
+step:949/1840 train_time:41293ms step_avg:43.51ms
+step:950/1840 train_time:41356ms step_avg:43.53ms
+step:951/1840 train_time:41415ms step_avg:43.55ms
+step:952/1840 train_time:41477ms step_avg:43.57ms
+step:953/1840 train_time:41537ms step_avg:43.59ms
+step:954/1840 train_time:41599ms step_avg:43.60ms
+step:955/1840 train_time:41659ms step_avg:43.62ms
+step:956/1840 train_time:41720ms step_avg:43.64ms
+step:957/1840 train_time:41780ms step_avg:43.66ms
+step:958/1840 train_time:41842ms step_avg:43.68ms
+step:959/1840 train_time:41902ms step_avg:43.69ms
+step:960/1840 train_time:41964ms step_avg:43.71ms
+step:961/1840 train_time:42025ms step_avg:43.73ms
+step:962/1840 train_time:42087ms step_avg:43.75ms
+step:963/1840 train_time:42147ms step_avg:43.77ms
+step:964/1840 train_time:42210ms step_avg:43.79ms
+step:965/1840 train_time:42269ms step_avg:43.80ms
+step:966/1840 train_time:42332ms step_avg:43.82ms
+step:967/1840 train_time:42392ms step_avg:43.84ms
+step:968/1840 train_time:42454ms step_avg:43.86ms
+step:969/1840 train_time:42514ms step_avg:43.87ms
+step:970/1840 train_time:42577ms step_avg:43.89ms
+step:971/1840 train_time:42636ms step_avg:43.91ms
+step:972/1840 train_time:42697ms step_avg:43.93ms
+step:973/1840 train_time:42758ms step_avg:43.94ms
+step:974/1840 train_time:42820ms step_avg:43.96ms
+step:975/1840 train_time:42880ms step_avg:43.98ms
+step:976/1840 train_time:42942ms step_avg:44.00ms
+step:977/1840 train_time:43001ms step_avg:44.01ms
+step:978/1840 train_time:43064ms step_avg:44.03ms
+step:979/1840 train_time:43125ms step_avg:44.05ms
+step:980/1840 train_time:43187ms step_avg:44.07ms
+step:981/1840 train_time:43247ms step_avg:44.08ms
+step:982/1840 train_time:43310ms step_avg:44.10ms
+step:983/1840 train_time:43370ms step_avg:44.12ms
+step:984/1840 train_time:43433ms step_avg:44.14ms
+step:985/1840 train_time:43493ms step_avg:44.16ms
+step:986/1840 train_time:43556ms step_avg:44.17ms
+step:987/1840 train_time:43616ms step_avg:44.19ms
+step:988/1840 train_time:43678ms step_avg:44.21ms
+step:989/1840 train_time:43737ms step_avg:44.22ms
+step:990/1840 train_time:43800ms step_avg:44.24ms
+step:991/1840 train_time:43859ms step_avg:44.26ms
+step:992/1840 train_time:43921ms step_avg:44.28ms
+step:993/1840 train_time:43981ms step_avg:44.29ms
+step:994/1840 train_time:44043ms step_avg:44.31ms
+step:995/1840 train_time:44103ms step_avg:44.33ms
+step:996/1840 train_time:44167ms step_avg:44.34ms
+step:997/1840 train_time:44227ms step_avg:44.36ms
+step:998/1840 train_time:44289ms step_avg:44.38ms
+step:999/1840 train_time:44349ms step_avg:44.39ms
+step:1000/1840 train_time:44412ms step_avg:44.41ms
+step:1000/1840 val_loss:3.7690 train_time:44483ms step_avg:44.48ms
+step:1001/1840 train_time:44503ms step_avg:44.46ms
+step:1002/1840 train_time:44536ms step_avg:44.45ms
+step:1003/1840 train_time:44597ms step_avg:44.46ms
+step:1004/1840 train_time:44662ms step_avg:44.48ms
+step:1005/1840 train_time:44721ms step_avg:44.50ms
+step:1006/1840 train_time:44783ms step_avg:44.52ms
+step:1007/1840 train_time:44843ms step_avg:44.53ms
+step:1008/1840 train_time:44905ms step_avg:44.55ms
+step:1009/1840 train_time:44964ms step_avg:44.56ms
+step:1010/1840 train_time:45026ms step_avg:44.58ms
+step:1011/1840 train_time:45087ms step_avg:44.60ms
+step:1012/1840 train_time:45149ms step_avg:44.61ms
+step:1013/1840 train_time:45208ms step_avg:44.63ms
+step:1014/1840 train_time:45270ms step_avg:44.64ms
+step:1015/1840 train_time:45329ms step_avg:44.66ms
+step:1016/1840 train_time:45391ms step_avg:44.68ms
+step:1017/1840 train_time:45452ms step_avg:44.69ms
+step:1018/1840 train_time:45517ms step_avg:44.71ms
+step:1019/1840 train_time:45578ms step_avg:44.73ms
+step:1020/1840 train_time:45641ms step_avg:44.75ms
+step:1021/1840 train_time:45702ms step_avg:44.76ms
+step:1022/1840 train_time:45763ms step_avg:44.78ms
+step:1023/1840 train_time:45823ms step_avg:44.79ms
+step:1024/1840 train_time:45884ms step_avg:44.81ms
+step:1025/1840 train_time:45943ms step_avg:44.82ms
+step:1026/1840 train_time:46005ms step_avg:44.84ms
+step:1027/1840 train_time:46065ms step_avg:44.85ms
+step:1028/1840 train_time:46127ms step_avg:44.87ms
+step:1029/1840 train_time:46187ms step_avg:44.88ms
+step:1030/1840 train_time:46248ms step_avg:44.90ms
+step:1031/1840 train_time:46308ms step_avg:44.92ms
+step:1032/1840 train_time:46369ms step_avg:44.93ms
+step:1033/1840 train_time:46429ms step_avg:44.95ms
+step:1034/1840 train_time:46492ms step_avg:44.96ms
+step:1035/1840 train_time:46553ms step_avg:44.98ms
+step:1036/1840 train_time:46617ms step_avg:45.00ms
+step:1037/1840 train_time:46677ms step_avg:45.01ms
+step:1038/1840 train_time:46740ms step_avg:45.03ms
+step:1039/1840 train_time:46800ms step_avg:45.04ms
+step:1040/1840 train_time:46863ms step_avg:45.06ms
+step:1041/1840 train_time:46923ms step_avg:45.07ms
+step:1042/1840 train_time:46984ms step_avg:45.09ms
+step:1043/1840 train_time:47044ms step_avg:45.10ms
+step:1044/1840 train_time:47106ms step_avg:45.12ms
+step:1045/1840 train_time:47166ms step_avg:45.14ms
+step:1046/1840 train_time:47228ms step_avg:45.15ms
+step:1047/1840 train_time:47288ms step_avg:45.17ms
+step:1048/1840 train_time:47350ms step_avg:45.18ms
+step:1049/1840 train_time:47410ms step_avg:45.20ms
+step:1050/1840 train_time:47472ms step_avg:45.21ms
+step:1051/1840 train_time:47533ms step_avg:45.23ms
+step:1052/1840 train_time:47595ms step_avg:45.24ms
+step:1053/1840 train_time:47655ms step_avg:45.26ms
+step:1054/1840 train_time:47718ms step_avg:45.27ms
+step:1055/1840 train_time:47778ms step_avg:45.29ms
+step:1056/1840 train_time:47841ms step_avg:45.30ms
+step:1057/1840 train_time:47901ms step_avg:45.32ms
+step:1058/1840 train_time:47963ms step_avg:45.33ms
+step:1059/1840 train_time:48023ms step_avg:45.35ms
+step:1060/1840 train_time:48085ms step_avg:45.36ms
+step:1061/1840 train_time:48144ms step_avg:45.38ms
+step:1062/1840 train_time:48207ms step_avg:45.39ms
+step:1063/1840 train_time:48267ms step_avg:45.41ms
+step:1064/1840 train_time:48329ms step_avg:45.42ms
+step:1065/1840 train_time:48389ms step_avg:45.44ms
+step:1066/1840 train_time:48450ms step_avg:45.45ms
+step:1067/1840 train_time:48510ms step_avg:45.46ms
+step:1068/1840 train_time:48574ms step_avg:45.48ms
+step:1069/1840 train_time:48633ms step_avg:45.49ms
+step:1070/1840 train_time:48695ms step_avg:45.51ms
+step:1071/1840 train_time:48755ms step_avg:45.52ms
+step:1072/1840 train_time:48819ms step_avg:45.54ms
+step:1073/1840 train_time:48879ms step_avg:45.55ms
+step:1074/1840 train_time:48941ms step_avg:45.57ms
+step:1075/1840 train_time:49001ms step_avg:45.58ms
+step:1076/1840 train_time:49063ms step_avg:45.60ms
+step:1077/1840 train_time:49124ms step_avg:45.61ms
+step:1078/1840 train_time:49186ms step_avg:45.63ms
+step:1079/1840 train_time:49245ms step_avg:45.64ms
+step:1080/1840 train_time:49308ms step_avg:45.66ms
+step:1081/1840 train_time:49368ms step_avg:45.67ms
+step:1082/1840 train_time:49429ms step_avg:45.68ms
+step:1083/1840 train_time:49489ms step_avg:45.70ms
+step:1084/1840 train_time:49551ms step_avg:45.71ms
+step:1085/1840 train_time:49612ms step_avg:45.72ms
+step:1086/1840 train_time:49673ms step_avg:45.74ms
+step:1087/1840 train_time:49732ms step_avg:45.75ms
+step:1088/1840 train_time:49795ms step_avg:45.77ms
+step:1089/1840 train_time:49855ms step_avg:45.78ms
+step:1090/1840 train_time:49919ms step_avg:45.80ms
+step:1091/1840 train_time:49979ms step_avg:45.81ms
+step:1092/1840 train_time:50042ms step_avg:45.83ms
+step:1093/1840 train_time:50103ms step_avg:45.84ms
+step:1094/1840 train_time:50164ms step_avg:45.85ms
+step:1095/1840 train_time:50224ms step_avg:45.87ms
+step:1096/1840 train_time:50286ms step_avg:45.88ms
+step:1097/1840 train_time:50346ms step_avg:45.89ms
+step:1098/1840 train_time:50408ms step_avg:45.91ms
+step:1099/1840 train_time:50468ms step_avg:45.92ms
+step:1100/1840 train_time:50530ms step_avg:45.94ms
+step:1101/1840 train_time:50590ms step_avg:45.95ms
+step:1102/1840 train_time:50652ms step_avg:45.96ms
+step:1103/1840 train_time:50713ms step_avg:45.98ms
+step:1104/1840 train_time:50775ms step_avg:45.99ms
+step:1105/1840 train_time:50836ms step_avg:46.01ms
+step:1106/1840 train_time:50899ms step_avg:46.02ms
+step:1107/1840 train_time:50960ms step_avg:46.03ms
+step:1108/1840 train_time:51023ms step_avg:46.05ms
+step:1109/1840 train_time:51082ms step_avg:46.06ms
+step:1110/1840 train_time:51145ms step_avg:46.08ms
+step:1111/1840 train_time:51204ms step_avg:46.09ms
+step:1112/1840 train_time:51267ms step_avg:46.10ms
+step:1113/1840 train_time:51326ms step_avg:46.12ms
+step:1114/1840 train_time:51388ms step_avg:46.13ms
+step:1115/1840 train_time:51448ms step_avg:46.14ms
+step:1116/1840 train_time:51510ms step_avg:46.16ms
+step:1117/1840 train_time:51569ms step_avg:46.17ms
+step:1118/1840 train_time:51632ms step_avg:46.18ms
+step:1119/1840 train_time:51692ms step_avg:46.20ms
+step:1120/1840 train_time:51754ms step_avg:46.21ms
+step:1121/1840 train_time:51813ms step_avg:46.22ms
+step:1122/1840 train_time:51877ms step_avg:46.24ms
+step:1123/1840 train_time:51937ms step_avg:46.25ms
+step:1124/1840 train_time:51999ms step_avg:46.26ms
+step:1125/1840 train_time:52060ms step_avg:46.28ms
+step:1126/1840 train_time:52122ms step_avg:46.29ms
+step:1127/1840 train_time:52183ms step_avg:46.30ms
+step:1128/1840 train_time:52244ms step_avg:46.32ms
+step:1129/1840 train_time:52304ms step_avg:46.33ms
+step:1130/1840 train_time:52367ms step_avg:46.34ms
+step:1131/1840 train_time:52427ms step_avg:46.35ms
+step:1132/1840 train_time:52489ms step_avg:46.37ms
+step:1133/1840 train_time:52549ms step_avg:46.38ms
+step:1134/1840 train_time:52612ms step_avg:46.39ms
+step:1135/1840 train_time:52672ms step_avg:46.41ms
+step:1136/1840 train_time:52734ms step_avg:46.42ms
+step:1137/1840 train_time:52794ms step_avg:46.43ms
+step:1138/1840 train_time:52857ms step_avg:46.45ms
+step:1139/1840 train_time:52917ms step_avg:46.46ms
+step:1140/1840 train_time:52978ms step_avg:46.47ms
+step:1141/1840 train_time:53038ms step_avg:46.48ms
+step:1142/1840 train_time:53101ms step_avg:46.50ms
+step:1143/1840 train_time:53161ms step_avg:46.51ms
+step:1144/1840 train_time:53223ms step_avg:46.52ms
+step:1145/1840 train_time:53284ms step_avg:46.54ms
+step:1146/1840 train_time:53346ms step_avg:46.55ms
+step:1147/1840 train_time:53406ms step_avg:46.56ms
+step:1148/1840 train_time:53468ms step_avg:46.57ms
+step:1149/1840 train_time:53527ms step_avg:46.59ms
+step:1150/1840 train_time:53589ms step_avg:46.60ms
+step:1151/1840 train_time:53650ms step_avg:46.61ms
+step:1152/1840 train_time:53712ms step_avg:46.63ms
+step:1153/1840 train_time:53771ms step_avg:46.64ms
+step:1154/1840 train_time:53834ms step_avg:46.65ms
+step:1155/1840 train_time:53894ms step_avg:46.66ms
+step:1156/1840 train_time:53957ms step_avg:46.68ms
+step:1157/1840 train_time:54017ms step_avg:46.69ms
+step:1158/1840 train_time:54079ms step_avg:46.70ms
+step:1159/1840 train_time:54140ms step_avg:46.71ms
+step:1160/1840 train_time:54202ms step_avg:46.73ms
+step:1161/1840 train_time:54262ms step_avg:46.74ms
+step:1162/1840 train_time:54325ms step_avg:46.75ms
+step:1163/1840 train_time:54385ms step_avg:46.76ms
+step:1164/1840 train_time:54447ms step_avg:46.78ms
+step:1165/1840 train_time:54507ms step_avg:46.79ms
+step:1166/1840 train_time:54569ms step_avg:46.80ms
+step:1167/1840 train_time:54628ms step_avg:46.81ms
+step:1168/1840 train_time:54691ms step_avg:46.82ms
+step:1169/1840 train_time:54750ms step_avg:46.83ms
+step:1170/1840 train_time:54813ms step_avg:46.85ms
+step:1171/1840 train_time:54872ms step_avg:46.86ms
+step:1172/1840 train_time:54934ms step_avg:46.87ms
+step:1173/1840 train_time:54994ms step_avg:46.88ms
+step:1174/1840 train_time:55056ms step_avg:46.90ms
+step:1175/1840 train_time:55116ms step_avg:46.91ms
+step:1176/1840 train_time:55178ms step_avg:46.92ms
+step:1177/1840 train_time:55239ms step_avg:46.93ms
+step:1178/1840 train_time:55302ms step_avg:46.95ms
+step:1179/1840 train_time:55362ms step_avg:46.96ms
+step:1180/1840 train_time:55424ms step_avg:46.97ms
+step:1181/1840 train_time:55484ms step_avg:46.98ms
+step:1182/1840 train_time:55547ms step_avg:46.99ms
+step:1183/1840 train_time:55607ms step_avg:47.01ms
+step:1184/1840 train_time:55670ms step_avg:47.02ms
+step:1185/1840 train_time:55729ms step_avg:47.03ms
+step:1186/1840 train_time:55791ms step_avg:47.04ms
+step:1187/1840 train_time:55851ms step_avg:47.05ms
+step:1188/1840 train_time:55913ms step_avg:47.06ms
+step:1189/1840 train_time:55973ms step_avg:47.08ms
+step:1190/1840 train_time:56035ms step_avg:47.09ms
+step:1191/1840 train_time:56095ms step_avg:47.10ms
+step:1192/1840 train_time:56157ms step_avg:47.11ms
+step:1193/1840 train_time:56218ms step_avg:47.12ms
+step:1194/1840 train_time:56281ms step_avg:47.14ms
+step:1195/1840 train_time:56341ms step_avg:47.15ms
+step:1196/1840 train_time:56404ms step_avg:47.16ms
+step:1197/1840 train_time:56464ms step_avg:47.17ms
+step:1198/1840 train_time:56526ms step_avg:47.18ms
+step:1199/1840 train_time:56587ms step_avg:47.20ms
+step:1200/1840 train_time:56649ms step_avg:47.21ms
+step:1201/1840 train_time:56710ms step_avg:47.22ms
+step:1202/1840 train_time:56796ms step_avg:47.25ms
+step:1203/1840 train_time:56882ms step_avg:47.28ms
+step:1204/1840 train_time:56973ms step_avg:47.32ms
+step:1205/1840 train_time:57060ms step_avg:47.35ms
+step:1206/1840 train_time:57150ms step_avg:47.39ms
+step:1207/1840 train_time:57236ms step_avg:47.42ms
+step:1208/1840 train_time:57325ms step_avg:47.45ms
+step:1209/1840 train_time:57413ms step_avg:47.49ms
+step:1210/1840 train_time:57502ms step_avg:47.52ms
+step:1211/1840 train_time:57592ms step_avg:47.56ms
+step:1212/1840 train_time:57680ms step_avg:47.59ms
+step:1213/1840 train_time:57767ms step_avg:47.62ms
+step:1214/1840 train_time:57856ms step_avg:47.66ms
+step:1215/1840 train_time:57941ms step_avg:47.69ms
+step:1216/1840 train_time:58030ms step_avg:47.72ms
+step:1217/1840 train_time:58116ms step_avg:47.75ms
+step:1218/1840 train_time:58205ms step_avg:47.79ms
+step:1219/1840 train_time:58291ms step_avg:47.82ms
+step:1220/1840 train_time:58380ms step_avg:47.85ms
+step:1221/1840 train_time:58468ms step_avg:47.89ms
+step:1222/1840 train_time:58558ms step_avg:47.92ms
+step:1223/1840 train_time:58644ms step_avg:47.95ms
+step:1224/1840 train_time:58734ms step_avg:47.99ms
+step:1225/1840 train_time:58819ms step_avg:48.02ms
+step:1226/1840 train_time:58909ms step_avg:48.05ms
+step:1227/1840 train_time:58995ms step_avg:48.08ms
+step:1228/1840 train_time:59082ms step_avg:48.11ms
+step:1229/1840 train_time:59169ms step_avg:48.14ms
+step:1230/1840 train_time:59259ms step_avg:48.18ms
+step:1231/1840 train_time:59346ms step_avg:48.21ms
+step:1232/1840 train_time:59436ms step_avg:48.24ms
+step:1233/1840 train_time:59522ms step_avg:48.27ms
+step:1234/1840 train_time:59612ms step_avg:48.31ms
+step:1235/1840 train_time:59700ms step_avg:48.34ms
+step:1236/1840 train_time:59788ms step_avg:48.37ms
+step:1237/1840 train_time:59875ms step_avg:48.40ms
+step:1238/1840 train_time:59962ms step_avg:48.43ms
+step:1239/1840 train_time:60049ms step_avg:48.47ms
+step:1240/1840 train_time:60138ms step_avg:48.50ms
+step:1241/1840 train_time:60223ms step_avg:48.53ms
+step:1242/1840 train_time:60313ms step_avg:48.56ms
+step:1243/1840 train_time:60399ms step_avg:48.59ms
+step:1244/1840 train_time:60486ms step_avg:48.62ms
+step:1245/1840 train_time:60575ms step_avg:48.65ms
+step:1246/1840 train_time:60662ms step_avg:48.69ms
+step:1247/1840 train_time:60749ms step_avg:48.72ms
+step:1248/1840 train_time:60839ms step_avg:48.75ms
+step:1249/1840 train_time:60925ms step_avg:48.78ms
+step:1250/1840 train_time:61014ms step_avg:48.81ms
+step:1250/1840 val_loss:3.5324 train_time:61113ms step_avg:48.89ms
+step:1251/1840 train_time:61134ms step_avg:48.87ms
+step:1252/1840 train_time:61194ms step_avg:48.88ms
+step:1253/1840 train_time:61283ms step_avg:48.91ms
+step:1254/1840 train_time:61371ms step_avg:48.94ms
+step:1255/1840 train_time:61457ms step_avg:48.97ms
+step:1256/1840 train_time:61547ms step_avg:49.00ms
+step:1257/1840 train_time:61633ms step_avg:49.03ms
+step:1258/1840 train_time:61721ms step_avg:49.06ms
+step:1259/1840 train_time:61806ms step_avg:49.09ms
+step:1260/1840 train_time:61895ms step_avg:49.12ms
+step:1261/1840 train_time:61980ms step_avg:49.15ms
+step:1262/1840 train_time:62070ms step_avg:49.18ms
+step:1263/1840 train_time:62158ms step_avg:49.21ms
+step:1264/1840 train_time:62249ms step_avg:49.25ms
+step:1265/1840 train_time:62338ms step_avg:49.28ms
+step:1266/1840 train_time:62429ms step_avg:49.31ms
+step:1267/1840 train_time:62514ms step_avg:49.34ms
+step:1268/1840 train_time:62604ms step_avg:49.37ms
+step:1269/1840 train_time:62689ms step_avg:49.40ms
+step:1270/1840 train_time:62778ms step_avg:49.43ms
+step:1271/1840 train_time:62864ms step_avg:49.46ms
+step:1272/1840 train_time:62951ms step_avg:49.49ms
+step:1273/1840 train_time:63037ms step_avg:49.52ms
+step:1274/1840 train_time:63127ms step_avg:49.55ms
+step:1275/1840 train_time:63214ms step_avg:49.58ms
+step:1276/1840 train_time:63305ms step_avg:49.61ms
+step:1277/1840 train_time:63390ms step_avg:49.64ms
+step:1278/1840 train_time:63480ms step_avg:49.67ms
+step:1279/1840 train_time:63565ms step_avg:49.70ms
+step:1280/1840 train_time:63653ms step_avg:49.73ms
+step:1281/1840 train_time:63739ms step_avg:49.76ms
+step:1282/1840 train_time:63826ms step_avg:49.79ms
+step:1283/1840 train_time:63912ms step_avg:49.81ms
+step:1284/1840 train_time:64001ms step_avg:49.85ms
+step:1285/1840 train_time:64088ms step_avg:49.87ms
+step:1286/1840 train_time:64178ms step_avg:49.91ms
+step:1287/1840 train_time:64267ms step_avg:49.94ms
+step:1288/1840 train_time:64355ms step_avg:49.97ms
+step:1289/1840 train_time:64442ms step_avg:49.99ms
+step:1290/1840 train_time:64530ms step_avg:50.02ms
+step:1291/1840 train_time:64616ms step_avg:50.05ms
+step:1292/1840 train_time:64705ms step_avg:50.08ms
+step:1293/1840 train_time:64791ms step_avg:50.11ms
+step:1294/1840 train_time:64879ms step_avg:50.14ms
+step:1295/1840 train_time:64967ms step_avg:50.17ms
+step:1296/1840 train_time:65056ms step_avg:50.20ms
+step:1297/1840 train_time:65142ms step_avg:50.23ms
+step:1298/1840 train_time:65230ms step_avg:50.25ms
+step:1299/1840 train_time:65316ms step_avg:50.28ms
+step:1300/1840 train_time:65407ms step_avg:50.31ms
+step:1301/1840 train_time:65493ms step_avg:50.34ms
+step:1302/1840 train_time:65582ms step_avg:50.37ms
+step:1303/1840 train_time:65668ms step_avg:50.40ms
+step:1304/1840 train_time:65755ms step_avg:50.43ms
+step:1305/1840 train_time:65841ms step_avg:50.45ms
+step:1306/1840 train_time:65929ms step_avg:50.48ms
+step:1307/1840 train_time:66015ms step_avg:50.51ms
+step:1308/1840 train_time:66105ms step_avg:50.54ms
+step:1309/1840 train_time:66192ms step_avg:50.57ms
+step:1310/1840 train_time:66280ms step_avg:50.60ms
+step:1311/1840 train_time:66368ms step_avg:50.62ms
+step:1312/1840 train_time:66456ms step_avg:50.65ms
+step:1313/1840 train_time:66542ms step_avg:50.68ms
+step:1314/1840 train_time:66630ms step_avg:50.71ms
+step:1315/1840 train_time:66716ms step_avg:50.73ms
+step:1316/1840 train_time:66806ms step_avg:50.76ms
+step:1317/1840 train_time:66891ms step_avg:50.79ms
+step:1318/1840 train_time:66979ms step_avg:50.82ms
+step:1319/1840 train_time:67066ms step_avg:50.85ms
+step:1320/1840 train_time:67156ms step_avg:50.88ms
+step:1321/1840 train_time:67242ms step_avg:50.90ms
+step:1322/1840 train_time:67330ms step_avg:50.93ms
+step:1323/1840 train_time:67416ms step_avg:50.96ms
+step:1324/1840 train_time:67506ms step_avg:50.99ms
+step:1325/1840 train_time:67592ms step_avg:51.01ms
+step:1326/1840 train_time:67682ms step_avg:51.04ms
+step:1327/1840 train_time:67767ms step_avg:51.07ms
+step:1328/1840 train_time:67855ms step_avg:51.10ms
+step:1329/1840 train_time:67941ms step_avg:51.12ms
+step:1330/1840 train_time:68029ms step_avg:51.15ms
+step:1331/1840 train_time:68114ms step_avg:51.18ms
+step:1332/1840 train_time:68205ms step_avg:51.21ms
+step:1333/1840 train_time:68292ms step_avg:51.23ms
+step:1334/1840 train_time:68382ms step_avg:51.26ms
+step:1335/1840 train_time:68468ms step_avg:51.29ms
+step:1336/1840 train_time:68556ms step_avg:51.31ms
+step:1337/1840 train_time:68642ms step_avg:51.34ms
+step:1338/1840 train_time:68731ms step_avg:51.37ms
+step:1339/1840 train_time:68816ms step_avg:51.39ms
+step:1340/1840 train_time:68906ms step_avg:51.42ms
+step:1341/1840 train_time:68991ms step_avg:51.45ms
+step:1342/1840 train_time:69080ms step_avg:51.48ms
+step:1343/1840 train_time:69166ms step_avg:51.50ms
+step:1344/1840 train_time:69255ms step_avg:51.53ms
+step:1345/1840 train_time:69342ms step_avg:51.56ms
+step:1346/1840 train_time:69431ms step_avg:51.58ms
+step:1347/1840 train_time:69517ms step_avg:51.61ms
+step:1348/1840 train_time:69607ms step_avg:51.64ms
+step:1349/1840 train_time:69693ms step_avg:51.66ms
+step:1350/1840 train_time:69781ms step_avg:51.69ms
+step:1351/1840 train_time:69867ms step_avg:51.72ms
+step:1352/1840 train_time:69955ms step_avg:51.74ms
+step:1353/1840 train_time:70041ms step_avg:51.77ms
+step:1354/1840 train_time:70129ms step_avg:51.79ms
+step:1355/1840 train_time:70215ms step_avg:51.82ms
+step:1356/1840 train_time:70306ms step_avg:51.85ms
+step:1357/1840 train_time:70392ms step_avg:51.87ms
+step:1358/1840 train_time:70480ms step_avg:51.90ms
+step:1359/1840 train_time:70567ms step_avg:51.93ms
+step:1360/1840 train_time:70656ms step_avg:51.95ms
+step:1361/1840 train_time:70742ms step_avg:51.98ms
+step:1362/1840 train_time:70830ms step_avg:52.00ms
+step:1363/1840 train_time:70917ms step_avg:52.03ms
+step:1364/1840 train_time:71005ms step_avg:52.06ms
+step:1365/1840 train_time:71090ms step_avg:52.08ms
+step:1366/1840 train_time:71180ms step_avg:52.11ms
+step:1367/1840 train_time:71268ms step_avg:52.13ms
+step:1368/1840 train_time:71357ms step_avg:52.16ms
+step:1369/1840 train_time:71442ms step_avg:52.19ms
+step:1370/1840 train_time:71529ms step_avg:52.21ms
+step:1371/1840 train_time:71616ms step_avg:52.24ms
+step:1372/1840 train_time:71706ms step_avg:52.26ms
+step:1373/1840 train_time:71791ms step_avg:52.29ms
+step:1374/1840 train_time:71880ms step_avg:52.31ms
+step:1375/1840 train_time:71966ms step_avg:52.34ms
+step:1376/1840 train_time:72056ms step_avg:52.37ms
+step:1377/1840 train_time:72141ms step_avg:52.39ms
+step:1378/1840 train_time:72230ms step_avg:52.42ms
+step:1379/1840 train_time:72317ms step_avg:52.44ms
+step:1380/1840 train_time:72407ms step_avg:52.47ms
+step:1381/1840 train_time:72492ms step_avg:52.49ms
+step:1382/1840 train_time:72581ms step_avg:52.52ms
+step:1383/1840 train_time:72667ms step_avg:52.54ms
+step:1384/1840 train_time:72755ms step_avg:52.57ms
+step:1385/1840 train_time:72841ms step_avg:52.59ms
+step:1386/1840 train_time:72930ms step_avg:52.62ms
+step:1387/1840 train_time:73016ms step_avg:52.64ms
+step:1388/1840 train_time:73105ms step_avg:52.67ms
+step:1389/1840 train_time:73191ms step_avg:52.69ms
+step:1390/1840 train_time:73280ms step_avg:52.72ms
+step:1391/1840 train_time:73367ms step_avg:52.74ms
+step:1392/1840 train_time:73456ms step_avg:52.77ms
+step:1393/1840 train_time:73541ms step_avg:52.79ms
+step:1394/1840 train_time:73629ms step_avg:52.82ms
+step:1395/1840 train_time:73715ms step_avg:52.84ms
+step:1396/1840 train_time:73806ms step_avg:52.87ms
+step:1397/1840 train_time:73891ms step_avg:52.89ms
+step:1398/1840 train_time:73980ms step_avg:52.92ms
+step:1399/1840 train_time:74067ms step_avg:52.94ms
+step:1400/1840 train_time:74155ms step_avg:52.97ms
+step:1401/1840 train_time:74240ms step_avg:52.99ms
+step:1402/1840 train_time:74329ms step_avg:53.02ms
+step:1403/1840 train_time:74415ms step_avg:53.04ms
+step:1404/1840 train_time:74506ms step_avg:53.07ms
+step:1405/1840 train_time:74592ms step_avg:53.09ms
+step:1406/1840 train_time:74681ms step_avg:53.12ms
+step:1407/1840 train_time:74767ms step_avg:53.14ms
+step:1408/1840 train_time:74856ms step_avg:53.16ms
+step:1409/1840 train_time:74942ms step_avg:53.19ms
+step:1410/1840 train_time:75029ms step_avg:53.21ms
+step:1411/1840 train_time:75116ms step_avg:53.24ms
+step:1412/1840 train_time:75206ms step_avg:53.26ms
+step:1413/1840 train_time:75291ms step_avg:53.28ms
+step:1414/1840 train_time:75380ms step_avg:53.31ms
+step:1415/1840 train_time:75467ms step_avg:53.33ms
+step:1416/1840 train_time:75556ms step_avg:53.36ms
+step:1417/1840 train_time:75642ms step_avg:53.38ms
+step:1418/1840 train_time:75729ms step_avg:53.41ms
+step:1419/1840 train_time:75816ms step_avg:53.43ms
+step:1420/1840 train_time:75906ms step_avg:53.46ms
+step:1421/1840 train_time:75992ms step_avg:53.48ms
+step:1422/1840 train_time:76081ms step_avg:53.50ms
+step:1423/1840 train_time:76167ms step_avg:53.53ms
+step:1424/1840 train_time:76255ms step_avg:53.55ms
+step:1425/1840 train_time:76342ms step_avg:53.57ms
+step:1426/1840 train_time:76429ms step_avg:53.60ms
+step:1427/1840 train_time:76515ms step_avg:53.62ms
+step:1428/1840 train_time:76606ms step_avg:53.65ms
+step:1429/1840 train_time:76692ms step_avg:53.67ms
+step:1430/1840 train_time:76781ms step_avg:53.69ms
+step:1431/1840 train_time:76868ms step_avg:53.72ms
+step:1432/1840 train_time:76955ms step_avg:53.74ms
+step:1433/1840 train_time:77042ms step_avg:53.76ms
+step:1434/1840 train_time:77130ms step_avg:53.79ms
+step:1435/1840 train_time:77215ms step_avg:53.81ms
+step:1436/1840 train_time:77306ms step_avg:53.83ms
+step:1437/1840 train_time:77392ms step_avg:53.86ms
+step:1438/1840 train_time:77482ms step_avg:53.88ms
+step:1439/1840 train_time:77568ms step_avg:53.90ms
+step:1440/1840 train_time:77656ms step_avg:53.93ms
+step:1441/1840 train_time:77743ms step_avg:53.95ms
+step:1442/1840 train_time:77831ms step_avg:53.97ms
+step:1443/1840 train_time:77917ms step_avg:54.00ms
+step:1444/1840 train_time:78007ms step_avg:54.02ms
+step:1445/1840 train_time:78093ms step_avg:54.04ms
+step:1446/1840 train_time:78181ms step_avg:54.07ms
+step:1447/1840 train_time:78268ms step_avg:54.09ms
+step:1448/1840 train_time:78355ms step_avg:54.11ms
+step:1449/1840 train_time:78440ms step_avg:54.13ms
+step:1450/1840 train_time:78531ms step_avg:54.16ms
+step:1451/1840 train_time:78617ms step_avg:54.18ms
+step:1452/1840 train_time:78707ms step_avg:54.21ms
+step:1453/1840 train_time:78793ms step_avg:54.23ms
+step:1454/1840 train_time:78883ms step_avg:54.25ms
+step:1455/1840 train_time:78968ms step_avg:54.27ms
+step:1456/1840 train_time:79057ms step_avg:54.30ms
+step:1457/1840 train_time:79145ms step_avg:54.32ms
+step:1458/1840 train_time:79234ms step_avg:54.34ms
+step:1459/1840 train_time:79321ms step_avg:54.37ms
+step:1460/1840 train_time:79409ms step_avg:54.39ms
+step:1461/1840 train_time:79494ms step_avg:54.41ms
+step:1462/1840 train_time:79584ms step_avg:54.44ms
+step:1463/1840 train_time:79670ms step_avg:54.46ms
+step:1464/1840 train_time:79760ms step_avg:54.48ms
+step:1465/1840 train_time:79846ms step_avg:54.50ms
+step:1466/1840 train_time:79935ms step_avg:54.53ms
+step:1467/1840 train_time:80020ms step_avg:54.55ms
+step:1468/1840 train_time:80108ms step_avg:54.57ms
+step:1469/1840 train_time:80195ms step_avg:54.59ms
+step:1470/1840 train_time:80285ms step_avg:54.62ms
+step:1471/1840 train_time:80372ms step_avg:54.64ms
+step:1472/1840 train_time:80460ms step_avg:54.66ms
+step:1473/1840 train_time:80545ms step_avg:54.68ms
+step:1474/1840 train_time:80635ms step_avg:54.70ms
+step:1475/1840 train_time:80720ms step_avg:54.73ms
+step:1476/1840 train_time:80809ms step_avg:54.75ms
+step:1477/1840 train_time:80895ms step_avg:54.77ms
+step:1478/1840 train_time:80984ms step_avg:54.79ms
+step:1479/1840 train_time:81070ms step_avg:54.81ms
+step:1480/1840 train_time:81159ms step_avg:54.84ms
+step:1481/1840 train_time:81246ms step_avg:54.86ms
+step:1482/1840 train_time:81335ms step_avg:54.88ms
+step:1483/1840 train_time:81421ms step_avg:54.90ms
+step:1484/1840 train_time:81509ms step_avg:54.93ms
+step:1485/1840 train_time:81596ms step_avg:54.95ms
+step:1486/1840 train_time:81686ms step_avg:54.97ms
+step:1487/1840 train_time:81772ms step_avg:54.99ms
+step:1488/1840 train_time:81861ms step_avg:55.01ms
+step:1489/1840 train_time:81946ms step_avg:55.03ms
+step:1490/1840 train_time:82034ms step_avg:55.06ms
+step:1491/1840 train_time:82121ms step_avg:55.08ms
+step:1492/1840 train_time:82210ms step_avg:55.10ms
+step:1493/1840 train_time:82296ms step_avg:55.12ms
+step:1494/1840 train_time:82386ms step_avg:55.14ms
+step:1495/1840 train_time:82471ms step_avg:55.16ms
+step:1496/1840 train_time:82560ms step_avg:55.19ms
+step:1497/1840 train_time:82646ms step_avg:55.21ms
+step:1498/1840 train_time:82735ms step_avg:55.23ms
+step:1499/1840 train_time:82820ms step_avg:55.25ms
+step:1500/1840 train_time:82908ms step_avg:55.27ms
+step:1500/1840 val_loss:3.4010 train_time:83011ms step_avg:55.34ms
+step:1501/1840 train_time:83034ms step_avg:55.32ms
+step:1502/1840 train_time:83090ms step_avg:55.32ms
+step:1503/1840 train_time:83181ms step_avg:55.34ms
+step:1504/1840 train_time:83269ms step_avg:55.36ms
+step:1505/1840 train_time:83354ms step_avg:55.38ms
+step:1506/1840 train_time:83441ms step_avg:55.41ms
+step:1507/1840 train_time:83527ms step_avg:55.43ms
+step:1508/1840 train_time:83613ms step_avg:55.45ms
+step:1509/1840 train_time:83698ms step_avg:55.47ms
+step:1510/1840 train_time:83787ms step_avg:55.49ms
+step:1511/1840 train_time:83872ms step_avg:55.51ms
+step:1512/1840 train_time:83962ms step_avg:55.53ms
+step:1513/1840 train_time:84052ms step_avg:55.55ms
+step:1514/1840 train_time:84143ms step_avg:55.58ms
+step:1515/1840 train_time:84231ms step_avg:55.60ms
+step:1516/1840 train_time:84318ms step_avg:55.62ms
+step:1517/1840 train_time:84404ms step_avg:55.64ms
+step:1518/1840 train_time:84491ms step_avg:55.66ms
+step:1519/1840 train_time:84577ms step_avg:55.68ms
+step:1520/1840 train_time:84664ms step_avg:55.70ms
+step:1521/1840 train_time:84750ms step_avg:55.72ms
+step:1522/1840 train_time:84838ms step_avg:55.74ms
+step:1523/1840 train_time:84926ms step_avg:55.76ms
+step:1524/1840 train_time:85015ms step_avg:55.78ms
+step:1525/1840 train_time:85103ms step_avg:55.81ms
+step:1526/1840 train_time:85194ms step_avg:55.83ms
+step:1527/1840 train_time:85280ms step_avg:55.85ms
+step:1528/1840 train_time:85370ms step_avg:55.87ms
+step:1529/1840 train_time:85455ms step_avg:55.89ms
+step:1530/1840 train_time:85543ms step_avg:55.91ms
+step:1531/1840 train_time:85628ms step_avg:55.93ms
+step:1532/1840 train_time:85716ms step_avg:55.95ms
+step:1533/1840 train_time:85801ms step_avg:55.97ms
+step:1534/1840 train_time:85891ms step_avg:55.99ms
+step:1535/1840 train_time:85977ms step_avg:56.01ms
+step:1536/1840 train_time:86069ms step_avg:56.03ms
+step:1537/1840 train_time:86155ms step_avg:56.05ms
+step:1538/1840 train_time:86244ms step_avg:56.08ms
+step:1539/1840 train_time:86331ms step_avg:56.10ms
+step:1540/1840 train_time:86419ms step_avg:56.12ms
+step:1541/1840 train_time:86505ms step_avg:56.14ms
+step:1542/1840 train_time:86594ms step_avg:56.16ms
+step:1543/1840 train_time:86679ms step_avg:56.18ms
+step:1544/1840 train_time:86769ms step_avg:56.20ms
+step:1545/1840 train_time:86854ms step_avg:56.22ms
+step:1546/1840 train_time:86942ms step_avg:56.24ms
+step:1547/1840 train_time:87030ms step_avg:56.26ms
+step:1548/1840 train_time:87119ms step_avg:56.28ms
+step:1549/1840 train_time:87206ms step_avg:56.30ms
+step:1550/1840 train_time:87294ms step_avg:56.32ms
+step:1551/1840 train_time:87380ms step_avg:56.34ms
+step:1552/1840 train_time:87470ms step_avg:56.36ms
+step:1553/1840 train_time:87555ms step_avg:56.38ms
+step:1554/1840 train_time:87643ms step_avg:56.40ms
+step:1555/1840 train_time:87729ms step_avg:56.42ms
+step:1556/1840 train_time:87817ms step_avg:56.44ms
+step:1557/1840 train_time:87904ms step_avg:56.46ms
+step:1558/1840 train_time:87992ms step_avg:56.48ms
+step:1559/1840 train_time:88079ms step_avg:56.50ms
+step:1560/1840 train_time:88170ms step_avg:56.52ms
+step:1561/1840 train_time:88258ms step_avg:56.54ms
+step:1562/1840 train_time:88348ms step_avg:56.56ms
+step:1563/1840 train_time:88433ms step_avg:56.58ms
+step:1564/1840 train_time:88523ms step_avg:56.60ms
+step:1565/1840 train_time:88609ms step_avg:56.62ms
+step:1566/1840 train_time:88696ms step_avg:56.64ms
+step:1567/1840 train_time:88782ms step_avg:56.66ms
+step:1568/1840 train_time:88870ms step_avg:56.68ms
+step:1569/1840 train_time:88956ms step_avg:56.70ms
+step:1570/1840 train_time:89044ms step_avg:56.72ms
+step:1571/1840 train_time:89131ms step_avg:56.74ms
+step:1572/1840 train_time:89220ms step_avg:56.76ms
+step:1573/1840 train_time:89307ms step_avg:56.78ms
+step:1574/1840 train_time:89395ms step_avg:56.80ms
+step:1575/1840 train_time:89482ms step_avg:56.81ms
+step:1576/1840 train_time:89571ms step_avg:56.83ms
+step:1577/1840 train_time:89656ms step_avg:56.85ms
+step:1578/1840 train_time:89745ms step_avg:56.87ms
+step:1579/1840 train_time:89831ms step_avg:56.89ms
+step:1580/1840 train_time:89920ms step_avg:56.91ms
+step:1581/1840 train_time:90006ms step_avg:56.93ms
+step:1582/1840 train_time:90094ms step_avg:56.95ms
+step:1583/1840 train_time:90182ms step_avg:56.97ms
+step:1584/1840 train_time:90271ms step_avg:56.99ms
+step:1585/1840 train_time:90357ms step_avg:57.01ms
+step:1586/1840 train_time:90446ms step_avg:57.03ms
+step:1587/1840 train_time:90531ms step_avg:57.05ms
+step:1588/1840 train_time:90620ms step_avg:57.07ms
+step:1589/1840 train_time:90706ms step_avg:57.08ms
+step:1590/1840 train_time:90795ms step_avg:57.10ms
+step:1591/1840 train_time:90881ms step_avg:57.12ms
+step:1592/1840 train_time:90970ms step_avg:57.14ms
+step:1593/1840 train_time:91056ms step_avg:57.16ms
+step:1594/1840 train_time:91144ms step_avg:57.18ms
+step:1595/1840 train_time:91231ms step_avg:57.20ms
+step:1596/1840 train_time:91320ms step_avg:57.22ms
+step:1597/1840 train_time:91407ms step_avg:57.24ms
+step:1598/1840 train_time:91495ms step_avg:57.26ms
+step:1599/1840 train_time:91581ms step_avg:57.27ms
+step:1600/1840 train_time:91670ms step_avg:57.29ms
+step:1601/1840 train_time:91755ms step_avg:57.31ms
+step:1602/1840 train_time:91844ms step_avg:57.33ms
+step:1603/1840 train_time:91931ms step_avg:57.35ms
+step:1604/1840 train_time:92020ms step_avg:57.37ms
+step:1605/1840 train_time:92105ms step_avg:57.39ms
+step:1606/1840 train_time:92194ms step_avg:57.41ms
+step:1607/1840 train_time:92280ms step_avg:57.42ms
+step:1608/1840 train_time:92370ms step_avg:57.44ms
+step:1609/1840 train_time:92457ms step_avg:57.46ms
+step:1610/1840 train_time:92547ms step_avg:57.48ms
+step:1611/1840 train_time:92632ms step_avg:57.50ms
+step:1612/1840 train_time:92722ms step_avg:57.52ms
+step:1613/1840 train_time:92808ms step_avg:57.54ms
+step:1614/1840 train_time:92896ms step_avg:57.56ms
+step:1615/1840 train_time:92983ms step_avg:57.57ms
+step:1616/1840 train_time:93071ms step_avg:57.59ms
+step:1617/1840 train_time:93158ms step_avg:57.61ms
+step:1618/1840 train_time:93249ms step_avg:57.63ms
+step:1619/1840 train_time:93334ms step_avg:57.65ms
+step:1620/1840 train_time:93422ms step_avg:57.67ms
+step:1621/1840 train_time:93509ms step_avg:57.69ms
+step:1622/1840 train_time:93596ms step_avg:57.70ms
+step:1623/1840 train_time:93683ms step_avg:57.72ms
+step:1624/1840 train_time:93771ms step_avg:57.74ms
+step:1625/1840 train_time:93857ms step_avg:57.76ms
+step:1626/1840 train_time:93946ms step_avg:57.78ms
+step:1627/1840 train_time:94032ms step_avg:57.79ms
+step:1628/1840 train_time:94121ms step_avg:57.81ms
+step:1629/1840 train_time:94208ms step_avg:57.83ms
+step:1630/1840 train_time:94296ms step_avg:57.85ms
+step:1631/1840 train_time:94382ms step_avg:57.87ms
+step:1632/1840 train_time:94471ms step_avg:57.89ms
+step:1633/1840 train_time:94556ms step_avg:57.90ms
+step:1634/1840 train_time:94644ms step_avg:57.92ms
+step:1635/1840 train_time:94732ms step_avg:57.94ms
+step:1636/1840 train_time:94820ms step_avg:57.96ms
+step:1637/1840 train_time:94906ms step_avg:57.98ms
+step:1638/1840 train_time:94995ms step_avg:57.99ms
+step:1639/1840 train_time:95081ms step_avg:58.01ms
+step:1640/1840 train_time:95169ms step_avg:58.03ms
+step:1641/1840 train_time:95255ms step_avg:58.05ms
+step:1642/1840 train_time:95345ms step_avg:58.07ms
+step:1643/1840 train_time:95432ms step_avg:58.08ms
+step:1644/1840 train_time:95521ms step_avg:58.10ms
+step:1645/1840 train_time:95608ms step_avg:58.12ms
+step:1646/1840 train_time:95696ms step_avg:58.14ms
+step:1647/1840 train_time:95782ms step_avg:58.16ms
+step:1648/1840 train_time:95871ms step_avg:58.17ms
+step:1649/1840 train_time:95955ms step_avg:58.19ms
+step:1650/1840 train_time:96045ms step_avg:58.21ms
+step:1651/1840 train_time:96132ms step_avg:58.23ms
+step:1652/1840 train_time:96220ms step_avg:58.24ms
+step:1653/1840 train_time:96307ms step_avg:58.26ms
+step:1654/1840 train_time:96395ms step_avg:58.28ms
+step:1655/1840 train_time:96481ms step_avg:58.30ms
+step:1656/1840 train_time:96570ms step_avg:58.32ms
+step:1657/1840 train_time:96656ms step_avg:58.33ms
+step:1658/1840 train_time:96745ms step_avg:58.35ms
+step:1659/1840 train_time:96831ms step_avg:58.37ms
+step:1660/1840 train_time:96919ms step_avg:58.39ms
+step:1661/1840 train_time:97005ms step_avg:58.40ms
+step:1662/1840 train_time:97094ms step_avg:58.42ms
+step:1663/1840 train_time:97180ms step_avg:58.44ms
+step:1664/1840 train_time:97269ms step_avg:58.46ms
+step:1665/1840 train_time:97355ms step_avg:58.47ms
+step:1666/1840 train_time:97444ms step_avg:58.49ms
+step:1667/1840 train_time:97531ms step_avg:58.51ms
+step:1668/1840 train_time:97619ms step_avg:58.52ms
+step:1669/1840 train_time:97705ms step_avg:58.54ms
+step:1670/1840 train_time:97793ms step_avg:58.56ms
+step:1671/1840 train_time:97879ms step_avg:58.58ms
+step:1672/1840 train_time:97968ms step_avg:58.59ms
+step:1673/1840 train_time:98054ms step_avg:58.61ms
+step:1674/1840 train_time:98143ms step_avg:58.63ms
+step:1675/1840 train_time:98231ms step_avg:58.65ms
+step:1676/1840 train_time:98320ms step_avg:58.66ms
+step:1677/1840 train_time:98407ms step_avg:58.68ms
+step:1678/1840 train_time:98496ms step_avg:58.70ms
+step:1679/1840 train_time:98583ms step_avg:58.72ms
+step:1680/1840 train_time:98672ms step_avg:58.73ms
+step:1681/1840 train_time:98758ms step_avg:58.75ms
+step:1682/1840 train_time:98847ms step_avg:58.77ms
+step:1683/1840 train_time:98932ms step_avg:58.78ms
+step:1684/1840 train_time:99022ms step_avg:58.80ms
+step:1685/1840 train_time:99109ms step_avg:58.82ms
+step:1686/1840 train_time:99198ms step_avg:58.84ms
+step:1687/1840 train_time:99284ms step_avg:58.85ms
+step:1688/1840 train_time:99372ms step_avg:58.87ms
+step:1689/1840 train_time:99459ms step_avg:58.89ms
+step:1690/1840 train_time:99549ms step_avg:58.90ms
+step:1691/1840 train_time:99634ms step_avg:58.92ms
+step:1692/1840 train_time:99723ms step_avg:58.94ms
+step:1693/1840 train_time:99809ms step_avg:58.95ms
+step:1694/1840 train_time:99897ms step_avg:58.97ms
+step:1695/1840 train_time:99983ms step_avg:58.99ms
+step:1696/1840 train_time:100072ms step_avg:59.00ms
+step:1697/1840 train_time:100158ms step_avg:59.02ms
+step:1698/1840 train_time:100249ms step_avg:59.04ms
+step:1699/1840 train_time:100335ms step_avg:59.06ms
+step:1700/1840 train_time:100425ms step_avg:59.07ms
+step:1701/1840 train_time:100511ms step_avg:59.09ms
+step:1702/1840 train_time:100600ms step_avg:59.11ms
+step:1703/1840 train_time:100686ms step_avg:59.12ms
+step:1704/1840 train_time:100774ms step_avg:59.14ms
+step:1705/1840 train_time:100860ms step_avg:59.16ms
+step:1706/1840 train_time:100949ms step_avg:59.17ms
+step:1707/1840 train_time:101035ms step_avg:59.19ms
+step:1708/1840 train_time:101124ms step_avg:59.21ms
+step:1709/1840 train_time:101211ms step_avg:59.22ms
+step:1710/1840 train_time:101300ms step_avg:59.24ms
+step:1711/1840 train_time:101387ms step_avg:59.26ms
+step:1712/1840 train_time:101474ms step_avg:59.27ms
+step:1713/1840 train_time:101560ms step_avg:59.29ms
+step:1714/1840 train_time:101650ms step_avg:59.31ms
+step:1715/1840 train_time:101736ms step_avg:59.32ms
+step:1716/1840 train_time:101825ms step_avg:59.34ms
+step:1717/1840 train_time:101910ms step_avg:59.35ms
+step:1718/1840 train_time:101999ms step_avg:59.37ms
+step:1719/1840 train_time:102085ms step_avg:59.39ms
+step:1720/1840 train_time:102173ms step_avg:59.40ms
+step:1721/1840 train_time:102261ms step_avg:59.42ms
+step:1722/1840 train_time:102351ms step_avg:59.44ms
+step:1723/1840 train_time:102436ms step_avg:59.45ms
+step:1724/1840 train_time:102527ms step_avg:59.47ms
+step:1725/1840 train_time:102613ms step_avg:59.49ms
+step:1726/1840 train_time:102702ms step_avg:59.50ms
+step:1727/1840 train_time:102788ms step_avg:59.52ms
+step:1728/1840 train_time:102876ms step_avg:59.53ms
+step:1729/1840 train_time:102962ms step_avg:59.55ms
+step:1730/1840 train_time:103050ms step_avg:59.57ms
+step:1731/1840 train_time:103136ms step_avg:59.58ms
+step:1732/1840 train_time:103226ms step_avg:59.60ms
+step:1733/1840 train_time:103312ms step_avg:59.61ms
+step:1734/1840 train_time:103401ms step_avg:59.63ms
+step:1735/1840 train_time:103489ms step_avg:59.65ms
+step:1736/1840 train_time:103577ms step_avg:59.66ms
+step:1737/1840 train_time:103663ms step_avg:59.68ms
+step:1738/1840 train_time:103751ms step_avg:59.70ms
+step:1739/1840 train_time:103838ms step_avg:59.71ms
+step:1740/1840 train_time:103928ms step_avg:59.73ms
+step:1741/1840 train_time:104014ms step_avg:59.74ms
+step:1742/1840 train_time:104103ms step_avg:59.76ms
+step:1743/1840 train_time:104191ms step_avg:59.78ms
+step:1744/1840 train_time:104278ms step_avg:59.79ms
+step:1745/1840 train_time:104365ms step_avg:59.81ms
+step:1746/1840 train_time:104454ms step_avg:59.82ms
+step:1747/1840 train_time:104539ms step_avg:59.84ms
+step:1748/1840 train_time:104629ms step_avg:59.86ms
+step:1749/1840 train_time:104714ms step_avg:59.87ms
+step:1750/1840 train_time:104803ms step_avg:59.89ms
+step:1750/1840 val_loss:3.3035 train_time:104904ms step_avg:59.95ms
+step:1751/1840 train_time:104926ms step_avg:59.92ms
+step:1752/1840 train_time:104981ms step_avg:59.92ms
+step:1753/1840 train_time:105070ms step_avg:59.94ms
+step:1754/1840 train_time:105160ms step_avg:59.95ms
+step:1755/1840 train_time:105248ms step_avg:59.97ms
+step:1756/1840 train_time:105337ms step_avg:59.99ms
+step:1757/1840 train_time:105422ms step_avg:60.00ms
+step:1758/1840 train_time:105510ms step_avg:60.02ms
+step:1759/1840 train_time:105595ms step_avg:60.03ms
+step:1760/1840 train_time:105682ms step_avg:60.05ms
+step:1761/1840 train_time:105768ms step_avg:60.06ms
+step:1762/1840 train_time:105857ms step_avg:60.08ms
+step:1763/1840 train_time:105945ms step_avg:60.09ms
+step:1764/1840 train_time:106037ms step_avg:60.11ms
+step:1765/1840 train_time:106125ms step_avg:60.13ms
+step:1766/1840 train_time:106216ms step_avg:60.14ms
+step:1767/1840 train_time:106302ms step_avg:60.16ms
+step:1768/1840 train_time:106391ms step_avg:60.18ms
+step:1769/1840 train_time:106477ms step_avg:60.19ms
+step:1770/1840 train_time:106564ms step_avg:60.21ms
+step:1771/1840 train_time:106650ms step_avg:60.22ms
+step:1772/1840 train_time:106737ms step_avg:60.24ms
+step:1773/1840 train_time:106823ms step_avg:60.25ms
+step:1774/1840 train_time:106913ms step_avg:60.27ms
+step:1775/1840 train_time:106999ms step_avg:60.28ms
+step:1776/1840 train_time:107090ms step_avg:60.30ms
+step:1777/1840 train_time:107177ms step_avg:60.31ms
+step:1778/1840 train_time:107264ms step_avg:60.33ms
+step:1779/1840 train_time:107351ms step_avg:60.34ms
+step:1780/1840 train_time:107438ms step_avg:60.36ms
+step:1781/1840 train_time:107524ms step_avg:60.37ms
+step:1782/1840 train_time:107613ms step_avg:60.39ms
+step:1783/1840 train_time:107699ms step_avg:60.40ms
+step:1784/1840 train_time:107787ms step_avg:60.42ms
+step:1785/1840 train_time:107873ms step_avg:60.43ms
+step:1786/1840 train_time:107963ms step_avg:60.45ms
+step:1787/1840 train_time:108053ms step_avg:60.47ms
+step:1788/1840 train_time:108141ms step_avg:60.48ms
+step:1789/1840 train_time:108228ms step_avg:60.50ms
+step:1790/1840 train_time:108317ms step_avg:60.51ms
+step:1791/1840 train_time:108402ms step_avg:60.53ms
+step:1792/1840 train_time:108492ms step_avg:60.54ms
+step:1793/1840 train_time:108577ms step_avg:60.56ms
+step:1794/1840 train_time:108664ms step_avg:60.57ms
+step:1795/1840 train_time:108750ms step_avg:60.59ms
+step:1796/1840 train_time:108838ms step_avg:60.60ms
+step:1797/1840 train_time:108925ms step_avg:60.62ms
+step:1798/1840 train_time:109017ms step_avg:60.63ms
+step:1799/1840 train_time:109103ms step_avg:60.65ms
+step:1800/1840 train_time:109192ms step_avg:60.66ms
+step:1801/1840 train_time:109279ms step_avg:60.68ms
+step:1802/1840 train_time:109366ms step_avg:60.69ms
+step:1803/1840 train_time:109454ms step_avg:60.71ms
+step:1804/1840 train_time:109542ms step_avg:60.72ms
+step:1805/1840 train_time:109630ms step_avg:60.74ms
+step:1806/1840 train_time:109718ms step_avg:60.75ms
+step:1807/1840 train_time:109803ms step_avg:60.77ms
+step:1808/1840 train_time:109894ms step_avg:60.78ms
+step:1809/1840 train_time:109981ms step_avg:60.80ms
+step:1810/1840 train_time:110069ms step_avg:60.81ms
+step:1811/1840 train_time:110157ms step_avg:60.83ms
+step:1812/1840 train_time:110245ms step_avg:60.84ms
+step:1813/1840 train_time:110331ms step_avg:60.86ms
+step:1814/1840 train_time:110420ms step_avg:60.87ms
+step:1815/1840 train_time:110506ms step_avg:60.88ms
+step:1816/1840 train_time:110595ms step_avg:60.90ms
+step:1817/1840 train_time:110680ms step_avg:60.91ms
+step:1818/1840 train_time:110770ms step_avg:60.93ms
+step:1819/1840 train_time:110857ms step_avg:60.94ms
+step:1820/1840 train_time:110946ms step_avg:60.96ms
+step:1821/1840 train_time:111033ms step_avg:60.97ms
+step:1822/1840 train_time:111122ms step_avg:60.99ms
+step:1823/1840 train_time:111208ms step_avg:61.00ms
+step:1824/1840 train_time:111299ms step_avg:61.02ms
+step:1825/1840 train_time:111386ms step_avg:61.03ms
+step:1826/1840 train_time:111476ms step_avg:61.05ms
+step:1827/1840 train_time:111563ms step_avg:61.06ms
+step:1828/1840 train_time:111651ms step_avg:61.08ms
+step:1829/1840 train_time:111737ms step_avg:61.09ms
+step:1830/1840 train_time:111827ms step_avg:61.11ms
+step:1831/1840 train_time:111914ms step_avg:61.12ms
+step:1832/1840 train_time:112002ms step_avg:61.14ms
+step:1833/1840 train_time:112089ms step_avg:61.15ms
+step:1834/1840 train_time:112177ms step_avg:61.17ms
+step:1835/1840 train_time:112263ms step_avg:61.18ms
+step:1836/1840 train_time:112353ms step_avg:61.19ms
+step:1837/1840 train_time:112438ms step_avg:61.21ms
+step:1838/1840 train_time:112528ms step_avg:61.22ms
+step:1839/1840 train_time:112616ms step_avg:61.24ms
+step:1840/1840 train_time:112704ms step_avg:61.25ms
+step:1840/1840 val_loss:3.2785 train_time:112805ms step_avg:61.31ms
+peak memory allocated: 28507 MiB reserved: 44038 MiB

--- a/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/f2ead954-f8fe-48f7-8b73-eee22091ed40.txt
+++ b/records/track_1_short/2026-01-04_MixedPrecisionInterweavedOptimizer/f2ead954-f8fe-48f7-8b73-eee22091ed40.txt
@@ -1,0 +1,3786 @@
+import os
+import sys
+
+with open(sys.argv[0]) as f:
+    code = f.read()  # read the code of this file ASAP, for logging
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from collections import defaultdict
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+import triton
+import triton.language as tl
+from kernels import get_kernel
+from torch import Tensor, nn
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+
+@torch.library.custom_op("nanogpt::mm", mutates_args=())
+def mm_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8.T,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[1]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w.T, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_backward", mutates_args=())
+def mm_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        x_inv_s = grad.new_tensor(x_s, dtype=torch.float32)
+        w_inv_s = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_inv_s = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T.contiguous().T,
+            out_dtype=torch.bfloat16,
+            scale_a=grad_inv_s,
+            scale_b=w_inv_s,
+            use_fast_accum=False,
+        )
+        # faster than grad_f8_t @ x_f8, for (d_out, d_in) == (50304, 768)
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_inv_s,
+            scale_b=grad_inv_s,
+            use_fast_accum=False,
+        ).T
+        return grad_x, grad_w
+
+    return impl(g, x_f8, w_f8)
+
+@mm_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.T.contiguous().T.to(torch.float32)
+
+def backward(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_op.register_autograd(backward, setup_context=setup_context)
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Compiled helpers for NorMuon by @chrisjmccormick
+
+@torch.compile(dynamic=False, fullgraph=True)
+def cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+    """
+    Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+    Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+    bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+    float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+    """
+    assert p.dtype == mantissa.dtype == torch.uint16
+    grad = grad.float()
+    wd_factor = wd_tensor.to(torch.float32)
+    lr_factor = lr_tensor.to(torch.float32)
+    p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+    p_precise = p_precise_raw.view(torch.float32)
+    mask = (grad * p_precise) >= 0
+    p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+    p.copy_((p_precise_raw >> 16).to(torch.uint16))
+    mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+@torch.compile(dynamic=False, fullgraph=True)
+def apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+    """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+    v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = v_chunk.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+    v_norm = v_norm_sq.sqrt_()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+    return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+
+# -----------------------------------------------------------------------------
+# NorMuon optimizer
+
+class NorMuon(torch.optim.Optimizer):
+    """
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, we use a Newton-Schulz iteration, which has
+    the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Warning: This optimizer should not be used for the embedding layer, the final fully connected layer,
+    or any {0,1}-D parameters; those should all be optimized by a standard method (e.g., AdamW).
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - small 1D parameters handled here instead of in Adam
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Custom distributed sizing:
+    The model stores all attn and mlp weights in the same shape, and then updates the view as
+    needed on the forward pass. This enables attn and mlp weights to be contained within the same
+    dist.reduce_scatter_tensor() call. The model architecture has been customized to enable
+    (n_attn_layers+n_mlp_layers*2)%8==0 for batching across 8 GPUs with zero padding on mlp and attn.
+    The scheduling is:
+        1. reduce scatter attn/mlp round 1 (10 attn params 6 mlp params)
+        2. reduce scatter attn/mlp round 2 (16 mlp params)
+        3. wait on step 1, then compute update of 1 and schedule all gather
+        4. wait on step 2, then compute update of 2 and schedule all gather
+            GPUs receive [2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 ATTN, 2 MLP, 2 MLP, 2 MLP]
+            GPUs that receive params of type attn reshape before computing update
+        5. wait for each all gather to complete and update params
+    """
+    def __init__(self, params, lr=0.02, weight_decay=0.01, momentum=0.95, beta2=0.95, custom_sizing=True):
+        defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, beta2=beta2)
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        # custom sizing requires 8 GPUs
+        if custom_sizing and dist.get_world_size()==8:
+            param_groups = self.generate_custom_param_groups(params)
+        else:
+            param_groups = self.generate_standard_param_groups(params)
+        super().__init__(param_groups, defaults)
+
+    def reset(self):
+        # expose a reset for clearing buffers
+        for group in self.param_groups:
+            if "momentum_buffer" in group:
+                group["momentum_buffer"].zero_()
+                group["mantissa"].zero_()
+                group["second_momentum_buffer"].zero_()
+
+    def generate_standard_param_groups(self, params):
+        """
+        Use this method if running on less than 8 GPU or experimenting with additional attn or mlp modules.
+        Creates one param group per module.
+        """
+        groups = defaultdict(list)
+        for param in params:
+            groups[param.label].append(param)
+
+        param_groups = []
+        for module_name, group_params in groups.items():
+            chunk_size = (len(group_params) + self.world_size - 1) // self.world_size
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+
+        return param_groups
+
+    def generate_custom_param_groups(self, params):
+        """
+        Implementation requires that a single GPU does not receive both attn
+        and mlp params when a param group is split across GPUs.
+        """
+        params_list = list(params)
+        module_group_order = ['attn', 'mlp']
+        group_sizes = [16, 16]  # 10 attn + 6 mlp, then 16 mlp
+        params_list.sort(key=lambda x: module_group_order.index(x.label))
+
+        idx = 0
+        assert len(params_list) == sum(group_sizes)
+        param_groups = []
+        for size in group_sizes:
+            chunk_size = (size + self.world_size - 1) // self.world_size
+            group_params = params_list[idx: idx + size]
+            param_groups.append(dict(params=group_params, chunk_size=chunk_size))
+            idx += size
+
+        return param_groups
+
+    def step(self):
+        self.step_p1()
+        self.step_p2()
+        self.step_p3()
+        
+    @torch.no_grad()
+    def step_p1(self):
+        """
+        Part 1: Launch distributed reduce_scatter operations for parameter groups.
+        """
+        rank = dist.get_rank()
+        self.group_infos = []
+        for group in self.param_groups:
+            params: list[Tensor] = group["params"]
+            if not params:
+                continue
+
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            stacked_grads = torch.empty(
+                (padded_num_params, *params[0].shape),
+                dtype=params[0].dtype,
+                device=params[0].device
+            )
+            for i, p in enumerate(params):
+                stacked_grads[i].copy_(p.grad, non_blocking=True)
+            if len(params) < padded_num_params:
+                stacked_grads[len(params):].zero_()
+
+            grad_chunk = torch.empty_like(stacked_grads[:chunk_size])
+
+            reduce_future = dist.reduce_scatter_tensor(
+                grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True
+            ).get_future()
+
+            self.group_infos.append(dict(grad_chunk=grad_chunk, reduce_future=reduce_future))
+    
+    @torch.no_grad()
+    def step_p2(self):
+        """
+        Part 2: Compute gradient updates and launch all_gather operations
+        Wait for all gather to complete for all parameter groups except final one
+        """
+        # Efficient distributed step by @YouJiacheng, @KonstantinWilleke, @alexrgilbert,
+        # @adricarda, @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+        rank = dist.get_rank()
+        group_infos = self.group_infos
+        
+        self.all_gather_infos = []
+        # Second pass: wait for gradients, compute updates for the local shard of parameters,
+        # and launch all async all_gather operations.
+        for group, info in zip(self.param_groups, group_infos):
+            info["reduce_future"].wait()
+
+            params = group["params"]
+            grad_chunk = info["grad_chunk"].float()
+            chunk_size = group["chunk_size"]
+            padded_num_params = chunk_size * self.world_size
+
+            start_idx = rank * chunk_size
+            module_idx = start_idx if start_idx < len(params) else 0
+
+            num_params = min(chunk_size, max(0, len(params) - start_idx))  # num params for this rank
+
+            if "momentum_buffer" not in group:
+                group["momentum_buffer"]  = torch.zeros_like(grad_chunk[:num_params], dtype=torch.float32)
+                
+            momentum_buffer = group["momentum_buffer"]
+            # Apply momentum update to the persistent momentum buffer in-place
+            momentum_buffer.lerp_(grad_chunk[:num_params], 1 - group["momentum"])
+            updated_grads = grad_chunk[:num_params].lerp_(momentum_buffer, group["momentum"])
+
+            grad_shape = updated_grads.shape
+            if params[module_idx].label == 'attn':
+                for p in params[module_idx:module_idx + num_params]:
+                    assert p.label == 'attn'
+                updated_grads = updated_grads.view(4 * grad_shape[0], grad_shape[1] // 4, grad_shape[2])
+
+            ref_param = params[module_idx]
+            param_shape = ref_param.shape
+
+            if "second_momentum_buffer" not in group:
+                group["second_momentum_buffer"] = (torch.zeros_like(updated_grads[..., :, :1], dtype=torch.float32)
+                    if param_shape[-2] >= param_shape[-1] else torch.zeros_like(updated_grads[..., :1, :])
+                )
+            second_momentum_buffer = group["second_momentum_buffer"]
+
+            if "param_lr_cpu" not in group:
+                # Define multipliers for ALL params in this group (global, not per-shard)
+                lr_mults = []
+                wd_mults = []
+                for p in params:
+                    # Increase learning rate for modules with larger inputs than outputs.
+                    # This shape check also assumes rows=input, columns=output, so take care
+                    # when changing memory layouts. @chrisjmccormick
+                    shape = p.shape
+                    if len(shape) >= 2:
+                        shape_mult = max(1.0, shape[-2] / shape[-1]) ** 0.5
+                    else:
+                        shape_mult = 1.0
+                    lr_mults.append(shape_mult * getattr(p, "lr_mul", 1.0))
+                    wd_mults.append(getattr(p, "wd_mul", 1.0))
+                # Define as cpu tensors to enable Inductor constant folding
+                group["param_lr_cpu"] = torch.tensor(lr_mults, dtype=torch.float32, device="cpu")
+                group["param_wd_cpu"] = torch.tensor(wd_mults, dtype=torch.float32, device="cpu")
+
+            eff_lr_all = group["param_lr_cpu"] * group["lr"]
+            eff_wd_all = group["param_wd_cpu"] * group["weight_decay"] * group["lr"]
+
+            # Slice the portion corresponding to this rank's shard
+            eff_lr_cpu = eff_lr_all[module_idx:module_idx + num_params]
+            eff_wd_cpu = eff_wd_all[module_idx:module_idx + num_params]
+
+            # Compute zeropower for the entire chunk in a single, batched call.
+            if num_params == 0:
+                v_chunk = updated_grads
+            else:
+                v_chunk = polar_express(updated_grads, split_baddbmm=(ref_param.label == 'mlp'))
+
+            # Note that the head orientation in O is transposed relative to QKV, so red_dim
+            # is 'incorrect' for O. However, correcting this showed no improvement. @chrisjmccormick
+            red_dim = -1 if param_shape[-2] >= param_shape[-1] else -2
+
+            v_chunk = apply_normuon_variance_reduction(
+                v_chunk, second_momentum_buffer, group["beta2"], red_dim
+            )
+
+            v_chunk = v_chunk.view(grad_shape)
+
+            # # "Cautious" weight decay (https://arxiv.org/abs/2510.12402)
+            updated_params = torch.empty_like(grad_chunk, dtype=torch.bfloat16)
+            if num_params > 0:
+                # Work on a stacked copy to avoid touching original params
+                param_chunk = torch.stack(params[module_idx:module_idx + num_params])
+
+                if "mantissa" not in group:
+                    group["mantissa"] = torch.zeros_like(param_chunk, dtype=torch.uint16)
+                mantissa = group["mantissa"]
+
+                for local_idx in range(num_params):
+                    cautious_wd_and_update_inplace(
+                        param_chunk[local_idx].view(torch.uint16),
+                        mantissa[local_idx],
+                        v_chunk[local_idx],
+                        eff_wd_cpu[local_idx],
+                        eff_lr_cpu[local_idx]
+                    )
+            else:
+                param_chunk = torch.zeros_like(v_chunk)
+
+            updated_params[:num_params].copy_(param_chunk)
+            if num_params < chunk_size:
+                updated_params[num_params:].zero_()
+
+            stacked_params = torch.empty(
+                (padded_num_params, *param_shape),
+                dtype=updated_params.dtype,
+                device=updated_params.device,
+            )
+
+            gather_future = dist.all_gather_into_tensor(
+                stacked_params, updated_params, async_op=True
+            ).get_future()
+
+            self.all_gather_infos.append(
+                {
+                    "gather_future": gather_future,
+                    "stacked_params": stacked_params,
+                    "orig_params": params,
+                }
+            )
+
+        # Final pass: wait for all_gather to complete for all except final and copy results back into original parameter tensors.
+        for info in self.all_gather_infos[:-1]:
+            info["gather_future"].wait()
+            stacked_params = info["stacked_params"]
+            orig_params = info["orig_params"]
+
+            unstacked_params = torch.unbind(stacked_params)
+            for i, p in enumerate(orig_params):
+                p.copy_(unstacked_params[i], non_blocking=True)
+
+    @torch.no_grad()
+    def step_p3(self):
+        """
+        Part 3: Wait for final all gather to complete and copy results back into original parameter tensors
+        """
+        info = self.all_gather_infos[-1]
+        info["gather_future"].wait()
+        stacked_params = info["stacked_params"]
+        orig_params = info["orig_params"]
+
+        unstacked_params = torch.unbind(stacked_params)
+        for i, p in enumerate(orig_params):
+            p.copy_(unstacked_params[i], non_blocking=True)
+
+
+class DistAdam(torch.optim.Optimizer):
+    def __init__(self, params, label_order: list[str], betas: list[list[float]], lr: float = 1e-3, eps: float = 1e-8, weight_decay: float = 0.01):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        defaults = dict(lr=lr, eps=eps, weight_decay=weight_decay)
+        params = list(params)
+        # Group by label, with explicit ordering for execution control.
+        params_by_label = defaultdict(list)
+        for p in params:
+            params_by_label[getattr(p, 'label', None)].append(p)
+        param_groups = []
+        for idx, label in enumerate(label_order):
+            if label in params_by_label:
+                param_groups.append(dict(params=params_by_label[label], betas=betas[idx]))
+        # include any unlabeled params at the end (processed last)
+        if None in params_by_label:
+            param_groups.append(dict(params=params_by_label[None]))
+        super().__init__(param_groups, defaults)
+        # init state: small params (numel < 1024) use full-sized state, others use sharded
+        for p in params:
+            chunk = p if p.numel() < 1024 else p[:p.size(0) // self.world_size]
+            exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=p.device)
+            self.state[p] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+
+        # tag the final param for optimizer pipelining, run all gather after muon copy
+        param_groups[-1]['params'][-1].is_final_param = True
+        
+        # DistributedAdam implementation by @vagrawal, @akash5474
+        self.should_sync = False
+        self._reduce_scatter_hooks = []
+        self._reduce_scatter_futures = {}
+        # 0-D CPU tensors to avoid recompilation in _update_step
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self.register_backward_hooks()
+
+    def register_backward_hooks(self):
+        for group in self.param_groups:
+            for param in group["params"]:
+                self._reduce_scatter_hooks.append(param.register_post_accumulate_grad_hook(self._sync_gradient))
+
+    def load_state_dict(self, state_dict):
+        """Override to preserve optimizer state dtypes (avoid BFloat16->Float32 cast that causes recompilation)."""
+        # Save original state dtypes before loading
+        original_dtypes = {}
+        for p, s in self.state.items():
+            original_dtypes[p] = {k: v.dtype for k, v in s.items() if isinstance(v, torch.Tensor)}
+        
+        # Call parent load_state_dict (which may cast dtypes to match param dtype)
+        super().load_state_dict(state_dict)
+        
+        # Restore original dtypes
+        for p, s in self.state.items():
+            if p in original_dtypes:
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor) and k in original_dtypes[p]:
+                        if v.dtype != original_dtypes[p][k]:
+                            s[k] = v.to(original_dtypes[p][k])
+
+    @torch.no_grad()
+    def _sync_gradient(self, param):
+        if not self.should_sync:
+            return
+
+        grad = param.grad
+        if param.numel() < 1024:
+            # Small params: use all_reduce (no scatter/gather needed)
+            self._reduce_scatter_futures[param] = (
+                dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                grad
+            )
+        else:
+            rank_size = grad.shape[0] // self.world_size
+            if grad is not None:
+                grad_slice = torch.empty_like(grad[:rank_size])
+                self._reduce_scatter_futures[param] = (
+                    dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future(),
+                    grad_slice
+                )
+
+    def copy_lm_to_embed(self):
+        # run at 2/3 of training
+        lm_head = self.param_groups[0]['params'][0]
+        embed = self.param_groups[-2]['params'][0]
+        lm_head_state = self.state[lm_head]
+        embed_state = self.state[embed]
+        embed_state['step'] = lm_head_state['step']
+        embed_state['exp_avg'] = lm_head_state['exp_avg'].clone()
+        embed_state['exp_avg_sq'] = lm_head_state['exp_avg_sq'].clone()
+        embed.data.copy_(lm_head.data)
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step. step_size_t and eff_wd_t are 0-D CPU tensors to avoid recompilation."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)  # exp_avg = beta1 * exp_avg + (1 - beta1) * g_slice
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)  # exp_avg_sq = beta2 * exp_avg_sq + (1 - beta2) * g_slice^2
+        # compute step
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)  # update = (exp_avg / (sqrt(exp_avg_sq) + eps)) * step_size
+        # cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)  # update += eff_wd_t * p_slice * mask
+        p_slice.add_(other=update, alpha=-1.0)  # p_slice -= update
+
+    @torch.no_grad()
+    def step(self, muon_opt):
+        muon_opt.step_p1()
+        rank = dist.get_rank()
+        all_gather_futures: list[torch.Future] = []
+
+        last_param = None
+        last_p_slice = None
+        for group in self.param_groups:      
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            wd = group['weight_decay']
+            for param in group['params']:
+                if param not in self._reduce_scatter_futures:
+                    continue
+
+                fut, g_slice = self._reduce_scatter_futures[param]
+                fut.wait()
+
+                is_small = param.numel() < 1024
+                if is_small:
+                    # Small params: g_slice is actually full grad, p_slice is full param
+                    p_slice = param
+                else:
+                    rank_size = param.shape[0] // self.world_size
+                    p_slice = param[rank * rank_size:(rank + 1) * rank_size]
+
+                lr = group['lr'] * getattr(param, "lr_mul", 1.0)
+                state = self.state[param]
+                state["step"] += 1
+                t = state["step"]
+                
+                # Pre-compute changing values as 0-D CPU tensors to avoid recompilation.
+                # `.fill_(value)` is the same as "= value", but doesn't change the tensor object.
+                bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+                self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+                self._eff_wd_t.fill_(lr * lr * wd * getattr(param, "wd_mul", 1.0)) # `lr` included twice to serve as weight decay schedule.
+
+                DistAdam._update_step(p_slice, g_slice, state["exp_avg"], state["exp_avg_sq"],
+                                      beta1, beta2, eps, self._step_size_t, self._eff_wd_t)
+
+                if not is_small:
+                    if getattr(param, "is_final_param", False):
+                        last_param = param
+                        last_p_slice = p_slice
+                    else:
+                        all_gather_futures.append(dist.all_gather_into_tensor(param, p_slice, async_op=True).get_future())
+        self._reduce_scatter_futures.clear()
+
+        muon_opt.step_p2()
+        torch.futures.collect_all(all_gather_futures).wait()
+
+        if last_param is not None:
+            last_all_gather_future = dist.all_gather_into_tensor(last_param, last_p_slice, async_op=True).get_future()
+        muon_opt.step_p3()
+        torch.futures.collect_all([last_all_gather_future]).wait()
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+class CastedLinear(nn.Linear):
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__(in_features, out_features, bias=False)
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            self.weight.zero_()  # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out: Tensor = torch.ops.nanogpt.mm(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return F.linear(x, self.weight.type_as(x))
+
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+# yarn implementation @classiclarryd
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//4)])
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.cos = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.sin = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.cos.copy_(theta.cos())
+        self.sin.copy_(theta.sin())
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+def rotary(x_BTHD: Tensor, cos: Tensor, sin: Tensor):
+    assert cos.size(0) >= x_BTHD.size(-3)
+    cos, sin = (
+        cos[None, : x_BTHD.size(-3), None, :],
+        sin[None, : x_BTHD.size(-3), None, :],
+    )
+    x1, x2 = x_BTHD.chunk(2, dim=-1)
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    return torch.cat((y1, y2), 3)
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    cos: torch.Tensor
+    sin: torch.Tensor
+    attn_scale: float
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        std = self.dim ** -0.5
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        self.qkvo_w = nn.Parameter(torch.empty(self.dim * 4, self.hdim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.qkvo_w.label = 'attn'
+
+        with torch.no_grad():
+            self.qkvo_w[:self.dim * 3].uniform_(-bound, bound)  # init QKV weights
+            self.qkvo_w[self.dim * 3:].zero_()  # init O weights to zero
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        cos, sin = attn_args.cos, attn_args.sin
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, attn_scale, bm_size = attn_args.seqlens, attn_args.attn_scale, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * self.qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = rotary(q, cos, sin), rotary(k, cos, sin)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
+            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * self.qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class MLP(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        hdim = 4 * dim
+        # Transposed layout to match attention weights
+        self.c_fc = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        self.c_proj = nn.Parameter(torch.empty(hdim, dim, dtype=torch.bfloat16))
+        # label all modules for explicit optimizer grouping
+        self.c_fc.label = 'mlp'
+        self.c_proj.label = 'mlp'
+        self.c_proj.lr_mul = 2.
+
+        std = 0.5 * (dim ** -0.5)
+        bound = (3 ** 0.5) * std # improved init scale by @YouJiacheng
+        with torch.no_grad():
+            self.c_fc.uniform_(-bound, bound)
+            self.c_proj.zero_() # zero init suggested by @Grad62304977
+
+    def forward(self, x: Tensor):
+        x = F.linear(x, self.c_fc.type_as(x))
+        x = F.relu(x).square() # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        x = F.linear(x, self.c_proj.T.type_as(x))
+        return x
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, layer_idx: int):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        self.attn = CausalSelfAttention(dim, head_dim, num_heads, layer_idx) if layer_idx != 6 else None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP(dim)
+
+    def forward(self, x: Tensor, attn_args: AttnArgs):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x))
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = CastedLinear(12, 1)
+        self.smear_gate.weight.label = 'smear_gate'
+        self.smear_gate.weight.lr_mul = 0.01
+        self.smear_gate.weight.wd_mul = 0.0
+
+        self.skip_gate = CastedLinear(12, 1)
+        self.skip_gate.weight.label = 'skip_gate'
+        self.skip_gate.weight.lr_mul = 0.05
+        self.skip_gate.weight.wd_mul = 0.0
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for ve in self.value_embeds:
+            ve.weight.label = 'value_embed'
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        self.blocks = nn.ModuleList([Block(model_dim, head_dim, num_heads, i) for i in range(num_layers)])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+
+        self.lm_head = CastedLinear(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+        self.x0_lambdas.lr_mul = 5.0
+        self.x0_lambdas.wd_mul = 0.0
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+
+        self.scalars.label = 'scalars'
+        # set learning rates
+        for param in self.value_embeds.parameters():
+            param.lr_mul = 75.
+            param.wd_mul = 5.
+        for param in self.embed.parameters():
+            param.wd_mul = 150.
+        for param in self.lm_head.parameters():
+            param.wd_mul = 150.
+        self.scalars.lr_mul = 5.0
+        self.scalars.wd_mul = 0.0
+
+        self.split_embed = False
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        smear_lambda = self.scalars[3 * self.num_layers]
+        backout_lambda = self.scalars[3 * self.num_layers+1]
+        skip_lambda = self.scalars[3 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # weight-tied: use lm_head.weight for embedding lookup (or separate embed after split)
+        if self.split_embed:
+            x = self.embed(input_seq)
+        else:
+            x = F.embedding(input_seq, self.lm_head.weight)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        for i in range(self.num_layers):
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                cos=self.yarn.cos,
+                sin=self.yarn.sin,
+                attn_scale=self.yarn.attn_scale,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+            x = self.blocks[i](x, attn_args)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+        logits_for_loss = logits.float() if not self.training else logits
+
+        n_predict = mtp_weights.size(0) if mtp_weights is not None else 1
+        if self.training and n_predict > 1:
+            # Multi-token prediction: take loss of the weighted average of next n_predict tokens
+            logits_flat = logits_for_loss.view(-1, logits_for_loss.size(-1))
+            idx = F.pad(target_seq, (0, n_predict - 1)).unfold(0, n_predict, 1)  # [T, n_predict] of shifted targets
+            target_logits = logits_flat.gather(1, idx)
+            cross_entropy = torch.logsumexp(logits_flat, dim=-1).unsqueeze(1) - target_logits
+            for k in range(1, n_predict):  # zero out preds past end of sequence
+                cross_entropy[-k:, k] = 0
+            loss = (cross_entropy * mtp_weights).sum()
+        elif self.training:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="sum")
+        else:
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages three optimizers for Adam embed/lm_head, Adam scalars, and Muon weight matrices.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Scalar weights are temporarily frozen during batch size or window size updates @ChrisJMcCormick
+        3. Adam optimizers are only stepped on odd steps @classiclarryd
+        4. Adam optimizers have hooks to start gradient communication during backwards pass @akash5474
+        5. Muon has a linear momentum warmup and cooldown schedule
+        6. Learning rates follow a linear decay schedule
+        7. Embed/lm_head weights and optimizer state splits at 2/3 of training @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm head at 2/3 of training
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        adam_betas = {
+            'lm_head': [0.5, 0.95],
+            'smear_gate': [0.9, 0.99],
+            'attn_gate_bank': [0.9, 0.99],
+            've_gate_bank': [0.9, 0.99],
+            'skip_gate': [0.9, 0.99],
+            'x0_lambdas': [0.65, 0.95],
+            'scalars': [0.9, 0.99],
+            'embed': [0.5, 0.95],
+            'value_embed': [0.75, 0.95]
+        }
+        adam_labels = list(adam_betas.keys())
+        adam_beta_values = list(adam_betas.values())
+        muon_labels = ['attn', 'mlp']
+        adam_params = [p for p in model.parameters() if getattr(p, 'label', None) in adam_labels]
+        muon_params = [p for p in model.parameters() if getattr(p, 'label', None) in muon_labels]
+        assert set(getattr(p, 'label', None) for p in model.parameters()) == set(adam_labels + muon_labels), "All params must have label"
+
+        self.adam_opt = DistAdam(adam_params, adam_labels, adam_beta_values, lr=0.008, eps=1e-10, weight_decay=0.005)
+        self.muon_opt = NorMuon(muon_params, lr=0.023, momentum=0.95, beta2=0.95, weight_decay=1.2)
+        self.optimizers = [self.adam_opt, self.muon_opt]
+
+        # split after odd number step
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        # set defaults
+        for opt in self.optimizers:
+            opt.odd_step_only = False 
+            opt.should_sync = True
+            for group in opt.param_groups:
+                group["initial_lr"] = group["lr"]
+
+        # on even steps, only step Muon params
+        self.adam_opt.odd_step_only = True
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_active_step(self, opt, step: int):
+        return (opt.odd_step_only and step%2==1) or not opt.odd_step_only
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):                
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        for group in self.muon_opt.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in self.optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["initial_lr"] * step_lr
+                
+        if self._is_active_step(self.adam_opt, step):
+            # adam will interleave calls to muon step
+            self.adam_opt.step(self.muon_opt)
+            self.model.zero_grad(set_to_none=True)
+            self.adam_opt.should_sync = False
+        else:
+            self.muon_opt.step()
+            self.muon_opt.zero_grad(set_to_none=True)
+            
+        if step == self.split_step:
+            self.adam_opt.copy_lm_to_embed()
+            self.model.split_embed = True
+    
+    def activate_hooks(self, step: int):
+        for opt in self.optimizers:
+            if self._is_active_step(opt, step):
+                opt.should_sync = True
+
+    def reset(self, state=None):
+        if state is not None:
+            for opt, opt_state in zip(self.optimizers, state):
+                opt.should_sync = False
+                opt.load_state_dict(opt_state)
+
+        # muon momentum buffers not in state dict
+        self.muon_opt.reset()
+        self.model.split_embed = False
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+
+    def get_state(self):
+        return [copy.deepcopy(opt.state_dict()) for opt in self.optimizers]
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1800  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizers=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens = next(val_loader)
+        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizers"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizers=[opt.state_dict() for opt in optimizers])
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        # enable gradient sync for the DistAdam optimizers on the last iteration before we step them
+        if idx == grad_accum_steps - 1:
+            training_manager.activate_hooks(step)
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan  5 08:10:11 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   42C    P0            126W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   34C    P0            130W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   33C    P0            126W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   41C    P0            128W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   43C    P0            131W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   35C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   41C    P0            127W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            125W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     58394      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     58395      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     58396      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     58397      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     58398      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     58399      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     58400      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     58401      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 599, 600, 601, 1199, 1200, 1201, 1799, 1800, 1801] for warmup
+Resetting Model
+step:0/1840 val_loss:10.8292 train_time:0ms step_avg:0.03ms
+step:1/1840 train_time:77ms step_avg:76.68ms
+step:2/1840 train_time:101ms step_avg:50.29ms
+step:3/1840 train_time:121ms step_avg:40.24ms
+step:4/1840 train_time:143ms step_avg:35.67ms
+step:5/1840 train_time:171ms step_avg:34.24ms
+step:6/1840 train_time:251ms step_avg:41.83ms
+step:7/1840 train_time:270ms step_avg:38.53ms
+step:8/1840 train_time:372ms step_avg:46.56ms
+step:9/1840 train_time:404ms step_avg:44.91ms
+step:10/1840 train_time:438ms step_avg:43.82ms
+step:11/1840 train_time:470ms step_avg:42.73ms
+step:12/1840 train_time:504ms step_avg:42.01ms
+step:13/1840 train_time:536ms step_avg:41.26ms
+step:14/1840 train_time:570ms step_avg:40.74ms
+step:15/1840 train_time:602ms step_avg:40.16ms
+step:16/1840 train_time:636ms step_avg:39.77ms
+step:17/1840 train_time:669ms step_avg:39.32ms
+step:18/1840 train_time:703ms step_avg:39.03ms
+step:19/1840 train_time:735ms step_avg:38.67ms
+step:20/1840 train_time:769ms step_avg:38.44ms
+step:21/1840 train_time:801ms step_avg:38.14ms
+step:22/1840 train_time:835ms step_avg:37.95ms
+step:23/1840 train_time:867ms step_avg:37.69ms
+step:24/1840 train_time:901ms step_avg:37.55ms
+step:25/1840 train_time:933ms step_avg:37.33ms
+step:26/1840 train_time:967ms step_avg:37.21ms
+step:27/1840 train_time:1000ms step_avg:37.02ms
+step:28/1840 train_time:1034ms step_avg:36.92ms
+step:29/1840 train_time:1066ms step_avg:36.75ms
+step:30/1840 train_time:1100ms step_avg:36.67ms
+step:31/1840 train_time:1132ms step_avg:36.51ms
+step:32/1840 train_time:1166ms step_avg:36.43ms
+step:33/1840 train_time:1198ms step_avg:36.31ms
+step:34/1840 train_time:1233ms step_avg:36.27ms
+step:35/1840 train_time:1267ms step_avg:36.21ms
+step:36/1840 train_time:1302ms step_avg:36.17ms
+step:37/1840 train_time:1335ms step_avg:36.09ms
+step:38/1840 train_time:1370ms step_avg:36.05ms
+step:39/1840 train_time:1402ms step_avg:35.96ms
+step:40/1840 train_time:1437ms step_avg:35.91ms
+step:41/1840 train_time:1469ms step_avg:35.82ms
+step:42/1840 train_time:1503ms step_avg:35.79ms
+step:43/1840 train_time:1535ms step_avg:35.69ms
+step:44/1840 train_time:1569ms step_avg:35.66ms
+step:45/1840 train_time:1602ms step_avg:35.59ms
+step:46/1840 train_time:1636ms step_avg:35.56ms
+step:47/1840 train_time:1668ms step_avg:35.48ms
+step:48/1840 train_time:1703ms step_avg:35.47ms
+step:49/1840 train_time:1735ms step_avg:35.40ms
+step:50/1840 train_time:1769ms step_avg:35.37ms
+step:51/1840 train_time:1801ms step_avg:35.32ms
+step:52/1840 train_time:1835ms step_avg:35.29ms
+step:53/1840 train_time:1867ms step_avg:35.23ms
+step:54/1840 train_time:1902ms step_avg:35.22ms
+step:55/1840 train_time:1933ms step_avg:35.15ms
+step:56/1840 train_time:1968ms step_avg:35.13ms
+step:57/1840 train_time:1999ms step_avg:35.08ms
+step:58/1840 train_time:2034ms step_avg:35.06ms
+step:59/1840 train_time:2066ms step_avg:35.01ms
+step:60/1840 train_time:2100ms step_avg:35.00ms
+step:61/1840 train_time:2132ms step_avg:34.95ms
+step:62/1840 train_time:2167ms step_avg:34.95ms
+step:63/1840 train_time:2199ms step_avg:34.90ms
+step:64/1840 train_time:2233ms step_avg:34.90ms
+step:65/1840 train_time:2265ms step_avg:34.85ms
+step:66/1840 train_time:2300ms step_avg:34.86ms
+step:67/1840 train_time:2333ms step_avg:34.82ms
+step:68/1840 train_time:2367ms step_avg:34.81ms
+step:69/1840 train_time:2399ms step_avg:34.77ms
+step:70/1840 train_time:2434ms step_avg:34.77ms
+step:71/1840 train_time:2466ms step_avg:34.73ms
+step:72/1840 train_time:2500ms step_avg:34.73ms
+step:73/1840 train_time:2532ms step_avg:34.69ms
+step:74/1840 train_time:2567ms step_avg:34.68ms
+step:75/1840 train_time:2599ms step_avg:34.66ms
+step:76/1840 train_time:2633ms step_avg:34.65ms
+step:77/1840 train_time:2665ms step_avg:34.61ms
+step:78/1840 train_time:2699ms step_avg:34.61ms
+step:79/1840 train_time:2731ms step_avg:34.57ms
+step:80/1840 train_time:2766ms step_avg:34.57ms
+step:81/1840 train_time:2798ms step_avg:34.54ms
+step:82/1840 train_time:2832ms step_avg:34.53ms
+step:83/1840 train_time:2864ms step_avg:34.50ms
+step:84/1840 train_time:2898ms step_avg:34.50ms
+step:85/1840 train_time:2930ms step_avg:34.47ms
+step:86/1840 train_time:2964ms step_avg:34.47ms
+step:87/1840 train_time:2997ms step_avg:34.45ms
+step:88/1840 train_time:3031ms step_avg:34.45ms
+step:89/1840 train_time:3063ms step_avg:34.42ms
+step:90/1840 train_time:3097ms step_avg:34.42ms
+step:91/1840 train_time:3130ms step_avg:34.39ms
+step:92/1840 train_time:3164ms step_avg:34.39ms
+step:93/1840 train_time:3196ms step_avg:34.37ms
+step:94/1840 train_time:3231ms step_avg:34.37ms
+step:95/1840 train_time:3263ms step_avg:34.34ms
+step:96/1840 train_time:3297ms step_avg:34.34ms
+step:97/1840 train_time:3329ms step_avg:34.32ms
+step:98/1840 train_time:3364ms step_avg:34.33ms
+step:99/1840 train_time:3396ms step_avg:34.31ms
+step:100/1840 train_time:3431ms step_avg:34.31ms
+step:101/1840 train_time:3463ms step_avg:34.29ms
+step:102/1840 train_time:3497ms step_avg:34.29ms
+step:103/1840 train_time:3529ms step_avg:34.27ms
+step:104/1840 train_time:3564ms step_avg:34.27ms
+step:105/1840 train_time:3596ms step_avg:34.25ms
+step:106/1840 train_time:3631ms step_avg:34.25ms
+step:107/1840 train_time:3663ms step_avg:34.24ms
+step:108/1840 train_time:3698ms step_avg:34.24ms
+step:109/1840 train_time:3730ms step_avg:34.22ms
+step:110/1840 train_time:3764ms step_avg:34.22ms
+step:111/1840 train_time:3797ms step_avg:34.21ms
+step:112/1840 train_time:3831ms step_avg:34.21ms
+step:113/1840 train_time:3864ms step_avg:34.19ms
+step:114/1840 train_time:3898ms step_avg:34.19ms
+step:115/1840 train_time:3930ms step_avg:34.17ms
+step:116/1840 train_time:3964ms step_avg:34.17ms
+step:117/1840 train_time:3996ms step_avg:34.16ms
+step:118/1840 train_time:4030ms step_avg:34.16ms
+step:119/1840 train_time:4063ms step_avg:34.14ms
+step:120/1840 train_time:4097ms step_avg:34.14ms
+step:121/1840 train_time:4129ms step_avg:34.12ms
+step:122/1840 train_time:4164ms step_avg:34.13ms
+step:123/1840 train_time:4196ms step_avg:34.11ms
+step:124/1840 train_time:4230ms step_avg:34.11ms
+step:125/1840 train_time:4263ms step_avg:34.10ms
+step:126/1840 train_time:4297ms step_avg:34.10ms
+step:127/1840 train_time:4329ms step_avg:34.09ms
+step:128/1840 train_time:4364ms step_avg:34.09ms
+step:129/1840 train_time:4396ms step_avg:34.08ms
+step:130/1840 train_time:4430ms step_avg:34.08ms
+step:131/1840 train_time:4463ms step_avg:34.07ms
+step:132/1840 train_time:4497ms step_avg:34.07ms
+step:133/1840 train_time:4529ms step_avg:34.05ms
+step:134/1840 train_time:4563ms step_avg:34.06ms
+step:135/1840 train_time:4596ms step_avg:34.04ms
+step:136/1840 train_time:4630ms step_avg:34.05ms
+step:137/1840 train_time:4663ms step_avg:34.04ms
+step:138/1840 train_time:4698ms step_avg:34.04ms
+step:139/1840 train_time:4730ms step_avg:34.03ms
+step:140/1840 train_time:4764ms step_avg:34.03ms
+step:141/1840 train_time:4796ms step_avg:34.02ms
+step:142/1840 train_time:4830ms step_avg:34.02ms
+step:143/1840 train_time:4863ms step_avg:34.01ms
+step:144/1840 train_time:4897ms step_avg:34.01ms
+step:145/1840 train_time:4929ms step_avg:34.00ms
+step:146/1840 train_time:4964ms step_avg:34.00ms
+step:147/1840 train_time:4996ms step_avg:33.98ms
+step:148/1840 train_time:5030ms step_avg:33.99ms
+step:149/1840 train_time:5062ms step_avg:33.97ms
+step:150/1840 train_time:5096ms step_avg:33.98ms
+step:151/1840 train_time:5128ms step_avg:33.96ms
+step:152/1840 train_time:5163ms step_avg:33.97ms
+step:153/1840 train_time:5195ms step_avg:33.95ms
+step:154/1840 train_time:5229ms step_avg:33.96ms
+step:155/1840 train_time:5261ms step_avg:33.94ms
+step:156/1840 train_time:5295ms step_avg:33.94ms
+step:157/1840 train_time:5328ms step_avg:33.93ms
+step:158/1840 train_time:5362ms step_avg:33.94ms
+step:159/1840 train_time:5394ms step_avg:33.92ms
+step:160/1840 train_time:5428ms step_avg:33.93ms
+step:161/1840 train_time:5461ms step_avg:33.92ms
+step:162/1840 train_time:5495ms step_avg:33.92ms
+step:163/1840 train_time:5527ms step_avg:33.91ms
+step:164/1840 train_time:5561ms step_avg:33.91ms
+step:165/1840 train_time:5593ms step_avg:33.90ms
+step:166/1840 train_time:5627ms step_avg:33.90ms
+step:167/1840 train_time:5659ms step_avg:33.89ms
+step:168/1840 train_time:5694ms step_avg:33.89ms
+step:169/1840 train_time:5725ms step_avg:33.88ms
+step:170/1840 train_time:5760ms step_avg:33.88ms
+step:171/1840 train_time:5792ms step_avg:33.87ms
+step:172/1840 train_time:5826ms step_avg:33.87ms
+step:173/1840 train_time:5858ms step_avg:33.86ms
+step:174/1840 train_time:5893ms step_avg:33.87ms
+step:175/1840 train_time:5925ms step_avg:33.86ms
+step:176/1840 train_time:5959ms step_avg:33.86ms
+step:177/1840 train_time:5991ms step_avg:33.85ms
+step:178/1840 train_time:6025ms step_avg:33.85ms
+step:179/1840 train_time:6057ms step_avg:33.84ms
+step:180/1840 train_time:6092ms step_avg:33.84ms
+step:181/1840 train_time:6124ms step_avg:33.83ms
+step:182/1840 train_time:6158ms step_avg:33.84ms
+step:183/1840 train_time:6190ms step_avg:33.83ms
+step:184/1840 train_time:6224ms step_avg:33.83ms
+step:185/1840 train_time:6256ms step_avg:33.82ms
+step:186/1840 train_time:6291ms step_avg:33.82ms
+step:187/1840 train_time:6322ms step_avg:33.81ms
+step:188/1840 train_time:6357ms step_avg:33.81ms
+step:189/1840 train_time:6389ms step_avg:33.81ms
+step:190/1840 train_time:6424ms step_avg:33.81ms
+step:191/1840 train_time:6456ms step_avg:33.80ms
+step:192/1840 train_time:6491ms step_avg:33.80ms
+step:193/1840 train_time:6522ms step_avg:33.80ms
+step:194/1840 train_time:6557ms step_avg:33.80ms
+step:195/1840 train_time:6589ms step_avg:33.79ms
+step:196/1840 train_time:6623ms step_avg:33.79ms
+step:197/1840 train_time:6655ms step_avg:33.78ms
+step:198/1840 train_time:6690ms step_avg:33.79ms
+step:199/1840 train_time:6722ms step_avg:33.78ms
+step:200/1840 train_time:6757ms step_avg:33.79ms
+step:201/1840 train_time:6788ms step_avg:33.77ms
+step:202/1840 train_time:6822ms step_avg:33.77ms
+step:203/1840 train_time:6854ms step_avg:33.76ms
+step:204/1840 train_time:6888ms step_avg:33.77ms
+step:205/1840 train_time:6920ms step_avg:33.76ms
+step:206/1840 train_time:6954ms step_avg:33.76ms
+step:207/1840 train_time:6987ms step_avg:33.75ms
+step:208/1840 train_time:7021ms step_avg:33.75ms
+step:209/1840 train_time:7053ms step_avg:33.74ms
+step:210/1840 train_time:7087ms step_avg:33.75ms
+step:211/1840 train_time:7119ms step_avg:33.74ms
+step:212/1840 train_time:7153ms step_avg:33.74ms
+step:213/1840 train_time:7185ms step_avg:33.73ms
+step:214/1840 train_time:7220ms step_avg:33.74ms
+step:215/1840 train_time:7251ms step_avg:33.73ms
+step:216/1840 train_time:7286ms step_avg:33.73ms
+step:217/1840 train_time:7318ms step_avg:33.72ms
+step:218/1840 train_time:7352ms step_avg:33.73ms
+step:219/1840 train_time:7384ms step_avg:33.72ms
+step:220/1840 train_time:7419ms step_avg:33.72ms
+step:221/1840 train_time:7451ms step_avg:33.71ms
+step:222/1840 train_time:7485ms step_avg:33.72ms
+step:223/1840 train_time:7518ms step_avg:33.71ms
+step:224/1840 train_time:7552ms step_avg:33.71ms
+step:225/1840 train_time:7584ms step_avg:33.71ms
+step:226/1840 train_time:7618ms step_avg:33.71ms
+step:227/1840 train_time:7650ms step_avg:33.70ms
+step:228/1840 train_time:7684ms step_avg:33.70ms
+step:229/1840 train_time:7716ms step_avg:33.70ms
+step:230/1840 train_time:7750ms step_avg:33.70ms
+step:231/1840 train_time:7782ms step_avg:33.69ms
+step:232/1840 train_time:7817ms step_avg:33.69ms
+step:233/1840 train_time:7849ms step_avg:33.69ms
+step:234/1840 train_time:7883ms step_avg:33.69ms
+step:235/1840 train_time:7915ms step_avg:33.68ms
+step:236/1840 train_time:7950ms step_avg:33.69ms
+step:237/1840 train_time:7982ms step_avg:33.68ms
+step:238/1840 train_time:8016ms step_avg:33.68ms
+step:239/1840 train_time:8048ms step_avg:33.68ms
+step:240/1840 train_time:8083ms step_avg:33.68ms
+step:241/1840 train_time:8115ms step_avg:33.67ms
+step:242/1840 train_time:8149ms step_avg:33.67ms
+step:243/1840 train_time:8181ms step_avg:33.67ms
+step:244/1840 train_time:8215ms step_avg:33.67ms
+step:245/1840 train_time:8247ms step_avg:33.66ms
+step:246/1840 train_time:8281ms step_avg:33.66ms
+step:247/1840 train_time:8313ms step_avg:33.66ms
+step:248/1840 train_time:8347ms step_avg:33.66ms
+step:249/1840 train_time:8379ms step_avg:33.65ms
+step:250/1840 train_time:8413ms step_avg:33.65ms
+step:250/1840 val_loss:4.6174 train_time:8455ms step_avg:33.82ms
+step:251/1840 train_time:8481ms step_avg:33.79ms
+step:252/1840 train_time:8503ms step_avg:33.74ms
+step:253/1840 train_time:8521ms step_avg:33.68ms
+step:254/1840 train_time:8550ms step_avg:33.66ms
+step:255/1840 train_time:8582ms step_avg:33.66ms
+step:256/1840 train_time:8617ms step_avg:33.66ms
+step:257/1840 train_time:8649ms step_avg:33.66ms
+step:258/1840 train_time:8683ms step_avg:33.66ms
+step:259/1840 train_time:8715ms step_avg:33.65ms
+step:260/1840 train_time:8750ms step_avg:33.65ms
+step:261/1840 train_time:8781ms step_avg:33.64ms
+step:262/1840 train_time:8815ms step_avg:33.65ms
+step:263/1840 train_time:8847ms step_avg:33.64ms
+step:264/1840 train_time:8881ms step_avg:33.64ms
+step:265/1840 train_time:8913ms step_avg:33.63ms
+step:266/1840 train_time:8947ms step_avg:33.64ms
+step:267/1840 train_time:8979ms step_avg:33.63ms
+step:268/1840 train_time:9013ms step_avg:33.63ms
+step:269/1840 train_time:9045ms step_avg:33.62ms
+step:270/1840 train_time:9079ms step_avg:33.62ms
+step:271/1840 train_time:9111ms step_avg:33.62ms
+step:272/1840 train_time:9145ms step_avg:33.62ms
+step:273/1840 train_time:9176ms step_avg:33.61ms
+step:274/1840 train_time:9210ms step_avg:33.61ms
+step:275/1840 train_time:9242ms step_avg:33.61ms
+step:276/1840 train_time:9276ms step_avg:33.61ms
+step:277/1840 train_time:9308ms step_avg:33.60ms
+step:278/1840 train_time:9342ms step_avg:33.60ms
+step:279/1840 train_time:9374ms step_avg:33.60ms
+step:280/1840 train_time:9409ms step_avg:33.60ms
+step:281/1840 train_time:9441ms step_avg:33.60ms
+step:282/1840 train_time:9475ms step_avg:33.60ms
+step:283/1840 train_time:9508ms step_avg:33.60ms
+step:284/1840 train_time:9542ms step_avg:33.60ms
+step:285/1840 train_time:9575ms step_avg:33.60ms
+step:286/1840 train_time:9610ms step_avg:33.60ms
+step:287/1840 train_time:9641ms step_avg:33.59ms
+step:288/1840 train_time:9675ms step_avg:33.60ms
+step:289/1840 train_time:9708ms step_avg:33.59ms
+step:290/1840 train_time:9742ms step_avg:33.59ms
+step:291/1840 train_time:9774ms step_avg:33.59ms
+step:292/1840 train_time:9808ms step_avg:33.59ms
+step:293/1840 train_time:9840ms step_avg:33.58ms
+step:294/1840 train_time:9875ms step_avg:33.59ms
+step:295/1840 train_time:9907ms step_avg:33.58ms
+step:296/1840 train_time:9941ms step_avg:33.58ms
+step:297/1840 train_time:9973ms step_avg:33.58ms
+step:298/1840 train_time:10007ms step_avg:33.58ms
+step:299/1840 train_time:10039ms step_avg:33.57ms
+step:300/1840 train_time:10073ms step_avg:33.58ms
+step:301/1840 train_time:10105ms step_avg:33.57ms
+step:302/1840 train_time:10139ms step_avg:33.57ms
+step:303/1840 train_time:10171ms step_avg:33.57ms
+step:304/1840 train_time:10205ms step_avg:33.57ms
+step:305/1840 train_time:10238ms step_avg:33.57ms
+step:306/1840 train_time:10272ms step_avg:33.57ms
+step:307/1840 train_time:10303ms step_avg:33.56ms
+step:308/1840 train_time:10338ms step_avg:33.56ms
+step:309/1840 train_time:10370ms step_avg:33.56ms
+step:310/1840 train_time:10404ms step_avg:33.56ms
+step:311/1840 train_time:10436ms step_avg:33.56ms
+step:312/1840 train_time:10470ms step_avg:33.56ms
+step:313/1840 train_time:10502ms step_avg:33.55ms
+step:314/1840 train_time:10537ms step_avg:33.56ms
+step:315/1840 train_time:10569ms step_avg:33.55ms
+step:316/1840 train_time:10603ms step_avg:33.55ms
+step:317/1840 train_time:10636ms step_avg:33.55ms
+step:318/1840 train_time:10670ms step_avg:33.55ms
+step:319/1840 train_time:10702ms step_avg:33.55ms
+step:320/1840 train_time:10736ms step_avg:33.55ms
+step:321/1840 train_time:10768ms step_avg:33.55ms
+step:322/1840 train_time:10803ms step_avg:33.55ms
+step:323/1840 train_time:10834ms step_avg:33.54ms
+step:324/1840 train_time:10868ms step_avg:33.54ms
+step:325/1840 train_time:10900ms step_avg:33.54ms
+step:326/1840 train_time:10935ms step_avg:33.54ms
+step:327/1840 train_time:10967ms step_avg:33.54ms
+step:328/1840 train_time:11001ms step_avg:33.54ms
+step:329/1840 train_time:11033ms step_avg:33.53ms
+step:330/1840 train_time:11067ms step_avg:33.54ms
+step:331/1840 train_time:11099ms step_avg:33.53ms
+step:332/1840 train_time:11133ms step_avg:33.53ms
+step:333/1840 train_time:11165ms step_avg:33.53ms
+step:334/1840 train_time:11199ms step_avg:33.53ms
+step:335/1840 train_time:11232ms step_avg:33.53ms
+step:336/1840 train_time:11266ms step_avg:33.53ms
+step:337/1840 train_time:11297ms step_avg:33.52ms
+step:338/1840 train_time:11332ms step_avg:33.53ms
+step:339/1840 train_time:11364ms step_avg:33.52ms
+step:340/1840 train_time:11398ms step_avg:33.52ms
+step:341/1840 train_time:11430ms step_avg:33.52ms
+step:342/1840 train_time:11464ms step_avg:33.52ms
+step:343/1840 train_time:11497ms step_avg:33.52ms
+step:344/1840 train_time:11531ms step_avg:33.52ms
+step:345/1840 train_time:11563ms step_avg:33.52ms
+step:346/1840 train_time:11598ms step_avg:33.52ms
+step:347/1840 train_time:11630ms step_avg:33.52ms
+step:348/1840 train_time:11664ms step_avg:33.52ms
+step:349/1840 train_time:11697ms step_avg:33.51ms
+step:350/1840 train_time:11731ms step_avg:33.52ms
+step:351/1840 train_time:11763ms step_avg:33.51ms
+step:352/1840 train_time:11797ms step_avg:33.51ms
+step:353/1840 train_time:11830ms step_avg:33.51ms
+step:354/1840 train_time:11864ms step_avg:33.51ms
+step:355/1840 train_time:11896ms step_avg:33.51ms
+step:356/1840 train_time:11930ms step_avg:33.51ms
+step:357/1840 train_time:11963ms step_avg:33.51ms
+step:358/1840 train_time:11997ms step_avg:33.51ms
+step:359/1840 train_time:12029ms step_avg:33.51ms
+step:360/1840 train_time:12063ms step_avg:33.51ms
+step:361/1840 train_time:12095ms step_avg:33.50ms
+step:362/1840 train_time:12129ms step_avg:33.51ms
+step:363/1840 train_time:12161ms step_avg:33.50ms
+step:364/1840 train_time:12195ms step_avg:33.50ms
+step:365/1840 train_time:12227ms step_avg:33.50ms
+step:366/1840 train_time:12261ms step_avg:33.50ms
+step:367/1840 train_time:12293ms step_avg:33.50ms
+step:368/1840 train_time:12327ms step_avg:33.50ms
+step:369/1840 train_time:12359ms step_avg:33.49ms
+step:370/1840 train_time:12393ms step_avg:33.49ms
+step:371/1840 train_time:12425ms step_avg:33.49ms
+step:372/1840 train_time:12460ms step_avg:33.49ms
+step:373/1840 train_time:12491ms step_avg:33.49ms
+step:374/1840 train_time:12526ms step_avg:33.49ms
+step:375/1840 train_time:12558ms step_avg:33.49ms
+step:376/1840 train_time:12593ms step_avg:33.49ms
+step:377/1840 train_time:12625ms step_avg:33.49ms
+step:378/1840 train_time:12660ms step_avg:33.49ms
+step:379/1840 train_time:12692ms step_avg:33.49ms
+step:380/1840 train_time:12726ms step_avg:33.49ms
+step:381/1840 train_time:12758ms step_avg:33.49ms
+step:382/1840 train_time:12792ms step_avg:33.49ms
+step:383/1840 train_time:12825ms step_avg:33.48ms
+step:384/1840 train_time:12859ms step_avg:33.49ms
+step:385/1840 train_time:12891ms step_avg:33.48ms
+step:386/1840 train_time:12925ms step_avg:33.48ms
+step:387/1840 train_time:12957ms step_avg:33.48ms
+step:388/1840 train_time:12992ms step_avg:33.48ms
+step:389/1840 train_time:13024ms step_avg:33.48ms
+step:390/1840 train_time:13058ms step_avg:33.48ms
+step:391/1840 train_time:13090ms step_avg:33.48ms
+step:392/1840 train_time:13124ms step_avg:33.48ms
+step:393/1840 train_time:13156ms step_avg:33.48ms
+step:394/1840 train_time:13190ms step_avg:33.48ms
+step:395/1840 train_time:13222ms step_avg:33.47ms
+step:396/1840 train_time:13256ms step_avg:33.48ms
+step:397/1840 train_time:13289ms step_avg:33.47ms
+step:398/1840 train_time:13322ms step_avg:33.47ms
+step:399/1840 train_time:13354ms step_avg:33.47ms
+step:400/1840 train_time:13388ms step_avg:33.47ms
+step:401/1840 train_time:13420ms step_avg:33.47ms
+step:402/1840 train_time:13454ms step_avg:33.47ms
+step:403/1840 train_time:13486ms step_avg:33.46ms
+step:404/1840 train_time:13520ms step_avg:33.47ms
+step:405/1840 train_time:13553ms step_avg:33.46ms
+step:406/1840 train_time:13587ms step_avg:33.47ms
+step:407/1840 train_time:13619ms step_avg:33.46ms
+step:408/1840 train_time:13654ms step_avg:33.46ms
+step:409/1840 train_time:13686ms step_avg:33.46ms
+step:410/1840 train_time:13720ms step_avg:33.46ms
+step:411/1840 train_time:13752ms step_avg:33.46ms
+step:412/1840 train_time:13786ms step_avg:33.46ms
+step:413/1840 train_time:13818ms step_avg:33.46ms
+step:414/1840 train_time:13853ms step_avg:33.46ms
+step:415/1840 train_time:13885ms step_avg:33.46ms
+step:416/1840 train_time:13920ms step_avg:33.46ms
+step:417/1840 train_time:13952ms step_avg:33.46ms
+step:418/1840 train_time:13986ms step_avg:33.46ms
+step:419/1840 train_time:14018ms step_avg:33.46ms
+step:420/1840 train_time:14053ms step_avg:33.46ms
+step:421/1840 train_time:14085ms step_avg:33.46ms
+step:422/1840 train_time:14120ms step_avg:33.46ms
+step:423/1840 train_time:14152ms step_avg:33.46ms
+step:424/1840 train_time:14186ms step_avg:33.46ms
+step:425/1840 train_time:14218ms step_avg:33.45ms
+step:426/1840 train_time:14252ms step_avg:33.46ms
+step:427/1840 train_time:14284ms step_avg:33.45ms
+step:428/1840 train_time:14319ms step_avg:33.46ms
+step:429/1840 train_time:14351ms step_avg:33.45ms
+step:430/1840 train_time:14386ms step_avg:33.45ms
+step:431/1840 train_time:14418ms step_avg:33.45ms
+step:432/1840 train_time:14452ms step_avg:33.45ms
+step:433/1840 train_time:14484ms step_avg:33.45ms
+step:434/1840 train_time:14518ms step_avg:33.45ms
+step:435/1840 train_time:14550ms step_avg:33.45ms
+step:436/1840 train_time:14584ms step_avg:33.45ms
+step:437/1840 train_time:14616ms step_avg:33.45ms
+step:438/1840 train_time:14650ms step_avg:33.45ms
+step:439/1840 train_time:14682ms step_avg:33.44ms
+step:440/1840 train_time:14716ms step_avg:33.45ms
+step:441/1840 train_time:14749ms step_avg:33.44ms
+step:442/1840 train_time:14783ms step_avg:33.45ms
+step:443/1840 train_time:14815ms step_avg:33.44ms
+step:444/1840 train_time:14850ms step_avg:33.45ms
+step:445/1840 train_time:14881ms step_avg:33.44ms
+step:446/1840 train_time:14916ms step_avg:33.44ms
+step:447/1840 train_time:14948ms step_avg:33.44ms
+step:448/1840 train_time:14982ms step_avg:33.44ms
+step:449/1840 train_time:15014ms step_avg:33.44ms
+step:450/1840 train_time:15048ms step_avg:33.44ms
+step:451/1840 train_time:15080ms step_avg:33.44ms
+step:452/1840 train_time:15114ms step_avg:33.44ms
+step:453/1840 train_time:15146ms step_avg:33.44ms
+step:454/1840 train_time:15180ms step_avg:33.44ms
+step:455/1840 train_time:15212ms step_avg:33.43ms
+step:456/1840 train_time:15247ms step_avg:33.44ms
+step:457/1840 train_time:15279ms step_avg:33.43ms
+step:458/1840 train_time:15314ms step_avg:33.44ms
+step:459/1840 train_time:15346ms step_avg:33.43ms
+step:460/1840 train_time:15380ms step_avg:33.43ms
+step:461/1840 train_time:15412ms step_avg:33.43ms
+step:462/1840 train_time:15446ms step_avg:33.43ms
+step:463/1840 train_time:15478ms step_avg:33.43ms
+step:464/1840 train_time:15512ms step_avg:33.43ms
+step:465/1840 train_time:15544ms step_avg:33.43ms
+step:466/1840 train_time:15579ms step_avg:33.43ms
+step:467/1840 train_time:15611ms step_avg:33.43ms
+step:468/1840 train_time:15645ms step_avg:33.43ms
+step:469/1840 train_time:15677ms step_avg:33.43ms
+step:470/1840 train_time:15712ms step_avg:33.43ms
+step:471/1840 train_time:15744ms step_avg:33.43ms
+step:472/1840 train_time:15778ms step_avg:33.43ms
+step:473/1840 train_time:15810ms step_avg:33.42ms
+step:474/1840 train_time:15844ms step_avg:33.43ms
+step:475/1840 train_time:15876ms step_avg:33.42ms
+step:476/1840 train_time:15910ms step_avg:33.42ms
+step:477/1840 train_time:15942ms step_avg:33.42ms
+step:478/1840 train_time:15976ms step_avg:33.42ms
+step:479/1840 train_time:16008ms step_avg:33.42ms
+step:480/1840 train_time:16042ms step_avg:33.42ms
+step:481/1840 train_time:16074ms step_avg:33.42ms
+step:482/1840 train_time:16109ms step_avg:33.42ms
+step:483/1840 train_time:16140ms step_avg:33.42ms
+step:484/1840 train_time:16174ms step_avg:33.42ms
+step:485/1840 train_time:16206ms step_avg:33.42ms
+step:486/1840 train_time:16240ms step_avg:33.42ms
+step:487/1840 train_time:16273ms step_avg:33.41ms
+step:488/1840 train_time:16307ms step_avg:33.42ms
+step:489/1840 train_time:16339ms step_avg:33.41ms
+step:490/1840 train_time:16373ms step_avg:33.41ms
+step:491/1840 train_time:16405ms step_avg:33.41ms
+step:492/1840 train_time:16440ms step_avg:33.41ms
+step:493/1840 train_time:16472ms step_avg:33.41ms
+step:494/1840 train_time:16506ms step_avg:33.41ms
+step:495/1840 train_time:16538ms step_avg:33.41ms
+step:496/1840 train_time:16572ms step_avg:33.41ms
+step:497/1840 train_time:16605ms step_avg:33.41ms
+step:498/1840 train_time:16639ms step_avg:33.41ms
+step:499/1840 train_time:16671ms step_avg:33.41ms
+step:500/1840 train_time:16705ms step_avg:33.41ms
+step:500/1840 val_loss:4.2816 train_time:16747ms step_avg:33.49ms
+step:501/1840 train_time:16773ms step_avg:33.48ms
+step:502/1840 train_time:16794ms step_avg:33.45ms
+step:503/1840 train_time:16813ms step_avg:33.42ms
+step:504/1840 train_time:16842ms step_avg:33.42ms
+step:505/1840 train_time:16875ms step_avg:33.42ms
+step:506/1840 train_time:16910ms step_avg:33.42ms
+step:507/1840 train_time:16943ms step_avg:33.42ms
+step:508/1840 train_time:16977ms step_avg:33.42ms
+step:509/1840 train_time:17009ms step_avg:33.42ms
+step:510/1840 train_time:17044ms step_avg:33.42ms
+step:511/1840 train_time:17076ms step_avg:33.42ms
+step:512/1840 train_time:17110ms step_avg:33.42ms
+step:513/1840 train_time:17141ms step_avg:33.41ms
+step:514/1840 train_time:17175ms step_avg:33.42ms
+step:515/1840 train_time:17207ms step_avg:33.41ms
+step:516/1840 train_time:17241ms step_avg:33.41ms
+step:517/1840 train_time:17273ms step_avg:33.41ms
+step:518/1840 train_time:17307ms step_avg:33.41ms
+step:519/1840 train_time:17339ms step_avg:33.41ms
+step:520/1840 train_time:17373ms step_avg:33.41ms
+step:521/1840 train_time:17405ms step_avg:33.41ms
+step:522/1840 train_time:17439ms step_avg:33.41ms
+step:523/1840 train_time:17470ms step_avg:33.40ms
+step:524/1840 train_time:17504ms step_avg:33.41ms
+step:525/1840 train_time:17536ms step_avg:33.40ms
+step:526/1840 train_time:17570ms step_avg:33.40ms
+step:527/1840 train_time:17602ms step_avg:33.40ms
+step:528/1840 train_time:17636ms step_avg:33.40ms
+step:529/1840 train_time:17668ms step_avg:33.40ms
+step:530/1840 train_time:17703ms step_avg:33.40ms
+step:531/1840 train_time:17737ms step_avg:33.40ms
+step:532/1840 train_time:17771ms step_avg:33.40ms
+step:533/1840 train_time:17804ms step_avg:33.40ms
+step:534/1840 train_time:17839ms step_avg:33.41ms
+step:535/1840 train_time:17871ms step_avg:33.40ms
+step:536/1840 train_time:17905ms step_avg:33.41ms
+step:537/1840 train_time:17937ms step_avg:33.40ms
+step:538/1840 train_time:17972ms step_avg:33.40ms
+step:539/1840 train_time:18004ms step_avg:33.40ms
+step:540/1840 train_time:18038ms step_avg:33.40ms
+step:541/1840 train_time:18070ms step_avg:33.40ms
+step:542/1840 train_time:18104ms step_avg:33.40ms
+step:543/1840 train_time:18136ms step_avg:33.40ms
+step:544/1840 train_time:18170ms step_avg:33.40ms
+step:545/1840 train_time:18202ms step_avg:33.40ms
+step:546/1840 train_time:18236ms step_avg:33.40ms
+step:547/1840 train_time:18268ms step_avg:33.40ms
+step:548/1840 train_time:18302ms step_avg:33.40ms
+step:549/1840 train_time:18334ms step_avg:33.40ms
+step:550/1840 train_time:18369ms step_avg:33.40ms
+step:551/1840 train_time:18401ms step_avg:33.40ms
+step:552/1840 train_time:18435ms step_avg:33.40ms
+step:553/1840 train_time:18467ms step_avg:33.39ms
+step:554/1840 train_time:18502ms step_avg:33.40ms
+step:555/1840 train_time:18533ms step_avg:33.39ms
+step:556/1840 train_time:18567ms step_avg:33.39ms
+step:557/1840 train_time:18599ms step_avg:33.39ms
+step:558/1840 train_time:18633ms step_avg:33.39ms
+step:559/1840 train_time:18665ms step_avg:33.39ms
+step:560/1840 train_time:18700ms step_avg:33.39ms
+step:561/1840 train_time:18732ms step_avg:33.39ms
+step:562/1840 train_time:18767ms step_avg:33.39ms
+step:563/1840 train_time:18799ms step_avg:33.39ms
+step:564/1840 train_time:18834ms step_avg:33.39ms
+step:565/1840 train_time:18866ms step_avg:33.39ms
+step:566/1840 train_time:18900ms step_avg:33.39ms
+step:567/1840 train_time:18932ms step_avg:33.39ms
+step:568/1840 train_time:18967ms step_avg:33.39ms
+step:569/1840 train_time:18999ms step_avg:33.39ms
+step:570/1840 train_time:19033ms step_avg:33.39ms
+step:571/1840 train_time:19065ms step_avg:33.39ms
+step:572/1840 train_time:19099ms step_avg:33.39ms
+step:573/1840 train_time:19131ms step_avg:33.39ms
+step:574/1840 train_time:19166ms step_avg:33.39ms
+step:575/1840 train_time:19198ms step_avg:33.39ms
+step:576/1840 train_time:19232ms step_avg:33.39ms
+step:577/1840 train_time:19264ms step_avg:33.39ms
+step:578/1840 train_time:19298ms step_avg:33.39ms
+step:579/1840 train_time:19330ms step_avg:33.38ms
+step:580/1840 train_time:19364ms step_avg:33.39ms
+step:581/1840 train_time:19396ms step_avg:33.38ms
+step:582/1840 train_time:19430ms step_avg:33.38ms
+step:583/1840 train_time:19462ms step_avg:33.38ms
+step:584/1840 train_time:19496ms step_avg:33.38ms
+step:585/1840 train_time:19528ms step_avg:33.38ms
+step:586/1840 train_time:19563ms step_avg:33.38ms
+step:587/1840 train_time:19595ms step_avg:33.38ms
+step:588/1840 train_time:19629ms step_avg:33.38ms
+step:589/1840 train_time:19661ms step_avg:33.38ms
+step:590/1840 train_time:19695ms step_avg:33.38ms
+step:591/1840 train_time:19728ms step_avg:33.38ms
+step:592/1840 train_time:19762ms step_avg:33.38ms
+step:593/1840 train_time:19795ms step_avg:33.38ms
+step:594/1840 train_time:19829ms step_avg:33.38ms
+step:595/1840 train_time:19861ms step_avg:33.38ms
+step:596/1840 train_time:19896ms step_avg:33.38ms
+step:597/1840 train_time:19928ms step_avg:33.38ms
+step:598/1840 train_time:19963ms step_avg:33.38ms
+step:599/1840 train_time:19995ms step_avg:33.38ms
+step:600/1840 train_time:20029ms step_avg:33.38ms
+step:601/1840 train_time:20064ms step_avg:33.38ms
+step:602/1840 train_time:20122ms step_avg:33.43ms
+step:603/1840 train_time:20182ms step_avg:33.47ms
+step:604/1840 train_time:20245ms step_avg:33.52ms
+step:605/1840 train_time:20304ms step_avg:33.56ms
+step:606/1840 train_time:20366ms step_avg:33.61ms
+step:607/1840 train_time:20427ms step_avg:33.65ms
+step:608/1840 train_time:20489ms step_avg:33.70ms
+step:609/1840 train_time:20549ms step_avg:33.74ms
+step:610/1840 train_time:20612ms step_avg:33.79ms
+step:611/1840 train_time:20671ms step_avg:33.83ms
+step:612/1840 train_time:20733ms step_avg:33.88ms
+step:613/1840 train_time:20792ms step_avg:33.92ms
+step:614/1840 train_time:20854ms step_avg:33.96ms
+step:615/1840 train_time:20914ms step_avg:34.01ms
+step:616/1840 train_time:20975ms step_avg:34.05ms
+step:617/1840 train_time:21035ms step_avg:34.09ms
+step:618/1840 train_time:21097ms step_avg:34.14ms
+step:619/1840 train_time:21157ms step_avg:34.18ms
+step:620/1840 train_time:21220ms step_avg:34.23ms
+step:621/1840 train_time:21279ms step_avg:34.27ms
+step:622/1840 train_time:21343ms step_avg:34.31ms
+step:623/1840 train_time:21403ms step_avg:34.35ms
+step:624/1840 train_time:21465ms step_avg:34.40ms
+step:625/1840 train_time:21525ms step_avg:34.44ms
+step:626/1840 train_time:21588ms step_avg:34.49ms
+step:627/1840 train_time:21649ms step_avg:34.53ms
+step:628/1840 train_time:21710ms step_avg:34.57ms
+step:629/1840 train_time:21770ms step_avg:34.61ms
+step:630/1840 train_time:21832ms step_avg:34.65ms
+step:631/1840 train_time:21892ms step_avg:34.69ms
+step:632/1840 train_time:21954ms step_avg:34.74ms
+step:633/1840 train_time:22014ms step_avg:34.78ms
+step:634/1840 train_time:22077ms step_avg:34.82ms
+step:635/1840 train_time:22137ms step_avg:34.86ms
+step:636/1840 train_time:22198ms step_avg:34.90ms
+step:637/1840 train_time:22258ms step_avg:34.94ms
+step:638/1840 train_time:22321ms step_avg:34.99ms
+step:639/1840 train_time:22382ms step_avg:35.03ms
+step:640/1840 train_time:22445ms step_avg:35.07ms
+step:641/1840 train_time:22505ms step_avg:35.11ms
+step:642/1840 train_time:22568ms step_avg:35.15ms
+step:643/1840 train_time:22627ms step_avg:35.19ms
+step:644/1840 train_time:22690ms step_avg:35.23ms
+step:645/1840 train_time:22750ms step_avg:35.27ms
+step:646/1840 train_time:22812ms step_avg:35.31ms
+step:647/1840 train_time:22872ms step_avg:35.35ms
+step:648/1840 train_time:22933ms step_avg:35.39ms
+step:649/1840 train_time:22993ms step_avg:35.43ms
+step:650/1840 train_time:23055ms step_avg:35.47ms
+step:651/1840 train_time:23115ms step_avg:35.51ms
+step:652/1840 train_time:23178ms step_avg:35.55ms
+step:653/1840 train_time:23237ms step_avg:35.59ms
+step:654/1840 train_time:23299ms step_avg:35.62ms
+step:655/1840 train_time:23358ms step_avg:35.66ms
+step:656/1840 train_time:23421ms step_avg:35.70ms
+step:657/1840 train_time:23483ms step_avg:35.74ms
+step:658/1840 train_time:23545ms step_avg:35.78ms
+step:659/1840 train_time:23605ms step_avg:35.82ms
+step:660/1840 train_time:23667ms step_avg:35.86ms
+step:661/1840 train_time:23728ms step_avg:35.90ms
+step:662/1840 train_time:23791ms step_avg:35.94ms
+step:663/1840 train_time:23851ms step_avg:35.97ms
+step:664/1840 train_time:23913ms step_avg:36.01ms
+step:665/1840 train_time:23973ms step_avg:36.05ms
+step:666/1840 train_time:24035ms step_avg:36.09ms
+step:667/1840 train_time:24094ms step_avg:36.12ms
+step:668/1840 train_time:24156ms step_avg:36.16ms
+step:669/1840 train_time:24216ms step_avg:36.20ms
+step:670/1840 train_time:24278ms step_avg:36.24ms
+step:671/1840 train_time:24338ms step_avg:36.27ms
+step:672/1840 train_time:24400ms step_avg:36.31ms
+step:673/1840 train_time:24460ms step_avg:36.35ms
+step:674/1840 train_time:24523ms step_avg:36.38ms
+step:675/1840 train_time:24584ms step_avg:36.42ms
+step:676/1840 train_time:24647ms step_avg:36.46ms
+step:677/1840 train_time:24707ms step_avg:36.50ms
+step:678/1840 train_time:24770ms step_avg:36.53ms
+step:679/1840 train_time:24830ms step_avg:36.57ms
+step:680/1840 train_time:24892ms step_avg:36.61ms
+step:681/1840 train_time:24952ms step_avg:36.64ms
+step:682/1840 train_time:25015ms step_avg:36.68ms
+step:683/1840 train_time:25074ms step_avg:36.71ms
+step:684/1840 train_time:25136ms step_avg:36.75ms
+step:685/1840 train_time:25196ms step_avg:36.78ms
+step:686/1840 train_time:25257ms step_avg:36.82ms
+step:687/1840 train_time:25317ms step_avg:36.85ms
+step:688/1840 train_time:25379ms step_avg:36.89ms
+step:689/1840 train_time:25439ms step_avg:36.92ms
+step:690/1840 train_time:25501ms step_avg:36.96ms
+step:691/1840 train_time:25562ms step_avg:36.99ms
+step:692/1840 train_time:25624ms step_avg:37.03ms
+step:693/1840 train_time:25685ms step_avg:37.06ms
+step:694/1840 train_time:25747ms step_avg:37.10ms
+step:695/1840 train_time:25808ms step_avg:37.13ms
+step:696/1840 train_time:25871ms step_avg:37.17ms
+step:697/1840 train_time:25931ms step_avg:37.20ms
+step:698/1840 train_time:25993ms step_avg:37.24ms
+step:699/1840 train_time:26052ms step_avg:37.27ms
+step:700/1840 train_time:26114ms step_avg:37.31ms
+step:701/1840 train_time:26174ms step_avg:37.34ms
+step:702/1840 train_time:26236ms step_avg:37.37ms
+step:703/1840 train_time:26295ms step_avg:37.40ms
+step:704/1840 train_time:26358ms step_avg:37.44ms
+step:705/1840 train_time:26417ms step_avg:37.47ms
+step:706/1840 train_time:26479ms step_avg:37.51ms
+step:707/1840 train_time:26539ms step_avg:37.54ms
+step:708/1840 train_time:26601ms step_avg:37.57ms
+step:709/1840 train_time:26661ms step_avg:37.60ms
+step:710/1840 train_time:26724ms step_avg:37.64ms
+step:711/1840 train_time:26784ms step_avg:37.67ms
+step:712/1840 train_time:26848ms step_avg:37.71ms
+step:713/1840 train_time:26909ms step_avg:37.74ms
+step:714/1840 train_time:26971ms step_avg:37.78ms
+step:715/1840 train_time:27032ms step_avg:37.81ms
+step:716/1840 train_time:27094ms step_avg:37.84ms
+step:717/1840 train_time:27153ms step_avg:37.87ms
+step:718/1840 train_time:27214ms step_avg:37.90ms
+step:719/1840 train_time:27273ms step_avg:37.93ms
+step:720/1840 train_time:27336ms step_avg:37.97ms
+step:721/1840 train_time:27396ms step_avg:38.00ms
+step:722/1840 train_time:27458ms step_avg:38.03ms
+step:723/1840 train_time:27517ms step_avg:38.06ms
+step:724/1840 train_time:27580ms step_avg:38.09ms
+step:725/1840 train_time:27640ms step_avg:38.12ms
+step:726/1840 train_time:27702ms step_avg:38.16ms
+step:727/1840 train_time:27763ms step_avg:38.19ms
+step:728/1840 train_time:27826ms step_avg:38.22ms
+step:729/1840 train_time:27886ms step_avg:38.25ms
+step:730/1840 train_time:27948ms step_avg:38.29ms
+step:731/1840 train_time:28009ms step_avg:38.32ms
+step:732/1840 train_time:28072ms step_avg:38.35ms
+step:733/1840 train_time:28131ms step_avg:38.38ms
+step:734/1840 train_time:28194ms step_avg:38.41ms
+step:735/1840 train_time:28253ms step_avg:38.44ms
+step:736/1840 train_time:28315ms step_avg:38.47ms
+step:737/1840 train_time:28374ms step_avg:38.50ms
+step:738/1840 train_time:28437ms step_avg:38.53ms
+step:739/1840 train_time:28496ms step_avg:38.56ms
+step:740/1840 train_time:28559ms step_avg:38.59ms
+step:741/1840 train_time:28618ms step_avg:38.62ms
+step:742/1840 train_time:28681ms step_avg:38.65ms
+step:743/1840 train_time:28742ms step_avg:38.68ms
+step:744/1840 train_time:28805ms step_avg:38.72ms
+step:745/1840 train_time:28865ms step_avg:38.75ms
+step:746/1840 train_time:28928ms step_avg:38.78ms
+step:747/1840 train_time:28989ms step_avg:38.81ms
+step:748/1840 train_time:29052ms step_avg:38.84ms
+step:749/1840 train_time:29112ms step_avg:38.87ms
+step:750/1840 train_time:29173ms step_avg:38.90ms
+step:750/1840 val_loss:4.0217 train_time:29245ms step_avg:38.99ms
+step:751/1840 train_time:29269ms step_avg:38.97ms
+step:752/1840 train_time:29297ms step_avg:38.96ms
+step:753/1840 train_time:29359ms step_avg:38.99ms
+step:754/1840 train_time:29424ms step_avg:39.02ms
+step:755/1840 train_time:29485ms step_avg:39.05ms
+step:756/1840 train_time:29548ms step_avg:39.09ms
+step:757/1840 train_time:29607ms step_avg:39.11ms
+step:758/1840 train_time:29668ms step_avg:39.14ms
+step:759/1840 train_time:29728ms step_avg:39.17ms
+step:760/1840 train_time:29789ms step_avg:39.20ms
+step:761/1840 train_time:29849ms step_avg:39.22ms
+step:762/1840 train_time:29910ms step_avg:39.25ms
+step:763/1840 train_time:29969ms step_avg:39.28ms
+step:764/1840 train_time:30032ms step_avg:39.31ms
+step:765/1840 train_time:30091ms step_avg:39.33ms
+step:766/1840 train_time:30153ms step_avg:39.36ms
+step:767/1840 train_time:30214ms step_avg:39.39ms
+step:768/1840 train_time:30277ms step_avg:39.42ms
+step:769/1840 train_time:30337ms step_avg:39.45ms
+step:770/1840 train_time:30401ms step_avg:39.48ms
+step:771/1840 train_time:30462ms step_avg:39.51ms
+step:772/1840 train_time:30526ms step_avg:39.54ms
+step:773/1840 train_time:30586ms step_avg:39.57ms
+step:774/1840 train_time:30647ms step_avg:39.60ms
+step:775/1840 train_time:30707ms step_avg:39.62ms
+step:776/1840 train_time:30768ms step_avg:39.65ms
+step:777/1840 train_time:30828ms step_avg:39.68ms
+step:778/1840 train_time:30889ms step_avg:39.70ms
+step:779/1840 train_time:30949ms step_avg:39.73ms
+step:780/1840 train_time:31011ms step_avg:39.76ms
+step:781/1840 train_time:31071ms step_avg:39.78ms
+step:782/1840 train_time:31132ms step_avg:39.81ms
+step:783/1840 train_time:31192ms step_avg:39.84ms
+step:784/1840 train_time:31254ms step_avg:39.87ms
+step:785/1840 train_time:31314ms step_avg:39.89ms
+step:786/1840 train_time:31378ms step_avg:39.92ms
+step:787/1840 train_time:31438ms step_avg:39.95ms
+step:788/1840 train_time:31500ms step_avg:39.97ms
+step:789/1840 train_time:31560ms step_avg:40.00ms
+step:790/1840 train_time:31622ms step_avg:40.03ms
+step:791/1840 train_time:31683ms step_avg:40.05ms
+step:792/1840 train_time:31745ms step_avg:40.08ms
+step:793/1840 train_time:31805ms step_avg:40.11ms
+step:794/1840 train_time:31868ms step_avg:40.14ms
+step:795/1840 train_time:31927ms step_avg:40.16ms
+step:796/1840 train_time:31989ms step_avg:40.19ms
+step:797/1840 train_time:32048ms step_avg:40.21ms
+step:798/1840 train_time:32110ms step_avg:40.24ms
+step:799/1840 train_time:32170ms step_avg:40.26ms
+step:800/1840 train_time:32233ms step_avg:40.29ms
+step:801/1840 train_time:32293ms step_avg:40.32ms
+step:802/1840 train_time:32355ms step_avg:40.34ms
+step:803/1840 train_time:32415ms step_avg:40.37ms
+step:804/1840 train_time:32478ms step_avg:40.40ms
+step:805/1840 train_time:32537ms step_avg:40.42ms
+step:806/1840 train_time:32599ms step_avg:40.45ms
+step:807/1840 train_time:32658ms step_avg:40.47ms
+step:808/1840 train_time:32720ms step_avg:40.50ms
+step:809/1840 train_time:32780ms step_avg:40.52ms
+step:810/1840 train_time:32842ms step_avg:40.55ms
+step:811/1840 train_time:32903ms step_avg:40.57ms
+step:812/1840 train_time:32966ms step_avg:40.60ms
+step:813/1840 train_time:33025ms step_avg:40.62ms
+step:814/1840 train_time:33087ms step_avg:40.65ms
+step:815/1840 train_time:33147ms step_avg:40.67ms
+step:816/1840 train_time:33210ms step_avg:40.70ms
+step:817/1840 train_time:33271ms step_avg:40.72ms
+step:818/1840 train_time:33333ms step_avg:40.75ms
+step:819/1840 train_time:33393ms step_avg:40.77ms
+step:820/1840 train_time:33455ms step_avg:40.80ms
+step:821/1840 train_time:33514ms step_avg:40.82ms
+step:822/1840 train_time:33577ms step_avg:40.85ms
+step:823/1840 train_time:33637ms step_avg:40.87ms
+step:824/1840 train_time:33699ms step_avg:40.90ms
+step:825/1840 train_time:33758ms step_avg:40.92ms
+step:826/1840 train_time:33821ms step_avg:40.95ms
+step:827/1840 train_time:33880ms step_avg:40.97ms
+step:828/1840 train_time:33942ms step_avg:40.99ms
+step:829/1840 train_time:34002ms step_avg:41.02ms
+step:830/1840 train_time:34065ms step_avg:41.04ms
+step:831/1840 train_time:34124ms step_avg:41.06ms
+step:832/1840 train_time:34187ms step_avg:41.09ms
+step:833/1840 train_time:34248ms step_avg:41.11ms
+step:834/1840 train_time:34310ms step_avg:41.14ms
+step:835/1840 train_time:34370ms step_avg:41.16ms
+step:836/1840 train_time:34434ms step_avg:41.19ms
+step:837/1840 train_time:34493ms step_avg:41.21ms
+step:838/1840 train_time:34556ms step_avg:41.24ms
+step:839/1840 train_time:34615ms step_avg:41.26ms
+step:840/1840 train_time:34678ms step_avg:41.28ms
+step:841/1840 train_time:34737ms step_avg:41.30ms
+step:842/1840 train_time:34799ms step_avg:41.33ms
+step:843/1840 train_time:34858ms step_avg:41.35ms
+step:844/1840 train_time:34920ms step_avg:41.37ms
+step:845/1840 train_time:34980ms step_avg:41.40ms
+step:846/1840 train_time:35043ms step_avg:41.42ms
+step:847/1840 train_time:35103ms step_avg:41.44ms
+step:848/1840 train_time:35166ms step_avg:41.47ms
+step:849/1840 train_time:35226ms step_avg:41.49ms
+step:850/1840 train_time:35288ms step_avg:41.52ms
+step:851/1840 train_time:35349ms step_avg:41.54ms
+step:852/1840 train_time:35412ms step_avg:41.56ms
+step:853/1840 train_time:35472ms step_avg:41.59ms
+step:854/1840 train_time:35534ms step_avg:41.61ms
+step:855/1840 train_time:35594ms step_avg:41.63ms
+step:856/1840 train_time:35657ms step_avg:41.66ms
+step:857/1840 train_time:35717ms step_avg:41.68ms
+step:858/1840 train_time:35779ms step_avg:41.70ms
+step:859/1840 train_time:35837ms step_avg:41.72ms
+step:860/1840 train_time:35900ms step_avg:41.74ms
+step:861/1840 train_time:35959ms step_avg:41.76ms
+step:862/1840 train_time:36021ms step_avg:41.79ms
+step:863/1840 train_time:36080ms step_avg:41.81ms
+step:864/1840 train_time:36143ms step_avg:41.83ms
+step:865/1840 train_time:36203ms step_avg:41.85ms
+step:866/1840 train_time:36266ms step_avg:41.88ms
+step:867/1840 train_time:36326ms step_avg:41.90ms
+step:868/1840 train_time:36389ms step_avg:41.92ms
+step:869/1840 train_time:36451ms step_avg:41.95ms
+step:870/1840 train_time:36513ms step_avg:41.97ms
+step:871/1840 train_time:36573ms step_avg:41.99ms
+step:872/1840 train_time:36634ms step_avg:42.01ms
+step:873/1840 train_time:36694ms step_avg:42.03ms
+step:874/1840 train_time:36756ms step_avg:42.06ms
+step:875/1840 train_time:36816ms step_avg:42.08ms
+step:876/1840 train_time:36878ms step_avg:42.10ms
+step:877/1840 train_time:36938ms step_avg:42.12ms
+step:878/1840 train_time:37000ms step_avg:42.14ms
+step:879/1840 train_time:37059ms step_avg:42.16ms
+step:880/1840 train_time:37121ms step_avg:42.18ms
+step:881/1840 train_time:37182ms step_avg:42.20ms
+step:882/1840 train_time:37245ms step_avg:42.23ms
+step:883/1840 train_time:37306ms step_avg:42.25ms
+step:884/1840 train_time:37368ms step_avg:42.27ms
+step:885/1840 train_time:37428ms step_avg:42.29ms
+step:886/1840 train_time:37492ms step_avg:42.32ms
+step:887/1840 train_time:37551ms step_avg:42.33ms
+step:888/1840 train_time:37613ms step_avg:42.36ms
+step:889/1840 train_time:37673ms step_avg:42.38ms
+step:890/1840 train_time:37734ms step_avg:42.40ms
+step:891/1840 train_time:37795ms step_avg:42.42ms
+step:892/1840 train_time:37858ms step_avg:42.44ms
+step:893/1840 train_time:37917ms step_avg:42.46ms
+step:894/1840 train_time:37979ms step_avg:42.48ms
+step:895/1840 train_time:38038ms step_avg:42.50ms
+step:896/1840 train_time:38100ms step_avg:42.52ms
+step:897/1840 train_time:38160ms step_avg:42.54ms
+step:898/1840 train_time:38222ms step_avg:42.56ms
+step:899/1840 train_time:38282ms step_avg:42.58ms
+step:900/1840 train_time:38346ms step_avg:42.61ms
+step:901/1840 train_time:38406ms step_avg:42.63ms
+step:902/1840 train_time:38469ms step_avg:42.65ms
+step:903/1840 train_time:38530ms step_avg:42.67ms
+step:904/1840 train_time:38592ms step_avg:42.69ms
+step:905/1840 train_time:38652ms step_avg:42.71ms
+step:906/1840 train_time:38714ms step_avg:42.73ms
+step:907/1840 train_time:38774ms step_avg:42.75ms
+step:908/1840 train_time:38836ms step_avg:42.77ms
+step:909/1840 train_time:38896ms step_avg:42.79ms
+step:910/1840 train_time:38958ms step_avg:42.81ms
+step:911/1840 train_time:39017ms step_avg:42.83ms
+step:912/1840 train_time:39080ms step_avg:42.85ms
+step:913/1840 train_time:39138ms step_avg:42.87ms
+step:914/1840 train_time:39201ms step_avg:42.89ms
+step:915/1840 train_time:39261ms step_avg:42.91ms
+step:916/1840 train_time:39323ms step_avg:42.93ms
+step:917/1840 train_time:39384ms step_avg:42.95ms
+step:918/1840 train_time:39447ms step_avg:42.97ms
+step:919/1840 train_time:39507ms step_avg:42.99ms
+step:920/1840 train_time:39570ms step_avg:43.01ms
+step:921/1840 train_time:39630ms step_avg:43.03ms
+step:922/1840 train_time:39692ms step_avg:43.05ms
+step:923/1840 train_time:39753ms step_avg:43.07ms
+step:924/1840 train_time:39814ms step_avg:43.09ms
+step:925/1840 train_time:39875ms step_avg:43.11ms
+step:926/1840 train_time:39937ms step_avg:43.13ms
+step:927/1840 train_time:39997ms step_avg:43.15ms
+step:928/1840 train_time:40059ms step_avg:43.17ms
+step:929/1840 train_time:40118ms step_avg:43.18ms
+step:930/1840 train_time:40181ms step_avg:43.20ms
+step:931/1840 train_time:40240ms step_avg:43.22ms
+step:932/1840 train_time:40303ms step_avg:43.24ms
+step:933/1840 train_time:40363ms step_avg:43.26ms
+step:934/1840 train_time:40425ms step_avg:43.28ms
+step:935/1840 train_time:40485ms step_avg:43.30ms
+step:936/1840 train_time:40548ms step_avg:43.32ms
+step:937/1840 train_time:40609ms step_avg:43.34ms
+step:938/1840 train_time:40673ms step_avg:43.36ms
+step:939/1840 train_time:40733ms step_avg:43.38ms
+step:940/1840 train_time:40795ms step_avg:43.40ms
+step:941/1840 train_time:40855ms step_avg:43.42ms
+step:942/1840 train_time:40917ms step_avg:43.44ms
+step:943/1840 train_time:40977ms step_avg:43.45ms
+step:944/1840 train_time:41039ms step_avg:43.47ms
+step:945/1840 train_time:41098ms step_avg:43.49ms
+step:946/1840 train_time:41160ms step_avg:43.51ms
+step:947/1840 train_time:41219ms step_avg:43.53ms
+step:948/1840 train_time:41282ms step_avg:43.55ms
+step:949/1840 train_time:41341ms step_avg:43.56ms
+step:950/1840 train_time:41404ms step_avg:43.58ms
+step:951/1840 train_time:41464ms step_avg:43.60ms
+step:952/1840 train_time:41527ms step_avg:43.62ms
+step:953/1840 train_time:41587ms step_avg:43.64ms
+step:954/1840 train_time:41651ms step_avg:43.66ms
+step:955/1840 train_time:41712ms step_avg:43.68ms
+step:956/1840 train_time:41774ms step_avg:43.70ms
+step:957/1840 train_time:41834ms step_avg:43.71ms
+step:958/1840 train_time:41895ms step_avg:43.73ms
+step:959/1840 train_time:41955ms step_avg:43.75ms
+step:960/1840 train_time:42017ms step_avg:43.77ms
+step:961/1840 train_time:42076ms step_avg:43.78ms
+step:962/1840 train_time:42138ms step_avg:43.80ms
+step:963/1840 train_time:42198ms step_avg:43.82ms
+step:964/1840 train_time:42261ms step_avg:43.84ms
+step:965/1840 train_time:42319ms step_avg:43.85ms
+step:966/1840 train_time:42382ms step_avg:43.87ms
+step:967/1840 train_time:42441ms step_avg:43.89ms
+step:968/1840 train_time:42504ms step_avg:43.91ms
+step:969/1840 train_time:42565ms step_avg:43.93ms
+step:970/1840 train_time:42628ms step_avg:43.95ms
+step:971/1840 train_time:42689ms step_avg:43.96ms
+step:972/1840 train_time:42751ms step_avg:43.98ms
+step:973/1840 train_time:42811ms step_avg:44.00ms
+step:974/1840 train_time:42874ms step_avg:44.02ms
+step:975/1840 train_time:42934ms step_avg:44.03ms
+step:976/1840 train_time:42995ms step_avg:44.05ms
+step:977/1840 train_time:43055ms step_avg:44.07ms
+step:978/1840 train_time:43116ms step_avg:44.09ms
+step:979/1840 train_time:43177ms step_avg:44.10ms
+step:980/1840 train_time:43238ms step_avg:44.12ms
+step:981/1840 train_time:43298ms step_avg:44.14ms
+step:982/1840 train_time:43361ms step_avg:44.16ms
+step:983/1840 train_time:43420ms step_avg:44.17ms
+step:984/1840 train_time:43483ms step_avg:44.19ms
+step:985/1840 train_time:43543ms step_avg:44.21ms
+step:986/1840 train_time:43606ms step_avg:44.23ms
+step:987/1840 train_time:43667ms step_avg:44.24ms
+step:988/1840 train_time:43730ms step_avg:44.26ms
+step:989/1840 train_time:43790ms step_avg:44.28ms
+step:990/1840 train_time:43853ms step_avg:44.30ms
+step:991/1840 train_time:43912ms step_avg:44.31ms
+step:992/1840 train_time:43974ms step_avg:44.33ms
+step:993/1840 train_time:44034ms step_avg:44.34ms
+step:994/1840 train_time:44096ms step_avg:44.36ms
+step:995/1840 train_time:44156ms step_avg:44.38ms
+step:996/1840 train_time:44217ms step_avg:44.39ms
+step:997/1840 train_time:44277ms step_avg:44.41ms
+step:998/1840 train_time:44339ms step_avg:44.43ms
+step:999/1840 train_time:44399ms step_avg:44.44ms
+step:1000/1840 train_time:44461ms step_avg:44.46ms
+step:1000/1840 val_loss:3.7699 train_time:44533ms step_avg:44.53ms
+step:1001/1840 train_time:44554ms step_avg:44.51ms
+step:1002/1840 train_time:44586ms step_avg:44.50ms
+step:1003/1840 train_time:44646ms step_avg:44.51ms
+step:1004/1840 train_time:44708ms step_avg:44.53ms
+step:1005/1840 train_time:44769ms step_avg:44.55ms
+step:1006/1840 train_time:44832ms step_avg:44.56ms
+step:1007/1840 train_time:44890ms step_avg:44.58ms
+step:1008/1840 train_time:44952ms step_avg:44.60ms
+step:1009/1840 train_time:45012ms step_avg:44.61ms
+step:1010/1840 train_time:45073ms step_avg:44.63ms
+step:1011/1840 train_time:45132ms step_avg:44.64ms
+step:1012/1840 train_time:45194ms step_avg:44.66ms
+step:1013/1840 train_time:45254ms step_avg:44.67ms
+step:1014/1840 train_time:45316ms step_avg:44.69ms
+step:1015/1840 train_time:45377ms step_avg:44.71ms
+step:1016/1840 train_time:45439ms step_avg:44.72ms
+step:1017/1840 train_time:45501ms step_avg:44.74ms
+step:1018/1840 train_time:45565ms step_avg:44.76ms
+step:1019/1840 train_time:45625ms step_avg:44.77ms
+step:1020/1840 train_time:45688ms step_avg:44.79ms
+step:1021/1840 train_time:45747ms step_avg:44.81ms
+step:1022/1840 train_time:45809ms step_avg:44.82ms
+step:1023/1840 train_time:45869ms step_avg:44.84ms
+step:1024/1840 train_time:45930ms step_avg:44.85ms
+step:1025/1840 train_time:45989ms step_avg:44.87ms
+step:1026/1840 train_time:46051ms step_avg:44.88ms
+step:1027/1840 train_time:46110ms step_avg:44.90ms
+step:1028/1840 train_time:46172ms step_avg:44.91ms
+step:1029/1840 train_time:46231ms step_avg:44.93ms
+step:1030/1840 train_time:46292ms step_avg:44.94ms
+step:1031/1840 train_time:46352ms step_avg:44.96ms
+step:1032/1840 train_time:46414ms step_avg:44.98ms
+step:1033/1840 train_time:46476ms step_avg:44.99ms
+step:1034/1840 train_time:46540ms step_avg:45.01ms
+step:1035/1840 train_time:46601ms step_avg:45.02ms
+step:1036/1840 train_time:46664ms step_avg:45.04ms
+step:1037/1840 train_time:46724ms step_avg:45.06ms
+step:1038/1840 train_time:46786ms step_avg:45.07ms
+step:1039/1840 train_time:46846ms step_avg:45.09ms
+step:1040/1840 train_time:46908ms step_avg:45.10ms
+step:1041/1840 train_time:46967ms step_avg:45.12ms
+step:1042/1840 train_time:47029ms step_avg:45.13ms
+step:1043/1840 train_time:47089ms step_avg:45.15ms
+step:1044/1840 train_time:47150ms step_avg:45.16ms
+step:1045/1840 train_time:47210ms step_avg:45.18ms
+step:1046/1840 train_time:47272ms step_avg:45.19ms
+step:1047/1840 train_time:47331ms step_avg:45.21ms
+step:1048/1840 train_time:47393ms step_avg:45.22ms
+step:1049/1840 train_time:47452ms step_avg:45.24ms
+step:1050/1840 train_time:47515ms step_avg:45.25ms
+step:1051/1840 train_time:47577ms step_avg:45.27ms
+step:1052/1840 train_time:47640ms step_avg:45.29ms
+step:1053/1840 train_time:47700ms step_avg:45.30ms
+step:1054/1840 train_time:47764ms step_avg:45.32ms
+step:1055/1840 train_time:47823ms step_avg:45.33ms
+step:1056/1840 train_time:47886ms step_avg:45.35ms
+step:1057/1840 train_time:47945ms step_avg:45.36ms
+step:1058/1840 train_time:48008ms step_avg:45.38ms
+step:1059/1840 train_time:48067ms step_avg:45.39ms
+step:1060/1840 train_time:48128ms step_avg:45.40ms
+step:1061/1840 train_time:48188ms step_avg:45.42ms
+step:1062/1840 train_time:48251ms step_avg:45.43ms
+step:1063/1840 train_time:48310ms step_avg:45.45ms
+step:1064/1840 train_time:48372ms step_avg:45.46ms
+step:1065/1840 train_time:48431ms step_avg:45.48ms
+step:1066/1840 train_time:48494ms step_avg:45.49ms
+step:1067/1840 train_time:48556ms step_avg:45.51ms
+step:1068/1840 train_time:48620ms step_avg:45.52ms
+step:1069/1840 train_time:48680ms step_avg:45.54ms
+step:1070/1840 train_time:48743ms step_avg:45.55ms
+step:1071/1840 train_time:48803ms step_avg:45.57ms
+step:1072/1840 train_time:48865ms step_avg:45.58ms
+step:1073/1840 train_time:48925ms step_avg:45.60ms
+step:1074/1840 train_time:48987ms step_avg:45.61ms
+step:1075/1840 train_time:49046ms step_avg:45.62ms
+step:1076/1840 train_time:49109ms step_avg:45.64ms
+step:1077/1840 train_time:49168ms step_avg:45.65ms
+step:1078/1840 train_time:49230ms step_avg:45.67ms
+step:1079/1840 train_time:49290ms step_avg:45.68ms
+step:1080/1840 train_time:49352ms step_avg:45.70ms
+step:1081/1840 train_time:49412ms step_avg:45.71ms
+step:1082/1840 train_time:49473ms step_avg:45.72ms
+step:1083/1840 train_time:49534ms step_avg:45.74ms
+step:1084/1840 train_time:49597ms step_avg:45.75ms
+step:1085/1840 train_time:49659ms step_avg:45.77ms
+step:1086/1840 train_time:49720ms step_avg:45.78ms
+step:1087/1840 train_time:49781ms step_avg:45.80ms
+step:1088/1840 train_time:49844ms step_avg:45.81ms
+step:1089/1840 train_time:49904ms step_avg:45.83ms
+step:1090/1840 train_time:49966ms step_avg:45.84ms
+step:1091/1840 train_time:50026ms step_avg:45.85ms
+step:1092/1840 train_time:50088ms step_avg:45.87ms
+step:1093/1840 train_time:50147ms step_avg:45.88ms
+step:1094/1840 train_time:50209ms step_avg:45.89ms
+step:1095/1840 train_time:50268ms step_avg:45.91ms
+step:1096/1840 train_time:50331ms step_avg:45.92ms
+step:1097/1840 train_time:50390ms step_avg:45.93ms
+step:1098/1840 train_time:50453ms step_avg:45.95ms
+step:1099/1840 train_time:50512ms step_avg:45.96ms
+step:1100/1840 train_time:50575ms step_avg:45.98ms
+step:1101/1840 train_time:50635ms step_avg:45.99ms
+step:1102/1840 train_time:50698ms step_avg:46.01ms
+step:1103/1840 train_time:50760ms step_avg:46.02ms
+step:1104/1840 train_time:50822ms step_avg:46.03ms
+step:1105/1840 train_time:50883ms step_avg:46.05ms
+step:1106/1840 train_time:50945ms step_avg:46.06ms
+step:1107/1840 train_time:51005ms step_avg:46.08ms
+step:1108/1840 train_time:51067ms step_avg:46.09ms
+step:1109/1840 train_time:51127ms step_avg:46.10ms
+step:1110/1840 train_time:51190ms step_avg:46.12ms
+step:1111/1840 train_time:51249ms step_avg:46.13ms
+step:1112/1840 train_time:51310ms step_avg:46.14ms
+step:1113/1840 train_time:51369ms step_avg:46.15ms
+step:1114/1840 train_time:51432ms step_avg:46.17ms
+step:1115/1840 train_time:51492ms step_avg:46.18ms
+step:1116/1840 train_time:51553ms step_avg:46.19ms
+step:1117/1840 train_time:51613ms step_avg:46.21ms
+step:1118/1840 train_time:51675ms step_avg:46.22ms
+step:1119/1840 train_time:51736ms step_avg:46.23ms
+step:1120/1840 train_time:51799ms step_avg:46.25ms
+step:1121/1840 train_time:51859ms step_avg:46.26ms
+step:1122/1840 train_time:51922ms step_avg:46.28ms
+step:1123/1840 train_time:51983ms step_avg:46.29ms
+step:1124/1840 train_time:52045ms step_avg:46.30ms
+step:1125/1840 train_time:52105ms step_avg:46.32ms
+step:1126/1840 train_time:52167ms step_avg:46.33ms
+step:1127/1840 train_time:52226ms step_avg:46.34ms
+step:1128/1840 train_time:52289ms step_avg:46.36ms
+step:1129/1840 train_time:52348ms step_avg:46.37ms
+step:1130/1840 train_time:52411ms step_avg:46.38ms
+step:1131/1840 train_time:52470ms step_avg:46.39ms
+step:1132/1840 train_time:52532ms step_avg:46.41ms
+step:1133/1840 train_time:52592ms step_avg:46.42ms
+step:1134/1840 train_time:52654ms step_avg:46.43ms
+step:1135/1840 train_time:52714ms step_avg:46.44ms
+step:1136/1840 train_time:52776ms step_avg:46.46ms
+step:1137/1840 train_time:52837ms step_avg:46.47ms
+step:1138/1840 train_time:52900ms step_avg:46.49ms
+step:1139/1840 train_time:52961ms step_avg:46.50ms
+step:1140/1840 train_time:53024ms step_avg:46.51ms
+step:1141/1840 train_time:53085ms step_avg:46.52ms
+step:1142/1840 train_time:53146ms step_avg:46.54ms
+step:1143/1840 train_time:53206ms step_avg:46.55ms
+step:1144/1840 train_time:53268ms step_avg:46.56ms
+step:1145/1840 train_time:53327ms step_avg:46.57ms
+step:1146/1840 train_time:53390ms step_avg:46.59ms
+step:1147/1840 train_time:53449ms step_avg:46.60ms
+step:1148/1840 train_time:53511ms step_avg:46.61ms
+step:1149/1840 train_time:53571ms step_avg:46.62ms
+step:1150/1840 train_time:53633ms step_avg:46.64ms
+step:1151/1840 train_time:53692ms step_avg:46.65ms
+step:1152/1840 train_time:53754ms step_avg:46.66ms
+step:1153/1840 train_time:53814ms step_avg:46.67ms
+step:1154/1840 train_time:53878ms step_avg:46.69ms
+step:1155/1840 train_time:53938ms step_avg:46.70ms
+step:1156/1840 train_time:54001ms step_avg:46.71ms
+step:1157/1840 train_time:54061ms step_avg:46.73ms
+step:1158/1840 train_time:54125ms step_avg:46.74ms
+step:1159/1840 train_time:54185ms step_avg:46.75ms
+step:1160/1840 train_time:54246ms step_avg:46.76ms
+step:1161/1840 train_time:54306ms step_avg:46.78ms
+step:1162/1840 train_time:54368ms step_avg:46.79ms
+step:1163/1840 train_time:54428ms step_avg:46.80ms
+step:1164/1840 train_time:54491ms step_avg:46.81ms
+step:1165/1840 train_time:54550ms step_avg:46.82ms
+step:1166/1840 train_time:54612ms step_avg:46.84ms
+step:1167/1840 train_time:54671ms step_avg:46.85ms
+step:1168/1840 train_time:54734ms step_avg:46.86ms
+step:1169/1840 train_time:54793ms step_avg:46.87ms
+step:1170/1840 train_time:54856ms step_avg:46.89ms
+step:1171/1840 train_time:54917ms step_avg:46.90ms
+step:1172/1840 train_time:54979ms step_avg:46.91ms
+step:1173/1840 train_time:55039ms step_avg:46.92ms
+step:1174/1840 train_time:55103ms step_avg:46.94ms
+step:1175/1840 train_time:55163ms step_avg:46.95ms
+step:1176/1840 train_time:55225ms step_avg:46.96ms
+step:1177/1840 train_time:55285ms step_avg:46.97ms
+step:1178/1840 train_time:55347ms step_avg:46.98ms
+step:1179/1840 train_time:55406ms step_avg:46.99ms
+step:1180/1840 train_time:55468ms step_avg:47.01ms
+step:1181/1840 train_time:55528ms step_avg:47.02ms
+step:1182/1840 train_time:55589ms step_avg:47.03ms
+step:1183/1840 train_time:55649ms step_avg:47.04ms
+step:1184/1840 train_time:55712ms step_avg:47.05ms
+step:1185/1840 train_time:55771ms step_avg:47.06ms
+step:1186/1840 train_time:55834ms step_avg:47.08ms
+step:1187/1840 train_time:55893ms step_avg:47.09ms
+step:1188/1840 train_time:55956ms step_avg:47.10ms
+step:1189/1840 train_time:56016ms step_avg:47.11ms
+step:1190/1840 train_time:56079ms step_avg:47.13ms
+step:1191/1840 train_time:56140ms step_avg:47.14ms
+step:1192/1840 train_time:56203ms step_avg:47.15ms
+step:1193/1840 train_time:56263ms step_avg:47.16ms
+step:1194/1840 train_time:56325ms step_avg:47.17ms
+step:1195/1840 train_time:56386ms step_avg:47.18ms
+step:1196/1840 train_time:56447ms step_avg:47.20ms
+step:1197/1840 train_time:56507ms step_avg:47.21ms
+step:1198/1840 train_time:56568ms step_avg:47.22ms
+step:1199/1840 train_time:56628ms step_avg:47.23ms
+step:1200/1840 train_time:56691ms step_avg:47.24ms
+step:1201/1840 train_time:56751ms step_avg:47.25ms
+step:1202/1840 train_time:56835ms step_avg:47.28ms
+step:1203/1840 train_time:56923ms step_avg:47.32ms
+step:1204/1840 train_time:57013ms step_avg:47.35ms
+step:1205/1840 train_time:57099ms step_avg:47.39ms
+step:1206/1840 train_time:57191ms step_avg:47.42ms
+step:1207/1840 train_time:57278ms step_avg:47.45ms
+step:1208/1840 train_time:57367ms step_avg:47.49ms
+step:1209/1840 train_time:57455ms step_avg:47.52ms
+step:1210/1840 train_time:57545ms step_avg:47.56ms
+step:1211/1840 train_time:57631ms step_avg:47.59ms
+step:1212/1840 train_time:57718ms step_avg:47.62ms
+step:1213/1840 train_time:57805ms step_avg:47.65ms
+step:1214/1840 train_time:57894ms step_avg:47.69ms
+step:1215/1840 train_time:57980ms step_avg:47.72ms
+step:1216/1840 train_time:58068ms step_avg:47.75ms
+step:1217/1840 train_time:58155ms step_avg:47.79ms
+step:1218/1840 train_time:58244ms step_avg:47.82ms
+step:1219/1840 train_time:58331ms step_avg:47.85ms
+step:1220/1840 train_time:58421ms step_avg:47.89ms
+step:1221/1840 train_time:58508ms step_avg:47.92ms
+step:1222/1840 train_time:58596ms step_avg:47.95ms
+step:1223/1840 train_time:58683ms step_avg:47.98ms
+step:1224/1840 train_time:58772ms step_avg:48.02ms
+step:1225/1840 train_time:58858ms step_avg:48.05ms
+step:1226/1840 train_time:58948ms step_avg:48.08ms
+step:1227/1840 train_time:59035ms step_avg:48.11ms
+step:1228/1840 train_time:59123ms step_avg:48.15ms
+step:1229/1840 train_time:59209ms step_avg:48.18ms
+step:1230/1840 train_time:59299ms step_avg:48.21ms
+step:1231/1840 train_time:59387ms step_avg:48.24ms
+step:1232/1840 train_time:59476ms step_avg:48.28ms
+step:1233/1840 train_time:59561ms step_avg:48.31ms
+step:1234/1840 train_time:59650ms step_avg:48.34ms
+step:1235/1840 train_time:59736ms step_avg:48.37ms
+step:1236/1840 train_time:59825ms step_avg:48.40ms
+step:1237/1840 train_time:59912ms step_avg:48.43ms
+step:1238/1840 train_time:60002ms step_avg:48.47ms
+step:1239/1840 train_time:60087ms step_avg:48.50ms
+step:1240/1840 train_time:60175ms step_avg:48.53ms
+step:1241/1840 train_time:60261ms step_avg:48.56ms
+step:1242/1840 train_time:60350ms step_avg:48.59ms
+step:1243/1840 train_time:60436ms step_avg:48.62ms
+step:1244/1840 train_time:60526ms step_avg:48.65ms
+step:1245/1840 train_time:60612ms step_avg:48.68ms
+step:1246/1840 train_time:60701ms step_avg:48.72ms
+step:1247/1840 train_time:60788ms step_avg:48.75ms
+step:1248/1840 train_time:60876ms step_avg:48.78ms
+step:1249/1840 train_time:60963ms step_avg:48.81ms
+step:1250/1840 train_time:61052ms step_avg:48.84ms
+step:1250/1840 val_loss:3.5335 train_time:61153ms step_avg:48.92ms
+step:1251/1840 train_time:61172ms step_avg:48.90ms
+step:1252/1840 train_time:61230ms step_avg:48.91ms
+step:1253/1840 train_time:61322ms step_avg:48.94ms
+step:1254/1840 train_time:61411ms step_avg:48.97ms
+step:1255/1840 train_time:61498ms step_avg:49.00ms
+step:1256/1840 train_time:61585ms step_avg:49.03ms
+step:1257/1840 train_time:61669ms step_avg:49.06ms
+step:1258/1840 train_time:61756ms step_avg:49.09ms
+step:1259/1840 train_time:61841ms step_avg:49.12ms
+step:1260/1840 train_time:61928ms step_avg:49.15ms
+step:1261/1840 train_time:62015ms step_avg:49.18ms
+step:1262/1840 train_time:62104ms step_avg:49.21ms
+step:1263/1840 train_time:62192ms step_avg:49.24ms
+step:1264/1840 train_time:62286ms step_avg:49.28ms
+step:1265/1840 train_time:62374ms step_avg:49.31ms
+step:1266/1840 train_time:62464ms step_avg:49.34ms
+step:1267/1840 train_time:62550ms step_avg:49.37ms
+step:1268/1840 train_time:62637ms step_avg:49.40ms
+step:1269/1840 train_time:62723ms step_avg:49.43ms
+step:1270/1840 train_time:62809ms step_avg:49.46ms
+step:1271/1840 train_time:62894ms step_avg:49.48ms
+step:1272/1840 train_time:62982ms step_avg:49.51ms
+step:1273/1840 train_time:63069ms step_avg:49.54ms
+step:1274/1840 train_time:63161ms step_avg:49.58ms
+step:1275/1840 train_time:63248ms step_avg:49.61ms
+step:1276/1840 train_time:63339ms step_avg:49.64ms
+step:1277/1840 train_time:63426ms step_avg:49.67ms
+step:1278/1840 train_time:63515ms step_avg:49.70ms
+step:1279/1840 train_time:63600ms step_avg:49.73ms
+step:1280/1840 train_time:63688ms step_avg:49.76ms
+step:1281/1840 train_time:63773ms step_avg:49.78ms
+step:1282/1840 train_time:63860ms step_avg:49.81ms
+step:1283/1840 train_time:63946ms step_avg:49.84ms
+step:1284/1840 train_time:64033ms step_avg:49.87ms
+step:1285/1840 train_time:64120ms step_avg:49.90ms
+step:1286/1840 train_time:64210ms step_avg:49.93ms
+step:1287/1840 train_time:64298ms step_avg:49.96ms
+step:1288/1840 train_time:64388ms step_avg:49.99ms
+step:1289/1840 train_time:64475ms step_avg:50.02ms
+step:1290/1840 train_time:64564ms step_avg:50.05ms
+step:1291/1840 train_time:64649ms step_avg:50.08ms
+step:1292/1840 train_time:64737ms step_avg:50.11ms
+step:1293/1840 train_time:64822ms step_avg:50.13ms
+step:1294/1840 train_time:64909ms step_avg:50.16ms
+step:1295/1840 train_time:64995ms step_avg:50.19ms
+step:1296/1840 train_time:65085ms step_avg:50.22ms
+step:1297/1840 train_time:65172ms step_avg:50.25ms
+step:1298/1840 train_time:65262ms step_avg:50.28ms
+step:1299/1840 train_time:65348ms step_avg:50.31ms
+step:1300/1840 train_time:65437ms step_avg:50.34ms
+step:1301/1840 train_time:65525ms step_avg:50.36ms
+step:1302/1840 train_time:65613ms step_avg:50.39ms
+step:1303/1840 train_time:65698ms step_avg:50.42ms
+step:1304/1840 train_time:65786ms step_avg:50.45ms
+step:1305/1840 train_time:65871ms step_avg:50.48ms
+step:1306/1840 train_time:65960ms step_avg:50.51ms
+step:1307/1840 train_time:66046ms step_avg:50.53ms
+step:1308/1840 train_time:66136ms step_avg:50.56ms
+step:1309/1840 train_time:66223ms step_avg:50.59ms
+step:1310/1840 train_time:66312ms step_avg:50.62ms
+step:1311/1840 train_time:66399ms step_avg:50.65ms
+step:1312/1840 train_time:66486ms step_avg:50.68ms
+step:1313/1840 train_time:66573ms step_avg:50.70ms
+step:1314/1840 train_time:66663ms step_avg:50.73ms
+step:1315/1840 train_time:66748ms step_avg:50.76ms
+step:1316/1840 train_time:66835ms step_avg:50.79ms
+step:1317/1840 train_time:66921ms step_avg:50.81ms
+step:1318/1840 train_time:67009ms step_avg:50.84ms
+step:1319/1840 train_time:67096ms step_avg:50.87ms
+step:1320/1840 train_time:67186ms step_avg:50.90ms
+step:1321/1840 train_time:67271ms step_avg:50.92ms
+step:1322/1840 train_time:67362ms step_avg:50.95ms
+step:1323/1840 train_time:67448ms step_avg:50.98ms
+step:1324/1840 train_time:67536ms step_avg:51.01ms
+step:1325/1840 train_time:67622ms step_avg:51.04ms
+step:1326/1840 train_time:67710ms step_avg:51.06ms
+step:1327/1840 train_time:67797ms step_avg:51.09ms
+step:1328/1840 train_time:67886ms step_avg:51.12ms
+step:1329/1840 train_time:67971ms step_avg:51.14ms
+step:1330/1840 train_time:68060ms step_avg:51.17ms
+step:1331/1840 train_time:68147ms step_avg:51.20ms
+step:1332/1840 train_time:68236ms step_avg:51.23ms
+step:1333/1840 train_time:68323ms step_avg:51.25ms
+step:1334/1840 train_time:68410ms step_avg:51.28ms
+step:1335/1840 train_time:68497ms step_avg:51.31ms
+step:1336/1840 train_time:68586ms step_avg:51.34ms
+step:1337/1840 train_time:68671ms step_avg:51.36ms
+step:1338/1840 train_time:68762ms step_avg:51.39ms
+step:1339/1840 train_time:68847ms step_avg:51.42ms
+step:1340/1840 train_time:68936ms step_avg:51.44ms
+step:1341/1840 train_time:69022ms step_avg:51.47ms
+step:1342/1840 train_time:69110ms step_avg:51.50ms
+step:1343/1840 train_time:69196ms step_avg:51.52ms
+step:1344/1840 train_time:69286ms step_avg:51.55ms
+step:1345/1840 train_time:69373ms step_avg:51.58ms
+step:1346/1840 train_time:69462ms step_avg:51.61ms
+step:1347/1840 train_time:69548ms step_avg:51.63ms
+step:1348/1840 train_time:69636ms step_avg:51.66ms
+step:1349/1840 train_time:69723ms step_avg:51.68ms
+step:1350/1840 train_time:69811ms step_avg:51.71ms
+step:1351/1840 train_time:69897ms step_avg:51.74ms
+step:1352/1840 train_time:69987ms step_avg:51.77ms
+step:1353/1840 train_time:70073ms step_avg:51.79ms
+step:1354/1840 train_time:70163ms step_avg:51.82ms
+step:1355/1840 train_time:70248ms step_avg:51.84ms
+step:1356/1840 train_time:70337ms step_avg:51.87ms
+step:1357/1840 train_time:70424ms step_avg:51.90ms
+step:1358/1840 train_time:70512ms step_avg:51.92ms
+step:1359/1840 train_time:70598ms step_avg:51.95ms
+step:1360/1840 train_time:70688ms step_avg:51.98ms
+step:1361/1840 train_time:70774ms step_avg:52.00ms
+step:1362/1840 train_time:70862ms step_avg:52.03ms
+step:1363/1840 train_time:70947ms step_avg:52.05ms
+step:1364/1840 train_time:71035ms step_avg:52.08ms
+step:1365/1840 train_time:71122ms step_avg:52.10ms
+step:1366/1840 train_time:71211ms step_avg:52.13ms
+step:1367/1840 train_time:71297ms step_avg:52.16ms
+step:1368/1840 train_time:71387ms step_avg:52.18ms
+step:1369/1840 train_time:71473ms step_avg:52.21ms
+step:1370/1840 train_time:71562ms step_avg:52.24ms
+step:1371/1840 train_time:71648ms step_avg:52.26ms
+step:1372/1840 train_time:71737ms step_avg:52.29ms
+step:1373/1840 train_time:71823ms step_avg:52.31ms
+step:1374/1840 train_time:71911ms step_avg:52.34ms
+step:1375/1840 train_time:71997ms step_avg:52.36ms
+step:1376/1840 train_time:72086ms step_avg:52.39ms
+step:1377/1840 train_time:72171ms step_avg:52.41ms
+step:1378/1840 train_time:72262ms step_avg:52.44ms
+step:1379/1840 train_time:72348ms step_avg:52.46ms
+step:1380/1840 train_time:72437ms step_avg:52.49ms
+step:1381/1840 train_time:72523ms step_avg:52.52ms
+step:1382/1840 train_time:72611ms step_avg:52.54ms
+step:1383/1840 train_time:72699ms step_avg:52.57ms
+step:1384/1840 train_time:72787ms step_avg:52.59ms
+step:1385/1840 train_time:72873ms step_avg:52.62ms
+step:1386/1840 train_time:72963ms step_avg:52.64ms
+step:1387/1840 train_time:73049ms step_avg:52.67ms
+step:1388/1840 train_time:73139ms step_avg:52.69ms
+step:1389/1840 train_time:73226ms step_avg:52.72ms
+step:1390/1840 train_time:73314ms step_avg:52.74ms
+step:1391/1840 train_time:73400ms step_avg:52.77ms
+step:1392/1840 train_time:73489ms step_avg:52.79ms
+step:1393/1840 train_time:73576ms step_avg:52.82ms
+step:1394/1840 train_time:73665ms step_avg:52.84ms
+step:1395/1840 train_time:73750ms step_avg:52.87ms
+step:1396/1840 train_time:73838ms step_avg:52.89ms
+step:1397/1840 train_time:73924ms step_avg:52.92ms
+step:1398/1840 train_time:74013ms step_avg:52.94ms
+step:1399/1840 train_time:74099ms step_avg:52.97ms
+step:1400/1840 train_time:74187ms step_avg:52.99ms
+step:1401/1840 train_time:74272ms step_avg:53.01ms
+step:1402/1840 train_time:74362ms step_avg:53.04ms
+step:1403/1840 train_time:74447ms step_avg:53.06ms
+step:1404/1840 train_time:74537ms step_avg:53.09ms
+step:1405/1840 train_time:74624ms step_avg:53.11ms
+step:1406/1840 train_time:74712ms step_avg:53.14ms
+step:1407/1840 train_time:74799ms step_avg:53.16ms
+step:1408/1840 train_time:74887ms step_avg:53.19ms
+step:1409/1840 train_time:74973ms step_avg:53.21ms
+step:1410/1840 train_time:75062ms step_avg:53.24ms
+step:1411/1840 train_time:75148ms step_avg:53.26ms
+step:1412/1840 train_time:75236ms step_avg:53.28ms
+step:1413/1840 train_time:75323ms step_avg:53.31ms
+step:1414/1840 train_time:75411ms step_avg:53.33ms
+step:1415/1840 train_time:75498ms step_avg:53.36ms
+step:1416/1840 train_time:75587ms step_avg:53.38ms
+step:1417/1840 train_time:75673ms step_avg:53.40ms
+step:1418/1840 train_time:75762ms step_avg:53.43ms
+step:1419/1840 train_time:75847ms step_avg:53.45ms
+step:1420/1840 train_time:75936ms step_avg:53.48ms
+step:1421/1840 train_time:76022ms step_avg:53.50ms
+step:1422/1840 train_time:76109ms step_avg:53.52ms
+step:1423/1840 train_time:76195ms step_avg:53.55ms
+step:1424/1840 train_time:76284ms step_avg:53.57ms
+step:1425/1840 train_time:76370ms step_avg:53.59ms
+step:1426/1840 train_time:76458ms step_avg:53.62ms
+step:1427/1840 train_time:76544ms step_avg:53.64ms
+step:1428/1840 train_time:76634ms step_avg:53.66ms
+step:1429/1840 train_time:76720ms step_avg:53.69ms
+step:1430/1840 train_time:76808ms step_avg:53.71ms
+step:1431/1840 train_time:76894ms step_avg:53.73ms
+step:1432/1840 train_time:76984ms step_avg:53.76ms
+step:1433/1840 train_time:77071ms step_avg:53.78ms
+step:1434/1840 train_time:77160ms step_avg:53.81ms
+step:1435/1840 train_time:77245ms step_avg:53.83ms
+step:1436/1840 train_time:77334ms step_avg:53.85ms
+step:1437/1840 train_time:77420ms step_avg:53.88ms
+step:1438/1840 train_time:77508ms step_avg:53.90ms
+step:1439/1840 train_time:77594ms step_avg:53.92ms
+step:1440/1840 train_time:77684ms step_avg:53.95ms
+step:1441/1840 train_time:77771ms step_avg:53.97ms
+step:1442/1840 train_time:77859ms step_avg:53.99ms
+step:1443/1840 train_time:77945ms step_avg:54.02ms
+step:1444/1840 train_time:78033ms step_avg:54.04ms
+step:1445/1840 train_time:78119ms step_avg:54.06ms
+step:1446/1840 train_time:78208ms step_avg:54.09ms
+step:1447/1840 train_time:78293ms step_avg:54.11ms
+step:1448/1840 train_time:78382ms step_avg:54.13ms
+step:1449/1840 train_time:78469ms step_avg:54.15ms
+step:1450/1840 train_time:78558ms step_avg:54.18ms
+step:1451/1840 train_time:78644ms step_avg:54.20ms
+step:1452/1840 train_time:78733ms step_avg:54.22ms
+step:1453/1840 train_time:78819ms step_avg:54.25ms
+step:1454/1840 train_time:78907ms step_avg:54.27ms
+step:1455/1840 train_time:78993ms step_avg:54.29ms
+step:1456/1840 train_time:79083ms step_avg:54.32ms
+step:1457/1840 train_time:79168ms step_avg:54.34ms
+step:1458/1840 train_time:79257ms step_avg:54.36ms
+step:1459/1840 train_time:79344ms step_avg:54.38ms
+step:1460/1840 train_time:79433ms step_avg:54.41ms
+step:1461/1840 train_time:79519ms step_avg:54.43ms
+step:1462/1840 train_time:79607ms step_avg:54.45ms
+step:1463/1840 train_time:79693ms step_avg:54.47ms
+step:1464/1840 train_time:79781ms step_avg:54.50ms
+step:1465/1840 train_time:79868ms step_avg:54.52ms
+step:1466/1840 train_time:79957ms step_avg:54.54ms
+step:1467/1840 train_time:80044ms step_avg:54.56ms
+step:1468/1840 train_time:80133ms step_avg:54.59ms
+step:1469/1840 train_time:80219ms step_avg:54.61ms
+step:1470/1840 train_time:80307ms step_avg:54.63ms
+step:1471/1840 train_time:80393ms step_avg:54.65ms
+step:1472/1840 train_time:80482ms step_avg:54.68ms
+step:1473/1840 train_time:80567ms step_avg:54.70ms
+step:1474/1840 train_time:80656ms step_avg:54.72ms
+step:1475/1840 train_time:80744ms step_avg:54.74ms
+step:1476/1840 train_time:80833ms step_avg:54.76ms
+step:1477/1840 train_time:80918ms step_avg:54.79ms
+step:1478/1840 train_time:81006ms step_avg:54.81ms
+step:1479/1840 train_time:81092ms step_avg:54.83ms
+step:1480/1840 train_time:81181ms step_avg:54.85ms
+step:1481/1840 train_time:81267ms step_avg:54.87ms
+step:1482/1840 train_time:81356ms step_avg:54.90ms
+step:1483/1840 train_time:81443ms step_avg:54.92ms
+step:1484/1840 train_time:81532ms step_avg:54.94ms
+step:1485/1840 train_time:81617ms step_avg:54.96ms
+step:1486/1840 train_time:81706ms step_avg:54.98ms
+step:1487/1840 train_time:81791ms step_avg:55.00ms
+step:1488/1840 train_time:81882ms step_avg:55.03ms
+step:1489/1840 train_time:81967ms step_avg:55.05ms
+step:1490/1840 train_time:82055ms step_avg:55.07ms
+step:1491/1840 train_time:82142ms step_avg:55.09ms
+step:1492/1840 train_time:82232ms step_avg:55.11ms
+step:1493/1840 train_time:82318ms step_avg:55.14ms
+step:1494/1840 train_time:82406ms step_avg:55.16ms
+step:1495/1840 train_time:82492ms step_avg:55.18ms
+step:1496/1840 train_time:82581ms step_avg:55.20ms
+step:1497/1840 train_time:82667ms step_avg:55.22ms
+step:1498/1840 train_time:82756ms step_avg:55.24ms
+step:1499/1840 train_time:82842ms step_avg:55.26ms
+step:1500/1840 train_time:82929ms step_avg:55.29ms
+step:1500/1840 val_loss:3.4017 train_time:83030ms step_avg:55.35ms
+step:1501/1840 train_time:83049ms step_avg:55.33ms
+step:1502/1840 train_time:83108ms step_avg:55.33ms
+step:1503/1840 train_time:83199ms step_avg:55.36ms
+step:1504/1840 train_time:83288ms step_avg:55.38ms
+step:1505/1840 train_time:83372ms step_avg:55.40ms
+step:1506/1840 train_time:83461ms step_avg:55.42ms
+step:1507/1840 train_time:83546ms step_avg:55.44ms
+step:1508/1840 train_time:83634ms step_avg:55.46ms
+step:1509/1840 train_time:83718ms step_avg:55.48ms
+step:1510/1840 train_time:83808ms step_avg:55.50ms
+step:1511/1840 train_time:83894ms step_avg:55.52ms
+step:1512/1840 train_time:83983ms step_avg:55.54ms
+step:1513/1840 train_time:84071ms step_avg:55.57ms
+step:1514/1840 train_time:84162ms step_avg:55.59ms
+step:1515/1840 train_time:84249ms step_avg:55.61ms
+step:1516/1840 train_time:84337ms step_avg:55.63ms
+step:1517/1840 train_time:84423ms step_avg:55.65ms
+step:1518/1840 train_time:84510ms step_avg:55.67ms
+step:1519/1840 train_time:84596ms step_avg:55.69ms
+step:1520/1840 train_time:84684ms step_avg:55.71ms
+step:1521/1840 train_time:84768ms step_avg:55.73ms
+step:1522/1840 train_time:84857ms step_avg:55.75ms
+step:1523/1840 train_time:84942ms step_avg:55.77ms
+step:1524/1840 train_time:85034ms step_avg:55.80ms
+step:1525/1840 train_time:85121ms step_avg:55.82ms
+step:1526/1840 train_time:85213ms step_avg:55.84ms
+step:1527/1840 train_time:85299ms step_avg:55.86ms
+step:1528/1840 train_time:85387ms step_avg:55.88ms
+step:1529/1840 train_time:85474ms step_avg:55.90ms
+step:1530/1840 train_time:85561ms step_avg:55.92ms
+step:1531/1840 train_time:85646ms step_avg:55.94ms
+step:1532/1840 train_time:85734ms step_avg:55.96ms
+step:1533/1840 train_time:85818ms step_avg:55.98ms
+step:1534/1840 train_time:85907ms step_avg:56.00ms
+step:1535/1840 train_time:85995ms step_avg:56.02ms
+step:1536/1840 train_time:86086ms step_avg:56.05ms
+step:1537/1840 train_time:86174ms step_avg:56.07ms
+step:1538/1840 train_time:86264ms step_avg:56.09ms
+step:1539/1840 train_time:86349ms step_avg:56.11ms
+step:1540/1840 train_time:86439ms step_avg:56.13ms
+step:1541/1840 train_time:86524ms step_avg:56.15ms
+step:1542/1840 train_time:86612ms step_avg:56.17ms
+step:1543/1840 train_time:86697ms step_avg:56.19ms
+step:1544/1840 train_time:86786ms step_avg:56.21ms
+step:1545/1840 train_time:86873ms step_avg:56.23ms
+step:1546/1840 train_time:86963ms step_avg:56.25ms
+step:1547/1840 train_time:87048ms step_avg:56.27ms
+step:1548/1840 train_time:87137ms step_avg:56.29ms
+step:1549/1840 train_time:87224ms step_avg:56.31ms
+step:1550/1840 train_time:87313ms step_avg:56.33ms
+step:1551/1840 train_time:87399ms step_avg:56.35ms
+step:1552/1840 train_time:87489ms step_avg:56.37ms
+step:1553/1840 train_time:87574ms step_avg:56.39ms
+step:1554/1840 train_time:87662ms step_avg:56.41ms
+step:1555/1840 train_time:87747ms step_avg:56.43ms
+step:1556/1840 train_time:87836ms step_avg:56.45ms
+step:1557/1840 train_time:87923ms step_avg:56.47ms
+step:1558/1840 train_time:88012ms step_avg:56.49ms
+step:1559/1840 train_time:88098ms step_avg:56.51ms
+step:1560/1840 train_time:88187ms step_avg:56.53ms
+step:1561/1840 train_time:88274ms step_avg:56.55ms
+step:1562/1840 train_time:88364ms step_avg:56.57ms
+step:1563/1840 train_time:88450ms step_avg:56.59ms
+step:1564/1840 train_time:88539ms step_avg:56.61ms
+step:1565/1840 train_time:88625ms step_avg:56.63ms
+step:1566/1840 train_time:88714ms step_avg:56.65ms
+step:1567/1840 train_time:88798ms step_avg:56.67ms
+step:1568/1840 train_time:88887ms step_avg:56.69ms
+step:1569/1840 train_time:88974ms step_avg:56.71ms
+step:1570/1840 train_time:89063ms step_avg:56.73ms
+step:1571/1840 train_time:89149ms step_avg:56.75ms
+step:1572/1840 train_time:89238ms step_avg:56.77ms
+step:1573/1840 train_time:89324ms step_avg:56.79ms
+step:1574/1840 train_time:89414ms step_avg:56.81ms
+step:1575/1840 train_time:89499ms step_avg:56.83ms
+step:1576/1840 train_time:89589ms step_avg:56.85ms
+step:1577/1840 train_time:89675ms step_avg:56.86ms
+step:1578/1840 train_time:89762ms step_avg:56.88ms
+step:1579/1840 train_time:89848ms step_avg:56.90ms
+step:1580/1840 train_time:89937ms step_avg:56.92ms
+step:1581/1840 train_time:90023ms step_avg:56.94ms
+step:1582/1840 train_time:90111ms step_avg:56.96ms
+step:1583/1840 train_time:90199ms step_avg:56.98ms
+step:1584/1840 train_time:90288ms step_avg:57.00ms
+step:1585/1840 train_time:90374ms step_avg:57.02ms
+step:1586/1840 train_time:90463ms step_avg:57.04ms
+step:1587/1840 train_time:90547ms step_avg:57.06ms
+step:1588/1840 train_time:90636ms step_avg:57.08ms
+step:1589/1840 train_time:90721ms step_avg:57.09ms
+step:1590/1840 train_time:90811ms step_avg:57.11ms
+step:1591/1840 train_time:90896ms step_avg:57.13ms
+step:1592/1840 train_time:90986ms step_avg:57.15ms
+step:1593/1840 train_time:91072ms step_avg:57.17ms
+step:1594/1840 train_time:91160ms step_avg:57.19ms
+step:1595/1840 train_time:91246ms step_avg:57.21ms
+step:1596/1840 train_time:91335ms step_avg:57.23ms
+step:1597/1840 train_time:91420ms step_avg:57.24ms
+step:1598/1840 train_time:91510ms step_avg:57.27ms
+step:1599/1840 train_time:91597ms step_avg:57.28ms
+step:1600/1840 train_time:91685ms step_avg:57.30ms
+step:1601/1840 train_time:91770ms step_avg:57.32ms
+step:1602/1840 train_time:91858ms step_avg:57.34ms
+step:1603/1840 train_time:91945ms step_avg:57.36ms
+step:1604/1840 train_time:92034ms step_avg:57.38ms
+step:1605/1840 train_time:92119ms step_avg:57.39ms
+step:1606/1840 train_time:92209ms step_avg:57.42ms
+step:1607/1840 train_time:92296ms step_avg:57.43ms
+step:1608/1840 train_time:92385ms step_avg:57.45ms
+step:1609/1840 train_time:92471ms step_avg:57.47ms
+step:1610/1840 train_time:92561ms step_avg:57.49ms
+step:1611/1840 train_time:92647ms step_avg:57.51ms
+step:1612/1840 train_time:92736ms step_avg:57.53ms
+step:1613/1840 train_time:92821ms step_avg:57.55ms
+step:1614/1840 train_time:92910ms step_avg:57.57ms
+step:1615/1840 train_time:92996ms step_avg:57.58ms
+step:1616/1840 train_time:93084ms step_avg:57.60ms
+step:1617/1840 train_time:93171ms step_avg:57.62ms
+step:1618/1840 train_time:93259ms step_avg:57.64ms
+step:1619/1840 train_time:93346ms step_avg:57.66ms
+step:1620/1840 train_time:93436ms step_avg:57.68ms
+step:1621/1840 train_time:93522ms step_avg:57.69ms
+step:1622/1840 train_time:93609ms step_avg:57.71ms
+step:1623/1840 train_time:93696ms step_avg:57.73ms
+step:1624/1840 train_time:93783ms step_avg:57.75ms
+step:1625/1840 train_time:93870ms step_avg:57.77ms
+step:1626/1840 train_time:93958ms step_avg:57.78ms
+step:1627/1840 train_time:94043ms step_avg:57.80ms
+step:1628/1840 train_time:94133ms step_avg:57.82ms
+step:1629/1840 train_time:94219ms step_avg:57.84ms
+step:1630/1840 train_time:94308ms step_avg:57.86ms
+step:1631/1840 train_time:94396ms step_avg:57.88ms
+step:1632/1840 train_time:94484ms step_avg:57.89ms
+step:1633/1840 train_time:94570ms step_avg:57.91ms
+step:1634/1840 train_time:94658ms step_avg:57.93ms
+step:1635/1840 train_time:94746ms step_avg:57.95ms
+step:1636/1840 train_time:94835ms step_avg:57.97ms
+step:1637/1840 train_time:94920ms step_avg:57.98ms
+step:1638/1840 train_time:95010ms step_avg:58.00ms
+step:1639/1840 train_time:95097ms step_avg:58.02ms
+step:1640/1840 train_time:95185ms step_avg:58.04ms
+step:1641/1840 train_time:95272ms step_avg:58.06ms
+step:1642/1840 train_time:95359ms step_avg:58.07ms
+step:1643/1840 train_time:95446ms step_avg:58.09ms
+step:1644/1840 train_time:95536ms step_avg:58.11ms
+step:1645/1840 train_time:95621ms step_avg:58.13ms
+step:1646/1840 train_time:95710ms step_avg:58.15ms
+step:1647/1840 train_time:95796ms step_avg:58.16ms
+step:1648/1840 train_time:95884ms step_avg:58.18ms
+step:1649/1840 train_time:95970ms step_avg:58.20ms
+step:1650/1840 train_time:96059ms step_avg:58.22ms
+step:1651/1840 train_time:96146ms step_avg:58.23ms
+step:1652/1840 train_time:96235ms step_avg:58.25ms
+step:1653/1840 train_time:96321ms step_avg:58.27ms
+step:1654/1840 train_time:96411ms step_avg:58.29ms
+step:1655/1840 train_time:96497ms step_avg:58.31ms
+step:1656/1840 train_time:96585ms step_avg:58.32ms
+step:1657/1840 train_time:96671ms step_avg:58.34ms
+step:1658/1840 train_time:96759ms step_avg:58.36ms
+step:1659/1840 train_time:96844ms step_avg:58.38ms
+step:1660/1840 train_time:96934ms step_avg:58.39ms
+step:1661/1840 train_time:97020ms step_avg:58.41ms
+step:1662/1840 train_time:97110ms step_avg:58.43ms
+step:1663/1840 train_time:97196ms step_avg:58.45ms
+step:1664/1840 train_time:97285ms step_avg:58.46ms
+step:1665/1840 train_time:97371ms step_avg:58.48ms
+step:1666/1840 train_time:97461ms step_avg:58.50ms
+step:1667/1840 train_time:97547ms step_avg:58.52ms
+step:1668/1840 train_time:97636ms step_avg:58.53ms
+step:1669/1840 train_time:97722ms step_avg:58.55ms
+step:1670/1840 train_time:97811ms step_avg:58.57ms
+step:1671/1840 train_time:97897ms step_avg:58.59ms
+step:1672/1840 train_time:97985ms step_avg:58.60ms
+step:1673/1840 train_time:98071ms step_avg:58.62ms
+step:1674/1840 train_time:98160ms step_avg:58.64ms
+step:1675/1840 train_time:98246ms step_avg:58.65ms
+step:1676/1840 train_time:98335ms step_avg:58.67ms
+step:1677/1840 train_time:98422ms step_avg:58.69ms
+step:1678/1840 train_time:98510ms step_avg:58.71ms
+step:1679/1840 train_time:98596ms step_avg:58.72ms
+step:1680/1840 train_time:98684ms step_avg:58.74ms
+step:1681/1840 train_time:98770ms step_avg:58.76ms
+step:1682/1840 train_time:98858ms step_avg:58.77ms
+step:1683/1840 train_time:98945ms step_avg:58.79ms
+step:1684/1840 train_time:99036ms step_avg:58.81ms
+step:1685/1840 train_time:99121ms step_avg:58.83ms
+step:1686/1840 train_time:99209ms step_avg:58.84ms
+step:1687/1840 train_time:99296ms step_avg:58.86ms
+step:1688/1840 train_time:99384ms step_avg:58.88ms
+step:1689/1840 train_time:99470ms step_avg:58.89ms
+step:1690/1840 train_time:99558ms step_avg:58.91ms
+step:1691/1840 train_time:99645ms step_avg:58.93ms
+step:1692/1840 train_time:99736ms step_avg:58.95ms
+step:1693/1840 train_time:99821ms step_avg:58.96ms
+step:1694/1840 train_time:99910ms step_avg:58.98ms
+step:1695/1840 train_time:99995ms step_avg:58.99ms
+step:1696/1840 train_time:100084ms step_avg:59.01ms
+step:1697/1840 train_time:100170ms step_avg:59.03ms
+step:1698/1840 train_time:100258ms step_avg:59.05ms
+step:1699/1840 train_time:100345ms step_avg:59.06ms
+step:1700/1840 train_time:100435ms step_avg:59.08ms
+step:1701/1840 train_time:100520ms step_avg:59.09ms
+step:1702/1840 train_time:100609ms step_avg:59.11ms
+step:1703/1840 train_time:100695ms step_avg:59.13ms
+step:1704/1840 train_time:100784ms step_avg:59.15ms
+step:1705/1840 train_time:100871ms step_avg:59.16ms
+step:1706/1840 train_time:100958ms step_avg:59.18ms
+step:1707/1840 train_time:101044ms step_avg:59.19ms
+step:1708/1840 train_time:101134ms step_avg:59.21ms
+step:1709/1840 train_time:101219ms step_avg:59.23ms
+step:1710/1840 train_time:101309ms step_avg:59.24ms
+step:1711/1840 train_time:101395ms step_avg:59.26ms
+step:1712/1840 train_time:101483ms step_avg:59.28ms
+step:1713/1840 train_time:101570ms step_avg:59.29ms
+step:1714/1840 train_time:101658ms step_avg:59.31ms
+step:1715/1840 train_time:101745ms step_avg:59.33ms
+step:1716/1840 train_time:101835ms step_avg:59.34ms
+step:1717/1840 train_time:101920ms step_avg:59.36ms
+step:1718/1840 train_time:102009ms step_avg:59.38ms
+step:1719/1840 train_time:102096ms step_avg:59.39ms
+step:1720/1840 train_time:102184ms step_avg:59.41ms
+step:1721/1840 train_time:102270ms step_avg:59.42ms
+step:1722/1840 train_time:102358ms step_avg:59.44ms
+step:1723/1840 train_time:102445ms step_avg:59.46ms
+step:1724/1840 train_time:102534ms step_avg:59.47ms
+step:1725/1840 train_time:102619ms step_avg:59.49ms
+step:1726/1840 train_time:102709ms step_avg:59.51ms
+step:1727/1840 train_time:102796ms step_avg:59.52ms
+step:1728/1840 train_time:102885ms step_avg:59.54ms
+step:1729/1840 train_time:102970ms step_avg:59.55ms
+step:1730/1840 train_time:103059ms step_avg:59.57ms
+step:1731/1840 train_time:103145ms step_avg:59.59ms
+step:1732/1840 train_time:103235ms step_avg:59.60ms
+step:1733/1840 train_time:103321ms step_avg:59.62ms
+step:1734/1840 train_time:103409ms step_avg:59.64ms
+step:1735/1840 train_time:103497ms step_avg:59.65ms
+step:1736/1840 train_time:103585ms step_avg:59.67ms
+step:1737/1840 train_time:103671ms step_avg:59.68ms
+step:1738/1840 train_time:103760ms step_avg:59.70ms
+step:1739/1840 train_time:103847ms step_avg:59.72ms
+step:1740/1840 train_time:103936ms step_avg:59.73ms
+step:1741/1840 train_time:104021ms step_avg:59.75ms
+step:1742/1840 train_time:104110ms step_avg:59.76ms
+step:1743/1840 train_time:104197ms step_avg:59.78ms
+step:1744/1840 train_time:104286ms step_avg:59.80ms
+step:1745/1840 train_time:104372ms step_avg:59.81ms
+step:1746/1840 train_time:104459ms step_avg:59.83ms
+step:1747/1840 train_time:104545ms step_avg:59.84ms
+step:1748/1840 train_time:104634ms step_avg:59.86ms
+step:1749/1840 train_time:104720ms step_avg:59.87ms
+step:1750/1840 train_time:104809ms step_avg:59.89ms
+step:1750/1840 val_loss:3.3038 train_time:104910ms step_avg:59.95ms
+step:1751/1840 train_time:104929ms step_avg:59.93ms
+step:1752/1840 train_time:104987ms step_avg:59.92ms
+step:1753/1840 train_time:105076ms step_avg:59.94ms
+step:1754/1840 train_time:105167ms step_avg:59.96ms
+step:1755/1840 train_time:105253ms step_avg:59.97ms
+step:1756/1840 train_time:105340ms step_avg:59.99ms
+step:1757/1840 train_time:105425ms step_avg:60.00ms
+step:1758/1840 train_time:105512ms step_avg:60.02ms
+step:1759/1840 train_time:105597ms step_avg:60.03ms
+step:1760/1840 train_time:105685ms step_avg:60.05ms
+step:1761/1840 train_time:105770ms step_avg:60.06ms
+step:1762/1840 train_time:105860ms step_avg:60.08ms
+step:1763/1840 train_time:105948ms step_avg:60.10ms
+step:1764/1840 train_time:106039ms step_avg:60.11ms
+step:1765/1840 train_time:106128ms step_avg:60.13ms
+step:1766/1840 train_time:106218ms step_avg:60.15ms
+step:1767/1840 train_time:106304ms step_avg:60.16ms
+step:1768/1840 train_time:106391ms step_avg:60.18ms
+step:1769/1840 train_time:106476ms step_avg:60.19ms
+step:1770/1840 train_time:106564ms step_avg:60.21ms
+step:1771/1840 train_time:106649ms step_avg:60.22ms
+step:1772/1840 train_time:106738ms step_avg:60.24ms
+step:1773/1840 train_time:106826ms step_avg:60.25ms
+step:1774/1840 train_time:106915ms step_avg:60.27ms
+step:1775/1840 train_time:107002ms step_avg:60.28ms
+step:1776/1840 train_time:107090ms step_avg:60.30ms
+step:1777/1840 train_time:107178ms step_avg:60.31ms
+step:1778/1840 train_time:107266ms step_avg:60.33ms
+step:1779/1840 train_time:107352ms step_avg:60.34ms
+step:1780/1840 train_time:107440ms step_avg:60.36ms
+step:1781/1840 train_time:107526ms step_avg:60.37ms
+step:1782/1840 train_time:107614ms step_avg:60.39ms
+step:1783/1840 train_time:107698ms step_avg:60.40ms
+step:1784/1840 train_time:107787ms step_avg:60.42ms
+step:1785/1840 train_time:107874ms step_avg:60.43ms
+step:1786/1840 train_time:107964ms step_avg:60.45ms
+step:1787/1840 train_time:108049ms step_avg:60.46ms
+step:1788/1840 train_time:108140ms step_avg:60.48ms
+step:1789/1840 train_time:108227ms step_avg:60.50ms
+step:1790/1840 train_time:108315ms step_avg:60.51ms
+step:1791/1840 train_time:108400ms step_avg:60.52ms
+step:1792/1840 train_time:108489ms step_avg:60.54ms
+step:1793/1840 train_time:108575ms step_avg:60.55ms
+step:1794/1840 train_time:108663ms step_avg:60.57ms
+step:1795/1840 train_time:108748ms step_avg:60.58ms
+step:1796/1840 train_time:108838ms step_avg:60.60ms
+step:1797/1840 train_time:108926ms step_avg:60.62ms
+step:1798/1840 train_time:109016ms step_avg:60.63ms
+step:1799/1840 train_time:109102ms step_avg:60.65ms
+step:1800/1840 train_time:109193ms step_avg:60.66ms
+step:1801/1840 train_time:109282ms step_avg:60.68ms
+step:1802/1840 train_time:109368ms step_avg:60.69ms
+step:1803/1840 train_time:109454ms step_avg:60.71ms
+step:1804/1840 train_time:109543ms step_avg:60.72ms
+step:1805/1840 train_time:109629ms step_avg:60.74ms
+step:1806/1840 train_time:109717ms step_avg:60.75ms
+step:1807/1840 train_time:109804ms step_avg:60.77ms
+step:1808/1840 train_time:109894ms step_avg:60.78ms
+step:1809/1840 train_time:109981ms step_avg:60.80ms
+step:1810/1840 train_time:110069ms step_avg:60.81ms
+step:1811/1840 train_time:110157ms step_avg:60.83ms
+step:1812/1840 train_time:110246ms step_avg:60.84ms
+step:1813/1840 train_time:110331ms step_avg:60.86ms
+step:1814/1840 train_time:110421ms step_avg:60.87ms
+step:1815/1840 train_time:110506ms step_avg:60.88ms
+step:1816/1840 train_time:110594ms step_avg:60.90ms
+step:1817/1840 train_time:110680ms step_avg:60.91ms
+step:1818/1840 train_time:110769ms step_avg:60.93ms
+step:1819/1840 train_time:110855ms step_avg:60.94ms
+step:1820/1840 train_time:110945ms step_avg:60.96ms
+step:1821/1840 train_time:111031ms step_avg:60.97ms
+step:1822/1840 train_time:111121ms step_avg:60.99ms
+step:1823/1840 train_time:111207ms step_avg:61.00ms
+step:1824/1840 train_time:111296ms step_avg:61.02ms
+step:1825/1840 train_time:111382ms step_avg:61.03ms
+step:1826/1840 train_time:111470ms step_avg:61.05ms
+step:1827/1840 train_time:111557ms step_avg:61.06ms
+step:1828/1840 train_time:111646ms step_avg:61.08ms
+step:1829/1840 train_time:111731ms step_avg:61.09ms
+step:1830/1840 train_time:111821ms step_avg:61.10ms
+step:1831/1840 train_time:111907ms step_avg:61.12ms
+step:1832/1840 train_time:111996ms step_avg:61.13ms
+step:1833/1840 train_time:112082ms step_avg:61.15ms
+step:1834/1840 train_time:112170ms step_avg:61.16ms
+step:1835/1840 train_time:112257ms step_avg:61.18ms
+step:1836/1840 train_time:112347ms step_avg:61.19ms
+step:1837/1840 train_time:112433ms step_avg:61.20ms
+step:1838/1840 train_time:112522ms step_avg:61.22ms
+step:1839/1840 train_time:112607ms step_avg:61.23ms
+step:1840/1840 train_time:112697ms step_avg:61.25ms
+step:1840/1840 val_loss:3.2789 train_time:112798ms step_avg:61.30ms
+peak memory allocated: 28507 MiB reserved: 43458 MiB


### PR DESCRIPTION
Updates in PR:
* Update MLP and ATTN weights from float32 to bfloat16. This gives faster fwd/bwk pass, and faster comms during optimizer step.
* Add a mantissa buffer to Muon such that parameter updates can be tracked in float32 even though weights are in bfloat16. Following work of YouJiacheng on Medium track record 7.
* Enable Adam beta values to be specified on a module level, and slightly adjust these
* Interleave Muon with Adam. Heavily based on the ideas of Chris McCormick here: https://github.com/KellerJordan/modded-nanogpt/discussions/170.
* Add 15 steps (not strictly necessary based on loss)
* Move Adam eps back to 1e-10 instead of 1e-8, now that we are back to float32 ema buffers. (I didn't run enough tests to confirm this is necessary, but won't hurt)

Without the mantissa tracking the bfloat16 update is substantially detrimental to loss. 

<img width="1920" height="527" alt="image" src="https://github.com/user-attachments/assets/21f044d7-6d1f-4285-9012-22aada5c131a" />

<img width="831" height="455" alt="image" src="https://github.com/user-attachments/assets/85127f19-f531-42fb-b645-821f374aa017" />

I observed that the lm_head/embed slightly benefits from a very low beta1 term in Adam (0.5), whereas standard convention is closer to 0.9 for Adam parameters. I hypothesis that this is driven by the asymmetrical gradient distribution caused by the nature of low frequency tokens. Consider a parameter with a very large gradient signal once every 100 steps. A small beta1 causes the parameter to take a massive step in the direction of the large gradient, and then quickly fall back to whatever the weak gradient signal is when the parameter is not the target. A large beta1 causes the parameter to continue moving in whatever direction activated it for 100+ steps, even after the signal is long gone and the network has a new topology. It may be worth exploring different beta1 values for different tokens as a function of token frequency. I find it quite unlikely that a token that occurs once every 1 million tokens should have the same beta as a token that occurs once every 100 tokens.

Muon.step() is separated into 3 modular components, such that when Adam.step() is called Adam can selectively interweave Muon components. 
* Adam first immediately calls the muon reduce scatter
* Adam kicks off every all gather except for the last value embed
* muon runs polar express and kicks off its all gathers and completes its first all gather and parameter copy
* Adam kicks off its last all gather
* Muon runs its final parameter copy
* Adam finishes its last all gather.

This enables close to zero communication downtime.

<img width="1478" height="554" alt="image" src="https://github.com/user-attachments/assets/7940283b-a181-46fb-8b62-5e829f88a7c7" />

Whereas before:

<img width="1450" height="603" alt="image" src="https://github.com/user-attachments/assets/ed744ade-976e-4f9b-86f2-c9b0a3fcf59d" />


## Timing and Validation
```
import scipy.stats
import torch

losses = [3.2795, 3.2789, 3.2776, 3.2763, 3.2785, 3.278, 3.2774, 3.2777, 3.2802, 3.2767]
times = [112.774,112.798,112.837,112.767,112.805,112.802,112.822,112.755,112.932,112.953]

print("p=%.4f" % scipy.stats.ttest_1samp(losses, 3.28, alternative="less").pvalue)
# p=0.0004

print("losses:", torch.std_mean(torch.tensor(losses)))
# losses: (tensor(0.0012), tensor(3.2781))

print("time:", torch.std_mean(torch.tensor(times)))
# time: (tensor(0.0671), tensor(112.8245))
```

retiming prior record: 113.895 [113.818, 113.896, 113.97]

If no changes, will merge at 112.7s to be consistent with 1.0s improvement.
