### PR TITLE
New Record: Bigram Hash Embedding (-5.6s, -165 steps)

### DIFF
--- a/records/track_1_short/2026-01-19_BigramHashEmbedding/40ec7bb6-14b3-46f8-90b7-bb5ed188faba.txt
+++ b/records/track_1_short/2026-01-19_BigramHashEmbedding/40ec7bb6-14b3-46f8-90b7-bb5ed188faba.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 19 22:41:41 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   28C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   28C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   27C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   29C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   25C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   29C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   25C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     63459      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     63460      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     63461      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     63462      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     63463      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     63464      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     63465      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     63466      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8308 train_time:0ms step_avg:0.04ms
+step:1/1600 train_time:90ms step_avg:90.05ms
+step:2/1600 train_time:111ms step_avg:55.64ms
+step:3/1600 train_time:130ms step_avg:43.34ms
+step:4/1600 train_time:159ms step_avg:39.81ms
+step:5/1600 train_time:189ms step_avg:37.90ms
+step:6/1600 train_time:281ms step_avg:46.87ms
+step:7/1600 train_time:298ms step_avg:42.58ms
+step:8/1600 train_time:321ms step_avg:40.08ms
+step:9/1600 train_time:351ms step_avg:39.04ms
+step:10/1600 train_time:388ms step_avg:38.83ms
+step:11/1600 train_time:419ms step_avg:38.13ms
+step:12/1600 train_time:456ms step_avg:38.01ms
+step:13/1600 train_time:487ms step_avg:37.46ms
+step:14/1600 train_time:524ms step_avg:37.42ms
+step:15/1600 train_time:555ms step_avg:36.99ms
+step:16/1600 train_time:592ms step_avg:36.99ms
+step:17/1600 train_time:623ms step_avg:36.63ms
+step:18/1600 train_time:660ms step_avg:36.65ms
+step:19/1600 train_time:691ms step_avg:36.38ms
+step:20/1600 train_time:728ms step_avg:36.40ms
+step:21/1600 train_time:759ms step_avg:36.15ms
+step:22/1600 train_time:796ms step_avg:36.19ms
+step:23/1600 train_time:827ms step_avg:35.97ms
+step:24/1600 train_time:864ms step_avg:36.01ms
+step:25/1600 train_time:895ms step_avg:35.81ms
+step:26/1600 train_time:932ms step_avg:35.86ms
+step:27/1600 train_time:963ms step_avg:35.68ms
+step:28/1600 train_time:1000ms step_avg:35.72ms
+step:29/1600 train_time:1032ms step_avg:35.58ms
+step:30/1600 train_time:1069ms step_avg:35.62ms
+step:31/1600 train_time:1100ms step_avg:35.48ms
+step:32/1600 train_time:1136ms step_avg:35.52ms
+step:33/1600 train_time:1168ms step_avg:35.38ms
+step:34/1600 train_time:1205ms step_avg:35.43ms
+step:35/1600 train_time:1235ms step_avg:35.30ms
+step:36/1600 train_time:1273ms step_avg:35.35ms
+step:37/1600 train_time:1304ms step_avg:35.25ms
+step:38/1600 train_time:1341ms step_avg:35.29ms
+step:39/1600 train_time:1372ms step_avg:35.18ms
+step:40/1600 train_time:1409ms step_avg:35.23ms
+step:41/1600 train_time:1440ms step_avg:35.13ms
+step:42/1600 train_time:1477ms step_avg:35.17ms
+step:43/1600 train_time:1508ms step_avg:35.08ms
+step:44/1600 train_time:1545ms step_avg:35.11ms
+step:45/1600 train_time:1576ms step_avg:35.02ms
+step:46/1600 train_time:1613ms step_avg:35.05ms
+step:47/1600 train_time:1644ms step_avg:34.98ms
+step:48/1600 train_time:1681ms step_avg:35.02ms
+step:49/1600 train_time:1712ms step_avg:34.94ms
+step:50/1600 train_time:1749ms step_avg:34.99ms
+step:51/1600 train_time:1780ms step_avg:34.91ms
+step:52/1600 train_time:1817ms step_avg:34.94ms
+step:53/1600 train_time:1848ms step_avg:34.87ms
+step:54/1600 train_time:1885ms step_avg:34.91ms
+step:55/1600 train_time:1916ms step_avg:34.84ms
+step:56/1600 train_time:1953ms step_avg:34.87ms
+step:57/1600 train_time:1984ms step_avg:34.80ms
+step:58/1600 train_time:2021ms step_avg:34.84ms
+step:59/1600 train_time:2052ms step_avg:34.77ms
+step:60/1600 train_time:2089ms step_avg:34.81ms
+step:61/1600 train_time:2120ms step_avg:34.75ms
+step:62/1600 train_time:2158ms step_avg:34.80ms
+step:63/1600 train_time:2188ms step_avg:34.73ms
+step:64/1600 train_time:2225ms step_avg:34.76ms
+step:65/1600 train_time:2256ms step_avg:34.70ms
+step:66/1600 train_time:2293ms step_avg:34.74ms
+step:67/1600 train_time:2323ms step_avg:34.68ms
+step:68/1600 train_time:2360ms step_avg:34.71ms
+step:69/1600 train_time:2391ms step_avg:34.65ms
+step:70/1600 train_time:2428ms step_avg:34.69ms
+step:71/1600 train_time:2459ms step_avg:34.64ms
+step:72/1600 train_time:2496ms step_avg:34.67ms
+step:73/1600 train_time:2527ms step_avg:34.62ms
+step:74/1600 train_time:2564ms step_avg:34.65ms
+step:75/1600 train_time:2595ms step_avg:34.60ms
+step:76/1600 train_time:2632ms step_avg:34.64ms
+step:77/1600 train_time:2663ms step_avg:34.59ms
+step:78/1600 train_time:2700ms step_avg:34.62ms
+step:79/1600 train_time:2732ms step_avg:34.58ms
+step:80/1600 train_time:2769ms step_avg:34.62ms
+step:81/1600 train_time:2801ms step_avg:34.58ms
+step:82/1600 train_time:2838ms step_avg:34.61ms
+step:83/1600 train_time:2869ms step_avg:34.57ms
+step:84/1600 train_time:2907ms step_avg:34.60ms
+step:85/1600 train_time:2937ms step_avg:34.56ms
+step:86/1600 train_time:2974ms step_avg:34.59ms
+step:87/1600 train_time:3005ms step_avg:34.54ms
+step:88/1600 train_time:3042ms step_avg:34.57ms
+step:89/1600 train_time:3073ms step_avg:34.53ms
+step:90/1600 train_time:3110ms step_avg:34.56ms
+step:91/1600 train_time:3142ms step_avg:34.52ms
+step:92/1600 train_time:3178ms step_avg:34.55ms
+step:93/1600 train_time:3209ms step_avg:34.51ms
+step:94/1600 train_time:3246ms step_avg:34.53ms
+step:95/1600 train_time:3277ms step_avg:34.49ms
+step:96/1600 train_time:3314ms step_avg:34.52ms
+step:97/1600 train_time:3344ms step_avg:34.48ms
+step:98/1600 train_time:3381ms step_avg:34.50ms
+step:99/1600 train_time:3412ms step_avg:34.47ms
+step:100/1600 train_time:3449ms step_avg:34.49ms
+step:101/1600 train_time:3480ms step_avg:34.45ms
+step:102/1600 train_time:3517ms step_avg:34.48ms
+step:103/1600 train_time:3547ms step_avg:34.44ms
+step:104/1600 train_time:3584ms step_avg:34.47ms
+step:105/1600 train_time:3615ms step_avg:34.43ms
+step:106/1600 train_time:3653ms step_avg:34.46ms
+step:107/1600 train_time:3684ms step_avg:34.43ms
+step:108/1600 train_time:3720ms step_avg:34.45ms
+step:109/1600 train_time:3751ms step_avg:34.41ms
+step:110/1600 train_time:3789ms step_avg:34.44ms
+step:111/1600 train_time:3820ms step_avg:34.41ms
+step:112/1600 train_time:3856ms step_avg:34.43ms
+step:113/1600 train_time:3887ms step_avg:34.40ms
+step:114/1600 train_time:3924ms step_avg:34.42ms
+step:115/1600 train_time:3955ms step_avg:34.39ms
+step:116/1600 train_time:3992ms step_avg:34.41ms
+step:117/1600 train_time:4023ms step_avg:34.38ms
+step:118/1600 train_time:4060ms step_avg:34.40ms
+step:119/1600 train_time:4091ms step_avg:34.38ms
+step:120/1600 train_time:4128ms step_avg:34.40ms
+step:121/1600 train_time:4159ms step_avg:34.37ms
+step:122/1600 train_time:4195ms step_avg:34.39ms
+step:123/1600 train_time:4226ms step_avg:34.36ms
+step:124/1600 train_time:4263ms step_avg:34.38ms
+step:125/1600 train_time:4294ms step_avg:34.35ms
+step:126/1600 train_time:4332ms step_avg:34.38ms
+step:127/1600 train_time:4363ms step_avg:34.35ms
+step:128/1600 train_time:4400ms step_avg:34.37ms
+step:129/1600 train_time:4431ms step_avg:34.35ms
+step:130/1600 train_time:4468ms step_avg:34.37ms
+step:131/1600 train_time:4499ms step_avg:34.35ms
+step:132/1600 train_time:4536ms step_avg:34.36ms
+step:133/1600 train_time:4567ms step_avg:34.34ms
+step:134/1600 train_time:4604ms step_avg:34.36ms
+step:135/1600 train_time:4635ms step_avg:34.33ms
+step:136/1600 train_time:4672ms step_avg:34.35ms
+step:137/1600 train_time:4703ms step_avg:34.33ms
+step:138/1600 train_time:4739ms step_avg:34.34ms
+step:139/1600 train_time:4771ms step_avg:34.32ms
+step:140/1600 train_time:4808ms step_avg:34.34ms
+step:141/1600 train_time:4839ms step_avg:34.32ms
+step:142/1600 train_time:4875ms step_avg:34.33ms
+step:143/1600 train_time:4906ms step_avg:34.31ms
+step:144/1600 train_time:4943ms step_avg:34.33ms
+step:145/1600 train_time:4974ms step_avg:34.30ms
+step:146/1600 train_time:5011ms step_avg:34.32ms
+step:147/1600 train_time:5042ms step_avg:34.30ms
+step:148/1600 train_time:5079ms step_avg:34.32ms
+step:149/1600 train_time:5110ms step_avg:34.30ms
+step:150/1600 train_time:5147ms step_avg:34.31ms
+step:151/1600 train_time:5178ms step_avg:34.29ms
+step:152/1600 train_time:5215ms step_avg:34.31ms
+step:153/1600 train_time:5246ms step_avg:34.29ms
+step:154/1600 train_time:5283ms step_avg:34.30ms
+step:155/1600 train_time:5314ms step_avg:34.28ms
+step:156/1600 train_time:5351ms step_avg:34.30ms
+step:157/1600 train_time:5382ms step_avg:34.28ms
+step:158/1600 train_time:5419ms step_avg:34.30ms
+step:159/1600 train_time:5451ms step_avg:34.28ms
+step:160/1600 train_time:5488ms step_avg:34.30ms
+step:161/1600 train_time:5518ms step_avg:34.28ms
+step:162/1600 train_time:5555ms step_avg:34.29ms
+step:163/1600 train_time:5586ms step_avg:34.27ms
+step:164/1600 train_time:5623ms step_avg:34.29ms
+step:165/1600 train_time:5654ms step_avg:34.27ms
+step:166/1600 train_time:5691ms step_avg:34.28ms
+step:167/1600 train_time:5722ms step_avg:34.26ms
+step:168/1600 train_time:5759ms step_avg:34.28ms
+step:169/1600 train_time:5790ms step_avg:34.26ms
+step:170/1600 train_time:5827ms step_avg:34.27ms
+step:171/1600 train_time:5857ms step_avg:34.25ms
+step:172/1600 train_time:5894ms step_avg:34.27ms
+step:173/1600 train_time:5925ms step_avg:34.25ms
+step:174/1600 train_time:5961ms step_avg:34.26ms
+step:175/1600 train_time:5992ms step_avg:34.24ms
+step:176/1600 train_time:6029ms step_avg:34.25ms
+step:177/1600 train_time:6060ms step_avg:34.24ms
+step:178/1600 train_time:6097ms step_avg:34.25ms
+step:179/1600 train_time:6127ms step_avg:34.23ms
+step:180/1600 train_time:6164ms step_avg:34.24ms
+step:181/1600 train_time:6195ms step_avg:34.22ms
+step:182/1600 train_time:6231ms step_avg:34.24ms
+step:183/1600 train_time:6262ms step_avg:34.22ms
+step:184/1600 train_time:6299ms step_avg:34.24ms
+step:185/1600 train_time:6330ms step_avg:34.22ms
+step:186/1600 train_time:6368ms step_avg:34.23ms
+step:187/1600 train_time:6399ms step_avg:34.22ms
+step:188/1600 train_time:6436ms step_avg:34.23ms
+step:189/1600 train_time:6466ms step_avg:34.21ms
+step:190/1600 train_time:6503ms step_avg:34.23ms
+step:191/1600 train_time:6534ms step_avg:34.21ms
+step:192/1600 train_time:6571ms step_avg:34.22ms
+step:193/1600 train_time:6602ms step_avg:34.21ms
+step:194/1600 train_time:6639ms step_avg:34.22ms
+step:195/1600 train_time:6670ms step_avg:34.21ms
+step:196/1600 train_time:6707ms step_avg:34.22ms
+step:197/1600 train_time:6738ms step_avg:34.21ms
+step:198/1600 train_time:6775ms step_avg:34.22ms
+step:199/1600 train_time:6806ms step_avg:34.20ms
+step:200/1600 train_time:6843ms step_avg:34.22ms
+step:201/1600 train_time:6874ms step_avg:34.20ms
+step:202/1600 train_time:6911ms step_avg:34.21ms
+step:203/1600 train_time:6942ms step_avg:34.20ms
+step:204/1600 train_time:6979ms step_avg:34.21ms
+step:205/1600 train_time:7010ms step_avg:34.20ms
+step:206/1600 train_time:7047ms step_avg:34.21ms
+step:207/1600 train_time:7078ms step_avg:34.19ms
+step:208/1600 train_time:7115ms step_avg:34.20ms
+step:209/1600 train_time:7146ms step_avg:34.19ms
+step:210/1600 train_time:7182ms step_avg:34.20ms
+step:211/1600 train_time:7213ms step_avg:34.19ms
+step:212/1600 train_time:7250ms step_avg:34.20ms
+step:213/1600 train_time:7281ms step_avg:34.18ms
+step:214/1600 train_time:7318ms step_avg:34.20ms
+step:215/1600 train_time:7349ms step_avg:34.18ms
+step:216/1600 train_time:7386ms step_avg:34.19ms
+step:217/1600 train_time:7417ms step_avg:34.18ms
+step:218/1600 train_time:7454ms step_avg:34.19ms
+step:219/1600 train_time:7484ms step_avg:34.18ms
+step:220/1600 train_time:7521ms step_avg:34.19ms
+step:221/1600 train_time:7552ms step_avg:34.17ms
+step:222/1600 train_time:7589ms step_avg:34.18ms
+step:223/1600 train_time:7620ms step_avg:34.17ms
+step:224/1600 train_time:7656ms step_avg:34.18ms
+step:225/1600 train_time:7687ms step_avg:34.17ms
+step:226/1600 train_time:7724ms step_avg:34.18ms
+step:227/1600 train_time:7755ms step_avg:34.16ms
+step:228/1600 train_time:7791ms step_avg:34.17ms
+step:229/1600 train_time:7823ms step_avg:34.16ms
+step:230/1600 train_time:7859ms step_avg:34.17ms
+step:231/1600 train_time:7890ms step_avg:34.16ms
+step:232/1600 train_time:7927ms step_avg:34.17ms
+step:233/1600 train_time:7958ms step_avg:34.16ms
+step:234/1600 train_time:7995ms step_avg:34.17ms
+step:235/1600 train_time:8026ms step_avg:34.15ms
+step:236/1600 train_time:8062ms step_avg:34.16ms
+step:237/1600 train_time:8093ms step_avg:34.15ms
+step:238/1600 train_time:8130ms step_avg:34.16ms
+step:239/1600 train_time:8161ms step_avg:34.15ms
+step:240/1600 train_time:8198ms step_avg:34.16ms
+step:241/1600 train_time:8228ms step_avg:34.14ms
+step:242/1600 train_time:8265ms step_avg:34.15ms
+step:243/1600 train_time:8296ms step_avg:34.14ms
+step:244/1600 train_time:8333ms step_avg:34.15ms
+step:245/1600 train_time:8364ms step_avg:34.14ms
+step:246/1600 train_time:8400ms step_avg:34.15ms
+step:247/1600 train_time:8431ms step_avg:34.13ms
+step:248/1600 train_time:8468ms step_avg:34.14ms
+step:249/1600 train_time:8499ms step_avg:34.13ms
+step:250/1600 train_time:8535ms step_avg:34.14ms
+step:250/1600 val_loss:4.5899 train_time:8583ms step_avg:34.33ms
+step:251/1600 train_time:8600ms step_avg:34.26ms
+step:252/1600 train_time:8618ms step_avg:34.20ms
+step:253/1600 train_time:8636ms step_avg:34.14ms
+step:254/1600 train_time:8675ms step_avg:34.15ms
+step:255/1600 train_time:8707ms step_avg:34.15ms
+step:256/1600 train_time:8745ms step_avg:34.16ms
+step:257/1600 train_time:8777ms step_avg:34.15ms
+step:258/1600 train_time:8814ms step_avg:34.16ms
+step:259/1600 train_time:8845ms step_avg:34.15ms
+step:260/1600 train_time:8881ms step_avg:34.16ms
+step:261/1600 train_time:8912ms step_avg:34.15ms
+step:262/1600 train_time:8950ms step_avg:34.16ms
+step:263/1600 train_time:8980ms step_avg:34.15ms
+step:264/1600 train_time:9017ms step_avg:34.16ms
+step:265/1600 train_time:9048ms step_avg:34.14ms
+step:266/1600 train_time:9085ms step_avg:34.15ms
+step:267/1600 train_time:9116ms step_avg:34.14ms
+step:268/1600 train_time:9152ms step_avg:34.15ms
+step:269/1600 train_time:9183ms step_avg:34.14ms
+step:270/1600 train_time:9220ms step_avg:34.15ms
+step:271/1600 train_time:9251ms step_avg:34.14ms
+step:272/1600 train_time:9287ms step_avg:34.14ms
+step:273/1600 train_time:9318ms step_avg:34.13ms
+step:274/1600 train_time:9355ms step_avg:34.14ms
+step:275/1600 train_time:9386ms step_avg:34.13ms
+step:276/1600 train_time:9423ms step_avg:34.14ms
+step:277/1600 train_time:9453ms step_avg:34.13ms
+step:278/1600 train_time:9490ms step_avg:34.14ms
+step:279/1600 train_time:9521ms step_avg:34.13ms
+step:280/1600 train_time:9558ms step_avg:34.13ms
+step:281/1600 train_time:9589ms step_avg:34.12ms
+step:282/1600 train_time:9625ms step_avg:34.13ms
+step:283/1600 train_time:9656ms step_avg:34.12ms
+step:284/1600 train_time:9693ms step_avg:34.13ms
+step:285/1600 train_time:9724ms step_avg:34.12ms
+step:286/1600 train_time:9761ms step_avg:34.13ms
+step:287/1600 train_time:9792ms step_avg:34.12ms
+step:288/1600 train_time:9829ms step_avg:34.13ms
+step:289/1600 train_time:9860ms step_avg:34.12ms
+step:290/1600 train_time:9897ms step_avg:34.13ms
+step:291/1600 train_time:9928ms step_avg:34.12ms
+step:292/1600 train_time:9964ms step_avg:34.12ms
+step:293/1600 train_time:9995ms step_avg:34.11ms
+step:294/1600 train_time:10032ms step_avg:34.12ms
+step:295/1600 train_time:10063ms step_avg:34.11ms
+step:296/1600 train_time:10100ms step_avg:34.12ms
+step:297/1600 train_time:10131ms step_avg:34.11ms
+step:298/1600 train_time:10167ms step_avg:34.12ms
+step:299/1600 train_time:10198ms step_avg:34.11ms
+step:300/1600 train_time:10235ms step_avg:34.12ms
+step:301/1600 train_time:10266ms step_avg:34.11ms
+step:302/1600 train_time:10303ms step_avg:34.11ms
+step:303/1600 train_time:10334ms step_avg:34.10ms
+step:304/1600 train_time:10370ms step_avg:34.11ms
+step:305/1600 train_time:10401ms step_avg:34.10ms
+step:306/1600 train_time:10438ms step_avg:34.11ms
+step:307/1600 train_time:10469ms step_avg:34.10ms
+step:308/1600 train_time:10505ms step_avg:34.11ms
+step:309/1600 train_time:10536ms step_avg:34.10ms
+step:310/1600 train_time:10573ms step_avg:34.11ms
+step:311/1600 train_time:10604ms step_avg:34.10ms
+step:312/1600 train_time:10640ms step_avg:34.10ms
+step:313/1600 train_time:10671ms step_avg:34.09ms
+step:314/1600 train_time:10708ms step_avg:34.10ms
+step:315/1600 train_time:10739ms step_avg:34.09ms
+step:316/1600 train_time:10776ms step_avg:34.10ms
+step:317/1600 train_time:10807ms step_avg:34.09ms
+step:318/1600 train_time:10844ms step_avg:34.10ms
+step:319/1600 train_time:10875ms step_avg:34.09ms
+step:320/1600 train_time:10911ms step_avg:34.10ms
+step:321/1600 train_time:10942ms step_avg:34.09ms
+step:322/1600 train_time:10979ms step_avg:34.10ms
+step:323/1600 train_time:11009ms step_avg:34.08ms
+step:324/1600 train_time:11046ms step_avg:34.09ms
+step:325/1600 train_time:11077ms step_avg:34.08ms
+step:326/1600 train_time:11114ms step_avg:34.09ms
+step:327/1600 train_time:11145ms step_avg:34.08ms
+step:328/1600 train_time:11182ms step_avg:34.09ms
+step:329/1600 train_time:11213ms step_avg:34.08ms
+step:330/1600 train_time:11250ms step_avg:34.09ms
+step:331/1600 train_time:11281ms step_avg:34.08ms
+step:332/1600 train_time:11318ms step_avg:34.09ms
+step:333/1600 train_time:11348ms step_avg:34.08ms
+step:334/1600 train_time:11385ms step_avg:34.09ms
+step:335/1600 train_time:11416ms step_avg:34.08ms
+step:336/1600 train_time:11453ms step_avg:34.09ms
+step:337/1600 train_time:11484ms step_avg:34.08ms
+step:338/1600 train_time:11521ms step_avg:34.08ms
+step:339/1600 train_time:11552ms step_avg:34.08ms
+step:340/1600 train_time:11589ms step_avg:34.08ms
+step:341/1600 train_time:11620ms step_avg:34.07ms
+step:342/1600 train_time:11656ms step_avg:34.08ms
+step:343/1600 train_time:11688ms step_avg:34.08ms
+step:344/1600 train_time:11725ms step_avg:34.08ms
+step:345/1600 train_time:11756ms step_avg:34.07ms
+step:346/1600 train_time:11793ms step_avg:34.08ms
+step:347/1600 train_time:11824ms step_avg:34.08ms
+step:348/1600 train_time:11861ms step_avg:34.08ms
+step:349/1600 train_time:11892ms step_avg:34.07ms
+step:350/1600 train_time:11929ms step_avg:34.08ms
+step:351/1600 train_time:11959ms step_avg:34.07ms
+step:352/1600 train_time:11996ms step_avg:34.08ms
+step:353/1600 train_time:12027ms step_avg:34.07ms
+step:354/1600 train_time:12064ms step_avg:34.08ms
+step:355/1600 train_time:12095ms step_avg:34.07ms
+step:356/1600 train_time:12131ms step_avg:34.08ms
+step:357/1600 train_time:12162ms step_avg:34.07ms
+step:358/1600 train_time:12199ms step_avg:34.07ms
+step:359/1600 train_time:12230ms step_avg:34.07ms
+step:360/1600 train_time:12266ms step_avg:34.07ms
+step:361/1600 train_time:12297ms step_avg:34.06ms
+step:362/1600 train_time:12334ms step_avg:34.07ms
+step:363/1600 train_time:12365ms step_avg:34.06ms
+step:364/1600 train_time:12401ms step_avg:34.07ms
+step:365/1600 train_time:12432ms step_avg:34.06ms
+step:366/1600 train_time:12470ms step_avg:34.07ms
+step:367/1600 train_time:12501ms step_avg:34.06ms
+step:368/1600 train_time:12537ms step_avg:34.07ms
+step:369/1600 train_time:12568ms step_avg:34.06ms
+step:370/1600 train_time:12605ms step_avg:34.07ms
+step:371/1600 train_time:12636ms step_avg:34.06ms
+step:372/1600 train_time:12672ms step_avg:34.07ms
+step:373/1600 train_time:12704ms step_avg:34.06ms
+step:374/1600 train_time:12741ms step_avg:34.07ms
+step:375/1600 train_time:12772ms step_avg:34.06ms
+step:376/1600 train_time:12809ms step_avg:34.07ms
+step:377/1600 train_time:12839ms step_avg:34.06ms
+step:378/1600 train_time:12876ms step_avg:34.06ms
+step:379/1600 train_time:12907ms step_avg:34.06ms
+step:380/1600 train_time:12944ms step_avg:34.06ms
+step:381/1600 train_time:12975ms step_avg:34.05ms
+step:382/1600 train_time:13012ms step_avg:34.06ms
+step:383/1600 train_time:13042ms step_avg:34.05ms
+step:384/1600 train_time:13079ms step_avg:34.06ms
+step:385/1600 train_time:13110ms step_avg:34.05ms
+step:386/1600 train_time:13146ms step_avg:34.06ms
+step:387/1600 train_time:13177ms step_avg:34.05ms
+step:388/1600 train_time:13213ms step_avg:34.06ms
+step:389/1600 train_time:13244ms step_avg:34.05ms
+step:390/1600 train_time:13281ms step_avg:34.05ms
+step:391/1600 train_time:13312ms step_avg:34.04ms
+step:392/1600 train_time:13349ms step_avg:34.05ms
+step:393/1600 train_time:13380ms step_avg:34.05ms
+step:394/1600 train_time:13417ms step_avg:34.05ms
+step:395/1600 train_time:13448ms step_avg:34.04ms
+step:396/1600 train_time:13484ms step_avg:34.05ms
+step:397/1600 train_time:13515ms step_avg:34.04ms
+step:398/1600 train_time:13552ms step_avg:34.05ms
+step:399/1600 train_time:13583ms step_avg:34.04ms
+step:400/1600 train_time:13620ms step_avg:34.05ms
+step:401/1600 train_time:13651ms step_avg:34.04ms
+step:402/1600 train_time:13688ms step_avg:34.05ms
+step:403/1600 train_time:13719ms step_avg:34.04ms
+step:404/1600 train_time:13755ms step_avg:34.05ms
+step:405/1600 train_time:13787ms step_avg:34.04ms
+step:406/1600 train_time:13824ms step_avg:34.05ms
+step:407/1600 train_time:13854ms step_avg:34.04ms
+step:408/1600 train_time:13891ms step_avg:34.05ms
+step:409/1600 train_time:13922ms step_avg:34.04ms
+step:410/1600 train_time:13959ms step_avg:34.05ms
+step:411/1600 train_time:13990ms step_avg:34.04ms
+step:412/1600 train_time:14027ms step_avg:34.04ms
+step:413/1600 train_time:14057ms step_avg:34.04ms
+step:414/1600 train_time:14094ms step_avg:34.04ms
+step:415/1600 train_time:14125ms step_avg:34.04ms
+step:416/1600 train_time:14162ms step_avg:34.04ms
+step:417/1600 train_time:14192ms step_avg:34.03ms
+step:418/1600 train_time:14229ms step_avg:34.04ms
+step:419/1600 train_time:14260ms step_avg:34.03ms
+step:420/1600 train_time:14297ms step_avg:34.04ms
+step:421/1600 train_time:14328ms step_avg:34.03ms
+step:422/1600 train_time:14364ms step_avg:34.04ms
+step:423/1600 train_time:14395ms step_avg:34.03ms
+step:424/1600 train_time:14432ms step_avg:34.04ms
+step:425/1600 train_time:14463ms step_avg:34.03ms
+step:426/1600 train_time:14499ms step_avg:34.04ms
+step:427/1600 train_time:14530ms step_avg:34.03ms
+step:428/1600 train_time:14567ms step_avg:34.04ms
+step:429/1600 train_time:14598ms step_avg:34.03ms
+step:430/1600 train_time:14634ms step_avg:34.03ms
+step:431/1600 train_time:14665ms step_avg:34.03ms
+step:432/1600 train_time:14702ms step_avg:34.03ms
+step:433/1600 train_time:14733ms step_avg:34.02ms
+step:434/1600 train_time:14770ms step_avg:34.03ms
+step:435/1600 train_time:14800ms step_avg:34.02ms
+step:436/1600 train_time:14837ms step_avg:34.03ms
+step:437/1600 train_time:14868ms step_avg:34.02ms
+step:438/1600 train_time:14905ms step_avg:34.03ms
+step:439/1600 train_time:14936ms step_avg:34.02ms
+step:440/1600 train_time:14972ms step_avg:34.03ms
+step:441/1600 train_time:15004ms step_avg:34.02ms
+step:442/1600 train_time:15040ms step_avg:34.03ms
+step:443/1600 train_time:15071ms step_avg:34.02ms
+step:444/1600 train_time:15108ms step_avg:34.03ms
+step:445/1600 train_time:15139ms step_avg:34.02ms
+step:446/1600 train_time:15176ms step_avg:34.03ms
+step:447/1600 train_time:15207ms step_avg:34.02ms
+step:448/1600 train_time:15243ms step_avg:34.03ms
+step:449/1600 train_time:15274ms step_avg:34.02ms
+step:450/1600 train_time:15311ms step_avg:34.02ms
+step:451/1600 train_time:15342ms step_avg:34.02ms
+step:452/1600 train_time:15379ms step_avg:34.02ms
+step:453/1600 train_time:15410ms step_avg:34.02ms
+step:454/1600 train_time:15446ms step_avg:34.02ms
+step:455/1600 train_time:15478ms step_avg:34.02ms
+step:456/1600 train_time:15515ms step_avg:34.02ms
+step:457/1600 train_time:15546ms step_avg:34.02ms
+step:458/1600 train_time:15583ms step_avg:34.02ms
+step:459/1600 train_time:15614ms step_avg:34.02ms
+step:460/1600 train_time:15651ms step_avg:34.02ms
+step:461/1600 train_time:15682ms step_avg:34.02ms
+step:462/1600 train_time:15719ms step_avg:34.02ms
+step:463/1600 train_time:15749ms step_avg:34.02ms
+step:464/1600 train_time:15786ms step_avg:34.02ms
+step:465/1600 train_time:15817ms step_avg:34.02ms
+step:466/1600 train_time:15854ms step_avg:34.02ms
+step:467/1600 train_time:15885ms step_avg:34.02ms
+step:468/1600 train_time:15922ms step_avg:34.02ms
+step:469/1600 train_time:15953ms step_avg:34.01ms
+step:470/1600 train_time:15990ms step_avg:34.02ms
+step:471/1600 train_time:16021ms step_avg:34.01ms
+step:472/1600 train_time:16057ms step_avg:34.02ms
+step:473/1600 train_time:16088ms step_avg:34.01ms
+step:474/1600 train_time:16125ms step_avg:34.02ms
+step:475/1600 train_time:16156ms step_avg:34.01ms
+step:476/1600 train_time:16193ms step_avg:34.02ms
+step:477/1600 train_time:16224ms step_avg:34.01ms
+step:478/1600 train_time:16261ms step_avg:34.02ms
+step:479/1600 train_time:16292ms step_avg:34.01ms
+step:480/1600 train_time:16328ms step_avg:34.02ms
+step:481/1600 train_time:16359ms step_avg:34.01ms
+step:482/1600 train_time:16396ms step_avg:34.02ms
+step:483/1600 train_time:16427ms step_avg:34.01ms
+step:484/1600 train_time:16464ms step_avg:34.02ms
+step:485/1600 train_time:16495ms step_avg:34.01ms
+step:486/1600 train_time:16531ms step_avg:34.02ms
+step:487/1600 train_time:16562ms step_avg:34.01ms
+step:488/1600 train_time:16599ms step_avg:34.01ms
+step:489/1600 train_time:16630ms step_avg:34.01ms
+step:490/1600 train_time:16667ms step_avg:34.01ms
+step:491/1600 train_time:16697ms step_avg:34.01ms
+step:492/1600 train_time:16734ms step_avg:34.01ms
+step:493/1600 train_time:16765ms step_avg:34.01ms
+step:494/1600 train_time:16802ms step_avg:34.01ms
+step:495/1600 train_time:16833ms step_avg:34.01ms
+step:496/1600 train_time:16870ms step_avg:34.01ms
+step:497/1600 train_time:16901ms step_avg:34.01ms
+step:498/1600 train_time:16937ms step_avg:34.01ms
+step:499/1600 train_time:16969ms step_avg:34.01ms
+step:500/1600 train_time:17005ms step_avg:34.01ms
+step:500/1600 val_loss:4.2373 train_time:17053ms step_avg:34.11ms
+step:501/1600 train_time:17073ms step_avg:34.08ms
+step:502/1600 train_time:17091ms step_avg:34.05ms
+step:503/1600 train_time:17107ms step_avg:34.01ms
+step:504/1600 train_time:17144ms step_avg:34.02ms
+step:505/1600 train_time:17176ms step_avg:34.01ms
+step:506/1600 train_time:17214ms step_avg:34.02ms
+step:507/1600 train_time:17247ms step_avg:34.02ms
+step:508/1600 train_time:17284ms step_avg:34.02ms
+step:509/1600 train_time:17315ms step_avg:34.02ms
+step:510/1600 train_time:17352ms step_avg:34.02ms
+step:511/1600 train_time:17383ms step_avg:34.02ms
+step:512/1600 train_time:17420ms step_avg:34.02ms
+step:513/1600 train_time:17450ms step_avg:34.02ms
+step:514/1600 train_time:17487ms step_avg:34.02ms
+step:515/1600 train_time:17518ms step_avg:34.02ms
+step:516/1600 train_time:17555ms step_avg:34.02ms
+step:517/1600 train_time:17585ms step_avg:34.01ms
+step:518/1600 train_time:17622ms step_avg:34.02ms
+step:519/1600 train_time:17653ms step_avg:34.01ms
+step:520/1600 train_time:17689ms step_avg:34.02ms
+step:521/1600 train_time:17763ms step_avg:34.09ms
+step:522/1600 train_time:17817ms step_avg:34.13ms
+step:523/1600 train_time:17878ms step_avg:34.18ms
+step:524/1600 train_time:17937ms step_avg:34.23ms
+step:525/1600 train_time:17998ms step_avg:34.28ms
+step:526/1600 train_time:18056ms step_avg:34.33ms
+step:527/1600 train_time:18118ms step_avg:34.38ms
+step:528/1600 train_time:18178ms step_avg:34.43ms
+step:529/1600 train_time:18242ms step_avg:34.48ms
+step:530/1600 train_time:18300ms step_avg:34.53ms
+step:531/1600 train_time:18363ms step_avg:34.58ms
+step:532/1600 train_time:18422ms step_avg:34.63ms
+step:533/1600 train_time:18485ms step_avg:34.68ms
+step:534/1600 train_time:18544ms step_avg:34.73ms
+step:535/1600 train_time:18606ms step_avg:34.78ms
+step:536/1600 train_time:18666ms step_avg:34.82ms
+step:537/1600 train_time:18728ms step_avg:34.88ms
+step:538/1600 train_time:18787ms step_avg:34.92ms
+step:539/1600 train_time:18850ms step_avg:34.97ms
+step:540/1600 train_time:18908ms step_avg:35.01ms
+step:541/1600 train_time:18970ms step_avg:35.07ms
+step:542/1600 train_time:19029ms step_avg:35.11ms
+step:543/1600 train_time:19092ms step_avg:35.16ms
+step:544/1600 train_time:19151ms step_avg:35.20ms
+step:545/1600 train_time:19214ms step_avg:35.25ms
+step:546/1600 train_time:19273ms step_avg:35.30ms
+step:547/1600 train_time:19336ms step_avg:35.35ms
+step:548/1600 train_time:19395ms step_avg:35.39ms
+step:549/1600 train_time:19459ms step_avg:35.44ms
+step:550/1600 train_time:19519ms step_avg:35.49ms
+step:551/1600 train_time:19580ms step_avg:35.54ms
+step:552/1600 train_time:19640ms step_avg:35.58ms
+step:553/1600 train_time:19702ms step_avg:35.63ms
+step:554/1600 train_time:19761ms step_avg:35.67ms
+step:555/1600 train_time:19824ms step_avg:35.72ms
+step:556/1600 train_time:19883ms step_avg:35.76ms
+step:557/1600 train_time:19946ms step_avg:35.81ms
+step:558/1600 train_time:20004ms step_avg:35.85ms
+step:559/1600 train_time:20068ms step_avg:35.90ms
+step:560/1600 train_time:20127ms step_avg:35.94ms
+step:561/1600 train_time:20190ms step_avg:35.99ms
+step:562/1600 train_time:20248ms step_avg:36.03ms
+step:563/1600 train_time:20311ms step_avg:36.08ms
+step:564/1600 train_time:20370ms step_avg:36.12ms
+step:565/1600 train_time:20433ms step_avg:36.16ms
+step:566/1600 train_time:20492ms step_avg:36.20ms
+step:567/1600 train_time:20554ms step_avg:36.25ms
+step:568/1600 train_time:20613ms step_avg:36.29ms
+step:569/1600 train_time:20675ms step_avg:36.34ms
+step:570/1600 train_time:20736ms step_avg:36.38ms
+step:571/1600 train_time:20797ms step_avg:36.42ms
+step:572/1600 train_time:20857ms step_avg:36.46ms
+step:573/1600 train_time:20921ms step_avg:36.51ms
+step:574/1600 train_time:20981ms step_avg:36.55ms
+step:575/1600 train_time:21043ms step_avg:36.60ms
+step:576/1600 train_time:21102ms step_avg:36.64ms
+step:577/1600 train_time:21163ms step_avg:36.68ms
+step:578/1600 train_time:21222ms step_avg:36.72ms
+step:579/1600 train_time:21284ms step_avg:36.76ms
+step:580/1600 train_time:21345ms step_avg:36.80ms
+step:581/1600 train_time:21407ms step_avg:36.84ms
+step:582/1600 train_time:21467ms step_avg:36.88ms
+step:583/1600 train_time:21529ms step_avg:36.93ms
+step:584/1600 train_time:21588ms step_avg:36.97ms
+step:585/1600 train_time:21651ms step_avg:37.01ms
+step:586/1600 train_time:21711ms step_avg:37.05ms
+step:587/1600 train_time:21773ms step_avg:37.09ms
+step:588/1600 train_time:21832ms step_avg:37.13ms
+step:589/1600 train_time:21894ms step_avg:37.17ms
+step:590/1600 train_time:21955ms step_avg:37.21ms
+step:591/1600 train_time:22017ms step_avg:37.25ms
+step:592/1600 train_time:22076ms step_avg:37.29ms
+step:593/1600 train_time:22138ms step_avg:37.33ms
+step:594/1600 train_time:22196ms step_avg:37.37ms
+step:595/1600 train_time:22259ms step_avg:37.41ms
+step:596/1600 train_time:22318ms step_avg:37.45ms
+step:597/1600 train_time:22381ms step_avg:37.49ms
+step:598/1600 train_time:22440ms step_avg:37.52ms
+step:599/1600 train_time:22503ms step_avg:37.57ms
+step:600/1600 train_time:22564ms step_avg:37.61ms
+step:601/1600 train_time:22625ms step_avg:37.65ms
+step:602/1600 train_time:22684ms step_avg:37.68ms
+step:603/1600 train_time:22747ms step_avg:37.72ms
+step:604/1600 train_time:22806ms step_avg:37.76ms
+step:605/1600 train_time:22868ms step_avg:37.80ms
+step:606/1600 train_time:22928ms step_avg:37.83ms
+step:607/1600 train_time:22991ms step_avg:37.88ms
+step:608/1600 train_time:23050ms step_avg:37.91ms
+step:609/1600 train_time:23112ms step_avg:37.95ms
+step:610/1600 train_time:23172ms step_avg:37.99ms
+step:611/1600 train_time:23233ms step_avg:38.02ms
+step:612/1600 train_time:23292ms step_avg:38.06ms
+step:613/1600 train_time:23355ms step_avg:38.10ms
+step:614/1600 train_time:23414ms step_avg:38.13ms
+step:615/1600 train_time:23476ms step_avg:38.17ms
+step:616/1600 train_time:23536ms step_avg:38.21ms
+step:617/1600 train_time:23598ms step_avg:38.25ms
+step:618/1600 train_time:23657ms step_avg:38.28ms
+step:619/1600 train_time:23720ms step_avg:38.32ms
+step:620/1600 train_time:23780ms step_avg:38.35ms
+step:621/1600 train_time:23841ms step_avg:38.39ms
+step:622/1600 train_time:23900ms step_avg:38.42ms
+step:623/1600 train_time:23963ms step_avg:38.46ms
+step:624/1600 train_time:24022ms step_avg:38.50ms
+step:625/1600 train_time:24085ms step_avg:38.54ms
+step:626/1600 train_time:24144ms step_avg:38.57ms
+step:627/1600 train_time:24207ms step_avg:38.61ms
+step:628/1600 train_time:24266ms step_avg:38.64ms
+step:629/1600 train_time:24329ms step_avg:38.68ms
+step:630/1600 train_time:24389ms step_avg:38.71ms
+step:631/1600 train_time:24451ms step_avg:38.75ms
+step:632/1600 train_time:24510ms step_avg:38.78ms
+step:633/1600 train_time:24572ms step_avg:38.82ms
+step:634/1600 train_time:24631ms step_avg:38.85ms
+step:635/1600 train_time:24693ms step_avg:38.89ms
+step:636/1600 train_time:24753ms step_avg:38.92ms
+step:637/1600 train_time:24815ms step_avg:38.96ms
+step:638/1600 train_time:24874ms step_avg:38.99ms
+step:639/1600 train_time:24937ms step_avg:39.02ms
+step:640/1600 train_time:24996ms step_avg:39.06ms
+step:641/1600 train_time:25059ms step_avg:39.09ms
+step:642/1600 train_time:25118ms step_avg:39.13ms
+step:643/1600 train_time:25179ms step_avg:39.16ms
+step:644/1600 train_time:25239ms step_avg:39.19ms
+step:645/1600 train_time:25301ms step_avg:39.23ms
+step:646/1600 train_time:25360ms step_avg:39.26ms
+step:647/1600 train_time:25423ms step_avg:39.29ms
+step:648/1600 train_time:25482ms step_avg:39.32ms
+step:649/1600 train_time:25545ms step_avg:39.36ms
+step:650/1600 train_time:25604ms step_avg:39.39ms
+step:651/1600 train_time:25666ms step_avg:39.43ms
+step:652/1600 train_time:25725ms step_avg:39.46ms
+step:653/1600 train_time:25788ms step_avg:39.49ms
+step:654/1600 train_time:25847ms step_avg:39.52ms
+step:655/1600 train_time:25910ms step_avg:39.56ms
+step:656/1600 train_time:25969ms step_avg:39.59ms
+step:657/1600 train_time:26032ms step_avg:39.62ms
+step:658/1600 train_time:26091ms step_avg:39.65ms
+step:659/1600 train_time:26153ms step_avg:39.69ms
+step:660/1600 train_time:26212ms step_avg:39.72ms
+step:661/1600 train_time:26274ms step_avg:39.75ms
+step:662/1600 train_time:26334ms step_avg:39.78ms
+step:663/1600 train_time:26396ms step_avg:39.81ms
+step:664/1600 train_time:26456ms step_avg:39.84ms
+step:665/1600 train_time:26519ms step_avg:39.88ms
+step:666/1600 train_time:26578ms step_avg:39.91ms
+step:667/1600 train_time:26641ms step_avg:39.94ms
+step:668/1600 train_time:26699ms step_avg:39.97ms
+step:669/1600 train_time:26762ms step_avg:40.00ms
+step:670/1600 train_time:26821ms step_avg:40.03ms
+step:671/1600 train_time:26883ms step_avg:40.06ms
+step:672/1600 train_time:26943ms step_avg:40.09ms
+step:673/1600 train_time:27005ms step_avg:40.13ms
+step:674/1600 train_time:27065ms step_avg:40.16ms
+step:675/1600 train_time:27128ms step_avg:40.19ms
+step:676/1600 train_time:27187ms step_avg:40.22ms
+step:677/1600 train_time:27250ms step_avg:40.25ms
+step:678/1600 train_time:27309ms step_avg:40.28ms
+step:679/1600 train_time:27374ms step_avg:40.31ms
+step:680/1600 train_time:27431ms step_avg:40.34ms
+step:681/1600 train_time:27494ms step_avg:40.37ms
+step:682/1600 train_time:27553ms step_avg:40.40ms
+step:683/1600 train_time:27615ms step_avg:40.43ms
+step:684/1600 train_time:27674ms step_avg:40.46ms
+step:685/1600 train_time:27736ms step_avg:40.49ms
+step:686/1600 train_time:27795ms step_avg:40.52ms
+step:687/1600 train_time:27858ms step_avg:40.55ms
+step:688/1600 train_time:27916ms step_avg:40.58ms
+step:689/1600 train_time:27978ms step_avg:40.61ms
+step:690/1600 train_time:28037ms step_avg:40.63ms
+step:691/1600 train_time:28101ms step_avg:40.67ms
+step:692/1600 train_time:28160ms step_avg:40.69ms
+step:693/1600 train_time:28222ms step_avg:40.73ms
+step:694/1600 train_time:28281ms step_avg:40.75ms
+step:695/1600 train_time:28344ms step_avg:40.78ms
+step:696/1600 train_time:28404ms step_avg:40.81ms
+step:697/1600 train_time:28467ms step_avg:40.84ms
+step:698/1600 train_time:28527ms step_avg:40.87ms
+step:699/1600 train_time:28590ms step_avg:40.90ms
+step:700/1600 train_time:28649ms step_avg:40.93ms
+step:701/1600 train_time:28711ms step_avg:40.96ms
+step:702/1600 train_time:28770ms step_avg:40.98ms
+step:703/1600 train_time:28834ms step_avg:41.02ms
+step:704/1600 train_time:28892ms step_avg:41.04ms
+step:705/1600 train_time:28955ms step_avg:41.07ms
+step:706/1600 train_time:29014ms step_avg:41.10ms
+step:707/1600 train_time:29076ms step_avg:41.13ms
+step:708/1600 train_time:29135ms step_avg:41.15ms
+step:709/1600 train_time:29198ms step_avg:41.18ms
+step:710/1600 train_time:29258ms step_avg:41.21ms
+step:711/1600 train_time:29320ms step_avg:41.24ms
+step:712/1600 train_time:29379ms step_avg:41.26ms
+step:713/1600 train_time:29441ms step_avg:41.29ms
+step:714/1600 train_time:29500ms step_avg:41.32ms
+step:715/1600 train_time:29564ms step_avg:41.35ms
+step:716/1600 train_time:29622ms step_avg:41.37ms
+step:717/1600 train_time:29684ms step_avg:41.40ms
+step:718/1600 train_time:29744ms step_avg:41.43ms
+step:719/1600 train_time:29807ms step_avg:41.46ms
+step:720/1600 train_time:29866ms step_avg:41.48ms
+step:721/1600 train_time:29929ms step_avg:41.51ms
+step:722/1600 train_time:29988ms step_avg:41.53ms
+step:723/1600 train_time:30051ms step_avg:41.56ms
+step:724/1600 train_time:30109ms step_avg:41.59ms
+step:725/1600 train_time:30172ms step_avg:41.62ms
+step:726/1600 train_time:30230ms step_avg:41.64ms
+step:727/1600 train_time:30293ms step_avg:41.67ms
+step:728/1600 train_time:30353ms step_avg:41.69ms
+step:729/1600 train_time:30415ms step_avg:41.72ms
+step:730/1600 train_time:30474ms step_avg:41.75ms
+step:731/1600 train_time:30537ms step_avg:41.77ms
+step:732/1600 train_time:30596ms step_avg:41.80ms
+step:733/1600 train_time:30658ms step_avg:41.83ms
+step:734/1600 train_time:30717ms step_avg:41.85ms
+step:735/1600 train_time:30780ms step_avg:41.88ms
+step:736/1600 train_time:30839ms step_avg:41.90ms
+step:737/1600 train_time:30902ms step_avg:41.93ms
+step:738/1600 train_time:30961ms step_avg:41.95ms
+step:739/1600 train_time:31025ms step_avg:41.98ms
+step:740/1600 train_time:31083ms step_avg:42.00ms
+step:741/1600 train_time:31145ms step_avg:42.03ms
+step:742/1600 train_time:31204ms step_avg:42.05ms
+step:743/1600 train_time:31267ms step_avg:42.08ms
+step:744/1600 train_time:31326ms step_avg:42.11ms
+step:745/1600 train_time:31389ms step_avg:42.13ms
+step:746/1600 train_time:31448ms step_avg:42.16ms
+step:747/1600 train_time:31510ms step_avg:42.18ms
+step:748/1600 train_time:31570ms step_avg:42.21ms
+step:749/1600 train_time:31632ms step_avg:42.23ms
+step:750/1600 train_time:31691ms step_avg:42.26ms
+step:750/1600 val_loss:3.9066 train_time:31739ms step_avg:42.32ms
+step:751/1600 train_time:31758ms step_avg:42.29ms
+step:752/1600 train_time:31817ms step_avg:42.31ms
+step:753/1600 train_time:31882ms step_avg:42.34ms
+step:754/1600 train_time:31943ms step_avg:42.36ms
+step:755/1600 train_time:32004ms step_avg:42.39ms
+step:756/1600 train_time:32063ms step_avg:42.41ms
+step:757/1600 train_time:32124ms step_avg:42.44ms
+step:758/1600 train_time:32183ms step_avg:42.46ms
+step:759/1600 train_time:32244ms step_avg:42.48ms
+step:760/1600 train_time:32302ms step_avg:42.50ms
+step:761/1600 train_time:32364ms step_avg:42.53ms
+step:762/1600 train_time:32422ms step_avg:42.55ms
+step:763/1600 train_time:32484ms step_avg:42.57ms
+step:764/1600 train_time:32544ms step_avg:42.60ms
+step:765/1600 train_time:32605ms step_avg:42.62ms
+step:766/1600 train_time:32663ms step_avg:42.64ms
+step:767/1600 train_time:32726ms step_avg:42.67ms
+step:768/1600 train_time:32787ms step_avg:42.69ms
+step:769/1600 train_time:32851ms step_avg:42.72ms
+step:770/1600 train_time:32912ms step_avg:42.74ms
+step:771/1600 train_time:32974ms step_avg:42.77ms
+step:772/1600 train_time:33033ms step_avg:42.79ms
+step:773/1600 train_time:33096ms step_avg:42.82ms
+step:774/1600 train_time:33155ms step_avg:42.84ms
+step:775/1600 train_time:33218ms step_avg:42.86ms
+step:776/1600 train_time:33276ms step_avg:42.88ms
+step:777/1600 train_time:33338ms step_avg:42.91ms
+step:778/1600 train_time:33397ms step_avg:42.93ms
+step:779/1600 train_time:33459ms step_avg:42.95ms
+step:780/1600 train_time:33517ms step_avg:42.97ms
+step:781/1600 train_time:33580ms step_avg:43.00ms
+step:782/1600 train_time:33638ms step_avg:43.02ms
+step:783/1600 train_time:33701ms step_avg:43.04ms
+step:784/1600 train_time:33761ms step_avg:43.06ms
+step:785/1600 train_time:33825ms step_avg:43.09ms
+step:786/1600 train_time:33884ms step_avg:43.11ms
+step:787/1600 train_time:33947ms step_avg:43.14ms
+step:788/1600 train_time:34007ms step_avg:43.16ms
+step:789/1600 train_time:34070ms step_avg:43.18ms
+step:790/1600 train_time:34128ms step_avg:43.20ms
+step:791/1600 train_time:34191ms step_avg:43.23ms
+step:792/1600 train_time:34250ms step_avg:43.24ms
+step:793/1600 train_time:34313ms step_avg:43.27ms
+step:794/1600 train_time:34372ms step_avg:43.29ms
+step:795/1600 train_time:34434ms step_avg:43.31ms
+step:796/1600 train_time:34493ms step_avg:43.33ms
+step:797/1600 train_time:34555ms step_avg:43.36ms
+step:798/1600 train_time:34614ms step_avg:43.38ms
+step:799/1600 train_time:34676ms step_avg:43.40ms
+step:800/1600 train_time:34735ms step_avg:43.42ms
+step:801/1600 train_time:34798ms step_avg:43.44ms
+step:802/1600 train_time:34857ms step_avg:43.46ms
+step:803/1600 train_time:34920ms step_avg:43.49ms
+step:804/1600 train_time:34980ms step_avg:43.51ms
+step:805/1600 train_time:35043ms step_avg:43.53ms
+step:806/1600 train_time:35103ms step_avg:43.55ms
+step:807/1600 train_time:35167ms step_avg:43.58ms
+step:808/1600 train_time:35225ms step_avg:43.60ms
+step:809/1600 train_time:35287ms step_avg:43.62ms
+step:810/1600 train_time:35346ms step_avg:43.64ms
+step:811/1600 train_time:35408ms step_avg:43.66ms
+step:812/1600 train_time:35467ms step_avg:43.68ms
+step:813/1600 train_time:35530ms step_avg:43.70ms
+step:814/1600 train_time:35590ms step_avg:43.72ms
+step:815/1600 train_time:35652ms step_avg:43.74ms
+step:816/1600 train_time:35711ms step_avg:43.76ms
+step:817/1600 train_time:35774ms step_avg:43.79ms
+step:818/1600 train_time:35834ms step_avg:43.81ms
+step:819/1600 train_time:35897ms step_avg:43.83ms
+step:820/1600 train_time:35956ms step_avg:43.85ms
+step:821/1600 train_time:36020ms step_avg:43.87ms
+step:822/1600 train_time:36077ms step_avg:43.89ms
+step:823/1600 train_time:36139ms step_avg:43.91ms
+step:824/1600 train_time:36199ms step_avg:43.93ms
+step:825/1600 train_time:36261ms step_avg:43.95ms
+step:826/1600 train_time:36320ms step_avg:43.97ms
+step:827/1600 train_time:36382ms step_avg:43.99ms
+step:828/1600 train_time:36442ms step_avg:44.01ms
+step:829/1600 train_time:36505ms step_avg:44.04ms
+step:830/1600 train_time:36564ms step_avg:44.05ms
+step:831/1600 train_time:36628ms step_avg:44.08ms
+step:832/1600 train_time:36687ms step_avg:44.09ms
+step:833/1600 train_time:36749ms step_avg:44.12ms
+step:834/1600 train_time:36808ms step_avg:44.13ms
+step:835/1600 train_time:36870ms step_avg:44.16ms
+step:836/1600 train_time:36931ms step_avg:44.18ms
+step:837/1600 train_time:36992ms step_avg:44.20ms
+step:838/1600 train_time:37051ms step_avg:44.21ms
+step:839/1600 train_time:37114ms step_avg:44.24ms
+step:840/1600 train_time:37173ms step_avg:44.25ms
+step:841/1600 train_time:37237ms step_avg:44.28ms
+step:842/1600 train_time:37296ms step_avg:44.29ms
+step:843/1600 train_time:37358ms step_avg:44.32ms
+step:844/1600 train_time:37417ms step_avg:44.33ms
+step:845/1600 train_time:37480ms step_avg:44.35ms
+step:846/1600 train_time:37539ms step_avg:44.37ms
+step:847/1600 train_time:37602ms step_avg:44.39ms
+step:848/1600 train_time:37661ms step_avg:44.41ms
+step:849/1600 train_time:37723ms step_avg:44.43ms
+step:850/1600 train_time:37784ms step_avg:44.45ms
+step:851/1600 train_time:37845ms step_avg:44.47ms
+step:852/1600 train_time:37904ms step_avg:44.49ms
+step:853/1600 train_time:37966ms step_avg:44.51ms
+step:854/1600 train_time:38025ms step_avg:44.53ms
+step:855/1600 train_time:38088ms step_avg:44.55ms
+step:856/1600 train_time:38147ms step_avg:44.56ms
+step:857/1600 train_time:38210ms step_avg:44.59ms
+step:858/1600 train_time:38270ms step_avg:44.60ms
+step:859/1600 train_time:38333ms step_avg:44.62ms
+step:860/1600 train_time:38392ms step_avg:44.64ms
+step:861/1600 train_time:38455ms step_avg:44.66ms
+step:862/1600 train_time:38514ms step_avg:44.68ms
+step:863/1600 train_time:38577ms step_avg:44.70ms
+step:864/1600 train_time:38636ms step_avg:44.72ms
+step:865/1600 train_time:38699ms step_avg:44.74ms
+step:866/1600 train_time:38758ms step_avg:44.75ms
+step:867/1600 train_time:38820ms step_avg:44.78ms
+step:868/1600 train_time:38880ms step_avg:44.79ms
+step:869/1600 train_time:38944ms step_avg:44.81ms
+step:870/1600 train_time:39002ms step_avg:44.83ms
+step:871/1600 train_time:39064ms step_avg:44.85ms
+step:872/1600 train_time:39124ms step_avg:44.87ms
+step:873/1600 train_time:39186ms step_avg:44.89ms
+step:874/1600 train_time:39245ms step_avg:44.90ms
+step:875/1600 train_time:39308ms step_avg:44.92ms
+step:876/1600 train_time:39367ms step_avg:44.94ms
+step:877/1600 train_time:39430ms step_avg:44.96ms
+step:878/1600 train_time:39489ms step_avg:44.98ms
+step:879/1600 train_time:39552ms step_avg:45.00ms
+step:880/1600 train_time:39610ms step_avg:45.01ms
+step:881/1600 train_time:39673ms step_avg:45.03ms
+step:882/1600 train_time:39732ms step_avg:45.05ms
+step:883/1600 train_time:39795ms step_avg:45.07ms
+step:884/1600 train_time:39854ms step_avg:45.08ms
+step:885/1600 train_time:39917ms step_avg:45.10ms
+step:886/1600 train_time:39976ms step_avg:45.12ms
+step:887/1600 train_time:40038ms step_avg:45.14ms
+step:888/1600 train_time:40097ms step_avg:45.15ms
+step:889/1600 train_time:40160ms step_avg:45.17ms
+step:890/1600 train_time:40222ms step_avg:45.19ms
+step:891/1600 train_time:40285ms step_avg:45.21ms
+step:892/1600 train_time:40346ms step_avg:45.23ms
+step:893/1600 train_time:40408ms step_avg:45.25ms
+step:894/1600 train_time:40465ms step_avg:45.26ms
+step:895/1600 train_time:40527ms step_avg:45.28ms
+step:896/1600 train_time:40587ms step_avg:45.30ms
+step:897/1600 train_time:40650ms step_avg:45.32ms
+step:898/1600 train_time:40709ms step_avg:45.33ms
+step:899/1600 train_time:40771ms step_avg:45.35ms
+step:900/1600 train_time:40830ms step_avg:45.37ms
+step:901/1600 train_time:40892ms step_avg:45.39ms
+step:902/1600 train_time:40951ms step_avg:45.40ms
+step:903/1600 train_time:41014ms step_avg:45.42ms
+step:904/1600 train_time:41074ms step_avg:45.44ms
+step:905/1600 train_time:41136ms step_avg:45.45ms
+step:906/1600 train_time:41196ms step_avg:45.47ms
+step:907/1600 train_time:41258ms step_avg:45.49ms
+step:908/1600 train_time:41318ms step_avg:45.50ms
+step:909/1600 train_time:41381ms step_avg:45.52ms
+step:910/1600 train_time:41439ms step_avg:45.54ms
+step:911/1600 train_time:41501ms step_avg:45.56ms
+step:912/1600 train_time:41560ms step_avg:45.57ms
+step:913/1600 train_time:41623ms step_avg:45.59ms
+step:914/1600 train_time:41684ms step_avg:45.61ms
+step:915/1600 train_time:41746ms step_avg:45.62ms
+step:916/1600 train_time:41805ms step_avg:45.64ms
+step:917/1600 train_time:41867ms step_avg:45.66ms
+step:918/1600 train_time:41926ms step_avg:45.67ms
+step:919/1600 train_time:41989ms step_avg:45.69ms
+step:920/1600 train_time:42048ms step_avg:45.70ms
+step:921/1600 train_time:42112ms step_avg:45.72ms
+step:922/1600 train_time:42171ms step_avg:45.74ms
+step:923/1600 train_time:42233ms step_avg:45.76ms
+step:924/1600 train_time:42293ms step_avg:45.77ms
+step:925/1600 train_time:42356ms step_avg:45.79ms
+step:926/1600 train_time:42415ms step_avg:45.80ms
+step:927/1600 train_time:42477ms step_avg:45.82ms
+step:928/1600 train_time:42536ms step_avg:45.84ms
+step:929/1600 train_time:42599ms step_avg:45.85ms
+step:930/1600 train_time:42658ms step_avg:45.87ms
+step:931/1600 train_time:42722ms step_avg:45.89ms
+step:932/1600 train_time:42781ms step_avg:45.90ms
+step:933/1600 train_time:42843ms step_avg:45.92ms
+step:934/1600 train_time:42902ms step_avg:45.93ms
+step:935/1600 train_time:42965ms step_avg:45.95ms
+step:936/1600 train_time:43023ms step_avg:45.97ms
+step:937/1600 train_time:43086ms step_avg:45.98ms
+step:938/1600 train_time:43145ms step_avg:46.00ms
+step:939/1600 train_time:43208ms step_avg:46.01ms
+step:940/1600 train_time:43267ms step_avg:46.03ms
+step:941/1600 train_time:43329ms step_avg:46.05ms
+step:942/1600 train_time:43388ms step_avg:46.06ms
+step:943/1600 train_time:43450ms step_avg:46.08ms
+step:944/1600 train_time:43510ms step_avg:46.09ms
+step:945/1600 train_time:43574ms step_avg:46.11ms
+step:946/1600 train_time:43634ms step_avg:46.12ms
+step:947/1600 train_time:43696ms step_avg:46.14ms
+step:948/1600 train_time:43755ms step_avg:46.16ms
+step:949/1600 train_time:43819ms step_avg:46.17ms
+step:950/1600 train_time:43877ms step_avg:46.19ms
+step:951/1600 train_time:43939ms step_avg:46.20ms
+step:952/1600 train_time:43998ms step_avg:46.22ms
+step:953/1600 train_time:44061ms step_avg:46.23ms
+step:954/1600 train_time:44120ms step_avg:46.25ms
+step:955/1600 train_time:44182ms step_avg:46.26ms
+step:956/1600 train_time:44241ms step_avg:46.28ms
+step:957/1600 train_time:44304ms step_avg:46.30ms
+step:958/1600 train_time:44364ms step_avg:46.31ms
+step:959/1600 train_time:44427ms step_avg:46.33ms
+step:960/1600 train_time:44486ms step_avg:46.34ms
+step:961/1600 train_time:44548ms step_avg:46.36ms
+step:962/1600 train_time:44607ms step_avg:46.37ms
+step:963/1600 train_time:44669ms step_avg:46.39ms
+step:964/1600 train_time:44728ms step_avg:46.40ms
+step:965/1600 train_time:44791ms step_avg:46.42ms
+step:966/1600 train_time:44852ms step_avg:46.43ms
+step:967/1600 train_time:44914ms step_avg:46.45ms
+step:968/1600 train_time:44973ms step_avg:46.46ms
+step:969/1600 train_time:45035ms step_avg:46.48ms
+step:970/1600 train_time:45095ms step_avg:46.49ms
+step:971/1600 train_time:45157ms step_avg:46.51ms
+step:972/1600 train_time:45216ms step_avg:46.52ms
+step:973/1600 train_time:45279ms step_avg:46.54ms
+step:974/1600 train_time:45338ms step_avg:46.55ms
+step:975/1600 train_time:45400ms step_avg:46.56ms
+step:976/1600 train_time:45459ms step_avg:46.58ms
+step:977/1600 train_time:45521ms step_avg:46.59ms
+step:978/1600 train_time:45581ms step_avg:46.61ms
+step:979/1600 train_time:45643ms step_avg:46.62ms
+step:980/1600 train_time:45702ms step_avg:46.63ms
+step:981/1600 train_time:45764ms step_avg:46.65ms
+step:982/1600 train_time:45823ms step_avg:46.66ms
+step:983/1600 train_time:45885ms step_avg:46.68ms
+step:984/1600 train_time:45946ms step_avg:46.69ms
+step:985/1600 train_time:46007ms step_avg:46.71ms
+step:986/1600 train_time:46066ms step_avg:46.72ms
+step:987/1600 train_time:46129ms step_avg:46.74ms
+step:988/1600 train_time:46189ms step_avg:46.75ms
+step:989/1600 train_time:46251ms step_avg:46.77ms
+step:990/1600 train_time:46310ms step_avg:46.78ms
+step:991/1600 train_time:46373ms step_avg:46.79ms
+step:992/1600 train_time:46432ms step_avg:46.81ms
+step:993/1600 train_time:46495ms step_avg:46.82ms
+step:994/1600 train_time:46554ms step_avg:46.83ms
+step:995/1600 train_time:46617ms step_avg:46.85ms
+step:996/1600 train_time:46676ms step_avg:46.86ms
+step:997/1600 train_time:46738ms step_avg:46.88ms
+step:998/1600 train_time:46797ms step_avg:46.89ms
+step:999/1600 train_time:46859ms step_avg:46.91ms
+step:1000/1600 train_time:46919ms step_avg:46.92ms
+step:1000/1600 val_loss:3.5968 train_time:46966ms step_avg:46.97ms
+step:1001/1600 train_time:46985ms step_avg:46.94ms
+step:1002/1600 train_time:47045ms step_avg:46.95ms
+step:1003/1600 train_time:47111ms step_avg:46.97ms
+step:1004/1600 train_time:47171ms step_avg:46.98ms
+step:1005/1600 train_time:47233ms step_avg:47.00ms
+step:1006/1600 train_time:47292ms step_avg:47.01ms
+step:1007/1600 train_time:47353ms step_avg:47.02ms
+step:1008/1600 train_time:47412ms step_avg:47.04ms
+step:1009/1600 train_time:47474ms step_avg:47.05ms
+step:1010/1600 train_time:47532ms step_avg:47.06ms
+step:1011/1600 train_time:47595ms step_avg:47.08ms
+step:1012/1600 train_time:47653ms step_avg:47.09ms
+step:1013/1600 train_time:47715ms step_avg:47.10ms
+step:1014/1600 train_time:47774ms step_avg:47.11ms
+step:1015/1600 train_time:47836ms step_avg:47.13ms
+step:1016/1600 train_time:47894ms step_avg:47.14ms
+step:1017/1600 train_time:47957ms step_avg:47.16ms
+step:1018/1600 train_time:48017ms step_avg:47.17ms
+step:1019/1600 train_time:48082ms step_avg:47.19ms
+step:1020/1600 train_time:48141ms step_avg:47.20ms
+step:1021/1600 train_time:48205ms step_avg:47.21ms
+step:1022/1600 train_time:48264ms step_avg:47.23ms
+step:1023/1600 train_time:48327ms step_avg:47.24ms
+step:1024/1600 train_time:48385ms step_avg:47.25ms
+step:1025/1600 train_time:48447ms step_avg:47.27ms
+step:1026/1600 train_time:48506ms step_avg:47.28ms
+step:1027/1600 train_time:48569ms step_avg:47.29ms
+step:1028/1600 train_time:48627ms step_avg:47.30ms
+step:1029/1600 train_time:48690ms step_avg:47.32ms
+step:1030/1600 train_time:48748ms step_avg:47.33ms
+step:1031/1600 train_time:48810ms step_avg:47.34ms
+step:1032/1600 train_time:48868ms step_avg:47.35ms
+step:1033/1600 train_time:48930ms step_avg:47.37ms
+step:1034/1600 train_time:48991ms step_avg:47.38ms
+step:1035/1600 train_time:49054ms step_avg:47.40ms
+step:1036/1600 train_time:49113ms step_avg:47.41ms
+step:1037/1600 train_time:49177ms step_avg:47.42ms
+step:1038/1600 train_time:49236ms step_avg:47.43ms
+step:1039/1600 train_time:49298ms step_avg:47.45ms
+step:1040/1600 train_time:49357ms step_avg:47.46ms
+step:1041/1600 train_time:49428ms step_avg:47.48ms
+step:1042/1600 train_time:49511ms step_avg:47.52ms
+step:1043/1600 train_time:49601ms step_avg:47.56ms
+step:1044/1600 train_time:49685ms step_avg:47.59ms
+step:1045/1600 train_time:49773ms step_avg:47.63ms
+step:1046/1600 train_time:49859ms step_avg:47.67ms
+step:1047/1600 train_time:49948ms step_avg:47.71ms
+step:1048/1600 train_time:50034ms step_avg:47.74ms
+step:1049/1600 train_time:50122ms step_avg:47.78ms
+step:1050/1600 train_time:50208ms step_avg:47.82ms
+step:1051/1600 train_time:50296ms step_avg:47.86ms
+step:1052/1600 train_time:50382ms step_avg:47.89ms
+step:1053/1600 train_time:50470ms step_avg:47.93ms
+step:1054/1600 train_time:50555ms step_avg:47.97ms
+step:1055/1600 train_time:50643ms step_avg:48.00ms
+step:1056/1600 train_time:50728ms step_avg:48.04ms
+step:1057/1600 train_time:50817ms step_avg:48.08ms
+step:1058/1600 train_time:50902ms step_avg:48.11ms
+step:1059/1600 train_time:50991ms step_avg:48.15ms
+step:1060/1600 train_time:51076ms step_avg:48.19ms
+step:1061/1600 train_time:51164ms step_avg:48.22ms
+step:1062/1600 train_time:51249ms step_avg:48.26ms
+step:1063/1600 train_time:51337ms step_avg:48.29ms
+step:1064/1600 train_time:51422ms step_avg:48.33ms
+step:1065/1600 train_time:51511ms step_avg:48.37ms
+step:1066/1600 train_time:51597ms step_avg:48.40ms
+step:1067/1600 train_time:51685ms step_avg:48.44ms
+step:1068/1600 train_time:51770ms step_avg:48.47ms
+step:1069/1600 train_time:51858ms step_avg:48.51ms
+step:1070/1600 train_time:51943ms step_avg:48.55ms
+step:1071/1600 train_time:52031ms step_avg:48.58ms
+step:1072/1600 train_time:52116ms step_avg:48.62ms
+step:1073/1600 train_time:52205ms step_avg:48.65ms
+step:1074/1600 train_time:52289ms step_avg:48.69ms
+step:1075/1600 train_time:52377ms step_avg:48.72ms
+step:1076/1600 train_time:52462ms step_avg:48.76ms
+step:1077/1600 train_time:52550ms step_avg:48.79ms
+step:1078/1600 train_time:52635ms step_avg:48.83ms
+step:1079/1600 train_time:52723ms step_avg:48.86ms
+step:1080/1600 train_time:52809ms step_avg:48.90ms
+step:1081/1600 train_time:52897ms step_avg:48.93ms
+step:1082/1600 train_time:52982ms step_avg:48.97ms
+step:1083/1600 train_time:53070ms step_avg:49.00ms
+step:1084/1600 train_time:53156ms step_avg:49.04ms
+step:1085/1600 train_time:53244ms step_avg:49.07ms
+step:1086/1600 train_time:53330ms step_avg:49.11ms
+step:1087/1600 train_time:53418ms step_avg:49.14ms
+step:1088/1600 train_time:53503ms step_avg:49.18ms
+step:1089/1600 train_time:53591ms step_avg:49.21ms
+step:1090/1600 train_time:53676ms step_avg:49.24ms
+step:1091/1600 train_time:53764ms step_avg:49.28ms
+step:1092/1600 train_time:53850ms step_avg:49.31ms
+step:1093/1600 train_time:53938ms step_avg:49.35ms
+step:1094/1600 train_time:54024ms step_avg:49.38ms
+step:1095/1600 train_time:54111ms step_avg:49.42ms
+step:1096/1600 train_time:54197ms step_avg:49.45ms
+step:1097/1600 train_time:54285ms step_avg:49.48ms
+step:1098/1600 train_time:54370ms step_avg:49.52ms
+step:1099/1600 train_time:54458ms step_avg:49.55ms
+step:1100/1600 train_time:54544ms step_avg:49.59ms
+step:1101/1600 train_time:54632ms step_avg:49.62ms
+step:1102/1600 train_time:54716ms step_avg:49.65ms
+step:1103/1600 train_time:54804ms step_avg:49.69ms
+step:1104/1600 train_time:54889ms step_avg:49.72ms
+step:1105/1600 train_time:54977ms step_avg:49.75ms
+step:1106/1600 train_time:55062ms step_avg:49.79ms
+step:1107/1600 train_time:55151ms step_avg:49.82ms
+step:1108/1600 train_time:55237ms step_avg:49.85ms
+step:1109/1600 train_time:55324ms step_avg:49.89ms
+step:1110/1600 train_time:55409ms step_avg:49.92ms
+step:1111/1600 train_time:55497ms step_avg:49.95ms
+step:1112/1600 train_time:55582ms step_avg:49.98ms
+step:1113/1600 train_time:55670ms step_avg:50.02ms
+step:1114/1600 train_time:55756ms step_avg:50.05ms
+step:1115/1600 train_time:55844ms step_avg:50.08ms
+step:1116/1600 train_time:55929ms step_avg:50.12ms
+step:1117/1600 train_time:56017ms step_avg:50.15ms
+step:1118/1600 train_time:56102ms step_avg:50.18ms
+step:1119/1600 train_time:56190ms step_avg:50.21ms
+step:1120/1600 train_time:56275ms step_avg:50.25ms
+step:1121/1600 train_time:56363ms step_avg:50.28ms
+step:1122/1600 train_time:56450ms step_avg:50.31ms
+step:1123/1600 train_time:56537ms step_avg:50.34ms
+step:1124/1600 train_time:56622ms step_avg:50.38ms
+step:1125/1600 train_time:56710ms step_avg:50.41ms
+step:1126/1600 train_time:56795ms step_avg:50.44ms
+step:1127/1600 train_time:56883ms step_avg:50.47ms
+step:1128/1600 train_time:56968ms step_avg:50.50ms
+step:1129/1600 train_time:57057ms step_avg:50.54ms
+step:1130/1600 train_time:57143ms step_avg:50.57ms
+step:1131/1600 train_time:57231ms step_avg:50.60ms
+step:1132/1600 train_time:57316ms step_avg:50.63ms
+step:1133/1600 train_time:57405ms step_avg:50.67ms
+step:1134/1600 train_time:57490ms step_avg:50.70ms
+step:1135/1600 train_time:57578ms step_avg:50.73ms
+step:1136/1600 train_time:57666ms step_avg:50.76ms
+step:1137/1600 train_time:57753ms step_avg:50.79ms
+step:1138/1600 train_time:57838ms step_avg:50.82ms
+step:1139/1600 train_time:57926ms step_avg:50.86ms
+step:1140/1600 train_time:58011ms step_avg:50.89ms
+step:1141/1600 train_time:58100ms step_avg:50.92ms
+step:1142/1600 train_time:58185ms step_avg:50.95ms
+step:1143/1600 train_time:58273ms step_avg:50.98ms
+step:1144/1600 train_time:58358ms step_avg:51.01ms
+step:1145/1600 train_time:58447ms step_avg:51.05ms
+step:1146/1600 train_time:58532ms step_avg:51.08ms
+step:1147/1600 train_time:58621ms step_avg:51.11ms
+step:1148/1600 train_time:58705ms step_avg:51.14ms
+step:1149/1600 train_time:58793ms step_avg:51.17ms
+step:1150/1600 train_time:58880ms step_avg:51.20ms
+step:1151/1600 train_time:58966ms step_avg:51.23ms
+step:1152/1600 train_time:59052ms step_avg:51.26ms
+step:1153/1600 train_time:59140ms step_avg:51.29ms
+step:1154/1600 train_time:59229ms step_avg:51.32ms
+step:1155/1600 train_time:59317ms step_avg:51.36ms
+step:1156/1600 train_time:59401ms step_avg:51.39ms
+step:1157/1600 train_time:59489ms step_avg:51.42ms
+step:1158/1600 train_time:59575ms step_avg:51.45ms
+step:1159/1600 train_time:59663ms step_avg:51.48ms
+step:1160/1600 train_time:59748ms step_avg:51.51ms
+step:1161/1600 train_time:59836ms step_avg:51.54ms
+step:1162/1600 train_time:59921ms step_avg:51.57ms
+step:1163/1600 train_time:60009ms step_avg:51.60ms
+step:1164/1600 train_time:60096ms step_avg:51.63ms
+step:1165/1600 train_time:60183ms step_avg:51.66ms
+step:1166/1600 train_time:60268ms step_avg:51.69ms
+step:1167/1600 train_time:60357ms step_avg:51.72ms
+step:1168/1600 train_time:60442ms step_avg:51.75ms
+step:1169/1600 train_time:60530ms step_avg:51.78ms
+step:1170/1600 train_time:60615ms step_avg:51.81ms
+step:1171/1600 train_time:60704ms step_avg:51.84ms
+step:1172/1600 train_time:60789ms step_avg:51.87ms
+step:1173/1600 train_time:60877ms step_avg:51.90ms
+step:1174/1600 train_time:60962ms step_avg:51.93ms
+step:1175/1600 train_time:61051ms step_avg:51.96ms
+step:1176/1600 train_time:61135ms step_avg:51.99ms
+step:1177/1600 train_time:61223ms step_avg:52.02ms
+step:1178/1600 train_time:61310ms step_avg:52.05ms
+step:1179/1600 train_time:61398ms step_avg:52.08ms
+step:1180/1600 train_time:61483ms step_avg:52.10ms
+step:1181/1600 train_time:61573ms step_avg:52.14ms
+step:1182/1600 train_time:61658ms step_avg:52.16ms
+step:1183/1600 train_time:61746ms step_avg:52.19ms
+step:1184/1600 train_time:61832ms step_avg:52.22ms
+step:1185/1600 train_time:61920ms step_avg:52.25ms
+step:1186/1600 train_time:62005ms step_avg:52.28ms
+step:1187/1600 train_time:62093ms step_avg:52.31ms
+step:1188/1600 train_time:62178ms step_avg:52.34ms
+step:1189/1600 train_time:62266ms step_avg:52.37ms
+step:1190/1600 train_time:62351ms step_avg:52.40ms
+step:1191/1600 train_time:62440ms step_avg:52.43ms
+step:1192/1600 train_time:62525ms step_avg:52.45ms
+step:1193/1600 train_time:62613ms step_avg:52.48ms
+step:1194/1600 train_time:62698ms step_avg:52.51ms
+step:1195/1600 train_time:62787ms step_avg:52.54ms
+step:1196/1600 train_time:62871ms step_avg:52.57ms
+step:1197/1600 train_time:62960ms step_avg:52.60ms
+step:1198/1600 train_time:63045ms step_avg:52.63ms
+step:1199/1600 train_time:63133ms step_avg:52.65ms
+step:1200/1600 train_time:63218ms step_avg:52.68ms
+step:1201/1600 train_time:63306ms step_avg:52.71ms
+step:1202/1600 train_time:63391ms step_avg:52.74ms
+step:1203/1600 train_time:63480ms step_avg:52.77ms
+step:1204/1600 train_time:63565ms step_avg:52.79ms
+step:1205/1600 train_time:63653ms step_avg:52.82ms
+step:1206/1600 train_time:63738ms step_avg:52.85ms
+step:1207/1600 train_time:63826ms step_avg:52.88ms
+step:1208/1600 train_time:63910ms step_avg:52.91ms
+step:1209/1600 train_time:63999ms step_avg:52.94ms
+step:1210/1600 train_time:64084ms step_avg:52.96ms
+step:1211/1600 train_time:64172ms step_avg:52.99ms
+step:1212/1600 train_time:64259ms step_avg:53.02ms
+step:1213/1600 train_time:64346ms step_avg:53.05ms
+step:1214/1600 train_time:64431ms step_avg:53.07ms
+step:1215/1600 train_time:64519ms step_avg:53.10ms
+step:1216/1600 train_time:64605ms step_avg:53.13ms
+step:1217/1600 train_time:64693ms step_avg:53.16ms
+step:1218/1600 train_time:64778ms step_avg:53.18ms
+step:1219/1600 train_time:64866ms step_avg:53.21ms
+step:1220/1600 train_time:64951ms step_avg:53.24ms
+step:1221/1600 train_time:65039ms step_avg:53.27ms
+step:1222/1600 train_time:65125ms step_avg:53.29ms
+step:1223/1600 train_time:65213ms step_avg:53.32ms
+step:1224/1600 train_time:65298ms step_avg:53.35ms
+step:1225/1600 train_time:65386ms step_avg:53.38ms
+step:1226/1600 train_time:65471ms step_avg:53.40ms
+step:1227/1600 train_time:65560ms step_avg:53.43ms
+step:1228/1600 train_time:65645ms step_avg:53.46ms
+step:1229/1600 train_time:65734ms step_avg:53.49ms
+step:1230/1600 train_time:65819ms step_avg:53.51ms
+step:1231/1600 train_time:65907ms step_avg:53.54ms
+step:1232/1600 train_time:65992ms step_avg:53.57ms
+step:1233/1600 train_time:66081ms step_avg:53.59ms
+step:1234/1600 train_time:66166ms step_avg:53.62ms
+step:1235/1600 train_time:66255ms step_avg:53.65ms
+step:1236/1600 train_time:66340ms step_avg:53.67ms
+step:1237/1600 train_time:66428ms step_avg:53.70ms
+step:1238/1600 train_time:66514ms step_avg:53.73ms
+step:1239/1600 train_time:66602ms step_avg:53.75ms
+step:1240/1600 train_time:66687ms step_avg:53.78ms
+step:1241/1600 train_time:66775ms step_avg:53.81ms
+step:1242/1600 train_time:66860ms step_avg:53.83ms
+step:1243/1600 train_time:66948ms step_avg:53.86ms
+step:1244/1600 train_time:67033ms step_avg:53.89ms
+step:1245/1600 train_time:67122ms step_avg:53.91ms
+step:1246/1600 train_time:67209ms step_avg:53.94ms
+step:1247/1600 train_time:67297ms step_avg:53.97ms
+step:1248/1600 train_time:67382ms step_avg:53.99ms
+step:1249/1600 train_time:67470ms step_avg:54.02ms
+step:1250/1600 train_time:67556ms step_avg:54.04ms
+step:1250/1600 val_loss:3.4160 train_time:67628ms step_avg:54.10ms
+step:1251/1600 train_time:67648ms step_avg:54.08ms
+step:1252/1600 train_time:67733ms step_avg:54.10ms
+step:1253/1600 train_time:67824ms step_avg:54.13ms
+step:1254/1600 train_time:67910ms step_avg:54.15ms
+step:1255/1600 train_time:67999ms step_avg:54.18ms
+step:1256/1600 train_time:68083ms step_avg:54.21ms
+step:1257/1600 train_time:68170ms step_avg:54.23ms
+step:1258/1600 train_time:68255ms step_avg:54.26ms
+step:1259/1600 train_time:68341ms step_avg:54.28ms
+step:1260/1600 train_time:68426ms step_avg:54.31ms
+step:1261/1600 train_time:68513ms step_avg:54.33ms
+step:1262/1600 train_time:68598ms step_avg:54.36ms
+step:1263/1600 train_time:68690ms step_avg:54.39ms
+step:1264/1600 train_time:68777ms step_avg:54.41ms
+step:1265/1600 train_time:68866ms step_avg:54.44ms
+step:1266/1600 train_time:68952ms step_avg:54.46ms
+step:1267/1600 train_time:69040ms step_avg:54.49ms
+step:1268/1600 train_time:69126ms step_avg:54.52ms
+step:1269/1600 train_time:69212ms step_avg:54.54ms
+step:1270/1600 train_time:69296ms step_avg:54.56ms
+step:1271/1600 train_time:69383ms step_avg:54.59ms
+step:1272/1600 train_time:69468ms step_avg:54.61ms
+step:1273/1600 train_time:69556ms step_avg:54.64ms
+step:1274/1600 train_time:69643ms step_avg:54.66ms
+step:1275/1600 train_time:69732ms step_avg:54.69ms
+step:1276/1600 train_time:69818ms step_avg:54.72ms
+step:1277/1600 train_time:69907ms step_avg:54.74ms
+step:1278/1600 train_time:69992ms step_avg:54.77ms
+step:1279/1600 train_time:70080ms step_avg:54.79ms
+step:1280/1600 train_time:70166ms step_avg:54.82ms
+step:1281/1600 train_time:70253ms step_avg:54.84ms
+step:1282/1600 train_time:70338ms step_avg:54.87ms
+step:1283/1600 train_time:70425ms step_avg:54.89ms
+step:1284/1600 train_time:70510ms step_avg:54.91ms
+step:1285/1600 train_time:70600ms step_avg:54.94ms
+step:1286/1600 train_time:70685ms step_avg:54.96ms
+step:1287/1600 train_time:70774ms step_avg:54.99ms
+step:1288/1600 train_time:70860ms step_avg:55.02ms
+step:1289/1600 train_time:70947ms step_avg:55.04ms
+step:1290/1600 train_time:71033ms step_avg:55.06ms
+step:1291/1600 train_time:71121ms step_avg:55.09ms
+step:1292/1600 train_time:71206ms step_avg:55.11ms
+step:1293/1600 train_time:71294ms step_avg:55.14ms
+step:1294/1600 train_time:71379ms step_avg:55.16ms
+step:1295/1600 train_time:71466ms step_avg:55.19ms
+step:1296/1600 train_time:71551ms step_avg:55.21ms
+step:1297/1600 train_time:71639ms step_avg:55.23ms
+step:1298/1600 train_time:71724ms step_avg:55.26ms
+step:1299/1600 train_time:71813ms step_avg:55.28ms
+step:1300/1600 train_time:71899ms step_avg:55.31ms
+step:1301/1600 train_time:71987ms step_avg:55.33ms
+step:1302/1600 train_time:72073ms step_avg:55.36ms
+step:1303/1600 train_time:72161ms step_avg:55.38ms
+step:1304/1600 train_time:72246ms step_avg:55.40ms
+step:1305/1600 train_time:72334ms step_avg:55.43ms
+step:1306/1600 train_time:72419ms step_avg:55.45ms
+step:1307/1600 train_time:72506ms step_avg:55.48ms
+step:1308/1600 train_time:72591ms step_avg:55.50ms
+step:1309/1600 train_time:72679ms step_avg:55.52ms
+step:1310/1600 train_time:72765ms step_avg:55.55ms
+step:1311/1600 train_time:72854ms step_avg:55.57ms
+step:1312/1600 train_time:72939ms step_avg:55.59ms
+step:1313/1600 train_time:73028ms step_avg:55.62ms
+step:1314/1600 train_time:73113ms step_avg:55.64ms
+step:1315/1600 train_time:73201ms step_avg:55.67ms
+step:1316/1600 train_time:73286ms step_avg:55.69ms
+step:1317/1600 train_time:73375ms step_avg:55.71ms
+step:1318/1600 train_time:73460ms step_avg:55.74ms
+step:1319/1600 train_time:73547ms step_avg:55.76ms
+step:1320/1600 train_time:73632ms step_avg:55.78ms
+step:1321/1600 train_time:73720ms step_avg:55.81ms
+step:1322/1600 train_time:73805ms step_avg:55.83ms
+step:1323/1600 train_time:73894ms step_avg:55.85ms
+step:1324/1600 train_time:73980ms step_avg:55.88ms
+step:1325/1600 train_time:74068ms step_avg:55.90ms
+step:1326/1600 train_time:74153ms step_avg:55.92ms
+step:1327/1600 train_time:74242ms step_avg:55.95ms
+step:1328/1600 train_time:74327ms step_avg:55.97ms
+step:1329/1600 train_time:74415ms step_avg:55.99ms
+step:1330/1600 train_time:74499ms step_avg:56.01ms
+step:1331/1600 train_time:74588ms step_avg:56.04ms
+step:1332/1600 train_time:74672ms step_avg:56.06ms
+step:1333/1600 train_time:74761ms step_avg:56.08ms
+step:1334/1600 train_time:74846ms step_avg:56.11ms
+step:1335/1600 train_time:74935ms step_avg:56.13ms
+step:1336/1600 train_time:75020ms step_avg:56.15ms
+step:1337/1600 train_time:75109ms step_avg:56.18ms
+step:1338/1600 train_time:75194ms step_avg:56.20ms
+step:1339/1600 train_time:75282ms step_avg:56.22ms
+step:1340/1600 train_time:75367ms step_avg:56.24ms
+step:1341/1600 train_time:75456ms step_avg:56.27ms
+step:1342/1600 train_time:75540ms step_avg:56.29ms
+step:1343/1600 train_time:75629ms step_avg:56.31ms
+step:1344/1600 train_time:75714ms step_avg:56.33ms
+step:1345/1600 train_time:75802ms step_avg:56.36ms
+step:1346/1600 train_time:75887ms step_avg:56.38ms
+step:1347/1600 train_time:75975ms step_avg:56.40ms
+step:1348/1600 train_time:76061ms step_avg:56.42ms
+step:1349/1600 train_time:76150ms step_avg:56.45ms
+step:1350/1600 train_time:76235ms step_avg:56.47ms
+step:1351/1600 train_time:76323ms step_avg:56.49ms
+step:1352/1600 train_time:76408ms step_avg:56.51ms
+step:1353/1600 train_time:76497ms step_avg:56.54ms
+step:1354/1600 train_time:76582ms step_avg:56.56ms
+step:1355/1600 train_time:76672ms step_avg:56.58ms
+step:1356/1600 train_time:76757ms step_avg:56.61ms
+step:1357/1600 train_time:76845ms step_avg:56.63ms
+step:1358/1600 train_time:76930ms step_avg:56.65ms
+step:1359/1600 train_time:77019ms step_avg:56.67ms
+step:1360/1600 train_time:77104ms step_avg:56.69ms
+step:1361/1600 train_time:77193ms step_avg:56.72ms
+step:1362/1600 train_time:77278ms step_avg:56.74ms
+step:1363/1600 train_time:77365ms step_avg:56.76ms
+step:1364/1600 train_time:77450ms step_avg:56.78ms
+step:1365/1600 train_time:77538ms step_avg:56.80ms
+step:1366/1600 train_time:77625ms step_avg:56.83ms
+step:1367/1600 train_time:77713ms step_avg:56.85ms
+step:1368/1600 train_time:77798ms step_avg:56.87ms
+step:1369/1600 train_time:77886ms step_avg:56.89ms
+step:1370/1600 train_time:77970ms step_avg:56.91ms
+step:1371/1600 train_time:78058ms step_avg:56.94ms
+step:1372/1600 train_time:78144ms step_avg:56.96ms
+step:1373/1600 train_time:78233ms step_avg:56.98ms
+step:1374/1600 train_time:78318ms step_avg:57.00ms
+step:1375/1600 train_time:78408ms step_avg:57.02ms
+step:1376/1600 train_time:78493ms step_avg:57.04ms
+step:1377/1600 train_time:78581ms step_avg:57.07ms
+step:1378/1600 train_time:78666ms step_avg:57.09ms
+step:1379/1600 train_time:78754ms step_avg:57.11ms
+step:1380/1600 train_time:78840ms step_avg:57.13ms
+step:1381/1600 train_time:78928ms step_avg:57.15ms
+step:1382/1600 train_time:79013ms step_avg:57.17ms
+step:1383/1600 train_time:79101ms step_avg:57.20ms
+step:1384/1600 train_time:79187ms step_avg:57.22ms
+step:1385/1600 train_time:79275ms step_avg:57.24ms
+step:1386/1600 train_time:79360ms step_avg:57.26ms
+step:1387/1600 train_time:79449ms step_avg:57.28ms
+step:1388/1600 train_time:79534ms step_avg:57.30ms
+step:1389/1600 train_time:79622ms step_avg:57.32ms
+step:1390/1600 train_time:79707ms step_avg:57.34ms
+step:1391/1600 train_time:79796ms step_avg:57.37ms
+step:1392/1600 train_time:79881ms step_avg:57.39ms
+step:1393/1600 train_time:79970ms step_avg:57.41ms
+step:1394/1600 train_time:80055ms step_avg:57.43ms
+step:1395/1600 train_time:80143ms step_avg:57.45ms
+step:1396/1600 train_time:80229ms step_avg:57.47ms
+step:1397/1600 train_time:80317ms step_avg:57.49ms
+step:1398/1600 train_time:80402ms step_avg:57.51ms
+step:1399/1600 train_time:80491ms step_avg:57.53ms
+step:1400/1600 train_time:80577ms step_avg:57.55ms
+step:1401/1600 train_time:80664ms step_avg:57.58ms
+step:1402/1600 train_time:80749ms step_avg:57.60ms
+step:1403/1600 train_time:80837ms step_avg:57.62ms
+step:1404/1600 train_time:80923ms step_avg:57.64ms
+step:1405/1600 train_time:81012ms step_avg:57.66ms
+step:1406/1600 train_time:81098ms step_avg:57.68ms
+step:1407/1600 train_time:81186ms step_avg:57.70ms
+step:1408/1600 train_time:81271ms step_avg:57.72ms
+step:1409/1600 train_time:81360ms step_avg:57.74ms
+step:1410/1600 train_time:81446ms step_avg:57.76ms
+step:1411/1600 train_time:81534ms step_avg:57.78ms
+step:1412/1600 train_time:81619ms step_avg:57.80ms
+step:1413/1600 train_time:81708ms step_avg:57.83ms
+step:1414/1600 train_time:81792ms step_avg:57.84ms
+step:1415/1600 train_time:81881ms step_avg:57.87ms
+step:1416/1600 train_time:81968ms step_avg:57.89ms
+step:1417/1600 train_time:82055ms step_avg:57.91ms
+step:1418/1600 train_time:82140ms step_avg:57.93ms
+step:1419/1600 train_time:82229ms step_avg:57.95ms
+step:1420/1600 train_time:82313ms step_avg:57.97ms
+step:1421/1600 train_time:82402ms step_avg:57.99ms
+step:1422/1600 train_time:82487ms step_avg:58.01ms
+step:1423/1600 train_time:82575ms step_avg:58.03ms
+step:1424/1600 train_time:82660ms step_avg:58.05ms
+step:1425/1600 train_time:82748ms step_avg:58.07ms
+step:1426/1600 train_time:82833ms step_avg:58.09ms
+step:1427/1600 train_time:82922ms step_avg:58.11ms
+step:1428/1600 train_time:83007ms step_avg:58.13ms
+step:1429/1600 train_time:83095ms step_avg:58.15ms
+step:1430/1600 train_time:83180ms step_avg:58.17ms
+step:1431/1600 train_time:83269ms step_avg:58.19ms
+step:1432/1600 train_time:83354ms step_avg:58.21ms
+step:1433/1600 train_time:83442ms step_avg:58.23ms
+step:1434/1600 train_time:83527ms step_avg:58.25ms
+step:1435/1600 train_time:83616ms step_avg:58.27ms
+step:1436/1600 train_time:83703ms step_avg:58.29ms
+step:1437/1600 train_time:83789ms step_avg:58.31ms
+step:1438/1600 train_time:83874ms step_avg:58.33ms
+step:1439/1600 train_time:83963ms step_avg:58.35ms
+step:1440/1600 train_time:84049ms step_avg:58.37ms
+step:1441/1600 train_time:84137ms step_avg:58.39ms
+step:1442/1600 train_time:84222ms step_avg:58.41ms
+step:1443/1600 train_time:84311ms step_avg:58.43ms
+step:1444/1600 train_time:84396ms step_avg:58.45ms
+step:1445/1600 train_time:84484ms step_avg:58.47ms
+step:1446/1600 train_time:84570ms step_avg:58.49ms
+step:1447/1600 train_time:84658ms step_avg:58.51ms
+step:1448/1600 train_time:84743ms step_avg:58.52ms
+step:1449/1600 train_time:84831ms step_avg:58.54ms
+step:1450/1600 train_time:84915ms step_avg:58.56ms
+step:1451/1600 train_time:85004ms step_avg:58.58ms
+step:1452/1600 train_time:85089ms step_avg:58.60ms
+step:1453/1600 train_time:85177ms step_avg:58.62ms
+step:1454/1600 train_time:85262ms step_avg:58.64ms
+step:1455/1600 train_time:85350ms step_avg:58.66ms
+step:1456/1600 train_time:85437ms step_avg:58.68ms
+step:1457/1600 train_time:85524ms step_avg:58.70ms
+step:1458/1600 train_time:85610ms step_avg:58.72ms
+step:1459/1600 train_time:85698ms step_avg:58.74ms
+step:1460/1600 train_time:85783ms step_avg:58.76ms
+step:1461/1600 train_time:85871ms step_avg:58.78ms
+step:1462/1600 train_time:85956ms step_avg:58.79ms
+step:1463/1600 train_time:86044ms step_avg:58.81ms
+step:1464/1600 train_time:86132ms step_avg:58.83ms
+step:1465/1600 train_time:86219ms step_avg:58.85ms
+step:1466/1600 train_time:86305ms step_avg:58.87ms
+step:1467/1600 train_time:86393ms step_avg:58.89ms
+step:1468/1600 train_time:86478ms step_avg:58.91ms
+step:1469/1600 train_time:86567ms step_avg:58.93ms
+step:1470/1600 train_time:86652ms step_avg:58.95ms
+step:1471/1600 train_time:86740ms step_avg:58.97ms
+step:1472/1600 train_time:86825ms step_avg:58.98ms
+step:1473/1600 train_time:86914ms step_avg:59.00ms
+step:1474/1600 train_time:86998ms step_avg:59.02ms
+step:1475/1600 train_time:87087ms step_avg:59.04ms
+step:1476/1600 train_time:87173ms step_avg:59.06ms
+step:1477/1600 train_time:87260ms step_avg:59.08ms
+step:1478/1600 train_time:87344ms step_avg:59.10ms
+step:1479/1600 train_time:87433ms step_avg:59.12ms
+step:1480/1600 train_time:87519ms step_avg:59.13ms
+step:1481/1600 train_time:87607ms step_avg:59.15ms
+step:1482/1600 train_time:87692ms step_avg:59.17ms
+step:1483/1600 train_time:87780ms step_avg:59.19ms
+step:1484/1600 train_time:87865ms step_avg:59.21ms
+step:1485/1600 train_time:87954ms step_avg:59.23ms
+step:1486/1600 train_time:88039ms step_avg:59.25ms
+step:1487/1600 train_time:88127ms step_avg:59.27ms
+step:1488/1600 train_time:88212ms step_avg:59.28ms
+step:1489/1600 train_time:88300ms step_avg:59.30ms
+step:1490/1600 train_time:88384ms step_avg:59.32ms
+step:1491/1600 train_time:88473ms step_avg:59.34ms
+step:1492/1600 train_time:88558ms step_avg:59.36ms
+step:1493/1600 train_time:88646ms step_avg:59.37ms
+step:1494/1600 train_time:88732ms step_avg:59.39ms
+step:1495/1600 train_time:88819ms step_avg:59.41ms
+step:1496/1600 train_time:88905ms step_avg:59.43ms
+step:1497/1600 train_time:88993ms step_avg:59.45ms
+step:1498/1600 train_time:89078ms step_avg:59.46ms
+step:1499/1600 train_time:89167ms step_avg:59.48ms
+step:1500/1600 train_time:89252ms step_avg:59.50ms
+step:1500/1600 val_loss:3.3068 train_time:89324ms step_avg:59.55ms
+step:1501/1600 train_time:89342ms step_avg:59.52ms
+step:1502/1600 train_time:89429ms step_avg:59.54ms
+step:1503/1600 train_time:89521ms step_avg:59.56ms
+step:1504/1600 train_time:89607ms step_avg:59.58ms
+step:1505/1600 train_time:89696ms step_avg:59.60ms
+step:1506/1600 train_time:89780ms step_avg:59.62ms
+step:1507/1600 train_time:89867ms step_avg:59.63ms
+step:1508/1600 train_time:89951ms step_avg:59.65ms
+step:1509/1600 train_time:90038ms step_avg:59.67ms
+step:1510/1600 train_time:90122ms step_avg:59.68ms
+step:1511/1600 train_time:90209ms step_avg:59.70ms
+step:1512/1600 train_time:90294ms step_avg:59.72ms
+step:1513/1600 train_time:90385ms step_avg:59.74ms
+step:1514/1600 train_time:90472ms step_avg:59.76ms
+step:1515/1600 train_time:90561ms step_avg:59.78ms
+step:1516/1600 train_time:90647ms step_avg:59.79ms
+step:1517/1600 train_time:90735ms step_avg:59.81ms
+step:1518/1600 train_time:90820ms step_avg:59.83ms
+step:1519/1600 train_time:90908ms step_avg:59.85ms
+step:1520/1600 train_time:90991ms step_avg:59.86ms
+step:1521/1600 train_time:91078ms step_avg:59.88ms
+step:1522/1600 train_time:91162ms step_avg:59.90ms
+step:1523/1600 train_time:91250ms step_avg:59.91ms
+step:1524/1600 train_time:91336ms step_avg:59.93ms
+step:1525/1600 train_time:91427ms step_avg:59.95ms
+step:1526/1600 train_time:91513ms step_avg:59.97ms
+step:1527/1600 train_time:91601ms step_avg:59.99ms
+step:1528/1600 train_time:91687ms step_avg:60.00ms
+step:1529/1600 train_time:91775ms step_avg:60.02ms
+step:1530/1600 train_time:91861ms step_avg:60.04ms
+step:1531/1600 train_time:91948ms step_avg:60.06ms
+step:1532/1600 train_time:92032ms step_avg:60.07ms
+step:1533/1600 train_time:92119ms step_avg:60.09ms
+step:1534/1600 train_time:92204ms step_avg:60.11ms
+step:1535/1600 train_time:92293ms step_avg:60.13ms
+step:1536/1600 train_time:92379ms step_avg:60.14ms
+step:1537/1600 train_time:92469ms step_avg:60.16ms
+step:1538/1600 train_time:92556ms step_avg:60.18ms
+step:1539/1600 train_time:92645ms step_avg:60.20ms
+step:1540/1600 train_time:92730ms step_avg:60.21ms
+step:1541/1600 train_time:92818ms step_avg:60.23ms
+step:1542/1600 train_time:92903ms step_avg:60.25ms
+step:1543/1600 train_time:92991ms step_avg:60.27ms
+step:1544/1600 train_time:93076ms step_avg:60.28ms
+step:1545/1600 train_time:93164ms step_avg:60.30ms
+step:1546/1600 train_time:93249ms step_avg:60.32ms
+step:1547/1600 train_time:93338ms step_avg:60.34ms
+step:1548/1600 train_time:93424ms step_avg:60.35ms
+step:1549/1600 train_time:93515ms step_avg:60.37ms
+step:1550/1600 train_time:93599ms step_avg:60.39ms
+step:1551/1600 train_time:93689ms step_avg:60.41ms
+step:1552/1600 train_time:93774ms step_avg:60.42ms
+step:1553/1600 train_time:93861ms step_avg:60.44ms
+step:1554/1600 train_time:93946ms step_avg:60.45ms
+step:1555/1600 train_time:94034ms step_avg:60.47ms
+step:1556/1600 train_time:94118ms step_avg:60.49ms
+step:1557/1600 train_time:94206ms step_avg:60.51ms
+step:1558/1600 train_time:94291ms step_avg:60.52ms
+step:1559/1600 train_time:94379ms step_avg:60.54ms
+step:1560/1600 train_time:94465ms step_avg:60.55ms
+step:1561/1600 train_time:94562ms step_avg:60.58ms
+step:1562/1600 train_time:94647ms step_avg:60.59ms
+step:1563/1600 train_time:94735ms step_avg:60.61ms
+step:1564/1600 train_time:94821ms step_avg:60.63ms
+step:1565/1600 train_time:94909ms step_avg:60.64ms
+step:1566/1600 train_time:94995ms step_avg:60.66ms
+step:1567/1600 train_time:95082ms step_avg:60.68ms
+step:1568/1600 train_time:95168ms step_avg:60.69ms
+step:1569/1600 train_time:95256ms step_avg:60.71ms
+step:1570/1600 train_time:95342ms step_avg:60.73ms
+step:1571/1600 train_time:95431ms step_avg:60.75ms
+step:1572/1600 train_time:95517ms step_avg:60.76ms
+step:1573/1600 train_time:95609ms step_avg:60.78ms
+step:1574/1600 train_time:95693ms step_avg:60.80ms
+step:1575/1600 train_time:95782ms step_avg:60.81ms
+step:1576/1600 train_time:95868ms step_avg:60.83ms
+step:1577/1600 train_time:95958ms step_avg:60.85ms
+step:1578/1600 train_time:96043ms step_avg:60.86ms
+step:1579/1600 train_time:96132ms step_avg:60.88ms
+step:1580/1600 train_time:96217ms step_avg:60.90ms
+step:1581/1600 train_time:96304ms step_avg:60.91ms
+step:1582/1600 train_time:96389ms step_avg:60.93ms
+step:1583/1600 train_time:96479ms step_avg:60.95ms
+step:1584/1600 train_time:96565ms step_avg:60.96ms
+step:1585/1600 train_time:96654ms step_avg:60.98ms
+step:1586/1600 train_time:96739ms step_avg:61.00ms
+step:1587/1600 train_time:96828ms step_avg:61.01ms
+step:1588/1600 train_time:96913ms step_avg:61.03ms
+step:1589/1600 train_time:97001ms step_avg:61.05ms
+step:1590/1600 train_time:97088ms step_avg:61.06ms
+step:1591/1600 train_time:97176ms step_avg:61.08ms
+step:1592/1600 train_time:97262ms step_avg:61.09ms
+step:1593/1600 train_time:97350ms step_avg:61.11ms
+step:1594/1600 train_time:97436ms step_avg:61.13ms
+step:1595/1600 train_time:97524ms step_avg:61.14ms
+step:1596/1600 train_time:97610ms step_avg:61.16ms
+step:1597/1600 train_time:97699ms step_avg:61.18ms
+step:1598/1600 train_time:97786ms step_avg:61.19ms
+step:1599/1600 train_time:97874ms step_avg:61.21ms
+step:1600/1600 train_time:97959ms step_avg:61.22ms
+step:1600/1600 val_loss:3.2770 train_time:98031ms step_avg:61.27ms
+peak memory allocated: 30181 MiB reserved: 46198 MiB

--- a/records/track_1_short/2026-01-19_BigramHashEmbedding/7ef7bf0e-c15a-4e3b-b832-9f733b9e02d7.txt
+++ b/records/track_1_short/2026-01-19_BigramHashEmbedding/7ef7bf0e-c15a-4e3b-b832-9f733b9e02d7.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 19 22:27:49 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   28C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   28C    P0            121W /  700W |    1520MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   26C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   29C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   25C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   29C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   25C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     53216      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     53217      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     53218      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     53219      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     53220      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     53221      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     53222      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     53223      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8317 train_time:0ms step_avg:0.04ms
+step:1/1600 train_time:81ms step_avg:81.42ms
+step:2/1600 train_time:104ms step_avg:51.90ms
+step:3/1600 train_time:123ms step_avg:40.86ms
+step:4/1600 train_time:150ms step_avg:37.47ms
+step:5/1600 train_time:180ms step_avg:36.02ms
+step:6/1600 train_time:272ms step_avg:45.35ms
+step:7/1600 train_time:289ms step_avg:41.31ms
+step:8/1600 train_time:314ms step_avg:39.26ms
+step:9/1600 train_time:345ms step_avg:38.32ms
+step:10/1600 train_time:382ms step_avg:38.16ms
+step:11/1600 train_time:413ms step_avg:37.52ms
+step:12/1600 train_time:450ms step_avg:37.49ms
+step:13/1600 train_time:481ms step_avg:37.01ms
+step:14/1600 train_time:518ms step_avg:37.01ms
+step:15/1600 train_time:549ms step_avg:36.61ms
+step:16/1600 train_time:586ms step_avg:36.65ms
+step:17/1600 train_time:618ms step_avg:36.34ms
+step:18/1600 train_time:654ms step_avg:36.36ms
+step:19/1600 train_time:686ms step_avg:36.09ms
+step:20/1600 train_time:722ms step_avg:36.12ms
+step:21/1600 train_time:754ms step_avg:35.88ms
+step:22/1600 train_time:790ms step_avg:35.93ms
+step:23/1600 train_time:821ms step_avg:35.71ms
+step:24/1600 train_time:858ms step_avg:35.76ms
+step:25/1600 train_time:889ms step_avg:35.57ms
+step:26/1600 train_time:926ms step_avg:35.63ms
+step:27/1600 train_time:957ms step_avg:35.46ms
+step:28/1600 train_time:994ms step_avg:35.51ms
+step:29/1600 train_time:1026ms step_avg:35.36ms
+step:30/1600 train_time:1063ms step_avg:35.42ms
+step:31/1600 train_time:1094ms step_avg:35.28ms
+step:32/1600 train_time:1131ms step_avg:35.34ms
+step:33/1600 train_time:1162ms step_avg:35.20ms
+step:34/1600 train_time:1199ms step_avg:35.25ms
+step:35/1600 train_time:1230ms step_avg:35.14ms
+step:36/1600 train_time:1267ms step_avg:35.19ms
+step:37/1600 train_time:1298ms step_avg:35.08ms
+step:38/1600 train_time:1335ms step_avg:35.13ms
+step:39/1600 train_time:1366ms step_avg:35.02ms
+step:40/1600 train_time:1403ms step_avg:35.07ms
+step:41/1600 train_time:1434ms step_avg:34.98ms
+step:42/1600 train_time:1472ms step_avg:35.04ms
+step:43/1600 train_time:1502ms step_avg:34.93ms
+step:44/1600 train_time:1539ms step_avg:34.98ms
+step:45/1600 train_time:1570ms step_avg:34.89ms
+step:46/1600 train_time:1607ms step_avg:34.93ms
+step:47/1600 train_time:1639ms step_avg:34.86ms
+step:48/1600 train_time:1676ms step_avg:34.91ms
+step:49/1600 train_time:1707ms step_avg:34.84ms
+step:50/1600 train_time:1744ms step_avg:34.88ms
+step:51/1600 train_time:1775ms step_avg:34.80ms
+step:52/1600 train_time:1811ms step_avg:34.84ms
+step:53/1600 train_time:1842ms step_avg:34.76ms
+step:54/1600 train_time:1880ms step_avg:34.81ms
+step:55/1600 train_time:1910ms step_avg:34.73ms
+step:56/1600 train_time:1947ms step_avg:34.77ms
+step:57/1600 train_time:1978ms step_avg:34.71ms
+step:58/1600 train_time:2016ms step_avg:34.75ms
+step:59/1600 train_time:2047ms step_avg:34.69ms
+step:60/1600 train_time:2084ms step_avg:34.73ms
+step:61/1600 train_time:2115ms step_avg:34.67ms
+step:62/1600 train_time:2152ms step_avg:34.70ms
+step:63/1600 train_time:2182ms step_avg:34.64ms
+step:64/1600 train_time:2220ms step_avg:34.69ms
+step:65/1600 train_time:2250ms step_avg:34.62ms
+step:66/1600 train_time:2288ms step_avg:34.66ms
+step:67/1600 train_time:2319ms step_avg:34.61ms
+step:68/1600 train_time:2356ms step_avg:34.64ms
+step:69/1600 train_time:2387ms step_avg:34.59ms
+step:70/1600 train_time:2424ms step_avg:34.62ms
+step:71/1600 train_time:2455ms step_avg:34.57ms
+step:72/1600 train_time:2492ms step_avg:34.61ms
+step:73/1600 train_time:2523ms step_avg:34.56ms
+step:74/1600 train_time:2560ms step_avg:34.59ms
+step:75/1600 train_time:2591ms step_avg:34.54ms
+step:76/1600 train_time:2628ms step_avg:34.58ms
+step:77/1600 train_time:2659ms step_avg:34.53ms
+step:78/1600 train_time:2696ms step_avg:34.56ms
+step:79/1600 train_time:2727ms step_avg:34.51ms
+step:80/1600 train_time:2763ms step_avg:34.54ms
+step:81/1600 train_time:2794ms step_avg:34.50ms
+step:82/1600 train_time:2831ms step_avg:34.53ms
+step:83/1600 train_time:2862ms step_avg:34.48ms
+step:84/1600 train_time:2899ms step_avg:34.51ms
+step:85/1600 train_time:2930ms step_avg:34.47ms
+step:86/1600 train_time:2967ms step_avg:34.50ms
+step:87/1600 train_time:2999ms step_avg:34.47ms
+step:88/1600 train_time:3036ms step_avg:34.50ms
+step:89/1600 train_time:3066ms step_avg:34.45ms
+step:90/1600 train_time:3104ms step_avg:34.49ms
+step:91/1600 train_time:3135ms step_avg:34.45ms
+step:92/1600 train_time:3172ms step_avg:34.47ms
+step:93/1600 train_time:3203ms step_avg:34.44ms
+step:94/1600 train_time:3240ms step_avg:34.46ms
+step:95/1600 train_time:3270ms step_avg:34.43ms
+step:96/1600 train_time:3308ms step_avg:34.45ms
+step:97/1600 train_time:3339ms step_avg:34.42ms
+step:98/1600 train_time:3376ms step_avg:34.45ms
+step:99/1600 train_time:3407ms step_avg:34.41ms
+step:100/1600 train_time:3444ms step_avg:34.44ms
+step:101/1600 train_time:3474ms step_avg:34.40ms
+step:102/1600 train_time:3511ms step_avg:34.42ms
+step:103/1600 train_time:3542ms step_avg:34.39ms
+step:104/1600 train_time:3579ms step_avg:34.42ms
+step:105/1600 train_time:3610ms step_avg:34.38ms
+step:106/1600 train_time:3647ms step_avg:34.41ms
+step:107/1600 train_time:3678ms step_avg:34.37ms
+step:108/1600 train_time:3715ms step_avg:34.40ms
+step:109/1600 train_time:3746ms step_avg:34.37ms
+step:110/1600 train_time:3783ms step_avg:34.39ms
+step:111/1600 train_time:3814ms step_avg:34.36ms
+step:112/1600 train_time:3851ms step_avg:34.38ms
+step:113/1600 train_time:3881ms step_avg:34.35ms
+step:114/1600 train_time:3919ms step_avg:34.38ms
+step:115/1600 train_time:3949ms step_avg:34.34ms
+step:116/1600 train_time:3986ms step_avg:34.36ms
+step:117/1600 train_time:4017ms step_avg:34.33ms
+step:118/1600 train_time:4054ms step_avg:34.36ms
+step:119/1600 train_time:4085ms step_avg:34.33ms
+step:120/1600 train_time:4122ms step_avg:34.35ms
+step:121/1600 train_time:4153ms step_avg:34.32ms
+step:122/1600 train_time:4190ms step_avg:34.34ms
+step:123/1600 train_time:4221ms step_avg:34.32ms
+step:124/1600 train_time:4258ms step_avg:34.34ms
+step:125/1600 train_time:4289ms step_avg:34.31ms
+step:126/1600 train_time:4326ms step_avg:34.33ms
+step:127/1600 train_time:4356ms step_avg:34.30ms
+step:128/1600 train_time:4393ms step_avg:34.32ms
+step:129/1600 train_time:4424ms step_avg:34.29ms
+step:130/1600 train_time:4461ms step_avg:34.32ms
+step:131/1600 train_time:4492ms step_avg:34.29ms
+step:132/1600 train_time:4529ms step_avg:34.31ms
+step:133/1600 train_time:4560ms step_avg:34.29ms
+step:134/1600 train_time:4597ms step_avg:34.30ms
+step:135/1600 train_time:4628ms step_avg:34.28ms
+step:136/1600 train_time:4665ms step_avg:34.30ms
+step:137/1600 train_time:4696ms step_avg:34.28ms
+step:138/1600 train_time:4733ms step_avg:34.30ms
+step:139/1600 train_time:4764ms step_avg:34.28ms
+step:140/1600 train_time:4801ms step_avg:34.29ms
+step:141/1600 train_time:4832ms step_avg:34.27ms
+step:142/1600 train_time:4870ms step_avg:34.29ms
+step:143/1600 train_time:4900ms step_avg:34.27ms
+step:144/1600 train_time:4937ms step_avg:34.29ms
+step:145/1600 train_time:4968ms step_avg:34.26ms
+step:146/1600 train_time:5005ms step_avg:34.28ms
+step:147/1600 train_time:5036ms step_avg:34.26ms
+step:148/1600 train_time:5073ms step_avg:34.28ms
+step:149/1600 train_time:5104ms step_avg:34.25ms
+step:150/1600 train_time:5141ms step_avg:34.28ms
+step:151/1600 train_time:5172ms step_avg:34.25ms
+step:152/1600 train_time:5209ms step_avg:34.27ms
+step:153/1600 train_time:5240ms step_avg:34.25ms
+step:154/1600 train_time:5276ms step_avg:34.26ms
+step:155/1600 train_time:5307ms step_avg:34.24ms
+step:156/1600 train_time:5344ms step_avg:34.26ms
+step:157/1600 train_time:5375ms step_avg:34.24ms
+step:158/1600 train_time:5413ms step_avg:34.26ms
+step:159/1600 train_time:5443ms step_avg:34.23ms
+step:160/1600 train_time:5480ms step_avg:34.25ms
+step:161/1600 train_time:5511ms step_avg:34.23ms
+step:162/1600 train_time:5548ms step_avg:34.25ms
+step:163/1600 train_time:5579ms step_avg:34.23ms
+step:164/1600 train_time:5616ms step_avg:34.24ms
+step:165/1600 train_time:5647ms step_avg:34.22ms
+step:166/1600 train_time:5684ms step_avg:34.24ms
+step:167/1600 train_time:5715ms step_avg:34.22ms
+step:168/1600 train_time:5752ms step_avg:34.24ms
+step:169/1600 train_time:5783ms step_avg:34.22ms
+step:170/1600 train_time:5820ms step_avg:34.23ms
+step:171/1600 train_time:5851ms step_avg:34.21ms
+step:172/1600 train_time:5888ms step_avg:34.23ms
+step:173/1600 train_time:5919ms step_avg:34.21ms
+step:174/1600 train_time:5956ms step_avg:34.23ms
+step:175/1600 train_time:5987ms step_avg:34.21ms
+step:176/1600 train_time:6024ms step_avg:34.23ms
+step:177/1600 train_time:6055ms step_avg:34.21ms
+step:178/1600 train_time:6092ms step_avg:34.22ms
+step:179/1600 train_time:6123ms step_avg:34.20ms
+step:180/1600 train_time:6160ms step_avg:34.22ms
+step:181/1600 train_time:6191ms step_avg:34.20ms
+step:182/1600 train_time:6228ms step_avg:34.22ms
+step:183/1600 train_time:6258ms step_avg:34.20ms
+step:184/1600 train_time:6295ms step_avg:34.21ms
+step:185/1600 train_time:6326ms step_avg:34.19ms
+step:186/1600 train_time:6363ms step_avg:34.21ms
+step:187/1600 train_time:6394ms step_avg:34.19ms
+step:188/1600 train_time:6431ms step_avg:34.21ms
+step:189/1600 train_time:6462ms step_avg:34.19ms
+step:190/1600 train_time:6499ms step_avg:34.20ms
+step:191/1600 train_time:6529ms step_avg:34.18ms
+step:192/1600 train_time:6566ms step_avg:34.20ms
+step:193/1600 train_time:6597ms step_avg:34.18ms
+step:194/1600 train_time:6634ms step_avg:34.20ms
+step:195/1600 train_time:6665ms step_avg:34.18ms
+step:196/1600 train_time:6702ms step_avg:34.19ms
+step:197/1600 train_time:6733ms step_avg:34.18ms
+step:198/1600 train_time:6770ms step_avg:34.19ms
+step:199/1600 train_time:6801ms step_avg:34.17ms
+step:200/1600 train_time:6838ms step_avg:34.19ms
+step:201/1600 train_time:6869ms step_avg:34.17ms
+step:202/1600 train_time:6905ms step_avg:34.19ms
+step:203/1600 train_time:6937ms step_avg:34.17ms
+step:204/1600 train_time:6974ms step_avg:34.18ms
+step:205/1600 train_time:7005ms step_avg:34.17ms
+step:206/1600 train_time:7042ms step_avg:34.18ms
+step:207/1600 train_time:7073ms step_avg:34.17ms
+step:208/1600 train_time:7110ms step_avg:34.18ms
+step:209/1600 train_time:7141ms step_avg:34.17ms
+step:210/1600 train_time:7178ms step_avg:34.18ms
+step:211/1600 train_time:7209ms step_avg:34.17ms
+step:212/1600 train_time:7246ms step_avg:34.18ms
+step:213/1600 train_time:7277ms step_avg:34.16ms
+step:214/1600 train_time:7314ms step_avg:34.18ms
+step:215/1600 train_time:7345ms step_avg:34.16ms
+step:216/1600 train_time:7382ms step_avg:34.18ms
+step:217/1600 train_time:7413ms step_avg:34.16ms
+step:218/1600 train_time:7450ms step_avg:34.17ms
+step:219/1600 train_time:7481ms step_avg:34.16ms
+step:220/1600 train_time:7518ms step_avg:34.17ms
+step:221/1600 train_time:7549ms step_avg:34.16ms
+step:222/1600 train_time:7586ms step_avg:34.17ms
+step:223/1600 train_time:7616ms step_avg:34.15ms
+step:224/1600 train_time:7653ms step_avg:34.17ms
+step:225/1600 train_time:7684ms step_avg:34.15ms
+step:226/1600 train_time:7722ms step_avg:34.17ms
+step:227/1600 train_time:7752ms step_avg:34.15ms
+step:228/1600 train_time:7789ms step_avg:34.16ms
+step:229/1600 train_time:7820ms step_avg:34.15ms
+step:230/1600 train_time:7857ms step_avg:34.16ms
+step:231/1600 train_time:7887ms step_avg:34.14ms
+step:232/1600 train_time:7924ms step_avg:34.16ms
+step:233/1600 train_time:7955ms step_avg:34.14ms
+step:234/1600 train_time:7992ms step_avg:34.15ms
+step:235/1600 train_time:8023ms step_avg:34.14ms
+step:236/1600 train_time:8060ms step_avg:34.15ms
+step:237/1600 train_time:8091ms step_avg:34.14ms
+step:238/1600 train_time:8128ms step_avg:34.15ms
+step:239/1600 train_time:8159ms step_avg:34.14ms
+step:240/1600 train_time:8196ms step_avg:34.15ms
+step:241/1600 train_time:8227ms step_avg:34.14ms
+step:242/1600 train_time:8264ms step_avg:34.15ms
+step:243/1600 train_time:8295ms step_avg:34.13ms
+step:244/1600 train_time:8332ms step_avg:34.15ms
+step:245/1600 train_time:8362ms step_avg:34.13ms
+step:246/1600 train_time:8400ms step_avg:34.14ms
+step:247/1600 train_time:8430ms step_avg:34.13ms
+step:248/1600 train_time:8467ms step_avg:34.14ms
+step:249/1600 train_time:8498ms step_avg:34.13ms
+step:250/1600 train_time:8536ms step_avg:34.14ms
+step:250/1600 val_loss:4.5955 train_time:8584ms step_avg:34.33ms
+step:251/1600 train_time:8602ms step_avg:34.27ms
+step:252/1600 train_time:8620ms step_avg:34.21ms
+step:253/1600 train_time:8638ms step_avg:34.14ms
+step:254/1600 train_time:8677ms step_avg:34.16ms
+step:255/1600 train_time:8709ms step_avg:34.15ms
+step:256/1600 train_time:8747ms step_avg:34.17ms
+step:257/1600 train_time:8778ms step_avg:34.16ms
+step:258/1600 train_time:8816ms step_avg:34.17ms
+step:259/1600 train_time:8846ms step_avg:34.16ms
+step:260/1600 train_time:8884ms step_avg:34.17ms
+step:261/1600 train_time:8915ms step_avg:34.16ms
+step:262/1600 train_time:8952ms step_avg:34.17ms
+step:263/1600 train_time:8983ms step_avg:34.15ms
+step:264/1600 train_time:9020ms step_avg:34.17ms
+step:265/1600 train_time:9050ms step_avg:34.15ms
+step:266/1600 train_time:9088ms step_avg:34.16ms
+step:267/1600 train_time:9118ms step_avg:34.15ms
+step:268/1600 train_time:9156ms step_avg:34.16ms
+step:269/1600 train_time:9186ms step_avg:34.15ms
+step:270/1600 train_time:9223ms step_avg:34.16ms
+step:271/1600 train_time:9253ms step_avg:34.15ms
+step:272/1600 train_time:9290ms step_avg:34.16ms
+step:273/1600 train_time:9321ms step_avg:34.14ms
+step:274/1600 train_time:9358ms step_avg:34.15ms
+step:275/1600 train_time:9389ms step_avg:34.14ms
+step:276/1600 train_time:9426ms step_avg:34.15ms
+step:277/1600 train_time:9456ms step_avg:34.14ms
+step:278/1600 train_time:9493ms step_avg:34.15ms
+step:279/1600 train_time:9524ms step_avg:34.14ms
+step:280/1600 train_time:9561ms step_avg:34.15ms
+step:281/1600 train_time:9592ms step_avg:34.13ms
+step:282/1600 train_time:9628ms step_avg:34.14ms
+step:283/1600 train_time:9659ms step_avg:34.13ms
+step:284/1600 train_time:9696ms step_avg:34.14ms
+step:285/1600 train_time:9727ms step_avg:34.13ms
+step:286/1600 train_time:9763ms step_avg:34.14ms
+step:287/1600 train_time:9794ms step_avg:34.13ms
+step:288/1600 train_time:9831ms step_avg:34.13ms
+step:289/1600 train_time:9862ms step_avg:34.12ms
+step:290/1600 train_time:9899ms step_avg:34.13ms
+step:291/1600 train_time:9929ms step_avg:34.12ms
+step:292/1600 train_time:9966ms step_avg:34.13ms
+step:293/1600 train_time:9998ms step_avg:34.12ms
+step:294/1600 train_time:10035ms step_avg:34.13ms
+step:295/1600 train_time:10066ms step_avg:34.12ms
+step:296/1600 train_time:10103ms step_avg:34.13ms
+step:297/1600 train_time:10134ms step_avg:34.12ms
+step:298/1600 train_time:10171ms step_avg:34.13ms
+step:299/1600 train_time:10201ms step_avg:34.12ms
+step:300/1600 train_time:10239ms step_avg:34.13ms
+step:301/1600 train_time:10269ms step_avg:34.12ms
+step:302/1600 train_time:10306ms step_avg:34.13ms
+step:303/1600 train_time:10337ms step_avg:34.11ms
+step:304/1600 train_time:10373ms step_avg:34.12ms
+step:305/1600 train_time:10404ms step_avg:34.11ms
+step:306/1600 train_time:10441ms step_avg:34.12ms
+step:307/1600 train_time:10472ms step_avg:34.11ms
+step:308/1600 train_time:10509ms step_avg:34.12ms
+step:309/1600 train_time:10540ms step_avg:34.11ms
+step:310/1600 train_time:10577ms step_avg:34.12ms
+step:311/1600 train_time:10607ms step_avg:34.11ms
+step:312/1600 train_time:10645ms step_avg:34.12ms
+step:313/1600 train_time:10676ms step_avg:34.11ms
+step:314/1600 train_time:10712ms step_avg:34.12ms
+step:315/1600 train_time:10743ms step_avg:34.11ms
+step:316/1600 train_time:10781ms step_avg:34.12ms
+step:317/1600 train_time:10811ms step_avg:34.10ms
+step:318/1600 train_time:10848ms step_avg:34.11ms
+step:319/1600 train_time:10878ms step_avg:34.10ms
+step:320/1600 train_time:10915ms step_avg:34.11ms
+step:321/1600 train_time:10946ms step_avg:34.10ms
+step:322/1600 train_time:10983ms step_avg:34.11ms
+step:323/1600 train_time:11013ms step_avg:34.10ms
+step:324/1600 train_time:11050ms step_avg:34.11ms
+step:325/1600 train_time:11081ms step_avg:34.10ms
+step:326/1600 train_time:11118ms step_avg:34.10ms
+step:327/1600 train_time:11148ms step_avg:34.09ms
+step:328/1600 train_time:11186ms step_avg:34.10ms
+step:329/1600 train_time:11216ms step_avg:34.09ms
+step:330/1600 train_time:11253ms step_avg:34.10ms
+step:331/1600 train_time:11284ms step_avg:34.09ms
+step:332/1600 train_time:11322ms step_avg:34.10ms
+step:333/1600 train_time:11353ms step_avg:34.09ms
+step:334/1600 train_time:11389ms step_avg:34.10ms
+step:335/1600 train_time:11420ms step_avg:34.09ms
+step:336/1600 train_time:11457ms step_avg:34.10ms
+step:337/1600 train_time:11488ms step_avg:34.09ms
+step:338/1600 train_time:11525ms step_avg:34.10ms
+step:339/1600 train_time:11556ms step_avg:34.09ms
+step:340/1600 train_time:11592ms step_avg:34.10ms
+step:341/1600 train_time:11623ms step_avg:34.09ms
+step:342/1600 train_time:11660ms step_avg:34.09ms
+step:343/1600 train_time:11691ms step_avg:34.08ms
+step:344/1600 train_time:11728ms step_avg:34.09ms
+step:345/1600 train_time:11759ms step_avg:34.08ms
+step:346/1600 train_time:11796ms step_avg:34.09ms
+step:347/1600 train_time:11827ms step_avg:34.08ms
+step:348/1600 train_time:11863ms step_avg:34.09ms
+step:349/1600 train_time:11894ms step_avg:34.08ms
+step:350/1600 train_time:11931ms step_avg:34.09ms
+step:351/1600 train_time:11962ms step_avg:34.08ms
+step:352/1600 train_time:11999ms step_avg:34.09ms
+step:353/1600 train_time:12030ms step_avg:34.08ms
+step:354/1600 train_time:12067ms step_avg:34.09ms
+step:355/1600 train_time:12098ms step_avg:34.08ms
+step:356/1600 train_time:12134ms step_avg:34.09ms
+step:357/1600 train_time:12165ms step_avg:34.08ms
+step:358/1600 train_time:12202ms step_avg:34.08ms
+step:359/1600 train_time:12233ms step_avg:34.07ms
+step:360/1600 train_time:12270ms step_avg:34.08ms
+step:361/1600 train_time:12301ms step_avg:34.08ms
+step:362/1600 train_time:12338ms step_avg:34.08ms
+step:363/1600 train_time:12369ms step_avg:34.07ms
+step:364/1600 train_time:12406ms step_avg:34.08ms
+step:365/1600 train_time:12437ms step_avg:34.07ms
+step:366/1600 train_time:12474ms step_avg:34.08ms
+step:367/1600 train_time:12504ms step_avg:34.07ms
+step:368/1600 train_time:12541ms step_avg:34.08ms
+step:369/1600 train_time:12572ms step_avg:34.07ms
+step:370/1600 train_time:12609ms step_avg:34.08ms
+step:371/1600 train_time:12640ms step_avg:34.07ms
+step:372/1600 train_time:12676ms step_avg:34.08ms
+step:373/1600 train_time:12707ms step_avg:34.07ms
+step:374/1600 train_time:12744ms step_avg:34.08ms
+step:375/1600 train_time:12775ms step_avg:34.07ms
+step:376/1600 train_time:12812ms step_avg:34.07ms
+step:377/1600 train_time:12843ms step_avg:34.07ms
+step:378/1600 train_time:12879ms step_avg:34.07ms
+step:379/1600 train_time:12910ms step_avg:34.06ms
+step:380/1600 train_time:12947ms step_avg:34.07ms
+step:381/1600 train_time:12978ms step_avg:34.06ms
+step:382/1600 train_time:13015ms step_avg:34.07ms
+step:383/1600 train_time:13046ms step_avg:34.06ms
+step:384/1600 train_time:13083ms step_avg:34.07ms
+step:385/1600 train_time:13114ms step_avg:34.06ms
+step:386/1600 train_time:13151ms step_avg:34.07ms
+step:387/1600 train_time:13181ms step_avg:34.06ms
+step:388/1600 train_time:13218ms step_avg:34.07ms
+step:389/1600 train_time:13249ms step_avg:34.06ms
+step:390/1600 train_time:13287ms step_avg:34.07ms
+step:391/1600 train_time:13317ms step_avg:34.06ms
+step:392/1600 train_time:13354ms step_avg:34.07ms
+step:393/1600 train_time:13385ms step_avg:34.06ms
+step:394/1600 train_time:13423ms step_avg:34.07ms
+step:395/1600 train_time:13453ms step_avg:34.06ms
+step:396/1600 train_time:13490ms step_avg:34.07ms
+step:397/1600 train_time:13521ms step_avg:34.06ms
+step:398/1600 train_time:13557ms step_avg:34.06ms
+step:399/1600 train_time:13588ms step_avg:34.06ms
+step:400/1600 train_time:13625ms step_avg:34.06ms
+step:401/1600 train_time:13656ms step_avg:34.05ms
+step:402/1600 train_time:13693ms step_avg:34.06ms
+step:403/1600 train_time:13724ms step_avg:34.05ms
+step:404/1600 train_time:13761ms step_avg:34.06ms
+step:405/1600 train_time:13792ms step_avg:34.05ms
+step:406/1600 train_time:13828ms step_avg:34.06ms
+step:407/1600 train_time:13859ms step_avg:34.05ms
+step:408/1600 train_time:13896ms step_avg:34.06ms
+step:409/1600 train_time:13927ms step_avg:34.05ms
+step:410/1600 train_time:13964ms step_avg:34.06ms
+step:411/1600 train_time:13994ms step_avg:34.05ms
+step:412/1600 train_time:14031ms step_avg:34.06ms
+step:413/1600 train_time:14062ms step_avg:34.05ms
+step:414/1600 train_time:14099ms step_avg:34.06ms
+step:415/1600 train_time:14130ms step_avg:34.05ms
+step:416/1600 train_time:14167ms step_avg:34.06ms
+step:417/1600 train_time:14198ms step_avg:34.05ms
+step:418/1600 train_time:14234ms step_avg:34.05ms
+step:419/1600 train_time:14265ms step_avg:34.05ms
+step:420/1600 train_time:14302ms step_avg:34.05ms
+step:421/1600 train_time:14333ms step_avg:34.04ms
+step:422/1600 train_time:14370ms step_avg:34.05ms
+step:423/1600 train_time:14400ms step_avg:34.04ms
+step:424/1600 train_time:14437ms step_avg:34.05ms
+step:425/1600 train_time:14468ms step_avg:34.04ms
+step:426/1600 train_time:14504ms step_avg:34.05ms
+step:427/1600 train_time:14535ms step_avg:34.04ms
+step:428/1600 train_time:14572ms step_avg:34.05ms
+step:429/1600 train_time:14603ms step_avg:34.04ms
+step:430/1600 train_time:14639ms step_avg:34.05ms
+step:431/1600 train_time:14671ms step_avg:34.04ms
+step:432/1600 train_time:14708ms step_avg:34.05ms
+step:433/1600 train_time:14738ms step_avg:34.04ms
+step:434/1600 train_time:14775ms step_avg:34.04ms
+step:435/1600 train_time:14806ms step_avg:34.04ms
+step:436/1600 train_time:14843ms step_avg:34.04ms
+step:437/1600 train_time:14874ms step_avg:34.04ms
+step:438/1600 train_time:14911ms step_avg:34.04ms
+step:439/1600 train_time:14942ms step_avg:34.04ms
+step:440/1600 train_time:14978ms step_avg:34.04ms
+step:441/1600 train_time:15009ms step_avg:34.03ms
+step:442/1600 train_time:15046ms step_avg:34.04ms
+step:443/1600 train_time:15077ms step_avg:34.03ms
+step:444/1600 train_time:15113ms step_avg:34.04ms
+step:445/1600 train_time:15144ms step_avg:34.03ms
+step:446/1600 train_time:15182ms step_avg:34.04ms
+step:447/1600 train_time:15212ms step_avg:34.03ms
+step:448/1600 train_time:15249ms step_avg:34.04ms
+step:449/1600 train_time:15280ms step_avg:34.03ms
+step:450/1600 train_time:15317ms step_avg:34.04ms
+step:451/1600 train_time:15348ms step_avg:34.03ms
+step:452/1600 train_time:15385ms step_avg:34.04ms
+step:453/1600 train_time:15416ms step_avg:34.03ms
+step:454/1600 train_time:15452ms step_avg:34.04ms
+step:455/1600 train_time:15483ms step_avg:34.03ms
+step:456/1600 train_time:15520ms step_avg:34.03ms
+step:457/1600 train_time:15550ms step_avg:34.03ms
+step:458/1600 train_time:15588ms step_avg:34.03ms
+step:459/1600 train_time:15618ms step_avg:34.03ms
+step:460/1600 train_time:15655ms step_avg:34.03ms
+step:461/1600 train_time:15686ms step_avg:34.03ms
+step:462/1600 train_time:15723ms step_avg:34.03ms
+step:463/1600 train_time:15754ms step_avg:34.03ms
+step:464/1600 train_time:15791ms step_avg:34.03ms
+step:465/1600 train_time:15822ms step_avg:34.03ms
+step:466/1600 train_time:15859ms step_avg:34.03ms
+step:467/1600 train_time:15890ms step_avg:34.02ms
+step:468/1600 train_time:15926ms step_avg:34.03ms
+step:469/1600 train_time:15957ms step_avg:34.02ms
+step:470/1600 train_time:15994ms step_avg:34.03ms
+step:471/1600 train_time:16025ms step_avg:34.02ms
+step:472/1600 train_time:16062ms step_avg:34.03ms
+step:473/1600 train_time:16093ms step_avg:34.02ms
+step:474/1600 train_time:16130ms step_avg:34.03ms
+step:475/1600 train_time:16161ms step_avg:34.02ms
+step:476/1600 train_time:16198ms step_avg:34.03ms
+step:477/1600 train_time:16229ms step_avg:34.02ms
+step:478/1600 train_time:16266ms step_avg:34.03ms
+step:479/1600 train_time:16297ms step_avg:34.02ms
+step:480/1600 train_time:16334ms step_avg:34.03ms
+step:481/1600 train_time:16365ms step_avg:34.02ms
+step:482/1600 train_time:16402ms step_avg:34.03ms
+step:483/1600 train_time:16433ms step_avg:34.02ms
+step:484/1600 train_time:16470ms step_avg:34.03ms
+step:485/1600 train_time:16501ms step_avg:34.02ms
+step:486/1600 train_time:16539ms step_avg:34.03ms
+step:487/1600 train_time:16569ms step_avg:34.02ms
+step:488/1600 train_time:16606ms step_avg:34.03ms
+step:489/1600 train_time:16637ms step_avg:34.02ms
+step:490/1600 train_time:16674ms step_avg:34.03ms
+step:491/1600 train_time:16704ms step_avg:34.02ms
+step:492/1600 train_time:16741ms step_avg:34.03ms
+step:493/1600 train_time:16772ms step_avg:34.02ms
+step:494/1600 train_time:16809ms step_avg:34.03ms
+step:495/1600 train_time:16840ms step_avg:34.02ms
+step:496/1600 train_time:16877ms step_avg:34.03ms
+step:497/1600 train_time:16907ms step_avg:34.02ms
+step:498/1600 train_time:16944ms step_avg:34.02ms
+step:499/1600 train_time:16975ms step_avg:34.02ms
+step:500/1600 train_time:17012ms step_avg:34.02ms
+step:500/1600 val_loss:4.2463 train_time:17060ms step_avg:34.12ms
+step:501/1600 train_time:17078ms step_avg:34.09ms
+step:502/1600 train_time:17097ms step_avg:34.06ms
+step:503/1600 train_time:17114ms step_avg:34.02ms
+step:504/1600 train_time:17152ms step_avg:34.03ms
+step:505/1600 train_time:17184ms step_avg:34.03ms
+step:506/1600 train_time:17223ms step_avg:34.04ms
+step:507/1600 train_time:17254ms step_avg:34.03ms
+step:508/1600 train_time:17291ms step_avg:34.04ms
+step:509/1600 train_time:17322ms step_avg:34.03ms
+step:510/1600 train_time:17359ms step_avg:34.04ms
+step:511/1600 train_time:17390ms step_avg:34.03ms
+step:512/1600 train_time:17427ms step_avg:34.04ms
+step:513/1600 train_time:17458ms step_avg:34.03ms
+step:514/1600 train_time:17495ms step_avg:34.04ms
+step:515/1600 train_time:17525ms step_avg:34.03ms
+step:516/1600 train_time:17562ms step_avg:34.04ms
+step:517/1600 train_time:17593ms step_avg:34.03ms
+step:518/1600 train_time:17629ms step_avg:34.03ms
+step:519/1600 train_time:17660ms step_avg:34.03ms
+step:520/1600 train_time:17697ms step_avg:34.03ms
+step:521/1600 train_time:17769ms step_avg:34.11ms
+step:522/1600 train_time:17824ms step_avg:34.15ms
+step:523/1600 train_time:17885ms step_avg:34.20ms
+step:524/1600 train_time:17943ms step_avg:34.24ms
+step:525/1600 train_time:18006ms step_avg:34.30ms
+step:526/1600 train_time:18063ms step_avg:34.34ms
+step:527/1600 train_time:18125ms step_avg:34.39ms
+step:528/1600 train_time:18185ms step_avg:34.44ms
+step:529/1600 train_time:18247ms step_avg:34.49ms
+step:530/1600 train_time:18308ms step_avg:34.54ms
+step:531/1600 train_time:18371ms step_avg:34.60ms
+step:532/1600 train_time:18430ms step_avg:34.64ms
+step:533/1600 train_time:18493ms step_avg:34.70ms
+step:534/1600 train_time:18553ms step_avg:34.74ms
+step:535/1600 train_time:18615ms step_avg:34.79ms
+step:536/1600 train_time:18674ms step_avg:34.84ms
+step:537/1600 train_time:18736ms step_avg:34.89ms
+step:538/1600 train_time:18795ms step_avg:34.94ms
+step:539/1600 train_time:18857ms step_avg:34.99ms
+step:540/1600 train_time:18916ms step_avg:35.03ms
+step:541/1600 train_time:18978ms step_avg:35.08ms
+step:542/1600 train_time:19037ms step_avg:35.12ms
+step:543/1600 train_time:19099ms step_avg:35.17ms
+step:544/1600 train_time:19158ms step_avg:35.22ms
+step:545/1600 train_time:19221ms step_avg:35.27ms
+step:546/1600 train_time:19281ms step_avg:35.31ms
+step:547/1600 train_time:19344ms step_avg:35.36ms
+step:548/1600 train_time:19403ms step_avg:35.41ms
+step:549/1600 train_time:19467ms step_avg:35.46ms
+step:550/1600 train_time:19526ms step_avg:35.50ms
+step:551/1600 train_time:19589ms step_avg:35.55ms
+step:552/1600 train_time:19648ms step_avg:35.59ms
+step:553/1600 train_time:19710ms step_avg:35.64ms
+step:554/1600 train_time:19769ms step_avg:35.68ms
+step:555/1600 train_time:19831ms step_avg:35.73ms
+step:556/1600 train_time:19890ms step_avg:35.77ms
+step:557/1600 train_time:19952ms step_avg:35.82ms
+step:558/1600 train_time:20012ms step_avg:35.86ms
+step:559/1600 train_time:20075ms step_avg:35.91ms
+step:560/1600 train_time:20134ms step_avg:35.95ms
+step:561/1600 train_time:20197ms step_avg:36.00ms
+step:562/1600 train_time:20256ms step_avg:36.04ms
+step:563/1600 train_time:20319ms step_avg:36.09ms
+step:564/1600 train_time:20378ms step_avg:36.13ms
+step:565/1600 train_time:20440ms step_avg:36.18ms
+step:566/1600 train_time:20501ms step_avg:36.22ms
+step:567/1600 train_time:20563ms step_avg:36.27ms
+step:568/1600 train_time:20623ms step_avg:36.31ms
+step:569/1600 train_time:20685ms step_avg:36.35ms
+step:570/1600 train_time:20744ms step_avg:36.39ms
+step:571/1600 train_time:20806ms step_avg:36.44ms
+step:572/1600 train_time:20866ms step_avg:36.48ms
+step:573/1600 train_time:20931ms step_avg:36.53ms
+step:574/1600 train_time:20990ms step_avg:36.57ms
+step:575/1600 train_time:21053ms step_avg:36.61ms
+step:576/1600 train_time:21111ms step_avg:36.65ms
+step:577/1600 train_time:21173ms step_avg:36.69ms
+step:578/1600 train_time:21233ms step_avg:36.74ms
+step:579/1600 train_time:21295ms step_avg:36.78ms
+step:580/1600 train_time:21354ms step_avg:36.82ms
+step:581/1600 train_time:21416ms step_avg:36.86ms
+step:582/1600 train_time:21476ms step_avg:36.90ms
+step:583/1600 train_time:21539ms step_avg:36.94ms
+step:584/1600 train_time:21598ms step_avg:36.98ms
+step:585/1600 train_time:21661ms step_avg:37.03ms
+step:586/1600 train_time:21720ms step_avg:37.07ms
+step:587/1600 train_time:21784ms step_avg:37.11ms
+step:588/1600 train_time:21843ms step_avg:37.15ms
+step:589/1600 train_time:21906ms step_avg:37.19ms
+step:590/1600 train_time:21966ms step_avg:37.23ms
+step:591/1600 train_time:22029ms step_avg:37.27ms
+step:592/1600 train_time:22088ms step_avg:37.31ms
+step:593/1600 train_time:22151ms step_avg:37.35ms
+step:594/1600 train_time:22210ms step_avg:37.39ms
+step:595/1600 train_time:22273ms step_avg:37.43ms
+step:596/1600 train_time:22332ms step_avg:37.47ms
+step:597/1600 train_time:22394ms step_avg:37.51ms
+step:598/1600 train_time:22454ms step_avg:37.55ms
+step:599/1600 train_time:22517ms step_avg:37.59ms
+step:600/1600 train_time:22576ms step_avg:37.63ms
+step:601/1600 train_time:22640ms step_avg:37.67ms
+step:602/1600 train_time:22698ms step_avg:37.70ms
+step:603/1600 train_time:22760ms step_avg:37.74ms
+step:604/1600 train_time:22819ms step_avg:37.78ms
+step:605/1600 train_time:22881ms step_avg:37.82ms
+step:606/1600 train_time:22941ms step_avg:37.86ms
+step:607/1600 train_time:23004ms step_avg:37.90ms
+step:608/1600 train_time:23064ms step_avg:37.93ms
+step:609/1600 train_time:23127ms step_avg:37.98ms
+step:610/1600 train_time:23186ms step_avg:38.01ms
+step:611/1600 train_time:23249ms step_avg:38.05ms
+step:612/1600 train_time:23308ms step_avg:38.09ms
+step:613/1600 train_time:23371ms step_avg:38.13ms
+step:614/1600 train_time:23430ms step_avg:38.16ms
+step:615/1600 train_time:23492ms step_avg:38.20ms
+step:616/1600 train_time:23551ms step_avg:38.23ms
+step:617/1600 train_time:23614ms step_avg:38.27ms
+step:618/1600 train_time:23673ms step_avg:38.31ms
+step:619/1600 train_time:23736ms step_avg:38.35ms
+step:620/1600 train_time:23795ms step_avg:38.38ms
+step:621/1600 train_time:23858ms step_avg:38.42ms
+step:622/1600 train_time:23917ms step_avg:38.45ms
+step:623/1600 train_time:23980ms step_avg:38.49ms
+step:624/1600 train_time:24039ms step_avg:38.52ms
+step:625/1600 train_time:24102ms step_avg:38.56ms
+step:626/1600 train_time:24162ms step_avg:38.60ms
+step:627/1600 train_time:24224ms step_avg:38.64ms
+step:628/1600 train_time:24284ms step_avg:38.67ms
+step:629/1600 train_time:24347ms step_avg:38.71ms
+step:630/1600 train_time:24406ms step_avg:38.74ms
+step:631/1600 train_time:24470ms step_avg:38.78ms
+step:632/1600 train_time:24528ms step_avg:38.81ms
+step:633/1600 train_time:24591ms step_avg:38.85ms
+step:634/1600 train_time:24649ms step_avg:38.88ms
+step:635/1600 train_time:24712ms step_avg:38.92ms
+step:636/1600 train_time:24772ms step_avg:38.95ms
+step:637/1600 train_time:24834ms step_avg:38.99ms
+step:638/1600 train_time:24893ms step_avg:39.02ms
+step:639/1600 train_time:24957ms step_avg:39.06ms
+step:640/1600 train_time:25016ms step_avg:39.09ms
+step:641/1600 train_time:25079ms step_avg:39.12ms
+step:642/1600 train_time:25138ms step_avg:39.16ms
+step:643/1600 train_time:25201ms step_avg:39.19ms
+step:644/1600 train_time:25260ms step_avg:39.22ms
+step:645/1600 train_time:25323ms step_avg:39.26ms
+step:646/1600 train_time:25382ms step_avg:39.29ms
+step:647/1600 train_time:25445ms step_avg:39.33ms
+step:648/1600 train_time:25505ms step_avg:39.36ms
+step:649/1600 train_time:25567ms step_avg:39.39ms
+step:650/1600 train_time:25626ms step_avg:39.43ms
+step:651/1600 train_time:25689ms step_avg:39.46ms
+step:652/1600 train_time:25748ms step_avg:39.49ms
+step:653/1600 train_time:25811ms step_avg:39.53ms
+step:654/1600 train_time:25870ms step_avg:39.56ms
+step:655/1600 train_time:25932ms step_avg:39.59ms
+step:656/1600 train_time:25991ms step_avg:39.62ms
+step:657/1600 train_time:26053ms step_avg:39.65ms
+step:658/1600 train_time:26112ms step_avg:39.68ms
+step:659/1600 train_time:26176ms step_avg:39.72ms
+step:660/1600 train_time:26235ms step_avg:39.75ms
+step:661/1600 train_time:26298ms step_avg:39.78ms
+step:662/1600 train_time:26357ms step_avg:39.81ms
+step:663/1600 train_time:26420ms step_avg:39.85ms
+step:664/1600 train_time:26479ms step_avg:39.88ms
+step:665/1600 train_time:26542ms step_avg:39.91ms
+step:666/1600 train_time:26601ms step_avg:39.94ms
+step:667/1600 train_time:26663ms step_avg:39.98ms
+step:668/1600 train_time:26723ms step_avg:40.00ms
+step:669/1600 train_time:26785ms step_avg:40.04ms
+step:670/1600 train_time:26845ms step_avg:40.07ms
+step:671/1600 train_time:26907ms step_avg:40.10ms
+step:672/1600 train_time:26967ms step_avg:40.13ms
+step:673/1600 train_time:27029ms step_avg:40.16ms
+step:674/1600 train_time:27088ms step_avg:40.19ms
+step:675/1600 train_time:27150ms step_avg:40.22ms
+step:676/1600 train_time:27213ms step_avg:40.26ms
+step:677/1600 train_time:27273ms step_avg:40.29ms
+step:678/1600 train_time:27332ms step_avg:40.31ms
+step:679/1600 train_time:27395ms step_avg:40.35ms
+step:680/1600 train_time:27455ms step_avg:40.37ms
+step:681/1600 train_time:27518ms step_avg:40.41ms
+step:682/1600 train_time:27576ms step_avg:40.43ms
+step:683/1600 train_time:27638ms step_avg:40.47ms
+step:684/1600 train_time:27698ms step_avg:40.49ms
+step:685/1600 train_time:27760ms step_avg:40.53ms
+step:686/1600 train_time:27820ms step_avg:40.55ms
+step:687/1600 train_time:27883ms step_avg:40.59ms
+step:688/1600 train_time:27942ms step_avg:40.61ms
+step:689/1600 train_time:28005ms step_avg:40.65ms
+step:690/1600 train_time:28065ms step_avg:40.67ms
+step:691/1600 train_time:28128ms step_avg:40.71ms
+step:692/1600 train_time:28187ms step_avg:40.73ms
+step:693/1600 train_time:28249ms step_avg:40.76ms
+step:694/1600 train_time:28308ms step_avg:40.79ms
+step:695/1600 train_time:28371ms step_avg:40.82ms
+step:696/1600 train_time:28429ms step_avg:40.85ms
+step:697/1600 train_time:28492ms step_avg:40.88ms
+step:698/1600 train_time:28551ms step_avg:40.90ms
+step:699/1600 train_time:28615ms step_avg:40.94ms
+step:700/1600 train_time:28674ms step_avg:40.96ms
+step:701/1600 train_time:28736ms step_avg:40.99ms
+step:702/1600 train_time:28794ms step_avg:41.02ms
+step:703/1600 train_time:28857ms step_avg:41.05ms
+step:704/1600 train_time:28917ms step_avg:41.07ms
+step:705/1600 train_time:28979ms step_avg:41.10ms
+step:706/1600 train_time:29038ms step_avg:41.13ms
+step:707/1600 train_time:29100ms step_avg:41.16ms
+step:708/1600 train_time:29160ms step_avg:41.19ms
+step:709/1600 train_time:29223ms step_avg:41.22ms
+step:710/1600 train_time:29282ms step_avg:41.24ms
+step:711/1600 train_time:29345ms step_avg:41.27ms
+step:712/1600 train_time:29404ms step_avg:41.30ms
+step:713/1600 train_time:29468ms step_avg:41.33ms
+step:714/1600 train_time:29527ms step_avg:41.35ms
+step:715/1600 train_time:29589ms step_avg:41.38ms
+step:716/1600 train_time:29648ms step_avg:41.41ms
+step:717/1600 train_time:29710ms step_avg:41.44ms
+step:718/1600 train_time:29769ms step_avg:41.46ms
+step:719/1600 train_time:29831ms step_avg:41.49ms
+step:720/1600 train_time:29890ms step_avg:41.51ms
+step:721/1600 train_time:29953ms step_avg:41.54ms
+step:722/1600 train_time:30012ms step_avg:41.57ms
+step:723/1600 train_time:30075ms step_avg:41.60ms
+step:724/1600 train_time:30134ms step_avg:41.62ms
+step:725/1600 train_time:30197ms step_avg:41.65ms
+step:726/1600 train_time:30257ms step_avg:41.68ms
+step:727/1600 train_time:30320ms step_avg:41.71ms
+step:728/1600 train_time:30378ms step_avg:41.73ms
+step:729/1600 train_time:30441ms step_avg:41.76ms
+step:730/1600 train_time:30501ms step_avg:41.78ms
+step:731/1600 train_time:30564ms step_avg:41.81ms
+step:732/1600 train_time:30623ms step_avg:41.83ms
+step:733/1600 train_time:30685ms step_avg:41.86ms
+step:734/1600 train_time:30744ms step_avg:41.89ms
+step:735/1600 train_time:30807ms step_avg:41.91ms
+step:736/1600 train_time:30866ms step_avg:41.94ms
+step:737/1600 train_time:30929ms step_avg:41.97ms
+step:738/1600 train_time:30988ms step_avg:41.99ms
+step:739/1600 train_time:31050ms step_avg:42.02ms
+step:740/1600 train_time:31109ms step_avg:42.04ms
+step:741/1600 train_time:31172ms step_avg:42.07ms
+step:742/1600 train_time:31231ms step_avg:42.09ms
+step:743/1600 train_time:31295ms step_avg:42.12ms
+step:744/1600 train_time:31354ms step_avg:42.14ms
+step:745/1600 train_time:31417ms step_avg:42.17ms
+step:746/1600 train_time:31476ms step_avg:42.19ms
+step:747/1600 train_time:31538ms step_avg:42.22ms
+step:748/1600 train_time:31597ms step_avg:42.24ms
+step:749/1600 train_time:31659ms step_avg:42.27ms
+step:750/1600 train_time:31719ms step_avg:42.29ms
+step:750/1600 val_loss:3.8894 train_time:31766ms step_avg:42.36ms
+step:751/1600 train_time:31786ms step_avg:42.32ms
+step:752/1600 train_time:31843ms step_avg:42.34ms
+step:753/1600 train_time:31907ms step_avg:42.37ms
+step:754/1600 train_time:31967ms step_avg:42.40ms
+step:755/1600 train_time:32029ms step_avg:42.42ms
+step:756/1600 train_time:32089ms step_avg:42.45ms
+step:757/1600 train_time:32151ms step_avg:42.47ms
+step:758/1600 train_time:32209ms step_avg:42.49ms
+step:759/1600 train_time:32271ms step_avg:42.52ms
+step:760/1600 train_time:32330ms step_avg:42.54ms
+step:761/1600 train_time:32393ms step_avg:42.57ms
+step:762/1600 train_time:32451ms step_avg:42.59ms
+step:763/1600 train_time:32513ms step_avg:42.61ms
+step:764/1600 train_time:32572ms step_avg:42.63ms
+step:765/1600 train_time:32633ms step_avg:42.66ms
+step:766/1600 train_time:32692ms step_avg:42.68ms
+step:767/1600 train_time:32755ms step_avg:42.71ms
+step:768/1600 train_time:32816ms step_avg:42.73ms
+step:769/1600 train_time:32880ms step_avg:42.76ms
+step:770/1600 train_time:32940ms step_avg:42.78ms
+step:771/1600 train_time:33002ms step_avg:42.80ms
+step:772/1600 train_time:33060ms step_avg:42.82ms
+step:773/1600 train_time:33123ms step_avg:42.85ms
+step:774/1600 train_time:33183ms step_avg:42.87ms
+step:775/1600 train_time:33245ms step_avg:42.90ms
+step:776/1600 train_time:33304ms step_avg:42.92ms
+step:777/1600 train_time:33366ms step_avg:42.94ms
+step:778/1600 train_time:33425ms step_avg:42.96ms
+step:779/1600 train_time:33487ms step_avg:42.99ms
+step:780/1600 train_time:33546ms step_avg:43.01ms
+step:781/1600 train_time:33608ms step_avg:43.03ms
+step:782/1600 train_time:33667ms step_avg:43.05ms
+step:783/1600 train_time:33730ms step_avg:43.08ms
+step:784/1600 train_time:33789ms step_avg:43.10ms
+step:785/1600 train_time:33852ms step_avg:43.12ms
+step:786/1600 train_time:33912ms step_avg:43.14ms
+step:787/1600 train_time:33974ms step_avg:43.17ms
+step:788/1600 train_time:34034ms step_avg:43.19ms
+step:789/1600 train_time:34097ms step_avg:43.22ms
+step:790/1600 train_time:34156ms step_avg:43.24ms
+step:791/1600 train_time:34219ms step_avg:43.26ms
+step:792/1600 train_time:34278ms step_avg:43.28ms
+step:793/1600 train_time:34341ms step_avg:43.31ms
+step:794/1600 train_time:34400ms step_avg:43.32ms
+step:795/1600 train_time:34462ms step_avg:43.35ms
+step:796/1600 train_time:34521ms step_avg:43.37ms
+step:797/1600 train_time:34583ms step_avg:43.39ms
+step:798/1600 train_time:34642ms step_avg:43.41ms
+step:799/1600 train_time:34705ms step_avg:43.44ms
+step:800/1600 train_time:34765ms step_avg:43.46ms
+step:801/1600 train_time:34827ms step_avg:43.48ms
+step:802/1600 train_time:34887ms step_avg:43.50ms
+step:803/1600 train_time:34950ms step_avg:43.52ms
+step:804/1600 train_time:35009ms step_avg:43.54ms
+step:805/1600 train_time:35072ms step_avg:43.57ms
+step:806/1600 train_time:35131ms step_avg:43.59ms
+step:807/1600 train_time:35194ms step_avg:43.61ms
+step:808/1600 train_time:35252ms step_avg:43.63ms
+step:809/1600 train_time:35316ms step_avg:43.65ms
+step:810/1600 train_time:35377ms step_avg:43.67ms
+step:811/1600 train_time:35437ms step_avg:43.70ms
+step:812/1600 train_time:35497ms step_avg:43.72ms
+step:813/1600 train_time:35559ms step_avg:43.74ms
+step:814/1600 train_time:35618ms step_avg:43.76ms
+step:815/1600 train_time:35680ms step_avg:43.78ms
+step:816/1600 train_time:35739ms step_avg:43.80ms
+step:817/1600 train_time:35802ms step_avg:43.82ms
+step:818/1600 train_time:35862ms step_avg:43.84ms
+step:819/1600 train_time:35924ms step_avg:43.86ms
+step:820/1600 train_time:35983ms step_avg:43.88ms
+step:821/1600 train_time:36046ms step_avg:43.90ms
+step:822/1600 train_time:36105ms step_avg:43.92ms
+step:823/1600 train_time:36167ms step_avg:43.95ms
+step:824/1600 train_time:36226ms step_avg:43.96ms
+step:825/1600 train_time:36289ms step_avg:43.99ms
+step:826/1600 train_time:36348ms step_avg:44.01ms
+step:827/1600 train_time:36411ms step_avg:44.03ms
+step:828/1600 train_time:36470ms step_avg:44.05ms
+step:829/1600 train_time:36533ms step_avg:44.07ms
+step:830/1600 train_time:36592ms step_avg:44.09ms
+step:831/1600 train_time:36654ms step_avg:44.11ms
+step:832/1600 train_time:36713ms step_avg:44.13ms
+step:833/1600 train_time:36776ms step_avg:44.15ms
+step:834/1600 train_time:36835ms step_avg:44.17ms
+step:835/1600 train_time:36898ms step_avg:44.19ms
+step:836/1600 train_time:36957ms step_avg:44.21ms
+step:837/1600 train_time:37019ms step_avg:44.23ms
+step:838/1600 train_time:37079ms step_avg:44.25ms
+step:839/1600 train_time:37142ms step_avg:44.27ms
+step:840/1600 train_time:37201ms step_avg:44.29ms
+step:841/1600 train_time:37264ms step_avg:44.31ms
+step:842/1600 train_time:37324ms step_avg:44.33ms
+step:843/1600 train_time:37386ms step_avg:44.35ms
+step:844/1600 train_time:37445ms step_avg:44.37ms
+step:845/1600 train_time:37507ms step_avg:44.39ms
+step:846/1600 train_time:37567ms step_avg:44.40ms
+step:847/1600 train_time:37630ms step_avg:44.43ms
+step:848/1600 train_time:37689ms step_avg:44.44ms
+step:849/1600 train_time:37752ms step_avg:44.47ms
+step:850/1600 train_time:37811ms step_avg:44.48ms
+step:851/1600 train_time:37874ms step_avg:44.50ms
+step:852/1600 train_time:37932ms step_avg:44.52ms
+step:853/1600 train_time:37995ms step_avg:44.54ms
+step:854/1600 train_time:38053ms step_avg:44.56ms
+step:855/1600 train_time:38116ms step_avg:44.58ms
+step:856/1600 train_time:38175ms step_avg:44.60ms
+step:857/1600 train_time:38238ms step_avg:44.62ms
+step:858/1600 train_time:38297ms step_avg:44.63ms
+step:859/1600 train_time:38359ms step_avg:44.66ms
+step:860/1600 train_time:38419ms step_avg:44.67ms
+step:861/1600 train_time:38481ms step_avg:44.69ms
+step:862/1600 train_time:38540ms step_avg:44.71ms
+step:863/1600 train_time:38603ms step_avg:44.73ms
+step:864/1600 train_time:38663ms step_avg:44.75ms
+step:865/1600 train_time:38726ms step_avg:44.77ms
+step:866/1600 train_time:38785ms step_avg:44.79ms
+step:867/1600 train_time:38847ms step_avg:44.81ms
+step:868/1600 train_time:38907ms step_avg:44.82ms
+step:869/1600 train_time:38969ms step_avg:44.84ms
+step:870/1600 train_time:39028ms step_avg:44.86ms
+step:871/1600 train_time:39090ms step_avg:44.88ms
+step:872/1600 train_time:39150ms step_avg:44.90ms
+step:873/1600 train_time:39213ms step_avg:44.92ms
+step:874/1600 train_time:39272ms step_avg:44.93ms
+step:875/1600 train_time:39334ms step_avg:44.95ms
+step:876/1600 train_time:39393ms step_avg:44.97ms
+step:877/1600 train_time:39456ms step_avg:44.99ms
+step:878/1600 train_time:39515ms step_avg:45.01ms
+step:879/1600 train_time:39578ms step_avg:45.03ms
+step:880/1600 train_time:39638ms step_avg:45.04ms
+step:881/1600 train_time:39700ms step_avg:45.06ms
+step:882/1600 train_time:39760ms step_avg:45.08ms
+step:883/1600 train_time:39822ms step_avg:45.10ms
+step:884/1600 train_time:39881ms step_avg:45.11ms
+step:885/1600 train_time:39944ms step_avg:45.13ms
+step:886/1600 train_time:40003ms step_avg:45.15ms
+step:887/1600 train_time:40065ms step_avg:45.17ms
+step:888/1600 train_time:40125ms step_avg:45.19ms
+step:889/1600 train_time:40187ms step_avg:45.20ms
+step:890/1600 train_time:40249ms step_avg:45.22ms
+step:891/1600 train_time:40311ms step_avg:45.24ms
+step:892/1600 train_time:40371ms step_avg:45.26ms
+step:893/1600 train_time:40433ms step_avg:45.28ms
+step:894/1600 train_time:40491ms step_avg:45.29ms
+step:895/1600 train_time:40553ms step_avg:45.31ms
+step:896/1600 train_time:40612ms step_avg:45.33ms
+step:897/1600 train_time:40675ms step_avg:45.35ms
+step:898/1600 train_time:40734ms step_avg:45.36ms
+step:899/1600 train_time:40796ms step_avg:45.38ms
+step:900/1600 train_time:40855ms step_avg:45.39ms
+step:901/1600 train_time:40917ms step_avg:45.41ms
+step:902/1600 train_time:40977ms step_avg:45.43ms
+step:903/1600 train_time:41040ms step_avg:45.45ms
+step:904/1600 train_time:41099ms step_avg:45.46ms
+step:905/1600 train_time:41162ms step_avg:45.48ms
+step:906/1600 train_time:41221ms step_avg:45.50ms
+step:907/1600 train_time:41284ms step_avg:45.52ms
+step:908/1600 train_time:41343ms step_avg:45.53ms
+step:909/1600 train_time:41406ms step_avg:45.55ms
+step:910/1600 train_time:41465ms step_avg:45.57ms
+step:911/1600 train_time:41528ms step_avg:45.58ms
+step:912/1600 train_time:41587ms step_avg:45.60ms
+step:913/1600 train_time:41650ms step_avg:45.62ms
+step:914/1600 train_time:41709ms step_avg:45.63ms
+step:915/1600 train_time:41772ms step_avg:45.65ms
+step:916/1600 train_time:41831ms step_avg:45.67ms
+step:917/1600 train_time:41893ms step_avg:45.68ms
+step:918/1600 train_time:41952ms step_avg:45.70ms
+step:919/1600 train_time:42015ms step_avg:45.72ms
+step:920/1600 train_time:42075ms step_avg:45.73ms
+step:921/1600 train_time:42138ms step_avg:45.75ms
+step:922/1600 train_time:42197ms step_avg:45.77ms
+step:923/1600 train_time:42260ms step_avg:45.78ms
+step:924/1600 train_time:42320ms step_avg:45.80ms
+step:925/1600 train_time:42381ms step_avg:45.82ms
+step:926/1600 train_time:42440ms step_avg:45.83ms
+step:927/1600 train_time:42503ms step_avg:45.85ms
+step:928/1600 train_time:42562ms step_avg:45.86ms
+step:929/1600 train_time:42624ms step_avg:45.88ms
+step:930/1600 train_time:42684ms step_avg:45.90ms
+step:931/1600 train_time:42747ms step_avg:45.91ms
+step:932/1600 train_time:42806ms step_avg:45.93ms
+step:933/1600 train_time:42869ms step_avg:45.95ms
+step:934/1600 train_time:42928ms step_avg:45.96ms
+step:935/1600 train_time:42990ms step_avg:45.98ms
+step:936/1600 train_time:43049ms step_avg:45.99ms
+step:937/1600 train_time:43112ms step_avg:46.01ms
+step:938/1600 train_time:43171ms step_avg:46.02ms
+step:939/1600 train_time:43234ms step_avg:46.04ms
+step:940/1600 train_time:43294ms step_avg:46.06ms
+step:941/1600 train_time:43356ms step_avg:46.07ms
+step:942/1600 train_time:43416ms step_avg:46.09ms
+step:943/1600 train_time:43478ms step_avg:46.11ms
+step:944/1600 train_time:43537ms step_avg:46.12ms
+step:945/1600 train_time:43600ms step_avg:46.14ms
+step:946/1600 train_time:43659ms step_avg:46.15ms
+step:947/1600 train_time:43721ms step_avg:46.17ms
+step:948/1600 train_time:43780ms step_avg:46.18ms
+step:949/1600 train_time:43843ms step_avg:46.20ms
+step:950/1600 train_time:43903ms step_avg:46.21ms
+step:951/1600 train_time:43965ms step_avg:46.23ms
+step:952/1600 train_time:44025ms step_avg:46.24ms
+step:953/1600 train_time:44087ms step_avg:46.26ms
+step:954/1600 train_time:44147ms step_avg:46.28ms
+step:955/1600 train_time:44210ms step_avg:46.29ms
+step:956/1600 train_time:44268ms step_avg:46.31ms
+step:957/1600 train_time:44332ms step_avg:46.32ms
+step:958/1600 train_time:44391ms step_avg:46.34ms
+step:959/1600 train_time:44453ms step_avg:46.35ms
+step:960/1600 train_time:44511ms step_avg:46.37ms
+step:961/1600 train_time:44574ms step_avg:46.38ms
+step:962/1600 train_time:44633ms step_avg:46.40ms
+step:963/1600 train_time:44695ms step_avg:46.41ms
+step:964/1600 train_time:44754ms step_avg:46.43ms
+step:965/1600 train_time:44817ms step_avg:46.44ms
+step:966/1600 train_time:44877ms step_avg:46.46ms
+step:967/1600 train_time:44940ms step_avg:46.47ms
+step:968/1600 train_time:44998ms step_avg:46.49ms
+step:969/1600 train_time:45061ms step_avg:46.50ms
+step:970/1600 train_time:45120ms step_avg:46.52ms
+step:971/1600 train_time:45182ms step_avg:46.53ms
+step:972/1600 train_time:45241ms step_avg:46.54ms
+step:973/1600 train_time:45304ms step_avg:46.56ms
+step:974/1600 train_time:45364ms step_avg:46.57ms
+step:975/1600 train_time:45426ms step_avg:46.59ms
+step:976/1600 train_time:45485ms step_avg:46.60ms
+step:977/1600 train_time:45548ms step_avg:46.62ms
+step:978/1600 train_time:45607ms step_avg:46.63ms
+step:979/1600 train_time:45670ms step_avg:46.65ms
+step:980/1600 train_time:45729ms step_avg:46.66ms
+step:981/1600 train_time:45792ms step_avg:46.68ms
+step:982/1600 train_time:45851ms step_avg:46.69ms
+step:983/1600 train_time:45913ms step_avg:46.71ms
+step:984/1600 train_time:45972ms step_avg:46.72ms
+step:985/1600 train_time:46034ms step_avg:46.74ms
+step:986/1600 train_time:46093ms step_avg:46.75ms
+step:987/1600 train_time:46156ms step_avg:46.76ms
+step:988/1600 train_time:46215ms step_avg:46.78ms
+step:989/1600 train_time:46278ms step_avg:46.79ms
+step:990/1600 train_time:46337ms step_avg:46.81ms
+step:991/1600 train_time:46400ms step_avg:46.82ms
+step:992/1600 train_time:46458ms step_avg:46.83ms
+step:993/1600 train_time:46521ms step_avg:46.85ms
+step:994/1600 train_time:46580ms step_avg:46.86ms
+step:995/1600 train_time:46643ms step_avg:46.88ms
+step:996/1600 train_time:46701ms step_avg:46.89ms
+step:997/1600 train_time:46765ms step_avg:46.91ms
+step:998/1600 train_time:46824ms step_avg:46.92ms
+step:999/1600 train_time:46887ms step_avg:46.93ms
+step:1000/1600 train_time:46946ms step_avg:46.95ms
+step:1000/1600 val_loss:3.5950 train_time:46993ms step_avg:46.99ms
+step:1001/1600 train_time:47012ms step_avg:46.96ms
+step:1002/1600 train_time:47069ms step_avg:46.98ms
+step:1003/1600 train_time:47134ms step_avg:46.99ms
+step:1004/1600 train_time:47194ms step_avg:47.01ms
+step:1005/1600 train_time:47257ms step_avg:47.02ms
+step:1006/1600 train_time:47317ms step_avg:47.03ms
+step:1007/1600 train_time:47379ms step_avg:47.05ms
+step:1008/1600 train_time:47437ms step_avg:47.06ms
+step:1009/1600 train_time:47499ms step_avg:47.08ms
+step:1010/1600 train_time:47557ms step_avg:47.09ms
+step:1011/1600 train_time:47620ms step_avg:47.10ms
+step:1012/1600 train_time:47680ms step_avg:47.11ms
+step:1013/1600 train_time:47740ms step_avg:47.13ms
+step:1014/1600 train_time:47799ms step_avg:47.14ms
+step:1015/1600 train_time:47861ms step_avg:47.15ms
+step:1016/1600 train_time:47919ms step_avg:47.16ms
+step:1017/1600 train_time:47982ms step_avg:47.18ms
+step:1018/1600 train_time:48043ms step_avg:47.19ms
+step:1019/1600 train_time:48106ms step_avg:47.21ms
+step:1020/1600 train_time:48168ms step_avg:47.22ms
+step:1021/1600 train_time:48229ms step_avg:47.24ms
+step:1022/1600 train_time:48288ms step_avg:47.25ms
+step:1023/1600 train_time:48350ms step_avg:47.26ms
+step:1024/1600 train_time:48409ms step_avg:47.27ms
+step:1025/1600 train_time:48471ms step_avg:47.29ms
+step:1026/1600 train_time:48529ms step_avg:47.30ms
+step:1027/1600 train_time:48592ms step_avg:47.31ms
+step:1028/1600 train_time:48651ms step_avg:47.33ms
+step:1029/1600 train_time:48714ms step_avg:47.34ms
+step:1030/1600 train_time:48773ms step_avg:47.35ms
+step:1031/1600 train_time:48835ms step_avg:47.37ms
+step:1032/1600 train_time:48894ms step_avg:47.38ms
+step:1033/1600 train_time:48957ms step_avg:47.39ms
+step:1034/1600 train_time:49016ms step_avg:47.40ms
+step:1035/1600 train_time:49079ms step_avg:47.42ms
+step:1036/1600 train_time:49138ms step_avg:47.43ms
+step:1037/1600 train_time:49201ms step_avg:47.45ms
+step:1038/1600 train_time:49260ms step_avg:47.46ms
+step:1039/1600 train_time:49323ms step_avg:47.47ms
+step:1040/1600 train_time:49382ms step_avg:47.48ms
+step:1041/1600 train_time:49454ms step_avg:47.51ms
+step:1042/1600 train_time:49537ms step_avg:47.54ms
+step:1043/1600 train_time:49626ms step_avg:47.58ms
+step:1044/1600 train_time:49711ms step_avg:47.62ms
+step:1045/1600 train_time:49801ms step_avg:47.66ms
+step:1046/1600 train_time:49885ms step_avg:47.69ms
+step:1047/1600 train_time:49974ms step_avg:47.73ms
+step:1048/1600 train_time:50060ms step_avg:47.77ms
+step:1049/1600 train_time:50149ms step_avg:47.81ms
+step:1050/1600 train_time:50234ms step_avg:47.84ms
+step:1051/1600 train_time:50323ms step_avg:47.88ms
+step:1052/1600 train_time:50408ms step_avg:47.92ms
+step:1053/1600 train_time:50497ms step_avg:47.96ms
+step:1054/1600 train_time:50583ms step_avg:47.99ms
+step:1055/1600 train_time:50671ms step_avg:48.03ms
+step:1056/1600 train_time:50757ms step_avg:48.07ms
+step:1057/1600 train_time:50845ms step_avg:48.10ms
+step:1058/1600 train_time:50931ms step_avg:48.14ms
+step:1059/1600 train_time:51019ms step_avg:48.18ms
+step:1060/1600 train_time:51104ms step_avg:48.21ms
+step:1061/1600 train_time:51194ms step_avg:48.25ms
+step:1062/1600 train_time:51279ms step_avg:48.28ms
+step:1063/1600 train_time:51368ms step_avg:48.32ms
+step:1064/1600 train_time:51453ms step_avg:48.36ms
+step:1065/1600 train_time:51541ms step_avg:48.40ms
+step:1066/1600 train_time:51626ms step_avg:48.43ms
+step:1067/1600 train_time:51715ms step_avg:48.47ms
+step:1068/1600 train_time:51800ms step_avg:48.50ms
+step:1069/1600 train_time:51888ms step_avg:48.54ms
+step:1070/1600 train_time:51973ms step_avg:48.57ms
+step:1071/1600 train_time:52061ms step_avg:48.61ms
+step:1072/1600 train_time:52147ms step_avg:48.64ms
+step:1073/1600 train_time:52235ms step_avg:48.68ms
+step:1074/1600 train_time:52320ms step_avg:48.72ms
+step:1075/1600 train_time:52409ms step_avg:48.75ms
+step:1076/1600 train_time:52494ms step_avg:48.79ms
+step:1077/1600 train_time:52582ms step_avg:48.82ms
+step:1078/1600 train_time:52669ms step_avg:48.86ms
+step:1079/1600 train_time:52757ms step_avg:48.89ms
+step:1080/1600 train_time:52841ms step_avg:48.93ms
+step:1081/1600 train_time:52929ms step_avg:48.96ms
+step:1082/1600 train_time:53014ms step_avg:49.00ms
+step:1083/1600 train_time:53102ms step_avg:49.03ms
+step:1084/1600 train_time:53189ms step_avg:49.07ms
+step:1085/1600 train_time:53277ms step_avg:49.10ms
+step:1086/1600 train_time:53363ms step_avg:49.14ms
+step:1087/1600 train_time:53452ms step_avg:49.17ms
+step:1088/1600 train_time:53537ms step_avg:49.21ms
+step:1089/1600 train_time:53625ms step_avg:49.24ms
+step:1090/1600 train_time:53710ms step_avg:49.28ms
+step:1091/1600 train_time:53799ms step_avg:49.31ms
+step:1092/1600 train_time:53883ms step_avg:49.34ms
+step:1093/1600 train_time:53971ms step_avg:49.38ms
+step:1094/1600 train_time:54057ms step_avg:49.41ms
+step:1095/1600 train_time:54144ms step_avg:49.45ms
+step:1096/1600 train_time:54230ms step_avg:49.48ms
+step:1097/1600 train_time:54318ms step_avg:49.51ms
+step:1098/1600 train_time:54403ms step_avg:49.55ms
+step:1099/1600 train_time:54491ms step_avg:49.58ms
+step:1100/1600 train_time:54576ms step_avg:49.61ms
+step:1101/1600 train_time:54664ms step_avg:49.65ms
+step:1102/1600 train_time:54749ms step_avg:49.68ms
+step:1103/1600 train_time:54837ms step_avg:49.72ms
+step:1104/1600 train_time:54922ms step_avg:49.75ms
+step:1105/1600 train_time:55010ms step_avg:49.78ms
+step:1106/1600 train_time:55096ms step_avg:49.82ms
+step:1107/1600 train_time:55185ms step_avg:49.85ms
+step:1108/1600 train_time:55270ms step_avg:49.88ms
+step:1109/1600 train_time:55358ms step_avg:49.92ms
+step:1110/1600 train_time:55443ms step_avg:49.95ms
+step:1111/1600 train_time:55531ms step_avg:49.98ms
+step:1112/1600 train_time:55615ms step_avg:50.01ms
+step:1113/1600 train_time:55703ms step_avg:50.05ms
+step:1114/1600 train_time:55788ms step_avg:50.08ms
+step:1115/1600 train_time:55876ms step_avg:50.11ms
+step:1116/1600 train_time:55961ms step_avg:50.14ms
+step:1117/1600 train_time:56049ms step_avg:50.18ms
+step:1118/1600 train_time:56135ms step_avg:50.21ms
+step:1119/1600 train_time:56223ms step_avg:50.24ms
+step:1120/1600 train_time:56308ms step_avg:50.28ms
+step:1121/1600 train_time:56397ms step_avg:50.31ms
+step:1122/1600 train_time:56481ms step_avg:50.34ms
+step:1123/1600 train_time:56570ms step_avg:50.37ms
+step:1124/1600 train_time:56655ms step_avg:50.40ms
+step:1125/1600 train_time:56743ms step_avg:50.44ms
+step:1126/1600 train_time:56829ms step_avg:50.47ms
+step:1127/1600 train_time:56916ms step_avg:50.50ms
+step:1128/1600 train_time:57001ms step_avg:50.53ms
+step:1129/1600 train_time:57089ms step_avg:50.57ms
+step:1130/1600 train_time:57174ms step_avg:50.60ms
+step:1131/1600 train_time:57262ms step_avg:50.63ms
+step:1132/1600 train_time:57347ms step_avg:50.66ms
+step:1133/1600 train_time:57436ms step_avg:50.69ms
+step:1134/1600 train_time:57522ms step_avg:50.72ms
+step:1135/1600 train_time:57610ms step_avg:50.76ms
+step:1136/1600 train_time:57695ms step_avg:50.79ms
+step:1137/1600 train_time:57783ms step_avg:50.82ms
+step:1138/1600 train_time:57869ms step_avg:50.85ms
+step:1139/1600 train_time:57957ms step_avg:50.88ms
+step:1140/1600 train_time:58042ms step_avg:50.91ms
+step:1141/1600 train_time:58130ms step_avg:50.95ms
+step:1142/1600 train_time:58216ms step_avg:50.98ms
+step:1143/1600 train_time:58304ms step_avg:51.01ms
+step:1144/1600 train_time:58389ms step_avg:51.04ms
+step:1145/1600 train_time:58478ms step_avg:51.07ms
+step:1146/1600 train_time:58562ms step_avg:51.10ms
+step:1147/1600 train_time:58651ms step_avg:51.13ms
+step:1148/1600 train_time:58736ms step_avg:51.16ms
+step:1149/1600 train_time:58825ms step_avg:51.20ms
+step:1150/1600 train_time:58910ms step_avg:51.23ms
+step:1151/1600 train_time:58998ms step_avg:51.26ms
+step:1152/1600 train_time:59082ms step_avg:51.29ms
+step:1153/1600 train_time:59171ms step_avg:51.32ms
+step:1154/1600 train_time:59259ms step_avg:51.35ms
+step:1155/1600 train_time:59346ms step_avg:51.38ms
+step:1156/1600 train_time:59431ms step_avg:51.41ms
+step:1157/1600 train_time:59519ms step_avg:51.44ms
+step:1158/1600 train_time:59604ms step_avg:51.47ms
+step:1159/1600 train_time:59693ms step_avg:51.50ms
+step:1160/1600 train_time:59777ms step_avg:51.53ms
+step:1161/1600 train_time:59865ms step_avg:51.56ms
+step:1162/1600 train_time:59950ms step_avg:51.59ms
+step:1163/1600 train_time:60039ms step_avg:51.62ms
+step:1164/1600 train_time:60125ms step_avg:51.65ms
+step:1165/1600 train_time:60213ms step_avg:51.69ms
+step:1166/1600 train_time:60298ms step_avg:51.71ms
+step:1167/1600 train_time:60388ms step_avg:51.75ms
+step:1168/1600 train_time:60472ms step_avg:51.77ms
+step:1169/1600 train_time:60560ms step_avg:51.81ms
+step:1170/1600 train_time:60645ms step_avg:51.83ms
+step:1171/1600 train_time:60733ms step_avg:51.86ms
+step:1172/1600 train_time:60819ms step_avg:51.89ms
+step:1173/1600 train_time:60907ms step_avg:51.92ms
+step:1174/1600 train_time:60992ms step_avg:51.95ms
+step:1175/1600 train_time:61080ms step_avg:51.98ms
+step:1176/1600 train_time:61166ms step_avg:52.01ms
+step:1177/1600 train_time:61254ms step_avg:52.04ms
+step:1178/1600 train_time:61339ms step_avg:52.07ms
+step:1179/1600 train_time:61428ms step_avg:52.10ms
+step:1180/1600 train_time:61512ms step_avg:52.13ms
+step:1181/1600 train_time:61601ms step_avg:52.16ms
+step:1182/1600 train_time:61686ms step_avg:52.19ms
+step:1183/1600 train_time:61775ms step_avg:52.22ms
+step:1184/1600 train_time:61860ms step_avg:52.25ms
+step:1185/1600 train_time:61948ms step_avg:52.28ms
+step:1186/1600 train_time:62034ms step_avg:52.30ms
+step:1187/1600 train_time:62122ms step_avg:52.33ms
+step:1188/1600 train_time:62207ms step_avg:52.36ms
+step:1189/1600 train_time:62295ms step_avg:52.39ms
+step:1190/1600 train_time:62379ms step_avg:52.42ms
+step:1191/1600 train_time:62467ms step_avg:52.45ms
+step:1192/1600 train_time:62552ms step_avg:52.48ms
+step:1193/1600 train_time:62641ms step_avg:52.51ms
+step:1194/1600 train_time:62726ms step_avg:52.53ms
+step:1195/1600 train_time:62814ms step_avg:52.56ms
+step:1196/1600 train_time:62900ms step_avg:52.59ms
+step:1197/1600 train_time:62988ms step_avg:52.62ms
+step:1198/1600 train_time:63072ms step_avg:52.65ms
+step:1199/1600 train_time:63160ms step_avg:52.68ms
+step:1200/1600 train_time:63246ms step_avg:52.70ms
+step:1201/1600 train_time:63334ms step_avg:52.73ms
+step:1202/1600 train_time:63419ms step_avg:52.76ms
+step:1203/1600 train_time:63507ms step_avg:52.79ms
+step:1204/1600 train_time:63592ms step_avg:52.82ms
+step:1205/1600 train_time:63680ms step_avg:52.85ms
+step:1206/1600 train_time:63765ms step_avg:52.87ms
+step:1207/1600 train_time:63854ms step_avg:52.90ms
+step:1208/1600 train_time:63939ms step_avg:52.93ms
+step:1209/1600 train_time:64028ms step_avg:52.96ms
+step:1210/1600 train_time:64113ms step_avg:52.99ms
+step:1211/1600 train_time:64201ms step_avg:53.02ms
+step:1212/1600 train_time:64287ms step_avg:53.04ms
+step:1213/1600 train_time:64375ms step_avg:53.07ms
+step:1214/1600 train_time:64461ms step_avg:53.10ms
+step:1215/1600 train_time:64550ms step_avg:53.13ms
+step:1216/1600 train_time:64635ms step_avg:53.15ms
+step:1217/1600 train_time:64724ms step_avg:53.18ms
+step:1218/1600 train_time:64809ms step_avg:53.21ms
+step:1219/1600 train_time:64897ms step_avg:53.24ms
+step:1220/1600 train_time:64982ms step_avg:53.26ms
+step:1221/1600 train_time:65071ms step_avg:53.29ms
+step:1222/1600 train_time:65156ms step_avg:53.32ms
+step:1223/1600 train_time:65244ms step_avg:53.35ms
+step:1224/1600 train_time:65330ms step_avg:53.37ms
+step:1225/1600 train_time:65418ms step_avg:53.40ms
+step:1226/1600 train_time:65504ms step_avg:53.43ms
+step:1227/1600 train_time:65592ms step_avg:53.46ms
+step:1228/1600 train_time:65678ms step_avg:53.48ms
+step:1229/1600 train_time:65766ms step_avg:53.51ms
+step:1230/1600 train_time:65853ms step_avg:53.54ms
+step:1231/1600 train_time:65940ms step_avg:53.57ms
+step:1232/1600 train_time:66026ms step_avg:53.59ms
+step:1233/1600 train_time:66113ms step_avg:53.62ms
+step:1234/1600 train_time:66199ms step_avg:53.65ms
+step:1235/1600 train_time:66287ms step_avg:53.67ms
+step:1236/1600 train_time:66372ms step_avg:53.70ms
+step:1237/1600 train_time:66460ms step_avg:53.73ms
+step:1238/1600 train_time:66546ms step_avg:53.75ms
+step:1239/1600 train_time:66634ms step_avg:53.78ms
+step:1240/1600 train_time:66720ms step_avg:53.81ms
+step:1241/1600 train_time:66808ms step_avg:53.83ms
+step:1242/1600 train_time:66893ms step_avg:53.86ms
+step:1243/1600 train_time:66981ms step_avg:53.89ms
+step:1244/1600 train_time:67066ms step_avg:53.91ms
+step:1245/1600 train_time:67155ms step_avg:53.94ms
+step:1246/1600 train_time:67240ms step_avg:53.96ms
+step:1247/1600 train_time:67328ms step_avg:53.99ms
+step:1248/1600 train_time:67412ms step_avg:54.02ms
+step:1249/1600 train_time:67501ms step_avg:54.04ms
+step:1250/1600 train_time:67586ms step_avg:54.07ms
+step:1250/1600 val_loss:3.4144 train_time:67660ms step_avg:54.13ms
+step:1251/1600 train_time:67679ms step_avg:54.10ms
+step:1252/1600 train_time:67767ms step_avg:54.13ms
+step:1253/1600 train_time:67860ms step_avg:54.16ms
+step:1254/1600 train_time:67946ms step_avg:54.18ms
+step:1255/1600 train_time:68033ms step_avg:54.21ms
+step:1256/1600 train_time:68118ms step_avg:54.23ms
+step:1257/1600 train_time:68205ms step_avg:54.26ms
+step:1258/1600 train_time:68290ms step_avg:54.28ms
+step:1259/1600 train_time:68377ms step_avg:54.31ms
+step:1260/1600 train_time:68462ms step_avg:54.33ms
+step:1261/1600 train_time:68548ms step_avg:54.36ms
+step:1262/1600 train_time:68634ms step_avg:54.38ms
+step:1263/1600 train_time:68724ms step_avg:54.41ms
+step:1264/1600 train_time:68811ms step_avg:54.44ms
+step:1265/1600 train_time:68901ms step_avg:54.47ms
+step:1266/1600 train_time:68987ms step_avg:54.49ms
+step:1267/1600 train_time:69074ms step_avg:54.52ms
+step:1268/1600 train_time:69159ms step_avg:54.54ms
+step:1269/1600 train_time:69247ms step_avg:54.57ms
+step:1270/1600 train_time:69332ms step_avg:54.59ms
+step:1271/1600 train_time:69419ms step_avg:54.62ms
+step:1272/1600 train_time:69504ms step_avg:54.64ms
+step:1273/1600 train_time:69591ms step_avg:54.67ms
+step:1274/1600 train_time:69676ms step_avg:54.69ms
+step:1275/1600 train_time:69766ms step_avg:54.72ms
+step:1276/1600 train_time:69852ms step_avg:54.74ms
+step:1277/1600 train_time:69940ms step_avg:54.77ms
+step:1278/1600 train_time:70025ms step_avg:54.79ms
+step:1279/1600 train_time:70115ms step_avg:54.82ms
+step:1280/1600 train_time:70200ms step_avg:54.84ms
+step:1281/1600 train_time:70288ms step_avg:54.87ms
+step:1282/1600 train_time:70373ms step_avg:54.89ms
+step:1283/1600 train_time:70460ms step_avg:54.92ms
+step:1284/1600 train_time:70545ms step_avg:54.94ms
+step:1285/1600 train_time:70633ms step_avg:54.97ms
+step:1286/1600 train_time:70719ms step_avg:54.99ms
+step:1287/1600 train_time:70809ms step_avg:55.02ms
+step:1288/1600 train_time:70894ms step_avg:55.04ms
+step:1289/1600 train_time:70983ms step_avg:55.07ms
+step:1290/1600 train_time:71069ms step_avg:55.09ms
+step:1291/1600 train_time:71157ms step_avg:55.12ms
+step:1292/1600 train_time:71242ms step_avg:55.14ms
+step:1293/1600 train_time:71329ms step_avg:55.17ms
+step:1294/1600 train_time:71415ms step_avg:55.19ms
+step:1295/1600 train_time:71503ms step_avg:55.21ms
+step:1296/1600 train_time:71588ms step_avg:55.24ms
+step:1297/1600 train_time:71676ms step_avg:55.26ms
+step:1298/1600 train_time:71762ms step_avg:55.29ms
+step:1299/1600 train_time:71851ms step_avg:55.31ms
+step:1300/1600 train_time:71936ms step_avg:55.34ms
+step:1301/1600 train_time:72024ms step_avg:55.36ms
+step:1302/1600 train_time:72109ms step_avg:55.38ms
+step:1303/1600 train_time:72197ms step_avg:55.41ms
+step:1304/1600 train_time:72282ms step_avg:55.43ms
+step:1305/1600 train_time:72370ms step_avg:55.46ms
+step:1306/1600 train_time:72456ms step_avg:55.48ms
+step:1307/1600 train_time:72544ms step_avg:55.50ms
+step:1308/1600 train_time:72629ms step_avg:55.53ms
+step:1309/1600 train_time:72717ms step_avg:55.55ms
+step:1310/1600 train_time:72803ms step_avg:55.57ms
+step:1311/1600 train_time:72891ms step_avg:55.60ms
+step:1312/1600 train_time:72977ms step_avg:55.62ms
+step:1313/1600 train_time:73065ms step_avg:55.65ms
+step:1314/1600 train_time:73150ms step_avg:55.67ms
+step:1315/1600 train_time:73238ms step_avg:55.69ms
+step:1316/1600 train_time:73323ms step_avg:55.72ms
+step:1317/1600 train_time:73411ms step_avg:55.74ms
+step:1318/1600 train_time:73496ms step_avg:55.76ms
+step:1319/1600 train_time:73584ms step_avg:55.79ms
+step:1320/1600 train_time:73671ms step_avg:55.81ms
+step:1321/1600 train_time:73758ms step_avg:55.84ms
+step:1322/1600 train_time:73844ms step_avg:55.86ms
+step:1323/1600 train_time:73933ms step_avg:55.88ms
+step:1324/1600 train_time:74018ms step_avg:55.90ms
+step:1325/1600 train_time:74106ms step_avg:55.93ms
+step:1326/1600 train_time:74191ms step_avg:55.95ms
+step:1327/1600 train_time:74279ms step_avg:55.98ms
+step:1328/1600 train_time:74364ms step_avg:56.00ms
+step:1329/1600 train_time:74452ms step_avg:56.02ms
+step:1330/1600 train_time:74538ms step_avg:56.04ms
+step:1331/1600 train_time:74626ms step_avg:56.07ms
+step:1332/1600 train_time:74711ms step_avg:56.09ms
+step:1333/1600 train_time:74799ms step_avg:56.11ms
+step:1334/1600 train_time:74884ms step_avg:56.14ms
+step:1335/1600 train_time:74973ms step_avg:56.16ms
+step:1336/1600 train_time:75058ms step_avg:56.18ms
+step:1337/1600 train_time:75146ms step_avg:56.21ms
+step:1338/1600 train_time:75231ms step_avg:56.23ms
+step:1339/1600 train_time:75319ms step_avg:56.25ms
+step:1340/1600 train_time:75405ms step_avg:56.27ms
+step:1341/1600 train_time:75493ms step_avg:56.30ms
+step:1342/1600 train_time:75579ms step_avg:56.32ms
+step:1343/1600 train_time:75667ms step_avg:56.34ms
+step:1344/1600 train_time:75752ms step_avg:56.36ms
+step:1345/1600 train_time:75840ms step_avg:56.39ms
+step:1346/1600 train_time:75926ms step_avg:56.41ms
+step:1347/1600 train_time:76014ms step_avg:56.43ms
+step:1348/1600 train_time:76099ms step_avg:56.45ms
+step:1349/1600 train_time:76188ms step_avg:56.48ms
+step:1350/1600 train_time:76273ms step_avg:56.50ms
+step:1351/1600 train_time:76361ms step_avg:56.52ms
+step:1352/1600 train_time:76446ms step_avg:56.54ms
+step:1353/1600 train_time:76535ms step_avg:56.57ms
+step:1354/1600 train_time:76619ms step_avg:56.59ms
+step:1355/1600 train_time:76708ms step_avg:56.61ms
+step:1356/1600 train_time:76793ms step_avg:56.63ms
+step:1357/1600 train_time:76882ms step_avg:56.66ms
+step:1358/1600 train_time:76968ms step_avg:56.68ms
+step:1359/1600 train_time:77056ms step_avg:56.70ms
+step:1360/1600 train_time:77142ms step_avg:56.72ms
+step:1361/1600 train_time:77230ms step_avg:56.75ms
+step:1362/1600 train_time:77316ms step_avg:56.77ms
+step:1363/1600 train_time:77403ms step_avg:56.79ms
+step:1364/1600 train_time:77489ms step_avg:56.81ms
+step:1365/1600 train_time:77577ms step_avg:56.83ms
+step:1366/1600 train_time:77665ms step_avg:56.86ms
+step:1367/1600 train_time:77753ms step_avg:56.88ms
+step:1368/1600 train_time:77838ms step_avg:56.90ms
+step:1369/1600 train_time:77925ms step_avg:56.92ms
+step:1370/1600 train_time:78010ms step_avg:56.94ms
+step:1371/1600 train_time:78099ms step_avg:56.96ms
+step:1372/1600 train_time:78184ms step_avg:56.99ms
+step:1373/1600 train_time:78272ms step_avg:57.01ms
+step:1374/1600 train_time:78358ms step_avg:57.03ms
+step:1375/1600 train_time:78447ms step_avg:57.05ms
+step:1376/1600 train_time:78531ms step_avg:57.07ms
+step:1377/1600 train_time:78619ms step_avg:57.09ms
+step:1378/1600 train_time:78705ms step_avg:57.12ms
+step:1379/1600 train_time:78794ms step_avg:57.14ms
+step:1380/1600 train_time:78879ms step_avg:57.16ms
+step:1381/1600 train_time:78967ms step_avg:57.18ms
+step:1382/1600 train_time:79053ms step_avg:57.20ms
+step:1383/1600 train_time:79140ms step_avg:57.22ms
+step:1384/1600 train_time:79225ms step_avg:57.24ms
+step:1385/1600 train_time:79313ms step_avg:57.27ms
+step:1386/1600 train_time:79399ms step_avg:57.29ms
+step:1387/1600 train_time:79487ms step_avg:57.31ms
+step:1388/1600 train_time:79573ms step_avg:57.33ms
+step:1389/1600 train_time:79661ms step_avg:57.35ms
+step:1390/1600 train_time:79746ms step_avg:57.37ms
+step:1391/1600 train_time:79834ms step_avg:57.39ms
+step:1392/1600 train_time:79919ms step_avg:57.41ms
+step:1393/1600 train_time:80007ms step_avg:57.44ms
+step:1394/1600 train_time:80093ms step_avg:57.46ms
+step:1395/1600 train_time:80181ms step_avg:57.48ms
+step:1396/1600 train_time:80267ms step_avg:57.50ms
+step:1397/1600 train_time:80355ms step_avg:57.52ms
+step:1398/1600 train_time:80440ms step_avg:57.54ms
+step:1399/1600 train_time:80528ms step_avg:57.56ms
+step:1400/1600 train_time:80613ms step_avg:57.58ms
+step:1401/1600 train_time:80702ms step_avg:57.60ms
+step:1402/1600 train_time:80787ms step_avg:57.62ms
+step:1403/1600 train_time:80875ms step_avg:57.64ms
+step:1404/1600 train_time:80960ms step_avg:57.66ms
+step:1405/1600 train_time:81049ms step_avg:57.69ms
+step:1406/1600 train_time:81137ms step_avg:57.71ms
+step:1407/1600 train_time:81224ms step_avg:57.73ms
+step:1408/1600 train_time:81309ms step_avg:57.75ms
+step:1409/1600 train_time:81396ms step_avg:57.77ms
+step:1410/1600 train_time:81482ms step_avg:57.79ms
+step:1411/1600 train_time:81573ms step_avg:57.81ms
+step:1412/1600 train_time:81657ms step_avg:57.83ms
+step:1413/1600 train_time:81745ms step_avg:57.85ms
+step:1414/1600 train_time:81830ms step_avg:57.87ms
+step:1415/1600 train_time:81918ms step_avg:57.89ms
+step:1416/1600 train_time:82003ms step_avg:57.91ms
+step:1417/1600 train_time:82091ms step_avg:57.93ms
+step:1418/1600 train_time:82176ms step_avg:57.95ms
+step:1419/1600 train_time:82263ms step_avg:57.97ms
+step:1420/1600 train_time:82349ms step_avg:57.99ms
+step:1421/1600 train_time:82438ms step_avg:58.01ms
+step:1422/1600 train_time:82525ms step_avg:58.03ms
+step:1423/1600 train_time:82612ms step_avg:58.06ms
+step:1424/1600 train_time:82697ms step_avg:58.07ms
+step:1425/1600 train_time:82785ms step_avg:58.10ms
+step:1426/1600 train_time:82870ms step_avg:58.11ms
+step:1427/1600 train_time:82960ms step_avg:58.14ms
+step:1428/1600 train_time:83045ms step_avg:58.15ms
+step:1429/1600 train_time:83134ms step_avg:58.18ms
+step:1430/1600 train_time:83219ms step_avg:58.20ms
+step:1431/1600 train_time:83307ms step_avg:58.22ms
+step:1432/1600 train_time:83392ms step_avg:58.23ms
+step:1433/1600 train_time:83480ms step_avg:58.26ms
+step:1434/1600 train_time:83566ms step_avg:58.27ms
+step:1435/1600 train_time:83654ms step_avg:58.30ms
+step:1436/1600 train_time:83740ms step_avg:58.32ms
+step:1437/1600 train_time:83828ms step_avg:58.34ms
+step:1438/1600 train_time:83913ms step_avg:58.35ms
+step:1439/1600 train_time:84001ms step_avg:58.37ms
+step:1440/1600 train_time:84087ms step_avg:58.39ms
+step:1441/1600 train_time:84175ms step_avg:58.41ms
+step:1442/1600 train_time:84261ms step_avg:58.43ms
+step:1443/1600 train_time:84349ms step_avg:58.45ms
+step:1444/1600 train_time:84434ms step_avg:58.47ms
+step:1445/1600 train_time:84522ms step_avg:58.49ms
+step:1446/1600 train_time:84608ms step_avg:58.51ms
+step:1447/1600 train_time:84697ms step_avg:58.53ms
+step:1448/1600 train_time:84782ms step_avg:58.55ms
+step:1449/1600 train_time:84870ms step_avg:58.57ms
+step:1450/1600 train_time:84955ms step_avg:58.59ms
+step:1451/1600 train_time:85043ms step_avg:58.61ms
+step:1452/1600 train_time:85128ms step_avg:58.63ms
+step:1453/1600 train_time:85217ms step_avg:58.65ms
+step:1454/1600 train_time:85301ms step_avg:58.67ms
+step:1455/1600 train_time:85390ms step_avg:58.69ms
+step:1456/1600 train_time:85475ms step_avg:58.71ms
+step:1457/1600 train_time:85564ms step_avg:58.73ms
+step:1458/1600 train_time:85648ms step_avg:58.74ms
+step:1459/1600 train_time:85737ms step_avg:58.76ms
+step:1460/1600 train_time:85822ms step_avg:58.78ms
+step:1461/1600 train_time:85911ms step_avg:58.80ms
+step:1462/1600 train_time:85996ms step_avg:58.82ms
+step:1463/1600 train_time:86083ms step_avg:58.84ms
+step:1464/1600 train_time:86169ms step_avg:58.86ms
+step:1465/1600 train_time:86258ms step_avg:58.88ms
+step:1466/1600 train_time:86343ms step_avg:58.90ms
+step:1467/1600 train_time:86432ms step_avg:58.92ms
+step:1468/1600 train_time:86517ms step_avg:58.94ms
+step:1469/1600 train_time:86605ms step_avg:58.96ms
+step:1470/1600 train_time:86690ms step_avg:58.97ms
+step:1471/1600 train_time:86778ms step_avg:58.99ms
+step:1472/1600 train_time:86866ms step_avg:59.01ms
+step:1473/1600 train_time:86953ms step_avg:59.03ms
+step:1474/1600 train_time:87038ms step_avg:59.05ms
+step:1475/1600 train_time:87126ms step_avg:59.07ms
+step:1476/1600 train_time:87211ms step_avg:59.09ms
+step:1477/1600 train_time:87299ms step_avg:59.11ms
+step:1478/1600 train_time:87385ms step_avg:59.12ms
+step:1479/1600 train_time:87473ms step_avg:59.14ms
+step:1480/1600 train_time:87558ms step_avg:59.16ms
+step:1481/1600 train_time:87646ms step_avg:59.18ms
+step:1482/1600 train_time:87731ms step_avg:59.20ms
+step:1483/1600 train_time:87819ms step_avg:59.22ms
+step:1484/1600 train_time:87904ms step_avg:59.23ms
+step:1485/1600 train_time:87993ms step_avg:59.25ms
+step:1486/1600 train_time:88079ms step_avg:59.27ms
+step:1487/1600 train_time:88168ms step_avg:59.29ms
+step:1488/1600 train_time:88253ms step_avg:59.31ms
+step:1489/1600 train_time:88342ms step_avg:59.33ms
+step:1490/1600 train_time:88426ms step_avg:59.35ms
+step:1491/1600 train_time:88514ms step_avg:59.37ms
+step:1492/1600 train_time:88599ms step_avg:59.38ms
+step:1493/1600 train_time:88688ms step_avg:59.40ms
+step:1494/1600 train_time:88773ms step_avg:59.42ms
+step:1495/1600 train_time:88862ms step_avg:59.44ms
+step:1496/1600 train_time:88947ms step_avg:59.46ms
+step:1497/1600 train_time:89034ms step_avg:59.48ms
+step:1498/1600 train_time:89120ms step_avg:59.49ms
+step:1499/1600 train_time:89208ms step_avg:59.51ms
+step:1500/1600 train_time:89294ms step_avg:59.53ms
+step:1500/1600 val_loss:3.3054 train_time:89366ms step_avg:59.58ms
+step:1501/1600 train_time:89385ms step_avg:59.55ms
+step:1502/1600 train_time:89469ms step_avg:59.57ms
+step:1503/1600 train_time:89559ms step_avg:59.59ms
+step:1504/1600 train_time:89644ms step_avg:59.60ms
+step:1505/1600 train_time:89732ms step_avg:59.62ms
+step:1506/1600 train_time:89817ms step_avg:59.64ms
+step:1507/1600 train_time:89904ms step_avg:59.66ms
+step:1508/1600 train_time:89989ms step_avg:59.67ms
+step:1509/1600 train_time:90077ms step_avg:59.69ms
+step:1510/1600 train_time:90161ms step_avg:59.71ms
+step:1511/1600 train_time:90249ms step_avg:59.73ms
+step:1512/1600 train_time:90337ms step_avg:59.75ms
+step:1513/1600 train_time:90425ms step_avg:59.77ms
+step:1514/1600 train_time:90511ms step_avg:59.78ms
+step:1515/1600 train_time:90601ms step_avg:59.80ms
+step:1516/1600 train_time:90687ms step_avg:59.82ms
+step:1517/1600 train_time:90776ms step_avg:59.84ms
+step:1518/1600 train_time:90861ms step_avg:59.86ms
+step:1519/1600 train_time:90948ms step_avg:59.87ms
+step:1520/1600 train_time:91032ms step_avg:59.89ms
+step:1521/1600 train_time:91120ms step_avg:59.91ms
+step:1522/1600 train_time:91204ms step_avg:59.92ms
+step:1523/1600 train_time:91294ms step_avg:59.94ms
+step:1524/1600 train_time:91379ms step_avg:59.96ms
+step:1525/1600 train_time:91469ms step_avg:59.98ms
+step:1526/1600 train_time:91555ms step_avg:60.00ms
+step:1527/1600 train_time:91644ms step_avg:60.02ms
+step:1528/1600 train_time:91728ms step_avg:60.03ms
+step:1529/1600 train_time:91816ms step_avg:60.05ms
+step:1530/1600 train_time:91901ms step_avg:60.07ms
+step:1531/1600 train_time:91989ms step_avg:60.08ms
+step:1532/1600 train_time:92074ms step_avg:60.10ms
+step:1533/1600 train_time:92162ms step_avg:60.12ms
+step:1534/1600 train_time:92247ms step_avg:60.14ms
+step:1535/1600 train_time:92336ms step_avg:60.15ms
+step:1536/1600 train_time:92421ms step_avg:60.17ms
+step:1537/1600 train_time:92510ms step_avg:60.19ms
+step:1538/1600 train_time:92596ms step_avg:60.21ms
+step:1539/1600 train_time:92684ms step_avg:60.22ms
+step:1540/1600 train_time:92769ms step_avg:60.24ms
+step:1541/1600 train_time:92857ms step_avg:60.26ms
+step:1542/1600 train_time:92942ms step_avg:60.27ms
+step:1543/1600 train_time:93030ms step_avg:60.29ms
+step:1544/1600 train_time:93115ms step_avg:60.31ms
+step:1545/1600 train_time:93203ms step_avg:60.33ms
+step:1546/1600 train_time:93289ms step_avg:60.34ms
+step:1547/1600 train_time:93378ms step_avg:60.36ms
+step:1548/1600 train_time:93464ms step_avg:60.38ms
+step:1549/1600 train_time:93553ms step_avg:60.40ms
+step:1550/1600 train_time:93638ms step_avg:60.41ms
+step:1551/1600 train_time:93726ms step_avg:60.43ms
+step:1552/1600 train_time:93811ms step_avg:60.45ms
+step:1553/1600 train_time:93899ms step_avg:60.46ms
+step:1554/1600 train_time:93984ms step_avg:60.48ms
+step:1555/1600 train_time:94071ms step_avg:60.50ms
+step:1556/1600 train_time:94156ms step_avg:60.51ms
+step:1557/1600 train_time:94243ms step_avg:60.53ms
+step:1558/1600 train_time:94329ms step_avg:60.54ms
+step:1559/1600 train_time:94417ms step_avg:60.56ms
+step:1560/1600 train_time:94503ms step_avg:60.58ms
+step:1561/1600 train_time:94599ms step_avg:60.60ms
+step:1562/1600 train_time:94685ms step_avg:60.62ms
+step:1563/1600 train_time:94771ms step_avg:60.63ms
+step:1564/1600 train_time:94857ms step_avg:60.65ms
+step:1565/1600 train_time:94944ms step_avg:60.67ms
+step:1566/1600 train_time:95029ms step_avg:60.68ms
+step:1567/1600 train_time:95118ms step_avg:60.70ms
+step:1568/1600 train_time:95204ms step_avg:60.72ms
+step:1569/1600 train_time:95292ms step_avg:60.73ms
+step:1570/1600 train_time:95378ms step_avg:60.75ms
+step:1571/1600 train_time:95467ms step_avg:60.77ms
+step:1572/1600 train_time:95553ms step_avg:60.78ms
+step:1573/1600 train_time:95643ms step_avg:60.80ms
+step:1574/1600 train_time:95728ms step_avg:60.82ms
+step:1575/1600 train_time:95817ms step_avg:60.84ms
+step:1576/1600 train_time:95903ms step_avg:60.85ms
+step:1577/1600 train_time:95994ms step_avg:60.87ms
+step:1578/1600 train_time:96079ms step_avg:60.89ms
+step:1579/1600 train_time:96168ms step_avg:60.90ms
+step:1580/1600 train_time:96253ms step_avg:60.92ms
+step:1581/1600 train_time:96341ms step_avg:60.94ms
+step:1582/1600 train_time:96426ms step_avg:60.95ms
+step:1583/1600 train_time:96515ms step_avg:60.97ms
+step:1584/1600 train_time:96601ms step_avg:60.99ms
+step:1585/1600 train_time:96690ms step_avg:61.00ms
+step:1586/1600 train_time:96775ms step_avg:61.02ms
+step:1587/1600 train_time:96863ms step_avg:61.04ms
+step:1588/1600 train_time:96949ms step_avg:61.05ms
+step:1589/1600 train_time:97037ms step_avg:61.07ms
+step:1590/1600 train_time:97122ms step_avg:61.08ms
+step:1591/1600 train_time:97211ms step_avg:61.10ms
+step:1592/1600 train_time:97296ms step_avg:61.12ms
+step:1593/1600 train_time:97385ms step_avg:61.13ms
+step:1594/1600 train_time:97471ms step_avg:61.15ms
+step:1595/1600 train_time:97559ms step_avg:61.17ms
+step:1596/1600 train_time:97645ms step_avg:61.18ms
+step:1597/1600 train_time:97734ms step_avg:61.20ms
+step:1598/1600 train_time:97819ms step_avg:61.21ms
+step:1599/1600 train_time:97907ms step_avg:61.23ms
+step:1600/1600 train_time:97992ms step_avg:61.25ms
+step:1600/1600 val_loss:3.2756 train_time:98065ms step_avg:61.29ms
+peak memory allocated: 30181 MiB reserved: 46138 MiB

--- a/records/track_1_short/2026-01-19_BigramHashEmbedding/9a4569a0-119e-441a-baab-b04e0d2ae298.txt
+++ b/records/track_1_short/2026-01-19_BigramHashEmbedding/9a4569a0-119e-441a-baab-b04e0d2ae298.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 19 22:34:45 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   29C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   28C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   27C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   29C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   25C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   29C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   25C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     58333      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     58334      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     58335      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     58336      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     58337      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     58338      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     58339      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     58340      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8304 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:205ms step_avg:204.64ms
+step:2/1600 train_time:274ms step_avg:136.77ms
+step:3/1600 train_time:336ms step_avg:111.98ms
+step:4/1600 train_time:403ms step_avg:100.86ms
+step:5/1600 train_time:465ms step_avg:92.97ms
+step:6/1600 train_time:1341ms step_avg:223.51ms
+step:7/1600 train_time:1359ms step_avg:194.15ms
+step:8/1600 train_time:1435ms step_avg:179.43ms
+step:9/1600 train_time:1466ms step_avg:162.85ms
+step:10/1600 train_time:1503ms step_avg:150.27ms
+step:11/1600 train_time:1533ms step_avg:139.39ms
+step:12/1600 train_time:1571ms step_avg:130.89ms
+step:13/1600 train_time:1602ms step_avg:123.21ms
+step:14/1600 train_time:1639ms step_avg:117.07ms
+step:15/1600 train_time:1670ms step_avg:111.33ms
+step:16/1600 train_time:1707ms step_avg:106.71ms
+step:17/1600 train_time:1738ms step_avg:102.25ms
+step:18/1600 train_time:1775ms step_avg:98.62ms
+step:19/1600 train_time:1806ms step_avg:95.06ms
+step:20/1600 train_time:1843ms step_avg:92.16ms
+step:21/1600 train_time:1874ms step_avg:89.25ms
+step:22/1600 train_time:1912ms step_avg:86.89ms
+step:23/1600 train_time:1942ms step_avg:84.46ms
+step:24/1600 train_time:1980ms step_avg:82.48ms
+step:25/1600 train_time:2011ms step_avg:80.42ms
+step:26/1600 train_time:2048ms step_avg:78.75ms
+step:27/1600 train_time:2078ms step_avg:76.98ms
+step:28/1600 train_time:2116ms step_avg:75.56ms
+step:29/1600 train_time:2146ms step_avg:74.01ms
+step:30/1600 train_time:2183ms step_avg:72.77ms
+step:31/1600 train_time:2214ms step_avg:71.41ms
+step:32/1600 train_time:2251ms step_avg:70.34ms
+step:33/1600 train_time:2282ms step_avg:69.15ms
+step:34/1600 train_time:2319ms step_avg:68.20ms
+step:35/1600 train_time:2350ms step_avg:67.14ms
+step:36/1600 train_time:2387ms step_avg:66.31ms
+step:37/1600 train_time:2418ms step_avg:65.36ms
+step:38/1600 train_time:2455ms step_avg:64.61ms
+step:39/1600 train_time:2486ms step_avg:63.74ms
+step:40/1600 train_time:2523ms step_avg:63.07ms
+step:41/1600 train_time:2554ms step_avg:62.29ms
+step:42/1600 train_time:2591ms step_avg:61.69ms
+step:43/1600 train_time:2622ms step_avg:60.98ms
+step:44/1600 train_time:2659ms step_avg:60.44ms
+step:45/1600 train_time:2690ms step_avg:59.78ms
+step:46/1600 train_time:2727ms step_avg:59.29ms
+step:47/1600 train_time:2758ms step_avg:58.68ms
+step:48/1600 train_time:2795ms step_avg:58.24ms
+step:49/1600 train_time:2826ms step_avg:57.68ms
+step:50/1600 train_time:2863ms step_avg:57.26ms
+step:51/1600 train_time:2894ms step_avg:56.75ms
+step:52/1600 train_time:2931ms step_avg:56.37ms
+step:53/1600 train_time:2962ms step_avg:55.89ms
+step:54/1600 train_time:2999ms step_avg:55.54ms
+step:55/1600 train_time:3031ms step_avg:55.10ms
+step:56/1600 train_time:3068ms step_avg:54.78ms
+step:57/1600 train_time:3099ms step_avg:54.37ms
+step:58/1600 train_time:3136ms step_avg:54.07ms
+step:59/1600 train_time:3167ms step_avg:53.68ms
+step:60/1600 train_time:3205ms step_avg:53.41ms
+step:61/1600 train_time:3235ms step_avg:53.04ms
+step:62/1600 train_time:3272ms step_avg:52.78ms
+step:63/1600 train_time:3303ms step_avg:52.44ms
+step:64/1600 train_time:3340ms step_avg:52.19ms
+step:65/1600 train_time:3372ms step_avg:51.87ms
+step:66/1600 train_time:3409ms step_avg:51.65ms
+step:67/1600 train_time:3440ms step_avg:51.34ms
+step:68/1600 train_time:3477ms step_avg:51.13ms
+step:69/1600 train_time:3508ms step_avg:50.84ms
+step:70/1600 train_time:3545ms step_avg:50.64ms
+step:71/1600 train_time:3576ms step_avg:50.36ms
+step:72/1600 train_time:3613ms step_avg:50.18ms
+step:73/1600 train_time:3644ms step_avg:49.92ms
+step:74/1600 train_time:3681ms step_avg:49.74ms
+step:75/1600 train_time:3712ms step_avg:49.49ms
+step:76/1600 train_time:3749ms step_avg:49.33ms
+step:77/1600 train_time:3780ms step_avg:49.09ms
+step:78/1600 train_time:3817ms step_avg:48.93ms
+step:79/1600 train_time:3848ms step_avg:48.70ms
+step:80/1600 train_time:3884ms step_avg:48.55ms
+step:81/1600 train_time:3915ms step_avg:48.34ms
+step:82/1600 train_time:3952ms step_avg:48.20ms
+step:83/1600 train_time:3983ms step_avg:47.99ms
+step:84/1600 train_time:4020ms step_avg:47.85ms
+step:85/1600 train_time:4051ms step_avg:47.65ms
+step:86/1600 train_time:4088ms step_avg:47.53ms
+step:87/1600 train_time:4118ms step_avg:47.34ms
+step:88/1600 train_time:4155ms step_avg:47.22ms
+step:89/1600 train_time:4186ms step_avg:47.04ms
+step:90/1600 train_time:4224ms step_avg:46.93ms
+step:91/1600 train_time:4255ms step_avg:46.75ms
+step:92/1600 train_time:4292ms step_avg:46.65ms
+step:93/1600 train_time:4322ms step_avg:46.48ms
+step:94/1600 train_time:4360ms step_avg:46.38ms
+step:95/1600 train_time:4391ms step_avg:46.22ms
+step:96/1600 train_time:4428ms step_avg:46.12ms
+step:97/1600 train_time:4459ms step_avg:45.97ms
+step:98/1600 train_time:4496ms step_avg:45.87ms
+step:99/1600 train_time:4527ms step_avg:45.72ms
+step:100/1600 train_time:4564ms step_avg:45.64ms
+step:101/1600 train_time:4595ms step_avg:45.49ms
+step:102/1600 train_time:4631ms step_avg:45.41ms
+step:103/1600 train_time:4662ms step_avg:45.26ms
+step:104/1600 train_time:4699ms step_avg:45.18ms
+step:105/1600 train_time:4730ms step_avg:45.05ms
+step:106/1600 train_time:4767ms step_avg:44.97ms
+step:107/1600 train_time:4799ms step_avg:44.85ms
+step:108/1600 train_time:4836ms step_avg:44.77ms
+step:109/1600 train_time:4867ms step_avg:44.65ms
+step:110/1600 train_time:4904ms step_avg:44.58ms
+step:111/1600 train_time:4935ms step_avg:44.46ms
+step:112/1600 train_time:4972ms step_avg:44.39ms
+step:113/1600 train_time:5003ms step_avg:44.27ms
+step:114/1600 train_time:5039ms step_avg:44.21ms
+step:115/1600 train_time:5070ms step_avg:44.09ms
+step:116/1600 train_time:5107ms step_avg:44.03ms
+step:117/1600 train_time:5138ms step_avg:43.92ms
+step:118/1600 train_time:5175ms step_avg:43.85ms
+step:119/1600 train_time:5206ms step_avg:43.75ms
+step:120/1600 train_time:5243ms step_avg:43.69ms
+step:121/1600 train_time:5274ms step_avg:43.59ms
+step:122/1600 train_time:5311ms step_avg:43.53ms
+step:123/1600 train_time:5342ms step_avg:43.43ms
+step:124/1600 train_time:5379ms step_avg:43.38ms
+step:125/1600 train_time:5410ms step_avg:43.28ms
+step:126/1600 train_time:5447ms step_avg:43.23ms
+step:127/1600 train_time:5478ms step_avg:43.13ms
+step:128/1600 train_time:5515ms step_avg:43.08ms
+step:129/1600 train_time:5546ms step_avg:42.99ms
+step:130/1600 train_time:5583ms step_avg:42.94ms
+step:131/1600 train_time:5614ms step_avg:42.85ms
+step:132/1600 train_time:5650ms step_avg:42.81ms
+step:133/1600 train_time:5681ms step_avg:42.72ms
+step:134/1600 train_time:5719ms step_avg:42.68ms
+step:135/1600 train_time:5750ms step_avg:42.59ms
+step:136/1600 train_time:5786ms step_avg:42.55ms
+step:137/1600 train_time:5817ms step_avg:42.46ms
+step:138/1600 train_time:5854ms step_avg:42.42ms
+step:139/1600 train_time:5885ms step_avg:42.34ms
+step:140/1600 train_time:5922ms step_avg:42.30ms
+step:141/1600 train_time:5953ms step_avg:42.22ms
+step:142/1600 train_time:5990ms step_avg:42.18ms
+step:143/1600 train_time:6021ms step_avg:42.10ms
+step:144/1600 train_time:6057ms step_avg:42.07ms
+step:145/1600 train_time:6089ms step_avg:41.99ms
+step:146/1600 train_time:6126ms step_avg:41.96ms
+step:147/1600 train_time:6157ms step_avg:41.88ms
+step:148/1600 train_time:6193ms step_avg:41.85ms
+step:149/1600 train_time:6224ms step_avg:41.77ms
+step:150/1600 train_time:6262ms step_avg:41.74ms
+step:151/1600 train_time:6293ms step_avg:41.67ms
+step:152/1600 train_time:6330ms step_avg:41.64ms
+step:153/1600 train_time:6361ms step_avg:41.57ms
+step:154/1600 train_time:6397ms step_avg:41.54ms
+step:155/1600 train_time:6428ms step_avg:41.47ms
+step:156/1600 train_time:6465ms step_avg:41.44ms
+step:157/1600 train_time:6496ms step_avg:41.38ms
+step:158/1600 train_time:6533ms step_avg:41.35ms
+step:159/1600 train_time:6564ms step_avg:41.28ms
+step:160/1600 train_time:6601ms step_avg:41.25ms
+step:161/1600 train_time:6632ms step_avg:41.19ms
+step:162/1600 train_time:6668ms step_avg:41.16ms
+step:163/1600 train_time:6699ms step_avg:41.10ms
+step:164/1600 train_time:6736ms step_avg:41.07ms
+step:165/1600 train_time:6767ms step_avg:41.01ms
+step:166/1600 train_time:6804ms step_avg:40.99ms
+step:167/1600 train_time:6835ms step_avg:40.93ms
+step:168/1600 train_time:6872ms step_avg:40.91ms
+step:169/1600 train_time:6904ms step_avg:40.85ms
+step:170/1600 train_time:6941ms step_avg:40.83ms
+step:171/1600 train_time:6972ms step_avg:40.77ms
+step:172/1600 train_time:7009ms step_avg:40.75ms
+step:173/1600 train_time:7040ms step_avg:40.69ms
+step:174/1600 train_time:7077ms step_avg:40.67ms
+step:175/1600 train_time:7108ms step_avg:40.61ms
+step:176/1600 train_time:7144ms step_avg:40.59ms
+step:177/1600 train_time:7175ms step_avg:40.54ms
+step:178/1600 train_time:7212ms step_avg:40.52ms
+step:179/1600 train_time:7243ms step_avg:40.46ms
+step:180/1600 train_time:7280ms step_avg:40.44ms
+step:181/1600 train_time:7312ms step_avg:40.40ms
+step:182/1600 train_time:7349ms step_avg:40.38ms
+step:183/1600 train_time:7380ms step_avg:40.33ms
+step:184/1600 train_time:7417ms step_avg:40.31ms
+step:185/1600 train_time:7447ms step_avg:40.26ms
+step:186/1600 train_time:7484ms step_avg:40.24ms
+step:187/1600 train_time:7515ms step_avg:40.19ms
+step:188/1600 train_time:7552ms step_avg:40.17ms
+step:189/1600 train_time:7583ms step_avg:40.12ms
+step:190/1600 train_time:7620ms step_avg:40.10ms
+step:191/1600 train_time:7651ms step_avg:40.06ms
+step:192/1600 train_time:7688ms step_avg:40.04ms
+step:193/1600 train_time:7719ms step_avg:39.99ms
+step:194/1600 train_time:7755ms step_avg:39.98ms
+step:195/1600 train_time:7786ms step_avg:39.93ms
+step:196/1600 train_time:7823ms step_avg:39.91ms
+step:197/1600 train_time:7854ms step_avg:39.87ms
+step:198/1600 train_time:7891ms step_avg:39.85ms
+step:199/1600 train_time:7922ms step_avg:39.81ms
+step:200/1600 train_time:7959ms step_avg:39.79ms
+step:201/1600 train_time:7990ms step_avg:39.75ms
+step:202/1600 train_time:8027ms step_avg:39.74ms
+step:203/1600 train_time:8058ms step_avg:39.69ms
+step:204/1600 train_time:8094ms step_avg:39.68ms
+step:205/1600 train_time:8125ms step_avg:39.63ms
+step:206/1600 train_time:8162ms step_avg:39.62ms
+step:207/1600 train_time:8193ms step_avg:39.58ms
+step:208/1600 train_time:8230ms step_avg:39.57ms
+step:209/1600 train_time:8261ms step_avg:39.53ms
+step:210/1600 train_time:8298ms step_avg:39.51ms
+step:211/1600 train_time:8329ms step_avg:39.47ms
+step:212/1600 train_time:8366ms step_avg:39.46ms
+step:213/1600 train_time:8397ms step_avg:39.42ms
+step:214/1600 train_time:8435ms step_avg:39.42ms
+step:215/1600 train_time:8465ms step_avg:39.37ms
+step:216/1600 train_time:8502ms step_avg:39.36ms
+step:217/1600 train_time:8533ms step_avg:39.32ms
+step:218/1600 train_time:8570ms step_avg:39.31ms
+step:219/1600 train_time:8601ms step_avg:39.28ms
+step:220/1600 train_time:8638ms step_avg:39.26ms
+step:221/1600 train_time:8669ms step_avg:39.23ms
+step:222/1600 train_time:8706ms step_avg:39.22ms
+step:223/1600 train_time:8737ms step_avg:39.18ms
+step:224/1600 train_time:8774ms step_avg:39.17ms
+step:225/1600 train_time:8805ms step_avg:39.13ms
+step:226/1600 train_time:8842ms step_avg:39.12ms
+step:227/1600 train_time:8873ms step_avg:39.09ms
+step:228/1600 train_time:8910ms step_avg:39.08ms
+step:229/1600 train_time:8941ms step_avg:39.04ms
+step:230/1600 train_time:8978ms step_avg:39.03ms
+step:231/1600 train_time:9009ms step_avg:39.00ms
+step:232/1600 train_time:9046ms step_avg:38.99ms
+step:233/1600 train_time:9076ms step_avg:38.95ms
+step:234/1600 train_time:9113ms step_avg:38.94ms
+step:235/1600 train_time:9144ms step_avg:38.91ms
+step:236/1600 train_time:9181ms step_avg:38.90ms
+step:237/1600 train_time:9212ms step_avg:38.87ms
+step:238/1600 train_time:9249ms step_avg:38.86ms
+step:239/1600 train_time:9280ms step_avg:38.83ms
+step:240/1600 train_time:9316ms step_avg:38.82ms
+step:241/1600 train_time:9348ms step_avg:38.79ms
+step:242/1600 train_time:9384ms step_avg:38.78ms
+step:243/1600 train_time:9415ms step_avg:38.75ms
+step:244/1600 train_time:9452ms step_avg:38.74ms
+step:245/1600 train_time:9483ms step_avg:38.71ms
+step:246/1600 train_time:9520ms step_avg:38.70ms
+step:247/1600 train_time:9551ms step_avg:38.67ms
+step:248/1600 train_time:9588ms step_avg:38.66ms
+step:249/1600 train_time:9619ms step_avg:38.63ms
+step:250/1600 train_time:9655ms step_avg:38.62ms
+step:250/1600 val_loss:4.5817 train_time:9704ms step_avg:38.81ms
+step:251/1600 train_time:9722ms step_avg:38.73ms
+step:252/1600 train_time:9740ms step_avg:38.65ms
+step:253/1600 train_time:9758ms step_avg:38.57ms
+step:254/1600 train_time:9796ms step_avg:38.57ms
+step:255/1600 train_time:9827ms step_avg:38.54ms
+step:256/1600 train_time:9865ms step_avg:38.54ms
+step:257/1600 train_time:9897ms step_avg:38.51ms
+step:258/1600 train_time:9934ms step_avg:38.50ms
+step:259/1600 train_time:9965ms step_avg:38.47ms
+step:260/1600 train_time:10001ms step_avg:38.47ms
+step:261/1600 train_time:10033ms step_avg:38.44ms
+step:262/1600 train_time:10070ms step_avg:38.43ms
+step:263/1600 train_time:10100ms step_avg:38.40ms
+step:264/1600 train_time:10137ms step_avg:38.40ms
+step:265/1600 train_time:10168ms step_avg:38.37ms
+step:266/1600 train_time:10205ms step_avg:38.36ms
+step:267/1600 train_time:10236ms step_avg:38.34ms
+step:268/1600 train_time:10272ms step_avg:38.33ms
+step:269/1600 train_time:10303ms step_avg:38.30ms
+step:270/1600 train_time:10340ms step_avg:38.30ms
+step:271/1600 train_time:10371ms step_avg:38.27ms
+step:272/1600 train_time:10407ms step_avg:38.26ms
+step:273/1600 train_time:10438ms step_avg:38.24ms
+step:274/1600 train_time:10475ms step_avg:38.23ms
+step:275/1600 train_time:10506ms step_avg:38.20ms
+step:276/1600 train_time:10543ms step_avg:38.20ms
+step:277/1600 train_time:10574ms step_avg:38.17ms
+step:278/1600 train_time:10611ms step_avg:38.17ms
+step:279/1600 train_time:10641ms step_avg:38.14ms
+step:280/1600 train_time:10678ms step_avg:38.14ms
+step:281/1600 train_time:10709ms step_avg:38.11ms
+step:282/1600 train_time:10746ms step_avg:38.10ms
+step:283/1600 train_time:10776ms step_avg:38.08ms
+step:284/1600 train_time:10813ms step_avg:38.07ms
+step:285/1600 train_time:10844ms step_avg:38.05ms
+step:286/1600 train_time:10880ms step_avg:38.04ms
+step:287/1600 train_time:10911ms step_avg:38.02ms
+step:288/1600 train_time:10948ms step_avg:38.02ms
+step:289/1600 train_time:10980ms step_avg:37.99ms
+step:290/1600 train_time:11016ms step_avg:37.99ms
+step:291/1600 train_time:11047ms step_avg:37.96ms
+step:292/1600 train_time:11084ms step_avg:37.96ms
+step:293/1600 train_time:11115ms step_avg:37.94ms
+step:294/1600 train_time:11152ms step_avg:37.93ms
+step:295/1600 train_time:11183ms step_avg:37.91ms
+step:296/1600 train_time:11220ms step_avg:37.90ms
+step:297/1600 train_time:11251ms step_avg:37.88ms
+step:298/1600 train_time:11287ms step_avg:37.88ms
+step:299/1600 train_time:11318ms step_avg:37.85ms
+step:300/1600 train_time:11355ms step_avg:37.85ms
+step:301/1600 train_time:11386ms step_avg:37.83ms
+step:302/1600 train_time:11423ms step_avg:37.82ms
+step:303/1600 train_time:11454ms step_avg:37.80ms
+step:304/1600 train_time:11491ms step_avg:37.80ms
+step:305/1600 train_time:11522ms step_avg:37.78ms
+step:306/1600 train_time:11559ms step_avg:37.77ms
+step:307/1600 train_time:11590ms step_avg:37.75ms
+step:308/1600 train_time:11626ms step_avg:37.75ms
+step:309/1600 train_time:11657ms step_avg:37.73ms
+step:310/1600 train_time:11694ms step_avg:37.72ms
+step:311/1600 train_time:11726ms step_avg:37.70ms
+step:312/1600 train_time:11762ms step_avg:37.70ms
+step:313/1600 train_time:11793ms step_avg:37.68ms
+step:314/1600 train_time:11830ms step_avg:37.68ms
+step:315/1600 train_time:11861ms step_avg:37.65ms
+step:316/1600 train_time:11898ms step_avg:37.65ms
+step:317/1600 train_time:11929ms step_avg:37.63ms
+step:318/1600 train_time:11966ms step_avg:37.63ms
+step:319/1600 train_time:11996ms step_avg:37.61ms
+step:320/1600 train_time:12033ms step_avg:37.60ms
+step:321/1600 train_time:12064ms step_avg:37.58ms
+step:322/1600 train_time:12101ms step_avg:37.58ms
+step:323/1600 train_time:12132ms step_avg:37.56ms
+step:324/1600 train_time:12168ms step_avg:37.56ms
+step:325/1600 train_time:12199ms step_avg:37.54ms
+step:326/1600 train_time:12236ms step_avg:37.53ms
+step:327/1600 train_time:12267ms step_avg:37.51ms
+step:328/1600 train_time:12304ms step_avg:37.51ms
+step:329/1600 train_time:12335ms step_avg:37.49ms
+step:330/1600 train_time:12371ms step_avg:37.49ms
+step:331/1600 train_time:12402ms step_avg:37.47ms
+step:332/1600 train_time:12439ms step_avg:37.47ms
+step:333/1600 train_time:12470ms step_avg:37.45ms
+step:334/1600 train_time:12507ms step_avg:37.45ms
+step:335/1600 train_time:12538ms step_avg:37.43ms
+step:336/1600 train_time:12575ms step_avg:37.43ms
+step:337/1600 train_time:12606ms step_avg:37.41ms
+step:338/1600 train_time:12643ms step_avg:37.40ms
+step:339/1600 train_time:12674ms step_avg:37.39ms
+step:340/1600 train_time:12711ms step_avg:37.39ms
+step:341/1600 train_time:12742ms step_avg:37.37ms
+step:342/1600 train_time:12779ms step_avg:37.37ms
+step:343/1600 train_time:12810ms step_avg:37.35ms
+step:344/1600 train_time:12847ms step_avg:37.34ms
+step:345/1600 train_time:12877ms step_avg:37.33ms
+step:346/1600 train_time:12914ms step_avg:37.32ms
+step:347/1600 train_time:12945ms step_avg:37.31ms
+step:348/1600 train_time:12982ms step_avg:37.30ms
+step:349/1600 train_time:13013ms step_avg:37.29ms
+step:350/1600 train_time:13050ms step_avg:37.28ms
+step:351/1600 train_time:13080ms step_avg:37.27ms
+step:352/1600 train_time:13118ms step_avg:37.27ms
+step:353/1600 train_time:13149ms step_avg:37.25ms
+step:354/1600 train_time:13186ms step_avg:37.25ms
+step:355/1600 train_time:13217ms step_avg:37.23ms
+step:356/1600 train_time:13254ms step_avg:37.23ms
+step:357/1600 train_time:13285ms step_avg:37.21ms
+step:358/1600 train_time:13322ms step_avg:37.21ms
+step:359/1600 train_time:13353ms step_avg:37.19ms
+step:360/1600 train_time:13390ms step_avg:37.19ms
+step:361/1600 train_time:13421ms step_avg:37.18ms
+step:362/1600 train_time:13457ms step_avg:37.17ms
+step:363/1600 train_time:13488ms step_avg:37.16ms
+step:364/1600 train_time:13525ms step_avg:37.16ms
+step:365/1600 train_time:13556ms step_avg:37.14ms
+step:366/1600 train_time:13593ms step_avg:37.14ms
+step:367/1600 train_time:13624ms step_avg:37.12ms
+step:368/1600 train_time:13660ms step_avg:37.12ms
+step:369/1600 train_time:13692ms step_avg:37.10ms
+step:370/1600 train_time:13728ms step_avg:37.10ms
+step:371/1600 train_time:13759ms step_avg:37.09ms
+step:372/1600 train_time:13796ms step_avg:37.09ms
+step:373/1600 train_time:13827ms step_avg:37.07ms
+step:374/1600 train_time:13863ms step_avg:37.07ms
+step:375/1600 train_time:13894ms step_avg:37.05ms
+step:376/1600 train_time:13931ms step_avg:37.05ms
+step:377/1600 train_time:13962ms step_avg:37.04ms
+step:378/1600 train_time:13999ms step_avg:37.03ms
+step:379/1600 train_time:14030ms step_avg:37.02ms
+step:380/1600 train_time:14067ms step_avg:37.02ms
+step:381/1600 train_time:14097ms step_avg:37.00ms
+step:382/1600 train_time:14135ms step_avg:37.00ms
+step:383/1600 train_time:14165ms step_avg:36.99ms
+step:384/1600 train_time:14202ms step_avg:36.99ms
+step:385/1600 train_time:14233ms step_avg:36.97ms
+step:386/1600 train_time:14270ms step_avg:36.97ms
+step:387/1600 train_time:14301ms step_avg:36.95ms
+step:388/1600 train_time:14338ms step_avg:36.95ms
+step:389/1600 train_time:14369ms step_avg:36.94ms
+step:390/1600 train_time:14406ms step_avg:36.94ms
+step:391/1600 train_time:14437ms step_avg:36.92ms
+step:392/1600 train_time:14474ms step_avg:36.92ms
+step:393/1600 train_time:14505ms step_avg:36.91ms
+step:394/1600 train_time:14541ms step_avg:36.91ms
+step:395/1600 train_time:14572ms step_avg:36.89ms
+step:396/1600 train_time:14609ms step_avg:36.89ms
+step:397/1600 train_time:14640ms step_avg:36.88ms
+step:398/1600 train_time:14677ms step_avg:36.88ms
+step:399/1600 train_time:14708ms step_avg:36.86ms
+step:400/1600 train_time:14745ms step_avg:36.86ms
+step:401/1600 train_time:14775ms step_avg:36.85ms
+step:402/1600 train_time:14812ms step_avg:36.85ms
+step:403/1600 train_time:14843ms step_avg:36.83ms
+step:404/1600 train_time:14880ms step_avg:36.83ms
+step:405/1600 train_time:14911ms step_avg:36.82ms
+step:406/1600 train_time:14948ms step_avg:36.82ms
+step:407/1600 train_time:14979ms step_avg:36.80ms
+step:408/1600 train_time:15016ms step_avg:36.80ms
+step:409/1600 train_time:15046ms step_avg:36.79ms
+step:410/1600 train_time:15083ms step_avg:36.79ms
+step:411/1600 train_time:15114ms step_avg:36.77ms
+step:412/1600 train_time:15151ms step_avg:36.78ms
+step:413/1600 train_time:15182ms step_avg:36.76ms
+step:414/1600 train_time:15219ms step_avg:36.76ms
+step:415/1600 train_time:15250ms step_avg:36.75ms
+step:416/1600 train_time:15287ms step_avg:36.75ms
+step:417/1600 train_time:15318ms step_avg:36.73ms
+step:418/1600 train_time:15355ms step_avg:36.73ms
+step:419/1600 train_time:15386ms step_avg:36.72ms
+step:420/1600 train_time:15422ms step_avg:36.72ms
+step:421/1600 train_time:15454ms step_avg:36.71ms
+step:422/1600 train_time:15490ms step_avg:36.71ms
+step:423/1600 train_time:15521ms step_avg:36.69ms
+step:424/1600 train_time:15558ms step_avg:36.69ms
+step:425/1600 train_time:15589ms step_avg:36.68ms
+step:426/1600 train_time:15626ms step_avg:36.68ms
+step:427/1600 train_time:15657ms step_avg:36.67ms
+step:428/1600 train_time:15694ms step_avg:36.67ms
+step:429/1600 train_time:15725ms step_avg:36.66ms
+step:430/1600 train_time:15762ms step_avg:36.66ms
+step:431/1600 train_time:15793ms step_avg:36.64ms
+step:432/1600 train_time:15829ms step_avg:36.64ms
+step:433/1600 train_time:15860ms step_avg:36.63ms
+step:434/1600 train_time:15897ms step_avg:36.63ms
+step:435/1600 train_time:15928ms step_avg:36.62ms
+step:436/1600 train_time:15964ms step_avg:36.62ms
+step:437/1600 train_time:15995ms step_avg:36.60ms
+step:438/1600 train_time:16032ms step_avg:36.60ms
+step:439/1600 train_time:16063ms step_avg:36.59ms
+step:440/1600 train_time:16100ms step_avg:36.59ms
+step:441/1600 train_time:16131ms step_avg:36.58ms
+step:442/1600 train_time:16167ms step_avg:36.58ms
+step:443/1600 train_time:16198ms step_avg:36.57ms
+step:444/1600 train_time:16235ms step_avg:36.57ms
+step:445/1600 train_time:16266ms step_avg:36.55ms
+step:446/1600 train_time:16303ms step_avg:36.55ms
+step:447/1600 train_time:16334ms step_avg:36.54ms
+step:448/1600 train_time:16371ms step_avg:36.54ms
+step:449/1600 train_time:16402ms step_avg:36.53ms
+step:450/1600 train_time:16438ms step_avg:36.53ms
+step:451/1600 train_time:16469ms step_avg:36.52ms
+step:452/1600 train_time:16506ms step_avg:36.52ms
+step:453/1600 train_time:16537ms step_avg:36.50ms
+step:454/1600 train_time:16573ms step_avg:36.51ms
+step:455/1600 train_time:16604ms step_avg:36.49ms
+step:456/1600 train_time:16641ms step_avg:36.49ms
+step:457/1600 train_time:16672ms step_avg:36.48ms
+step:458/1600 train_time:16709ms step_avg:36.48ms
+step:459/1600 train_time:16740ms step_avg:36.47ms
+step:460/1600 train_time:16777ms step_avg:36.47ms
+step:461/1600 train_time:16808ms step_avg:36.46ms
+step:462/1600 train_time:16845ms step_avg:36.46ms
+step:463/1600 train_time:16876ms step_avg:36.45ms
+step:464/1600 train_time:16913ms step_avg:36.45ms
+step:465/1600 train_time:16944ms step_avg:36.44ms
+step:466/1600 train_time:16981ms step_avg:36.44ms
+step:467/1600 train_time:17012ms step_avg:36.43ms
+step:468/1600 train_time:17048ms step_avg:36.43ms
+step:469/1600 train_time:17079ms step_avg:36.42ms
+step:470/1600 train_time:17116ms step_avg:36.42ms
+step:471/1600 train_time:17147ms step_avg:36.41ms
+step:472/1600 train_time:17184ms step_avg:36.41ms
+step:473/1600 train_time:17215ms step_avg:36.40ms
+step:474/1600 train_time:17252ms step_avg:36.40ms
+step:475/1600 train_time:17282ms step_avg:36.38ms
+step:476/1600 train_time:17319ms step_avg:36.38ms
+step:477/1600 train_time:17350ms step_avg:36.37ms
+step:478/1600 train_time:17387ms step_avg:36.37ms
+step:479/1600 train_time:17418ms step_avg:36.36ms
+step:480/1600 train_time:17455ms step_avg:36.36ms
+step:481/1600 train_time:17486ms step_avg:36.35ms
+step:482/1600 train_time:17522ms step_avg:36.35ms
+step:483/1600 train_time:17553ms step_avg:36.34ms
+step:484/1600 train_time:17590ms step_avg:36.34ms
+step:485/1600 train_time:17621ms step_avg:36.33ms
+step:486/1600 train_time:17658ms step_avg:36.33ms
+step:487/1600 train_time:17689ms step_avg:36.32ms
+step:488/1600 train_time:17725ms step_avg:36.32ms
+step:489/1600 train_time:17756ms step_avg:36.31ms
+step:490/1600 train_time:17793ms step_avg:36.31ms
+step:491/1600 train_time:17824ms step_avg:36.30ms
+step:492/1600 train_time:17861ms step_avg:36.30ms
+step:493/1600 train_time:17892ms step_avg:36.29ms
+step:494/1600 train_time:17928ms step_avg:36.29ms
+step:495/1600 train_time:17959ms step_avg:36.28ms
+step:496/1600 train_time:17996ms step_avg:36.28ms
+step:497/1600 train_time:18026ms step_avg:36.27ms
+step:498/1600 train_time:18063ms step_avg:36.27ms
+step:499/1600 train_time:18094ms step_avg:36.26ms
+step:500/1600 train_time:18131ms step_avg:36.26ms
+step:500/1600 val_loss:4.2442 train_time:18179ms step_avg:36.36ms
+step:501/1600 train_time:18197ms step_avg:36.32ms
+step:502/1600 train_time:18215ms step_avg:36.28ms
+step:503/1600 train_time:18232ms step_avg:36.25ms
+step:504/1600 train_time:18269ms step_avg:36.25ms
+step:505/1600 train_time:18301ms step_avg:36.24ms
+step:506/1600 train_time:18338ms step_avg:36.24ms
+step:507/1600 train_time:18369ms step_avg:36.23ms
+step:508/1600 train_time:18406ms step_avg:36.23ms
+step:509/1600 train_time:18438ms step_avg:36.22ms
+step:510/1600 train_time:18475ms step_avg:36.23ms
+step:511/1600 train_time:18506ms step_avg:36.22ms
+step:512/1600 train_time:18543ms step_avg:36.22ms
+step:513/1600 train_time:18574ms step_avg:36.21ms
+step:514/1600 train_time:18611ms step_avg:36.21ms
+step:515/1600 train_time:18642ms step_avg:36.20ms
+step:516/1600 train_time:18679ms step_avg:36.20ms
+step:517/1600 train_time:18709ms step_avg:36.19ms
+step:518/1600 train_time:18746ms step_avg:36.19ms
+step:519/1600 train_time:18777ms step_avg:36.18ms
+step:520/1600 train_time:18814ms step_avg:36.18ms
+step:521/1600 train_time:18887ms step_avg:36.25ms
+step:522/1600 train_time:18941ms step_avg:36.29ms
+step:523/1600 train_time:19002ms step_avg:36.33ms
+step:524/1600 train_time:19060ms step_avg:36.37ms
+step:525/1600 train_time:19121ms step_avg:36.42ms
+step:526/1600 train_time:19182ms step_avg:36.47ms
+step:527/1600 train_time:19243ms step_avg:36.51ms
+step:528/1600 train_time:19303ms step_avg:36.56ms
+step:529/1600 train_time:19366ms step_avg:36.61ms
+step:530/1600 train_time:19426ms step_avg:36.65ms
+step:531/1600 train_time:19489ms step_avg:36.70ms
+step:532/1600 train_time:19548ms step_avg:36.74ms
+step:533/1600 train_time:19611ms step_avg:36.79ms
+step:534/1600 train_time:19670ms step_avg:36.84ms
+step:535/1600 train_time:19732ms step_avg:36.88ms
+step:536/1600 train_time:19791ms step_avg:36.92ms
+step:537/1600 train_time:19853ms step_avg:36.97ms
+step:538/1600 train_time:19913ms step_avg:37.01ms
+step:539/1600 train_time:19974ms step_avg:37.06ms
+step:540/1600 train_time:20034ms step_avg:37.10ms
+step:541/1600 train_time:20095ms step_avg:37.14ms
+step:542/1600 train_time:20155ms step_avg:37.19ms
+step:543/1600 train_time:20216ms step_avg:37.23ms
+step:544/1600 train_time:20276ms step_avg:37.27ms
+step:545/1600 train_time:20338ms step_avg:37.32ms
+step:546/1600 train_time:20398ms step_avg:37.36ms
+step:547/1600 train_time:20461ms step_avg:37.41ms
+step:548/1600 train_time:20520ms step_avg:37.44ms
+step:549/1600 train_time:20582ms step_avg:37.49ms
+step:550/1600 train_time:20641ms step_avg:37.53ms
+step:551/1600 train_time:20704ms step_avg:37.57ms
+step:552/1600 train_time:20764ms step_avg:37.62ms
+step:553/1600 train_time:20826ms step_avg:37.66ms
+step:554/1600 train_time:20885ms step_avg:37.70ms
+step:555/1600 train_time:20948ms step_avg:37.74ms
+step:556/1600 train_time:21007ms step_avg:37.78ms
+step:557/1600 train_time:21069ms step_avg:37.83ms
+step:558/1600 train_time:21128ms step_avg:37.86ms
+step:559/1600 train_time:21190ms step_avg:37.91ms
+step:560/1600 train_time:21249ms step_avg:37.95ms
+step:561/1600 train_time:21313ms step_avg:37.99ms
+step:562/1600 train_time:21372ms step_avg:38.03ms
+step:563/1600 train_time:21435ms step_avg:38.07ms
+step:564/1600 train_time:21496ms step_avg:38.11ms
+step:565/1600 train_time:21558ms step_avg:38.16ms
+step:566/1600 train_time:21617ms step_avg:38.19ms
+step:567/1600 train_time:21680ms step_avg:38.24ms
+step:568/1600 train_time:21740ms step_avg:38.27ms
+step:569/1600 train_time:21803ms step_avg:38.32ms
+step:570/1600 train_time:21863ms step_avg:38.36ms
+step:571/1600 train_time:21926ms step_avg:38.40ms
+step:572/1600 train_time:21983ms step_avg:38.43ms
+step:573/1600 train_time:22049ms step_avg:38.48ms
+step:574/1600 train_time:22107ms step_avg:38.51ms
+step:575/1600 train_time:22169ms step_avg:38.56ms
+step:576/1600 train_time:22229ms step_avg:38.59ms
+step:577/1600 train_time:22290ms step_avg:38.63ms
+step:578/1600 train_time:22349ms step_avg:38.67ms
+step:579/1600 train_time:22411ms step_avg:38.71ms
+step:580/1600 train_time:22470ms step_avg:38.74ms
+step:581/1600 train_time:22534ms step_avg:38.78ms
+step:582/1600 train_time:22593ms step_avg:38.82ms
+step:583/1600 train_time:22656ms step_avg:38.86ms
+step:584/1600 train_time:22715ms step_avg:38.90ms
+step:585/1600 train_time:22778ms step_avg:38.94ms
+step:586/1600 train_time:22838ms step_avg:38.97ms
+step:587/1600 train_time:22900ms step_avg:39.01ms
+step:588/1600 train_time:22959ms step_avg:39.05ms
+step:589/1600 train_time:23022ms step_avg:39.09ms
+step:590/1600 train_time:23081ms step_avg:39.12ms
+step:591/1600 train_time:23143ms step_avg:39.16ms
+step:592/1600 train_time:23202ms step_avg:39.19ms
+step:593/1600 train_time:23265ms step_avg:39.23ms
+step:594/1600 train_time:23324ms step_avg:39.27ms
+step:595/1600 train_time:23386ms step_avg:39.30ms
+step:596/1600 train_time:23446ms step_avg:39.34ms
+step:597/1600 train_time:23508ms step_avg:39.38ms
+step:598/1600 train_time:23567ms step_avg:39.41ms
+step:599/1600 train_time:23629ms step_avg:39.45ms
+step:600/1600 train_time:23688ms step_avg:39.48ms
+step:601/1600 train_time:23751ms step_avg:39.52ms
+step:602/1600 train_time:23811ms step_avg:39.55ms
+step:603/1600 train_time:23874ms step_avg:39.59ms
+step:604/1600 train_time:23934ms step_avg:39.63ms
+step:605/1600 train_time:23996ms step_avg:39.66ms
+step:606/1600 train_time:24056ms step_avg:39.70ms
+step:607/1600 train_time:24118ms step_avg:39.73ms
+step:608/1600 train_time:24177ms step_avg:39.76ms
+step:609/1600 train_time:24239ms step_avg:39.80ms
+step:610/1600 train_time:24298ms step_avg:39.83ms
+step:611/1600 train_time:24360ms step_avg:39.87ms
+step:612/1600 train_time:24419ms step_avg:39.90ms
+step:613/1600 train_time:24481ms step_avg:39.94ms
+step:614/1600 train_time:24541ms step_avg:39.97ms
+step:615/1600 train_time:24606ms step_avg:40.01ms
+step:616/1600 train_time:24664ms step_avg:40.04ms
+step:617/1600 train_time:24726ms step_avg:40.07ms
+step:618/1600 train_time:24786ms step_avg:40.11ms
+step:619/1600 train_time:24849ms step_avg:40.14ms
+step:620/1600 train_time:24908ms step_avg:40.17ms
+step:621/1600 train_time:24971ms step_avg:40.21ms
+step:622/1600 train_time:25030ms step_avg:40.24ms
+step:623/1600 train_time:25093ms step_avg:40.28ms
+step:624/1600 train_time:25151ms step_avg:40.31ms
+step:625/1600 train_time:25213ms step_avg:40.34ms
+step:626/1600 train_time:25272ms step_avg:40.37ms
+step:627/1600 train_time:25335ms step_avg:40.41ms
+step:628/1600 train_time:25394ms step_avg:40.44ms
+step:629/1600 train_time:25457ms step_avg:40.47ms
+step:630/1600 train_time:25516ms step_avg:40.50ms
+step:631/1600 train_time:25579ms step_avg:40.54ms
+step:632/1600 train_time:25638ms step_avg:40.57ms
+step:633/1600 train_time:25701ms step_avg:40.60ms
+step:634/1600 train_time:25760ms step_avg:40.63ms
+step:635/1600 train_time:25823ms step_avg:40.67ms
+step:636/1600 train_time:25883ms step_avg:40.70ms
+step:637/1600 train_time:25945ms step_avg:40.73ms
+step:638/1600 train_time:26003ms step_avg:40.76ms
+step:639/1600 train_time:26066ms step_avg:40.79ms
+step:640/1600 train_time:26125ms step_avg:40.82ms
+step:641/1600 train_time:26187ms step_avg:40.85ms
+step:642/1600 train_time:26246ms step_avg:40.88ms
+step:643/1600 train_time:26308ms step_avg:40.92ms
+step:644/1600 train_time:26367ms step_avg:40.94ms
+step:645/1600 train_time:26430ms step_avg:40.98ms
+step:646/1600 train_time:26491ms step_avg:41.01ms
+step:647/1600 train_time:26554ms step_avg:41.04ms
+step:648/1600 train_time:26614ms step_avg:41.07ms
+step:649/1600 train_time:26677ms step_avg:41.10ms
+step:650/1600 train_time:26737ms step_avg:41.13ms
+step:651/1600 train_time:26799ms step_avg:41.17ms
+step:652/1600 train_time:26857ms step_avg:41.19ms
+step:653/1600 train_time:26919ms step_avg:41.22ms
+step:654/1600 train_time:26978ms step_avg:41.25ms
+step:655/1600 train_time:27040ms step_avg:41.28ms
+step:656/1600 train_time:27099ms step_avg:41.31ms
+step:657/1600 train_time:27162ms step_avg:41.34ms
+step:658/1600 train_time:27221ms step_avg:41.37ms
+step:659/1600 train_time:27284ms step_avg:41.40ms
+step:660/1600 train_time:27344ms step_avg:41.43ms
+step:661/1600 train_time:27408ms step_avg:41.46ms
+step:662/1600 train_time:27466ms step_avg:41.49ms
+step:663/1600 train_time:27529ms step_avg:41.52ms
+step:664/1600 train_time:27588ms step_avg:41.55ms
+step:665/1600 train_time:27651ms step_avg:41.58ms
+step:666/1600 train_time:27710ms step_avg:41.61ms
+step:667/1600 train_time:27773ms step_avg:41.64ms
+step:668/1600 train_time:27832ms step_avg:41.66ms
+step:669/1600 train_time:27894ms step_avg:41.70ms
+step:670/1600 train_time:27954ms step_avg:41.72ms
+step:671/1600 train_time:28016ms step_avg:41.75ms
+step:672/1600 train_time:28076ms step_avg:41.78ms
+step:673/1600 train_time:28138ms step_avg:41.81ms
+step:674/1600 train_time:28197ms step_avg:41.84ms
+step:675/1600 train_time:28260ms step_avg:41.87ms
+step:676/1600 train_time:28320ms step_avg:41.89ms
+step:677/1600 train_time:28383ms step_avg:41.92ms
+step:678/1600 train_time:28442ms step_avg:41.95ms
+step:679/1600 train_time:28505ms step_avg:41.98ms
+step:680/1600 train_time:28564ms step_avg:42.01ms
+step:681/1600 train_time:28626ms step_avg:42.04ms
+step:682/1600 train_time:28685ms step_avg:42.06ms
+step:683/1600 train_time:28747ms step_avg:42.09ms
+step:684/1600 train_time:28806ms step_avg:42.11ms
+step:685/1600 train_time:28868ms step_avg:42.14ms
+step:686/1600 train_time:28928ms step_avg:42.17ms
+step:687/1600 train_time:28991ms step_avg:42.20ms
+step:688/1600 train_time:29051ms step_avg:42.22ms
+step:689/1600 train_time:29114ms step_avg:42.25ms
+step:690/1600 train_time:29173ms step_avg:42.28ms
+step:691/1600 train_time:29235ms step_avg:42.31ms
+step:692/1600 train_time:29294ms step_avg:42.33ms
+step:693/1600 train_time:29357ms step_avg:42.36ms
+step:694/1600 train_time:29415ms step_avg:42.38ms
+step:695/1600 train_time:29478ms step_avg:42.41ms
+step:696/1600 train_time:29537ms step_avg:42.44ms
+step:697/1600 train_time:29600ms step_avg:42.47ms
+step:698/1600 train_time:29659ms step_avg:42.49ms
+step:699/1600 train_time:29722ms step_avg:42.52ms
+step:700/1600 train_time:29782ms step_avg:42.55ms
+step:701/1600 train_time:29845ms step_avg:42.57ms
+step:702/1600 train_time:29904ms step_avg:42.60ms
+step:703/1600 train_time:29966ms step_avg:42.63ms
+step:704/1600 train_time:30026ms step_avg:42.65ms
+step:705/1600 train_time:30088ms step_avg:42.68ms
+step:706/1600 train_time:30147ms step_avg:42.70ms
+step:707/1600 train_time:30210ms step_avg:42.73ms
+step:708/1600 train_time:30269ms step_avg:42.75ms
+step:709/1600 train_time:30332ms step_avg:42.78ms
+step:710/1600 train_time:30392ms step_avg:42.81ms
+step:711/1600 train_time:30455ms step_avg:42.83ms
+step:712/1600 train_time:30514ms step_avg:42.86ms
+step:713/1600 train_time:30575ms step_avg:42.88ms
+step:714/1600 train_time:30635ms step_avg:42.91ms
+step:715/1600 train_time:30697ms step_avg:42.93ms
+step:716/1600 train_time:30756ms step_avg:42.96ms
+step:717/1600 train_time:30819ms step_avg:42.98ms
+step:718/1600 train_time:30878ms step_avg:43.01ms
+step:719/1600 train_time:30940ms step_avg:43.03ms
+step:720/1600 train_time:30999ms step_avg:43.05ms
+step:721/1600 train_time:31062ms step_avg:43.08ms
+step:722/1600 train_time:31122ms step_avg:43.11ms
+step:723/1600 train_time:31185ms step_avg:43.13ms
+step:724/1600 train_time:31243ms step_avg:43.15ms
+step:725/1600 train_time:31306ms step_avg:43.18ms
+step:726/1600 train_time:31365ms step_avg:43.20ms
+step:727/1600 train_time:31426ms step_avg:43.23ms
+step:728/1600 train_time:31485ms step_avg:43.25ms
+step:729/1600 train_time:31548ms step_avg:43.28ms
+step:730/1600 train_time:31607ms step_avg:43.30ms
+step:731/1600 train_time:31670ms step_avg:43.32ms
+step:732/1600 train_time:31729ms step_avg:43.35ms
+step:733/1600 train_time:31791ms step_avg:43.37ms
+step:734/1600 train_time:31851ms step_avg:43.39ms
+step:735/1600 train_time:31914ms step_avg:43.42ms
+step:736/1600 train_time:31972ms step_avg:43.44ms
+step:737/1600 train_time:32034ms step_avg:43.47ms
+step:738/1600 train_time:32093ms step_avg:43.49ms
+step:739/1600 train_time:32156ms step_avg:43.51ms
+step:740/1600 train_time:32215ms step_avg:43.53ms
+step:741/1600 train_time:32277ms step_avg:43.56ms
+step:742/1600 train_time:32336ms step_avg:43.58ms
+step:743/1600 train_time:32399ms step_avg:43.61ms
+step:744/1600 train_time:32459ms step_avg:43.63ms
+step:745/1600 train_time:32521ms step_avg:43.65ms
+step:746/1600 train_time:32580ms step_avg:43.67ms
+step:747/1600 train_time:32643ms step_avg:43.70ms
+step:748/1600 train_time:32702ms step_avg:43.72ms
+step:749/1600 train_time:32766ms step_avg:43.75ms
+step:750/1600 train_time:32824ms step_avg:43.77ms
+step:750/1600 val_loss:3.8945 train_time:32870ms step_avg:43.83ms
+step:751/1600 train_time:32889ms step_avg:43.79ms
+step:752/1600 train_time:32948ms step_avg:43.81ms
+step:753/1600 train_time:33010ms step_avg:43.84ms
+step:754/1600 train_time:33070ms step_avg:43.86ms
+step:755/1600 train_time:33131ms step_avg:43.88ms
+step:756/1600 train_time:33190ms step_avg:43.90ms
+step:757/1600 train_time:33252ms step_avg:43.93ms
+step:758/1600 train_time:33311ms step_avg:43.95ms
+step:759/1600 train_time:33373ms step_avg:43.97ms
+step:760/1600 train_time:33431ms step_avg:43.99ms
+step:761/1600 train_time:33493ms step_avg:44.01ms
+step:762/1600 train_time:33551ms step_avg:44.03ms
+step:763/1600 train_time:33613ms step_avg:44.05ms
+step:764/1600 train_time:33671ms step_avg:44.07ms
+step:765/1600 train_time:33732ms step_avg:44.09ms
+step:766/1600 train_time:33792ms step_avg:44.11ms
+step:767/1600 train_time:33856ms step_avg:44.14ms
+step:768/1600 train_time:33917ms step_avg:44.16ms
+step:769/1600 train_time:33980ms step_avg:44.19ms
+step:770/1600 train_time:34040ms step_avg:44.21ms
+step:771/1600 train_time:34102ms step_avg:44.23ms
+step:772/1600 train_time:34162ms step_avg:44.25ms
+step:773/1600 train_time:34225ms step_avg:44.28ms
+step:774/1600 train_time:34284ms step_avg:44.30ms
+step:775/1600 train_time:34347ms step_avg:44.32ms
+step:776/1600 train_time:34405ms step_avg:44.34ms
+step:777/1600 train_time:34470ms step_avg:44.36ms
+step:778/1600 train_time:34527ms step_avg:44.38ms
+step:779/1600 train_time:34588ms step_avg:44.40ms
+step:780/1600 train_time:34647ms step_avg:44.42ms
+step:781/1600 train_time:34709ms step_avg:44.44ms
+step:782/1600 train_time:34767ms step_avg:44.46ms
+step:783/1600 train_time:34831ms step_avg:44.48ms
+step:784/1600 train_time:34890ms step_avg:44.50ms
+step:785/1600 train_time:34953ms step_avg:44.53ms
+step:786/1600 train_time:35012ms step_avg:44.54ms
+step:787/1600 train_time:35075ms step_avg:44.57ms
+step:788/1600 train_time:35135ms step_avg:44.59ms
+step:789/1600 train_time:35198ms step_avg:44.61ms
+step:790/1600 train_time:35257ms step_avg:44.63ms
+step:791/1600 train_time:35320ms step_avg:44.65ms
+step:792/1600 train_time:35379ms step_avg:44.67ms
+step:793/1600 train_time:35441ms step_avg:44.69ms
+step:794/1600 train_time:35501ms step_avg:44.71ms
+step:795/1600 train_time:35563ms step_avg:44.73ms
+step:796/1600 train_time:35623ms step_avg:44.75ms
+step:797/1600 train_time:35685ms step_avg:44.77ms
+step:798/1600 train_time:35745ms step_avg:44.79ms
+step:799/1600 train_time:35807ms step_avg:44.81ms
+step:800/1600 train_time:35867ms step_avg:44.83ms
+step:801/1600 train_time:35928ms step_avg:44.85ms
+step:802/1600 train_time:35988ms step_avg:44.87ms
+step:803/1600 train_time:36050ms step_avg:44.89ms
+step:804/1600 train_time:36110ms step_avg:44.91ms
+step:805/1600 train_time:36173ms step_avg:44.94ms
+step:806/1600 train_time:36233ms step_avg:44.95ms
+step:807/1600 train_time:36295ms step_avg:44.98ms
+step:808/1600 train_time:36354ms step_avg:44.99ms
+step:809/1600 train_time:36416ms step_avg:45.01ms
+step:810/1600 train_time:36476ms step_avg:45.03ms
+step:811/1600 train_time:36538ms step_avg:45.05ms
+step:812/1600 train_time:36597ms step_avg:45.07ms
+step:813/1600 train_time:36660ms step_avg:45.09ms
+step:814/1600 train_time:36720ms step_avg:45.11ms
+step:815/1600 train_time:36782ms step_avg:45.13ms
+step:816/1600 train_time:36843ms step_avg:45.15ms
+step:817/1600 train_time:36905ms step_avg:45.17ms
+step:818/1600 train_time:36964ms step_avg:45.19ms
+step:819/1600 train_time:37027ms step_avg:45.21ms
+step:820/1600 train_time:37085ms step_avg:45.23ms
+step:821/1600 train_time:37149ms step_avg:45.25ms
+step:822/1600 train_time:37207ms step_avg:45.26ms
+step:823/1600 train_time:37269ms step_avg:45.28ms
+step:824/1600 train_time:37328ms step_avg:45.30ms
+step:825/1600 train_time:37390ms step_avg:45.32ms
+step:826/1600 train_time:37450ms step_avg:45.34ms
+step:827/1600 train_time:37513ms step_avg:45.36ms
+step:828/1600 train_time:37572ms step_avg:45.38ms
+step:829/1600 train_time:37635ms step_avg:45.40ms
+step:830/1600 train_time:37695ms step_avg:45.42ms
+step:831/1600 train_time:37757ms step_avg:45.44ms
+step:832/1600 train_time:37816ms step_avg:45.45ms
+step:833/1600 train_time:37878ms step_avg:45.47ms
+step:834/1600 train_time:37938ms step_avg:45.49ms
+step:835/1600 train_time:38001ms step_avg:45.51ms
+step:836/1600 train_time:38060ms step_avg:45.53ms
+step:837/1600 train_time:38123ms step_avg:45.55ms
+step:838/1600 train_time:38181ms step_avg:45.56ms
+step:839/1600 train_time:38244ms step_avg:45.58ms
+step:840/1600 train_time:38304ms step_avg:45.60ms
+step:841/1600 train_time:38367ms step_avg:45.62ms
+step:842/1600 train_time:38425ms step_avg:45.64ms
+step:843/1600 train_time:38488ms step_avg:45.66ms
+step:844/1600 train_time:38547ms step_avg:45.67ms
+step:845/1600 train_time:38610ms step_avg:45.69ms
+step:846/1600 train_time:38669ms step_avg:45.71ms
+step:847/1600 train_time:38731ms step_avg:45.73ms
+step:848/1600 train_time:38791ms step_avg:45.74ms
+step:849/1600 train_time:38853ms step_avg:45.76ms
+step:850/1600 train_time:38912ms step_avg:45.78ms
+step:851/1600 train_time:38975ms step_avg:45.80ms
+step:852/1600 train_time:39034ms step_avg:45.81ms
+step:853/1600 train_time:39096ms step_avg:45.83ms
+step:854/1600 train_time:39155ms step_avg:45.85ms
+step:855/1600 train_time:39218ms step_avg:45.87ms
+step:856/1600 train_time:39277ms step_avg:45.88ms
+step:857/1600 train_time:39340ms step_avg:45.90ms
+step:858/1600 train_time:39400ms step_avg:45.92ms
+step:859/1600 train_time:39462ms step_avg:45.94ms
+step:860/1600 train_time:39521ms step_avg:45.96ms
+step:861/1600 train_time:39585ms step_avg:45.98ms
+step:862/1600 train_time:39643ms step_avg:45.99ms
+step:863/1600 train_time:39706ms step_avg:46.01ms
+step:864/1600 train_time:39764ms step_avg:46.02ms
+step:865/1600 train_time:39828ms step_avg:46.04ms
+step:866/1600 train_time:39889ms step_avg:46.06ms
+step:867/1600 train_time:39952ms step_avg:46.08ms
+step:868/1600 train_time:40010ms step_avg:46.09ms
+step:869/1600 train_time:40073ms step_avg:46.11ms
+step:870/1600 train_time:40132ms step_avg:46.13ms
+step:871/1600 train_time:40194ms step_avg:46.15ms
+step:872/1600 train_time:40254ms step_avg:46.16ms
+step:873/1600 train_time:40316ms step_avg:46.18ms
+step:874/1600 train_time:40375ms step_avg:46.20ms
+step:875/1600 train_time:40438ms step_avg:46.21ms
+step:876/1600 train_time:40497ms step_avg:46.23ms
+step:877/1600 train_time:40559ms step_avg:46.25ms
+step:878/1600 train_time:40618ms step_avg:46.26ms
+step:879/1600 train_time:40680ms step_avg:46.28ms
+step:880/1600 train_time:40740ms step_avg:46.30ms
+step:881/1600 train_time:40804ms step_avg:46.32ms
+step:882/1600 train_time:40864ms step_avg:46.33ms
+step:883/1600 train_time:40927ms step_avg:46.35ms
+step:884/1600 train_time:40985ms step_avg:46.36ms
+step:885/1600 train_time:41049ms step_avg:46.38ms
+step:886/1600 train_time:41107ms step_avg:46.40ms
+step:887/1600 train_time:41168ms step_avg:46.41ms
+step:888/1600 train_time:41227ms step_avg:46.43ms
+step:889/1600 train_time:41289ms step_avg:46.44ms
+step:890/1600 train_time:41352ms step_avg:46.46ms
+step:891/1600 train_time:41414ms step_avg:46.48ms
+step:892/1600 train_time:41473ms step_avg:46.49ms
+step:893/1600 train_time:41535ms step_avg:46.51ms
+step:894/1600 train_time:41593ms step_avg:46.52ms
+step:895/1600 train_time:41655ms step_avg:46.54ms
+step:896/1600 train_time:41715ms step_avg:46.56ms
+step:897/1600 train_time:41778ms step_avg:46.58ms
+step:898/1600 train_time:41838ms step_avg:46.59ms
+step:899/1600 train_time:41900ms step_avg:46.61ms
+step:900/1600 train_time:41959ms step_avg:46.62ms
+step:901/1600 train_time:42022ms step_avg:46.64ms
+step:902/1600 train_time:42081ms step_avg:46.65ms
+step:903/1600 train_time:42144ms step_avg:46.67ms
+step:904/1600 train_time:42203ms step_avg:46.68ms
+step:905/1600 train_time:42265ms step_avg:46.70ms
+step:906/1600 train_time:42325ms step_avg:46.72ms
+step:907/1600 train_time:42387ms step_avg:46.73ms
+step:908/1600 train_time:42446ms step_avg:46.75ms
+step:909/1600 train_time:42510ms step_avg:46.77ms
+step:910/1600 train_time:42570ms step_avg:46.78ms
+step:911/1600 train_time:42631ms step_avg:46.80ms
+step:912/1600 train_time:42691ms step_avg:46.81ms
+step:913/1600 train_time:42753ms step_avg:46.83ms
+step:914/1600 train_time:42812ms step_avg:46.84ms
+step:915/1600 train_time:42875ms step_avg:46.86ms
+step:916/1600 train_time:42934ms step_avg:46.87ms
+step:917/1600 train_time:42997ms step_avg:46.89ms
+step:918/1600 train_time:43056ms step_avg:46.90ms
+step:919/1600 train_time:43119ms step_avg:46.92ms
+step:920/1600 train_time:43179ms step_avg:46.93ms
+step:921/1600 train_time:43242ms step_avg:46.95ms
+step:922/1600 train_time:43301ms step_avg:46.96ms
+step:923/1600 train_time:43363ms step_avg:46.98ms
+step:924/1600 train_time:43422ms step_avg:46.99ms
+step:925/1600 train_time:43485ms step_avg:47.01ms
+step:926/1600 train_time:43544ms step_avg:47.02ms
+step:927/1600 train_time:43607ms step_avg:47.04ms
+step:928/1600 train_time:43666ms step_avg:47.05ms
+step:929/1600 train_time:43730ms step_avg:47.07ms
+step:930/1600 train_time:43788ms step_avg:47.08ms
+step:931/1600 train_time:43852ms step_avg:47.10ms
+step:932/1600 train_time:43911ms step_avg:47.12ms
+step:933/1600 train_time:43974ms step_avg:47.13ms
+step:934/1600 train_time:44032ms step_avg:47.14ms
+step:935/1600 train_time:44095ms step_avg:47.16ms
+step:936/1600 train_time:44155ms step_avg:47.17ms
+step:937/1600 train_time:44217ms step_avg:47.19ms
+step:938/1600 train_time:44275ms step_avg:47.20ms
+step:939/1600 train_time:44338ms step_avg:47.22ms
+step:940/1600 train_time:44399ms step_avg:47.23ms
+step:941/1600 train_time:44462ms step_avg:47.25ms
+step:942/1600 train_time:44521ms step_avg:47.26ms
+step:943/1600 train_time:44584ms step_avg:47.28ms
+step:944/1600 train_time:44643ms step_avg:47.29ms
+step:945/1600 train_time:44706ms step_avg:47.31ms
+step:946/1600 train_time:44764ms step_avg:47.32ms
+step:947/1600 train_time:44827ms step_avg:47.34ms
+step:948/1600 train_time:44885ms step_avg:47.35ms
+step:949/1600 train_time:44948ms step_avg:47.36ms
+step:950/1600 train_time:45008ms step_avg:47.38ms
+step:951/1600 train_time:45071ms step_avg:47.39ms
+step:952/1600 train_time:45130ms step_avg:47.41ms
+step:953/1600 train_time:45193ms step_avg:47.42ms
+step:954/1600 train_time:45253ms step_avg:47.44ms
+step:955/1600 train_time:45317ms step_avg:47.45ms
+step:956/1600 train_time:45375ms step_avg:47.46ms
+step:957/1600 train_time:45438ms step_avg:47.48ms
+step:958/1600 train_time:45496ms step_avg:47.49ms
+step:959/1600 train_time:45559ms step_avg:47.51ms
+step:960/1600 train_time:45618ms step_avg:47.52ms
+step:961/1600 train_time:45681ms step_avg:47.53ms
+step:962/1600 train_time:45740ms step_avg:47.55ms
+step:963/1600 train_time:45804ms step_avg:47.56ms
+step:964/1600 train_time:45863ms step_avg:47.58ms
+step:965/1600 train_time:45926ms step_avg:47.59ms
+step:966/1600 train_time:45985ms step_avg:47.60ms
+step:967/1600 train_time:46049ms step_avg:47.62ms
+step:968/1600 train_time:46108ms step_avg:47.63ms
+step:969/1600 train_time:46170ms step_avg:47.65ms
+step:970/1600 train_time:46228ms step_avg:47.66ms
+step:971/1600 train_time:46291ms step_avg:47.67ms
+step:972/1600 train_time:46350ms step_avg:47.69ms
+step:973/1600 train_time:46411ms step_avg:47.70ms
+step:974/1600 train_time:46471ms step_avg:47.71ms
+step:975/1600 train_time:46535ms step_avg:47.73ms
+step:976/1600 train_time:46593ms step_avg:47.74ms
+step:977/1600 train_time:46656ms step_avg:47.75ms
+step:978/1600 train_time:46717ms step_avg:47.77ms
+step:979/1600 train_time:46779ms step_avg:47.78ms
+step:980/1600 train_time:46839ms step_avg:47.79ms
+step:981/1600 train_time:46902ms step_avg:47.81ms
+step:982/1600 train_time:46962ms step_avg:47.82ms
+step:983/1600 train_time:47024ms step_avg:47.84ms
+step:984/1600 train_time:47084ms step_avg:47.85ms
+step:985/1600 train_time:47147ms step_avg:47.86ms
+step:986/1600 train_time:47206ms step_avg:47.88ms
+step:987/1600 train_time:47268ms step_avg:47.89ms
+step:988/1600 train_time:47327ms step_avg:47.90ms
+step:989/1600 train_time:47388ms step_avg:47.92ms
+step:990/1600 train_time:47448ms step_avg:47.93ms
+step:991/1600 train_time:47510ms step_avg:47.94ms
+step:992/1600 train_time:47570ms step_avg:47.95ms
+step:993/1600 train_time:47632ms step_avg:47.97ms
+step:994/1600 train_time:47692ms step_avg:47.98ms
+step:995/1600 train_time:47756ms step_avg:48.00ms
+step:996/1600 train_time:47816ms step_avg:48.01ms
+step:997/1600 train_time:47879ms step_avg:48.02ms
+step:998/1600 train_time:47937ms step_avg:48.03ms
+step:999/1600 train_time:48000ms step_avg:48.05ms
+step:1000/1600 train_time:48059ms step_avg:48.06ms
+step:1000/1600 val_loss:3.5975 train_time:48105ms step_avg:48.11ms
+step:1001/1600 train_time:48126ms step_avg:48.08ms
+step:1002/1600 train_time:48183ms step_avg:48.09ms
+step:1003/1600 train_time:48246ms step_avg:48.10ms
+step:1004/1600 train_time:48305ms step_avg:48.11ms
+step:1005/1600 train_time:48368ms step_avg:48.13ms
+step:1006/1600 train_time:48427ms step_avg:48.14ms
+step:1007/1600 train_time:48489ms step_avg:48.15ms
+step:1008/1600 train_time:48547ms step_avg:48.16ms
+step:1009/1600 train_time:48609ms step_avg:48.18ms
+step:1010/1600 train_time:48668ms step_avg:48.19ms
+step:1011/1600 train_time:48730ms step_avg:48.20ms
+step:1012/1600 train_time:48789ms step_avg:48.21ms
+step:1013/1600 train_time:48851ms step_avg:48.22ms
+step:1014/1600 train_time:48910ms step_avg:48.24ms
+step:1015/1600 train_time:48973ms step_avg:48.25ms
+step:1016/1600 train_time:49031ms step_avg:48.26ms
+step:1017/1600 train_time:49096ms step_avg:48.27ms
+step:1018/1600 train_time:49157ms step_avg:48.29ms
+step:1019/1600 train_time:49220ms step_avg:48.30ms
+step:1020/1600 train_time:49280ms step_avg:48.31ms
+step:1021/1600 train_time:49342ms step_avg:48.33ms
+step:1022/1600 train_time:49401ms step_avg:48.34ms
+step:1023/1600 train_time:49463ms step_avg:48.35ms
+step:1024/1600 train_time:49521ms step_avg:48.36ms
+step:1025/1600 train_time:49583ms step_avg:48.37ms
+step:1026/1600 train_time:49642ms step_avg:48.38ms
+step:1027/1600 train_time:49704ms step_avg:48.40ms
+step:1028/1600 train_time:49762ms step_avg:48.41ms
+step:1029/1600 train_time:49826ms step_avg:48.42ms
+step:1030/1600 train_time:49885ms step_avg:48.43ms
+step:1031/1600 train_time:49948ms step_avg:48.45ms
+step:1032/1600 train_time:50006ms step_avg:48.46ms
+step:1033/1600 train_time:50070ms step_avg:48.47ms
+step:1034/1600 train_time:50129ms step_avg:48.48ms
+step:1035/1600 train_time:50193ms step_avg:48.50ms
+step:1036/1600 train_time:50253ms step_avg:48.51ms
+step:1037/1600 train_time:50315ms step_avg:48.52ms
+step:1038/1600 train_time:50374ms step_avg:48.53ms
+step:1039/1600 train_time:50437ms step_avg:48.54ms
+step:1040/1600 train_time:50496ms step_avg:48.55ms
+step:1041/1600 train_time:50568ms step_avg:48.58ms
+step:1042/1600 train_time:50649ms step_avg:48.61ms
+step:1043/1600 train_time:50738ms step_avg:48.65ms
+step:1044/1600 train_time:50823ms step_avg:48.68ms
+step:1045/1600 train_time:50912ms step_avg:48.72ms
+step:1046/1600 train_time:50997ms step_avg:48.75ms
+step:1047/1600 train_time:51086ms step_avg:48.79ms
+step:1048/1600 train_time:51171ms step_avg:48.83ms
+step:1049/1600 train_time:51260ms step_avg:48.87ms
+step:1050/1600 train_time:51347ms step_avg:48.90ms
+step:1051/1600 train_time:51435ms step_avg:48.94ms
+step:1052/1600 train_time:51521ms step_avg:48.97ms
+step:1053/1600 train_time:51609ms step_avg:49.01ms
+step:1054/1600 train_time:51695ms step_avg:49.05ms
+step:1055/1600 train_time:51783ms step_avg:49.08ms
+step:1056/1600 train_time:51868ms step_avg:49.12ms
+step:1057/1600 train_time:51958ms step_avg:49.16ms
+step:1058/1600 train_time:52043ms step_avg:49.19ms
+step:1059/1600 train_time:52131ms step_avg:49.23ms
+step:1060/1600 train_time:52217ms step_avg:49.26ms
+step:1061/1600 train_time:52306ms step_avg:49.30ms
+step:1062/1600 train_time:52392ms step_avg:49.33ms
+step:1063/1600 train_time:52480ms step_avg:49.37ms
+step:1064/1600 train_time:52566ms step_avg:49.40ms
+step:1065/1600 train_time:52653ms step_avg:49.44ms
+step:1066/1600 train_time:52739ms step_avg:49.47ms
+step:1067/1600 train_time:52827ms step_avg:49.51ms
+step:1068/1600 train_time:52912ms step_avg:49.54ms
+step:1069/1600 train_time:53000ms step_avg:49.58ms
+step:1070/1600 train_time:53086ms step_avg:49.61ms
+step:1071/1600 train_time:53174ms step_avg:49.65ms
+step:1072/1600 train_time:53259ms step_avg:49.68ms
+step:1073/1600 train_time:53348ms step_avg:49.72ms
+step:1074/1600 train_time:53435ms step_avg:49.75ms
+step:1075/1600 train_time:53524ms step_avg:49.79ms
+step:1076/1600 train_time:53609ms step_avg:49.82ms
+step:1077/1600 train_time:53696ms step_avg:49.86ms
+step:1078/1600 train_time:53781ms step_avg:49.89ms
+step:1079/1600 train_time:53869ms step_avg:49.93ms
+step:1080/1600 train_time:53955ms step_avg:49.96ms
+step:1081/1600 train_time:54043ms step_avg:49.99ms
+step:1082/1600 train_time:54129ms step_avg:50.03ms
+step:1083/1600 train_time:54218ms step_avg:50.06ms
+step:1084/1600 train_time:54304ms step_avg:50.10ms
+step:1085/1600 train_time:54393ms step_avg:50.13ms
+step:1086/1600 train_time:54478ms step_avg:50.16ms
+step:1087/1600 train_time:54566ms step_avg:50.20ms
+step:1088/1600 train_time:54650ms step_avg:50.23ms
+step:1089/1600 train_time:54738ms step_avg:50.26ms
+step:1090/1600 train_time:54823ms step_avg:50.30ms
+step:1091/1600 train_time:54912ms step_avg:50.33ms
+step:1092/1600 train_time:54997ms step_avg:50.36ms
+step:1093/1600 train_time:55085ms step_avg:50.40ms
+step:1094/1600 train_time:55170ms step_avg:50.43ms
+step:1095/1600 train_time:55258ms step_avg:50.46ms
+step:1096/1600 train_time:55343ms step_avg:50.50ms
+step:1097/1600 train_time:55430ms step_avg:50.53ms
+step:1098/1600 train_time:55516ms step_avg:50.56ms
+step:1099/1600 train_time:55605ms step_avg:50.60ms
+step:1100/1600 train_time:55689ms step_avg:50.63ms
+step:1101/1600 train_time:55778ms step_avg:50.66ms
+step:1102/1600 train_time:55864ms step_avg:50.69ms
+step:1103/1600 train_time:55952ms step_avg:50.73ms
+step:1104/1600 train_time:56037ms step_avg:50.76ms
+step:1105/1600 train_time:56126ms step_avg:50.79ms
+step:1106/1600 train_time:56211ms step_avg:50.82ms
+step:1107/1600 train_time:56299ms step_avg:50.86ms
+step:1108/1600 train_time:56384ms step_avg:50.89ms
+step:1109/1600 train_time:56472ms step_avg:50.92ms
+step:1110/1600 train_time:56558ms step_avg:50.95ms
+step:1111/1600 train_time:56647ms step_avg:50.99ms
+step:1112/1600 train_time:56734ms step_avg:51.02ms
+step:1113/1600 train_time:56821ms step_avg:51.05ms
+step:1114/1600 train_time:56907ms step_avg:51.08ms
+step:1115/1600 train_time:56995ms step_avg:51.12ms
+step:1116/1600 train_time:57080ms step_avg:51.15ms
+step:1117/1600 train_time:57169ms step_avg:51.18ms
+step:1118/1600 train_time:57255ms step_avg:51.21ms
+step:1119/1600 train_time:57343ms step_avg:51.24ms
+step:1120/1600 train_time:57428ms step_avg:51.27ms
+step:1121/1600 train_time:57518ms step_avg:51.31ms
+step:1122/1600 train_time:57601ms step_avg:51.34ms
+step:1123/1600 train_time:57689ms step_avg:51.37ms
+step:1124/1600 train_time:57774ms step_avg:51.40ms
+step:1125/1600 train_time:57861ms step_avg:51.43ms
+step:1126/1600 train_time:57947ms step_avg:51.46ms
+step:1127/1600 train_time:58036ms step_avg:51.50ms
+step:1128/1600 train_time:58122ms step_avg:51.53ms
+step:1129/1600 train_time:58210ms step_avg:51.56ms
+step:1130/1600 train_time:58295ms step_avg:51.59ms
+step:1131/1600 train_time:58383ms step_avg:51.62ms
+step:1132/1600 train_time:58467ms step_avg:51.65ms
+step:1133/1600 train_time:58555ms step_avg:51.68ms
+step:1134/1600 train_time:58640ms step_avg:51.71ms
+step:1135/1600 train_time:58728ms step_avg:51.74ms
+step:1136/1600 train_time:58813ms step_avg:51.77ms
+step:1137/1600 train_time:58902ms step_avg:51.80ms
+step:1138/1600 train_time:58987ms step_avg:51.83ms
+step:1139/1600 train_time:59075ms step_avg:51.87ms
+step:1140/1600 train_time:59160ms step_avg:51.90ms
+step:1141/1600 train_time:59248ms step_avg:51.93ms
+step:1142/1600 train_time:59334ms step_avg:51.96ms
+step:1143/1600 train_time:59423ms step_avg:51.99ms
+step:1144/1600 train_time:59509ms step_avg:52.02ms
+step:1145/1600 train_time:59597ms step_avg:52.05ms
+step:1146/1600 train_time:59682ms step_avg:52.08ms
+step:1147/1600 train_time:59770ms step_avg:52.11ms
+step:1148/1600 train_time:59855ms step_avg:52.14ms
+step:1149/1600 train_time:59944ms step_avg:52.17ms
+step:1150/1600 train_time:60028ms step_avg:52.20ms
+step:1151/1600 train_time:60116ms step_avg:52.23ms
+step:1152/1600 train_time:60201ms step_avg:52.26ms
+step:1153/1600 train_time:60290ms step_avg:52.29ms
+step:1154/1600 train_time:60379ms step_avg:52.32ms
+step:1155/1600 train_time:60466ms step_avg:52.35ms
+step:1156/1600 train_time:60551ms step_avg:52.38ms
+step:1157/1600 train_time:60642ms step_avg:52.41ms
+step:1158/1600 train_time:60725ms step_avg:52.44ms
+step:1159/1600 train_time:60813ms step_avg:52.47ms
+step:1160/1600 train_time:60898ms step_avg:52.50ms
+step:1161/1600 train_time:60985ms step_avg:52.53ms
+step:1162/1600 train_time:61070ms step_avg:52.56ms
+step:1163/1600 train_time:61158ms step_avg:52.59ms
+step:1164/1600 train_time:61244ms step_avg:52.61ms
+step:1165/1600 train_time:61332ms step_avg:52.65ms
+step:1166/1600 train_time:61417ms step_avg:52.67ms
+step:1167/1600 train_time:61507ms step_avg:52.71ms
+step:1168/1600 train_time:61592ms step_avg:52.73ms
+step:1169/1600 train_time:61681ms step_avg:52.76ms
+step:1170/1600 train_time:61766ms step_avg:52.79ms
+step:1171/1600 train_time:61854ms step_avg:52.82ms
+step:1172/1600 train_time:61938ms step_avg:52.85ms
+step:1173/1600 train_time:62027ms step_avg:52.88ms
+step:1174/1600 train_time:62112ms step_avg:52.91ms
+step:1175/1600 train_time:62200ms step_avg:52.94ms
+step:1176/1600 train_time:62285ms step_avg:52.96ms
+step:1177/1600 train_time:62373ms step_avg:52.99ms
+step:1178/1600 train_time:62458ms step_avg:53.02ms
+step:1179/1600 train_time:62548ms step_avg:53.05ms
+step:1180/1600 train_time:62633ms step_avg:53.08ms
+step:1181/1600 train_time:62721ms step_avg:53.11ms
+step:1182/1600 train_time:62806ms step_avg:53.14ms
+step:1183/1600 train_time:62894ms step_avg:53.17ms
+step:1184/1600 train_time:62979ms step_avg:53.19ms
+step:1185/1600 train_time:63068ms step_avg:53.22ms
+step:1186/1600 train_time:63153ms step_avg:53.25ms
+step:1187/1600 train_time:63242ms step_avg:53.28ms
+step:1188/1600 train_time:63327ms step_avg:53.31ms
+step:1189/1600 train_time:63416ms step_avg:53.34ms
+step:1190/1600 train_time:63501ms step_avg:53.36ms
+step:1191/1600 train_time:63589ms step_avg:53.39ms
+step:1192/1600 train_time:63675ms step_avg:53.42ms
+step:1193/1600 train_time:63764ms step_avg:53.45ms
+step:1194/1600 train_time:63848ms step_avg:53.47ms
+step:1195/1600 train_time:63937ms step_avg:53.50ms
+step:1196/1600 train_time:64022ms step_avg:53.53ms
+step:1197/1600 train_time:64110ms step_avg:53.56ms
+step:1198/1600 train_time:64196ms step_avg:53.59ms
+step:1199/1600 train_time:64283ms step_avg:53.61ms
+step:1200/1600 train_time:64367ms step_avg:53.64ms
+step:1201/1600 train_time:64455ms step_avg:53.67ms
+step:1202/1600 train_time:64541ms step_avg:53.69ms
+step:1203/1600 train_time:64629ms step_avg:53.72ms
+step:1204/1600 train_time:64714ms step_avg:53.75ms
+step:1205/1600 train_time:64804ms step_avg:53.78ms
+step:1206/1600 train_time:64889ms step_avg:53.81ms
+step:1207/1600 train_time:64977ms step_avg:53.83ms
+step:1208/1600 train_time:65062ms step_avg:53.86ms
+step:1209/1600 train_time:65150ms step_avg:53.89ms
+step:1210/1600 train_time:65235ms step_avg:53.91ms
+step:1211/1600 train_time:65323ms step_avg:53.94ms
+step:1212/1600 train_time:65408ms step_avg:53.97ms
+step:1213/1600 train_time:65497ms step_avg:54.00ms
+step:1214/1600 train_time:65582ms step_avg:54.02ms
+step:1215/1600 train_time:65670ms step_avg:54.05ms
+step:1216/1600 train_time:65755ms step_avg:54.07ms
+step:1217/1600 train_time:65844ms step_avg:54.10ms
+step:1218/1600 train_time:65929ms step_avg:54.13ms
+step:1219/1600 train_time:66017ms step_avg:54.16ms
+step:1220/1600 train_time:66101ms step_avg:54.18ms
+step:1221/1600 train_time:66190ms step_avg:54.21ms
+step:1222/1600 train_time:66276ms step_avg:54.24ms
+step:1223/1600 train_time:66364ms step_avg:54.26ms
+step:1224/1600 train_time:66450ms step_avg:54.29ms
+step:1225/1600 train_time:66538ms step_avg:54.32ms
+step:1226/1600 train_time:66625ms step_avg:54.34ms
+step:1227/1600 train_time:66712ms step_avg:54.37ms
+step:1228/1600 train_time:66798ms step_avg:54.40ms
+step:1229/1600 train_time:66887ms step_avg:54.42ms
+step:1230/1600 train_time:66971ms step_avg:54.45ms
+step:1231/1600 train_time:67058ms step_avg:54.47ms
+step:1232/1600 train_time:67144ms step_avg:54.50ms
+step:1233/1600 train_time:67232ms step_avg:54.53ms
+step:1234/1600 train_time:67318ms step_avg:54.55ms
+step:1235/1600 train_time:67405ms step_avg:54.58ms
+step:1236/1600 train_time:67491ms step_avg:54.60ms
+step:1237/1600 train_time:67580ms step_avg:54.63ms
+step:1238/1600 train_time:67666ms step_avg:54.66ms
+step:1239/1600 train_time:67753ms step_avg:54.68ms
+step:1240/1600 train_time:67838ms step_avg:54.71ms
+step:1241/1600 train_time:67927ms step_avg:54.74ms
+step:1242/1600 train_time:68012ms step_avg:54.76ms
+step:1243/1600 train_time:68100ms step_avg:54.79ms
+step:1244/1600 train_time:68185ms step_avg:54.81ms
+step:1245/1600 train_time:68274ms step_avg:54.84ms
+step:1246/1600 train_time:68359ms step_avg:54.86ms
+step:1247/1600 train_time:68448ms step_avg:54.89ms
+step:1248/1600 train_time:68533ms step_avg:54.91ms
+step:1249/1600 train_time:68621ms step_avg:54.94ms
+step:1250/1600 train_time:68706ms step_avg:54.96ms
+step:1250/1600 val_loss:3.4163 train_time:68778ms step_avg:55.02ms
+step:1251/1600 train_time:68797ms step_avg:54.99ms
+step:1252/1600 train_time:68882ms step_avg:55.02ms
+step:1253/1600 train_time:68972ms step_avg:55.05ms
+step:1254/1600 train_time:69058ms step_avg:55.07ms
+step:1255/1600 train_time:69145ms step_avg:55.10ms
+step:1256/1600 train_time:69230ms step_avg:55.12ms
+step:1257/1600 train_time:69316ms step_avg:55.14ms
+step:1258/1600 train_time:69402ms step_avg:55.17ms
+step:1259/1600 train_time:69489ms step_avg:55.19ms
+step:1260/1600 train_time:69574ms step_avg:55.22ms
+step:1261/1600 train_time:69662ms step_avg:55.24ms
+step:1262/1600 train_time:69748ms step_avg:55.27ms
+step:1263/1600 train_time:69838ms step_avg:55.30ms
+step:1264/1600 train_time:69925ms step_avg:55.32ms
+step:1265/1600 train_time:70014ms step_avg:55.35ms
+step:1266/1600 train_time:70100ms step_avg:55.37ms
+step:1267/1600 train_time:70188ms step_avg:55.40ms
+step:1268/1600 train_time:70272ms step_avg:55.42ms
+step:1269/1600 train_time:70359ms step_avg:55.44ms
+step:1270/1600 train_time:70445ms step_avg:55.47ms
+step:1271/1600 train_time:70532ms step_avg:55.49ms
+step:1272/1600 train_time:70618ms step_avg:55.52ms
+step:1273/1600 train_time:70706ms step_avg:55.54ms
+step:1274/1600 train_time:70792ms step_avg:55.57ms
+step:1275/1600 train_time:70882ms step_avg:55.59ms
+step:1276/1600 train_time:70968ms step_avg:55.62ms
+step:1277/1600 train_time:71056ms step_avg:55.64ms
+step:1278/1600 train_time:71141ms step_avg:55.67ms
+step:1279/1600 train_time:71229ms step_avg:55.69ms
+step:1280/1600 train_time:71314ms step_avg:55.71ms
+step:1281/1600 train_time:71402ms step_avg:55.74ms
+step:1282/1600 train_time:71487ms step_avg:55.76ms
+step:1283/1600 train_time:71575ms step_avg:55.79ms
+step:1284/1600 train_time:71660ms step_avg:55.81ms
+step:1285/1600 train_time:71748ms step_avg:55.84ms
+step:1286/1600 train_time:71834ms step_avg:55.86ms
+step:1287/1600 train_time:71922ms step_avg:55.88ms
+step:1288/1600 train_time:72008ms step_avg:55.91ms
+step:1289/1600 train_time:72097ms step_avg:55.93ms
+step:1290/1600 train_time:72182ms step_avg:55.96ms
+step:1291/1600 train_time:72271ms step_avg:55.98ms
+step:1292/1600 train_time:72356ms step_avg:56.00ms
+step:1293/1600 train_time:72444ms step_avg:56.03ms
+step:1294/1600 train_time:72530ms step_avg:56.05ms
+step:1295/1600 train_time:72618ms step_avg:56.08ms
+step:1296/1600 train_time:72703ms step_avg:56.10ms
+step:1297/1600 train_time:72793ms step_avg:56.12ms
+step:1298/1600 train_time:72878ms step_avg:56.15ms
+step:1299/1600 train_time:72967ms step_avg:56.17ms
+step:1300/1600 train_time:73054ms step_avg:56.20ms
+step:1301/1600 train_time:73142ms step_avg:56.22ms
+step:1302/1600 train_time:73228ms step_avg:56.24ms
+step:1303/1600 train_time:73316ms step_avg:56.27ms
+step:1304/1600 train_time:73400ms step_avg:56.29ms
+step:1305/1600 train_time:73488ms step_avg:56.31ms
+step:1306/1600 train_time:73573ms step_avg:56.33ms
+step:1307/1600 train_time:73661ms step_avg:56.36ms
+step:1308/1600 train_time:73746ms step_avg:56.38ms
+step:1309/1600 train_time:73834ms step_avg:56.41ms
+step:1310/1600 train_time:73921ms step_avg:56.43ms
+step:1311/1600 train_time:74011ms step_avg:56.45ms
+step:1312/1600 train_time:74096ms step_avg:56.48ms
+step:1313/1600 train_time:74184ms step_avg:56.50ms
+step:1314/1600 train_time:74269ms step_avg:56.52ms
+step:1315/1600 train_time:74356ms step_avg:56.54ms
+step:1316/1600 train_time:74441ms step_avg:56.57ms
+step:1317/1600 train_time:74529ms step_avg:56.59ms
+step:1318/1600 train_time:74614ms step_avg:56.61ms
+step:1319/1600 train_time:74702ms step_avg:56.64ms
+step:1320/1600 train_time:74787ms step_avg:56.66ms
+step:1321/1600 train_time:74876ms step_avg:56.68ms
+step:1322/1600 train_time:74961ms step_avg:56.70ms
+step:1323/1600 train_time:75050ms step_avg:56.73ms
+step:1324/1600 train_time:75135ms step_avg:56.75ms
+step:1325/1600 train_time:75224ms step_avg:56.77ms
+step:1326/1600 train_time:75310ms step_avg:56.79ms
+step:1327/1600 train_time:75398ms step_avg:56.82ms
+step:1328/1600 train_time:75484ms step_avg:56.84ms
+step:1329/1600 train_time:75572ms step_avg:56.86ms
+step:1330/1600 train_time:75657ms step_avg:56.88ms
+step:1331/1600 train_time:75746ms step_avg:56.91ms
+step:1332/1600 train_time:75831ms step_avg:56.93ms
+step:1333/1600 train_time:75920ms step_avg:56.95ms
+step:1334/1600 train_time:76005ms step_avg:56.98ms
+step:1335/1600 train_time:76093ms step_avg:57.00ms
+step:1336/1600 train_time:76178ms step_avg:57.02ms
+step:1337/1600 train_time:76267ms step_avg:57.04ms
+step:1338/1600 train_time:76353ms step_avg:57.06ms
+step:1339/1600 train_time:76442ms step_avg:57.09ms
+step:1340/1600 train_time:76527ms step_avg:57.11ms
+step:1341/1600 train_time:76614ms step_avg:57.13ms
+step:1342/1600 train_time:76700ms step_avg:57.15ms
+step:1343/1600 train_time:76789ms step_avg:57.18ms
+step:1344/1600 train_time:76874ms step_avg:57.20ms
+step:1345/1600 train_time:76962ms step_avg:57.22ms
+step:1346/1600 train_time:77048ms step_avg:57.24ms
+step:1347/1600 train_time:77136ms step_avg:57.26ms
+step:1348/1600 train_time:77221ms step_avg:57.29ms
+step:1349/1600 train_time:77309ms step_avg:57.31ms
+step:1350/1600 train_time:77394ms step_avg:57.33ms
+step:1351/1600 train_time:77482ms step_avg:57.35ms
+step:1352/1600 train_time:77567ms step_avg:57.37ms
+step:1353/1600 train_time:77655ms step_avg:57.39ms
+step:1354/1600 train_time:77741ms step_avg:57.42ms
+step:1355/1600 train_time:77829ms step_avg:57.44ms
+step:1356/1600 train_time:77915ms step_avg:57.46ms
+step:1357/1600 train_time:78003ms step_avg:57.48ms
+step:1358/1600 train_time:78088ms step_avg:57.50ms
+step:1359/1600 train_time:78176ms step_avg:57.52ms
+step:1360/1600 train_time:78262ms step_avg:57.55ms
+step:1361/1600 train_time:78350ms step_avg:57.57ms
+step:1362/1600 train_time:78438ms step_avg:57.59ms
+step:1363/1600 train_time:78526ms step_avg:57.61ms
+step:1364/1600 train_time:78611ms step_avg:57.63ms
+step:1365/1600 train_time:78698ms step_avg:57.65ms
+step:1366/1600 train_time:78786ms step_avg:57.68ms
+step:1367/1600 train_time:78874ms step_avg:57.70ms
+step:1368/1600 train_time:78959ms step_avg:57.72ms
+step:1369/1600 train_time:79047ms step_avg:57.74ms
+step:1370/1600 train_time:79132ms step_avg:57.76ms
+step:1371/1600 train_time:79221ms step_avg:57.78ms
+step:1372/1600 train_time:79306ms step_avg:57.80ms
+step:1373/1600 train_time:79395ms step_avg:57.83ms
+step:1374/1600 train_time:79482ms step_avg:57.85ms
+step:1375/1600 train_time:79570ms step_avg:57.87ms
+step:1376/1600 train_time:79654ms step_avg:57.89ms
+step:1377/1600 train_time:79742ms step_avg:57.91ms
+step:1378/1600 train_time:79828ms step_avg:57.93ms
+step:1379/1600 train_time:79916ms step_avg:57.95ms
+step:1380/1600 train_time:80001ms step_avg:57.97ms
+step:1381/1600 train_time:80090ms step_avg:57.99ms
+step:1382/1600 train_time:80175ms step_avg:58.01ms
+step:1383/1600 train_time:80264ms step_avg:58.04ms
+step:1384/1600 train_time:80348ms step_avg:58.06ms
+step:1385/1600 train_time:80436ms step_avg:58.08ms
+step:1386/1600 train_time:80521ms step_avg:58.10ms
+step:1387/1600 train_time:80610ms step_avg:58.12ms
+step:1388/1600 train_time:80697ms step_avg:58.14ms
+step:1389/1600 train_time:80784ms step_avg:58.16ms
+step:1390/1600 train_time:80871ms step_avg:58.18ms
+step:1391/1600 train_time:80958ms step_avg:58.20ms
+step:1392/1600 train_time:81043ms step_avg:58.22ms
+step:1393/1600 train_time:81130ms step_avg:58.24ms
+step:1394/1600 train_time:81215ms step_avg:58.26ms
+step:1395/1600 train_time:81303ms step_avg:58.28ms
+step:1396/1600 train_time:81388ms step_avg:58.30ms
+step:1397/1600 train_time:81477ms step_avg:58.32ms
+step:1398/1600 train_time:81563ms step_avg:58.34ms
+step:1399/1600 train_time:81652ms step_avg:58.36ms
+step:1400/1600 train_time:81738ms step_avg:58.38ms
+step:1401/1600 train_time:81827ms step_avg:58.41ms
+step:1402/1600 train_time:81913ms step_avg:58.43ms
+step:1403/1600 train_time:82001ms step_avg:58.45ms
+step:1404/1600 train_time:82086ms step_avg:58.47ms
+step:1405/1600 train_time:82173ms step_avg:58.49ms
+step:1406/1600 train_time:82258ms step_avg:58.51ms
+step:1407/1600 train_time:82347ms step_avg:58.53ms
+step:1408/1600 train_time:82433ms step_avg:58.55ms
+step:1409/1600 train_time:82521ms step_avg:58.57ms
+step:1410/1600 train_time:82607ms step_avg:58.59ms
+step:1411/1600 train_time:82697ms step_avg:58.61ms
+step:1412/1600 train_time:82783ms step_avg:58.63ms
+step:1413/1600 train_time:82870ms step_avg:58.65ms
+step:1414/1600 train_time:82956ms step_avg:58.67ms
+step:1415/1600 train_time:83044ms step_avg:58.69ms
+step:1416/1600 train_time:83129ms step_avg:58.71ms
+step:1417/1600 train_time:83216ms step_avg:58.73ms
+step:1418/1600 train_time:83301ms step_avg:58.75ms
+step:1419/1600 train_time:83390ms step_avg:58.77ms
+step:1420/1600 train_time:83475ms step_avg:58.79ms
+step:1421/1600 train_time:83565ms step_avg:58.81ms
+step:1422/1600 train_time:83650ms step_avg:58.83ms
+step:1423/1600 train_time:83738ms step_avg:58.85ms
+step:1424/1600 train_time:83823ms step_avg:58.86ms
+step:1425/1600 train_time:83911ms step_avg:58.89ms
+step:1426/1600 train_time:83997ms step_avg:58.90ms
+step:1427/1600 train_time:84084ms step_avg:58.92ms
+step:1428/1600 train_time:84169ms step_avg:58.94ms
+step:1429/1600 train_time:84257ms step_avg:58.96ms
+step:1430/1600 train_time:84342ms step_avg:58.98ms
+step:1431/1600 train_time:84430ms step_avg:59.00ms
+step:1432/1600 train_time:84516ms step_avg:59.02ms
+step:1433/1600 train_time:84604ms step_avg:59.04ms
+step:1434/1600 train_time:84689ms step_avg:59.06ms
+step:1435/1600 train_time:84777ms step_avg:59.08ms
+step:1436/1600 train_time:84863ms step_avg:59.10ms
+step:1437/1600 train_time:84951ms step_avg:59.12ms
+step:1438/1600 train_time:85037ms step_avg:59.14ms
+step:1439/1600 train_time:85125ms step_avg:59.16ms
+step:1440/1600 train_time:85211ms step_avg:59.17ms
+step:1441/1600 train_time:85299ms step_avg:59.19ms
+step:1442/1600 train_time:85385ms step_avg:59.21ms
+step:1443/1600 train_time:85473ms step_avg:59.23ms
+step:1444/1600 train_time:85558ms step_avg:59.25ms
+step:1445/1600 train_time:85646ms step_avg:59.27ms
+step:1446/1600 train_time:85731ms step_avg:59.29ms
+step:1447/1600 train_time:85820ms step_avg:59.31ms
+step:1448/1600 train_time:85905ms step_avg:59.33ms
+step:1449/1600 train_time:85994ms step_avg:59.35ms
+step:1450/1600 train_time:86081ms step_avg:59.37ms
+step:1451/1600 train_time:86169ms step_avg:59.39ms
+step:1452/1600 train_time:86254ms step_avg:59.40ms
+step:1453/1600 train_time:86342ms step_avg:59.42ms
+step:1454/1600 train_time:86428ms step_avg:59.44ms
+step:1455/1600 train_time:86515ms step_avg:59.46ms
+step:1456/1600 train_time:86599ms step_avg:59.48ms
+step:1457/1600 train_time:86688ms step_avg:59.50ms
+step:1458/1600 train_time:86772ms step_avg:59.51ms
+step:1459/1600 train_time:86860ms step_avg:59.53ms
+step:1460/1600 train_time:86945ms step_avg:59.55ms
+step:1461/1600 train_time:87035ms step_avg:59.57ms
+step:1462/1600 train_time:87121ms step_avg:59.59ms
+step:1463/1600 train_time:87209ms step_avg:59.61ms
+step:1464/1600 train_time:87294ms step_avg:59.63ms
+step:1465/1600 train_time:87382ms step_avg:59.65ms
+step:1466/1600 train_time:87467ms step_avg:59.66ms
+step:1467/1600 train_time:87555ms step_avg:59.68ms
+step:1468/1600 train_time:87640ms step_avg:59.70ms
+step:1469/1600 train_time:87730ms step_avg:59.72ms
+step:1470/1600 train_time:87813ms step_avg:59.74ms
+step:1471/1600 train_time:87901ms step_avg:59.76ms
+step:1472/1600 train_time:87987ms step_avg:59.77ms
+step:1473/1600 train_time:88075ms step_avg:59.79ms
+step:1474/1600 train_time:88160ms step_avg:59.81ms
+step:1475/1600 train_time:88249ms step_avg:59.83ms
+step:1476/1600 train_time:88335ms step_avg:59.85ms
+step:1477/1600 train_time:88423ms step_avg:59.87ms
+step:1478/1600 train_time:88508ms step_avg:59.88ms
+step:1479/1600 train_time:88597ms step_avg:59.90ms
+step:1480/1600 train_time:88682ms step_avg:59.92ms
+step:1481/1600 train_time:88770ms step_avg:59.94ms
+step:1482/1600 train_time:88855ms step_avg:59.96ms
+step:1483/1600 train_time:88944ms step_avg:59.98ms
+step:1484/1600 train_time:89029ms step_avg:59.99ms
+step:1485/1600 train_time:89117ms step_avg:60.01ms
+step:1486/1600 train_time:89202ms step_avg:60.03ms
+step:1487/1600 train_time:89290ms step_avg:60.05ms
+step:1488/1600 train_time:89375ms step_avg:60.06ms
+step:1489/1600 train_time:89462ms step_avg:60.08ms
+step:1490/1600 train_time:89547ms step_avg:60.10ms
+step:1491/1600 train_time:89635ms step_avg:60.12ms
+step:1492/1600 train_time:89721ms step_avg:60.13ms
+step:1493/1600 train_time:89809ms step_avg:60.15ms
+step:1494/1600 train_time:89895ms step_avg:60.17ms
+step:1495/1600 train_time:89983ms step_avg:60.19ms
+step:1496/1600 train_time:90068ms step_avg:60.21ms
+step:1497/1600 train_time:90156ms step_avg:60.22ms
+step:1498/1600 train_time:90243ms step_avg:60.24ms
+step:1499/1600 train_time:90333ms step_avg:60.26ms
+step:1500/1600 train_time:90418ms step_avg:60.28ms
+step:1500/1600 val_loss:3.3065 train_time:90489ms step_avg:60.33ms
+step:1501/1600 train_time:90511ms step_avg:60.30ms
+step:1502/1600 train_time:90595ms step_avg:60.32ms
+step:1503/1600 train_time:90687ms step_avg:60.34ms
+step:1504/1600 train_time:90774ms step_avg:60.35ms
+step:1505/1600 train_time:90861ms step_avg:60.37ms
+step:1506/1600 train_time:90946ms step_avg:60.39ms
+step:1507/1600 train_time:91033ms step_avg:60.41ms
+step:1508/1600 train_time:91117ms step_avg:60.42ms
+step:1509/1600 train_time:91204ms step_avg:60.44ms
+step:1510/1600 train_time:91288ms step_avg:60.46ms
+step:1511/1600 train_time:91374ms step_avg:60.47ms
+step:1512/1600 train_time:91461ms step_avg:60.49ms
+step:1513/1600 train_time:91551ms step_avg:60.51ms
+step:1514/1600 train_time:91639ms step_avg:60.53ms
+step:1515/1600 train_time:91728ms step_avg:60.55ms
+step:1516/1600 train_time:91814ms step_avg:60.56ms
+step:1517/1600 train_time:91902ms step_avg:60.58ms
+step:1518/1600 train_time:91987ms step_avg:60.60ms
+step:1519/1600 train_time:92074ms step_avg:60.62ms
+step:1520/1600 train_time:92159ms step_avg:60.63ms
+step:1521/1600 train_time:92247ms step_avg:60.65ms
+step:1522/1600 train_time:92331ms step_avg:60.66ms
+step:1523/1600 train_time:92420ms step_avg:60.68ms
+step:1524/1600 train_time:92506ms step_avg:60.70ms
+step:1525/1600 train_time:92596ms step_avg:60.72ms
+step:1526/1600 train_time:92682ms step_avg:60.73ms
+step:1527/1600 train_time:92770ms step_avg:60.75ms
+step:1528/1600 train_time:92856ms step_avg:60.77ms
+step:1529/1600 train_time:92943ms step_avg:60.79ms
+step:1530/1600 train_time:93028ms step_avg:60.80ms
+step:1531/1600 train_time:93115ms step_avg:60.82ms
+step:1532/1600 train_time:93201ms step_avg:60.84ms
+step:1533/1600 train_time:93289ms step_avg:60.85ms
+step:1534/1600 train_time:93375ms step_avg:60.87ms
+step:1535/1600 train_time:93464ms step_avg:60.89ms
+step:1536/1600 train_time:93549ms step_avg:60.90ms
+step:1537/1600 train_time:93638ms step_avg:60.92ms
+step:1538/1600 train_time:93723ms step_avg:60.94ms
+step:1539/1600 train_time:93812ms step_avg:60.96ms
+step:1540/1600 train_time:93897ms step_avg:60.97ms
+step:1541/1600 train_time:93985ms step_avg:60.99ms
+step:1542/1600 train_time:94070ms step_avg:61.00ms
+step:1543/1600 train_time:94158ms step_avg:61.02ms
+step:1544/1600 train_time:94245ms step_avg:61.04ms
+step:1545/1600 train_time:94331ms step_avg:61.06ms
+step:1546/1600 train_time:94417ms step_avg:61.07ms
+step:1547/1600 train_time:94506ms step_avg:61.09ms
+step:1548/1600 train_time:94591ms step_avg:61.11ms
+step:1549/1600 train_time:94679ms step_avg:61.12ms
+step:1550/1600 train_time:94765ms step_avg:61.14ms
+step:1551/1600 train_time:94853ms step_avg:61.16ms
+step:1552/1600 train_time:94939ms step_avg:61.17ms
+step:1553/1600 train_time:95028ms step_avg:61.19ms
+step:1554/1600 train_time:95113ms step_avg:61.21ms
+step:1555/1600 train_time:95200ms step_avg:61.22ms
+step:1556/1600 train_time:95285ms step_avg:61.24ms
+step:1557/1600 train_time:95375ms step_avg:61.26ms
+step:1558/1600 train_time:95459ms step_avg:61.27ms
+step:1559/1600 train_time:95548ms step_avg:61.29ms
+step:1560/1600 train_time:95635ms step_avg:61.30ms
+step:1561/1600 train_time:95731ms step_avg:61.33ms
+step:1562/1600 train_time:95815ms step_avg:61.34ms
+step:1563/1600 train_time:95904ms step_avg:61.36ms
+step:1564/1600 train_time:95989ms step_avg:61.37ms
+step:1565/1600 train_time:96077ms step_avg:61.39ms
+step:1566/1600 train_time:96162ms step_avg:61.41ms
+step:1567/1600 train_time:96251ms step_avg:61.42ms
+step:1568/1600 train_time:96336ms step_avg:61.44ms
+step:1569/1600 train_time:96424ms step_avg:61.46ms
+step:1570/1600 train_time:96511ms step_avg:61.47ms
+step:1571/1600 train_time:96599ms step_avg:61.49ms
+step:1572/1600 train_time:96685ms step_avg:61.50ms
+step:1573/1600 train_time:96774ms step_avg:61.52ms
+step:1574/1600 train_time:96861ms step_avg:61.54ms
+step:1575/1600 train_time:96950ms step_avg:61.56ms
+step:1576/1600 train_time:97036ms step_avg:61.57ms
+step:1577/1600 train_time:97127ms step_avg:61.59ms
+step:1578/1600 train_time:97212ms step_avg:61.60ms
+step:1579/1600 train_time:97300ms step_avg:61.62ms
+step:1580/1600 train_time:97384ms step_avg:61.64ms
+step:1581/1600 train_time:97472ms step_avg:61.65ms
+step:1582/1600 train_time:97560ms step_avg:61.67ms
+step:1583/1600 train_time:97649ms step_avg:61.69ms
+step:1584/1600 train_time:97735ms step_avg:61.70ms
+step:1585/1600 train_time:97824ms step_avg:61.72ms
+step:1586/1600 train_time:97909ms step_avg:61.73ms
+step:1587/1600 train_time:97998ms step_avg:61.75ms
+step:1588/1600 train_time:98083ms step_avg:61.76ms
+step:1589/1600 train_time:98170ms step_avg:61.78ms
+step:1590/1600 train_time:98256ms step_avg:61.80ms
+step:1591/1600 train_time:98345ms step_avg:61.81ms
+step:1592/1600 train_time:98430ms step_avg:61.83ms
+step:1593/1600 train_time:98518ms step_avg:61.84ms
+step:1594/1600 train_time:98603ms step_avg:61.86ms
+step:1595/1600 train_time:98692ms step_avg:61.88ms
+step:1596/1600 train_time:98777ms step_avg:61.89ms
+step:1597/1600 train_time:98868ms step_avg:61.91ms
+step:1598/1600 train_time:98955ms step_avg:61.92ms
+step:1599/1600 train_time:99044ms step_avg:61.94ms
+step:1600/1600 train_time:99129ms step_avg:61.96ms
+step:1600/1600 val_loss:3.2773 train_time:99201ms step_avg:62.00ms
+peak memory allocated: 30264 MiB reserved: 46240 MiB

--- a/records/track_1_short/2026-01-19_BigramHashEmbedding/README.md
+++ b/records/track_1_short/2026-01-19_BigramHashEmbedding/README.md
@@ -1,0 +1,76 @@
+## New Record: Bigram Hash Embedding (-5.6s, -165 steps)
+
+Updates in PR:
+* Bigram Hash Embedding (-5.1s)
+* Fix partial key offset to apply to stationary dims instead of 50/50 stationary/rotating (-0.5s) [bug was introduced in paired head PR]
+* Reduce step count from 1765 to 1600
+* Increase cooldown frac from 0.5 to 0.55 (I find it works to increase this as step count decreases)
+
+Bigram hash code which runs on CPU during each dataloader iteration:
+```
+args.bigram_vocab_size = 5 * vocab_size
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+```
+
+Model structure:
+```
+# model args
+embed = nn.Embedding(vocab_size, model_dim)
+bigram_embed = nn.Embedding(bigram_vocab_size, model_dim).zero_init()
+x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+bigram_lambdas = nn.Parameter(0.1*torch.ones(num_layers))
+
+# model forward pass
+x = x0 = norm(nn.Embedding(input))
+x0_bigram = nn.Embedding(get_bigram_hash(input))
+for i in range(num_layers):
+    x = x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+    x = block(x)
+logits = lm_head(x)
+```
+
+Recent discussion on Deepseek's Engram got me looking into hash embeddings, and this 2017 paper: https://arxiv.org/abs/1709.03933. Meaningful hash collisions are rare due to token distribution, so hashing seems good. 
+
+I did some of testing on more advanced ways to integrate the hashed embeddings with gating, trigrams, and multiple hashes. Very simple direct addition to the residual stream outperformed by a decent margin.
+
+### Ideas
+Interestingly, the model now has more parameters than training tokens. Typically when a feature gets added the step count is reduced. At some point it may be better to drop an attn/mlp.
+
+Now that we have an additional 5*50304 params getting communicated across GPUs and the bottleneck is overwhelmingly on comms, it could be worthwhile to build a sparse communication approach to only send embeds with nonzero grads. I did not look at the profiler here or try other comms orderings. Due to stepping Adam every other step, early step times alternate between 31ms and 37ms. (Could be other ideas like step bigram embed once every 4 steps)
+
+There is an average of 0.4s extra due to a stall on step 6. Chris pointed this out and I believe Varun has been working on a fix. I may have also gotten a worse machine here that was making the issue more pronounced.
+
+## Timing and Validation
+```
+import scipy.stats
+import torch
+
+losses = [3.2756, 3.2786, 3.2773, 3.2791, 3.2778, 3.277]
+times = [98.065, 98.017, 99.201, 99.151, 98.112, 98.031]
+
+print("p=%.4f" % scipy.stats.ttest_1samp(losses, 3.28, alternative="less").pvalue)
+# p=0.0025
+
+print("losses:", torch.std_mean(torch.tensor(losses)))
+# losses: (tensor(0.0012), tensor(3.2776))
+
+print("time:", torch.std_mean(torch.tensor(times)))
+# time: (tensor(0.5794), tensor(98.4295))
+```
+
+retiming prior record: 104.062 [104.129, 103.995]
+
+If no changes, will merge at 99.3s to be consistent with 5.6s improvement over 104.9s.

--- a/records/track_1_short/2026-01-19_BigramHashEmbedding/abd3f67a-487a-4df3-8d00-d43afc74185a.txt
+++ b/records/track_1_short/2026-01-19_BigramHashEmbedding/abd3f67a-487a-4df3-8d00-d43afc74185a.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 19 22:31:15 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   29C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   28C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   27C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   29C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   25C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   29C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   25C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     55772      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     55773      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     55774      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     55775      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     55776      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     55777      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     55778      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     55779      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8300 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:200ms step_avg:199.59ms
+step:2/1600 train_time:269ms step_avg:134.55ms
+step:3/1600 train_time:332ms step_avg:110.60ms
+step:4/1600 train_time:400ms step_avg:99.90ms
+step:5/1600 train_time:462ms step_avg:92.44ms
+step:6/1600 train_time:1313ms step_avg:218.76ms
+step:7/1600 train_time:1330ms step_avg:190.02ms
+step:8/1600 train_time:1383ms step_avg:172.89ms
+step:9/1600 train_time:1414ms step_avg:157.08ms
+step:10/1600 train_time:1451ms step_avg:145.10ms
+step:11/1600 train_time:1482ms step_avg:134.69ms
+step:12/1600 train_time:1519ms step_avg:126.56ms
+step:13/1600 train_time:1550ms step_avg:119.21ms
+step:14/1600 train_time:1587ms step_avg:113.35ms
+step:15/1600 train_time:1618ms step_avg:107.85ms
+step:16/1600 train_time:1655ms step_avg:103.44ms
+step:17/1600 train_time:1686ms step_avg:99.19ms
+step:18/1600 train_time:1724ms step_avg:95.76ms
+step:19/1600 train_time:1754ms step_avg:92.32ms
+step:20/1600 train_time:1791ms step_avg:89.57ms
+step:21/1600 train_time:1822ms step_avg:86.77ms
+step:22/1600 train_time:1859ms step_avg:84.51ms
+step:23/1600 train_time:1890ms step_avg:82.19ms
+step:24/1600 train_time:1928ms step_avg:80.33ms
+step:25/1600 train_time:1959ms step_avg:78.35ms
+step:26/1600 train_time:1996ms step_avg:76.76ms
+step:27/1600 train_time:2026ms step_avg:75.05ms
+step:28/1600 train_time:2063ms step_avg:73.69ms
+step:29/1600 train_time:2094ms step_avg:72.21ms
+step:30/1600 train_time:2132ms step_avg:71.07ms
+step:31/1600 train_time:2163ms step_avg:69.76ms
+step:32/1600 train_time:2200ms step_avg:68.74ms
+step:33/1600 train_time:2231ms step_avg:67.59ms
+step:34/1600 train_time:2267ms step_avg:66.69ms
+step:35/1600 train_time:2298ms step_avg:65.66ms
+step:36/1600 train_time:2335ms step_avg:64.87ms
+step:37/1600 train_time:2366ms step_avg:63.95ms
+step:38/1600 train_time:2403ms step_avg:63.25ms
+step:39/1600 train_time:2434ms step_avg:62.42ms
+step:40/1600 train_time:2471ms step_avg:61.78ms
+step:41/1600 train_time:2502ms step_avg:61.03ms
+step:42/1600 train_time:2540ms step_avg:60.47ms
+step:43/1600 train_time:2571ms step_avg:59.79ms
+step:44/1600 train_time:2608ms step_avg:59.28ms
+step:45/1600 train_time:2639ms step_avg:58.65ms
+step:46/1600 train_time:2676ms step_avg:58.18ms
+step:47/1600 train_time:2707ms step_avg:57.60ms
+step:48/1600 train_time:2744ms step_avg:57.17ms
+step:49/1600 train_time:2775ms step_avg:56.63ms
+step:50/1600 train_time:2812ms step_avg:56.24ms
+step:51/1600 train_time:2843ms step_avg:55.74ms
+step:52/1600 train_time:2880ms step_avg:55.39ms
+step:53/1600 train_time:2911ms step_avg:54.92ms
+step:54/1600 train_time:2948ms step_avg:54.60ms
+step:55/1600 train_time:2979ms step_avg:54.17ms
+step:56/1600 train_time:3016ms step_avg:53.86ms
+step:57/1600 train_time:3047ms step_avg:53.45ms
+step:58/1600 train_time:3084ms step_avg:53.17ms
+step:59/1600 train_time:3115ms step_avg:52.79ms
+step:60/1600 train_time:3153ms step_avg:52.54ms
+step:61/1600 train_time:3183ms step_avg:52.19ms
+step:62/1600 train_time:3220ms step_avg:51.94ms
+step:63/1600 train_time:3252ms step_avg:51.61ms
+step:64/1600 train_time:3289ms step_avg:51.39ms
+step:65/1600 train_time:3320ms step_avg:51.07ms
+step:66/1600 train_time:3357ms step_avg:50.87ms
+step:67/1600 train_time:3388ms step_avg:50.57ms
+step:68/1600 train_time:3425ms step_avg:50.36ms
+step:69/1600 train_time:3456ms step_avg:50.08ms
+step:70/1600 train_time:3493ms step_avg:49.90ms
+step:71/1600 train_time:3524ms step_avg:49.63ms
+step:72/1600 train_time:3561ms step_avg:49.46ms
+step:73/1600 train_time:3592ms step_avg:49.20ms
+step:74/1600 train_time:3629ms step_avg:49.04ms
+step:75/1600 train_time:3659ms step_avg:48.79ms
+step:76/1600 train_time:3697ms step_avg:48.64ms
+step:77/1600 train_time:3728ms step_avg:48.42ms
+step:78/1600 train_time:3765ms step_avg:48.27ms
+step:79/1600 train_time:3796ms step_avg:48.05ms
+step:80/1600 train_time:3834ms step_avg:47.92ms
+step:81/1600 train_time:3864ms step_avg:47.71ms
+step:82/1600 train_time:3901ms step_avg:47.58ms
+step:83/1600 train_time:3932ms step_avg:47.38ms
+step:84/1600 train_time:3969ms step_avg:47.25ms
+step:85/1600 train_time:4000ms step_avg:47.06ms
+step:86/1600 train_time:4037ms step_avg:46.95ms
+step:87/1600 train_time:4068ms step_avg:46.76ms
+step:88/1600 train_time:4105ms step_avg:46.65ms
+step:89/1600 train_time:4136ms step_avg:46.47ms
+step:90/1600 train_time:4173ms step_avg:46.37ms
+step:91/1600 train_time:4204ms step_avg:46.20ms
+step:92/1600 train_time:4241ms step_avg:46.10ms
+step:93/1600 train_time:4273ms step_avg:45.94ms
+step:94/1600 train_time:4309ms step_avg:45.85ms
+step:95/1600 train_time:4340ms step_avg:45.69ms
+step:96/1600 train_time:4377ms step_avg:45.60ms
+step:97/1600 train_time:4409ms step_avg:45.45ms
+step:98/1600 train_time:4446ms step_avg:45.36ms
+step:99/1600 train_time:4476ms step_avg:45.22ms
+step:100/1600 train_time:4514ms step_avg:45.14ms
+step:101/1600 train_time:4545ms step_avg:45.00ms
+step:102/1600 train_time:4582ms step_avg:44.92ms
+step:103/1600 train_time:4613ms step_avg:44.79ms
+step:104/1600 train_time:4650ms step_avg:44.71ms
+step:105/1600 train_time:4681ms step_avg:44.58ms
+step:106/1600 train_time:4718ms step_avg:44.51ms
+step:107/1600 train_time:4749ms step_avg:44.38ms
+step:108/1600 train_time:4786ms step_avg:44.32ms
+step:109/1600 train_time:4817ms step_avg:44.19ms
+step:110/1600 train_time:4854ms step_avg:44.13ms
+step:111/1600 train_time:4886ms step_avg:44.01ms
+step:112/1600 train_time:4922ms step_avg:43.95ms
+step:113/1600 train_time:4953ms step_avg:43.83ms
+step:114/1600 train_time:4991ms step_avg:43.78ms
+step:115/1600 train_time:5022ms step_avg:43.67ms
+step:116/1600 train_time:5058ms step_avg:43.61ms
+step:117/1600 train_time:5089ms step_avg:43.50ms
+step:118/1600 train_time:5126ms step_avg:43.44ms
+step:119/1600 train_time:5157ms step_avg:43.33ms
+step:120/1600 train_time:5194ms step_avg:43.28ms
+step:121/1600 train_time:5225ms step_avg:43.18ms
+step:122/1600 train_time:5262ms step_avg:43.13ms
+step:123/1600 train_time:5293ms step_avg:43.03ms
+step:124/1600 train_time:5330ms step_avg:42.99ms
+step:125/1600 train_time:5361ms step_avg:42.89ms
+step:126/1600 train_time:5398ms step_avg:42.84ms
+step:127/1600 train_time:5429ms step_avg:42.75ms
+step:128/1600 train_time:5466ms step_avg:42.70ms
+step:129/1600 train_time:5497ms step_avg:42.61ms
+step:130/1600 train_time:5535ms step_avg:42.57ms
+step:131/1600 train_time:5566ms step_avg:42.49ms
+step:132/1600 train_time:5602ms step_avg:42.44ms
+step:133/1600 train_time:5633ms step_avg:42.35ms
+step:134/1600 train_time:5671ms step_avg:42.32ms
+step:135/1600 train_time:5702ms step_avg:42.24ms
+step:136/1600 train_time:5739ms step_avg:42.20ms
+step:137/1600 train_time:5769ms step_avg:42.11ms
+step:138/1600 train_time:5806ms step_avg:42.07ms
+step:139/1600 train_time:5837ms step_avg:41.99ms
+step:140/1600 train_time:5874ms step_avg:41.96ms
+step:141/1600 train_time:5905ms step_avg:41.88ms
+step:142/1600 train_time:5942ms step_avg:41.84ms
+step:143/1600 train_time:5973ms step_avg:41.77ms
+step:144/1600 train_time:6009ms step_avg:41.73ms
+step:145/1600 train_time:6041ms step_avg:41.66ms
+step:146/1600 train_time:6078ms step_avg:41.63ms
+step:147/1600 train_time:6109ms step_avg:41.56ms
+step:148/1600 train_time:6146ms step_avg:41.53ms
+step:149/1600 train_time:6177ms step_avg:41.46ms
+step:150/1600 train_time:6214ms step_avg:41.42ms
+step:151/1600 train_time:6245ms step_avg:41.36ms
+step:152/1600 train_time:6281ms step_avg:41.32ms
+step:153/1600 train_time:6312ms step_avg:41.26ms
+step:154/1600 train_time:6350ms step_avg:41.23ms
+step:155/1600 train_time:6380ms step_avg:41.16ms
+step:156/1600 train_time:6417ms step_avg:41.14ms
+step:157/1600 train_time:6448ms step_avg:41.07ms
+step:158/1600 train_time:6485ms step_avg:41.04ms
+step:159/1600 train_time:6516ms step_avg:40.98ms
+step:160/1600 train_time:6553ms step_avg:40.96ms
+step:161/1600 train_time:6584ms step_avg:40.89ms
+step:162/1600 train_time:6621ms step_avg:40.87ms
+step:163/1600 train_time:6652ms step_avg:40.81ms
+step:164/1600 train_time:6689ms step_avg:40.79ms
+step:165/1600 train_time:6720ms step_avg:40.73ms
+step:166/1600 train_time:6757ms step_avg:40.71ms
+step:167/1600 train_time:6788ms step_avg:40.65ms
+step:168/1600 train_time:6825ms step_avg:40.62ms
+step:169/1600 train_time:6856ms step_avg:40.57ms
+step:170/1600 train_time:6893ms step_avg:40.55ms
+step:171/1600 train_time:6925ms step_avg:40.49ms
+step:172/1600 train_time:6962ms step_avg:40.47ms
+step:173/1600 train_time:6992ms step_avg:40.42ms
+step:174/1600 train_time:7029ms step_avg:40.40ms
+step:175/1600 train_time:7060ms step_avg:40.34ms
+step:176/1600 train_time:7097ms step_avg:40.32ms
+step:177/1600 train_time:7128ms step_avg:40.27ms
+step:178/1600 train_time:7165ms step_avg:40.25ms
+step:179/1600 train_time:7196ms step_avg:40.20ms
+step:180/1600 train_time:7232ms step_avg:40.18ms
+step:181/1600 train_time:7263ms step_avg:40.13ms
+step:182/1600 train_time:7300ms step_avg:40.11ms
+step:183/1600 train_time:7331ms step_avg:40.06ms
+step:184/1600 train_time:7368ms step_avg:40.04ms
+step:185/1600 train_time:7399ms step_avg:39.99ms
+step:186/1600 train_time:7435ms step_avg:39.98ms
+step:187/1600 train_time:7466ms step_avg:39.93ms
+step:188/1600 train_time:7503ms step_avg:39.91ms
+step:189/1600 train_time:7534ms step_avg:39.86ms
+step:190/1600 train_time:7571ms step_avg:39.85ms
+step:191/1600 train_time:7602ms step_avg:39.80ms
+step:192/1600 train_time:7639ms step_avg:39.79ms
+step:193/1600 train_time:7670ms step_avg:39.74ms
+step:194/1600 train_time:7707ms step_avg:39.73ms
+step:195/1600 train_time:7738ms step_avg:39.68ms
+step:196/1600 train_time:7775ms step_avg:39.67ms
+step:197/1600 train_time:7806ms step_avg:39.62ms
+step:198/1600 train_time:7842ms step_avg:39.61ms
+step:199/1600 train_time:7873ms step_avg:39.56ms
+step:200/1600 train_time:7910ms step_avg:39.55ms
+step:201/1600 train_time:7941ms step_avg:39.51ms
+step:202/1600 train_time:7978ms step_avg:39.49ms
+step:203/1600 train_time:8009ms step_avg:39.45ms
+step:204/1600 train_time:8046ms step_avg:39.44ms
+step:205/1600 train_time:8077ms step_avg:39.40ms
+step:206/1600 train_time:8114ms step_avg:39.39ms
+step:207/1600 train_time:8145ms step_avg:39.35ms
+step:208/1600 train_time:8181ms step_avg:39.33ms
+step:209/1600 train_time:8212ms step_avg:39.29ms
+step:210/1600 train_time:8250ms step_avg:39.29ms
+step:211/1600 train_time:8281ms step_avg:39.24ms
+step:212/1600 train_time:8317ms step_avg:39.23ms
+step:213/1600 train_time:8348ms step_avg:39.19ms
+step:214/1600 train_time:8385ms step_avg:39.18ms
+step:215/1600 train_time:8416ms step_avg:39.15ms
+step:216/1600 train_time:8453ms step_avg:39.13ms
+step:217/1600 train_time:8484ms step_avg:39.10ms
+step:218/1600 train_time:8520ms step_avg:39.08ms
+step:219/1600 train_time:8552ms step_avg:39.05ms
+step:220/1600 train_time:8588ms step_avg:39.04ms
+step:221/1600 train_time:8619ms step_avg:39.00ms
+step:222/1600 train_time:8656ms step_avg:38.99ms
+step:223/1600 train_time:8687ms step_avg:38.96ms
+step:224/1600 train_time:8724ms step_avg:38.95ms
+step:225/1600 train_time:8755ms step_avg:38.91ms
+step:226/1600 train_time:8792ms step_avg:38.90ms
+step:227/1600 train_time:8823ms step_avg:38.87ms
+step:228/1600 train_time:8860ms step_avg:38.86ms
+step:229/1600 train_time:8890ms step_avg:38.82ms
+step:230/1600 train_time:8927ms step_avg:38.81ms
+step:231/1600 train_time:8958ms step_avg:38.78ms
+step:232/1600 train_time:8995ms step_avg:38.77ms
+step:233/1600 train_time:9026ms step_avg:38.74ms
+step:234/1600 train_time:9063ms step_avg:38.73ms
+step:235/1600 train_time:9093ms step_avg:38.69ms
+step:236/1600 train_time:9130ms step_avg:38.69ms
+step:237/1600 train_time:9161ms step_avg:38.66ms
+step:238/1600 train_time:9198ms step_avg:38.65ms
+step:239/1600 train_time:9229ms step_avg:38.61ms
+step:240/1600 train_time:9266ms step_avg:38.61ms
+step:241/1600 train_time:9297ms step_avg:38.58ms
+step:242/1600 train_time:9334ms step_avg:38.57ms
+step:243/1600 train_time:9365ms step_avg:38.54ms
+step:244/1600 train_time:9401ms step_avg:38.53ms
+step:245/1600 train_time:9433ms step_avg:38.50ms
+step:246/1600 train_time:9469ms step_avg:38.49ms
+step:247/1600 train_time:9500ms step_avg:38.46ms
+step:248/1600 train_time:9537ms step_avg:38.46ms
+step:249/1600 train_time:9568ms step_avg:38.43ms
+step:250/1600 train_time:9605ms step_avg:38.42ms
+step:250/1600 val_loss:4.5764 train_time:9653ms step_avg:38.61ms
+step:251/1600 train_time:9673ms step_avg:38.54ms
+step:252/1600 train_time:9692ms step_avg:38.46ms
+step:253/1600 train_time:9708ms step_avg:38.37ms
+step:254/1600 train_time:9744ms step_avg:38.36ms
+step:255/1600 train_time:9777ms step_avg:38.34ms
+step:256/1600 train_time:9814ms step_avg:38.34ms
+step:257/1600 train_time:9846ms step_avg:38.31ms
+step:258/1600 train_time:9884ms step_avg:38.31ms
+step:259/1600 train_time:9914ms step_avg:38.28ms
+step:260/1600 train_time:9951ms step_avg:38.27ms
+step:261/1600 train_time:9983ms step_avg:38.25ms
+step:262/1600 train_time:10020ms step_avg:38.25ms
+step:263/1600 train_time:10051ms step_avg:38.22ms
+step:264/1600 train_time:10088ms step_avg:38.21ms
+step:265/1600 train_time:10119ms step_avg:38.18ms
+step:266/1600 train_time:10156ms step_avg:38.18ms
+step:267/1600 train_time:10187ms step_avg:38.15ms
+step:268/1600 train_time:10224ms step_avg:38.15ms
+step:269/1600 train_time:10255ms step_avg:38.12ms
+step:270/1600 train_time:10292ms step_avg:38.12ms
+step:271/1600 train_time:10322ms step_avg:38.09ms
+step:272/1600 train_time:10359ms step_avg:38.09ms
+step:273/1600 train_time:10390ms step_avg:38.06ms
+step:274/1600 train_time:10427ms step_avg:38.05ms
+step:275/1600 train_time:10458ms step_avg:38.03ms
+step:276/1600 train_time:10495ms step_avg:38.02ms
+step:277/1600 train_time:10525ms step_avg:38.00ms
+step:278/1600 train_time:10562ms step_avg:37.99ms
+step:279/1600 train_time:10593ms step_avg:37.97ms
+step:280/1600 train_time:10630ms step_avg:37.96ms
+step:281/1600 train_time:10661ms step_avg:37.94ms
+step:282/1600 train_time:10698ms step_avg:37.93ms
+step:283/1600 train_time:10729ms step_avg:37.91ms
+step:284/1600 train_time:10765ms step_avg:37.91ms
+step:285/1600 train_time:10796ms step_avg:37.88ms
+step:286/1600 train_time:10833ms step_avg:37.88ms
+step:287/1600 train_time:10864ms step_avg:37.85ms
+step:288/1600 train_time:10901ms step_avg:37.85ms
+step:289/1600 train_time:10932ms step_avg:37.83ms
+step:290/1600 train_time:10969ms step_avg:37.82ms
+step:291/1600 train_time:10999ms step_avg:37.80ms
+step:292/1600 train_time:11036ms step_avg:37.80ms
+step:293/1600 train_time:11067ms step_avg:37.77ms
+step:294/1600 train_time:11105ms step_avg:37.77ms
+step:295/1600 train_time:11136ms step_avg:37.75ms
+step:296/1600 train_time:11172ms step_avg:37.74ms
+step:297/1600 train_time:11203ms step_avg:37.72ms
+step:298/1600 train_time:11240ms step_avg:37.72ms
+step:299/1600 train_time:11271ms step_avg:37.70ms
+step:300/1600 train_time:11308ms step_avg:37.69ms
+step:301/1600 train_time:11339ms step_avg:37.67ms
+step:302/1600 train_time:11375ms step_avg:37.67ms
+step:303/1600 train_time:11406ms step_avg:37.64ms
+step:304/1600 train_time:11443ms step_avg:37.64ms
+step:305/1600 train_time:11474ms step_avg:37.62ms
+step:306/1600 train_time:11511ms step_avg:37.62ms
+step:307/1600 train_time:11542ms step_avg:37.60ms
+step:308/1600 train_time:11579ms step_avg:37.60ms
+step:309/1600 train_time:11610ms step_avg:37.57ms
+step:310/1600 train_time:11647ms step_avg:37.57ms
+step:311/1600 train_time:11678ms step_avg:37.55ms
+step:312/1600 train_time:11715ms step_avg:37.55ms
+step:313/1600 train_time:11746ms step_avg:37.53ms
+step:314/1600 train_time:11783ms step_avg:37.53ms
+step:315/1600 train_time:11814ms step_avg:37.50ms
+step:316/1600 train_time:11851ms step_avg:37.50ms
+step:317/1600 train_time:11882ms step_avg:37.48ms
+step:318/1600 train_time:11919ms step_avg:37.48ms
+step:319/1600 train_time:11950ms step_avg:37.46ms
+step:320/1600 train_time:11986ms step_avg:37.46ms
+step:321/1600 train_time:12017ms step_avg:37.44ms
+step:322/1600 train_time:12054ms step_avg:37.43ms
+step:323/1600 train_time:12085ms step_avg:37.41ms
+step:324/1600 train_time:12122ms step_avg:37.41ms
+step:325/1600 train_time:12153ms step_avg:37.39ms
+step:326/1600 train_time:12189ms step_avg:37.39ms
+step:327/1600 train_time:12220ms step_avg:37.37ms
+step:328/1600 train_time:12257ms step_avg:37.37ms
+step:329/1600 train_time:12288ms step_avg:37.35ms
+step:330/1600 train_time:12325ms step_avg:37.35ms
+step:331/1600 train_time:12356ms step_avg:37.33ms
+step:332/1600 train_time:12393ms step_avg:37.33ms
+step:333/1600 train_time:12424ms step_avg:37.31ms
+step:334/1600 train_time:12461ms step_avg:37.31ms
+step:335/1600 train_time:12492ms step_avg:37.29ms
+step:336/1600 train_time:12529ms step_avg:37.29ms
+step:337/1600 train_time:12559ms step_avg:37.27ms
+step:338/1600 train_time:12596ms step_avg:37.27ms
+step:339/1600 train_time:12627ms step_avg:37.25ms
+step:340/1600 train_time:12664ms step_avg:37.25ms
+step:341/1600 train_time:12695ms step_avg:37.23ms
+step:342/1600 train_time:12731ms step_avg:37.23ms
+step:343/1600 train_time:12762ms step_avg:37.21ms
+step:344/1600 train_time:12799ms step_avg:37.21ms
+step:345/1600 train_time:12830ms step_avg:37.19ms
+step:346/1600 train_time:12867ms step_avg:37.19ms
+step:347/1600 train_time:12898ms step_avg:37.17ms
+step:348/1600 train_time:12935ms step_avg:37.17ms
+step:349/1600 train_time:12966ms step_avg:37.15ms
+step:350/1600 train_time:13003ms step_avg:37.15ms
+step:351/1600 train_time:13034ms step_avg:37.13ms
+step:352/1600 train_time:13070ms step_avg:37.13ms
+step:353/1600 train_time:13101ms step_avg:37.11ms
+step:354/1600 train_time:13138ms step_avg:37.11ms
+step:355/1600 train_time:13168ms step_avg:37.09ms
+step:356/1600 train_time:13205ms step_avg:37.09ms
+step:357/1600 train_time:13236ms step_avg:37.08ms
+step:358/1600 train_time:13273ms step_avg:37.08ms
+step:359/1600 train_time:13304ms step_avg:37.06ms
+step:360/1600 train_time:13341ms step_avg:37.06ms
+step:361/1600 train_time:13372ms step_avg:37.04ms
+step:362/1600 train_time:13409ms step_avg:37.04ms
+step:363/1600 train_time:13439ms step_avg:37.02ms
+step:364/1600 train_time:13476ms step_avg:37.02ms
+step:365/1600 train_time:13507ms step_avg:37.01ms
+step:366/1600 train_time:13544ms step_avg:37.00ms
+step:367/1600 train_time:13575ms step_avg:36.99ms
+step:368/1600 train_time:13612ms step_avg:36.99ms
+step:369/1600 train_time:13643ms step_avg:36.97ms
+step:370/1600 train_time:13680ms step_avg:36.97ms
+step:371/1600 train_time:13710ms step_avg:36.96ms
+step:372/1600 train_time:13747ms step_avg:36.95ms
+step:373/1600 train_time:13778ms step_avg:36.94ms
+step:374/1600 train_time:13815ms step_avg:36.94ms
+step:375/1600 train_time:13845ms step_avg:36.92ms
+step:376/1600 train_time:13882ms step_avg:36.92ms
+step:377/1600 train_time:13913ms step_avg:36.90ms
+step:378/1600 train_time:13950ms step_avg:36.90ms
+step:379/1600 train_time:13981ms step_avg:36.89ms
+step:380/1600 train_time:14018ms step_avg:36.89ms
+step:381/1600 train_time:14049ms step_avg:36.87ms
+step:382/1600 train_time:14086ms step_avg:36.87ms
+step:383/1600 train_time:14117ms step_avg:36.86ms
+step:384/1600 train_time:14154ms step_avg:36.86ms
+step:385/1600 train_time:14185ms step_avg:36.84ms
+step:386/1600 train_time:14222ms step_avg:36.85ms
+step:387/1600 train_time:14253ms step_avg:36.83ms
+step:388/1600 train_time:14290ms step_avg:36.83ms
+step:389/1600 train_time:14321ms step_avg:36.81ms
+step:390/1600 train_time:14358ms step_avg:36.81ms
+step:391/1600 train_time:14388ms step_avg:36.80ms
+step:392/1600 train_time:14425ms step_avg:36.80ms
+step:393/1600 train_time:14456ms step_avg:36.78ms
+step:394/1600 train_time:14493ms step_avg:36.78ms
+step:395/1600 train_time:14523ms step_avg:36.77ms
+step:396/1600 train_time:14561ms step_avg:36.77ms
+step:397/1600 train_time:14591ms step_avg:36.75ms
+step:398/1600 train_time:14628ms step_avg:36.75ms
+step:399/1600 train_time:14659ms step_avg:36.74ms
+step:400/1600 train_time:14696ms step_avg:36.74ms
+step:401/1600 train_time:14726ms step_avg:36.72ms
+step:402/1600 train_time:14763ms step_avg:36.72ms
+step:403/1600 train_time:14794ms step_avg:36.71ms
+step:404/1600 train_time:14831ms step_avg:36.71ms
+step:405/1600 train_time:14862ms step_avg:36.70ms
+step:406/1600 train_time:14899ms step_avg:36.70ms
+step:407/1600 train_time:14929ms step_avg:36.68ms
+step:408/1600 train_time:14966ms step_avg:36.68ms
+step:409/1600 train_time:14997ms step_avg:36.67ms
+step:410/1600 train_time:15034ms step_avg:36.67ms
+step:411/1600 train_time:15065ms step_avg:36.65ms
+step:412/1600 train_time:15102ms step_avg:36.65ms
+step:413/1600 train_time:15133ms step_avg:36.64ms
+step:414/1600 train_time:15170ms step_avg:36.64ms
+step:415/1600 train_time:15201ms step_avg:36.63ms
+step:416/1600 train_time:15238ms step_avg:36.63ms
+step:417/1600 train_time:15269ms step_avg:36.62ms
+step:418/1600 train_time:15306ms step_avg:36.62ms
+step:419/1600 train_time:15336ms step_avg:36.60ms
+step:420/1600 train_time:15373ms step_avg:36.60ms
+step:421/1600 train_time:15404ms step_avg:36.59ms
+step:422/1600 train_time:15441ms step_avg:36.59ms
+step:423/1600 train_time:15472ms step_avg:36.58ms
+step:424/1600 train_time:15509ms step_avg:36.58ms
+step:425/1600 train_time:15539ms step_avg:36.56ms
+step:426/1600 train_time:15577ms step_avg:36.56ms
+step:427/1600 train_time:15607ms step_avg:36.55ms
+step:428/1600 train_time:15644ms step_avg:36.55ms
+step:429/1600 train_time:15675ms step_avg:36.54ms
+step:430/1600 train_time:15712ms step_avg:36.54ms
+step:431/1600 train_time:15743ms step_avg:36.53ms
+step:432/1600 train_time:15780ms step_avg:36.53ms
+step:433/1600 train_time:15810ms step_avg:36.51ms
+step:434/1600 train_time:15847ms step_avg:36.51ms
+step:435/1600 train_time:15878ms step_avg:36.50ms
+step:436/1600 train_time:15915ms step_avg:36.50ms
+step:437/1600 train_time:15946ms step_avg:36.49ms
+step:438/1600 train_time:15983ms step_avg:36.49ms
+step:439/1600 train_time:16014ms step_avg:36.48ms
+step:440/1600 train_time:16050ms step_avg:36.48ms
+step:441/1600 train_time:16081ms step_avg:36.47ms
+step:442/1600 train_time:16118ms step_avg:36.47ms
+step:443/1600 train_time:16149ms step_avg:36.45ms
+step:444/1600 train_time:16186ms step_avg:36.45ms
+step:445/1600 train_time:16217ms step_avg:36.44ms
+step:446/1600 train_time:16253ms step_avg:36.44ms
+step:447/1600 train_time:16285ms step_avg:36.43ms
+step:448/1600 train_time:16322ms step_avg:36.43ms
+step:449/1600 train_time:16353ms step_avg:36.42ms
+step:450/1600 train_time:16389ms step_avg:36.42ms
+step:451/1600 train_time:16420ms step_avg:36.41ms
+step:452/1600 train_time:16458ms step_avg:36.41ms
+step:453/1600 train_time:16488ms step_avg:36.40ms
+step:454/1600 train_time:16525ms step_avg:36.40ms
+step:455/1600 train_time:16556ms step_avg:36.39ms
+step:456/1600 train_time:16593ms step_avg:36.39ms
+step:457/1600 train_time:16624ms step_avg:36.38ms
+step:458/1600 train_time:16661ms step_avg:36.38ms
+step:459/1600 train_time:16692ms step_avg:36.37ms
+step:460/1600 train_time:16729ms step_avg:36.37ms
+step:461/1600 train_time:16760ms step_avg:36.36ms
+step:462/1600 train_time:16797ms step_avg:36.36ms
+step:463/1600 train_time:16827ms step_avg:36.34ms
+step:464/1600 train_time:16864ms step_avg:36.35ms
+step:465/1600 train_time:16895ms step_avg:36.33ms
+step:466/1600 train_time:16932ms step_avg:36.34ms
+step:467/1600 train_time:16963ms step_avg:36.32ms
+step:468/1600 train_time:17000ms step_avg:36.32ms
+step:469/1600 train_time:17031ms step_avg:36.31ms
+step:470/1600 train_time:17068ms step_avg:36.31ms
+step:471/1600 train_time:17099ms step_avg:36.30ms
+step:472/1600 train_time:17135ms step_avg:36.30ms
+step:473/1600 train_time:17166ms step_avg:36.29ms
+step:474/1600 train_time:17203ms step_avg:36.29ms
+step:475/1600 train_time:17234ms step_avg:36.28ms
+step:476/1600 train_time:17271ms step_avg:36.28ms
+step:477/1600 train_time:17302ms step_avg:36.27ms
+step:478/1600 train_time:17339ms step_avg:36.27ms
+step:479/1600 train_time:17370ms step_avg:36.26ms
+step:480/1600 train_time:17406ms step_avg:36.26ms
+step:481/1600 train_time:17437ms step_avg:36.25ms
+step:482/1600 train_time:17474ms step_avg:36.25ms
+step:483/1600 train_time:17505ms step_avg:36.24ms
+step:484/1600 train_time:17542ms step_avg:36.24ms
+step:485/1600 train_time:17573ms step_avg:36.23ms
+step:486/1600 train_time:17610ms step_avg:36.23ms
+step:487/1600 train_time:17640ms step_avg:36.22ms
+step:488/1600 train_time:17678ms step_avg:36.22ms
+step:489/1600 train_time:17709ms step_avg:36.21ms
+step:490/1600 train_time:17745ms step_avg:36.22ms
+step:491/1600 train_time:17776ms step_avg:36.20ms
+step:492/1600 train_time:17813ms step_avg:36.21ms
+step:493/1600 train_time:17844ms step_avg:36.19ms
+step:494/1600 train_time:17881ms step_avg:36.20ms
+step:495/1600 train_time:17912ms step_avg:36.19ms
+step:496/1600 train_time:17949ms step_avg:36.19ms
+step:497/1600 train_time:17980ms step_avg:36.18ms
+step:498/1600 train_time:18017ms step_avg:36.18ms
+step:499/1600 train_time:18047ms step_avg:36.17ms
+step:500/1600 train_time:18084ms step_avg:36.17ms
+step:500/1600 val_loss:4.2355 train_time:18132ms step_avg:36.26ms
+step:501/1600 train_time:18151ms step_avg:36.23ms
+step:502/1600 train_time:18169ms step_avg:36.19ms
+step:503/1600 train_time:18186ms step_avg:36.15ms
+step:504/1600 train_time:18224ms step_avg:36.16ms
+step:505/1600 train_time:18256ms step_avg:36.15ms
+step:506/1600 train_time:18294ms step_avg:36.15ms
+step:507/1600 train_time:18325ms step_avg:36.14ms
+step:508/1600 train_time:18363ms step_avg:36.15ms
+step:509/1600 train_time:18393ms step_avg:36.14ms
+step:510/1600 train_time:18430ms step_avg:36.14ms
+step:511/1600 train_time:18461ms step_avg:36.13ms
+step:512/1600 train_time:18498ms step_avg:36.13ms
+step:513/1600 train_time:18529ms step_avg:36.12ms
+step:514/1600 train_time:18566ms step_avg:36.12ms
+step:515/1600 train_time:18596ms step_avg:36.11ms
+step:516/1600 train_time:18633ms step_avg:36.11ms
+step:517/1600 train_time:18664ms step_avg:36.10ms
+step:518/1600 train_time:18701ms step_avg:36.10ms
+step:519/1600 train_time:18732ms step_avg:36.09ms
+step:520/1600 train_time:18768ms step_avg:36.09ms
+step:521/1600 train_time:18840ms step_avg:36.16ms
+step:522/1600 train_time:18900ms step_avg:36.21ms
+step:523/1600 train_time:18959ms step_avg:36.25ms
+step:524/1600 train_time:19017ms step_avg:36.29ms
+step:525/1600 train_time:19079ms step_avg:36.34ms
+step:526/1600 train_time:19139ms step_avg:36.39ms
+step:527/1600 train_time:19202ms step_avg:36.44ms
+step:528/1600 train_time:19263ms step_avg:36.48ms
+step:529/1600 train_time:19325ms step_avg:36.53ms
+step:530/1600 train_time:19385ms step_avg:36.57ms
+step:531/1600 train_time:19447ms step_avg:36.62ms
+step:532/1600 train_time:19507ms step_avg:36.67ms
+step:533/1600 train_time:19570ms step_avg:36.72ms
+step:534/1600 train_time:19630ms step_avg:36.76ms
+step:535/1600 train_time:19692ms step_avg:36.81ms
+step:536/1600 train_time:19752ms step_avg:36.85ms
+step:537/1600 train_time:19814ms step_avg:36.90ms
+step:538/1600 train_time:19873ms step_avg:36.94ms
+step:539/1600 train_time:19935ms step_avg:36.99ms
+step:540/1600 train_time:19995ms step_avg:37.03ms
+step:541/1600 train_time:20057ms step_avg:37.07ms
+step:542/1600 train_time:20117ms step_avg:37.12ms
+step:543/1600 train_time:20179ms step_avg:37.16ms
+step:544/1600 train_time:20239ms step_avg:37.20ms
+step:545/1600 train_time:20301ms step_avg:37.25ms
+step:546/1600 train_time:20361ms step_avg:37.29ms
+step:547/1600 train_time:20424ms step_avg:37.34ms
+step:548/1600 train_time:20483ms step_avg:37.38ms
+step:549/1600 train_time:20545ms step_avg:37.42ms
+step:550/1600 train_time:20604ms step_avg:37.46ms
+step:551/1600 train_time:20667ms step_avg:37.51ms
+step:552/1600 train_time:20727ms step_avg:37.55ms
+step:553/1600 train_time:20788ms step_avg:37.59ms
+step:554/1600 train_time:20847ms step_avg:37.63ms
+step:555/1600 train_time:20910ms step_avg:37.68ms
+step:556/1600 train_time:20969ms step_avg:37.71ms
+step:557/1600 train_time:21032ms step_avg:37.76ms
+step:558/1600 train_time:21091ms step_avg:37.80ms
+step:559/1600 train_time:21153ms step_avg:37.84ms
+step:560/1600 train_time:21214ms step_avg:37.88ms
+step:561/1600 train_time:21277ms step_avg:37.93ms
+step:562/1600 train_time:21336ms step_avg:37.96ms
+step:563/1600 train_time:21398ms step_avg:38.01ms
+step:564/1600 train_time:21458ms step_avg:38.05ms
+step:565/1600 train_time:21521ms step_avg:38.09ms
+step:566/1600 train_time:21580ms step_avg:38.13ms
+step:567/1600 train_time:21643ms step_avg:38.17ms
+step:568/1600 train_time:21702ms step_avg:38.21ms
+step:569/1600 train_time:21764ms step_avg:38.25ms
+step:570/1600 train_time:21823ms step_avg:38.29ms
+step:571/1600 train_time:21885ms step_avg:38.33ms
+step:572/1600 train_time:21945ms step_avg:38.36ms
+step:573/1600 train_time:22011ms step_avg:38.41ms
+step:574/1600 train_time:22070ms step_avg:38.45ms
+step:575/1600 train_time:22132ms step_avg:38.49ms
+step:576/1600 train_time:22191ms step_avg:38.53ms
+step:577/1600 train_time:22253ms step_avg:38.57ms
+step:578/1600 train_time:22312ms step_avg:38.60ms
+step:579/1600 train_time:22374ms step_avg:38.64ms
+step:580/1600 train_time:22433ms step_avg:38.68ms
+step:581/1600 train_time:22498ms step_avg:38.72ms
+step:582/1600 train_time:22555ms step_avg:38.75ms
+step:583/1600 train_time:22617ms step_avg:38.79ms
+step:584/1600 train_time:22678ms step_avg:38.83ms
+step:585/1600 train_time:22740ms step_avg:38.87ms
+step:586/1600 train_time:22800ms step_avg:38.91ms
+step:587/1600 train_time:22863ms step_avg:38.95ms
+step:588/1600 train_time:22923ms step_avg:38.98ms
+step:589/1600 train_time:22985ms step_avg:39.02ms
+step:590/1600 train_time:23044ms step_avg:39.06ms
+step:591/1600 train_time:23106ms step_avg:39.10ms
+step:592/1600 train_time:23165ms step_avg:39.13ms
+step:593/1600 train_time:23228ms step_avg:39.17ms
+step:594/1600 train_time:23287ms step_avg:39.20ms
+step:595/1600 train_time:23349ms step_avg:39.24ms
+step:596/1600 train_time:23409ms step_avg:39.28ms
+step:597/1600 train_time:23470ms step_avg:39.31ms
+step:598/1600 train_time:23530ms step_avg:39.35ms
+step:599/1600 train_time:23592ms step_avg:39.39ms
+step:600/1600 train_time:23652ms step_avg:39.42ms
+step:601/1600 train_time:23714ms step_avg:39.46ms
+step:602/1600 train_time:23773ms step_avg:39.49ms
+step:603/1600 train_time:23836ms step_avg:39.53ms
+step:604/1600 train_time:23896ms step_avg:39.56ms
+step:605/1600 train_time:23958ms step_avg:39.60ms
+step:606/1600 train_time:24018ms step_avg:39.63ms
+step:607/1600 train_time:24080ms step_avg:39.67ms
+step:608/1600 train_time:24140ms step_avg:39.70ms
+step:609/1600 train_time:24202ms step_avg:39.74ms
+step:610/1600 train_time:24261ms step_avg:39.77ms
+step:611/1600 train_time:24325ms step_avg:39.81ms
+step:612/1600 train_time:24383ms step_avg:39.84ms
+step:613/1600 train_time:24446ms step_avg:39.88ms
+step:614/1600 train_time:24507ms step_avg:39.91ms
+step:615/1600 train_time:24569ms step_avg:39.95ms
+step:616/1600 train_time:24629ms step_avg:39.98ms
+step:617/1600 train_time:24691ms step_avg:40.02ms
+step:618/1600 train_time:24750ms step_avg:40.05ms
+step:619/1600 train_time:24813ms step_avg:40.09ms
+step:620/1600 train_time:24872ms step_avg:40.12ms
+step:621/1600 train_time:24933ms step_avg:40.15ms
+step:622/1600 train_time:24992ms step_avg:40.18ms
+step:623/1600 train_time:25055ms step_avg:40.22ms
+step:624/1600 train_time:25115ms step_avg:40.25ms
+step:625/1600 train_time:25177ms step_avg:40.28ms
+step:626/1600 train_time:25236ms step_avg:40.31ms
+step:627/1600 train_time:25298ms step_avg:40.35ms
+step:628/1600 train_time:25358ms step_avg:40.38ms
+step:629/1600 train_time:25422ms step_avg:40.42ms
+step:630/1600 train_time:25481ms step_avg:40.45ms
+step:631/1600 train_time:25543ms step_avg:40.48ms
+step:632/1600 train_time:25602ms step_avg:40.51ms
+step:633/1600 train_time:25665ms step_avg:40.54ms
+step:634/1600 train_time:25724ms step_avg:40.57ms
+step:635/1600 train_time:25787ms step_avg:40.61ms
+step:636/1600 train_time:25845ms step_avg:40.64ms
+step:637/1600 train_time:25908ms step_avg:40.67ms
+step:638/1600 train_time:25968ms step_avg:40.70ms
+step:639/1600 train_time:26030ms step_avg:40.74ms
+step:640/1600 train_time:26091ms step_avg:40.77ms
+step:641/1600 train_time:26152ms step_avg:40.80ms
+step:642/1600 train_time:26211ms step_avg:40.83ms
+step:643/1600 train_time:26273ms step_avg:40.86ms
+step:644/1600 train_time:26333ms step_avg:40.89ms
+step:645/1600 train_time:26395ms step_avg:40.92ms
+step:646/1600 train_time:26454ms step_avg:40.95ms
+step:647/1600 train_time:26516ms step_avg:40.98ms
+step:648/1600 train_time:26575ms step_avg:41.01ms
+step:649/1600 train_time:26637ms step_avg:41.04ms
+step:650/1600 train_time:26696ms step_avg:41.07ms
+step:651/1600 train_time:26759ms step_avg:41.10ms
+step:652/1600 train_time:26818ms step_avg:41.13ms
+step:653/1600 train_time:26881ms step_avg:41.17ms
+step:654/1600 train_time:26940ms step_avg:41.19ms
+step:655/1600 train_time:27003ms step_avg:41.23ms
+step:656/1600 train_time:27062ms step_avg:41.25ms
+step:657/1600 train_time:27124ms step_avg:41.28ms
+step:658/1600 train_time:27183ms step_avg:41.31ms
+step:659/1600 train_time:27245ms step_avg:41.34ms
+step:660/1600 train_time:27305ms step_avg:41.37ms
+step:661/1600 train_time:27368ms step_avg:41.40ms
+step:662/1600 train_time:27427ms step_avg:41.43ms
+step:663/1600 train_time:27490ms step_avg:41.46ms
+step:664/1600 train_time:27549ms step_avg:41.49ms
+step:665/1600 train_time:27613ms step_avg:41.52ms
+step:666/1600 train_time:27671ms step_avg:41.55ms
+step:667/1600 train_time:27734ms step_avg:41.58ms
+step:668/1600 train_time:27793ms step_avg:41.61ms
+step:669/1600 train_time:27855ms step_avg:41.64ms
+step:670/1600 train_time:27914ms step_avg:41.66ms
+step:671/1600 train_time:27977ms step_avg:41.69ms
+step:672/1600 train_time:28036ms step_avg:41.72ms
+step:673/1600 train_time:28099ms step_avg:41.75ms
+step:674/1600 train_time:28158ms step_avg:41.78ms
+step:675/1600 train_time:28220ms step_avg:41.81ms
+step:676/1600 train_time:28280ms step_avg:41.83ms
+step:677/1600 train_time:28342ms step_avg:41.86ms
+step:678/1600 train_time:28401ms step_avg:41.89ms
+step:679/1600 train_time:28463ms step_avg:41.92ms
+step:680/1600 train_time:28522ms step_avg:41.94ms
+step:681/1600 train_time:28585ms step_avg:41.98ms
+step:682/1600 train_time:28644ms step_avg:42.00ms
+step:683/1600 train_time:28706ms step_avg:42.03ms
+step:684/1600 train_time:28765ms step_avg:42.05ms
+step:685/1600 train_time:28828ms step_avg:42.08ms
+step:686/1600 train_time:28887ms step_avg:42.11ms
+step:687/1600 train_time:28950ms step_avg:42.14ms
+step:688/1600 train_time:29009ms step_avg:42.16ms
+step:689/1600 train_time:29072ms step_avg:42.19ms
+step:690/1600 train_time:29131ms step_avg:42.22ms
+step:691/1600 train_time:29194ms step_avg:42.25ms
+step:692/1600 train_time:29254ms step_avg:42.27ms
+step:693/1600 train_time:29318ms step_avg:42.31ms
+step:694/1600 train_time:29377ms step_avg:42.33ms
+step:695/1600 train_time:29439ms step_avg:42.36ms
+step:696/1600 train_time:29498ms step_avg:42.38ms
+step:697/1600 train_time:29560ms step_avg:42.41ms
+step:698/1600 train_time:29620ms step_avg:42.43ms
+step:699/1600 train_time:29681ms step_avg:42.46ms
+step:700/1600 train_time:29740ms step_avg:42.49ms
+step:701/1600 train_time:29803ms step_avg:42.52ms
+step:702/1600 train_time:29862ms step_avg:42.54ms
+step:703/1600 train_time:29925ms step_avg:42.57ms
+step:704/1600 train_time:29984ms step_avg:42.59ms
+step:705/1600 train_time:30047ms step_avg:42.62ms
+step:706/1600 train_time:30106ms step_avg:42.64ms
+step:707/1600 train_time:30168ms step_avg:42.67ms
+step:708/1600 train_time:30228ms step_avg:42.69ms
+step:709/1600 train_time:30291ms step_avg:42.72ms
+step:710/1600 train_time:30350ms step_avg:42.75ms
+step:711/1600 train_time:30413ms step_avg:42.78ms
+step:712/1600 train_time:30472ms step_avg:42.80ms
+step:713/1600 train_time:30535ms step_avg:42.83ms
+step:714/1600 train_time:30593ms step_avg:42.85ms
+step:715/1600 train_time:30656ms step_avg:42.88ms
+step:716/1600 train_time:30716ms step_avg:42.90ms
+step:717/1600 train_time:30778ms step_avg:42.93ms
+step:718/1600 train_time:30838ms step_avg:42.95ms
+step:719/1600 train_time:30900ms step_avg:42.98ms
+step:720/1600 train_time:30960ms step_avg:43.00ms
+step:721/1600 train_time:31023ms step_avg:43.03ms
+step:722/1600 train_time:31082ms step_avg:43.05ms
+step:723/1600 train_time:31144ms step_avg:43.08ms
+step:724/1600 train_time:31204ms step_avg:43.10ms
+step:725/1600 train_time:31266ms step_avg:43.13ms
+step:726/1600 train_time:31327ms step_avg:43.15ms
+step:727/1600 train_time:31389ms step_avg:43.18ms
+step:728/1600 train_time:31448ms step_avg:43.20ms
+step:729/1600 train_time:31510ms step_avg:43.22ms
+step:730/1600 train_time:31569ms step_avg:43.25ms
+step:731/1600 train_time:31632ms step_avg:43.27ms
+step:732/1600 train_time:31692ms step_avg:43.29ms
+step:733/1600 train_time:31754ms step_avg:43.32ms
+step:734/1600 train_time:31813ms step_avg:43.34ms
+step:735/1600 train_time:31876ms step_avg:43.37ms
+step:736/1600 train_time:31935ms step_avg:43.39ms
+step:737/1600 train_time:31998ms step_avg:43.42ms
+step:738/1600 train_time:32058ms step_avg:43.44ms
+step:739/1600 train_time:32121ms step_avg:43.47ms
+step:740/1600 train_time:32181ms step_avg:43.49ms
+step:741/1600 train_time:32243ms step_avg:43.51ms
+step:742/1600 train_time:32302ms step_avg:43.53ms
+step:743/1600 train_time:32364ms step_avg:43.56ms
+step:744/1600 train_time:32423ms step_avg:43.58ms
+step:745/1600 train_time:32486ms step_avg:43.61ms
+step:746/1600 train_time:32545ms step_avg:43.63ms
+step:747/1600 train_time:32608ms step_avg:43.65ms
+step:748/1600 train_time:32668ms step_avg:43.67ms
+step:749/1600 train_time:32730ms step_avg:43.70ms
+step:750/1600 train_time:32789ms step_avg:43.72ms
+step:750/1600 val_loss:3.9044 train_time:32835ms step_avg:43.78ms
+step:751/1600 train_time:32854ms step_avg:43.75ms
+step:752/1600 train_time:32911ms step_avg:43.76ms
+step:753/1600 train_time:32976ms step_avg:43.79ms
+step:754/1600 train_time:33037ms step_avg:43.82ms
+step:755/1600 train_time:33099ms step_avg:43.84ms
+step:756/1600 train_time:33158ms step_avg:43.86ms
+step:757/1600 train_time:33219ms step_avg:43.88ms
+step:758/1600 train_time:33277ms step_avg:43.90ms
+step:759/1600 train_time:33339ms step_avg:43.93ms
+step:760/1600 train_time:33397ms step_avg:43.94ms
+step:761/1600 train_time:33459ms step_avg:43.97ms
+step:762/1600 train_time:33518ms step_avg:43.99ms
+step:763/1600 train_time:33579ms step_avg:44.01ms
+step:764/1600 train_time:33639ms step_avg:44.03ms
+step:765/1600 train_time:33701ms step_avg:44.05ms
+step:766/1600 train_time:33760ms step_avg:44.07ms
+step:767/1600 train_time:33824ms step_avg:44.10ms
+step:768/1600 train_time:33886ms step_avg:44.12ms
+step:769/1600 train_time:33950ms step_avg:44.15ms
+step:770/1600 train_time:34009ms step_avg:44.17ms
+step:771/1600 train_time:34072ms step_avg:44.19ms
+step:772/1600 train_time:34130ms step_avg:44.21ms
+step:773/1600 train_time:34193ms step_avg:44.23ms
+step:774/1600 train_time:34252ms step_avg:44.25ms
+step:775/1600 train_time:34314ms step_avg:44.28ms
+step:776/1600 train_time:34372ms step_avg:44.29ms
+step:777/1600 train_time:34434ms step_avg:44.32ms
+step:778/1600 train_time:34493ms step_avg:44.34ms
+step:779/1600 train_time:34556ms step_avg:44.36ms
+step:780/1600 train_time:34615ms step_avg:44.38ms
+step:781/1600 train_time:34677ms step_avg:44.40ms
+step:782/1600 train_time:34736ms step_avg:44.42ms
+step:783/1600 train_time:34798ms step_avg:44.44ms
+step:784/1600 train_time:34859ms step_avg:44.46ms
+step:785/1600 train_time:34922ms step_avg:44.49ms
+step:786/1600 train_time:34981ms step_avg:44.51ms
+step:787/1600 train_time:35044ms step_avg:44.53ms
+step:788/1600 train_time:35104ms step_avg:44.55ms
+step:789/1600 train_time:35168ms step_avg:44.57ms
+step:790/1600 train_time:35226ms step_avg:44.59ms
+step:791/1600 train_time:35288ms step_avg:44.61ms
+step:792/1600 train_time:35347ms step_avg:44.63ms
+step:793/1600 train_time:35409ms step_avg:44.65ms
+step:794/1600 train_time:35470ms step_avg:44.67ms
+step:795/1600 train_time:35531ms step_avg:44.69ms
+step:796/1600 train_time:35589ms step_avg:44.71ms
+step:797/1600 train_time:35651ms step_avg:44.73ms
+step:798/1600 train_time:35710ms step_avg:44.75ms
+step:799/1600 train_time:35773ms step_avg:44.77ms
+step:800/1600 train_time:35833ms step_avg:44.79ms
+step:801/1600 train_time:35896ms step_avg:44.81ms
+step:802/1600 train_time:35956ms step_avg:44.83ms
+step:803/1600 train_time:36019ms step_avg:44.86ms
+step:804/1600 train_time:36077ms step_avg:44.87ms
+step:805/1600 train_time:36140ms step_avg:44.89ms
+step:806/1600 train_time:36200ms step_avg:44.91ms
+step:807/1600 train_time:36262ms step_avg:44.93ms
+step:808/1600 train_time:36321ms step_avg:44.95ms
+step:809/1600 train_time:36384ms step_avg:44.97ms
+step:810/1600 train_time:36443ms step_avg:44.99ms
+step:811/1600 train_time:36506ms step_avg:45.01ms
+step:812/1600 train_time:36565ms step_avg:45.03ms
+step:813/1600 train_time:36627ms step_avg:45.05ms
+step:814/1600 train_time:36686ms step_avg:45.07ms
+step:815/1600 train_time:36749ms step_avg:45.09ms
+step:816/1600 train_time:36808ms step_avg:45.11ms
+step:817/1600 train_time:36870ms step_avg:45.13ms
+step:818/1600 train_time:36929ms step_avg:45.15ms
+step:819/1600 train_time:36992ms step_avg:45.17ms
+step:820/1600 train_time:37052ms step_avg:45.18ms
+step:821/1600 train_time:37115ms step_avg:45.21ms
+step:822/1600 train_time:37174ms step_avg:45.22ms
+step:823/1600 train_time:37237ms step_avg:45.25ms
+step:824/1600 train_time:37296ms step_avg:45.26ms
+step:825/1600 train_time:37358ms step_avg:45.28ms
+step:826/1600 train_time:37417ms step_avg:45.30ms
+step:827/1600 train_time:37480ms step_avg:45.32ms
+step:828/1600 train_time:37539ms step_avg:45.34ms
+step:829/1600 train_time:37602ms step_avg:45.36ms
+step:830/1600 train_time:37663ms step_avg:45.38ms
+step:831/1600 train_time:37724ms step_avg:45.40ms
+step:832/1600 train_time:37783ms step_avg:45.41ms
+step:833/1600 train_time:37846ms step_avg:45.43ms
+step:834/1600 train_time:37905ms step_avg:45.45ms
+step:835/1600 train_time:37968ms step_avg:45.47ms
+step:836/1600 train_time:38027ms step_avg:45.49ms
+step:837/1600 train_time:38090ms step_avg:45.51ms
+step:838/1600 train_time:38149ms step_avg:45.52ms
+step:839/1600 train_time:38212ms step_avg:45.54ms
+step:840/1600 train_time:38271ms step_avg:45.56ms
+step:841/1600 train_time:38333ms step_avg:45.58ms
+step:842/1600 train_time:38392ms step_avg:45.60ms
+step:843/1600 train_time:38454ms step_avg:45.62ms
+step:844/1600 train_time:38513ms step_avg:45.63ms
+step:845/1600 train_time:38576ms step_avg:45.65ms
+step:846/1600 train_time:38636ms step_avg:45.67ms
+step:847/1600 train_time:38699ms step_avg:45.69ms
+step:848/1600 train_time:38758ms step_avg:45.71ms
+step:849/1600 train_time:38820ms step_avg:45.72ms
+step:850/1600 train_time:38879ms step_avg:45.74ms
+step:851/1600 train_time:38942ms step_avg:45.76ms
+step:852/1600 train_time:39001ms step_avg:45.78ms
+step:853/1600 train_time:39063ms step_avg:45.80ms
+step:854/1600 train_time:39122ms step_avg:45.81ms
+step:855/1600 train_time:39185ms step_avg:45.83ms
+step:856/1600 train_time:39245ms step_avg:45.85ms
+step:857/1600 train_time:39308ms step_avg:45.87ms
+step:858/1600 train_time:39367ms step_avg:45.88ms
+step:859/1600 train_time:39429ms step_avg:45.90ms
+step:860/1600 train_time:39489ms step_avg:45.92ms
+step:861/1600 train_time:39552ms step_avg:45.94ms
+step:862/1600 train_time:39611ms step_avg:45.95ms
+step:863/1600 train_time:39675ms step_avg:45.97ms
+step:864/1600 train_time:39733ms step_avg:45.99ms
+step:865/1600 train_time:39797ms step_avg:46.01ms
+step:866/1600 train_time:39855ms step_avg:46.02ms
+step:867/1600 train_time:39917ms step_avg:46.04ms
+step:868/1600 train_time:39976ms step_avg:46.05ms
+step:869/1600 train_time:40038ms step_avg:46.07ms
+step:870/1600 train_time:40097ms step_avg:46.09ms
+step:871/1600 train_time:40160ms step_avg:46.11ms
+step:872/1600 train_time:40220ms step_avg:46.12ms
+step:873/1600 train_time:40282ms step_avg:46.14ms
+step:874/1600 train_time:40342ms step_avg:46.16ms
+step:875/1600 train_time:40404ms step_avg:46.18ms
+step:876/1600 train_time:40463ms step_avg:46.19ms
+step:877/1600 train_time:40526ms step_avg:46.21ms
+step:878/1600 train_time:40585ms step_avg:46.22ms
+step:879/1600 train_time:40648ms step_avg:46.24ms
+step:880/1600 train_time:40707ms step_avg:46.26ms
+step:881/1600 train_time:40770ms step_avg:46.28ms
+step:882/1600 train_time:40829ms step_avg:46.29ms
+step:883/1600 train_time:40891ms step_avg:46.31ms
+step:884/1600 train_time:40950ms step_avg:46.32ms
+step:885/1600 train_time:41013ms step_avg:46.34ms
+step:886/1600 train_time:41072ms step_avg:46.36ms
+step:887/1600 train_time:41133ms step_avg:46.37ms
+step:888/1600 train_time:41193ms step_avg:46.39ms
+step:889/1600 train_time:41255ms step_avg:46.41ms
+step:890/1600 train_time:41318ms step_avg:46.42ms
+step:891/1600 train_time:41381ms step_avg:46.44ms
+step:892/1600 train_time:41440ms step_avg:46.46ms
+step:893/1600 train_time:41502ms step_avg:46.47ms
+step:894/1600 train_time:41560ms step_avg:46.49ms
+step:895/1600 train_time:41623ms step_avg:46.51ms
+step:896/1600 train_time:41681ms step_avg:46.52ms
+step:897/1600 train_time:41744ms step_avg:46.54ms
+step:898/1600 train_time:41804ms step_avg:46.55ms
+step:899/1600 train_time:41866ms step_avg:46.57ms
+step:900/1600 train_time:41928ms step_avg:46.59ms
+step:901/1600 train_time:41987ms step_avg:46.60ms
+step:902/1600 train_time:42047ms step_avg:46.62ms
+step:903/1600 train_time:42109ms step_avg:46.63ms
+step:904/1600 train_time:42169ms step_avg:46.65ms
+step:905/1600 train_time:42231ms step_avg:46.66ms
+step:906/1600 train_time:42291ms step_avg:46.68ms
+step:907/1600 train_time:42354ms step_avg:46.70ms
+step:908/1600 train_time:42413ms step_avg:46.71ms
+step:909/1600 train_time:42475ms step_avg:46.73ms
+step:910/1600 train_time:42535ms step_avg:46.74ms
+step:911/1600 train_time:42598ms step_avg:46.76ms
+step:912/1600 train_time:42657ms step_avg:46.77ms
+step:913/1600 train_time:42719ms step_avg:46.79ms
+step:914/1600 train_time:42778ms step_avg:46.80ms
+step:915/1600 train_time:42841ms step_avg:46.82ms
+step:916/1600 train_time:42899ms step_avg:46.83ms
+step:917/1600 train_time:42961ms step_avg:46.85ms
+step:918/1600 train_time:43020ms step_avg:46.86ms
+step:919/1600 train_time:43083ms step_avg:46.88ms
+step:920/1600 train_time:43144ms step_avg:46.90ms
+step:921/1600 train_time:43206ms step_avg:46.91ms
+step:922/1600 train_time:43266ms step_avg:46.93ms
+step:923/1600 train_time:43328ms step_avg:46.94ms
+step:924/1600 train_time:43388ms step_avg:46.96ms
+step:925/1600 train_time:43451ms step_avg:46.97ms
+step:926/1600 train_time:43509ms step_avg:46.99ms
+step:927/1600 train_time:43572ms step_avg:47.00ms
+step:928/1600 train_time:43630ms step_avg:47.02ms
+step:929/1600 train_time:43692ms step_avg:47.03ms
+step:930/1600 train_time:43751ms step_avg:47.04ms
+step:931/1600 train_time:43814ms step_avg:47.06ms
+step:932/1600 train_time:43873ms step_avg:47.07ms
+step:933/1600 train_time:43937ms step_avg:47.09ms
+step:934/1600 train_time:43996ms step_avg:47.10ms
+step:935/1600 train_time:44058ms step_avg:47.12ms
+step:936/1600 train_time:44118ms step_avg:47.13ms
+step:937/1600 train_time:44181ms step_avg:47.15ms
+step:938/1600 train_time:44240ms step_avg:47.16ms
+step:939/1600 train_time:44302ms step_avg:47.18ms
+step:940/1600 train_time:44361ms step_avg:47.19ms
+step:941/1600 train_time:44424ms step_avg:47.21ms
+step:942/1600 train_time:44483ms step_avg:47.22ms
+step:943/1600 train_time:44545ms step_avg:47.24ms
+step:944/1600 train_time:44605ms step_avg:47.25ms
+step:945/1600 train_time:44667ms step_avg:47.27ms
+step:946/1600 train_time:44726ms step_avg:47.28ms
+step:947/1600 train_time:44789ms step_avg:47.30ms
+step:948/1600 train_time:44848ms step_avg:47.31ms
+step:949/1600 train_time:44910ms step_avg:47.32ms
+step:950/1600 train_time:44969ms step_avg:47.34ms
+step:951/1600 train_time:45032ms step_avg:47.35ms
+step:952/1600 train_time:45091ms step_avg:47.36ms
+step:953/1600 train_time:45154ms step_avg:47.38ms
+step:954/1600 train_time:45213ms step_avg:47.39ms
+step:955/1600 train_time:45275ms step_avg:47.41ms
+step:956/1600 train_time:45334ms step_avg:47.42ms
+step:957/1600 train_time:45397ms step_avg:47.44ms
+step:958/1600 train_time:45456ms step_avg:47.45ms
+step:959/1600 train_time:45520ms step_avg:47.47ms
+step:960/1600 train_time:45579ms step_avg:47.48ms
+step:961/1600 train_time:45642ms step_avg:47.49ms
+step:962/1600 train_time:45701ms step_avg:47.51ms
+step:963/1600 train_time:45764ms step_avg:47.52ms
+step:964/1600 train_time:45823ms step_avg:47.53ms
+step:965/1600 train_time:45885ms step_avg:47.55ms
+step:966/1600 train_time:45944ms step_avg:47.56ms
+step:967/1600 train_time:46006ms step_avg:47.58ms
+step:968/1600 train_time:46066ms step_avg:47.59ms
+step:969/1600 train_time:46128ms step_avg:47.60ms
+step:970/1600 train_time:46188ms step_avg:47.62ms
+step:971/1600 train_time:46251ms step_avg:47.63ms
+step:972/1600 train_time:46308ms step_avg:47.64ms
+step:973/1600 train_time:46371ms step_avg:47.66ms
+step:974/1600 train_time:46430ms step_avg:47.67ms
+step:975/1600 train_time:46493ms step_avg:47.68ms
+step:976/1600 train_time:46553ms step_avg:47.70ms
+step:977/1600 train_time:46615ms step_avg:47.71ms
+step:978/1600 train_time:46675ms step_avg:47.72ms
+step:979/1600 train_time:46737ms step_avg:47.74ms
+step:980/1600 train_time:46796ms step_avg:47.75ms
+step:981/1600 train_time:46859ms step_avg:47.77ms
+step:982/1600 train_time:46919ms step_avg:47.78ms
+step:983/1600 train_time:46981ms step_avg:47.79ms
+step:984/1600 train_time:47040ms step_avg:47.80ms
+step:985/1600 train_time:47102ms step_avg:47.82ms
+step:986/1600 train_time:47161ms step_avg:47.83ms
+step:987/1600 train_time:47224ms step_avg:47.85ms
+step:988/1600 train_time:47283ms step_avg:47.86ms
+step:989/1600 train_time:47345ms step_avg:47.87ms
+step:990/1600 train_time:47404ms step_avg:47.88ms
+step:991/1600 train_time:47466ms step_avg:47.90ms
+step:992/1600 train_time:47526ms step_avg:47.91ms
+step:993/1600 train_time:47589ms step_avg:47.92ms
+step:994/1600 train_time:47649ms step_avg:47.94ms
+step:995/1600 train_time:47711ms step_avg:47.95ms
+step:996/1600 train_time:47770ms step_avg:47.96ms
+step:997/1600 train_time:47834ms step_avg:47.98ms
+step:998/1600 train_time:47892ms step_avg:47.99ms
+step:999/1600 train_time:47955ms step_avg:48.00ms
+step:1000/1600 train_time:48013ms step_avg:48.01ms
+step:1000/1600 val_loss:3.6006 train_time:48059ms step_avg:48.06ms
+step:1001/1600 train_time:48078ms step_avg:48.03ms
+step:1002/1600 train_time:48138ms step_avg:48.04ms
+step:1003/1600 train_time:48200ms step_avg:48.06ms
+step:1004/1600 train_time:48262ms step_avg:48.07ms
+step:1005/1600 train_time:48324ms step_avg:48.08ms
+step:1006/1600 train_time:48383ms step_avg:48.09ms
+step:1007/1600 train_time:48444ms step_avg:48.11ms
+step:1008/1600 train_time:48503ms step_avg:48.12ms
+step:1009/1600 train_time:48563ms step_avg:48.13ms
+step:1010/1600 train_time:48621ms step_avg:48.14ms
+step:1011/1600 train_time:48683ms step_avg:48.15ms
+step:1012/1600 train_time:48742ms step_avg:48.16ms
+step:1013/1600 train_time:48804ms step_avg:48.18ms
+step:1014/1600 train_time:48862ms step_avg:48.19ms
+step:1015/1600 train_time:48924ms step_avg:48.20ms
+step:1016/1600 train_time:48983ms step_avg:48.21ms
+step:1017/1600 train_time:49047ms step_avg:48.23ms
+step:1018/1600 train_time:49109ms step_avg:48.24ms
+step:1019/1600 train_time:49173ms step_avg:48.26ms
+step:1020/1600 train_time:49232ms step_avg:48.27ms
+step:1021/1600 train_time:49295ms step_avg:48.28ms
+step:1022/1600 train_time:49353ms step_avg:48.29ms
+step:1023/1600 train_time:49416ms step_avg:48.30ms
+step:1024/1600 train_time:49474ms step_avg:48.31ms
+step:1025/1600 train_time:49536ms step_avg:48.33ms
+step:1026/1600 train_time:49595ms step_avg:48.34ms
+step:1027/1600 train_time:49659ms step_avg:48.35ms
+step:1028/1600 train_time:49716ms step_avg:48.36ms
+step:1029/1600 train_time:49778ms step_avg:48.38ms
+step:1030/1600 train_time:49836ms step_avg:48.38ms
+step:1031/1600 train_time:49899ms step_avg:48.40ms
+step:1032/1600 train_time:49959ms step_avg:48.41ms
+step:1033/1600 train_time:50021ms step_avg:48.42ms
+step:1034/1600 train_time:50081ms step_avg:48.43ms
+step:1035/1600 train_time:50144ms step_avg:48.45ms
+step:1036/1600 train_time:50203ms step_avg:48.46ms
+step:1037/1600 train_time:50266ms step_avg:48.47ms
+step:1038/1600 train_time:50326ms step_avg:48.48ms
+step:1039/1600 train_time:50388ms step_avg:48.50ms
+step:1040/1600 train_time:50447ms step_avg:48.51ms
+step:1041/1600 train_time:50519ms step_avg:48.53ms
+step:1042/1600 train_time:50602ms step_avg:48.56ms
+step:1043/1600 train_time:50690ms step_avg:48.60ms
+step:1044/1600 train_time:50776ms step_avg:48.64ms
+step:1045/1600 train_time:50864ms step_avg:48.67ms
+step:1046/1600 train_time:50950ms step_avg:48.71ms
+step:1047/1600 train_time:51039ms step_avg:48.75ms
+step:1048/1600 train_time:51125ms step_avg:48.78ms
+step:1049/1600 train_time:51213ms step_avg:48.82ms
+step:1050/1600 train_time:51298ms step_avg:48.85ms
+step:1051/1600 train_time:51387ms step_avg:48.89ms
+step:1052/1600 train_time:51472ms step_avg:48.93ms
+step:1053/1600 train_time:51560ms step_avg:48.97ms
+step:1054/1600 train_time:51647ms step_avg:49.00ms
+step:1055/1600 train_time:51735ms step_avg:49.04ms
+step:1056/1600 train_time:51821ms step_avg:49.07ms
+step:1057/1600 train_time:51909ms step_avg:49.11ms
+step:1058/1600 train_time:51995ms step_avg:49.14ms
+step:1059/1600 train_time:52084ms step_avg:49.18ms
+step:1060/1600 train_time:52169ms step_avg:49.22ms
+step:1061/1600 train_time:52257ms step_avg:49.25ms
+step:1062/1600 train_time:52343ms step_avg:49.29ms
+step:1063/1600 train_time:52432ms step_avg:49.32ms
+step:1064/1600 train_time:52519ms step_avg:49.36ms
+step:1065/1600 train_time:52606ms step_avg:49.40ms
+step:1066/1600 train_time:52692ms step_avg:49.43ms
+step:1067/1600 train_time:52779ms step_avg:49.47ms
+step:1068/1600 train_time:52863ms step_avg:49.50ms
+step:1069/1600 train_time:52952ms step_avg:49.53ms
+step:1070/1600 train_time:53038ms step_avg:49.57ms
+step:1071/1600 train_time:53125ms step_avg:49.60ms
+step:1072/1600 train_time:53210ms step_avg:49.64ms
+step:1073/1600 train_time:53298ms step_avg:49.67ms
+step:1074/1600 train_time:53384ms step_avg:49.71ms
+step:1075/1600 train_time:53472ms step_avg:49.74ms
+step:1076/1600 train_time:53556ms step_avg:49.77ms
+step:1077/1600 train_time:53645ms step_avg:49.81ms
+step:1078/1600 train_time:53730ms step_avg:49.84ms
+step:1079/1600 train_time:53819ms step_avg:49.88ms
+step:1080/1600 train_time:53906ms step_avg:49.91ms
+step:1081/1600 train_time:53993ms step_avg:49.95ms
+step:1082/1600 train_time:54079ms step_avg:49.98ms
+step:1083/1600 train_time:54167ms step_avg:50.02ms
+step:1084/1600 train_time:54252ms step_avg:50.05ms
+step:1085/1600 train_time:54340ms step_avg:50.08ms
+step:1086/1600 train_time:54426ms step_avg:50.12ms
+step:1087/1600 train_time:54514ms step_avg:50.15ms
+step:1088/1600 train_time:54599ms step_avg:50.18ms
+step:1089/1600 train_time:54686ms step_avg:50.22ms
+step:1090/1600 train_time:54773ms step_avg:50.25ms
+step:1091/1600 train_time:54861ms step_avg:50.29ms
+step:1092/1600 train_time:54947ms step_avg:50.32ms
+step:1093/1600 train_time:55035ms step_avg:50.35ms
+step:1094/1600 train_time:55119ms step_avg:50.38ms
+step:1095/1600 train_time:55209ms step_avg:50.42ms
+step:1096/1600 train_time:55294ms step_avg:50.45ms
+step:1097/1600 train_time:55382ms step_avg:50.49ms
+step:1098/1600 train_time:55467ms step_avg:50.52ms
+step:1099/1600 train_time:55556ms step_avg:50.55ms
+step:1100/1600 train_time:55643ms step_avg:50.58ms
+step:1101/1600 train_time:55731ms step_avg:50.62ms
+step:1102/1600 train_time:55816ms step_avg:50.65ms
+step:1103/1600 train_time:55905ms step_avg:50.68ms
+step:1104/1600 train_time:55990ms step_avg:50.72ms
+step:1105/1600 train_time:56077ms step_avg:50.75ms
+step:1106/1600 train_time:56161ms step_avg:50.78ms
+step:1107/1600 train_time:56249ms step_avg:50.81ms
+step:1108/1600 train_time:56336ms step_avg:50.84ms
+step:1109/1600 train_time:56424ms step_avg:50.88ms
+step:1110/1600 train_time:56510ms step_avg:50.91ms
+step:1111/1600 train_time:56598ms step_avg:50.94ms
+step:1112/1600 train_time:56683ms step_avg:50.97ms
+step:1113/1600 train_time:56771ms step_avg:51.01ms
+step:1114/1600 train_time:56856ms step_avg:51.04ms
+step:1115/1600 train_time:56945ms step_avg:51.07ms
+step:1116/1600 train_time:57031ms step_avg:51.10ms
+step:1117/1600 train_time:57121ms step_avg:51.14ms
+step:1118/1600 train_time:57206ms step_avg:51.17ms
+step:1119/1600 train_time:57293ms step_avg:51.20ms
+step:1120/1600 train_time:57379ms step_avg:51.23ms
+step:1121/1600 train_time:57469ms step_avg:51.27ms
+step:1122/1600 train_time:57553ms step_avg:51.29ms
+step:1123/1600 train_time:57641ms step_avg:51.33ms
+step:1124/1600 train_time:57726ms step_avg:51.36ms
+step:1125/1600 train_time:57814ms step_avg:51.39ms
+step:1126/1600 train_time:57899ms step_avg:51.42ms
+step:1127/1600 train_time:57989ms step_avg:51.45ms
+step:1128/1600 train_time:58074ms step_avg:51.48ms
+step:1129/1600 train_time:58162ms step_avg:51.52ms
+step:1130/1600 train_time:58247ms step_avg:51.55ms
+step:1131/1600 train_time:58335ms step_avg:51.58ms
+step:1132/1600 train_time:58421ms step_avg:51.61ms
+step:1133/1600 train_time:58509ms step_avg:51.64ms
+step:1134/1600 train_time:58594ms step_avg:51.67ms
+step:1135/1600 train_time:58681ms step_avg:51.70ms
+step:1136/1600 train_time:58766ms step_avg:51.73ms
+step:1137/1600 train_time:58854ms step_avg:51.76ms
+step:1138/1600 train_time:58939ms step_avg:51.79ms
+step:1139/1600 train_time:59027ms step_avg:51.82ms
+step:1140/1600 train_time:59112ms step_avg:51.85ms
+step:1141/1600 train_time:59200ms step_avg:51.88ms
+step:1142/1600 train_time:59285ms step_avg:51.91ms
+step:1143/1600 train_time:59373ms step_avg:51.94ms
+step:1144/1600 train_time:59458ms step_avg:51.97ms
+step:1145/1600 train_time:59546ms step_avg:52.01ms
+step:1146/1600 train_time:59631ms step_avg:52.03ms
+step:1147/1600 train_time:59720ms step_avg:52.07ms
+step:1148/1600 train_time:59805ms step_avg:52.10ms
+step:1149/1600 train_time:59895ms step_avg:52.13ms
+step:1150/1600 train_time:59979ms step_avg:52.16ms
+step:1151/1600 train_time:60068ms step_avg:52.19ms
+step:1152/1600 train_time:60154ms step_avg:52.22ms
+step:1153/1600 train_time:60243ms step_avg:52.25ms
+step:1154/1600 train_time:60331ms step_avg:52.28ms
+step:1155/1600 train_time:60419ms step_avg:52.31ms
+step:1156/1600 train_time:60504ms step_avg:52.34ms
+step:1157/1600 train_time:60591ms step_avg:52.37ms
+step:1158/1600 train_time:60676ms step_avg:52.40ms
+step:1159/1600 train_time:60764ms step_avg:52.43ms
+step:1160/1600 train_time:60849ms step_avg:52.46ms
+step:1161/1600 train_time:60938ms step_avg:52.49ms
+step:1162/1600 train_time:61024ms step_avg:52.52ms
+step:1163/1600 train_time:61113ms step_avg:52.55ms
+step:1164/1600 train_time:61199ms step_avg:52.58ms
+step:1165/1600 train_time:61286ms step_avg:52.61ms
+step:1166/1600 train_time:61372ms step_avg:52.63ms
+step:1167/1600 train_time:61459ms step_avg:52.66ms
+step:1168/1600 train_time:61545ms step_avg:52.69ms
+step:1169/1600 train_time:61633ms step_avg:52.72ms
+step:1170/1600 train_time:61718ms step_avg:52.75ms
+step:1171/1600 train_time:61806ms step_avg:52.78ms
+step:1172/1600 train_time:61891ms step_avg:52.81ms
+step:1173/1600 train_time:61980ms step_avg:52.84ms
+step:1174/1600 train_time:62065ms step_avg:52.87ms
+step:1175/1600 train_time:62153ms step_avg:52.90ms
+step:1176/1600 train_time:62239ms step_avg:52.92ms
+step:1177/1600 train_time:62327ms step_avg:52.95ms
+step:1178/1600 train_time:62414ms step_avg:52.98ms
+step:1179/1600 train_time:62501ms step_avg:53.01ms
+step:1180/1600 train_time:62586ms step_avg:53.04ms
+step:1181/1600 train_time:62674ms step_avg:53.07ms
+step:1182/1600 train_time:62759ms step_avg:53.10ms
+step:1183/1600 train_time:62848ms step_avg:53.13ms
+step:1184/1600 train_time:62933ms step_avg:53.15ms
+step:1185/1600 train_time:63022ms step_avg:53.18ms
+step:1186/1600 train_time:63109ms step_avg:53.21ms
+step:1187/1600 train_time:63197ms step_avg:53.24ms
+step:1188/1600 train_time:63283ms step_avg:53.27ms
+step:1189/1600 train_time:63371ms step_avg:53.30ms
+step:1190/1600 train_time:63456ms step_avg:53.32ms
+step:1191/1600 train_time:63543ms step_avg:53.35ms
+step:1192/1600 train_time:63628ms step_avg:53.38ms
+step:1193/1600 train_time:63716ms step_avg:53.41ms
+step:1194/1600 train_time:63801ms step_avg:53.43ms
+step:1195/1600 train_time:63890ms step_avg:53.46ms
+step:1196/1600 train_time:63975ms step_avg:53.49ms
+step:1197/1600 train_time:64065ms step_avg:53.52ms
+step:1198/1600 train_time:64149ms step_avg:53.55ms
+step:1199/1600 train_time:64238ms step_avg:53.58ms
+step:1200/1600 train_time:64323ms step_avg:53.60ms
+step:1201/1600 train_time:64412ms step_avg:53.63ms
+step:1202/1600 train_time:64496ms step_avg:53.66ms
+step:1203/1600 train_time:64584ms step_avg:53.69ms
+step:1204/1600 train_time:64669ms step_avg:53.71ms
+step:1205/1600 train_time:64757ms step_avg:53.74ms
+step:1206/1600 train_time:64844ms step_avg:53.77ms
+step:1207/1600 train_time:64930ms step_avg:53.79ms
+step:1208/1600 train_time:65017ms step_avg:53.82ms
+step:1209/1600 train_time:65107ms step_avg:53.85ms
+step:1210/1600 train_time:65191ms step_avg:53.88ms
+step:1211/1600 train_time:65279ms step_avg:53.91ms
+step:1212/1600 train_time:65365ms step_avg:53.93ms
+step:1213/1600 train_time:65452ms step_avg:53.96ms
+step:1214/1600 train_time:65536ms step_avg:53.98ms
+step:1215/1600 train_time:65624ms step_avg:54.01ms
+step:1216/1600 train_time:65710ms step_avg:54.04ms
+step:1217/1600 train_time:65798ms step_avg:54.07ms
+step:1218/1600 train_time:65884ms step_avg:54.09ms
+step:1219/1600 train_time:65972ms step_avg:54.12ms
+step:1220/1600 train_time:66056ms step_avg:54.14ms
+step:1221/1600 train_time:66144ms step_avg:54.17ms
+step:1222/1600 train_time:66230ms step_avg:54.20ms
+step:1223/1600 train_time:66318ms step_avg:54.23ms
+step:1224/1600 train_time:66403ms step_avg:54.25ms
+step:1225/1600 train_time:66493ms step_avg:54.28ms
+step:1226/1600 train_time:66578ms step_avg:54.30ms
+step:1227/1600 train_time:66666ms step_avg:54.33ms
+step:1228/1600 train_time:66751ms step_avg:54.36ms
+step:1229/1600 train_time:66837ms step_avg:54.38ms
+step:1230/1600 train_time:66923ms step_avg:54.41ms
+step:1231/1600 train_time:67011ms step_avg:54.44ms
+step:1232/1600 train_time:67096ms step_avg:54.46ms
+step:1233/1600 train_time:67185ms step_avg:54.49ms
+step:1234/1600 train_time:67270ms step_avg:54.51ms
+step:1235/1600 train_time:67359ms step_avg:54.54ms
+step:1236/1600 train_time:67444ms step_avg:54.57ms
+step:1237/1600 train_time:67533ms step_avg:54.59ms
+step:1238/1600 train_time:67618ms step_avg:54.62ms
+step:1239/1600 train_time:67706ms step_avg:54.65ms
+step:1240/1600 train_time:67791ms step_avg:54.67ms
+step:1241/1600 train_time:67879ms step_avg:54.70ms
+step:1242/1600 train_time:67965ms step_avg:54.72ms
+step:1243/1600 train_time:68053ms step_avg:54.75ms
+step:1244/1600 train_time:68138ms step_avg:54.77ms
+step:1245/1600 train_time:68227ms step_avg:54.80ms
+step:1246/1600 train_time:68313ms step_avg:54.83ms
+step:1247/1600 train_time:68401ms step_avg:54.85ms
+step:1248/1600 train_time:68486ms step_avg:54.88ms
+step:1249/1600 train_time:68573ms step_avg:54.90ms
+step:1250/1600 train_time:68658ms step_avg:54.93ms
+step:1250/1600 val_loss:3.4182 train_time:68729ms step_avg:54.98ms
+step:1251/1600 train_time:68748ms step_avg:54.95ms
+step:1252/1600 train_time:68837ms step_avg:54.98ms
+step:1253/1600 train_time:68928ms step_avg:55.01ms
+step:1254/1600 train_time:69013ms step_avg:55.03ms
+step:1255/1600 train_time:69101ms step_avg:55.06ms
+step:1256/1600 train_time:69186ms step_avg:55.08ms
+step:1257/1600 train_time:69273ms step_avg:55.11ms
+step:1258/1600 train_time:69358ms step_avg:55.13ms
+step:1259/1600 train_time:69444ms step_avg:55.16ms
+step:1260/1600 train_time:69529ms step_avg:55.18ms
+step:1261/1600 train_time:69616ms step_avg:55.21ms
+step:1262/1600 train_time:69702ms step_avg:55.23ms
+step:1263/1600 train_time:69791ms step_avg:55.26ms
+step:1264/1600 train_time:69879ms step_avg:55.28ms
+step:1265/1600 train_time:69968ms step_avg:55.31ms
+step:1266/1600 train_time:70054ms step_avg:55.34ms
+step:1267/1600 train_time:70143ms step_avg:55.36ms
+step:1268/1600 train_time:70229ms step_avg:55.39ms
+step:1269/1600 train_time:70316ms step_avg:55.41ms
+step:1270/1600 train_time:70399ms step_avg:55.43ms
+step:1271/1600 train_time:70487ms step_avg:55.46ms
+step:1272/1600 train_time:70571ms step_avg:55.48ms
+step:1273/1600 train_time:70661ms step_avg:55.51ms
+step:1274/1600 train_time:70748ms step_avg:55.53ms
+step:1275/1600 train_time:70837ms step_avg:55.56ms
+step:1276/1600 train_time:70924ms step_avg:55.58ms
+step:1277/1600 train_time:71012ms step_avg:55.61ms
+step:1278/1600 train_time:71097ms step_avg:55.63ms
+step:1279/1600 train_time:71185ms step_avg:55.66ms
+step:1280/1600 train_time:71270ms step_avg:55.68ms
+step:1281/1600 train_time:71358ms step_avg:55.71ms
+step:1282/1600 train_time:71444ms step_avg:55.73ms
+step:1283/1600 train_time:71531ms step_avg:55.75ms
+step:1284/1600 train_time:71616ms step_avg:55.78ms
+step:1285/1600 train_time:71704ms step_avg:55.80ms
+step:1286/1600 train_time:71789ms step_avg:55.82ms
+step:1287/1600 train_time:71878ms step_avg:55.85ms
+step:1288/1600 train_time:71964ms step_avg:55.87ms
+step:1289/1600 train_time:72053ms step_avg:55.90ms
+step:1290/1600 train_time:72139ms step_avg:55.92ms
+step:1291/1600 train_time:72228ms step_avg:55.95ms
+step:1292/1600 train_time:72312ms step_avg:55.97ms
+step:1293/1600 train_time:72400ms step_avg:55.99ms
+step:1294/1600 train_time:72484ms step_avg:56.02ms
+step:1295/1600 train_time:72571ms step_avg:56.04ms
+step:1296/1600 train_time:72656ms step_avg:56.06ms
+step:1297/1600 train_time:72744ms step_avg:56.09ms
+step:1298/1600 train_time:72830ms step_avg:56.11ms
+step:1299/1600 train_time:72918ms step_avg:56.13ms
+step:1300/1600 train_time:73003ms step_avg:56.16ms
+step:1301/1600 train_time:73093ms step_avg:56.18ms
+step:1302/1600 train_time:73178ms step_avg:56.20ms
+step:1303/1600 train_time:73267ms step_avg:56.23ms
+step:1304/1600 train_time:73353ms step_avg:56.25ms
+step:1305/1600 train_time:73441ms step_avg:56.28ms
+step:1306/1600 train_time:73525ms step_avg:56.30ms
+step:1307/1600 train_time:73613ms step_avg:56.32ms
+step:1308/1600 train_time:73698ms step_avg:56.34ms
+step:1309/1600 train_time:73786ms step_avg:56.37ms
+step:1310/1600 train_time:73872ms step_avg:56.39ms
+step:1311/1600 train_time:73961ms step_avg:56.42ms
+step:1312/1600 train_time:74047ms step_avg:56.44ms
+step:1313/1600 train_time:74135ms step_avg:56.46ms
+step:1314/1600 train_time:74221ms step_avg:56.48ms
+step:1315/1600 train_time:74310ms step_avg:56.51ms
+step:1316/1600 train_time:74394ms step_avg:56.53ms
+step:1317/1600 train_time:74482ms step_avg:56.55ms
+step:1318/1600 train_time:74567ms step_avg:56.58ms
+step:1319/1600 train_time:74655ms step_avg:56.60ms
+step:1320/1600 train_time:74740ms step_avg:56.62ms
+step:1321/1600 train_time:74828ms step_avg:56.65ms
+step:1322/1600 train_time:74914ms step_avg:56.67ms
+step:1323/1600 train_time:75002ms step_avg:56.69ms
+step:1324/1600 train_time:75088ms step_avg:56.71ms
+step:1325/1600 train_time:75177ms step_avg:56.74ms
+step:1326/1600 train_time:75263ms step_avg:56.76ms
+step:1327/1600 train_time:75351ms step_avg:56.78ms
+step:1328/1600 train_time:75436ms step_avg:56.80ms
+step:1329/1600 train_time:75523ms step_avg:56.83ms
+step:1330/1600 train_time:75608ms step_avg:56.85ms
+step:1331/1600 train_time:75696ms step_avg:56.87ms
+step:1332/1600 train_time:75782ms step_avg:56.89ms
+step:1333/1600 train_time:75871ms step_avg:56.92ms
+step:1334/1600 train_time:75957ms step_avg:56.94ms
+step:1335/1600 train_time:76046ms step_avg:56.96ms
+step:1336/1600 train_time:76131ms step_avg:56.98ms
+step:1337/1600 train_time:76218ms step_avg:57.01ms
+step:1338/1600 train_time:76303ms step_avg:57.03ms
+step:1339/1600 train_time:76391ms step_avg:57.05ms
+step:1340/1600 train_time:76476ms step_avg:57.07ms
+step:1341/1600 train_time:76565ms step_avg:57.10ms
+step:1342/1600 train_time:76650ms step_avg:57.12ms
+step:1343/1600 train_time:76739ms step_avg:57.14ms
+step:1344/1600 train_time:76824ms step_avg:57.16ms
+step:1345/1600 train_time:76913ms step_avg:57.18ms
+step:1346/1600 train_time:76999ms step_avg:57.21ms
+step:1347/1600 train_time:77087ms step_avg:57.23ms
+step:1348/1600 train_time:77171ms step_avg:57.25ms
+step:1349/1600 train_time:77260ms step_avg:57.27ms
+step:1350/1600 train_time:77345ms step_avg:57.29ms
+step:1351/1600 train_time:77434ms step_avg:57.32ms
+step:1352/1600 train_time:77519ms step_avg:57.34ms
+step:1353/1600 train_time:77606ms step_avg:57.36ms
+step:1354/1600 train_time:77691ms step_avg:57.38ms
+step:1355/1600 train_time:77779ms step_avg:57.40ms
+step:1356/1600 train_time:77865ms step_avg:57.42ms
+step:1357/1600 train_time:77953ms step_avg:57.45ms
+step:1358/1600 train_time:78038ms step_avg:57.47ms
+step:1359/1600 train_time:78129ms step_avg:57.49ms
+step:1360/1600 train_time:78213ms step_avg:57.51ms
+step:1361/1600 train_time:78302ms step_avg:57.53ms
+step:1362/1600 train_time:78388ms step_avg:57.55ms
+step:1363/1600 train_time:78474ms step_avg:57.57ms
+step:1364/1600 train_time:78561ms step_avg:57.60ms
+step:1365/1600 train_time:78650ms step_avg:57.62ms
+step:1366/1600 train_time:78738ms step_avg:57.64ms
+step:1367/1600 train_time:78824ms step_avg:57.66ms
+step:1368/1600 train_time:78909ms step_avg:57.68ms
+step:1369/1600 train_time:78997ms step_avg:57.70ms
+step:1370/1600 train_time:79082ms step_avg:57.72ms
+step:1371/1600 train_time:79170ms step_avg:57.75ms
+step:1372/1600 train_time:79256ms step_avg:57.77ms
+step:1373/1600 train_time:79344ms step_avg:57.79ms
+step:1374/1600 train_time:79429ms step_avg:57.81ms
+step:1375/1600 train_time:79517ms step_avg:57.83ms
+step:1376/1600 train_time:79602ms step_avg:57.85ms
+step:1377/1600 train_time:79689ms step_avg:57.87ms
+step:1378/1600 train_time:79774ms step_avg:57.89ms
+step:1379/1600 train_time:79862ms step_avg:57.91ms
+step:1380/1600 train_time:79948ms step_avg:57.93ms
+step:1381/1600 train_time:80036ms step_avg:57.96ms
+step:1382/1600 train_time:80122ms step_avg:57.98ms
+step:1383/1600 train_time:80211ms step_avg:58.00ms
+step:1384/1600 train_time:80297ms step_avg:58.02ms
+step:1385/1600 train_time:80384ms step_avg:58.04ms
+step:1386/1600 train_time:80469ms step_avg:58.06ms
+step:1387/1600 train_time:80557ms step_avg:58.08ms
+step:1388/1600 train_time:80642ms step_avg:58.10ms
+step:1389/1600 train_time:80729ms step_avg:58.12ms
+step:1390/1600 train_time:80815ms step_avg:58.14ms
+step:1391/1600 train_time:80903ms step_avg:58.16ms
+step:1392/1600 train_time:80988ms step_avg:58.18ms
+step:1393/1600 train_time:81077ms step_avg:58.20ms
+step:1394/1600 train_time:81163ms step_avg:58.22ms
+step:1395/1600 train_time:81252ms step_avg:58.24ms
+step:1396/1600 train_time:81337ms step_avg:58.26ms
+step:1397/1600 train_time:81424ms step_avg:58.28ms
+step:1398/1600 train_time:81509ms step_avg:58.30ms
+step:1399/1600 train_time:81597ms step_avg:58.33ms
+step:1400/1600 train_time:81683ms step_avg:58.34ms
+step:1401/1600 train_time:81771ms step_avg:58.37ms
+step:1402/1600 train_time:81856ms step_avg:58.39ms
+step:1403/1600 train_time:81946ms step_avg:58.41ms
+step:1404/1600 train_time:82030ms step_avg:58.43ms
+step:1405/1600 train_time:82118ms step_avg:58.45ms
+step:1406/1600 train_time:82203ms step_avg:58.47ms
+step:1407/1600 train_time:82291ms step_avg:58.49ms
+step:1408/1600 train_time:82376ms step_avg:58.51ms
+step:1409/1600 train_time:82465ms step_avg:58.53ms
+step:1410/1600 train_time:82550ms step_avg:58.55ms
+step:1411/1600 train_time:82638ms step_avg:58.57ms
+step:1412/1600 train_time:82724ms step_avg:58.59ms
+step:1413/1600 train_time:82812ms step_avg:58.61ms
+step:1414/1600 train_time:82898ms step_avg:58.63ms
+step:1415/1600 train_time:82986ms step_avg:58.65ms
+step:1416/1600 train_time:83072ms step_avg:58.67ms
+step:1417/1600 train_time:83162ms step_avg:58.69ms
+step:1418/1600 train_time:83247ms step_avg:58.71ms
+step:1419/1600 train_time:83334ms step_avg:58.73ms
+step:1420/1600 train_time:83420ms step_avg:58.75ms
+step:1421/1600 train_time:83508ms step_avg:58.77ms
+step:1422/1600 train_time:83594ms step_avg:58.79ms
+step:1423/1600 train_time:83682ms step_avg:58.81ms
+step:1424/1600 train_time:83767ms step_avg:58.82ms
+step:1425/1600 train_time:83855ms step_avg:58.85ms
+step:1426/1600 train_time:83940ms step_avg:58.86ms
+step:1427/1600 train_time:84029ms step_avg:58.89ms
+step:1428/1600 train_time:84115ms step_avg:58.90ms
+step:1429/1600 train_time:84203ms step_avg:58.92ms
+step:1430/1600 train_time:84289ms step_avg:58.94ms
+step:1431/1600 train_time:84376ms step_avg:58.96ms
+step:1432/1600 train_time:84462ms step_avg:58.98ms
+step:1433/1600 train_time:84549ms step_avg:59.00ms
+step:1434/1600 train_time:84634ms step_avg:59.02ms
+step:1435/1600 train_time:84722ms step_avg:59.04ms
+step:1436/1600 train_time:84807ms step_avg:59.06ms
+step:1437/1600 train_time:84895ms step_avg:59.08ms
+step:1438/1600 train_time:84981ms step_avg:59.10ms
+step:1439/1600 train_time:85071ms step_avg:59.12ms
+step:1440/1600 train_time:85156ms step_avg:59.14ms
+step:1441/1600 train_time:85244ms step_avg:59.16ms
+step:1442/1600 train_time:85330ms step_avg:59.17ms
+step:1443/1600 train_time:85419ms step_avg:59.20ms
+step:1444/1600 train_time:85504ms step_avg:59.21ms
+step:1445/1600 train_time:85592ms step_avg:59.23ms
+step:1446/1600 train_time:85677ms step_avg:59.25ms
+step:1447/1600 train_time:85765ms step_avg:59.27ms
+step:1448/1600 train_time:85849ms step_avg:59.29ms
+step:1449/1600 train_time:85938ms step_avg:59.31ms
+step:1450/1600 train_time:86023ms step_avg:59.33ms
+step:1451/1600 train_time:86113ms step_avg:59.35ms
+step:1452/1600 train_time:86197ms step_avg:59.36ms
+step:1453/1600 train_time:86287ms step_avg:59.39ms
+step:1454/1600 train_time:86373ms step_avg:59.40ms
+step:1455/1600 train_time:86461ms step_avg:59.42ms
+step:1456/1600 train_time:86546ms step_avg:59.44ms
+step:1457/1600 train_time:86634ms step_avg:59.46ms
+step:1458/1600 train_time:86719ms step_avg:59.48ms
+step:1459/1600 train_time:86806ms step_avg:59.50ms
+step:1460/1600 train_time:86891ms step_avg:59.51ms
+step:1461/1600 train_time:86980ms step_avg:59.53ms
+step:1462/1600 train_time:87066ms step_avg:59.55ms
+step:1463/1600 train_time:87153ms step_avg:59.57ms
+step:1464/1600 train_time:87239ms step_avg:59.59ms
+step:1465/1600 train_time:87328ms step_avg:59.61ms
+step:1466/1600 train_time:87412ms step_avg:59.63ms
+step:1467/1600 train_time:87500ms step_avg:59.65ms
+step:1468/1600 train_time:87586ms step_avg:59.66ms
+step:1469/1600 train_time:87674ms step_avg:59.68ms
+step:1470/1600 train_time:87759ms step_avg:59.70ms
+step:1471/1600 train_time:87848ms step_avg:59.72ms
+step:1472/1600 train_time:87933ms step_avg:59.74ms
+step:1473/1600 train_time:88022ms step_avg:59.76ms
+step:1474/1600 train_time:88108ms step_avg:59.77ms
+step:1475/1600 train_time:88197ms step_avg:59.79ms
+step:1476/1600 train_time:88283ms step_avg:59.81ms
+step:1477/1600 train_time:88371ms step_avg:59.83ms
+step:1478/1600 train_time:88456ms step_avg:59.85ms
+step:1479/1600 train_time:88544ms step_avg:59.87ms
+step:1480/1600 train_time:88630ms step_avg:59.88ms
+step:1481/1600 train_time:88717ms step_avg:59.90ms
+step:1482/1600 train_time:88803ms step_avg:59.92ms
+step:1483/1600 train_time:88891ms step_avg:59.94ms
+step:1484/1600 train_time:88976ms step_avg:59.96ms
+step:1485/1600 train_time:89063ms step_avg:59.98ms
+step:1486/1600 train_time:89150ms step_avg:59.99ms
+step:1487/1600 train_time:89237ms step_avg:60.01ms
+step:1488/1600 train_time:89322ms step_avg:60.03ms
+step:1489/1600 train_time:89411ms step_avg:60.05ms
+step:1490/1600 train_time:89497ms step_avg:60.06ms
+step:1491/1600 train_time:89585ms step_avg:60.08ms
+step:1492/1600 train_time:89670ms step_avg:60.10ms
+step:1493/1600 train_time:89758ms step_avg:60.12ms
+step:1494/1600 train_time:89843ms step_avg:60.14ms
+step:1495/1600 train_time:89930ms step_avg:60.15ms
+step:1496/1600 train_time:90016ms step_avg:60.17ms
+step:1497/1600 train_time:90104ms step_avg:60.19ms
+step:1498/1600 train_time:90189ms step_avg:60.21ms
+step:1499/1600 train_time:90278ms step_avg:60.23ms
+step:1500/1600 train_time:90364ms step_avg:60.24ms
+step:1500/1600 val_loss:3.3087 train_time:90435ms step_avg:60.29ms
+step:1501/1600 train_time:90455ms step_avg:60.26ms
+step:1502/1600 train_time:90541ms step_avg:60.28ms
+step:1503/1600 train_time:90636ms step_avg:60.30ms
+step:1504/1600 train_time:90722ms step_avg:60.32ms
+step:1505/1600 train_time:90809ms step_avg:60.34ms
+step:1506/1600 train_time:90894ms step_avg:60.35ms
+step:1507/1600 train_time:90981ms step_avg:60.37ms
+step:1508/1600 train_time:91066ms step_avg:60.39ms
+step:1509/1600 train_time:91154ms step_avg:60.41ms
+step:1510/1600 train_time:91236ms step_avg:60.42ms
+step:1511/1600 train_time:91323ms step_avg:60.44ms
+step:1512/1600 train_time:91408ms step_avg:60.46ms
+step:1513/1600 train_time:91499ms step_avg:60.47ms
+step:1514/1600 train_time:91588ms step_avg:60.49ms
+step:1515/1600 train_time:91678ms step_avg:60.51ms
+step:1516/1600 train_time:91763ms step_avg:60.53ms
+step:1517/1600 train_time:91851ms step_avg:60.55ms
+step:1518/1600 train_time:91936ms step_avg:60.56ms
+step:1519/1600 train_time:92022ms step_avg:60.58ms
+step:1520/1600 train_time:92106ms step_avg:60.60ms
+step:1521/1600 train_time:92193ms step_avg:60.61ms
+step:1522/1600 train_time:92278ms step_avg:60.63ms
+step:1523/1600 train_time:92367ms step_avg:60.65ms
+step:1524/1600 train_time:92454ms step_avg:60.67ms
+step:1525/1600 train_time:92544ms step_avg:60.68ms
+step:1526/1600 train_time:92631ms step_avg:60.70ms
+step:1527/1600 train_time:92720ms step_avg:60.72ms
+step:1528/1600 train_time:92804ms step_avg:60.74ms
+step:1529/1600 train_time:92892ms step_avg:60.75ms
+step:1530/1600 train_time:92976ms step_avg:60.77ms
+step:1531/1600 train_time:93064ms step_avg:60.79ms
+step:1532/1600 train_time:93148ms step_avg:60.80ms
+step:1533/1600 train_time:93236ms step_avg:60.82ms
+step:1534/1600 train_time:93322ms step_avg:60.84ms
+step:1535/1600 train_time:93411ms step_avg:60.85ms
+step:1536/1600 train_time:93496ms step_avg:60.87ms
+step:1537/1600 train_time:93586ms step_avg:60.89ms
+step:1538/1600 train_time:93671ms step_avg:60.90ms
+step:1539/1600 train_time:93761ms step_avg:60.92ms
+step:1540/1600 train_time:93846ms step_avg:60.94ms
+step:1541/1600 train_time:93934ms step_avg:60.96ms
+step:1542/1600 train_time:94020ms step_avg:60.97ms
+step:1543/1600 train_time:94109ms step_avg:60.99ms
+step:1544/1600 train_time:94192ms step_avg:61.01ms
+step:1545/1600 train_time:94279ms step_avg:61.02ms
+step:1546/1600 train_time:94365ms step_avg:61.04ms
+step:1547/1600 train_time:94455ms step_avg:61.06ms
+step:1548/1600 train_time:94541ms step_avg:61.07ms
+step:1549/1600 train_time:94630ms step_avg:61.09ms
+step:1550/1600 train_time:94716ms step_avg:61.11ms
+step:1551/1600 train_time:94806ms step_avg:61.13ms
+step:1552/1600 train_time:94891ms step_avg:61.14ms
+step:1553/1600 train_time:94979ms step_avg:61.16ms
+step:1554/1600 train_time:95064ms step_avg:61.17ms
+step:1555/1600 train_time:95152ms step_avg:61.19ms
+step:1556/1600 train_time:95238ms step_avg:61.21ms
+step:1557/1600 train_time:95326ms step_avg:61.22ms
+step:1558/1600 train_time:95412ms step_avg:61.24ms
+step:1559/1600 train_time:95501ms step_avg:61.26ms
+step:1560/1600 train_time:95587ms step_avg:61.27ms
+step:1561/1600 train_time:95683ms step_avg:61.30ms
+step:1562/1600 train_time:95767ms step_avg:61.31ms
+step:1563/1600 train_time:95855ms step_avg:61.33ms
+step:1564/1600 train_time:95940ms step_avg:61.34ms
+step:1565/1600 train_time:96028ms step_avg:61.36ms
+step:1566/1600 train_time:96114ms step_avg:61.38ms
+step:1567/1600 train_time:96202ms step_avg:61.39ms
+step:1568/1600 train_time:96287ms step_avg:61.41ms
+step:1569/1600 train_time:96377ms step_avg:61.43ms
+step:1570/1600 train_time:96463ms step_avg:61.44ms
+step:1571/1600 train_time:96552ms step_avg:61.46ms
+step:1572/1600 train_time:96638ms step_avg:61.47ms
+step:1573/1600 train_time:96727ms step_avg:61.49ms
+step:1574/1600 train_time:96813ms step_avg:61.51ms
+step:1575/1600 train_time:96901ms step_avg:61.52ms
+step:1576/1600 train_time:96987ms step_avg:61.54ms
+step:1577/1600 train_time:97079ms step_avg:61.56ms
+step:1578/1600 train_time:97163ms step_avg:61.57ms
+step:1579/1600 train_time:97251ms step_avg:61.59ms
+step:1580/1600 train_time:97337ms step_avg:61.61ms
+step:1581/1600 train_time:97425ms step_avg:61.62ms
+step:1582/1600 train_time:97510ms step_avg:61.64ms
+step:1583/1600 train_time:97598ms step_avg:61.65ms
+step:1584/1600 train_time:97684ms step_avg:61.67ms
+step:1585/1600 train_time:97773ms step_avg:61.69ms
+step:1586/1600 train_time:97859ms step_avg:61.70ms
+step:1587/1600 train_time:97949ms step_avg:61.72ms
+step:1588/1600 train_time:98035ms step_avg:61.73ms
+step:1589/1600 train_time:98124ms step_avg:61.75ms
+step:1590/1600 train_time:98209ms step_avg:61.77ms
+step:1591/1600 train_time:98297ms step_avg:61.78ms
+step:1592/1600 train_time:98382ms step_avg:61.80ms
+step:1593/1600 train_time:98470ms step_avg:61.81ms
+step:1594/1600 train_time:98555ms step_avg:61.83ms
+step:1595/1600 train_time:98644ms step_avg:61.85ms
+step:1596/1600 train_time:98729ms step_avg:61.86ms
+step:1597/1600 train_time:98820ms step_avg:61.88ms
+step:1598/1600 train_time:98906ms step_avg:61.89ms
+step:1599/1600 train_time:98995ms step_avg:61.91ms
+step:1600/1600 train_time:99080ms step_avg:61.92ms
+step:1600/1600 val_loss:3.2791 train_time:99151ms step_avg:61.97ms
+peak memory allocated: 30264 MiB reserved: 46240 MiB

--- a/records/track_1_short/2026-01-19_BigramHashEmbedding/c1137b71-d0cd-475d-8f57-b99fcc71956a.txt
+++ b/records/track_1_short/2026-01-19_BigramHashEmbedding/c1137b71-d0cd-475d-8f57-b99fcc71956a.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 19 22:24:22 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   24C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   27C    P0            120W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   25C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   26C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   26C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   23C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   25C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   23C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     50660      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     50661      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     50662      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     50663      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     50664      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     50665      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     50666      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     50667      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8283 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:72ms step_avg:72.07ms
+step:2/1600 train_time:94ms step_avg:47.16ms
+step:3/1600 train_time:114ms step_avg:37.99ms
+step:4/1600 train_time:139ms step_avg:34.86ms
+step:5/1600 train_time:170ms step_avg:33.92ms
+step:6/1600 train_time:264ms step_avg:44.00ms
+step:7/1600 train_time:282ms step_avg:40.26ms
+step:8/1600 train_time:309ms step_avg:38.58ms
+step:9/1600 train_time:339ms step_avg:37.72ms
+step:10/1600 train_time:376ms step_avg:37.63ms
+step:11/1600 train_time:407ms step_avg:37.02ms
+step:12/1600 train_time:444ms step_avg:37.03ms
+step:13/1600 train_time:475ms step_avg:36.57ms
+step:14/1600 train_time:513ms step_avg:36.62ms
+step:15/1600 train_time:544ms step_avg:36.25ms
+step:16/1600 train_time:581ms step_avg:36.29ms
+step:17/1600 train_time:612ms step_avg:35.97ms
+step:18/1600 train_time:649ms step_avg:36.06ms
+step:19/1600 train_time:680ms step_avg:35.79ms
+step:20/1600 train_time:717ms step_avg:35.86ms
+step:21/1600 train_time:748ms step_avg:35.64ms
+step:22/1600 train_time:785ms step_avg:35.69ms
+step:23/1600 train_time:816ms step_avg:35.49ms
+step:24/1600 train_time:853ms step_avg:35.55ms
+step:25/1600 train_time:884ms step_avg:35.35ms
+step:26/1600 train_time:921ms step_avg:35.41ms
+step:27/1600 train_time:952ms step_avg:35.26ms
+step:28/1600 train_time:989ms step_avg:35.33ms
+step:29/1600 train_time:1021ms step_avg:35.19ms
+step:30/1600 train_time:1058ms step_avg:35.25ms
+step:31/1600 train_time:1088ms step_avg:35.11ms
+step:32/1600 train_time:1125ms step_avg:35.17ms
+step:33/1600 train_time:1156ms step_avg:35.04ms
+step:34/1600 train_time:1193ms step_avg:35.10ms
+step:35/1600 train_time:1225ms step_avg:34.99ms
+step:36/1600 train_time:1262ms step_avg:35.05ms
+step:37/1600 train_time:1293ms step_avg:34.94ms
+step:38/1600 train_time:1330ms step_avg:34.99ms
+step:39/1600 train_time:1361ms step_avg:34.90ms
+step:40/1600 train_time:1398ms step_avg:34.95ms
+step:41/1600 train_time:1429ms step_avg:34.85ms
+step:42/1600 train_time:1466ms step_avg:34.91ms
+step:43/1600 train_time:1497ms step_avg:34.82ms
+step:44/1600 train_time:1534ms step_avg:34.86ms
+step:45/1600 train_time:1565ms step_avg:34.78ms
+step:46/1600 train_time:1603ms step_avg:34.84ms
+step:47/1600 train_time:1634ms step_avg:34.76ms
+step:48/1600 train_time:1670ms step_avg:34.80ms
+step:49/1600 train_time:1701ms step_avg:34.72ms
+step:50/1600 train_time:1739ms step_avg:34.77ms
+step:51/1600 train_time:1770ms step_avg:34.70ms
+step:52/1600 train_time:1807ms step_avg:34.76ms
+step:53/1600 train_time:1838ms step_avg:34.68ms
+step:54/1600 train_time:1875ms step_avg:34.72ms
+step:55/1600 train_time:1906ms step_avg:34.65ms
+step:56/1600 train_time:1943ms step_avg:34.69ms
+step:57/1600 train_time:1974ms step_avg:34.63ms
+step:58/1600 train_time:2011ms step_avg:34.67ms
+step:59/1600 train_time:2042ms step_avg:34.61ms
+step:60/1600 train_time:2079ms step_avg:34.65ms
+step:61/1600 train_time:2110ms step_avg:34.59ms
+step:62/1600 train_time:2147ms step_avg:34.62ms
+step:63/1600 train_time:2178ms step_avg:34.57ms
+step:64/1600 train_time:2215ms step_avg:34.61ms
+step:65/1600 train_time:2246ms step_avg:34.55ms
+step:66/1600 train_time:2283ms step_avg:34.59ms
+step:67/1600 train_time:2314ms step_avg:34.53ms
+step:68/1600 train_time:2351ms step_avg:34.57ms
+step:69/1600 train_time:2382ms step_avg:34.52ms
+step:70/1600 train_time:2419ms step_avg:34.55ms
+step:71/1600 train_time:2450ms step_avg:34.50ms
+step:72/1600 train_time:2487ms step_avg:34.54ms
+step:73/1600 train_time:2517ms step_avg:34.48ms
+step:74/1600 train_time:2554ms step_avg:34.52ms
+step:75/1600 train_time:2585ms step_avg:34.47ms
+step:76/1600 train_time:2622ms step_avg:34.51ms
+step:77/1600 train_time:2653ms step_avg:34.46ms
+step:78/1600 train_time:2691ms step_avg:34.50ms
+step:79/1600 train_time:2722ms step_avg:34.46ms
+step:80/1600 train_time:2759ms step_avg:34.49ms
+step:81/1600 train_time:2790ms step_avg:34.45ms
+step:82/1600 train_time:2828ms step_avg:34.48ms
+step:83/1600 train_time:2858ms step_avg:34.44ms
+step:84/1600 train_time:2895ms step_avg:34.47ms
+step:85/1600 train_time:2926ms step_avg:34.43ms
+step:86/1600 train_time:2963ms step_avg:34.46ms
+step:87/1600 train_time:2994ms step_avg:34.41ms
+step:88/1600 train_time:3031ms step_avg:34.44ms
+step:89/1600 train_time:3062ms step_avg:34.40ms
+step:90/1600 train_time:3099ms step_avg:34.43ms
+step:91/1600 train_time:3130ms step_avg:34.39ms
+step:92/1600 train_time:3167ms step_avg:34.42ms
+step:93/1600 train_time:3198ms step_avg:34.39ms
+step:94/1600 train_time:3235ms step_avg:34.41ms
+step:95/1600 train_time:3266ms step_avg:34.38ms
+step:96/1600 train_time:3303ms step_avg:34.41ms
+step:97/1600 train_time:3334ms step_avg:34.37ms
+step:98/1600 train_time:3371ms step_avg:34.40ms
+step:99/1600 train_time:3402ms step_avg:34.36ms
+step:100/1600 train_time:3439ms step_avg:34.39ms
+step:101/1600 train_time:3469ms step_avg:34.35ms
+step:102/1600 train_time:3506ms step_avg:34.38ms
+step:103/1600 train_time:3537ms step_avg:34.34ms
+step:104/1600 train_time:3574ms step_avg:34.37ms
+step:105/1600 train_time:3605ms step_avg:34.33ms
+step:106/1600 train_time:3642ms step_avg:34.36ms
+step:107/1600 train_time:3673ms step_avg:34.33ms
+step:108/1600 train_time:3710ms step_avg:34.35ms
+step:109/1600 train_time:3741ms step_avg:34.32ms
+step:110/1600 train_time:3778ms step_avg:34.34ms
+step:111/1600 train_time:3809ms step_avg:34.31ms
+step:112/1600 train_time:3846ms step_avg:34.34ms
+step:113/1600 train_time:3877ms step_avg:34.31ms
+step:114/1600 train_time:3914ms step_avg:34.33ms
+step:115/1600 train_time:3945ms step_avg:34.30ms
+step:116/1600 train_time:3982ms step_avg:34.32ms
+step:117/1600 train_time:4013ms step_avg:34.30ms
+step:118/1600 train_time:4050ms step_avg:34.32ms
+step:119/1600 train_time:4080ms step_avg:34.29ms
+step:120/1600 train_time:4118ms step_avg:34.32ms
+step:121/1600 train_time:4149ms step_avg:34.29ms
+step:122/1600 train_time:4186ms step_avg:34.31ms
+step:123/1600 train_time:4217ms step_avg:34.29ms
+step:124/1600 train_time:4254ms step_avg:34.31ms
+step:125/1600 train_time:4285ms step_avg:34.28ms
+step:126/1600 train_time:4322ms step_avg:34.30ms
+step:127/1600 train_time:4353ms step_avg:34.28ms
+step:128/1600 train_time:4390ms step_avg:34.30ms
+step:129/1600 train_time:4421ms step_avg:34.27ms
+step:130/1600 train_time:4458ms step_avg:34.29ms
+step:131/1600 train_time:4489ms step_avg:34.27ms
+step:132/1600 train_time:4526ms step_avg:34.29ms
+step:133/1600 train_time:4557ms step_avg:34.26ms
+step:134/1600 train_time:4594ms step_avg:34.28ms
+step:135/1600 train_time:4624ms step_avg:34.25ms
+step:136/1600 train_time:4661ms step_avg:34.27ms
+step:137/1600 train_time:4692ms step_avg:34.25ms
+step:138/1600 train_time:4729ms step_avg:34.27ms
+step:139/1600 train_time:4760ms step_avg:34.25ms
+step:140/1600 train_time:4797ms step_avg:34.26ms
+step:141/1600 train_time:4828ms step_avg:34.24ms
+step:142/1600 train_time:4865ms step_avg:34.26ms
+step:143/1600 train_time:4896ms step_avg:34.24ms
+step:144/1600 train_time:4933ms step_avg:34.25ms
+step:145/1600 train_time:4964ms step_avg:34.23ms
+step:146/1600 train_time:5001ms step_avg:34.25ms
+step:147/1600 train_time:5032ms step_avg:34.23ms
+step:148/1600 train_time:5069ms step_avg:34.25ms
+step:149/1600 train_time:5100ms step_avg:34.23ms
+step:150/1600 train_time:5137ms step_avg:34.25ms
+step:151/1600 train_time:5168ms step_avg:34.22ms
+step:152/1600 train_time:5205ms step_avg:34.24ms
+step:153/1600 train_time:5236ms step_avg:34.22ms
+step:154/1600 train_time:5273ms step_avg:34.24ms
+step:155/1600 train_time:5304ms step_avg:34.22ms
+step:156/1600 train_time:5341ms step_avg:34.24ms
+step:157/1600 train_time:5371ms step_avg:34.21ms
+step:158/1600 train_time:5408ms step_avg:34.23ms
+step:159/1600 train_time:5439ms step_avg:34.21ms
+step:160/1600 train_time:5476ms step_avg:34.23ms
+step:161/1600 train_time:5507ms step_avg:34.20ms
+step:162/1600 train_time:5544ms step_avg:34.22ms
+step:163/1600 train_time:5575ms step_avg:34.20ms
+step:164/1600 train_time:5612ms step_avg:34.22ms
+step:165/1600 train_time:5643ms step_avg:34.20ms
+step:166/1600 train_time:5680ms step_avg:34.22ms
+step:167/1600 train_time:5711ms step_avg:34.20ms
+step:168/1600 train_time:5748ms step_avg:34.21ms
+step:169/1600 train_time:5779ms step_avg:34.19ms
+step:170/1600 train_time:5815ms step_avg:34.21ms
+step:171/1600 train_time:5846ms step_avg:34.19ms
+step:172/1600 train_time:5884ms step_avg:34.21ms
+step:173/1600 train_time:5914ms step_avg:34.19ms
+step:174/1600 train_time:5952ms step_avg:34.21ms
+step:175/1600 train_time:5982ms step_avg:34.19ms
+step:176/1600 train_time:6019ms step_avg:34.20ms
+step:177/1600 train_time:6051ms step_avg:34.18ms
+step:178/1600 train_time:6088ms step_avg:34.20ms
+step:179/1600 train_time:6119ms step_avg:34.18ms
+step:180/1600 train_time:6156ms step_avg:34.20ms
+step:181/1600 train_time:6186ms step_avg:34.18ms
+step:182/1600 train_time:6223ms step_avg:34.19ms
+step:183/1600 train_time:6254ms step_avg:34.17ms
+step:184/1600 train_time:6291ms step_avg:34.19ms
+step:185/1600 train_time:6321ms step_avg:34.17ms
+step:186/1600 train_time:6358ms step_avg:34.19ms
+step:187/1600 train_time:6389ms step_avg:34.17ms
+step:188/1600 train_time:6426ms step_avg:34.18ms
+step:189/1600 train_time:6457ms step_avg:34.17ms
+step:190/1600 train_time:6494ms step_avg:34.18ms
+step:191/1600 train_time:6525ms step_avg:34.16ms
+step:192/1600 train_time:6563ms step_avg:34.18ms
+step:193/1600 train_time:6593ms step_avg:34.16ms
+step:194/1600 train_time:6630ms step_avg:34.18ms
+step:195/1600 train_time:6661ms step_avg:34.16ms
+step:196/1600 train_time:6698ms step_avg:34.17ms
+step:197/1600 train_time:6730ms step_avg:34.16ms
+step:198/1600 train_time:6767ms step_avg:34.17ms
+step:199/1600 train_time:6798ms step_avg:34.16ms
+step:200/1600 train_time:6835ms step_avg:34.17ms
+step:201/1600 train_time:6866ms step_avg:34.16ms
+step:202/1600 train_time:6902ms step_avg:34.17ms
+step:203/1600 train_time:6933ms step_avg:34.15ms
+step:204/1600 train_time:6970ms step_avg:34.17ms
+step:205/1600 train_time:7001ms step_avg:34.15ms
+step:206/1600 train_time:7038ms step_avg:34.17ms
+step:207/1600 train_time:7069ms step_avg:34.15ms
+step:208/1600 train_time:7106ms step_avg:34.16ms
+step:209/1600 train_time:7137ms step_avg:34.15ms
+step:210/1600 train_time:7174ms step_avg:34.16ms
+step:211/1600 train_time:7205ms step_avg:34.15ms
+step:212/1600 train_time:7242ms step_avg:34.16ms
+step:213/1600 train_time:7272ms step_avg:34.14ms
+step:214/1600 train_time:7309ms step_avg:34.16ms
+step:215/1600 train_time:7341ms step_avg:34.14ms
+step:216/1600 train_time:7378ms step_avg:34.16ms
+step:217/1600 train_time:7409ms step_avg:34.14ms
+step:218/1600 train_time:7446ms step_avg:34.15ms
+step:219/1600 train_time:7477ms step_avg:34.14ms
+step:220/1600 train_time:7513ms step_avg:34.15ms
+step:221/1600 train_time:7544ms step_avg:34.14ms
+step:222/1600 train_time:7581ms step_avg:34.15ms
+step:223/1600 train_time:7612ms step_avg:34.13ms
+step:224/1600 train_time:7649ms step_avg:34.15ms
+step:225/1600 train_time:7680ms step_avg:34.13ms
+step:226/1600 train_time:7717ms step_avg:34.14ms
+step:227/1600 train_time:7748ms step_avg:34.13ms
+step:228/1600 train_time:7785ms step_avg:34.14ms
+step:229/1600 train_time:7816ms step_avg:34.13ms
+step:230/1600 train_time:7853ms step_avg:34.14ms
+step:231/1600 train_time:7883ms step_avg:34.13ms
+step:232/1600 train_time:7920ms step_avg:34.14ms
+step:233/1600 train_time:7951ms step_avg:34.12ms
+step:234/1600 train_time:7988ms step_avg:34.14ms
+step:235/1600 train_time:8019ms step_avg:34.12ms
+step:236/1600 train_time:8056ms step_avg:34.13ms
+step:237/1600 train_time:8087ms step_avg:34.12ms
+step:238/1600 train_time:8124ms step_avg:34.13ms
+step:239/1600 train_time:8155ms step_avg:34.12ms
+step:240/1600 train_time:8191ms step_avg:34.13ms
+step:241/1600 train_time:8222ms step_avg:34.12ms
+step:242/1600 train_time:8259ms step_avg:34.13ms
+step:243/1600 train_time:8290ms step_avg:34.12ms
+step:244/1600 train_time:8327ms step_avg:34.13ms
+step:245/1600 train_time:8358ms step_avg:34.12ms
+step:246/1600 train_time:8395ms step_avg:34.13ms
+step:247/1600 train_time:8426ms step_avg:34.11ms
+step:248/1600 train_time:8463ms step_avg:34.13ms
+step:249/1600 train_time:8494ms step_avg:34.11ms
+step:250/1600 train_time:8531ms step_avg:34.12ms
+step:250/1600 val_loss:4.6055 train_time:8579ms step_avg:34.32ms
+step:251/1600 train_time:8598ms step_avg:34.26ms
+step:252/1600 train_time:8617ms step_avg:34.19ms
+step:253/1600 train_time:8634ms step_avg:34.13ms
+step:254/1600 train_time:8671ms step_avg:34.14ms
+step:255/1600 train_time:8703ms step_avg:34.13ms
+step:256/1600 train_time:8741ms step_avg:34.14ms
+step:257/1600 train_time:8772ms step_avg:34.13ms
+step:258/1600 train_time:8809ms step_avg:34.14ms
+step:259/1600 train_time:8840ms step_avg:34.13ms
+step:260/1600 train_time:8877ms step_avg:34.14ms
+step:261/1600 train_time:8908ms step_avg:34.13ms
+step:262/1600 train_time:8945ms step_avg:34.14ms
+step:263/1600 train_time:8976ms step_avg:34.13ms
+step:264/1600 train_time:9013ms step_avg:34.14ms
+step:265/1600 train_time:9044ms step_avg:34.13ms
+step:266/1600 train_time:9080ms step_avg:34.14ms
+step:267/1600 train_time:9112ms step_avg:34.13ms
+step:268/1600 train_time:9148ms step_avg:34.14ms
+step:269/1600 train_time:9179ms step_avg:34.12ms
+step:270/1600 train_time:9216ms step_avg:34.13ms
+step:271/1600 train_time:9247ms step_avg:34.12ms
+step:272/1600 train_time:9284ms step_avg:34.13ms
+step:273/1600 train_time:9315ms step_avg:34.12ms
+step:274/1600 train_time:9352ms step_avg:34.13ms
+step:275/1600 train_time:9382ms step_avg:34.12ms
+step:276/1600 train_time:9419ms step_avg:34.13ms
+step:277/1600 train_time:9450ms step_avg:34.12ms
+step:278/1600 train_time:9486ms step_avg:34.12ms
+step:279/1600 train_time:9517ms step_avg:34.11ms
+step:280/1600 train_time:9555ms step_avg:34.12ms
+step:281/1600 train_time:9585ms step_avg:34.11ms
+step:282/1600 train_time:9622ms step_avg:34.12ms
+step:283/1600 train_time:9653ms step_avg:34.11ms
+step:284/1600 train_time:9690ms step_avg:34.12ms
+step:285/1600 train_time:9721ms step_avg:34.11ms
+step:286/1600 train_time:9758ms step_avg:34.12ms
+step:287/1600 train_time:9789ms step_avg:34.11ms
+step:288/1600 train_time:9826ms step_avg:34.12ms
+step:289/1600 train_time:9857ms step_avg:34.11ms
+step:290/1600 train_time:9894ms step_avg:34.12ms
+step:291/1600 train_time:9925ms step_avg:34.11ms
+step:292/1600 train_time:9962ms step_avg:34.12ms
+step:293/1600 train_time:9993ms step_avg:34.10ms
+step:294/1600 train_time:10030ms step_avg:34.12ms
+step:295/1600 train_time:10061ms step_avg:34.10ms
+step:296/1600 train_time:10098ms step_avg:34.11ms
+step:297/1600 train_time:10129ms step_avg:34.10ms
+step:298/1600 train_time:10166ms step_avg:34.11ms
+step:299/1600 train_time:10196ms step_avg:34.10ms
+step:300/1600 train_time:10234ms step_avg:34.11ms
+step:301/1600 train_time:10264ms step_avg:34.10ms
+step:302/1600 train_time:10301ms step_avg:34.11ms
+step:303/1600 train_time:10332ms step_avg:34.10ms
+step:304/1600 train_time:10369ms step_avg:34.11ms
+step:305/1600 train_time:10399ms step_avg:34.10ms
+step:306/1600 train_time:10436ms step_avg:34.11ms
+step:307/1600 train_time:10467ms step_avg:34.10ms
+step:308/1600 train_time:10504ms step_avg:34.11ms
+step:309/1600 train_time:10535ms step_avg:34.09ms
+step:310/1600 train_time:10572ms step_avg:34.10ms
+step:311/1600 train_time:10603ms step_avg:34.09ms
+step:312/1600 train_time:10640ms step_avg:34.10ms
+step:313/1600 train_time:10670ms step_avg:34.09ms
+step:314/1600 train_time:10707ms step_avg:34.10ms
+step:315/1600 train_time:10738ms step_avg:34.09ms
+step:316/1600 train_time:10775ms step_avg:34.10ms
+step:317/1600 train_time:10806ms step_avg:34.09ms
+step:318/1600 train_time:10843ms step_avg:34.10ms
+step:319/1600 train_time:10874ms step_avg:34.09ms
+step:320/1600 train_time:10911ms step_avg:34.10ms
+step:321/1600 train_time:10942ms step_avg:34.09ms
+step:322/1600 train_time:10979ms step_avg:34.10ms
+step:323/1600 train_time:11010ms step_avg:34.09ms
+step:324/1600 train_time:11046ms step_avg:34.09ms
+step:325/1600 train_time:11077ms step_avg:34.08ms
+step:326/1600 train_time:11115ms step_avg:34.09ms
+step:327/1600 train_time:11145ms step_avg:34.08ms
+step:328/1600 train_time:11182ms step_avg:34.09ms
+step:329/1600 train_time:11213ms step_avg:34.08ms
+step:330/1600 train_time:11250ms step_avg:34.09ms
+step:331/1600 train_time:11280ms step_avg:34.08ms
+step:332/1600 train_time:11317ms step_avg:34.09ms
+step:333/1600 train_time:11348ms step_avg:34.08ms
+step:334/1600 train_time:11385ms step_avg:34.09ms
+step:335/1600 train_time:11416ms step_avg:34.08ms
+step:336/1600 train_time:11453ms step_avg:34.09ms
+step:337/1600 train_time:11484ms step_avg:34.08ms
+step:338/1600 train_time:11521ms step_avg:34.08ms
+step:339/1600 train_time:11551ms step_avg:34.08ms
+step:340/1600 train_time:11588ms step_avg:34.08ms
+step:341/1600 train_time:11619ms step_avg:34.07ms
+step:342/1600 train_time:11656ms step_avg:34.08ms
+step:343/1600 train_time:11687ms step_avg:34.07ms
+step:344/1600 train_time:11724ms step_avg:34.08ms
+step:345/1600 train_time:11754ms step_avg:34.07ms
+step:346/1600 train_time:11792ms step_avg:34.08ms
+step:347/1600 train_time:11823ms step_avg:34.07ms
+step:348/1600 train_time:11859ms step_avg:34.08ms
+step:349/1600 train_time:11890ms step_avg:34.07ms
+step:350/1600 train_time:11927ms step_avg:34.08ms
+step:351/1600 train_time:11958ms step_avg:34.07ms
+step:352/1600 train_time:11994ms step_avg:34.07ms
+step:353/1600 train_time:12025ms step_avg:34.07ms
+step:354/1600 train_time:12062ms step_avg:34.07ms
+step:355/1600 train_time:12092ms step_avg:34.06ms
+step:356/1600 train_time:12129ms step_avg:34.07ms
+step:357/1600 train_time:12160ms step_avg:34.06ms
+step:358/1600 train_time:12197ms step_avg:34.07ms
+step:359/1600 train_time:12228ms step_avg:34.06ms
+step:360/1600 train_time:12265ms step_avg:34.07ms
+step:361/1600 train_time:12295ms step_avg:34.06ms
+step:362/1600 train_time:12332ms step_avg:34.07ms
+step:363/1600 train_time:12363ms step_avg:34.06ms
+step:364/1600 train_time:12400ms step_avg:34.07ms
+step:365/1600 train_time:12431ms step_avg:34.06ms
+step:366/1600 train_time:12467ms step_avg:34.06ms
+step:367/1600 train_time:12498ms step_avg:34.05ms
+step:368/1600 train_time:12535ms step_avg:34.06ms
+step:369/1600 train_time:12566ms step_avg:34.05ms
+step:370/1600 train_time:12603ms step_avg:34.06ms
+step:371/1600 train_time:12633ms step_avg:34.05ms
+step:372/1600 train_time:12671ms step_avg:34.06ms
+step:373/1600 train_time:12701ms step_avg:34.05ms
+step:374/1600 train_time:12738ms step_avg:34.06ms
+step:375/1600 train_time:12769ms step_avg:34.05ms
+step:376/1600 train_time:12806ms step_avg:34.06ms
+step:377/1600 train_time:12837ms step_avg:34.05ms
+step:378/1600 train_time:12874ms step_avg:34.06ms
+step:379/1600 train_time:12905ms step_avg:34.05ms
+step:380/1600 train_time:12942ms step_avg:34.06ms
+step:381/1600 train_time:12973ms step_avg:34.05ms
+step:382/1600 train_time:13010ms step_avg:34.06ms
+step:383/1600 train_time:13041ms step_avg:34.05ms
+step:384/1600 train_time:13078ms step_avg:34.06ms
+step:385/1600 train_time:13109ms step_avg:34.05ms
+step:386/1600 train_time:13146ms step_avg:34.06ms
+step:387/1600 train_time:13177ms step_avg:34.05ms
+step:388/1600 train_time:13214ms step_avg:34.06ms
+step:389/1600 train_time:13245ms step_avg:34.05ms
+step:390/1600 train_time:13282ms step_avg:34.06ms
+step:391/1600 train_time:13313ms step_avg:34.05ms
+step:392/1600 train_time:13349ms step_avg:34.05ms
+step:393/1600 train_time:13380ms step_avg:34.05ms
+step:394/1600 train_time:13417ms step_avg:34.05ms
+step:395/1600 train_time:13448ms step_avg:34.05ms
+step:396/1600 train_time:13485ms step_avg:34.05ms
+step:397/1600 train_time:13515ms step_avg:34.04ms
+step:398/1600 train_time:13552ms step_avg:34.05ms
+step:399/1600 train_time:13583ms step_avg:34.04ms
+step:400/1600 train_time:13620ms step_avg:34.05ms
+step:401/1600 train_time:13651ms step_avg:34.04ms
+step:402/1600 train_time:13688ms step_avg:34.05ms
+step:403/1600 train_time:13718ms step_avg:34.04ms
+step:404/1600 train_time:13755ms step_avg:34.05ms
+step:405/1600 train_time:13786ms step_avg:34.04ms
+step:406/1600 train_time:13823ms step_avg:34.05ms
+step:407/1600 train_time:13854ms step_avg:34.04ms
+step:408/1600 train_time:13891ms step_avg:34.05ms
+step:409/1600 train_time:13921ms step_avg:34.04ms
+step:410/1600 train_time:13958ms step_avg:34.04ms
+step:411/1600 train_time:13989ms step_avg:34.04ms
+step:412/1600 train_time:14026ms step_avg:34.04ms
+step:413/1600 train_time:14057ms step_avg:34.04ms
+step:414/1600 train_time:14093ms step_avg:34.04ms
+step:415/1600 train_time:14124ms step_avg:34.03ms
+step:416/1600 train_time:14161ms step_avg:34.04ms
+step:417/1600 train_time:14192ms step_avg:34.03ms
+step:418/1600 train_time:14229ms step_avg:34.04ms
+step:419/1600 train_time:14260ms step_avg:34.03ms
+step:420/1600 train_time:14297ms step_avg:34.04ms
+step:421/1600 train_time:14328ms step_avg:34.03ms
+step:422/1600 train_time:14364ms step_avg:34.04ms
+step:423/1600 train_time:14395ms step_avg:34.03ms
+step:424/1600 train_time:14432ms step_avg:34.04ms
+step:425/1600 train_time:14463ms step_avg:34.03ms
+step:426/1600 train_time:14500ms step_avg:34.04ms
+step:427/1600 train_time:14531ms step_avg:34.03ms
+step:428/1600 train_time:14568ms step_avg:34.04ms
+step:429/1600 train_time:14599ms step_avg:34.03ms
+step:430/1600 train_time:14636ms step_avg:34.04ms
+step:431/1600 train_time:14666ms step_avg:34.03ms
+step:432/1600 train_time:14703ms step_avg:34.04ms
+step:433/1600 train_time:14734ms step_avg:34.03ms
+step:434/1600 train_time:14771ms step_avg:34.03ms
+step:435/1600 train_time:14802ms step_avg:34.03ms
+step:436/1600 train_time:14839ms step_avg:34.03ms
+step:437/1600 train_time:14870ms step_avg:34.03ms
+step:438/1600 train_time:14907ms step_avg:34.03ms
+step:439/1600 train_time:14938ms step_avg:34.03ms
+step:440/1600 train_time:14975ms step_avg:34.03ms
+step:441/1600 train_time:15006ms step_avg:34.03ms
+step:442/1600 train_time:15043ms step_avg:34.03ms
+step:443/1600 train_time:15074ms step_avg:34.03ms
+step:444/1600 train_time:15111ms step_avg:34.03ms
+step:445/1600 train_time:15142ms step_avg:34.03ms
+step:446/1600 train_time:15179ms step_avg:34.03ms
+step:447/1600 train_time:15210ms step_avg:34.03ms
+step:448/1600 train_time:15247ms step_avg:34.03ms
+step:449/1600 train_time:15277ms step_avg:34.03ms
+step:450/1600 train_time:15314ms step_avg:34.03ms
+step:451/1600 train_time:15345ms step_avg:34.03ms
+step:452/1600 train_time:15382ms step_avg:34.03ms
+step:453/1600 train_time:15413ms step_avg:34.02ms
+step:454/1600 train_time:15450ms step_avg:34.03ms
+step:455/1600 train_time:15481ms step_avg:34.02ms
+step:456/1600 train_time:15518ms step_avg:34.03ms
+step:457/1600 train_time:15549ms step_avg:34.02ms
+step:458/1600 train_time:15586ms step_avg:34.03ms
+step:459/1600 train_time:15617ms step_avg:34.02ms
+step:460/1600 train_time:15654ms step_avg:34.03ms
+step:461/1600 train_time:15685ms step_avg:34.02ms
+step:462/1600 train_time:15721ms step_avg:34.03ms
+step:463/1600 train_time:15752ms step_avg:34.02ms
+step:464/1600 train_time:15789ms step_avg:34.03ms
+step:465/1600 train_time:15820ms step_avg:34.02ms
+step:466/1600 train_time:15857ms step_avg:34.03ms
+step:467/1600 train_time:15887ms step_avg:34.02ms
+step:468/1600 train_time:15924ms step_avg:34.03ms
+step:469/1600 train_time:15955ms step_avg:34.02ms
+step:470/1600 train_time:15992ms step_avg:34.03ms
+step:471/1600 train_time:16023ms step_avg:34.02ms
+step:472/1600 train_time:16060ms step_avg:34.02ms
+step:473/1600 train_time:16090ms step_avg:34.02ms
+step:474/1600 train_time:16127ms step_avg:34.02ms
+step:475/1600 train_time:16158ms step_avg:34.02ms
+step:476/1600 train_time:16195ms step_avg:34.02ms
+step:477/1600 train_time:16225ms step_avg:34.02ms
+step:478/1600 train_time:16262ms step_avg:34.02ms
+step:479/1600 train_time:16293ms step_avg:34.01ms
+step:480/1600 train_time:16330ms step_avg:34.02ms
+step:481/1600 train_time:16360ms step_avg:34.01ms
+step:482/1600 train_time:16398ms step_avg:34.02ms
+step:483/1600 train_time:16429ms step_avg:34.01ms
+step:484/1600 train_time:16465ms step_avg:34.02ms
+step:485/1600 train_time:16496ms step_avg:34.01ms
+step:486/1600 train_time:16533ms step_avg:34.02ms
+step:487/1600 train_time:16564ms step_avg:34.01ms
+step:488/1600 train_time:16601ms step_avg:34.02ms
+step:489/1600 train_time:16632ms step_avg:34.01ms
+step:490/1600 train_time:16669ms step_avg:34.02ms
+step:491/1600 train_time:16700ms step_avg:34.01ms
+step:492/1600 train_time:16737ms step_avg:34.02ms
+step:493/1600 train_time:16768ms step_avg:34.01ms
+step:494/1600 train_time:16805ms step_avg:34.02ms
+step:495/1600 train_time:16836ms step_avg:34.01ms
+step:496/1600 train_time:16873ms step_avg:34.02ms
+step:497/1600 train_time:16903ms step_avg:34.01ms
+step:498/1600 train_time:16940ms step_avg:34.02ms
+step:499/1600 train_time:16971ms step_avg:34.01ms
+step:500/1600 train_time:17008ms step_avg:34.02ms
+step:500/1600 val_loss:4.2354 train_time:17056ms step_avg:34.11ms
+step:501/1600 train_time:17075ms step_avg:34.08ms
+step:502/1600 train_time:17094ms step_avg:34.05ms
+step:503/1600 train_time:17111ms step_avg:34.02ms
+step:504/1600 train_time:17146ms step_avg:34.02ms
+step:505/1600 train_time:17178ms step_avg:34.02ms
+step:506/1600 train_time:17216ms step_avg:34.02ms
+step:507/1600 train_time:17247ms step_avg:34.02ms
+step:508/1600 train_time:17284ms step_avg:34.02ms
+step:509/1600 train_time:17315ms step_avg:34.02ms
+step:510/1600 train_time:17352ms step_avg:34.02ms
+step:511/1600 train_time:17382ms step_avg:34.02ms
+step:512/1600 train_time:17419ms step_avg:34.02ms
+step:513/1600 train_time:17450ms step_avg:34.02ms
+step:514/1600 train_time:17487ms step_avg:34.02ms
+step:515/1600 train_time:17518ms step_avg:34.01ms
+step:516/1600 train_time:17554ms step_avg:34.02ms
+step:517/1600 train_time:17585ms step_avg:34.01ms
+step:518/1600 train_time:17622ms step_avg:34.02ms
+step:519/1600 train_time:17653ms step_avg:34.01ms
+step:520/1600 train_time:17690ms step_avg:34.02ms
+step:521/1600 train_time:17761ms step_avg:34.09ms
+step:522/1600 train_time:17818ms step_avg:34.13ms
+step:523/1600 train_time:17879ms step_avg:34.19ms
+step:524/1600 train_time:17937ms step_avg:34.23ms
+step:525/1600 train_time:17999ms step_avg:34.28ms
+step:526/1600 train_time:18057ms step_avg:34.33ms
+step:527/1600 train_time:18119ms step_avg:34.38ms
+step:528/1600 train_time:18179ms step_avg:34.43ms
+step:529/1600 train_time:18243ms step_avg:34.49ms
+step:530/1600 train_time:18302ms step_avg:34.53ms
+step:531/1600 train_time:18365ms step_avg:34.58ms
+step:532/1600 train_time:18426ms step_avg:34.64ms
+step:533/1600 train_time:18486ms step_avg:34.68ms
+step:534/1600 train_time:18545ms step_avg:34.73ms
+step:535/1600 train_time:18608ms step_avg:34.78ms
+step:536/1600 train_time:18667ms step_avg:34.83ms
+step:537/1600 train_time:18730ms step_avg:34.88ms
+step:538/1600 train_time:18789ms step_avg:34.92ms
+step:539/1600 train_time:18851ms step_avg:34.97ms
+step:540/1600 train_time:18911ms step_avg:35.02ms
+step:541/1600 train_time:18973ms step_avg:35.07ms
+step:542/1600 train_time:19032ms step_avg:35.11ms
+step:543/1600 train_time:19095ms step_avg:35.17ms
+step:544/1600 train_time:19154ms step_avg:35.21ms
+step:545/1600 train_time:19216ms step_avg:35.26ms
+step:546/1600 train_time:19275ms step_avg:35.30ms
+step:547/1600 train_time:19338ms step_avg:35.35ms
+step:548/1600 train_time:19398ms step_avg:35.40ms
+step:549/1600 train_time:19460ms step_avg:35.45ms
+step:550/1600 train_time:19520ms step_avg:35.49ms
+step:551/1600 train_time:19583ms step_avg:35.54ms
+step:552/1600 train_time:19641ms step_avg:35.58ms
+step:553/1600 train_time:19704ms step_avg:35.63ms
+step:554/1600 train_time:19763ms step_avg:35.67ms
+step:555/1600 train_time:19826ms step_avg:35.72ms
+step:556/1600 train_time:19886ms step_avg:35.77ms
+step:557/1600 train_time:19948ms step_avg:35.81ms
+step:558/1600 train_time:20006ms step_avg:35.85ms
+step:559/1600 train_time:20068ms step_avg:35.90ms
+step:560/1600 train_time:20128ms step_avg:35.94ms
+step:561/1600 train_time:20191ms step_avg:35.99ms
+step:562/1600 train_time:20251ms step_avg:36.03ms
+step:563/1600 train_time:20313ms step_avg:36.08ms
+step:564/1600 train_time:20373ms step_avg:36.12ms
+step:565/1600 train_time:20435ms step_avg:36.17ms
+step:566/1600 train_time:20495ms step_avg:36.21ms
+step:567/1600 train_time:20557ms step_avg:36.26ms
+step:568/1600 train_time:20616ms step_avg:36.30ms
+step:569/1600 train_time:20680ms step_avg:36.34ms
+step:570/1600 train_time:20738ms step_avg:36.38ms
+step:571/1600 train_time:20801ms step_avg:36.43ms
+step:572/1600 train_time:20860ms step_avg:36.47ms
+step:573/1600 train_time:20926ms step_avg:36.52ms
+step:574/1600 train_time:20985ms step_avg:36.56ms
+step:575/1600 train_time:21047ms step_avg:36.60ms
+step:576/1600 train_time:21105ms step_avg:36.64ms
+step:577/1600 train_time:21167ms step_avg:36.68ms
+step:578/1600 train_time:21226ms step_avg:36.72ms
+step:579/1600 train_time:21289ms step_avg:36.77ms
+step:580/1600 train_time:21349ms step_avg:36.81ms
+step:581/1600 train_time:21412ms step_avg:36.85ms
+step:582/1600 train_time:21471ms step_avg:36.89ms
+step:583/1600 train_time:21534ms step_avg:36.94ms
+step:584/1600 train_time:21592ms step_avg:36.97ms
+step:585/1600 train_time:21655ms step_avg:37.02ms
+step:586/1600 train_time:21713ms step_avg:37.05ms
+step:587/1600 train_time:21776ms step_avg:37.10ms
+step:588/1600 train_time:21835ms step_avg:37.13ms
+step:589/1600 train_time:21898ms step_avg:37.18ms
+step:590/1600 train_time:21957ms step_avg:37.22ms
+step:591/1600 train_time:22019ms step_avg:37.26ms
+step:592/1600 train_time:22078ms step_avg:37.29ms
+step:593/1600 train_time:22141ms step_avg:37.34ms
+step:594/1600 train_time:22200ms step_avg:37.37ms
+step:595/1600 train_time:22263ms step_avg:37.42ms
+step:596/1600 train_time:22321ms step_avg:37.45ms
+step:597/1600 train_time:22384ms step_avg:37.49ms
+step:598/1600 train_time:22444ms step_avg:37.53ms
+step:599/1600 train_time:22507ms step_avg:37.57ms
+step:600/1600 train_time:22566ms step_avg:37.61ms
+step:601/1600 train_time:22629ms step_avg:37.65ms
+step:602/1600 train_time:22688ms step_avg:37.69ms
+step:603/1600 train_time:22751ms step_avg:37.73ms
+step:604/1600 train_time:22810ms step_avg:37.76ms
+step:605/1600 train_time:22872ms step_avg:37.80ms
+step:606/1600 train_time:22932ms step_avg:37.84ms
+step:607/1600 train_time:22994ms step_avg:37.88ms
+step:608/1600 train_time:23053ms step_avg:37.92ms
+step:609/1600 train_time:23115ms step_avg:37.96ms
+step:610/1600 train_time:23174ms step_avg:37.99ms
+step:611/1600 train_time:23237ms step_avg:38.03ms
+step:612/1600 train_time:23297ms step_avg:38.07ms
+step:613/1600 train_time:23359ms step_avg:38.11ms
+step:614/1600 train_time:23418ms step_avg:38.14ms
+step:615/1600 train_time:23481ms step_avg:38.18ms
+step:616/1600 train_time:23540ms step_avg:38.21ms
+step:617/1600 train_time:23602ms step_avg:38.25ms
+step:618/1600 train_time:23661ms step_avg:38.29ms
+step:619/1600 train_time:23723ms step_avg:38.32ms
+step:620/1600 train_time:23783ms step_avg:38.36ms
+step:621/1600 train_time:23845ms step_avg:38.40ms
+step:622/1600 train_time:23904ms step_avg:38.43ms
+step:623/1600 train_time:23966ms step_avg:38.47ms
+step:624/1600 train_time:24026ms step_avg:38.50ms
+step:625/1600 train_time:24088ms step_avg:38.54ms
+step:626/1600 train_time:24147ms step_avg:38.57ms
+step:627/1600 train_time:24210ms step_avg:38.61ms
+step:628/1600 train_time:24269ms step_avg:38.65ms
+step:629/1600 train_time:24332ms step_avg:38.68ms
+step:630/1600 train_time:24392ms step_avg:38.72ms
+step:631/1600 train_time:24453ms step_avg:38.75ms
+step:632/1600 train_time:24513ms step_avg:38.79ms
+step:633/1600 train_time:24576ms step_avg:38.82ms
+step:634/1600 train_time:24635ms step_avg:38.86ms
+step:635/1600 train_time:24697ms step_avg:38.89ms
+step:636/1600 train_time:24756ms step_avg:38.92ms
+step:637/1600 train_time:24819ms step_avg:38.96ms
+step:638/1600 train_time:24878ms step_avg:38.99ms
+step:639/1600 train_time:24941ms step_avg:39.03ms
+step:640/1600 train_time:25000ms step_avg:39.06ms
+step:641/1600 train_time:25062ms step_avg:39.10ms
+step:642/1600 train_time:25121ms step_avg:39.13ms
+step:643/1600 train_time:25184ms step_avg:39.17ms
+step:644/1600 train_time:25243ms step_avg:39.20ms
+step:645/1600 train_time:25306ms step_avg:39.23ms
+step:646/1600 train_time:25365ms step_avg:39.26ms
+step:647/1600 train_time:25428ms step_avg:39.30ms
+step:648/1600 train_time:25487ms step_avg:39.33ms
+step:649/1600 train_time:25550ms step_avg:39.37ms
+step:650/1600 train_time:25609ms step_avg:39.40ms
+step:651/1600 train_time:25671ms step_avg:39.43ms
+step:652/1600 train_time:25731ms step_avg:39.46ms
+step:653/1600 train_time:25794ms step_avg:39.50ms
+step:654/1600 train_time:25853ms step_avg:39.53ms
+step:655/1600 train_time:25914ms step_avg:39.56ms
+step:656/1600 train_time:25974ms step_avg:39.59ms
+step:657/1600 train_time:26036ms step_avg:39.63ms
+step:658/1600 train_time:26096ms step_avg:39.66ms
+step:659/1600 train_time:26159ms step_avg:39.69ms
+step:660/1600 train_time:26218ms step_avg:39.72ms
+step:661/1600 train_time:26280ms step_avg:39.76ms
+step:662/1600 train_time:26339ms step_avg:39.79ms
+step:663/1600 train_time:26401ms step_avg:39.82ms
+step:664/1600 train_time:26460ms step_avg:39.85ms
+step:665/1600 train_time:26522ms step_avg:39.88ms
+step:666/1600 train_time:26581ms step_avg:39.91ms
+step:667/1600 train_time:26646ms step_avg:39.95ms
+step:668/1600 train_time:26704ms step_avg:39.98ms
+step:669/1600 train_time:26767ms step_avg:40.01ms
+step:670/1600 train_time:26826ms step_avg:40.04ms
+step:671/1600 train_time:26888ms step_avg:40.07ms
+step:672/1600 train_time:26948ms step_avg:40.10ms
+step:673/1600 train_time:27011ms step_avg:40.13ms
+step:674/1600 train_time:27070ms step_avg:40.16ms
+step:675/1600 train_time:27132ms step_avg:40.20ms
+step:676/1600 train_time:27192ms step_avg:40.22ms
+step:677/1600 train_time:27254ms step_avg:40.26ms
+step:678/1600 train_time:27312ms step_avg:40.28ms
+step:679/1600 train_time:27375ms step_avg:40.32ms
+step:680/1600 train_time:27434ms step_avg:40.34ms
+step:681/1600 train_time:27496ms step_avg:40.38ms
+step:682/1600 train_time:27557ms step_avg:40.41ms
+step:683/1600 train_time:27618ms step_avg:40.44ms
+step:684/1600 train_time:27678ms step_avg:40.46ms
+step:685/1600 train_time:27741ms step_avg:40.50ms
+step:686/1600 train_time:27800ms step_avg:40.52ms
+step:687/1600 train_time:27862ms step_avg:40.56ms
+step:688/1600 train_time:27922ms step_avg:40.58ms
+step:689/1600 train_time:27984ms step_avg:40.61ms
+step:690/1600 train_time:28044ms step_avg:40.64ms
+step:691/1600 train_time:28106ms step_avg:40.67ms
+step:692/1600 train_time:28166ms step_avg:40.70ms
+step:693/1600 train_time:28228ms step_avg:40.73ms
+step:694/1600 train_time:28287ms step_avg:40.76ms
+step:695/1600 train_time:28349ms step_avg:40.79ms
+step:696/1600 train_time:28410ms step_avg:40.82ms
+step:697/1600 train_time:28471ms step_avg:40.85ms
+step:698/1600 train_time:28530ms step_avg:40.87ms
+step:699/1600 train_time:28593ms step_avg:40.91ms
+step:700/1600 train_time:28652ms step_avg:40.93ms
+step:701/1600 train_time:28714ms step_avg:40.96ms
+step:702/1600 train_time:28773ms step_avg:40.99ms
+step:703/1600 train_time:28836ms step_avg:41.02ms
+step:704/1600 train_time:28895ms step_avg:41.04ms
+step:705/1600 train_time:28957ms step_avg:41.07ms
+step:706/1600 train_time:29017ms step_avg:41.10ms
+step:707/1600 train_time:29079ms step_avg:41.13ms
+step:708/1600 train_time:29138ms step_avg:41.16ms
+step:709/1600 train_time:29201ms step_avg:41.19ms
+step:710/1600 train_time:29260ms step_avg:41.21ms
+step:711/1600 train_time:29325ms step_avg:41.24ms
+step:712/1600 train_time:29382ms step_avg:41.27ms
+step:713/1600 train_time:29444ms step_avg:41.30ms
+step:714/1600 train_time:29504ms step_avg:41.32ms
+step:715/1600 train_time:29566ms step_avg:41.35ms
+step:716/1600 train_time:29625ms step_avg:41.38ms
+step:717/1600 train_time:29688ms step_avg:41.41ms
+step:718/1600 train_time:29748ms step_avg:41.43ms
+step:719/1600 train_time:29811ms step_avg:41.46ms
+step:720/1600 train_time:29870ms step_avg:41.49ms
+step:721/1600 train_time:29932ms step_avg:41.51ms
+step:722/1600 train_time:29991ms step_avg:41.54ms
+step:723/1600 train_time:30053ms step_avg:41.57ms
+step:724/1600 train_time:30113ms step_avg:41.59ms
+step:725/1600 train_time:30175ms step_avg:41.62ms
+step:726/1600 train_time:30233ms step_avg:41.64ms
+step:727/1600 train_time:30295ms step_avg:41.67ms
+step:728/1600 train_time:30354ms step_avg:41.70ms
+step:729/1600 train_time:30417ms step_avg:41.72ms
+step:730/1600 train_time:30476ms step_avg:41.75ms
+step:731/1600 train_time:30539ms step_avg:41.78ms
+step:732/1600 train_time:30598ms step_avg:41.80ms
+step:733/1600 train_time:30660ms step_avg:41.83ms
+step:734/1600 train_time:30720ms step_avg:41.85ms
+step:735/1600 train_time:30782ms step_avg:41.88ms
+step:736/1600 train_time:30841ms step_avg:41.90ms
+step:737/1600 train_time:30904ms step_avg:41.93ms
+step:738/1600 train_time:30963ms step_avg:41.96ms
+step:739/1600 train_time:31026ms step_avg:41.98ms
+step:740/1600 train_time:31088ms step_avg:42.01ms
+step:741/1600 train_time:31148ms step_avg:42.04ms
+step:742/1600 train_time:31207ms step_avg:42.06ms
+step:743/1600 train_time:31270ms step_avg:42.09ms
+step:744/1600 train_time:31328ms step_avg:42.11ms
+step:745/1600 train_time:31391ms step_avg:42.14ms
+step:746/1600 train_time:31450ms step_avg:42.16ms
+step:747/1600 train_time:31513ms step_avg:42.19ms
+step:748/1600 train_time:31572ms step_avg:42.21ms
+step:749/1600 train_time:31634ms step_avg:42.24ms
+step:750/1600 train_time:31694ms step_avg:42.26ms
+step:750/1600 val_loss:3.8923 train_time:31741ms step_avg:42.32ms
+step:751/1600 train_time:31760ms step_avg:42.29ms
+step:752/1600 train_time:31823ms step_avg:42.32ms
+step:753/1600 train_time:31883ms step_avg:42.34ms
+step:754/1600 train_time:31943ms step_avg:42.36ms
+step:755/1600 train_time:32003ms step_avg:42.39ms
+step:756/1600 train_time:32062ms step_avg:42.41ms
+step:757/1600 train_time:32123ms step_avg:42.43ms
+step:758/1600 train_time:32182ms step_avg:42.46ms
+step:759/1600 train_time:32243ms step_avg:42.48ms
+step:760/1600 train_time:32302ms step_avg:42.50ms
+step:761/1600 train_time:32364ms step_avg:42.53ms
+step:762/1600 train_time:32423ms step_avg:42.55ms
+step:763/1600 train_time:32484ms step_avg:42.57ms
+step:764/1600 train_time:32544ms step_avg:42.60ms
+step:765/1600 train_time:32605ms step_avg:42.62ms
+step:766/1600 train_time:32665ms step_avg:42.64ms
+step:767/1600 train_time:32731ms step_avg:42.67ms
+step:768/1600 train_time:32791ms step_avg:42.70ms
+step:769/1600 train_time:32854ms step_avg:42.72ms
+step:770/1600 train_time:32914ms step_avg:42.75ms
+step:771/1600 train_time:32976ms step_avg:42.77ms
+step:772/1600 train_time:33035ms step_avg:42.79ms
+step:773/1600 train_time:33097ms step_avg:42.82ms
+step:774/1600 train_time:33156ms step_avg:42.84ms
+step:775/1600 train_time:33218ms step_avg:42.86ms
+step:776/1600 train_time:33276ms step_avg:42.88ms
+step:777/1600 train_time:33339ms step_avg:42.91ms
+step:778/1600 train_time:33397ms step_avg:42.93ms
+step:779/1600 train_time:33460ms step_avg:42.95ms
+step:780/1600 train_time:33519ms step_avg:42.97ms
+step:781/1600 train_time:33582ms step_avg:43.00ms
+step:782/1600 train_time:33641ms step_avg:43.02ms
+step:783/1600 train_time:33704ms step_avg:43.04ms
+step:784/1600 train_time:33764ms step_avg:43.07ms
+step:785/1600 train_time:33826ms step_avg:43.09ms
+step:786/1600 train_time:33886ms step_avg:43.11ms
+step:787/1600 train_time:33948ms step_avg:43.14ms
+step:788/1600 train_time:34007ms step_avg:43.16ms
+step:789/1600 train_time:34069ms step_avg:43.18ms
+step:790/1600 train_time:34128ms step_avg:43.20ms
+step:791/1600 train_time:34191ms step_avg:43.22ms
+step:792/1600 train_time:34250ms step_avg:43.24ms
+step:793/1600 train_time:34312ms step_avg:43.27ms
+step:794/1600 train_time:34372ms step_avg:43.29ms
+step:795/1600 train_time:34434ms step_avg:43.31ms
+step:796/1600 train_time:34493ms step_avg:43.33ms
+step:797/1600 train_time:34556ms step_avg:43.36ms
+step:798/1600 train_time:34615ms step_avg:43.38ms
+step:799/1600 train_time:34679ms step_avg:43.40ms
+step:800/1600 train_time:34738ms step_avg:43.42ms
+step:801/1600 train_time:34801ms step_avg:43.45ms
+step:802/1600 train_time:34860ms step_avg:43.47ms
+step:803/1600 train_time:34923ms step_avg:43.49ms
+step:804/1600 train_time:34981ms step_avg:43.51ms
+step:805/1600 train_time:35044ms step_avg:43.53ms
+step:806/1600 train_time:35103ms step_avg:43.55ms
+step:807/1600 train_time:35166ms step_avg:43.58ms
+step:808/1600 train_time:35224ms step_avg:43.59ms
+step:809/1600 train_time:35287ms step_avg:43.62ms
+step:810/1600 train_time:35346ms step_avg:43.64ms
+step:811/1600 train_time:35409ms step_avg:43.66ms
+step:812/1600 train_time:35467ms step_avg:43.68ms
+step:813/1600 train_time:35530ms step_avg:43.70ms
+step:814/1600 train_time:35589ms step_avg:43.72ms
+step:815/1600 train_time:35652ms step_avg:43.74ms
+step:816/1600 train_time:35711ms step_avg:43.76ms
+step:817/1600 train_time:35774ms step_avg:43.79ms
+step:818/1600 train_time:35833ms step_avg:43.81ms
+step:819/1600 train_time:35896ms step_avg:43.83ms
+step:820/1600 train_time:35955ms step_avg:43.85ms
+step:821/1600 train_time:36018ms step_avg:43.87ms
+step:822/1600 train_time:36077ms step_avg:43.89ms
+step:823/1600 train_time:36140ms step_avg:43.91ms
+step:824/1600 train_time:36199ms step_avg:43.93ms
+step:825/1600 train_time:36261ms step_avg:43.95ms
+step:826/1600 train_time:36321ms step_avg:43.97ms
+step:827/1600 train_time:36385ms step_avg:44.00ms
+step:828/1600 train_time:36443ms step_avg:44.01ms
+step:829/1600 train_time:36506ms step_avg:44.04ms
+step:830/1600 train_time:36566ms step_avg:44.06ms
+step:831/1600 train_time:36628ms step_avg:44.08ms
+step:832/1600 train_time:36687ms step_avg:44.10ms
+step:833/1600 train_time:36750ms step_avg:44.12ms
+step:834/1600 train_time:36809ms step_avg:44.14ms
+step:835/1600 train_time:36872ms step_avg:44.16ms
+step:836/1600 train_time:36931ms step_avg:44.18ms
+step:837/1600 train_time:36994ms step_avg:44.20ms
+step:838/1600 train_time:37053ms step_avg:44.22ms
+step:839/1600 train_time:37115ms step_avg:44.24ms
+step:840/1600 train_time:37174ms step_avg:44.25ms
+step:841/1600 train_time:37236ms step_avg:44.28ms
+step:842/1600 train_time:37296ms step_avg:44.29ms
+step:843/1600 train_time:37359ms step_avg:44.32ms
+step:844/1600 train_time:37418ms step_avg:44.33ms
+step:845/1600 train_time:37481ms step_avg:44.36ms
+step:846/1600 train_time:37540ms step_avg:44.37ms
+step:847/1600 train_time:37602ms step_avg:44.39ms
+step:848/1600 train_time:37661ms step_avg:44.41ms
+step:849/1600 train_time:37724ms step_avg:44.43ms
+step:850/1600 train_time:37783ms step_avg:44.45ms
+step:851/1600 train_time:37847ms step_avg:44.47ms
+step:852/1600 train_time:37906ms step_avg:44.49ms
+step:853/1600 train_time:37969ms step_avg:44.51ms
+step:854/1600 train_time:38027ms step_avg:44.53ms
+step:855/1600 train_time:38090ms step_avg:44.55ms
+step:856/1600 train_time:38149ms step_avg:44.57ms
+step:857/1600 train_time:38212ms step_avg:44.59ms
+step:858/1600 train_time:38271ms step_avg:44.60ms
+step:859/1600 train_time:38333ms step_avg:44.62ms
+step:860/1600 train_time:38392ms step_avg:44.64ms
+step:861/1600 train_time:38455ms step_avg:44.66ms
+step:862/1600 train_time:38514ms step_avg:44.68ms
+step:863/1600 train_time:38577ms step_avg:44.70ms
+step:864/1600 train_time:38636ms step_avg:44.72ms
+step:865/1600 train_time:38698ms step_avg:44.74ms
+step:866/1600 train_time:38757ms step_avg:44.75ms
+step:867/1600 train_time:38820ms step_avg:44.78ms
+step:868/1600 train_time:38881ms step_avg:44.79ms
+step:869/1600 train_time:38942ms step_avg:44.81ms
+step:870/1600 train_time:39002ms step_avg:44.83ms
+step:871/1600 train_time:39065ms step_avg:44.85ms
+step:872/1600 train_time:39124ms step_avg:44.87ms
+step:873/1600 train_time:39186ms step_avg:44.89ms
+step:874/1600 train_time:39245ms step_avg:44.90ms
+step:875/1600 train_time:39307ms step_avg:44.92ms
+step:876/1600 train_time:39366ms step_avg:44.94ms
+step:877/1600 train_time:39428ms step_avg:44.96ms
+step:878/1600 train_time:39488ms step_avg:44.97ms
+step:879/1600 train_time:39551ms step_avg:45.00ms
+step:880/1600 train_time:39610ms step_avg:45.01ms
+step:881/1600 train_time:39672ms step_avg:45.03ms
+step:882/1600 train_time:39732ms step_avg:45.05ms
+step:883/1600 train_time:39794ms step_avg:45.07ms
+step:884/1600 train_time:39854ms step_avg:45.08ms
+step:885/1600 train_time:39917ms step_avg:45.10ms
+step:886/1600 train_time:39976ms step_avg:45.12ms
+step:887/1600 train_time:40039ms step_avg:45.14ms
+step:888/1600 train_time:40098ms step_avg:45.16ms
+step:889/1600 train_time:40160ms step_avg:45.17ms
+step:890/1600 train_time:40223ms step_avg:45.19ms
+step:891/1600 train_time:40285ms step_avg:45.21ms
+step:892/1600 train_time:40344ms step_avg:45.23ms
+step:893/1600 train_time:40406ms step_avg:45.25ms
+step:894/1600 train_time:40464ms step_avg:45.26ms
+step:895/1600 train_time:40526ms step_avg:45.28ms
+step:896/1600 train_time:40586ms step_avg:45.30ms
+step:897/1600 train_time:40649ms step_avg:45.32ms
+step:898/1600 train_time:40708ms step_avg:45.33ms
+step:899/1600 train_time:40770ms step_avg:45.35ms
+step:900/1600 train_time:40829ms step_avg:45.37ms
+step:901/1600 train_time:40892ms step_avg:45.39ms
+step:902/1600 train_time:40951ms step_avg:45.40ms
+step:903/1600 train_time:41015ms step_avg:45.42ms
+step:904/1600 train_time:41074ms step_avg:45.44ms
+step:905/1600 train_time:41137ms step_avg:45.45ms
+step:906/1600 train_time:41197ms step_avg:45.47ms
+step:907/1600 train_time:41258ms step_avg:45.49ms
+step:908/1600 train_time:41317ms step_avg:45.50ms
+step:909/1600 train_time:41379ms step_avg:45.52ms
+step:910/1600 train_time:41438ms step_avg:45.54ms
+step:911/1600 train_time:41501ms step_avg:45.56ms
+step:912/1600 train_time:41561ms step_avg:45.57ms
+step:913/1600 train_time:41624ms step_avg:45.59ms
+step:914/1600 train_time:41683ms step_avg:45.60ms
+step:915/1600 train_time:41745ms step_avg:45.62ms
+step:916/1600 train_time:41805ms step_avg:45.64ms
+step:917/1600 train_time:41867ms step_avg:45.66ms
+step:918/1600 train_time:41926ms step_avg:45.67ms
+step:919/1600 train_time:41989ms step_avg:45.69ms
+step:920/1600 train_time:42051ms step_avg:45.71ms
+step:921/1600 train_time:42112ms step_avg:45.72ms
+step:922/1600 train_time:42172ms step_avg:45.74ms
+step:923/1600 train_time:42234ms step_avg:45.76ms
+step:924/1600 train_time:42293ms step_avg:45.77ms
+step:925/1600 train_time:42355ms step_avg:45.79ms
+step:926/1600 train_time:42415ms step_avg:45.80ms
+step:927/1600 train_time:42477ms step_avg:45.82ms
+step:928/1600 train_time:42536ms step_avg:45.84ms
+step:929/1600 train_time:42600ms step_avg:45.86ms
+step:930/1600 train_time:42658ms step_avg:45.87ms
+step:931/1600 train_time:42720ms step_avg:45.89ms
+step:932/1600 train_time:42780ms step_avg:45.90ms
+step:933/1600 train_time:42842ms step_avg:45.92ms
+step:934/1600 train_time:42902ms step_avg:45.93ms
+step:935/1600 train_time:42965ms step_avg:45.95ms
+step:936/1600 train_time:43023ms step_avg:45.97ms
+step:937/1600 train_time:43087ms step_avg:45.98ms
+step:938/1600 train_time:43146ms step_avg:46.00ms
+step:939/1600 train_time:43209ms step_avg:46.02ms
+step:940/1600 train_time:43268ms step_avg:46.03ms
+step:941/1600 train_time:43330ms step_avg:46.05ms
+step:942/1600 train_time:43390ms step_avg:46.06ms
+step:943/1600 train_time:43453ms step_avg:46.08ms
+step:944/1600 train_time:43512ms step_avg:46.09ms
+step:945/1600 train_time:43575ms step_avg:46.11ms
+step:946/1600 train_time:43634ms step_avg:46.12ms
+step:947/1600 train_time:43696ms step_avg:46.14ms
+step:948/1600 train_time:43756ms step_avg:46.16ms
+step:949/1600 train_time:43818ms step_avg:46.17ms
+step:950/1600 train_time:43877ms step_avg:46.19ms
+step:951/1600 train_time:43940ms step_avg:46.20ms
+step:952/1600 train_time:43999ms step_avg:46.22ms
+step:953/1600 train_time:44062ms step_avg:46.23ms
+step:954/1600 train_time:44121ms step_avg:46.25ms
+step:955/1600 train_time:44186ms step_avg:46.27ms
+step:956/1600 train_time:44243ms step_avg:46.28ms
+step:957/1600 train_time:44306ms step_avg:46.30ms
+step:958/1600 train_time:44365ms step_avg:46.31ms
+step:959/1600 train_time:44427ms step_avg:46.33ms
+step:960/1600 train_time:44486ms step_avg:46.34ms
+step:961/1600 train_time:44549ms step_avg:46.36ms
+step:962/1600 train_time:44608ms step_avg:46.37ms
+step:963/1600 train_time:44670ms step_avg:46.39ms
+step:964/1600 train_time:44730ms step_avg:46.40ms
+step:965/1600 train_time:44793ms step_avg:46.42ms
+step:966/1600 train_time:44852ms step_avg:46.43ms
+step:967/1600 train_time:44915ms step_avg:46.45ms
+step:968/1600 train_time:44974ms step_avg:46.46ms
+step:969/1600 train_time:45037ms step_avg:46.48ms
+step:970/1600 train_time:45096ms step_avg:46.49ms
+step:971/1600 train_time:45159ms step_avg:46.51ms
+step:972/1600 train_time:45218ms step_avg:46.52ms
+step:973/1600 train_time:45281ms step_avg:46.54ms
+step:974/1600 train_time:45340ms step_avg:46.55ms
+step:975/1600 train_time:45403ms step_avg:46.57ms
+step:976/1600 train_time:45462ms step_avg:46.58ms
+step:977/1600 train_time:45524ms step_avg:46.60ms
+step:978/1600 train_time:45583ms step_avg:46.61ms
+step:979/1600 train_time:45645ms step_avg:46.62ms
+step:980/1600 train_time:45704ms step_avg:46.64ms
+step:981/1600 train_time:45766ms step_avg:46.65ms
+step:982/1600 train_time:45825ms step_avg:46.67ms
+step:983/1600 train_time:45888ms step_avg:46.68ms
+step:984/1600 train_time:45947ms step_avg:46.69ms
+step:985/1600 train_time:46010ms step_avg:46.71ms
+step:986/1600 train_time:46069ms step_avg:46.72ms
+step:987/1600 train_time:46132ms step_avg:46.74ms
+step:988/1600 train_time:46191ms step_avg:46.75ms
+step:989/1600 train_time:46254ms step_avg:46.77ms
+step:990/1600 train_time:46314ms step_avg:46.78ms
+step:991/1600 train_time:46376ms step_avg:46.80ms
+step:992/1600 train_time:46435ms step_avg:46.81ms
+step:993/1600 train_time:46498ms step_avg:46.83ms
+step:994/1600 train_time:46557ms step_avg:46.84ms
+step:995/1600 train_time:46619ms step_avg:46.85ms
+step:996/1600 train_time:46678ms step_avg:46.87ms
+step:997/1600 train_time:46741ms step_avg:46.88ms
+step:998/1600 train_time:46800ms step_avg:46.89ms
+step:999/1600 train_time:46862ms step_avg:46.91ms
+step:1000/1600 train_time:46922ms step_avg:46.92ms
+step:1000/1600 val_loss:3.5971 train_time:46968ms step_avg:46.97ms
+step:1001/1600 train_time:46988ms step_avg:46.94ms
+step:1002/1600 train_time:47046ms step_avg:46.95ms
+step:1003/1600 train_time:47109ms step_avg:46.97ms
+step:1004/1600 train_time:47170ms step_avg:46.98ms
+step:1005/1600 train_time:47232ms step_avg:47.00ms
+step:1006/1600 train_time:47290ms step_avg:47.01ms
+step:1007/1600 train_time:47351ms step_avg:47.02ms
+step:1008/1600 train_time:47410ms step_avg:47.03ms
+step:1009/1600 train_time:47471ms step_avg:47.05ms
+step:1010/1600 train_time:47530ms step_avg:47.06ms
+step:1011/1600 train_time:47593ms step_avg:47.08ms
+step:1012/1600 train_time:47651ms step_avg:47.09ms
+step:1013/1600 train_time:47713ms step_avg:47.10ms
+step:1014/1600 train_time:47771ms step_avg:47.11ms
+step:1015/1600 train_time:47833ms step_avg:47.13ms
+step:1016/1600 train_time:47892ms step_avg:47.14ms
+step:1017/1600 train_time:47957ms step_avg:47.16ms
+step:1018/1600 train_time:48019ms step_avg:47.17ms
+step:1019/1600 train_time:48081ms step_avg:47.18ms
+step:1020/1600 train_time:48141ms step_avg:47.20ms
+step:1021/1600 train_time:48203ms step_avg:47.21ms
+step:1022/1600 train_time:48262ms step_avg:47.22ms
+step:1023/1600 train_time:48324ms step_avg:47.24ms
+step:1024/1600 train_time:48382ms step_avg:47.25ms
+step:1025/1600 train_time:48445ms step_avg:47.26ms
+step:1026/1600 train_time:48504ms step_avg:47.27ms
+step:1027/1600 train_time:48566ms step_avg:47.29ms
+step:1028/1600 train_time:48626ms step_avg:47.30ms
+step:1029/1600 train_time:48689ms step_avg:47.32ms
+step:1030/1600 train_time:48746ms step_avg:47.33ms
+step:1031/1600 train_time:48810ms step_avg:47.34ms
+step:1032/1600 train_time:48869ms step_avg:47.35ms
+step:1033/1600 train_time:48932ms step_avg:47.37ms
+step:1034/1600 train_time:48991ms step_avg:47.38ms
+step:1035/1600 train_time:49054ms step_avg:47.40ms
+step:1036/1600 train_time:49114ms step_avg:47.41ms
+step:1037/1600 train_time:49176ms step_avg:47.42ms
+step:1038/1600 train_time:49235ms step_avg:47.43ms
+step:1039/1600 train_time:49297ms step_avg:47.45ms
+step:1040/1600 train_time:49357ms step_avg:47.46ms
+step:1041/1600 train_time:49428ms step_avg:47.48ms
+step:1042/1600 train_time:49511ms step_avg:47.52ms
+step:1043/1600 train_time:49600ms step_avg:47.55ms
+step:1044/1600 train_time:49684ms step_avg:47.59ms
+step:1045/1600 train_time:49773ms step_avg:47.63ms
+step:1046/1600 train_time:49858ms step_avg:47.67ms
+step:1047/1600 train_time:49948ms step_avg:47.71ms
+step:1048/1600 train_time:50033ms step_avg:47.74ms
+step:1049/1600 train_time:50123ms step_avg:47.78ms
+step:1050/1600 train_time:50207ms step_avg:47.82ms
+step:1051/1600 train_time:50296ms step_avg:47.86ms
+step:1052/1600 train_time:50381ms step_avg:47.89ms
+step:1053/1600 train_time:50469ms step_avg:47.93ms
+step:1054/1600 train_time:50554ms step_avg:47.96ms
+step:1055/1600 train_time:50642ms step_avg:48.00ms
+step:1056/1600 train_time:50727ms step_avg:48.04ms
+step:1057/1600 train_time:50816ms step_avg:48.08ms
+step:1058/1600 train_time:50901ms step_avg:48.11ms
+step:1059/1600 train_time:50990ms step_avg:48.15ms
+step:1060/1600 train_time:51075ms step_avg:48.18ms
+step:1061/1600 train_time:51165ms step_avg:48.22ms
+step:1062/1600 train_time:51249ms step_avg:48.26ms
+step:1063/1600 train_time:51337ms step_avg:48.29ms
+step:1064/1600 train_time:51422ms step_avg:48.33ms
+step:1065/1600 train_time:51511ms step_avg:48.37ms
+step:1066/1600 train_time:51596ms step_avg:48.40ms
+step:1067/1600 train_time:51684ms step_avg:48.44ms
+step:1068/1600 train_time:51769ms step_avg:48.47ms
+step:1069/1600 train_time:51857ms step_avg:48.51ms
+step:1070/1600 train_time:51943ms step_avg:48.55ms
+step:1071/1600 train_time:52032ms step_avg:48.58ms
+step:1072/1600 train_time:52117ms step_avg:48.62ms
+step:1073/1600 train_time:52206ms step_avg:48.65ms
+step:1074/1600 train_time:52291ms step_avg:48.69ms
+step:1075/1600 train_time:52381ms step_avg:48.73ms
+step:1076/1600 train_time:52465ms step_avg:48.76ms
+step:1077/1600 train_time:52553ms step_avg:48.80ms
+step:1078/1600 train_time:52637ms step_avg:48.83ms
+step:1079/1600 train_time:52725ms step_avg:48.86ms
+step:1080/1600 train_time:52811ms step_avg:48.90ms
+step:1081/1600 train_time:52899ms step_avg:48.94ms
+step:1082/1600 train_time:52984ms step_avg:48.97ms
+step:1083/1600 train_time:53073ms step_avg:49.01ms
+step:1084/1600 train_time:53160ms step_avg:49.04ms
+step:1085/1600 train_time:53247ms step_avg:49.08ms
+step:1086/1600 train_time:53333ms step_avg:49.11ms
+step:1087/1600 train_time:53421ms step_avg:49.15ms
+step:1088/1600 train_time:53506ms step_avg:49.18ms
+step:1089/1600 train_time:53596ms step_avg:49.22ms
+step:1090/1600 train_time:53680ms step_avg:49.25ms
+step:1091/1600 train_time:53768ms step_avg:49.28ms
+step:1092/1600 train_time:53853ms step_avg:49.32ms
+step:1093/1600 train_time:53941ms step_avg:49.35ms
+step:1094/1600 train_time:54026ms step_avg:49.38ms
+step:1095/1600 train_time:54114ms step_avg:49.42ms
+step:1096/1600 train_time:54200ms step_avg:49.45ms
+step:1097/1600 train_time:54288ms step_avg:49.49ms
+step:1098/1600 train_time:54373ms step_avg:49.52ms
+step:1099/1600 train_time:54460ms step_avg:49.55ms
+step:1100/1600 train_time:54547ms step_avg:49.59ms
+step:1101/1600 train_time:54635ms step_avg:49.62ms
+step:1102/1600 train_time:54720ms step_avg:49.66ms
+step:1103/1600 train_time:54809ms step_avg:49.69ms
+step:1104/1600 train_time:54893ms step_avg:49.72ms
+step:1105/1600 train_time:54981ms step_avg:49.76ms
+step:1106/1600 train_time:55066ms step_avg:49.79ms
+step:1107/1600 train_time:55154ms step_avg:49.82ms
+step:1108/1600 train_time:55239ms step_avg:49.86ms
+step:1109/1600 train_time:55327ms step_avg:49.89ms
+step:1110/1600 train_time:55412ms step_avg:49.92ms
+step:1111/1600 train_time:55501ms step_avg:49.96ms
+step:1112/1600 train_time:55587ms step_avg:49.99ms
+step:1113/1600 train_time:55675ms step_avg:50.02ms
+step:1114/1600 train_time:55760ms step_avg:50.05ms
+step:1115/1600 train_time:55849ms step_avg:50.09ms
+step:1116/1600 train_time:55934ms step_avg:50.12ms
+step:1117/1600 train_time:56025ms step_avg:50.16ms
+step:1118/1600 train_time:56109ms step_avg:50.19ms
+step:1119/1600 train_time:56196ms step_avg:50.22ms
+step:1120/1600 train_time:56281ms step_avg:50.25ms
+step:1121/1600 train_time:56369ms step_avg:50.28ms
+step:1122/1600 train_time:56455ms step_avg:50.32ms
+step:1123/1600 train_time:56543ms step_avg:50.35ms
+step:1124/1600 train_time:56628ms step_avg:50.38ms
+step:1125/1600 train_time:56716ms step_avg:50.41ms
+step:1126/1600 train_time:56801ms step_avg:50.44ms
+step:1127/1600 train_time:56888ms step_avg:50.48ms
+step:1128/1600 train_time:56974ms step_avg:50.51ms
+step:1129/1600 train_time:57062ms step_avg:50.54ms
+step:1130/1600 train_time:57148ms step_avg:50.57ms
+step:1131/1600 train_time:57236ms step_avg:50.61ms
+step:1132/1600 train_time:57322ms step_avg:50.64ms
+step:1133/1600 train_time:57410ms step_avg:50.67ms
+step:1134/1600 train_time:57495ms step_avg:50.70ms
+step:1135/1600 train_time:57583ms step_avg:50.73ms
+step:1136/1600 train_time:57668ms step_avg:50.76ms
+step:1137/1600 train_time:57757ms step_avg:50.80ms
+step:1138/1600 train_time:57842ms step_avg:50.83ms
+step:1139/1600 train_time:57930ms step_avg:50.86ms
+step:1140/1600 train_time:58014ms step_avg:50.89ms
+step:1141/1600 train_time:58103ms step_avg:50.92ms
+step:1142/1600 train_time:58188ms step_avg:50.95ms
+step:1143/1600 train_time:58276ms step_avg:50.99ms
+step:1144/1600 train_time:58361ms step_avg:51.01ms
+step:1145/1600 train_time:58449ms step_avg:51.05ms
+step:1146/1600 train_time:58535ms step_avg:51.08ms
+step:1147/1600 train_time:58623ms step_avg:51.11ms
+step:1148/1600 train_time:58708ms step_avg:51.14ms
+step:1149/1600 train_time:58795ms step_avg:51.17ms
+step:1150/1600 train_time:58880ms step_avg:51.20ms
+step:1151/1600 train_time:58968ms step_avg:51.23ms
+step:1152/1600 train_time:59053ms step_avg:51.26ms
+step:1153/1600 train_time:59142ms step_avg:51.29ms
+step:1154/1600 train_time:59230ms step_avg:51.33ms
+step:1155/1600 train_time:59318ms step_avg:51.36ms
+step:1156/1600 train_time:59402ms step_avg:51.39ms
+step:1157/1600 train_time:59490ms step_avg:51.42ms
+step:1158/1600 train_time:59575ms step_avg:51.45ms
+step:1159/1600 train_time:59663ms step_avg:51.48ms
+step:1160/1600 train_time:59750ms step_avg:51.51ms
+step:1161/1600 train_time:59837ms step_avg:51.54ms
+step:1162/1600 train_time:59923ms step_avg:51.57ms
+step:1163/1600 train_time:60012ms step_avg:51.60ms
+step:1164/1600 train_time:60097ms step_avg:51.63ms
+step:1165/1600 train_time:60186ms step_avg:51.66ms
+step:1166/1600 train_time:60271ms step_avg:51.69ms
+step:1167/1600 train_time:60359ms step_avg:51.72ms
+step:1168/1600 train_time:60444ms step_avg:51.75ms
+step:1169/1600 train_time:60532ms step_avg:51.78ms
+step:1170/1600 train_time:60618ms step_avg:51.81ms
+step:1171/1600 train_time:60706ms step_avg:51.84ms
+step:1172/1600 train_time:60791ms step_avg:51.87ms
+step:1173/1600 train_time:60879ms step_avg:51.90ms
+step:1174/1600 train_time:60964ms step_avg:51.93ms
+step:1175/1600 train_time:61052ms step_avg:51.96ms
+step:1176/1600 train_time:61138ms step_avg:51.99ms
+step:1177/1600 train_time:61226ms step_avg:52.02ms
+step:1178/1600 train_time:61312ms step_avg:52.05ms
+step:1179/1600 train_time:61400ms step_avg:52.08ms
+step:1180/1600 train_time:61484ms step_avg:52.11ms
+step:1181/1600 train_time:61574ms step_avg:52.14ms
+step:1182/1600 train_time:61660ms step_avg:52.17ms
+step:1183/1600 train_time:61748ms step_avg:52.20ms
+step:1184/1600 train_time:61832ms step_avg:52.22ms
+step:1185/1600 train_time:61921ms step_avg:52.25ms
+step:1186/1600 train_time:62005ms step_avg:52.28ms
+step:1187/1600 train_time:62094ms step_avg:52.31ms
+step:1188/1600 train_time:62179ms step_avg:52.34ms
+step:1189/1600 train_time:62267ms step_avg:52.37ms
+step:1190/1600 train_time:62352ms step_avg:52.40ms
+step:1191/1600 train_time:62440ms step_avg:52.43ms
+step:1192/1600 train_time:62525ms step_avg:52.45ms
+step:1193/1600 train_time:62614ms step_avg:52.48ms
+step:1194/1600 train_time:62699ms step_avg:52.51ms
+step:1195/1600 train_time:62786ms step_avg:52.54ms
+step:1196/1600 train_time:62872ms step_avg:52.57ms
+step:1197/1600 train_time:62960ms step_avg:52.60ms
+step:1198/1600 train_time:63045ms step_avg:52.63ms
+step:1199/1600 train_time:63133ms step_avg:52.65ms
+step:1200/1600 train_time:63218ms step_avg:52.68ms
+step:1201/1600 train_time:63306ms step_avg:52.71ms
+step:1202/1600 train_time:63391ms step_avg:52.74ms
+step:1203/1600 train_time:63479ms step_avg:52.77ms
+step:1204/1600 train_time:63564ms step_avg:52.79ms
+step:1205/1600 train_time:63653ms step_avg:52.82ms
+step:1206/1600 train_time:63738ms step_avg:52.85ms
+step:1207/1600 train_time:63828ms step_avg:52.88ms
+step:1208/1600 train_time:63913ms step_avg:52.91ms
+step:1209/1600 train_time:64001ms step_avg:52.94ms
+step:1210/1600 train_time:64086ms step_avg:52.96ms
+step:1211/1600 train_time:64174ms step_avg:52.99ms
+step:1212/1600 train_time:64260ms step_avg:53.02ms
+step:1213/1600 train_time:64348ms step_avg:53.05ms
+step:1214/1600 train_time:64433ms step_avg:53.07ms
+step:1215/1600 train_time:64522ms step_avg:53.10ms
+step:1216/1600 train_time:64607ms step_avg:53.13ms
+step:1217/1600 train_time:64695ms step_avg:53.16ms
+step:1218/1600 train_time:64781ms step_avg:53.19ms
+step:1219/1600 train_time:64869ms step_avg:53.22ms
+step:1220/1600 train_time:64954ms step_avg:53.24ms
+step:1221/1600 train_time:65042ms step_avg:53.27ms
+step:1222/1600 train_time:65127ms step_avg:53.30ms
+step:1223/1600 train_time:65215ms step_avg:53.32ms
+step:1224/1600 train_time:65300ms step_avg:53.35ms
+step:1225/1600 train_time:65388ms step_avg:53.38ms
+step:1226/1600 train_time:65473ms step_avg:53.40ms
+step:1227/1600 train_time:65561ms step_avg:53.43ms
+step:1228/1600 train_time:65646ms step_avg:53.46ms
+step:1229/1600 train_time:65735ms step_avg:53.49ms
+step:1230/1600 train_time:65820ms step_avg:53.51ms
+step:1231/1600 train_time:65908ms step_avg:53.54ms
+step:1232/1600 train_time:65993ms step_avg:53.57ms
+step:1233/1600 train_time:66081ms step_avg:53.59ms
+step:1234/1600 train_time:66166ms step_avg:53.62ms
+step:1235/1600 train_time:66254ms step_avg:53.65ms
+step:1236/1600 train_time:66339ms step_avg:53.67ms
+step:1237/1600 train_time:66427ms step_avg:53.70ms
+step:1238/1600 train_time:66512ms step_avg:53.73ms
+step:1239/1600 train_time:66600ms step_avg:53.75ms
+step:1240/1600 train_time:66685ms step_avg:53.78ms
+step:1241/1600 train_time:66775ms step_avg:53.81ms
+step:1242/1600 train_time:66860ms step_avg:53.83ms
+step:1243/1600 train_time:66948ms step_avg:53.86ms
+step:1244/1600 train_time:67033ms step_avg:53.89ms
+step:1245/1600 train_time:67121ms step_avg:53.91ms
+step:1246/1600 train_time:67206ms step_avg:53.94ms
+step:1247/1600 train_time:67294ms step_avg:53.96ms
+step:1248/1600 train_time:67378ms step_avg:53.99ms
+step:1249/1600 train_time:67466ms step_avg:54.02ms
+step:1250/1600 train_time:67552ms step_avg:54.04ms
+step:1250/1600 val_loss:3.4162 train_time:67624ms step_avg:54.10ms
+step:1251/1600 train_time:67645ms step_avg:54.07ms
+step:1252/1600 train_time:67732ms step_avg:54.10ms
+step:1253/1600 train_time:67825ms step_avg:54.13ms
+step:1254/1600 train_time:67912ms step_avg:54.16ms
+step:1255/1600 train_time:67998ms step_avg:54.18ms
+step:1256/1600 train_time:68083ms step_avg:54.21ms
+step:1257/1600 train_time:68169ms step_avg:54.23ms
+step:1258/1600 train_time:68254ms step_avg:54.26ms
+step:1259/1600 train_time:68341ms step_avg:54.28ms
+step:1260/1600 train_time:68425ms step_avg:54.31ms
+step:1261/1600 train_time:68513ms step_avg:54.33ms
+step:1262/1600 train_time:68598ms step_avg:54.36ms
+step:1263/1600 train_time:68687ms step_avg:54.38ms
+step:1264/1600 train_time:68775ms step_avg:54.41ms
+step:1265/1600 train_time:68864ms step_avg:54.44ms
+step:1266/1600 train_time:68950ms step_avg:54.46ms
+step:1267/1600 train_time:69038ms step_avg:54.49ms
+step:1268/1600 train_time:69122ms step_avg:54.51ms
+step:1269/1600 train_time:69209ms step_avg:54.54ms
+step:1270/1600 train_time:69294ms step_avg:54.56ms
+step:1271/1600 train_time:69380ms step_avg:54.59ms
+step:1272/1600 train_time:69465ms step_avg:54.61ms
+step:1273/1600 train_time:69552ms step_avg:54.64ms
+step:1274/1600 train_time:69639ms step_avg:54.66ms
+step:1275/1600 train_time:69727ms step_avg:54.69ms
+step:1276/1600 train_time:69814ms step_avg:54.71ms
+step:1277/1600 train_time:69903ms step_avg:54.74ms
+step:1278/1600 train_time:69990ms step_avg:54.76ms
+step:1279/1600 train_time:70078ms step_avg:54.79ms
+step:1280/1600 train_time:70163ms step_avg:54.82ms
+step:1281/1600 train_time:70251ms step_avg:54.84ms
+step:1282/1600 train_time:70335ms step_avg:54.86ms
+step:1283/1600 train_time:70422ms step_avg:54.89ms
+step:1284/1600 train_time:70507ms step_avg:54.91ms
+step:1285/1600 train_time:70595ms step_avg:54.94ms
+step:1286/1600 train_time:70681ms step_avg:54.96ms
+step:1287/1600 train_time:70769ms step_avg:54.99ms
+step:1288/1600 train_time:70855ms step_avg:55.01ms
+step:1289/1600 train_time:70944ms step_avg:55.04ms
+step:1290/1600 train_time:71030ms step_avg:55.06ms
+step:1291/1600 train_time:71119ms step_avg:55.09ms
+step:1292/1600 train_time:71203ms step_avg:55.11ms
+step:1293/1600 train_time:71291ms step_avg:55.14ms
+step:1294/1600 train_time:71376ms step_avg:55.16ms
+step:1295/1600 train_time:71463ms step_avg:55.18ms
+step:1296/1600 train_time:71548ms step_avg:55.21ms
+step:1297/1600 train_time:71638ms step_avg:55.23ms
+step:1298/1600 train_time:71722ms step_avg:55.26ms
+step:1299/1600 train_time:71812ms step_avg:55.28ms
+step:1300/1600 train_time:71898ms step_avg:55.31ms
+step:1301/1600 train_time:71987ms step_avg:55.33ms
+step:1302/1600 train_time:72072ms step_avg:55.36ms
+step:1303/1600 train_time:72160ms step_avg:55.38ms
+step:1304/1600 train_time:72245ms step_avg:55.40ms
+step:1305/1600 train_time:72333ms step_avg:55.43ms
+step:1306/1600 train_time:72418ms step_avg:55.45ms
+step:1307/1600 train_time:72506ms step_avg:55.48ms
+step:1308/1600 train_time:72592ms step_avg:55.50ms
+step:1309/1600 train_time:72680ms step_avg:55.52ms
+step:1310/1600 train_time:72766ms step_avg:55.55ms
+step:1311/1600 train_time:72854ms step_avg:55.57ms
+step:1312/1600 train_time:72939ms step_avg:55.59ms
+step:1313/1600 train_time:73028ms step_avg:55.62ms
+step:1314/1600 train_time:73114ms step_avg:55.64ms
+step:1315/1600 train_time:73201ms step_avg:55.67ms
+step:1316/1600 train_time:73286ms step_avg:55.69ms
+step:1317/1600 train_time:73375ms step_avg:55.71ms
+step:1318/1600 train_time:73459ms step_avg:55.74ms
+step:1319/1600 train_time:73546ms step_avg:55.76ms
+step:1320/1600 train_time:73632ms step_avg:55.78ms
+step:1321/1600 train_time:73720ms step_avg:55.81ms
+step:1322/1600 train_time:73805ms step_avg:55.83ms
+step:1323/1600 train_time:73894ms step_avg:55.85ms
+step:1324/1600 train_time:73979ms step_avg:55.88ms
+step:1325/1600 train_time:74068ms step_avg:55.90ms
+step:1326/1600 train_time:74152ms step_avg:55.92ms
+step:1327/1600 train_time:74241ms step_avg:55.95ms
+step:1328/1600 train_time:74326ms step_avg:55.97ms
+step:1329/1600 train_time:74414ms step_avg:55.99ms
+step:1330/1600 train_time:74499ms step_avg:56.01ms
+step:1331/1600 train_time:74588ms step_avg:56.04ms
+step:1332/1600 train_time:74673ms step_avg:56.06ms
+step:1333/1600 train_time:74762ms step_avg:56.09ms
+step:1334/1600 train_time:74847ms step_avg:56.11ms
+step:1335/1600 train_time:74936ms step_avg:56.13ms
+step:1336/1600 train_time:75021ms step_avg:56.15ms
+step:1337/1600 train_time:75110ms step_avg:56.18ms
+step:1338/1600 train_time:75195ms step_avg:56.20ms
+step:1339/1600 train_time:75284ms step_avg:56.22ms
+step:1340/1600 train_time:75368ms step_avg:56.24ms
+step:1341/1600 train_time:75457ms step_avg:56.27ms
+step:1342/1600 train_time:75541ms step_avg:56.29ms
+step:1343/1600 train_time:75629ms step_avg:56.31ms
+step:1344/1600 train_time:75714ms step_avg:56.33ms
+step:1345/1600 train_time:75802ms step_avg:56.36ms
+step:1346/1600 train_time:75887ms step_avg:56.38ms
+step:1347/1600 train_time:75974ms step_avg:56.40ms
+step:1348/1600 train_time:76060ms step_avg:56.42ms
+step:1349/1600 train_time:76148ms step_avg:56.45ms
+step:1350/1600 train_time:76234ms step_avg:56.47ms
+step:1351/1600 train_time:76323ms step_avg:56.49ms
+step:1352/1600 train_time:76408ms step_avg:56.51ms
+step:1353/1600 train_time:76496ms step_avg:56.54ms
+step:1354/1600 train_time:76581ms step_avg:56.56ms
+step:1355/1600 train_time:76669ms step_avg:56.58ms
+step:1356/1600 train_time:76754ms step_avg:56.60ms
+step:1357/1600 train_time:76842ms step_avg:56.63ms
+step:1358/1600 train_time:76927ms step_avg:56.65ms
+step:1359/1600 train_time:77015ms step_avg:56.67ms
+step:1360/1600 train_time:77101ms step_avg:56.69ms
+step:1361/1600 train_time:77189ms step_avg:56.71ms
+step:1362/1600 train_time:77275ms step_avg:56.74ms
+step:1363/1600 train_time:77362ms step_avg:56.76ms
+step:1364/1600 train_time:77447ms step_avg:56.78ms
+step:1365/1600 train_time:77535ms step_avg:56.80ms
+step:1366/1600 train_time:77622ms step_avg:56.82ms
+step:1367/1600 train_time:77710ms step_avg:56.85ms
+step:1368/1600 train_time:77796ms step_avg:56.87ms
+step:1369/1600 train_time:77883ms step_avg:56.89ms
+step:1370/1600 train_time:77968ms step_avg:56.91ms
+step:1371/1600 train_time:78055ms step_avg:56.93ms
+step:1372/1600 train_time:78140ms step_avg:56.95ms
+step:1373/1600 train_time:78229ms step_avg:56.98ms
+step:1374/1600 train_time:78315ms step_avg:57.00ms
+step:1375/1600 train_time:78403ms step_avg:57.02ms
+step:1376/1600 train_time:78489ms step_avg:57.04ms
+step:1377/1600 train_time:78576ms step_avg:57.06ms
+step:1378/1600 train_time:78661ms step_avg:57.08ms
+step:1379/1600 train_time:78749ms step_avg:57.11ms
+step:1380/1600 train_time:78835ms step_avg:57.13ms
+step:1381/1600 train_time:78925ms step_avg:57.15ms
+step:1382/1600 train_time:79010ms step_avg:57.17ms
+step:1383/1600 train_time:79099ms step_avg:57.19ms
+step:1384/1600 train_time:79184ms step_avg:57.21ms
+step:1385/1600 train_time:79272ms step_avg:57.24ms
+step:1386/1600 train_time:79358ms step_avg:57.26ms
+step:1387/1600 train_time:79446ms step_avg:57.28ms
+step:1388/1600 train_time:79532ms step_avg:57.30ms
+step:1389/1600 train_time:79619ms step_avg:57.32ms
+step:1390/1600 train_time:79704ms step_avg:57.34ms
+step:1391/1600 train_time:79792ms step_avg:57.36ms
+step:1392/1600 train_time:79877ms step_avg:57.38ms
+step:1393/1600 train_time:79966ms step_avg:57.41ms
+step:1394/1600 train_time:80050ms step_avg:57.42ms
+step:1395/1600 train_time:80139ms step_avg:57.45ms
+step:1396/1600 train_time:80224ms step_avg:57.47ms
+step:1397/1600 train_time:80311ms step_avg:57.49ms
+step:1398/1600 train_time:80397ms step_avg:57.51ms
+step:1399/1600 train_time:80487ms step_avg:57.53ms
+step:1400/1600 train_time:80571ms step_avg:57.55ms
+step:1401/1600 train_time:80658ms step_avg:57.57ms
+step:1402/1600 train_time:80743ms step_avg:57.59ms
+step:1403/1600 train_time:80831ms step_avg:57.61ms
+step:1404/1600 train_time:80917ms step_avg:57.63ms
+step:1405/1600 train_time:81005ms step_avg:57.65ms
+step:1406/1600 train_time:81090ms step_avg:57.67ms
+step:1407/1600 train_time:81179ms step_avg:57.70ms
+step:1408/1600 train_time:81264ms step_avg:57.72ms
+step:1409/1600 train_time:81352ms step_avg:57.74ms
+step:1410/1600 train_time:81437ms step_avg:57.76ms
+step:1411/1600 train_time:81525ms step_avg:57.78ms
+step:1412/1600 train_time:81611ms step_avg:57.80ms
+step:1413/1600 train_time:81699ms step_avg:57.82ms
+step:1414/1600 train_time:81785ms step_avg:57.84ms
+step:1415/1600 train_time:81873ms step_avg:57.86ms
+step:1416/1600 train_time:81959ms step_avg:57.88ms
+step:1417/1600 train_time:82047ms step_avg:57.90ms
+step:1418/1600 train_time:82133ms step_avg:57.92ms
+step:1419/1600 train_time:82221ms step_avg:57.94ms
+step:1420/1600 train_time:82306ms step_avg:57.96ms
+step:1421/1600 train_time:82394ms step_avg:57.98ms
+step:1422/1600 train_time:82478ms step_avg:58.00ms
+step:1423/1600 train_time:82566ms step_avg:58.02ms
+step:1424/1600 train_time:82651ms step_avg:58.04ms
+step:1425/1600 train_time:82739ms step_avg:58.06ms
+step:1426/1600 train_time:82824ms step_avg:58.08ms
+step:1427/1600 train_time:82913ms step_avg:58.10ms
+step:1428/1600 train_time:82998ms step_avg:58.12ms
+step:1429/1600 train_time:83088ms step_avg:58.14ms
+step:1430/1600 train_time:83173ms step_avg:58.16ms
+step:1431/1600 train_time:83260ms step_avg:58.18ms
+step:1432/1600 train_time:83345ms step_avg:58.20ms
+step:1433/1600 train_time:83433ms step_avg:58.22ms
+step:1434/1600 train_time:83518ms step_avg:58.24ms
+step:1435/1600 train_time:83606ms step_avg:58.26ms
+step:1436/1600 train_time:83691ms step_avg:58.28ms
+step:1437/1600 train_time:83780ms step_avg:58.30ms
+step:1438/1600 train_time:83865ms step_avg:58.32ms
+step:1439/1600 train_time:83954ms step_avg:58.34ms
+step:1440/1600 train_time:84039ms step_avg:58.36ms
+step:1441/1600 train_time:84128ms step_avg:58.38ms
+step:1442/1600 train_time:84213ms step_avg:58.40ms
+step:1443/1600 train_time:84301ms step_avg:58.42ms
+step:1444/1600 train_time:84386ms step_avg:58.44ms
+step:1445/1600 train_time:84474ms step_avg:58.46ms
+step:1446/1600 train_time:84559ms step_avg:58.48ms
+step:1447/1600 train_time:84648ms step_avg:58.50ms
+step:1448/1600 train_time:84733ms step_avg:58.52ms
+step:1449/1600 train_time:84822ms step_avg:58.54ms
+step:1450/1600 train_time:84906ms step_avg:58.56ms
+step:1451/1600 train_time:84994ms step_avg:58.58ms
+step:1452/1600 train_time:85080ms step_avg:58.59ms
+step:1453/1600 train_time:85168ms step_avg:58.62ms
+step:1454/1600 train_time:85252ms step_avg:58.63ms
+step:1455/1600 train_time:85340ms step_avg:58.65ms
+step:1456/1600 train_time:85426ms step_avg:58.67ms
+step:1457/1600 train_time:85513ms step_avg:58.69ms
+step:1458/1600 train_time:85598ms step_avg:58.71ms
+step:1459/1600 train_time:85687ms step_avg:58.73ms
+step:1460/1600 train_time:85772ms step_avg:58.75ms
+step:1461/1600 train_time:85860ms step_avg:58.77ms
+step:1462/1600 train_time:85946ms step_avg:58.79ms
+step:1463/1600 train_time:86034ms step_avg:58.81ms
+step:1464/1600 train_time:86119ms step_avg:58.82ms
+step:1465/1600 train_time:86207ms step_avg:58.84ms
+step:1466/1600 train_time:86293ms step_avg:58.86ms
+step:1467/1600 train_time:86382ms step_avg:58.88ms
+step:1468/1600 train_time:86467ms step_avg:58.90ms
+step:1469/1600 train_time:86555ms step_avg:58.92ms
+step:1470/1600 train_time:86640ms step_avg:58.94ms
+step:1471/1600 train_time:86729ms step_avg:58.96ms
+step:1472/1600 train_time:86815ms step_avg:58.98ms
+step:1473/1600 train_time:86903ms step_avg:59.00ms
+step:1474/1600 train_time:86989ms step_avg:59.02ms
+step:1475/1600 train_time:87077ms step_avg:59.04ms
+step:1476/1600 train_time:87162ms step_avg:59.05ms
+step:1477/1600 train_time:87250ms step_avg:59.07ms
+step:1478/1600 train_time:87336ms step_avg:59.09ms
+step:1479/1600 train_time:87424ms step_avg:59.11ms
+step:1480/1600 train_time:87510ms step_avg:59.13ms
+step:1481/1600 train_time:87598ms step_avg:59.15ms
+step:1482/1600 train_time:87682ms step_avg:59.16ms
+step:1483/1600 train_time:87770ms step_avg:59.18ms
+step:1484/1600 train_time:87855ms step_avg:59.20ms
+step:1485/1600 train_time:87944ms step_avg:59.22ms
+step:1486/1600 train_time:88028ms step_avg:59.24ms
+step:1487/1600 train_time:88117ms step_avg:59.26ms
+step:1488/1600 train_time:88202ms step_avg:59.28ms
+step:1489/1600 train_time:88292ms step_avg:59.30ms
+step:1490/1600 train_time:88375ms step_avg:59.31ms
+step:1491/1600 train_time:88463ms step_avg:59.33ms
+step:1492/1600 train_time:88549ms step_avg:59.35ms
+step:1493/1600 train_time:88637ms step_avg:59.37ms
+step:1494/1600 train_time:88721ms step_avg:59.39ms
+step:1495/1600 train_time:88810ms step_avg:59.40ms
+step:1496/1600 train_time:88895ms step_avg:59.42ms
+step:1497/1600 train_time:88983ms step_avg:59.44ms
+step:1498/1600 train_time:89069ms step_avg:59.46ms
+step:1499/1600 train_time:89157ms step_avg:59.48ms
+step:1500/1600 train_time:89242ms step_avg:59.49ms
+step:1500/1600 val_loss:3.3079 train_time:89313ms step_avg:59.54ms
+step:1501/1600 train_time:89335ms step_avg:59.52ms
+step:1502/1600 train_time:89419ms step_avg:59.53ms
+step:1503/1600 train_time:89510ms step_avg:59.55ms
+step:1504/1600 train_time:89595ms step_avg:59.57ms
+step:1505/1600 train_time:89681ms step_avg:59.59ms
+step:1506/1600 train_time:89766ms step_avg:59.61ms
+step:1507/1600 train_time:89852ms step_avg:59.62ms
+step:1508/1600 train_time:89939ms step_avg:59.64ms
+step:1509/1600 train_time:90026ms step_avg:59.66ms
+step:1510/1600 train_time:90110ms step_avg:59.68ms
+step:1511/1600 train_time:90197ms step_avg:59.69ms
+step:1512/1600 train_time:90282ms step_avg:59.71ms
+step:1513/1600 train_time:90375ms step_avg:59.73ms
+step:1514/1600 train_time:90462ms step_avg:59.75ms
+step:1515/1600 train_time:90550ms step_avg:59.77ms
+step:1516/1600 train_time:90636ms step_avg:59.79ms
+step:1517/1600 train_time:90725ms step_avg:59.81ms
+step:1518/1600 train_time:90808ms step_avg:59.82ms
+step:1519/1600 train_time:90896ms step_avg:59.84ms
+step:1520/1600 train_time:90979ms step_avg:59.85ms
+step:1521/1600 train_time:91068ms step_avg:59.87ms
+step:1522/1600 train_time:91153ms step_avg:59.89ms
+step:1523/1600 train_time:91241ms step_avg:59.91ms
+step:1524/1600 train_time:91327ms step_avg:59.93ms
+step:1525/1600 train_time:91418ms step_avg:59.95ms
+step:1526/1600 train_time:91504ms step_avg:59.96ms
+step:1527/1600 train_time:91593ms step_avg:59.98ms
+step:1528/1600 train_time:91679ms step_avg:60.00ms
+step:1529/1600 train_time:91767ms step_avg:60.02ms
+step:1530/1600 train_time:91850ms step_avg:60.03ms
+step:1531/1600 train_time:91938ms step_avg:60.05ms
+step:1532/1600 train_time:92024ms step_avg:60.07ms
+step:1533/1600 train_time:92111ms step_avg:60.09ms
+step:1534/1600 train_time:92195ms step_avg:60.10ms
+step:1535/1600 train_time:92284ms step_avg:60.12ms
+step:1536/1600 train_time:92369ms step_avg:60.14ms
+step:1537/1600 train_time:92458ms step_avg:60.15ms
+step:1538/1600 train_time:92544ms step_avg:60.17ms
+step:1539/1600 train_time:92633ms step_avg:60.19ms
+step:1540/1600 train_time:92718ms step_avg:60.21ms
+step:1541/1600 train_time:92806ms step_avg:60.22ms
+step:1542/1600 train_time:92890ms step_avg:60.24ms
+step:1543/1600 train_time:92978ms step_avg:60.26ms
+step:1544/1600 train_time:93062ms step_avg:60.27ms
+step:1545/1600 train_time:93150ms step_avg:60.29ms
+step:1546/1600 train_time:93235ms step_avg:60.31ms
+step:1547/1600 train_time:93324ms step_avg:60.33ms
+step:1548/1600 train_time:93410ms step_avg:60.34ms
+step:1549/1600 train_time:93499ms step_avg:60.36ms
+step:1550/1600 train_time:93584ms step_avg:60.38ms
+step:1551/1600 train_time:93672ms step_avg:60.39ms
+step:1552/1600 train_time:93757ms step_avg:60.41ms
+step:1553/1600 train_time:93845ms step_avg:60.43ms
+step:1554/1600 train_time:93930ms step_avg:60.44ms
+step:1555/1600 train_time:94018ms step_avg:60.46ms
+step:1556/1600 train_time:94102ms step_avg:60.48ms
+step:1557/1600 train_time:94191ms step_avg:60.50ms
+step:1558/1600 train_time:94277ms step_avg:60.51ms
+step:1559/1600 train_time:94365ms step_avg:60.53ms
+step:1560/1600 train_time:94450ms step_avg:60.54ms
+step:1561/1600 train_time:94547ms step_avg:60.57ms
+step:1562/1600 train_time:94631ms step_avg:60.58ms
+step:1563/1600 train_time:94720ms step_avg:60.60ms
+step:1564/1600 train_time:94806ms step_avg:60.62ms
+step:1565/1600 train_time:94894ms step_avg:60.64ms
+step:1566/1600 train_time:94979ms step_avg:60.65ms
+step:1567/1600 train_time:95067ms step_avg:60.67ms
+step:1568/1600 train_time:95153ms step_avg:60.68ms
+step:1569/1600 train_time:95242ms step_avg:60.70ms
+step:1570/1600 train_time:95327ms step_avg:60.72ms
+step:1571/1600 train_time:95415ms step_avg:60.74ms
+step:1572/1600 train_time:95502ms step_avg:60.75ms
+step:1573/1600 train_time:95590ms step_avg:60.77ms
+step:1574/1600 train_time:95678ms step_avg:60.79ms
+step:1575/1600 train_time:95765ms step_avg:60.80ms
+step:1576/1600 train_time:95851ms step_avg:60.82ms
+step:1577/1600 train_time:95941ms step_avg:60.84ms
+step:1578/1600 train_time:96029ms step_avg:60.85ms
+step:1579/1600 train_time:96116ms step_avg:60.87ms
+step:1580/1600 train_time:96201ms step_avg:60.89ms
+step:1581/1600 train_time:96289ms step_avg:60.90ms
+step:1582/1600 train_time:96375ms step_avg:60.92ms
+step:1583/1600 train_time:96464ms step_avg:60.94ms
+step:1584/1600 train_time:96552ms step_avg:60.95ms
+step:1585/1600 train_time:96639ms step_avg:60.97ms
+step:1586/1600 train_time:96725ms step_avg:60.99ms
+step:1587/1600 train_time:96814ms step_avg:61.00ms
+step:1588/1600 train_time:96902ms step_avg:61.02ms
+step:1589/1600 train_time:96989ms step_avg:61.04ms
+step:1590/1600 train_time:97074ms step_avg:61.05ms
+step:1591/1600 train_time:97162ms step_avg:61.07ms
+step:1592/1600 train_time:97248ms step_avg:61.09ms
+step:1593/1600 train_time:97338ms step_avg:61.10ms
+step:1594/1600 train_time:97422ms step_avg:61.12ms
+step:1595/1600 train_time:97513ms step_avg:61.14ms
+step:1596/1600 train_time:97597ms step_avg:61.15ms
+step:1597/1600 train_time:97685ms step_avg:61.17ms
+step:1598/1600 train_time:97771ms step_avg:61.18ms
+step:1599/1600 train_time:97859ms step_avg:61.20ms
+step:1600/1600 train_time:97947ms step_avg:61.22ms
+step:1600/1600 val_loss:3.2786 train_time:98017ms step_avg:61.26ms
+peak memory allocated: 30181 MiB reserved: 46138 MiB

--- a/records/track_1_short/2026-01-19_BigramHashEmbedding/d2bfbc0f-ecde-4482-a7ec-7b8949f8be11.txt
+++ b/records/track_1_short/2026-01-19_BigramHashEmbedding/d2bfbc0f-ecde-4482-a7ec-7b8949f8be11.txt
@@ -1,0 +1,4120 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 19 22:38:13 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.03              Driver Version: 560.35.03      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   29C    P0            119W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   29C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   27C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   30C    P0            118W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   25C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   30C    P0            121W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   25C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A     60894      C   /usr/bin/python                                 0MiB |
+|    1   N/A  N/A     60895      C   /usr/bin/python                                 0MiB |
+|    2   N/A  N/A     60896      C   /usr/bin/python                                 0MiB |
+|    3   N/A  N/A     60897      C   /usr/bin/python                                 0MiB |
+|    4   N/A  N/A     60898      C   /usr/bin/python                                 0MiB |
+|    5   N/A  N/A     60899      C   /usr/bin/python                                 0MiB |
+|    6   N/A  N/A     60900      C   /usr/bin/python                                 0MiB |
+|    7   N/A  N/A     60901      C   /usr/bin/python                                 0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8313 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:80ms step_avg:79.53ms
+step:2/1600 train_time:102ms step_avg:51.04ms
+step:3/1600 train_time:122ms step_avg:40.56ms
+step:4/1600 train_time:150ms step_avg:37.52ms
+step:5/1600 train_time:180ms step_avg:35.99ms
+step:6/1600 train_time:278ms step_avg:46.39ms
+step:7/1600 train_time:296ms step_avg:42.29ms
+step:8/1600 train_time:322ms step_avg:40.23ms
+step:9/1600 train_time:353ms step_avg:39.18ms
+step:10/1600 train_time:390ms step_avg:38.96ms
+step:11/1600 train_time:421ms step_avg:38.24ms
+step:12/1600 train_time:458ms step_avg:38.14ms
+step:13/1600 train_time:489ms step_avg:37.61ms
+step:14/1600 train_time:526ms step_avg:37.54ms
+step:15/1600 train_time:557ms step_avg:37.12ms
+step:16/1600 train_time:594ms step_avg:37.10ms
+step:17/1600 train_time:625ms step_avg:36.75ms
+step:18/1600 train_time:662ms step_avg:36.76ms
+step:19/1600 train_time:693ms step_avg:36.46ms
+step:20/1600 train_time:730ms step_avg:36.48ms
+step:21/1600 train_time:761ms step_avg:36.22ms
+step:22/1600 train_time:798ms step_avg:36.27ms
+step:23/1600 train_time:829ms step_avg:36.05ms
+step:24/1600 train_time:866ms step_avg:36.09ms
+step:25/1600 train_time:897ms step_avg:35.88ms
+step:26/1600 train_time:934ms step_avg:35.92ms
+step:27/1600 train_time:965ms step_avg:35.75ms
+step:28/1600 train_time:1002ms step_avg:35.79ms
+step:29/1600 train_time:1033ms step_avg:35.63ms
+step:30/1600 train_time:1070ms step_avg:35.68ms
+step:31/1600 train_time:1101ms step_avg:35.53ms
+step:32/1600 train_time:1138ms step_avg:35.57ms
+step:33/1600 train_time:1169ms step_avg:35.43ms
+step:34/1600 train_time:1206ms step_avg:35.48ms
+step:35/1600 train_time:1237ms step_avg:35.35ms
+step:36/1600 train_time:1274ms step_avg:35.40ms
+step:37/1600 train_time:1305ms step_avg:35.28ms
+step:38/1600 train_time:1342ms step_avg:35.32ms
+step:39/1600 train_time:1373ms step_avg:35.22ms
+step:40/1600 train_time:1411ms step_avg:35.26ms
+step:41/1600 train_time:1442ms step_avg:35.16ms
+step:42/1600 train_time:1479ms step_avg:35.20ms
+step:43/1600 train_time:1510ms step_avg:35.11ms
+step:44/1600 train_time:1547ms step_avg:35.15ms
+step:45/1600 train_time:1578ms step_avg:35.06ms
+step:46/1600 train_time:1615ms step_avg:35.11ms
+step:47/1600 train_time:1646ms step_avg:35.02ms
+step:48/1600 train_time:1683ms step_avg:35.05ms
+step:49/1600 train_time:1714ms step_avg:34.97ms
+step:50/1600 train_time:1751ms step_avg:35.01ms
+step:51/1600 train_time:1782ms step_avg:34.94ms
+step:52/1600 train_time:1819ms step_avg:34.97ms
+step:53/1600 train_time:1850ms step_avg:34.91ms
+step:54/1600 train_time:1887ms step_avg:34.94ms
+step:55/1600 train_time:1918ms step_avg:34.88ms
+step:56/1600 train_time:1956ms step_avg:34.92ms
+step:57/1600 train_time:1987ms step_avg:34.85ms
+step:58/1600 train_time:2023ms step_avg:34.88ms
+step:59/1600 train_time:2054ms step_avg:34.82ms
+step:60/1600 train_time:2091ms step_avg:34.86ms
+step:61/1600 train_time:2123ms step_avg:34.80ms
+step:62/1600 train_time:2159ms step_avg:34.83ms
+step:63/1600 train_time:2190ms step_avg:34.77ms
+step:64/1600 train_time:2227ms step_avg:34.80ms
+step:65/1600 train_time:2259ms step_avg:34.75ms
+step:66/1600 train_time:2296ms step_avg:34.78ms
+step:67/1600 train_time:2326ms step_avg:34.72ms
+step:68/1600 train_time:2363ms step_avg:34.75ms
+step:69/1600 train_time:2394ms step_avg:34.70ms
+step:70/1600 train_time:2431ms step_avg:34.73ms
+step:71/1600 train_time:2462ms step_avg:34.68ms
+step:72/1600 train_time:2500ms step_avg:34.72ms
+step:73/1600 train_time:2531ms step_avg:34.66ms
+step:74/1600 train_time:2567ms step_avg:34.69ms
+step:75/1600 train_time:2599ms step_avg:34.65ms
+step:76/1600 train_time:2636ms step_avg:34.68ms
+step:77/1600 train_time:2667ms step_avg:34.63ms
+step:78/1600 train_time:2704ms step_avg:34.66ms
+step:79/1600 train_time:2735ms step_avg:34.62ms
+step:80/1600 train_time:2773ms step_avg:34.66ms
+step:81/1600 train_time:2804ms step_avg:34.62ms
+step:82/1600 train_time:2841ms step_avg:34.65ms
+step:83/1600 train_time:2872ms step_avg:34.60ms
+step:84/1600 train_time:2909ms step_avg:34.63ms
+step:85/1600 train_time:2940ms step_avg:34.59ms
+step:86/1600 train_time:2977ms step_avg:34.62ms
+step:87/1600 train_time:3009ms step_avg:34.58ms
+step:88/1600 train_time:3046ms step_avg:34.61ms
+step:89/1600 train_time:3077ms step_avg:34.57ms
+step:90/1600 train_time:3114ms step_avg:34.60ms
+step:91/1600 train_time:3145ms step_avg:34.56ms
+step:92/1600 train_time:3182ms step_avg:34.58ms
+step:93/1600 train_time:3213ms step_avg:34.55ms
+step:94/1600 train_time:3250ms step_avg:34.58ms
+step:95/1600 train_time:3281ms step_avg:34.54ms
+step:96/1600 train_time:3318ms step_avg:34.56ms
+step:97/1600 train_time:3349ms step_avg:34.52ms
+step:98/1600 train_time:3386ms step_avg:34.55ms
+step:99/1600 train_time:3417ms step_avg:34.52ms
+step:100/1600 train_time:3454ms step_avg:34.54ms
+step:101/1600 train_time:3485ms step_avg:34.51ms
+step:102/1600 train_time:3522ms step_avg:34.53ms
+step:103/1600 train_time:3554ms step_avg:34.50ms
+step:104/1600 train_time:3591ms step_avg:34.52ms
+step:105/1600 train_time:3621ms step_avg:34.49ms
+step:106/1600 train_time:3659ms step_avg:34.52ms
+step:107/1600 train_time:3689ms step_avg:34.48ms
+step:108/1600 train_time:3726ms step_avg:34.50ms
+step:109/1600 train_time:3757ms step_avg:34.47ms
+step:110/1600 train_time:3794ms step_avg:34.49ms
+step:111/1600 train_time:3825ms step_avg:34.46ms
+step:112/1600 train_time:3862ms step_avg:34.48ms
+step:113/1600 train_time:3893ms step_avg:34.45ms
+step:114/1600 train_time:3930ms step_avg:34.47ms
+step:115/1600 train_time:3961ms step_avg:34.44ms
+step:116/1600 train_time:3998ms step_avg:34.46ms
+step:117/1600 train_time:4029ms step_avg:34.44ms
+step:118/1600 train_time:4066ms step_avg:34.46ms
+step:119/1600 train_time:4097ms step_avg:34.43ms
+step:120/1600 train_time:4134ms step_avg:34.45ms
+step:121/1600 train_time:4165ms step_avg:34.42ms
+step:122/1600 train_time:4202ms step_avg:34.44ms
+step:123/1600 train_time:4233ms step_avg:34.41ms
+step:124/1600 train_time:4271ms step_avg:34.44ms
+step:125/1600 train_time:4301ms step_avg:34.40ms
+step:126/1600 train_time:4337ms step_avg:34.42ms
+step:127/1600 train_time:4368ms step_avg:34.40ms
+step:128/1600 train_time:4405ms step_avg:34.41ms
+step:129/1600 train_time:4436ms step_avg:34.39ms
+step:130/1600 train_time:4473ms step_avg:34.41ms
+step:131/1600 train_time:4504ms step_avg:34.38ms
+step:132/1600 train_time:4541ms step_avg:34.40ms
+step:133/1600 train_time:4572ms step_avg:34.38ms
+step:134/1600 train_time:4609ms step_avg:34.39ms
+step:135/1600 train_time:4640ms step_avg:34.37ms
+step:136/1600 train_time:4677ms step_avg:34.39ms
+step:137/1600 train_time:4708ms step_avg:34.36ms
+step:138/1600 train_time:4745ms step_avg:34.38ms
+step:139/1600 train_time:4776ms step_avg:34.36ms
+step:140/1600 train_time:4813ms step_avg:34.38ms
+step:141/1600 train_time:4844ms step_avg:34.35ms
+step:142/1600 train_time:4881ms step_avg:34.37ms
+step:143/1600 train_time:4912ms step_avg:34.35ms
+step:144/1600 train_time:4949ms step_avg:34.37ms
+step:145/1600 train_time:4980ms step_avg:34.34ms
+step:146/1600 train_time:5017ms step_avg:34.36ms
+step:147/1600 train_time:5048ms step_avg:34.34ms
+step:148/1600 train_time:5085ms step_avg:34.36ms
+step:149/1600 train_time:5116ms step_avg:34.33ms
+step:150/1600 train_time:5153ms step_avg:34.35ms
+step:151/1600 train_time:5184ms step_avg:34.33ms
+step:152/1600 train_time:5221ms step_avg:34.35ms
+step:153/1600 train_time:5251ms step_avg:34.32ms
+step:154/1600 train_time:5288ms step_avg:34.34ms
+step:155/1600 train_time:5319ms step_avg:34.32ms
+step:156/1600 train_time:5355ms step_avg:34.33ms
+step:157/1600 train_time:5386ms step_avg:34.31ms
+step:158/1600 train_time:5423ms step_avg:34.33ms
+step:159/1600 train_time:5454ms step_avg:34.30ms
+step:160/1600 train_time:5491ms step_avg:34.32ms
+step:161/1600 train_time:5522ms step_avg:34.30ms
+step:162/1600 train_time:5559ms step_avg:34.31ms
+step:163/1600 train_time:5590ms step_avg:34.29ms
+step:164/1600 train_time:5626ms step_avg:34.31ms
+step:165/1600 train_time:5657ms step_avg:34.29ms
+step:166/1600 train_time:5695ms step_avg:34.30ms
+step:167/1600 train_time:5726ms step_avg:34.28ms
+step:168/1600 train_time:5763ms step_avg:34.30ms
+step:169/1600 train_time:5793ms step_avg:34.28ms
+step:170/1600 train_time:5830ms step_avg:34.29ms
+step:171/1600 train_time:5861ms step_avg:34.27ms
+step:172/1600 train_time:5898ms step_avg:34.29ms
+step:173/1600 train_time:5929ms step_avg:34.27ms
+step:174/1600 train_time:5966ms step_avg:34.29ms
+step:175/1600 train_time:5997ms step_avg:34.27ms
+step:176/1600 train_time:6033ms step_avg:34.28ms
+step:177/1600 train_time:6064ms step_avg:34.26ms
+step:178/1600 train_time:6101ms step_avg:34.27ms
+step:179/1600 train_time:6132ms step_avg:34.26ms
+step:180/1600 train_time:6169ms step_avg:34.27ms
+step:181/1600 train_time:6199ms step_avg:34.25ms
+step:182/1600 train_time:6236ms step_avg:34.26ms
+step:183/1600 train_time:6268ms step_avg:34.25ms
+step:184/1600 train_time:6305ms step_avg:34.26ms
+step:185/1600 train_time:6335ms step_avg:34.24ms
+step:186/1600 train_time:6372ms step_avg:34.26ms
+step:187/1600 train_time:6403ms step_avg:34.24ms
+step:188/1600 train_time:6440ms step_avg:34.26ms
+step:189/1600 train_time:6471ms step_avg:34.24ms
+step:190/1600 train_time:6508ms step_avg:34.25ms
+step:191/1600 train_time:6539ms step_avg:34.24ms
+step:192/1600 train_time:6576ms step_avg:34.25ms
+step:193/1600 train_time:6607ms step_avg:34.23ms
+step:194/1600 train_time:6644ms step_avg:34.25ms
+step:195/1600 train_time:6675ms step_avg:34.23ms
+step:196/1600 train_time:6712ms step_avg:34.25ms
+step:197/1600 train_time:6743ms step_avg:34.23ms
+step:198/1600 train_time:6780ms step_avg:34.24ms
+step:199/1600 train_time:6811ms step_avg:34.22ms
+step:200/1600 train_time:6847ms step_avg:34.24ms
+step:201/1600 train_time:6879ms step_avg:34.22ms
+step:202/1600 train_time:6915ms step_avg:34.23ms
+step:203/1600 train_time:6947ms step_avg:34.22ms
+step:204/1600 train_time:6983ms step_avg:34.23ms
+step:205/1600 train_time:7014ms step_avg:34.21ms
+step:206/1600 train_time:7051ms step_avg:34.23ms
+step:207/1600 train_time:7082ms step_avg:34.21ms
+step:208/1600 train_time:7119ms step_avg:34.23ms
+step:209/1600 train_time:7150ms step_avg:34.21ms
+step:210/1600 train_time:7187ms step_avg:34.22ms
+step:211/1600 train_time:7218ms step_avg:34.21ms
+step:212/1600 train_time:7255ms step_avg:34.22ms
+step:213/1600 train_time:7285ms step_avg:34.20ms
+step:214/1600 train_time:7322ms step_avg:34.21ms
+step:215/1600 train_time:7353ms step_avg:34.20ms
+step:216/1600 train_time:7390ms step_avg:34.21ms
+step:217/1600 train_time:7421ms step_avg:34.20ms
+step:218/1600 train_time:7458ms step_avg:34.21ms
+step:219/1600 train_time:7489ms step_avg:34.19ms
+step:220/1600 train_time:7525ms step_avg:34.21ms
+step:221/1600 train_time:7556ms step_avg:34.19ms
+step:222/1600 train_time:7594ms step_avg:34.21ms
+step:223/1600 train_time:7624ms step_avg:34.19ms
+step:224/1600 train_time:7661ms step_avg:34.20ms
+step:225/1600 train_time:7692ms step_avg:34.19ms
+step:226/1600 train_time:7729ms step_avg:34.20ms
+step:227/1600 train_time:7760ms step_avg:34.19ms
+step:228/1600 train_time:7797ms step_avg:34.20ms
+step:229/1600 train_time:7828ms step_avg:34.18ms
+step:230/1600 train_time:7865ms step_avg:34.19ms
+step:231/1600 train_time:7895ms step_avg:34.18ms
+step:232/1600 train_time:7932ms step_avg:34.19ms
+step:233/1600 train_time:7963ms step_avg:34.18ms
+step:234/1600 train_time:8001ms step_avg:34.19ms
+step:235/1600 train_time:8031ms step_avg:34.17ms
+step:236/1600 train_time:8067ms step_avg:34.18ms
+step:237/1600 train_time:8098ms step_avg:34.17ms
+step:238/1600 train_time:8135ms step_avg:34.18ms
+step:239/1600 train_time:8166ms step_avg:34.17ms
+step:240/1600 train_time:8203ms step_avg:34.18ms
+step:241/1600 train_time:8234ms step_avg:34.17ms
+step:242/1600 train_time:8271ms step_avg:34.18ms
+step:243/1600 train_time:8301ms step_avg:34.16ms
+step:244/1600 train_time:8338ms step_avg:34.17ms
+step:245/1600 train_time:8369ms step_avg:34.16ms
+step:246/1600 train_time:8406ms step_avg:34.17ms
+step:247/1600 train_time:8437ms step_avg:34.16ms
+step:248/1600 train_time:8474ms step_avg:34.17ms
+step:249/1600 train_time:8505ms step_avg:34.16ms
+step:250/1600 train_time:8541ms step_avg:34.17ms
+step:250/1600 val_loss:4.5733 train_time:8589ms step_avg:34.36ms
+step:251/1600 train_time:8607ms step_avg:34.29ms
+step:252/1600 train_time:8626ms step_avg:34.23ms
+step:253/1600 train_time:8643ms step_avg:34.16ms
+step:254/1600 train_time:8681ms step_avg:34.18ms
+step:255/1600 train_time:8713ms step_avg:34.17ms
+step:256/1600 train_time:8751ms step_avg:34.19ms
+step:257/1600 train_time:8784ms step_avg:34.18ms
+step:258/1600 train_time:8821ms step_avg:34.19ms
+step:259/1600 train_time:8852ms step_avg:34.18ms
+step:260/1600 train_time:8889ms step_avg:34.19ms
+step:261/1600 train_time:8920ms step_avg:34.18ms
+step:262/1600 train_time:8957ms step_avg:34.19ms
+step:263/1600 train_time:8988ms step_avg:34.18ms
+step:264/1600 train_time:9025ms step_avg:34.19ms
+step:265/1600 train_time:9056ms step_avg:34.17ms
+step:266/1600 train_time:9093ms step_avg:34.18ms
+step:267/1600 train_time:9124ms step_avg:34.17ms
+step:268/1600 train_time:9160ms step_avg:34.18ms
+step:269/1600 train_time:9191ms step_avg:34.17ms
+step:270/1600 train_time:9228ms step_avg:34.18ms
+step:271/1600 train_time:9259ms step_avg:34.17ms
+step:272/1600 train_time:9296ms step_avg:34.18ms
+step:273/1600 train_time:9326ms step_avg:34.16ms
+step:274/1600 train_time:9363ms step_avg:34.17ms
+step:275/1600 train_time:9394ms step_avg:34.16ms
+step:276/1600 train_time:9430ms step_avg:34.17ms
+step:277/1600 train_time:9461ms step_avg:34.16ms
+step:278/1600 train_time:9499ms step_avg:34.17ms
+step:279/1600 train_time:9529ms step_avg:34.16ms
+step:280/1600 train_time:9566ms step_avg:34.17ms
+step:281/1600 train_time:9597ms step_avg:34.15ms
+step:282/1600 train_time:9634ms step_avg:34.16ms
+step:283/1600 train_time:9665ms step_avg:34.15ms
+step:284/1600 train_time:9702ms step_avg:34.16ms
+step:285/1600 train_time:9733ms step_avg:34.15ms
+step:286/1600 train_time:9770ms step_avg:34.16ms
+step:287/1600 train_time:9801ms step_avg:34.15ms
+step:288/1600 train_time:9838ms step_avg:34.16ms
+step:289/1600 train_time:9869ms step_avg:34.15ms
+step:290/1600 train_time:9906ms step_avg:34.16ms
+step:291/1600 train_time:9937ms step_avg:34.15ms
+step:292/1600 train_time:9974ms step_avg:34.16ms
+step:293/1600 train_time:10005ms step_avg:34.15ms
+step:294/1600 train_time:10042ms step_avg:34.16ms
+step:295/1600 train_time:10072ms step_avg:34.14ms
+step:296/1600 train_time:10109ms step_avg:34.15ms
+step:297/1600 train_time:10140ms step_avg:34.14ms
+step:298/1600 train_time:10177ms step_avg:34.15ms
+step:299/1600 train_time:10208ms step_avg:34.14ms
+step:300/1600 train_time:10245ms step_avg:34.15ms
+step:301/1600 train_time:10276ms step_avg:34.14ms
+step:302/1600 train_time:10313ms step_avg:34.15ms
+step:303/1600 train_time:10343ms step_avg:34.14ms
+step:304/1600 train_time:10380ms step_avg:34.15ms
+step:305/1600 train_time:10411ms step_avg:34.13ms
+step:306/1600 train_time:10448ms step_avg:34.14ms
+step:307/1600 train_time:10479ms step_avg:34.13ms
+step:308/1600 train_time:10516ms step_avg:34.14ms
+step:309/1600 train_time:10547ms step_avg:34.13ms
+step:310/1600 train_time:10583ms step_avg:34.14ms
+step:311/1600 train_time:10614ms step_avg:34.13ms
+step:312/1600 train_time:10651ms step_avg:34.14ms
+step:313/1600 train_time:10682ms step_avg:34.13ms
+step:314/1600 train_time:10719ms step_avg:34.14ms
+step:315/1600 train_time:10750ms step_avg:34.13ms
+step:316/1600 train_time:10787ms step_avg:34.13ms
+step:317/1600 train_time:10818ms step_avg:34.13ms
+step:318/1600 train_time:10854ms step_avg:34.13ms
+step:319/1600 train_time:10886ms step_avg:34.12ms
+step:320/1600 train_time:10922ms step_avg:34.13ms
+step:321/1600 train_time:10953ms step_avg:34.12ms
+step:322/1600 train_time:10990ms step_avg:34.13ms
+step:323/1600 train_time:11021ms step_avg:34.12ms
+step:324/1600 train_time:11058ms step_avg:34.13ms
+step:325/1600 train_time:11088ms step_avg:34.12ms
+step:326/1600 train_time:11125ms step_avg:34.13ms
+step:327/1600 train_time:11156ms step_avg:34.12ms
+step:328/1600 train_time:11193ms step_avg:34.13ms
+step:329/1600 train_time:11224ms step_avg:34.12ms
+step:330/1600 train_time:11261ms step_avg:34.12ms
+step:331/1600 train_time:11292ms step_avg:34.11ms
+step:332/1600 train_time:11328ms step_avg:34.12ms
+step:333/1600 train_time:11359ms step_avg:34.11ms
+step:334/1600 train_time:11396ms step_avg:34.12ms
+step:335/1600 train_time:11427ms step_avg:34.11ms
+step:336/1600 train_time:11464ms step_avg:34.12ms
+step:337/1600 train_time:11494ms step_avg:34.11ms
+step:338/1600 train_time:11532ms step_avg:34.12ms
+step:339/1600 train_time:11563ms step_avg:34.11ms
+step:340/1600 train_time:11599ms step_avg:34.12ms
+step:341/1600 train_time:11630ms step_avg:34.11ms
+step:342/1600 train_time:11667ms step_avg:34.11ms
+step:343/1600 train_time:11698ms step_avg:34.10ms
+step:344/1600 train_time:11735ms step_avg:34.11ms
+step:345/1600 train_time:11765ms step_avg:34.10ms
+step:346/1600 train_time:11802ms step_avg:34.11ms
+step:347/1600 train_time:11833ms step_avg:34.10ms
+step:348/1600 train_time:11869ms step_avg:34.11ms
+step:349/1600 train_time:11900ms step_avg:34.10ms
+step:350/1600 train_time:11937ms step_avg:34.11ms
+step:351/1600 train_time:11969ms step_avg:34.10ms
+step:352/1600 train_time:12005ms step_avg:34.11ms
+step:353/1600 train_time:12036ms step_avg:34.10ms
+step:354/1600 train_time:12073ms step_avg:34.10ms
+step:355/1600 train_time:12104ms step_avg:34.09ms
+step:356/1600 train_time:12140ms step_avg:34.10ms
+step:357/1600 train_time:12171ms step_avg:34.09ms
+step:358/1600 train_time:12208ms step_avg:34.10ms
+step:359/1600 train_time:12239ms step_avg:34.09ms
+step:360/1600 train_time:12277ms step_avg:34.10ms
+step:361/1600 train_time:12307ms step_avg:34.09ms
+step:362/1600 train_time:12344ms step_avg:34.10ms
+step:363/1600 train_time:12375ms step_avg:34.09ms
+step:364/1600 train_time:12411ms step_avg:34.10ms
+step:365/1600 train_time:12442ms step_avg:34.09ms
+step:366/1600 train_time:12479ms step_avg:34.10ms
+step:367/1600 train_time:12510ms step_avg:34.09ms
+step:368/1600 train_time:12547ms step_avg:34.10ms
+step:369/1600 train_time:12578ms step_avg:34.09ms
+step:370/1600 train_time:12615ms step_avg:34.09ms
+step:371/1600 train_time:12646ms step_avg:34.09ms
+step:372/1600 train_time:12683ms step_avg:34.09ms
+step:373/1600 train_time:12714ms step_avg:34.09ms
+step:374/1600 train_time:12751ms step_avg:34.09ms
+step:375/1600 train_time:12782ms step_avg:34.08ms
+step:376/1600 train_time:12819ms step_avg:34.09ms
+step:377/1600 train_time:12849ms step_avg:34.08ms
+step:378/1600 train_time:12886ms step_avg:34.09ms
+step:379/1600 train_time:12917ms step_avg:34.08ms
+step:380/1600 train_time:12954ms step_avg:34.09ms
+step:381/1600 train_time:12985ms step_avg:34.08ms
+step:382/1600 train_time:13022ms step_avg:34.09ms
+step:383/1600 train_time:13053ms step_avg:34.08ms
+step:384/1600 train_time:13090ms step_avg:34.09ms
+step:385/1600 train_time:13121ms step_avg:34.08ms
+step:386/1600 train_time:13158ms step_avg:34.09ms
+step:387/1600 train_time:13188ms step_avg:34.08ms
+step:388/1600 train_time:13226ms step_avg:34.09ms
+step:389/1600 train_time:13256ms step_avg:34.08ms
+step:390/1600 train_time:13294ms step_avg:34.09ms
+step:391/1600 train_time:13324ms step_avg:34.08ms
+step:392/1600 train_time:13361ms step_avg:34.09ms
+step:393/1600 train_time:13392ms step_avg:34.08ms
+step:394/1600 train_time:13429ms step_avg:34.08ms
+step:395/1600 train_time:13460ms step_avg:34.08ms
+step:396/1600 train_time:13497ms step_avg:34.08ms
+step:397/1600 train_time:13528ms step_avg:34.08ms
+step:398/1600 train_time:13565ms step_avg:34.08ms
+step:399/1600 train_time:13596ms step_avg:34.07ms
+step:400/1600 train_time:13632ms step_avg:34.08ms
+step:401/1600 train_time:13663ms step_avg:34.07ms
+step:402/1600 train_time:13700ms step_avg:34.08ms
+step:403/1600 train_time:13731ms step_avg:34.07ms
+step:404/1600 train_time:13767ms step_avg:34.08ms
+step:405/1600 train_time:13798ms step_avg:34.07ms
+step:406/1600 train_time:13835ms step_avg:34.08ms
+step:407/1600 train_time:13866ms step_avg:34.07ms
+step:408/1600 train_time:13903ms step_avg:34.08ms
+step:409/1600 train_time:13934ms step_avg:34.07ms
+step:410/1600 train_time:13970ms step_avg:34.07ms
+step:411/1600 train_time:14001ms step_avg:34.07ms
+step:412/1600 train_time:14038ms step_avg:34.07ms
+step:413/1600 train_time:14069ms step_avg:34.07ms
+step:414/1600 train_time:14106ms step_avg:34.07ms
+step:415/1600 train_time:14137ms step_avg:34.06ms
+step:416/1600 train_time:14173ms step_avg:34.07ms
+step:417/1600 train_time:14204ms step_avg:34.06ms
+step:418/1600 train_time:14241ms step_avg:34.07ms
+step:419/1600 train_time:14272ms step_avg:34.06ms
+step:420/1600 train_time:14308ms step_avg:34.07ms
+step:421/1600 train_time:14339ms step_avg:34.06ms
+step:422/1600 train_time:14376ms step_avg:34.07ms
+step:423/1600 train_time:14407ms step_avg:34.06ms
+step:424/1600 train_time:14444ms step_avg:34.07ms
+step:425/1600 train_time:14475ms step_avg:34.06ms
+step:426/1600 train_time:14511ms step_avg:34.06ms
+step:427/1600 train_time:14542ms step_avg:34.06ms
+step:428/1600 train_time:14579ms step_avg:34.06ms
+step:429/1600 train_time:14610ms step_avg:34.06ms
+step:430/1600 train_time:14647ms step_avg:34.06ms
+step:431/1600 train_time:14678ms step_avg:34.05ms
+step:432/1600 train_time:14715ms step_avg:34.06ms
+step:433/1600 train_time:14746ms step_avg:34.05ms
+step:434/1600 train_time:14782ms step_avg:34.06ms
+step:435/1600 train_time:14813ms step_avg:34.05ms
+step:436/1600 train_time:14850ms step_avg:34.06ms
+step:437/1600 train_time:14880ms step_avg:34.05ms
+step:438/1600 train_time:14917ms step_avg:34.06ms
+step:439/1600 train_time:14948ms step_avg:34.05ms
+step:440/1600 train_time:14985ms step_avg:34.06ms
+step:441/1600 train_time:15016ms step_avg:34.05ms
+step:442/1600 train_time:15053ms step_avg:34.06ms
+step:443/1600 train_time:15084ms step_avg:34.05ms
+step:444/1600 train_time:15121ms step_avg:34.06ms
+step:445/1600 train_time:15151ms step_avg:34.05ms
+step:446/1600 train_time:15188ms step_avg:34.05ms
+step:447/1600 train_time:15219ms step_avg:34.05ms
+step:448/1600 train_time:15256ms step_avg:34.05ms
+step:449/1600 train_time:15286ms step_avg:34.05ms
+step:450/1600 train_time:15323ms step_avg:34.05ms
+step:451/1600 train_time:15354ms step_avg:34.05ms
+step:452/1600 train_time:15392ms step_avg:34.05ms
+step:453/1600 train_time:15422ms step_avg:34.04ms
+step:454/1600 train_time:15459ms step_avg:34.05ms
+step:455/1600 train_time:15490ms step_avg:34.04ms
+step:456/1600 train_time:15528ms step_avg:34.05ms
+step:457/1600 train_time:15559ms step_avg:34.05ms
+step:458/1600 train_time:15596ms step_avg:34.05ms
+step:459/1600 train_time:15626ms step_avg:34.04ms
+step:460/1600 train_time:15663ms step_avg:34.05ms
+step:461/1600 train_time:15694ms step_avg:34.04ms
+step:462/1600 train_time:15731ms step_avg:34.05ms
+step:463/1600 train_time:15761ms step_avg:34.04ms
+step:464/1600 train_time:15798ms step_avg:34.05ms
+step:465/1600 train_time:15829ms step_avg:34.04ms
+step:466/1600 train_time:15865ms step_avg:34.05ms
+step:467/1600 train_time:15896ms step_avg:34.04ms
+step:468/1600 train_time:15933ms step_avg:34.05ms
+step:469/1600 train_time:15964ms step_avg:34.04ms
+step:470/1600 train_time:16001ms step_avg:34.05ms
+step:471/1600 train_time:16032ms step_avg:34.04ms
+step:472/1600 train_time:16069ms step_avg:34.04ms
+step:473/1600 train_time:16100ms step_avg:34.04ms
+step:474/1600 train_time:16137ms step_avg:34.04ms
+step:475/1600 train_time:16168ms step_avg:34.04ms
+step:476/1600 train_time:16205ms step_avg:34.04ms
+step:477/1600 train_time:16236ms step_avg:34.04ms
+step:478/1600 train_time:16273ms step_avg:34.04ms
+step:479/1600 train_time:16304ms step_avg:34.04ms
+step:480/1600 train_time:16341ms step_avg:34.04ms
+step:481/1600 train_time:16372ms step_avg:34.04ms
+step:482/1600 train_time:16408ms step_avg:34.04ms
+step:483/1600 train_time:16439ms step_avg:34.04ms
+step:484/1600 train_time:16476ms step_avg:34.04ms
+step:485/1600 train_time:16507ms step_avg:34.04ms
+step:486/1600 train_time:16544ms step_avg:34.04ms
+step:487/1600 train_time:16575ms step_avg:34.03ms
+step:488/1600 train_time:16612ms step_avg:34.04ms
+step:489/1600 train_time:16644ms step_avg:34.04ms
+step:490/1600 train_time:16681ms step_avg:34.04ms
+step:491/1600 train_time:16712ms step_avg:34.04ms
+step:492/1600 train_time:16748ms step_avg:34.04ms
+step:493/1600 train_time:16779ms step_avg:34.03ms
+step:494/1600 train_time:16816ms step_avg:34.04ms
+step:495/1600 train_time:16847ms step_avg:34.03ms
+step:496/1600 train_time:16884ms step_avg:34.04ms
+step:497/1600 train_time:16915ms step_avg:34.03ms
+step:498/1600 train_time:16952ms step_avg:34.04ms
+step:499/1600 train_time:16983ms step_avg:34.03ms
+step:500/1600 train_time:17019ms step_avg:34.04ms
+step:500/1600 val_loss:4.2466 train_time:17067ms step_avg:34.13ms
+step:501/1600 train_time:17085ms step_avg:34.10ms
+step:502/1600 train_time:17104ms step_avg:34.07ms
+step:503/1600 train_time:17122ms step_avg:34.04ms
+step:504/1600 train_time:17159ms step_avg:34.05ms
+step:505/1600 train_time:17191ms step_avg:34.04ms
+step:506/1600 train_time:17230ms step_avg:34.05ms
+step:507/1600 train_time:17261ms step_avg:34.05ms
+step:508/1600 train_time:17298ms step_avg:34.05ms
+step:509/1600 train_time:17329ms step_avg:34.05ms
+step:510/1600 train_time:17366ms step_avg:34.05ms
+step:511/1600 train_time:17397ms step_avg:34.04ms
+step:512/1600 train_time:17434ms step_avg:34.05ms
+step:513/1600 train_time:17465ms step_avg:34.04ms
+step:514/1600 train_time:17501ms step_avg:34.05ms
+step:515/1600 train_time:17532ms step_avg:34.04ms
+step:516/1600 train_time:17569ms step_avg:34.05ms
+step:517/1600 train_time:17600ms step_avg:34.04ms
+step:518/1600 train_time:17637ms step_avg:34.05ms
+step:519/1600 train_time:17668ms step_avg:34.04ms
+step:520/1600 train_time:17705ms step_avg:34.05ms
+step:521/1600 train_time:17778ms step_avg:34.12ms
+step:522/1600 train_time:17832ms step_avg:34.16ms
+step:523/1600 train_time:17893ms step_avg:34.21ms
+step:524/1600 train_time:17952ms step_avg:34.26ms
+step:525/1600 train_time:18014ms step_avg:34.31ms
+step:526/1600 train_time:18071ms step_avg:34.36ms
+step:527/1600 train_time:18135ms step_avg:34.41ms
+step:528/1600 train_time:18194ms step_avg:34.46ms
+step:529/1600 train_time:18257ms step_avg:34.51ms
+step:530/1600 train_time:18316ms step_avg:34.56ms
+step:531/1600 train_time:18379ms step_avg:34.61ms
+step:532/1600 train_time:18439ms step_avg:34.66ms
+step:533/1600 train_time:18502ms step_avg:34.71ms
+step:534/1600 train_time:18561ms step_avg:34.76ms
+step:535/1600 train_time:18625ms step_avg:34.81ms
+step:536/1600 train_time:18684ms step_avg:34.86ms
+step:537/1600 train_time:18747ms step_avg:34.91ms
+step:538/1600 train_time:18806ms step_avg:34.96ms
+step:539/1600 train_time:18868ms step_avg:35.01ms
+step:540/1600 train_time:18928ms step_avg:35.05ms
+step:541/1600 train_time:18989ms step_avg:35.10ms
+step:542/1600 train_time:19048ms step_avg:35.14ms
+step:543/1600 train_time:19111ms step_avg:35.19ms
+step:544/1600 train_time:19170ms step_avg:35.24ms
+step:545/1600 train_time:19232ms step_avg:35.29ms
+step:546/1600 train_time:19291ms step_avg:35.33ms
+step:547/1600 train_time:19355ms step_avg:35.38ms
+step:548/1600 train_time:19414ms step_avg:35.43ms
+step:549/1600 train_time:19476ms step_avg:35.48ms
+step:550/1600 train_time:19536ms step_avg:35.52ms
+step:551/1600 train_time:19599ms step_avg:35.57ms
+step:552/1600 train_time:19658ms step_avg:35.61ms
+step:553/1600 train_time:19721ms step_avg:35.66ms
+step:554/1600 train_time:19780ms step_avg:35.70ms
+step:555/1600 train_time:19843ms step_avg:35.75ms
+step:556/1600 train_time:19902ms step_avg:35.80ms
+step:557/1600 train_time:19964ms step_avg:35.84ms
+step:558/1600 train_time:20023ms step_avg:35.88ms
+step:559/1600 train_time:20086ms step_avg:35.93ms
+step:560/1600 train_time:20144ms step_avg:35.97ms
+step:561/1600 train_time:20208ms step_avg:36.02ms
+step:562/1600 train_time:20267ms step_avg:36.06ms
+step:563/1600 train_time:20330ms step_avg:36.11ms
+step:564/1600 train_time:20391ms step_avg:36.15ms
+step:565/1600 train_time:20453ms step_avg:36.20ms
+step:566/1600 train_time:20513ms step_avg:36.24ms
+step:567/1600 train_time:20575ms step_avg:36.29ms
+step:568/1600 train_time:20634ms step_avg:36.33ms
+step:569/1600 train_time:20697ms step_avg:36.37ms
+step:570/1600 train_time:20756ms step_avg:36.41ms
+step:571/1600 train_time:20818ms step_avg:36.46ms
+step:572/1600 train_time:20877ms step_avg:36.50ms
+step:573/1600 train_time:20943ms step_avg:36.55ms
+step:574/1600 train_time:21002ms step_avg:36.59ms
+step:575/1600 train_time:21064ms step_avg:36.63ms
+step:576/1600 train_time:21123ms step_avg:36.67ms
+step:577/1600 train_time:21185ms step_avg:36.72ms
+step:578/1600 train_time:21243ms step_avg:36.75ms
+step:579/1600 train_time:21305ms step_avg:36.80ms
+step:580/1600 train_time:21365ms step_avg:36.84ms
+step:581/1600 train_time:21428ms step_avg:36.88ms
+step:582/1600 train_time:21487ms step_avg:36.92ms
+step:583/1600 train_time:21549ms step_avg:36.96ms
+step:584/1600 train_time:21609ms step_avg:37.00ms
+step:585/1600 train_time:21671ms step_avg:37.04ms
+step:586/1600 train_time:21730ms step_avg:37.08ms
+step:587/1600 train_time:21794ms step_avg:37.13ms
+step:588/1600 train_time:21853ms step_avg:37.17ms
+step:589/1600 train_time:21916ms step_avg:37.21ms
+step:590/1600 train_time:21975ms step_avg:37.25ms
+step:591/1600 train_time:22037ms step_avg:37.29ms
+step:592/1600 train_time:22095ms step_avg:37.32ms
+step:593/1600 train_time:22158ms step_avg:37.37ms
+step:594/1600 train_time:22218ms step_avg:37.40ms
+step:595/1600 train_time:22280ms step_avg:37.45ms
+step:596/1600 train_time:22339ms step_avg:37.48ms
+step:597/1600 train_time:22402ms step_avg:37.52ms
+step:598/1600 train_time:22461ms step_avg:37.56ms
+step:599/1600 train_time:22525ms step_avg:37.60ms
+step:600/1600 train_time:22583ms step_avg:37.64ms
+step:601/1600 train_time:22646ms step_avg:37.68ms
+step:602/1600 train_time:22705ms step_avg:37.72ms
+step:603/1600 train_time:22769ms step_avg:37.76ms
+step:604/1600 train_time:22828ms step_avg:37.80ms
+step:605/1600 train_time:22891ms step_avg:37.84ms
+step:606/1600 train_time:22950ms step_avg:37.87ms
+step:607/1600 train_time:23012ms step_avg:37.91ms
+step:608/1600 train_time:23071ms step_avg:37.95ms
+step:609/1600 train_time:23134ms step_avg:37.99ms
+step:610/1600 train_time:23193ms step_avg:38.02ms
+step:611/1600 train_time:23255ms step_avg:38.06ms
+step:612/1600 train_time:23314ms step_avg:38.10ms
+step:613/1600 train_time:23377ms step_avg:38.14ms
+step:614/1600 train_time:23437ms step_avg:38.17ms
+step:615/1600 train_time:23499ms step_avg:38.21ms
+step:616/1600 train_time:23558ms step_avg:38.24ms
+step:617/1600 train_time:23620ms step_avg:38.28ms
+step:618/1600 train_time:23679ms step_avg:38.32ms
+step:619/1600 train_time:23742ms step_avg:38.36ms
+step:620/1600 train_time:23801ms step_avg:38.39ms
+step:621/1600 train_time:23863ms step_avg:38.43ms
+step:622/1600 train_time:23923ms step_avg:38.46ms
+step:623/1600 train_time:23986ms step_avg:38.50ms
+step:624/1600 train_time:24045ms step_avg:38.53ms
+step:625/1600 train_time:24108ms step_avg:38.57ms
+step:626/1600 train_time:24167ms step_avg:38.61ms
+step:627/1600 train_time:24231ms step_avg:38.65ms
+step:628/1600 train_time:24290ms step_avg:38.68ms
+step:629/1600 train_time:24352ms step_avg:38.72ms
+step:630/1600 train_time:24411ms step_avg:38.75ms
+step:631/1600 train_time:24474ms step_avg:38.79ms
+step:632/1600 train_time:24532ms step_avg:38.82ms
+step:633/1600 train_time:24595ms step_avg:38.85ms
+step:634/1600 train_time:24654ms step_avg:38.89ms
+step:635/1600 train_time:24717ms step_avg:38.92ms
+step:636/1600 train_time:24776ms step_avg:38.96ms
+step:637/1600 train_time:24839ms step_avg:38.99ms
+step:638/1600 train_time:24898ms step_avg:39.03ms
+step:639/1600 train_time:24961ms step_avg:39.06ms
+step:640/1600 train_time:25020ms step_avg:39.09ms
+step:641/1600 train_time:25083ms step_avg:39.13ms
+step:642/1600 train_time:25142ms step_avg:39.16ms
+step:643/1600 train_time:25205ms step_avg:39.20ms
+step:644/1600 train_time:25264ms step_avg:39.23ms
+step:645/1600 train_time:25327ms step_avg:39.27ms
+step:646/1600 train_time:25387ms step_avg:39.30ms
+step:647/1600 train_time:25450ms step_avg:39.33ms
+step:648/1600 train_time:25508ms step_avg:39.36ms
+step:649/1600 train_time:25571ms step_avg:39.40ms
+step:650/1600 train_time:25631ms step_avg:39.43ms
+step:651/1600 train_time:25693ms step_avg:39.47ms
+step:652/1600 train_time:25752ms step_avg:39.50ms
+step:653/1600 train_time:25815ms step_avg:39.53ms
+step:654/1600 train_time:25874ms step_avg:39.56ms
+step:655/1600 train_time:25936ms step_avg:39.60ms
+step:656/1600 train_time:25995ms step_avg:39.63ms
+step:657/1600 train_time:26057ms step_avg:39.66ms
+step:658/1600 train_time:26117ms step_avg:39.69ms
+step:659/1600 train_time:26180ms step_avg:39.73ms
+step:660/1600 train_time:26239ms step_avg:39.76ms
+step:661/1600 train_time:26301ms step_avg:39.79ms
+step:662/1600 train_time:26360ms step_avg:39.82ms
+step:663/1600 train_time:26423ms step_avg:39.85ms
+step:664/1600 train_time:26483ms step_avg:39.88ms
+step:665/1600 train_time:26545ms step_avg:39.92ms
+step:666/1600 train_time:26605ms step_avg:39.95ms
+step:667/1600 train_time:26668ms step_avg:39.98ms
+step:668/1600 train_time:26728ms step_avg:40.01ms
+step:669/1600 train_time:26790ms step_avg:40.04ms
+step:670/1600 train_time:26849ms step_avg:40.07ms
+step:671/1600 train_time:26912ms step_avg:40.11ms
+step:672/1600 train_time:26972ms step_avg:40.14ms
+step:673/1600 train_time:27035ms step_avg:40.17ms
+step:674/1600 train_time:27094ms step_avg:40.20ms
+step:675/1600 train_time:27156ms step_avg:40.23ms
+step:676/1600 train_time:27216ms step_avg:40.26ms
+step:677/1600 train_time:27278ms step_avg:40.29ms
+step:678/1600 train_time:27337ms step_avg:40.32ms
+step:679/1600 train_time:27399ms step_avg:40.35ms
+step:680/1600 train_time:27458ms step_avg:40.38ms
+step:681/1600 train_time:27522ms step_avg:40.41ms
+step:682/1600 train_time:27580ms step_avg:40.44ms
+step:683/1600 train_time:27643ms step_avg:40.47ms
+step:684/1600 train_time:27701ms step_avg:40.50ms
+step:685/1600 train_time:27764ms step_avg:40.53ms
+step:686/1600 train_time:27823ms step_avg:40.56ms
+step:687/1600 train_time:27886ms step_avg:40.59ms
+step:688/1600 train_time:27945ms step_avg:40.62ms
+step:689/1600 train_time:28009ms step_avg:40.65ms
+step:690/1600 train_time:28067ms step_avg:40.68ms
+step:691/1600 train_time:28131ms step_avg:40.71ms
+step:692/1600 train_time:28190ms step_avg:40.74ms
+step:693/1600 train_time:28252ms step_avg:40.77ms
+step:694/1600 train_time:28312ms step_avg:40.80ms
+step:695/1600 train_time:28375ms step_avg:40.83ms
+step:696/1600 train_time:28434ms step_avg:40.85ms
+step:697/1600 train_time:28497ms step_avg:40.89ms
+step:698/1600 train_time:28556ms step_avg:40.91ms
+step:699/1600 train_time:28618ms step_avg:40.94ms
+step:700/1600 train_time:28677ms step_avg:40.97ms
+step:701/1600 train_time:28740ms step_avg:41.00ms
+step:702/1600 train_time:28800ms step_avg:41.03ms
+step:703/1600 train_time:28862ms step_avg:41.06ms
+step:704/1600 train_time:28921ms step_avg:41.08ms
+step:705/1600 train_time:28983ms step_avg:41.11ms
+step:706/1600 train_time:29043ms step_avg:41.14ms
+step:707/1600 train_time:29106ms step_avg:41.17ms
+step:708/1600 train_time:29165ms step_avg:41.19ms
+step:709/1600 train_time:29228ms step_avg:41.22ms
+step:710/1600 train_time:29287ms step_avg:41.25ms
+step:711/1600 train_time:29350ms step_avg:41.28ms
+step:712/1600 train_time:29409ms step_avg:41.31ms
+step:713/1600 train_time:29472ms step_avg:41.34ms
+step:714/1600 train_time:29532ms step_avg:41.36ms
+step:715/1600 train_time:29594ms step_avg:41.39ms
+step:716/1600 train_time:29653ms step_avg:41.41ms
+step:717/1600 train_time:29714ms step_avg:41.44ms
+step:718/1600 train_time:29773ms step_avg:41.47ms
+step:719/1600 train_time:29835ms step_avg:41.50ms
+step:720/1600 train_time:29894ms step_avg:41.52ms
+step:721/1600 train_time:29957ms step_avg:41.55ms
+step:722/1600 train_time:30016ms step_avg:41.57ms
+step:723/1600 train_time:30078ms step_avg:41.60ms
+step:724/1600 train_time:30138ms step_avg:41.63ms
+step:725/1600 train_time:30201ms step_avg:41.66ms
+step:726/1600 train_time:30260ms step_avg:41.68ms
+step:727/1600 train_time:30323ms step_avg:41.71ms
+step:728/1600 train_time:30382ms step_avg:41.73ms
+step:729/1600 train_time:30445ms step_avg:41.76ms
+step:730/1600 train_time:30505ms step_avg:41.79ms
+step:731/1600 train_time:30568ms step_avg:41.82ms
+step:732/1600 train_time:30627ms step_avg:41.84ms
+step:733/1600 train_time:30690ms step_avg:41.87ms
+step:734/1600 train_time:30749ms step_avg:41.89ms
+step:735/1600 train_time:30812ms step_avg:41.92ms
+step:736/1600 train_time:30870ms step_avg:41.94ms
+step:737/1600 train_time:30933ms step_avg:41.97ms
+step:738/1600 train_time:30993ms step_avg:42.00ms
+step:739/1600 train_time:31055ms step_avg:42.02ms
+step:740/1600 train_time:31114ms step_avg:42.05ms
+step:741/1600 train_time:31176ms step_avg:42.07ms
+step:742/1600 train_time:31236ms step_avg:42.10ms
+step:743/1600 train_time:31298ms step_avg:42.12ms
+step:744/1600 train_time:31357ms step_avg:42.15ms
+step:745/1600 train_time:31419ms step_avg:42.17ms
+step:746/1600 train_time:31479ms step_avg:42.20ms
+step:747/1600 train_time:31541ms step_avg:42.22ms
+step:748/1600 train_time:31601ms step_avg:42.25ms
+step:749/1600 train_time:31663ms step_avg:42.27ms
+step:750/1600 train_time:31722ms step_avg:42.30ms
+step:750/1600 val_loss:3.8986 train_time:31770ms step_avg:42.36ms
+step:751/1600 train_time:31789ms step_avg:42.33ms
+step:752/1600 train_time:31850ms step_avg:42.35ms
+step:753/1600 train_time:31914ms step_avg:42.38ms
+step:754/1600 train_time:31974ms step_avg:42.41ms
+step:755/1600 train_time:32038ms step_avg:42.43ms
+step:756/1600 train_time:32097ms step_avg:42.46ms
+step:757/1600 train_time:32159ms step_avg:42.48ms
+step:758/1600 train_time:32217ms step_avg:42.50ms
+step:759/1600 train_time:32279ms step_avg:42.53ms
+step:760/1600 train_time:32338ms step_avg:42.55ms
+step:761/1600 train_time:32399ms step_avg:42.57ms
+step:762/1600 train_time:32457ms step_avg:42.60ms
+step:763/1600 train_time:32519ms step_avg:42.62ms
+step:764/1600 train_time:32578ms step_avg:42.64ms
+step:765/1600 train_time:32639ms step_avg:42.67ms
+step:766/1600 train_time:32698ms step_avg:42.69ms
+step:767/1600 train_time:32761ms step_avg:42.71ms
+step:768/1600 train_time:32822ms step_avg:42.74ms
+step:769/1600 train_time:32886ms step_avg:42.76ms
+step:770/1600 train_time:32946ms step_avg:42.79ms
+step:771/1600 train_time:33010ms step_avg:42.81ms
+step:772/1600 train_time:33068ms step_avg:42.83ms
+step:773/1600 train_time:33131ms step_avg:42.86ms
+step:774/1600 train_time:33190ms step_avg:42.88ms
+step:775/1600 train_time:33252ms step_avg:42.91ms
+step:776/1600 train_time:33311ms step_avg:42.93ms
+step:777/1600 train_time:33373ms step_avg:42.95ms
+step:778/1600 train_time:33432ms step_avg:42.97ms
+step:779/1600 train_time:33494ms step_avg:43.00ms
+step:780/1600 train_time:33553ms step_avg:43.02ms
+step:781/1600 train_time:33615ms step_avg:43.04ms
+step:782/1600 train_time:33674ms step_avg:43.06ms
+step:783/1600 train_time:33737ms step_avg:43.09ms
+step:784/1600 train_time:33796ms step_avg:43.11ms
+step:785/1600 train_time:33861ms step_avg:43.13ms
+step:786/1600 train_time:33920ms step_avg:43.15ms
+step:787/1600 train_time:33983ms step_avg:43.18ms
+step:788/1600 train_time:34041ms step_avg:43.20ms
+step:789/1600 train_time:34104ms step_avg:43.22ms
+step:790/1600 train_time:34163ms step_avg:43.24ms
+step:791/1600 train_time:34224ms step_avg:43.27ms
+step:792/1600 train_time:34283ms step_avg:43.29ms
+step:793/1600 train_time:34346ms step_avg:43.31ms
+step:794/1600 train_time:34405ms step_avg:43.33ms
+step:795/1600 train_time:34467ms step_avg:43.35ms
+step:796/1600 train_time:34526ms step_avg:43.37ms
+step:797/1600 train_time:34589ms step_avg:43.40ms
+step:798/1600 train_time:34648ms step_avg:43.42ms
+step:799/1600 train_time:34710ms step_avg:43.44ms
+step:800/1600 train_time:34770ms step_avg:43.46ms
+step:801/1600 train_time:34833ms step_avg:43.49ms
+step:802/1600 train_time:34893ms step_avg:43.51ms
+step:803/1600 train_time:34955ms step_avg:43.53ms
+step:804/1600 train_time:35016ms step_avg:43.55ms
+step:805/1600 train_time:35078ms step_avg:43.58ms
+step:806/1600 train_time:35137ms step_avg:43.59ms
+step:807/1600 train_time:35200ms step_avg:43.62ms
+step:808/1600 train_time:35259ms step_avg:43.64ms
+step:809/1600 train_time:35321ms step_avg:43.66ms
+step:810/1600 train_time:35380ms step_avg:43.68ms
+step:811/1600 train_time:35442ms step_avg:43.70ms
+step:812/1600 train_time:35501ms step_avg:43.72ms
+step:813/1600 train_time:35564ms step_avg:43.74ms
+step:814/1600 train_time:35623ms step_avg:43.76ms
+step:815/1600 train_time:35686ms step_avg:43.79ms
+step:816/1600 train_time:35746ms step_avg:43.81ms
+step:817/1600 train_time:35809ms step_avg:43.83ms
+step:818/1600 train_time:35868ms step_avg:43.85ms
+step:819/1600 train_time:35931ms step_avg:43.87ms
+step:820/1600 train_time:35990ms step_avg:43.89ms
+step:821/1600 train_time:36052ms step_avg:43.91ms
+step:822/1600 train_time:36111ms step_avg:43.93ms
+step:823/1600 train_time:36174ms step_avg:43.95ms
+step:824/1600 train_time:36233ms step_avg:43.97ms
+step:825/1600 train_time:36296ms step_avg:44.00ms
+step:826/1600 train_time:36355ms step_avg:44.01ms
+step:827/1600 train_time:36417ms step_avg:44.04ms
+step:828/1600 train_time:36477ms step_avg:44.05ms
+step:829/1600 train_time:36540ms step_avg:44.08ms
+step:830/1600 train_time:36599ms step_avg:44.09ms
+step:831/1600 train_time:36661ms step_avg:44.12ms
+step:832/1600 train_time:36720ms step_avg:44.13ms
+step:833/1600 train_time:36783ms step_avg:44.16ms
+step:834/1600 train_time:36843ms step_avg:44.18ms
+step:835/1600 train_time:36906ms step_avg:44.20ms
+step:836/1600 train_time:36965ms step_avg:44.22ms
+step:837/1600 train_time:37028ms step_avg:44.24ms
+step:838/1600 train_time:37087ms step_avg:44.26ms
+step:839/1600 train_time:37150ms step_avg:44.28ms
+step:840/1600 train_time:37209ms step_avg:44.30ms
+step:841/1600 train_time:37272ms step_avg:44.32ms
+step:842/1600 train_time:37332ms step_avg:44.34ms
+step:843/1600 train_time:37394ms step_avg:44.36ms
+step:844/1600 train_time:37454ms step_avg:44.38ms
+step:845/1600 train_time:37516ms step_avg:44.40ms
+step:846/1600 train_time:37575ms step_avg:44.41ms
+step:847/1600 train_time:37638ms step_avg:44.44ms
+step:848/1600 train_time:37697ms step_avg:44.45ms
+step:849/1600 train_time:37759ms step_avg:44.47ms
+step:850/1600 train_time:37818ms step_avg:44.49ms
+step:851/1600 train_time:37881ms step_avg:44.51ms
+step:852/1600 train_time:37940ms step_avg:44.53ms
+step:853/1600 train_time:38003ms step_avg:44.55ms
+step:854/1600 train_time:38062ms step_avg:44.57ms
+step:855/1600 train_time:38124ms step_avg:44.59ms
+step:856/1600 train_time:38183ms step_avg:44.61ms
+step:857/1600 train_time:38246ms step_avg:44.63ms
+step:858/1600 train_time:38305ms step_avg:44.64ms
+step:859/1600 train_time:38368ms step_avg:44.67ms
+step:860/1600 train_time:38426ms step_avg:44.68ms
+step:861/1600 train_time:38489ms step_avg:44.70ms
+step:862/1600 train_time:38549ms step_avg:44.72ms
+step:863/1600 train_time:38613ms step_avg:44.74ms
+step:864/1600 train_time:38673ms step_avg:44.76ms
+step:865/1600 train_time:38734ms step_avg:44.78ms
+step:866/1600 train_time:38793ms step_avg:44.80ms
+step:867/1600 train_time:38856ms step_avg:44.82ms
+step:868/1600 train_time:38915ms step_avg:44.83ms
+step:869/1600 train_time:38978ms step_avg:44.85ms
+step:870/1600 train_time:39037ms step_avg:44.87ms
+step:871/1600 train_time:39100ms step_avg:44.89ms
+step:872/1600 train_time:39159ms step_avg:44.91ms
+step:873/1600 train_time:39221ms step_avg:44.93ms
+step:874/1600 train_time:39280ms step_avg:44.94ms
+step:875/1600 train_time:39342ms step_avg:44.96ms
+step:876/1600 train_time:39402ms step_avg:44.98ms
+step:877/1600 train_time:39464ms step_avg:45.00ms
+step:878/1600 train_time:39523ms step_avg:45.02ms
+step:879/1600 train_time:39586ms step_avg:45.03ms
+step:880/1600 train_time:39645ms step_avg:45.05ms
+step:881/1600 train_time:39708ms step_avg:45.07ms
+step:882/1600 train_time:39769ms step_avg:45.09ms
+step:883/1600 train_time:39830ms step_avg:45.11ms
+step:884/1600 train_time:39889ms step_avg:45.12ms
+step:885/1600 train_time:39951ms step_avg:45.14ms
+step:886/1600 train_time:40010ms step_avg:45.16ms
+step:887/1600 train_time:40072ms step_avg:45.18ms
+step:888/1600 train_time:40132ms step_avg:45.19ms
+step:889/1600 train_time:40195ms step_avg:45.21ms
+step:890/1600 train_time:40257ms step_avg:45.23ms
+step:891/1600 train_time:40319ms step_avg:45.25ms
+step:892/1600 train_time:40379ms step_avg:45.27ms
+step:893/1600 train_time:40442ms step_avg:45.29ms
+step:894/1600 train_time:40499ms step_avg:45.30ms
+step:895/1600 train_time:40562ms step_avg:45.32ms
+step:896/1600 train_time:40620ms step_avg:45.34ms
+step:897/1600 train_time:40683ms step_avg:45.35ms
+step:898/1600 train_time:40742ms step_avg:45.37ms
+step:899/1600 train_time:40804ms step_avg:45.39ms
+step:900/1600 train_time:40864ms step_avg:45.40ms
+step:901/1600 train_time:40927ms step_avg:45.42ms
+step:902/1600 train_time:40986ms step_avg:45.44ms
+step:903/1600 train_time:41048ms step_avg:45.46ms
+step:904/1600 train_time:41107ms step_avg:45.47ms
+step:905/1600 train_time:41170ms step_avg:45.49ms
+step:906/1600 train_time:41229ms step_avg:45.51ms
+step:907/1600 train_time:41292ms step_avg:45.53ms
+step:908/1600 train_time:41351ms step_avg:45.54ms
+step:909/1600 train_time:41414ms step_avg:45.56ms
+step:910/1600 train_time:41473ms step_avg:45.58ms
+step:911/1600 train_time:41536ms step_avg:45.59ms
+step:912/1600 train_time:41595ms step_avg:45.61ms
+step:913/1600 train_time:41657ms step_avg:45.63ms
+step:914/1600 train_time:41716ms step_avg:45.64ms
+step:915/1600 train_time:41779ms step_avg:45.66ms
+step:916/1600 train_time:41838ms step_avg:45.67ms
+step:917/1600 train_time:41901ms step_avg:45.69ms
+step:918/1600 train_time:41960ms step_avg:45.71ms
+step:919/1600 train_time:42022ms step_avg:45.73ms
+step:920/1600 train_time:42081ms step_avg:45.74ms
+step:921/1600 train_time:42144ms step_avg:45.76ms
+step:922/1600 train_time:42203ms step_avg:45.77ms
+step:923/1600 train_time:42266ms step_avg:45.79ms
+step:924/1600 train_time:42325ms step_avg:45.81ms
+step:925/1600 train_time:42388ms step_avg:45.82ms
+step:926/1600 train_time:42447ms step_avg:45.84ms
+step:927/1600 train_time:42509ms step_avg:45.86ms
+step:928/1600 train_time:42568ms step_avg:45.87ms
+step:929/1600 train_time:42630ms step_avg:45.89ms
+step:930/1600 train_time:42689ms step_avg:45.90ms
+step:931/1600 train_time:42753ms step_avg:45.92ms
+step:932/1600 train_time:42813ms step_avg:45.94ms
+step:933/1600 train_time:42875ms step_avg:45.95ms
+step:934/1600 train_time:42935ms step_avg:45.97ms
+step:935/1600 train_time:42997ms step_avg:45.99ms
+step:936/1600 train_time:43057ms step_avg:46.00ms
+step:937/1600 train_time:43119ms step_avg:46.02ms
+step:938/1600 train_time:43178ms step_avg:46.03ms
+step:939/1600 train_time:43241ms step_avg:46.05ms
+step:940/1600 train_time:43300ms step_avg:46.06ms
+step:941/1600 train_time:43362ms step_avg:46.08ms
+step:942/1600 train_time:43421ms step_avg:46.09ms
+step:943/1600 train_time:43484ms step_avg:46.11ms
+step:944/1600 train_time:43544ms step_avg:46.13ms
+step:945/1600 train_time:43606ms step_avg:46.14ms
+step:946/1600 train_time:43666ms step_avg:46.16ms
+step:947/1600 train_time:43728ms step_avg:46.18ms
+step:948/1600 train_time:43787ms step_avg:46.19ms
+step:949/1600 train_time:43850ms step_avg:46.21ms
+step:950/1600 train_time:43910ms step_avg:46.22ms
+step:951/1600 train_time:43972ms step_avg:46.24ms
+step:952/1600 train_time:44031ms step_avg:46.25ms
+step:953/1600 train_time:44095ms step_avg:46.27ms
+step:954/1600 train_time:44153ms step_avg:46.28ms
+step:955/1600 train_time:44216ms step_avg:46.30ms
+step:956/1600 train_time:44276ms step_avg:46.31ms
+step:957/1600 train_time:44340ms step_avg:46.33ms
+step:958/1600 train_time:44398ms step_avg:46.34ms
+step:959/1600 train_time:44461ms step_avg:46.36ms
+step:960/1600 train_time:44519ms step_avg:46.37ms
+step:961/1600 train_time:44582ms step_avg:46.39ms
+step:962/1600 train_time:44641ms step_avg:46.40ms
+step:963/1600 train_time:44704ms step_avg:46.42ms
+step:964/1600 train_time:44763ms step_avg:46.43ms
+step:965/1600 train_time:44826ms step_avg:46.45ms
+step:966/1600 train_time:44886ms step_avg:46.47ms
+step:967/1600 train_time:44949ms step_avg:46.48ms
+step:968/1600 train_time:45008ms step_avg:46.50ms
+step:969/1600 train_time:45070ms step_avg:46.51ms
+step:970/1600 train_time:45129ms step_avg:46.52ms
+step:971/1600 train_time:45192ms step_avg:46.54ms
+step:972/1600 train_time:45250ms step_avg:46.55ms
+step:973/1600 train_time:45314ms step_avg:46.57ms
+step:974/1600 train_time:45373ms step_avg:46.58ms
+step:975/1600 train_time:45436ms step_avg:46.60ms
+step:976/1600 train_time:45495ms step_avg:46.61ms
+step:977/1600 train_time:45559ms step_avg:46.63ms
+step:978/1600 train_time:45618ms step_avg:46.64ms
+step:979/1600 train_time:45681ms step_avg:46.66ms
+step:980/1600 train_time:45739ms step_avg:46.67ms
+step:981/1600 train_time:45802ms step_avg:46.69ms
+step:982/1600 train_time:45861ms step_avg:46.70ms
+step:983/1600 train_time:45923ms step_avg:46.72ms
+step:984/1600 train_time:45983ms step_avg:46.73ms
+step:985/1600 train_time:46046ms step_avg:46.75ms
+step:986/1600 train_time:46105ms step_avg:46.76ms
+step:987/1600 train_time:46168ms step_avg:46.78ms
+step:988/1600 train_time:46227ms step_avg:46.79ms
+step:989/1600 train_time:46289ms step_avg:46.80ms
+step:990/1600 train_time:46348ms step_avg:46.82ms
+step:991/1600 train_time:46411ms step_avg:46.83ms
+step:992/1600 train_time:46470ms step_avg:46.84ms
+step:993/1600 train_time:46533ms step_avg:46.86ms
+step:994/1600 train_time:46592ms step_avg:46.87ms
+step:995/1600 train_time:46655ms step_avg:46.89ms
+step:996/1600 train_time:46714ms step_avg:46.90ms
+step:997/1600 train_time:46777ms step_avg:46.92ms
+step:998/1600 train_time:46836ms step_avg:46.93ms
+step:999/1600 train_time:46899ms step_avg:46.95ms
+step:1000/1600 train_time:46958ms step_avg:46.96ms
+step:1000/1600 val_loss:3.5958 train_time:47005ms step_avg:47.01ms
+step:1001/1600 train_time:47024ms step_avg:46.98ms
+step:1002/1600 train_time:47083ms step_avg:46.99ms
+step:1003/1600 train_time:47150ms step_avg:47.01ms
+step:1004/1600 train_time:47213ms step_avg:47.02ms
+step:1005/1600 train_time:47275ms step_avg:47.04ms
+step:1006/1600 train_time:47334ms step_avg:47.05ms
+step:1007/1600 train_time:47396ms step_avg:47.07ms
+step:1008/1600 train_time:47454ms step_avg:47.08ms
+step:1009/1600 train_time:47515ms step_avg:47.09ms
+step:1010/1600 train_time:47573ms step_avg:47.10ms
+step:1011/1600 train_time:47636ms step_avg:47.12ms
+step:1012/1600 train_time:47694ms step_avg:47.13ms
+step:1013/1600 train_time:47756ms step_avg:47.14ms
+step:1014/1600 train_time:47814ms step_avg:47.15ms
+step:1015/1600 train_time:47876ms step_avg:47.17ms
+step:1016/1600 train_time:47937ms step_avg:47.18ms
+step:1017/1600 train_time:47999ms step_avg:47.20ms
+step:1018/1600 train_time:48060ms step_avg:47.21ms
+step:1019/1600 train_time:48124ms step_avg:47.23ms
+step:1020/1600 train_time:48184ms step_avg:47.24ms
+step:1021/1600 train_time:48247ms step_avg:47.25ms
+step:1022/1600 train_time:48306ms step_avg:47.27ms
+step:1023/1600 train_time:48368ms step_avg:47.28ms
+step:1024/1600 train_time:48427ms step_avg:47.29ms
+step:1025/1600 train_time:48490ms step_avg:47.31ms
+step:1026/1600 train_time:48549ms step_avg:47.32ms
+step:1027/1600 train_time:48611ms step_avg:47.33ms
+step:1028/1600 train_time:48671ms step_avg:47.35ms
+step:1029/1600 train_time:48733ms step_avg:47.36ms
+step:1030/1600 train_time:48791ms step_avg:47.37ms
+step:1031/1600 train_time:48853ms step_avg:47.38ms
+step:1032/1600 train_time:48912ms step_avg:47.40ms
+step:1033/1600 train_time:48975ms step_avg:47.41ms
+step:1034/1600 train_time:49035ms step_avg:47.42ms
+step:1035/1600 train_time:49099ms step_avg:47.44ms
+step:1036/1600 train_time:49158ms step_avg:47.45ms
+step:1037/1600 train_time:49221ms step_avg:47.46ms
+step:1038/1600 train_time:49281ms step_avg:47.48ms
+step:1039/1600 train_time:49343ms step_avg:47.49ms
+step:1040/1600 train_time:49402ms step_avg:47.50ms
+step:1041/1600 train_time:49474ms step_avg:47.53ms
+step:1042/1600 train_time:49557ms step_avg:47.56ms
+step:1043/1600 train_time:49646ms step_avg:47.60ms
+step:1044/1600 train_time:49731ms step_avg:47.63ms
+step:1045/1600 train_time:49818ms step_avg:47.67ms
+step:1046/1600 train_time:49903ms step_avg:47.71ms
+step:1047/1600 train_time:49991ms step_avg:47.75ms
+step:1048/1600 train_time:50077ms step_avg:47.78ms
+step:1049/1600 train_time:50167ms step_avg:47.82ms
+step:1050/1600 train_time:50252ms step_avg:47.86ms
+step:1051/1600 train_time:50341ms step_avg:47.90ms
+step:1052/1600 train_time:50426ms step_avg:47.93ms
+step:1053/1600 train_time:50514ms step_avg:47.97ms
+step:1054/1600 train_time:50600ms step_avg:48.01ms
+step:1055/1600 train_time:50688ms step_avg:48.05ms
+step:1056/1600 train_time:50773ms step_avg:48.08ms
+step:1057/1600 train_time:50862ms step_avg:48.12ms
+step:1058/1600 train_time:50947ms step_avg:48.15ms
+step:1059/1600 train_time:51035ms step_avg:48.19ms
+step:1060/1600 train_time:51121ms step_avg:48.23ms
+step:1061/1600 train_time:51209ms step_avg:48.27ms
+step:1062/1600 train_time:51295ms step_avg:48.30ms
+step:1063/1600 train_time:51383ms step_avg:48.34ms
+step:1064/1600 train_time:51468ms step_avg:48.37ms
+step:1065/1600 train_time:51557ms step_avg:48.41ms
+step:1066/1600 train_time:51642ms step_avg:48.45ms
+step:1067/1600 train_time:51730ms step_avg:48.48ms
+step:1068/1600 train_time:51814ms step_avg:48.52ms
+step:1069/1600 train_time:51903ms step_avg:48.55ms
+step:1070/1600 train_time:51989ms step_avg:48.59ms
+step:1071/1600 train_time:52078ms step_avg:48.63ms
+step:1072/1600 train_time:52163ms step_avg:48.66ms
+step:1073/1600 train_time:52251ms step_avg:48.70ms
+step:1074/1600 train_time:52337ms step_avg:48.73ms
+step:1075/1600 train_time:52426ms step_avg:48.77ms
+step:1076/1600 train_time:52511ms step_avg:48.80ms
+step:1077/1600 train_time:52600ms step_avg:48.84ms
+step:1078/1600 train_time:52685ms step_avg:48.87ms
+step:1079/1600 train_time:52773ms step_avg:48.91ms
+step:1080/1600 train_time:52858ms step_avg:48.94ms
+step:1081/1600 train_time:52945ms step_avg:48.98ms
+step:1082/1600 train_time:53030ms step_avg:49.01ms
+step:1083/1600 train_time:53118ms step_avg:49.05ms
+step:1084/1600 train_time:53204ms step_avg:49.08ms
+step:1085/1600 train_time:53292ms step_avg:49.12ms
+step:1086/1600 train_time:53377ms step_avg:49.15ms
+step:1087/1600 train_time:53466ms step_avg:49.19ms
+step:1088/1600 train_time:53552ms step_avg:49.22ms
+step:1089/1600 train_time:53641ms step_avg:49.26ms
+step:1090/1600 train_time:53725ms step_avg:49.29ms
+step:1091/1600 train_time:53813ms step_avg:49.32ms
+step:1092/1600 train_time:53898ms step_avg:49.36ms
+step:1093/1600 train_time:53987ms step_avg:49.39ms
+step:1094/1600 train_time:54073ms step_avg:49.43ms
+step:1095/1600 train_time:54161ms step_avg:49.46ms
+step:1096/1600 train_time:54245ms step_avg:49.49ms
+step:1097/1600 train_time:54334ms step_avg:49.53ms
+step:1098/1600 train_time:54419ms step_avg:49.56ms
+step:1099/1600 train_time:54508ms step_avg:49.60ms
+step:1100/1600 train_time:54593ms step_avg:49.63ms
+step:1101/1600 train_time:54682ms step_avg:49.67ms
+step:1102/1600 train_time:54766ms step_avg:49.70ms
+step:1103/1600 train_time:54855ms step_avg:49.73ms
+step:1104/1600 train_time:54939ms step_avg:49.76ms
+step:1105/1600 train_time:55028ms step_avg:49.80ms
+step:1106/1600 train_time:55113ms step_avg:49.83ms
+step:1107/1600 train_time:55201ms step_avg:49.87ms
+step:1108/1600 train_time:55286ms step_avg:49.90ms
+step:1109/1600 train_time:55374ms step_avg:49.93ms
+step:1110/1600 train_time:55459ms step_avg:49.96ms
+step:1111/1600 train_time:55548ms step_avg:50.00ms
+step:1112/1600 train_time:55634ms step_avg:50.03ms
+step:1113/1600 train_time:55721ms step_avg:50.06ms
+step:1114/1600 train_time:55806ms step_avg:50.10ms
+step:1115/1600 train_time:55894ms step_avg:50.13ms
+step:1116/1600 train_time:55979ms step_avg:50.16ms
+step:1117/1600 train_time:56068ms step_avg:50.20ms
+step:1118/1600 train_time:56154ms step_avg:50.23ms
+step:1119/1600 train_time:56241ms step_avg:50.26ms
+step:1120/1600 train_time:56326ms step_avg:50.29ms
+step:1121/1600 train_time:56415ms step_avg:50.33ms
+step:1122/1600 train_time:56500ms step_avg:50.36ms
+step:1123/1600 train_time:56589ms step_avg:50.39ms
+step:1124/1600 train_time:56675ms step_avg:50.42ms
+step:1125/1600 train_time:56763ms step_avg:50.46ms
+step:1126/1600 train_time:56850ms step_avg:50.49ms
+step:1127/1600 train_time:56937ms step_avg:50.52ms
+step:1128/1600 train_time:57023ms step_avg:50.55ms
+step:1129/1600 train_time:57111ms step_avg:50.59ms
+step:1130/1600 train_time:57197ms step_avg:50.62ms
+step:1131/1600 train_time:57285ms step_avg:50.65ms
+step:1132/1600 train_time:57370ms step_avg:50.68ms
+step:1133/1600 train_time:57458ms step_avg:50.71ms
+step:1134/1600 train_time:57544ms step_avg:50.74ms
+step:1135/1600 train_time:57634ms step_avg:50.78ms
+step:1136/1600 train_time:57719ms step_avg:50.81ms
+step:1137/1600 train_time:57807ms step_avg:50.84ms
+step:1138/1600 train_time:57892ms step_avg:50.87ms
+step:1139/1600 train_time:57979ms step_avg:50.90ms
+step:1140/1600 train_time:58064ms step_avg:50.93ms
+step:1141/1600 train_time:58152ms step_avg:50.97ms
+step:1142/1600 train_time:58238ms step_avg:51.00ms
+step:1143/1600 train_time:58327ms step_avg:51.03ms
+step:1144/1600 train_time:58413ms step_avg:51.06ms
+step:1145/1600 train_time:58501ms step_avg:51.09ms
+step:1146/1600 train_time:58586ms step_avg:51.12ms
+step:1147/1600 train_time:58675ms step_avg:51.15ms
+step:1148/1600 train_time:58760ms step_avg:51.18ms
+step:1149/1600 train_time:58848ms step_avg:51.22ms
+step:1150/1600 train_time:58933ms step_avg:51.25ms
+step:1151/1600 train_time:59021ms step_avg:51.28ms
+step:1152/1600 train_time:59107ms step_avg:51.31ms
+step:1153/1600 train_time:59195ms step_avg:51.34ms
+step:1154/1600 train_time:59283ms step_avg:51.37ms
+step:1155/1600 train_time:59371ms step_avg:51.40ms
+step:1156/1600 train_time:59457ms step_avg:51.43ms
+step:1157/1600 train_time:59545ms step_avg:51.46ms
+step:1158/1600 train_time:59630ms step_avg:51.49ms
+step:1159/1600 train_time:59718ms step_avg:51.53ms
+step:1160/1600 train_time:59803ms step_avg:51.55ms
+step:1161/1600 train_time:59891ms step_avg:51.59ms
+step:1162/1600 train_time:59977ms step_avg:51.62ms
+step:1163/1600 train_time:60064ms step_avg:51.65ms
+step:1164/1600 train_time:60150ms step_avg:51.67ms
+step:1165/1600 train_time:60238ms step_avg:51.71ms
+step:1166/1600 train_time:60324ms step_avg:51.74ms
+step:1167/1600 train_time:60414ms step_avg:51.77ms
+step:1168/1600 train_time:60499ms step_avg:51.80ms
+step:1169/1600 train_time:60587ms step_avg:51.83ms
+step:1170/1600 train_time:60673ms step_avg:51.86ms
+step:1171/1600 train_time:60761ms step_avg:51.89ms
+step:1172/1600 train_time:60846ms step_avg:51.92ms
+step:1173/1600 train_time:60936ms step_avg:51.95ms
+step:1174/1600 train_time:61020ms step_avg:51.98ms
+step:1175/1600 train_time:61108ms step_avg:52.01ms
+step:1176/1600 train_time:61193ms step_avg:52.04ms
+step:1177/1600 train_time:61281ms step_avg:52.07ms
+step:1178/1600 train_time:61367ms step_avg:52.09ms
+step:1179/1600 train_time:61456ms step_avg:52.13ms
+step:1180/1600 train_time:61542ms step_avg:52.15ms
+step:1181/1600 train_time:61630ms step_avg:52.18ms
+step:1182/1600 train_time:61715ms step_avg:52.21ms
+step:1183/1600 train_time:61803ms step_avg:52.24ms
+step:1184/1600 train_time:61890ms step_avg:52.27ms
+step:1185/1600 train_time:61978ms step_avg:52.30ms
+step:1186/1600 train_time:62063ms step_avg:52.33ms
+step:1187/1600 train_time:62151ms step_avg:52.36ms
+step:1188/1600 train_time:62236ms step_avg:52.39ms
+step:1189/1600 train_time:62324ms step_avg:52.42ms
+step:1190/1600 train_time:62409ms step_avg:52.44ms
+step:1191/1600 train_time:62497ms step_avg:52.47ms
+step:1192/1600 train_time:62582ms step_avg:52.50ms
+step:1193/1600 train_time:62670ms step_avg:52.53ms
+step:1194/1600 train_time:62755ms step_avg:52.56ms
+step:1195/1600 train_time:62843ms step_avg:52.59ms
+step:1196/1600 train_time:62929ms step_avg:52.62ms
+step:1197/1600 train_time:63017ms step_avg:52.65ms
+step:1198/1600 train_time:63102ms step_avg:52.67ms
+step:1199/1600 train_time:63190ms step_avg:52.70ms
+step:1200/1600 train_time:63275ms step_avg:52.73ms
+step:1201/1600 train_time:63364ms step_avg:52.76ms
+step:1202/1600 train_time:63449ms step_avg:52.79ms
+step:1203/1600 train_time:63538ms step_avg:52.82ms
+step:1204/1600 train_time:63623ms step_avg:52.84ms
+step:1205/1600 train_time:63711ms step_avg:52.87ms
+step:1206/1600 train_time:63796ms step_avg:52.90ms
+step:1207/1600 train_time:63884ms step_avg:52.93ms
+step:1208/1600 train_time:63969ms step_avg:52.95ms
+step:1209/1600 train_time:64057ms step_avg:52.98ms
+step:1210/1600 train_time:64142ms step_avg:53.01ms
+step:1211/1600 train_time:64231ms step_avg:53.04ms
+step:1212/1600 train_time:64315ms step_avg:53.07ms
+step:1213/1600 train_time:64404ms step_avg:53.10ms
+step:1214/1600 train_time:64489ms step_avg:53.12ms
+step:1215/1600 train_time:64578ms step_avg:53.15ms
+step:1216/1600 train_time:64665ms step_avg:53.18ms
+step:1217/1600 train_time:64754ms step_avg:53.21ms
+step:1218/1600 train_time:64838ms step_avg:53.23ms
+step:1219/1600 train_time:64926ms step_avg:53.26ms
+step:1220/1600 train_time:65011ms step_avg:53.29ms
+step:1221/1600 train_time:65099ms step_avg:53.32ms
+step:1222/1600 train_time:65185ms step_avg:53.34ms
+step:1223/1600 train_time:65273ms step_avg:53.37ms
+step:1224/1600 train_time:65357ms step_avg:53.40ms
+step:1225/1600 train_time:65446ms step_avg:53.43ms
+step:1226/1600 train_time:65532ms step_avg:53.45ms
+step:1227/1600 train_time:65622ms step_avg:53.48ms
+step:1228/1600 train_time:65707ms step_avg:53.51ms
+step:1229/1600 train_time:65795ms step_avg:53.54ms
+step:1230/1600 train_time:65880ms step_avg:53.56ms
+step:1231/1600 train_time:65968ms step_avg:53.59ms
+step:1232/1600 train_time:66054ms step_avg:53.62ms
+step:1233/1600 train_time:66142ms step_avg:53.64ms
+step:1234/1600 train_time:66228ms step_avg:53.67ms
+step:1235/1600 train_time:66315ms step_avg:53.70ms
+step:1236/1600 train_time:66401ms step_avg:53.72ms
+step:1237/1600 train_time:66489ms step_avg:53.75ms
+step:1238/1600 train_time:66575ms step_avg:53.78ms
+step:1239/1600 train_time:66663ms step_avg:53.80ms
+step:1240/1600 train_time:66747ms step_avg:53.83ms
+step:1241/1600 train_time:66836ms step_avg:53.86ms
+step:1242/1600 train_time:66922ms step_avg:53.88ms
+step:1243/1600 train_time:67010ms step_avg:53.91ms
+step:1244/1600 train_time:67095ms step_avg:53.93ms
+step:1245/1600 train_time:67183ms step_avg:53.96ms
+step:1246/1600 train_time:67268ms step_avg:53.99ms
+step:1247/1600 train_time:67356ms step_avg:54.01ms
+step:1248/1600 train_time:67442ms step_avg:54.04ms
+step:1249/1600 train_time:67530ms step_avg:54.07ms
+step:1250/1600 train_time:67616ms step_avg:54.09ms
+step:1250/1600 val_loss:3.4170 train_time:67688ms step_avg:54.15ms
+step:1251/1600 train_time:67708ms step_avg:54.12ms
+step:1252/1600 train_time:67793ms step_avg:54.15ms
+step:1253/1600 train_time:67885ms step_avg:54.18ms
+step:1254/1600 train_time:67971ms step_avg:54.20ms
+step:1255/1600 train_time:68060ms step_avg:54.23ms
+step:1256/1600 train_time:68145ms step_avg:54.26ms
+step:1257/1600 train_time:68232ms step_avg:54.28ms
+step:1258/1600 train_time:68315ms step_avg:54.30ms
+step:1259/1600 train_time:68402ms step_avg:54.33ms
+step:1260/1600 train_time:68486ms step_avg:54.35ms
+step:1261/1600 train_time:68573ms step_avg:54.38ms
+step:1262/1600 train_time:68659ms step_avg:54.40ms
+step:1263/1600 train_time:68750ms step_avg:54.43ms
+step:1264/1600 train_time:68838ms step_avg:54.46ms
+step:1265/1600 train_time:68928ms step_avg:54.49ms
+step:1266/1600 train_time:69014ms step_avg:54.51ms
+step:1267/1600 train_time:69104ms step_avg:54.54ms
+step:1268/1600 train_time:69188ms step_avg:54.56ms
+step:1269/1600 train_time:69275ms step_avg:54.59ms
+step:1270/1600 train_time:69359ms step_avg:54.61ms
+step:1271/1600 train_time:69447ms step_avg:54.64ms
+step:1272/1600 train_time:69532ms step_avg:54.66ms
+step:1273/1600 train_time:69619ms step_avg:54.69ms
+step:1274/1600 train_time:69705ms step_avg:54.71ms
+step:1275/1600 train_time:69794ms step_avg:54.74ms
+step:1276/1600 train_time:69881ms step_avg:54.77ms
+step:1277/1600 train_time:69969ms step_avg:54.79ms
+step:1278/1600 train_time:70055ms step_avg:54.82ms
+step:1279/1600 train_time:70143ms step_avg:54.84ms
+step:1280/1600 train_time:70228ms step_avg:54.87ms
+step:1281/1600 train_time:70315ms step_avg:54.89ms
+step:1282/1600 train_time:70400ms step_avg:54.91ms
+step:1283/1600 train_time:70487ms step_avg:54.94ms
+step:1284/1600 train_time:70573ms step_avg:54.96ms
+step:1285/1600 train_time:70660ms step_avg:54.99ms
+step:1286/1600 train_time:70746ms step_avg:55.01ms
+step:1287/1600 train_time:70835ms step_avg:55.04ms
+step:1288/1600 train_time:70921ms step_avg:55.06ms
+step:1289/1600 train_time:71009ms step_avg:55.09ms
+step:1290/1600 train_time:71094ms step_avg:55.11ms
+step:1291/1600 train_time:71183ms step_avg:55.14ms
+step:1292/1600 train_time:71268ms step_avg:55.16ms
+step:1293/1600 train_time:71356ms step_avg:55.19ms
+step:1294/1600 train_time:71441ms step_avg:55.21ms
+step:1295/1600 train_time:71529ms step_avg:55.23ms
+step:1296/1600 train_time:71614ms step_avg:55.26ms
+step:1297/1600 train_time:71702ms step_avg:55.28ms
+step:1298/1600 train_time:71788ms step_avg:55.31ms
+step:1299/1600 train_time:71877ms step_avg:55.33ms
+step:1300/1600 train_time:71962ms step_avg:55.36ms
+step:1301/1600 train_time:72051ms step_avg:55.38ms
+step:1302/1600 train_time:72136ms step_avg:55.40ms
+step:1303/1600 train_time:72225ms step_avg:55.43ms
+step:1304/1600 train_time:72310ms step_avg:55.45ms
+step:1305/1600 train_time:72398ms step_avg:55.48ms
+step:1306/1600 train_time:72483ms step_avg:55.50ms
+step:1307/1600 train_time:72571ms step_avg:55.52ms
+step:1308/1600 train_time:72657ms step_avg:55.55ms
+step:1309/1600 train_time:72745ms step_avg:55.57ms
+step:1310/1600 train_time:72831ms step_avg:55.60ms
+step:1311/1600 train_time:72919ms step_avg:55.62ms
+step:1312/1600 train_time:73006ms step_avg:55.64ms
+step:1313/1600 train_time:73094ms step_avg:55.67ms
+step:1314/1600 train_time:73180ms step_avg:55.69ms
+step:1315/1600 train_time:73268ms step_avg:55.72ms
+step:1316/1600 train_time:73353ms step_avg:55.74ms
+step:1317/1600 train_time:73441ms step_avg:55.76ms
+step:1318/1600 train_time:73525ms step_avg:55.79ms
+step:1319/1600 train_time:73613ms step_avg:55.81ms
+step:1320/1600 train_time:73698ms step_avg:55.83ms
+step:1321/1600 train_time:73787ms step_avg:55.86ms
+step:1322/1600 train_time:73873ms step_avg:55.88ms
+step:1323/1600 train_time:73962ms step_avg:55.90ms
+step:1324/1600 train_time:74047ms step_avg:55.93ms
+step:1325/1600 train_time:74135ms step_avg:55.95ms
+step:1326/1600 train_time:74221ms step_avg:55.97ms
+step:1327/1600 train_time:74309ms step_avg:56.00ms
+step:1328/1600 train_time:74394ms step_avg:56.02ms
+step:1329/1600 train_time:74483ms step_avg:56.04ms
+step:1330/1600 train_time:74568ms step_avg:56.07ms
+step:1331/1600 train_time:74656ms step_avg:56.09ms
+step:1332/1600 train_time:74741ms step_avg:56.11ms
+step:1333/1600 train_time:74829ms step_avg:56.14ms
+step:1334/1600 train_time:74915ms step_avg:56.16ms
+step:1335/1600 train_time:75003ms step_avg:56.18ms
+step:1336/1600 train_time:75088ms step_avg:56.20ms
+step:1337/1600 train_time:75176ms step_avg:56.23ms
+step:1338/1600 train_time:75262ms step_avg:56.25ms
+step:1339/1600 train_time:75350ms step_avg:56.27ms
+step:1340/1600 train_time:75435ms step_avg:56.30ms
+step:1341/1600 train_time:75524ms step_avg:56.32ms
+step:1342/1600 train_time:75609ms step_avg:56.34ms
+step:1343/1600 train_time:75697ms step_avg:56.36ms
+step:1344/1600 train_time:75781ms step_avg:56.38ms
+step:1345/1600 train_time:75870ms step_avg:56.41ms
+step:1346/1600 train_time:75955ms step_avg:56.43ms
+step:1347/1600 train_time:76044ms step_avg:56.45ms
+step:1348/1600 train_time:76130ms step_avg:56.48ms
+step:1349/1600 train_time:76218ms step_avg:56.50ms
+step:1350/1600 train_time:76303ms step_avg:56.52ms
+step:1351/1600 train_time:76391ms step_avg:56.54ms
+step:1352/1600 train_time:76476ms step_avg:56.56ms
+step:1353/1600 train_time:76563ms step_avg:56.59ms
+step:1354/1600 train_time:76649ms step_avg:56.61ms
+step:1355/1600 train_time:76736ms step_avg:56.63ms
+step:1356/1600 train_time:76821ms step_avg:56.65ms
+step:1357/1600 train_time:76910ms step_avg:56.68ms
+step:1358/1600 train_time:76995ms step_avg:56.70ms
+step:1359/1600 train_time:77084ms step_avg:56.72ms
+step:1360/1600 train_time:77170ms step_avg:56.74ms
+step:1361/1600 train_time:77259ms step_avg:56.77ms
+step:1362/1600 train_time:77345ms step_avg:56.79ms
+step:1363/1600 train_time:77434ms step_avg:56.81ms
+step:1364/1600 train_time:77519ms step_avg:56.83ms
+step:1365/1600 train_time:77607ms step_avg:56.86ms
+step:1366/1600 train_time:77695ms step_avg:56.88ms
+step:1367/1600 train_time:77782ms step_avg:56.90ms
+step:1368/1600 train_time:77869ms step_avg:56.92ms
+step:1369/1600 train_time:77956ms step_avg:56.94ms
+step:1370/1600 train_time:78041ms step_avg:56.96ms
+step:1371/1600 train_time:78129ms step_avg:56.99ms
+step:1372/1600 train_time:78215ms step_avg:57.01ms
+step:1373/1600 train_time:78303ms step_avg:57.03ms
+step:1374/1600 train_time:78389ms step_avg:57.05ms
+step:1375/1600 train_time:78478ms step_avg:57.08ms
+step:1376/1600 train_time:78563ms step_avg:57.10ms
+step:1377/1600 train_time:78651ms step_avg:57.12ms
+step:1378/1600 train_time:78735ms step_avg:57.14ms
+step:1379/1600 train_time:78824ms step_avg:57.16ms
+step:1380/1600 train_time:78910ms step_avg:57.18ms
+step:1381/1600 train_time:78998ms step_avg:57.20ms
+step:1382/1600 train_time:79084ms step_avg:57.22ms
+step:1383/1600 train_time:79173ms step_avg:57.25ms
+step:1384/1600 train_time:79258ms step_avg:57.27ms
+step:1385/1600 train_time:79346ms step_avg:57.29ms
+step:1386/1600 train_time:79432ms step_avg:57.31ms
+step:1387/1600 train_time:79521ms step_avg:57.33ms
+step:1388/1600 train_time:79605ms step_avg:57.35ms
+step:1389/1600 train_time:79693ms step_avg:57.37ms
+step:1390/1600 train_time:79778ms step_avg:57.39ms
+step:1391/1600 train_time:79867ms step_avg:57.42ms
+step:1392/1600 train_time:79952ms step_avg:57.44ms
+step:1393/1600 train_time:80039ms step_avg:57.46ms
+step:1394/1600 train_time:80124ms step_avg:57.48ms
+step:1395/1600 train_time:80214ms step_avg:57.50ms
+step:1396/1600 train_time:80300ms step_avg:57.52ms
+step:1397/1600 train_time:80387ms step_avg:57.54ms
+step:1398/1600 train_time:80473ms step_avg:57.56ms
+step:1399/1600 train_time:80561ms step_avg:57.58ms
+step:1400/1600 train_time:80646ms step_avg:57.60ms
+step:1401/1600 train_time:80734ms step_avg:57.63ms
+step:1402/1600 train_time:80820ms step_avg:57.65ms
+step:1403/1600 train_time:80908ms step_avg:57.67ms
+step:1404/1600 train_time:80993ms step_avg:57.69ms
+step:1405/1600 train_time:81081ms step_avg:57.71ms
+step:1406/1600 train_time:81166ms step_avg:57.73ms
+step:1407/1600 train_time:81255ms step_avg:57.75ms
+step:1408/1600 train_time:81340ms step_avg:57.77ms
+step:1409/1600 train_time:81428ms step_avg:57.79ms
+step:1410/1600 train_time:81514ms step_avg:57.81ms
+step:1411/1600 train_time:81602ms step_avg:57.83ms
+step:1412/1600 train_time:81686ms step_avg:57.85ms
+step:1413/1600 train_time:81774ms step_avg:57.87ms
+step:1414/1600 train_time:81860ms step_avg:57.89ms
+step:1415/1600 train_time:81948ms step_avg:57.91ms
+step:1416/1600 train_time:82034ms step_avg:57.93ms
+step:1417/1600 train_time:82122ms step_avg:57.95ms
+step:1418/1600 train_time:82207ms step_avg:57.97ms
+step:1419/1600 train_time:82298ms step_avg:58.00ms
+step:1420/1600 train_time:82382ms step_avg:58.02ms
+step:1421/1600 train_time:82470ms step_avg:58.04ms
+step:1422/1600 train_time:82555ms step_avg:58.06ms
+step:1423/1600 train_time:82642ms step_avg:58.08ms
+step:1424/1600 train_time:82727ms step_avg:58.10ms
+step:1425/1600 train_time:82815ms step_avg:58.12ms
+step:1426/1600 train_time:82900ms step_avg:58.13ms
+step:1427/1600 train_time:82988ms step_avg:58.16ms
+step:1428/1600 train_time:83074ms step_avg:58.17ms
+step:1429/1600 train_time:83162ms step_avg:58.20ms
+step:1430/1600 train_time:83249ms step_avg:58.22ms
+step:1431/1600 train_time:83337ms step_avg:58.24ms
+step:1432/1600 train_time:83423ms step_avg:58.26ms
+step:1433/1600 train_time:83511ms step_avg:58.28ms
+step:1434/1600 train_time:83596ms step_avg:58.30ms
+step:1435/1600 train_time:83684ms step_avg:58.32ms
+step:1436/1600 train_time:83770ms step_avg:58.34ms
+step:1437/1600 train_time:83857ms step_avg:58.36ms
+step:1438/1600 train_time:83943ms step_avg:58.37ms
+step:1439/1600 train_time:84032ms step_avg:58.40ms
+step:1440/1600 train_time:84118ms step_avg:58.42ms
+step:1441/1600 train_time:84206ms step_avg:58.44ms
+step:1442/1600 train_time:84292ms step_avg:58.46ms
+step:1443/1600 train_time:84380ms step_avg:58.48ms
+step:1444/1600 train_time:84466ms step_avg:58.49ms
+step:1445/1600 train_time:84555ms step_avg:58.52ms
+step:1446/1600 train_time:84640ms step_avg:58.53ms
+step:1447/1600 train_time:84728ms step_avg:58.55ms
+step:1448/1600 train_time:84813ms step_avg:58.57ms
+step:1449/1600 train_time:84902ms step_avg:58.59ms
+step:1450/1600 train_time:84988ms step_avg:58.61ms
+step:1451/1600 train_time:85077ms step_avg:58.63ms
+step:1452/1600 train_time:85162ms step_avg:58.65ms
+step:1453/1600 train_time:85250ms step_avg:58.67ms
+step:1454/1600 train_time:85335ms step_avg:58.69ms
+step:1455/1600 train_time:85423ms step_avg:58.71ms
+step:1456/1600 train_time:85509ms step_avg:58.73ms
+step:1457/1600 train_time:85597ms step_avg:58.75ms
+step:1458/1600 train_time:85682ms step_avg:58.77ms
+step:1459/1600 train_time:85770ms step_avg:58.79ms
+step:1460/1600 train_time:85855ms step_avg:58.80ms
+step:1461/1600 train_time:85944ms step_avg:58.83ms
+step:1462/1600 train_time:86031ms step_avg:58.85ms
+step:1463/1600 train_time:86119ms step_avg:58.86ms
+step:1464/1600 train_time:86205ms step_avg:58.88ms
+step:1465/1600 train_time:86293ms step_avg:58.90ms
+step:1466/1600 train_time:86378ms step_avg:58.92ms
+step:1467/1600 train_time:86467ms step_avg:58.94ms
+step:1468/1600 train_time:86553ms step_avg:58.96ms
+step:1469/1600 train_time:86641ms step_avg:58.98ms
+step:1470/1600 train_time:86726ms step_avg:59.00ms
+step:1471/1600 train_time:86813ms step_avg:59.02ms
+step:1472/1600 train_time:86899ms step_avg:59.03ms
+step:1473/1600 train_time:86987ms step_avg:59.05ms
+step:1474/1600 train_time:87072ms step_avg:59.07ms
+step:1475/1600 train_time:87160ms step_avg:59.09ms
+step:1476/1600 train_time:87245ms step_avg:59.11ms
+step:1477/1600 train_time:87333ms step_avg:59.13ms
+step:1478/1600 train_time:87419ms step_avg:59.15ms
+step:1479/1600 train_time:87508ms step_avg:59.17ms
+step:1480/1600 train_time:87593ms step_avg:59.18ms
+step:1481/1600 train_time:87681ms step_avg:59.20ms
+step:1482/1600 train_time:87766ms step_avg:59.22ms
+step:1483/1600 train_time:87855ms step_avg:59.24ms
+step:1484/1600 train_time:87940ms step_avg:59.26ms
+step:1485/1600 train_time:88029ms step_avg:59.28ms
+step:1486/1600 train_time:88113ms step_avg:59.30ms
+step:1487/1600 train_time:88201ms step_avg:59.31ms
+step:1488/1600 train_time:88286ms step_avg:59.33ms
+step:1489/1600 train_time:88375ms step_avg:59.35ms
+step:1490/1600 train_time:88459ms step_avg:59.37ms
+step:1491/1600 train_time:88547ms step_avg:59.39ms
+step:1492/1600 train_time:88632ms step_avg:59.40ms
+step:1493/1600 train_time:88720ms step_avg:59.42ms
+step:1494/1600 train_time:88805ms step_avg:59.44ms
+step:1495/1600 train_time:88893ms step_avg:59.46ms
+step:1496/1600 train_time:88979ms step_avg:59.48ms
+step:1497/1600 train_time:89067ms step_avg:59.50ms
+step:1498/1600 train_time:89153ms step_avg:59.51ms
+step:1499/1600 train_time:89241ms step_avg:59.53ms
+step:1500/1600 train_time:89326ms step_avg:59.55ms
+step:1500/1600 val_loss:3.3074 train_time:89398ms step_avg:59.60ms
+step:1501/1600 train_time:89417ms step_avg:59.57ms
+step:1502/1600 train_time:89503ms step_avg:59.59ms
+step:1503/1600 train_time:89597ms step_avg:59.61ms
+step:1504/1600 train_time:89683ms step_avg:59.63ms
+step:1505/1600 train_time:89770ms step_avg:59.65ms
+step:1506/1600 train_time:89855ms step_avg:59.66ms
+step:1507/1600 train_time:89942ms step_avg:59.68ms
+step:1508/1600 train_time:90027ms step_avg:59.70ms
+step:1509/1600 train_time:90115ms step_avg:59.72ms
+step:1510/1600 train_time:90199ms step_avg:59.73ms
+step:1511/1600 train_time:90286ms step_avg:59.75ms
+step:1512/1600 train_time:90372ms step_avg:59.77ms
+step:1513/1600 train_time:90463ms step_avg:59.79ms
+step:1514/1600 train_time:90551ms step_avg:59.81ms
+step:1515/1600 train_time:90639ms step_avg:59.83ms
+step:1516/1600 train_time:90725ms step_avg:59.85ms
+step:1517/1600 train_time:90813ms step_avg:59.86ms
+step:1518/1600 train_time:90899ms step_avg:59.88ms
+step:1519/1600 train_time:90986ms step_avg:59.90ms
+step:1520/1600 train_time:91070ms step_avg:59.91ms
+step:1521/1600 train_time:91158ms step_avg:59.93ms
+step:1522/1600 train_time:91243ms step_avg:59.95ms
+step:1523/1600 train_time:91331ms step_avg:59.97ms
+step:1524/1600 train_time:91417ms step_avg:59.99ms
+step:1525/1600 train_time:91507ms step_avg:60.00ms
+step:1526/1600 train_time:91593ms step_avg:60.02ms
+step:1527/1600 train_time:91681ms step_avg:60.04ms
+step:1528/1600 train_time:91766ms step_avg:60.06ms
+step:1529/1600 train_time:91854ms step_avg:60.07ms
+step:1530/1600 train_time:91939ms step_avg:60.09ms
+step:1531/1600 train_time:92027ms step_avg:60.11ms
+step:1532/1600 train_time:92112ms step_avg:60.13ms
+step:1533/1600 train_time:92199ms step_avg:60.14ms
+step:1534/1600 train_time:92284ms step_avg:60.16ms
+step:1535/1600 train_time:92373ms step_avg:60.18ms
+step:1536/1600 train_time:92458ms step_avg:60.19ms
+step:1537/1600 train_time:92548ms step_avg:60.21ms
+step:1538/1600 train_time:92633ms step_avg:60.23ms
+step:1539/1600 train_time:92722ms step_avg:60.25ms
+step:1540/1600 train_time:92807ms step_avg:60.26ms
+step:1541/1600 train_time:92895ms step_avg:60.28ms
+step:1542/1600 train_time:92981ms step_avg:60.30ms
+step:1543/1600 train_time:93068ms step_avg:60.32ms
+step:1544/1600 train_time:93153ms step_avg:60.33ms
+step:1545/1600 train_time:93241ms step_avg:60.35ms
+step:1546/1600 train_time:93327ms step_avg:60.37ms
+step:1547/1600 train_time:93415ms step_avg:60.38ms
+step:1548/1600 train_time:93501ms step_avg:60.40ms
+step:1549/1600 train_time:93589ms step_avg:60.42ms
+step:1550/1600 train_time:93675ms step_avg:60.44ms
+step:1551/1600 train_time:93763ms step_avg:60.45ms
+step:1552/1600 train_time:93848ms step_avg:60.47ms
+step:1553/1600 train_time:93937ms step_avg:60.49ms
+step:1554/1600 train_time:94022ms step_avg:60.50ms
+step:1555/1600 train_time:94110ms step_avg:60.52ms
+step:1556/1600 train_time:94195ms step_avg:60.54ms
+step:1557/1600 train_time:94283ms step_avg:60.55ms
+step:1558/1600 train_time:94369ms step_avg:60.57ms
+step:1559/1600 train_time:94460ms step_avg:60.59ms
+step:1560/1600 train_time:94545ms step_avg:60.61ms
+step:1561/1600 train_time:94641ms step_avg:60.63ms
+step:1562/1600 train_time:94725ms step_avg:60.64ms
+step:1563/1600 train_time:94813ms step_avg:60.66ms
+step:1564/1600 train_time:94899ms step_avg:60.68ms
+step:1565/1600 train_time:94987ms step_avg:60.69ms
+step:1566/1600 train_time:95072ms step_avg:60.71ms
+step:1567/1600 train_time:95160ms step_avg:60.73ms
+step:1568/1600 train_time:95246ms step_avg:60.74ms
+step:1569/1600 train_time:95335ms step_avg:60.76ms
+step:1570/1600 train_time:95420ms step_avg:60.78ms
+step:1571/1600 train_time:95510ms step_avg:60.80ms
+step:1572/1600 train_time:95596ms step_avg:60.81ms
+step:1573/1600 train_time:95686ms step_avg:60.83ms
+step:1574/1600 train_time:95771ms step_avg:60.85ms
+step:1575/1600 train_time:95859ms step_avg:60.86ms
+step:1576/1600 train_time:95945ms step_avg:60.88ms
+step:1577/1600 train_time:96036ms step_avg:60.90ms
+step:1578/1600 train_time:96123ms step_avg:60.91ms
+step:1579/1600 train_time:96211ms step_avg:60.93ms
+step:1580/1600 train_time:96296ms step_avg:60.95ms
+step:1581/1600 train_time:96384ms step_avg:60.96ms
+step:1582/1600 train_time:96469ms step_avg:60.98ms
+step:1583/1600 train_time:96558ms step_avg:61.00ms
+step:1584/1600 train_time:96645ms step_avg:61.01ms
+step:1585/1600 train_time:96733ms step_avg:61.03ms
+step:1586/1600 train_time:96818ms step_avg:61.05ms
+step:1587/1600 train_time:96908ms step_avg:61.06ms
+step:1588/1600 train_time:96993ms step_avg:61.08ms
+step:1589/1600 train_time:97081ms step_avg:61.10ms
+step:1590/1600 train_time:97167ms step_avg:61.11ms
+step:1591/1600 train_time:97255ms step_avg:61.13ms
+step:1592/1600 train_time:97342ms step_avg:61.14ms
+step:1593/1600 train_time:97430ms step_avg:61.16ms
+step:1594/1600 train_time:97516ms step_avg:61.18ms
+step:1595/1600 train_time:97606ms step_avg:61.19ms
+step:1596/1600 train_time:97691ms step_avg:61.21ms
+step:1597/1600 train_time:97780ms step_avg:61.23ms
+step:1598/1600 train_time:97865ms step_avg:61.24ms
+step:1599/1600 train_time:97953ms step_avg:61.26ms
+step:1600/1600 train_time:98039ms step_avg:61.27ms
+step:1600/1600 val_loss:3.2778 train_time:98112ms step_avg:61.32ms
+peak memory allocated: 30264 MiB reserved: 46238 MiB

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -952,8 +952,7 @@ class CausalSelfAttention(nn.Module):
         q, k = yarn.rotary(q), yarn.rotary(k)
         if key_offset:
             # shift keys forward for the stationary head dims. Enables 1-layer induction.
-            k[:, 1:, :, self.head_dim // 4:self.head_dim // 2] = k[:, :-1, :, self.head_dim // 4:self.head_dim // 2]
-            k[:, 1:, :, 3 * self.head_dim // 4:] = k[:, :-1, :, 3 * self.head_dim // 4:]
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
         if ve is not None:
             ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
             v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
@@ -1058,7 +1057,6 @@ class Block(nn.Module):
         if self.mlp is not None:
             x = x + self.mlp(norm(x), c_fc, c_proj)
         return x
-
 
 # -----------------------------------------------------------------------------
 # The main model
@@ -1174,6 +1172,10 @@ class GPT(nn.Module):
         with torch.no_grad():
             self.embed.weight.copy_(self.lm_head.weight.T)
 
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
         # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
         self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
         self.x0_lambdas.label = 'x0_lambdas'
@@ -1184,6 +1186,7 @@ class GPT(nn.Module):
                 [
                     1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
                     *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
                     torch.zeros(1), # smear_lambda
                     0.5*torch.ones(1), # backout_lambda
                     -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
@@ -1193,7 +1196,7 @@ class GPT(nn.Module):
         )
         self.scalars.label = 'scalars'
 
-    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, schedule_cfg: ForwardScheduleConfig):
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
         assert input_seq.ndim == 1
 
         # unpack schedule_cfg
@@ -1210,9 +1213,10 @@ class GPT(nn.Module):
         resid_lambdas = self.scalars[: 1 * self.num_layers]
         x0_lambdas = self.x0_lambdas
         sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
-        smear_lambda = self.scalars[3 * self.num_layers]
-        backout_lambda = self.scalars[3 * self.num_layers+1]
-        skip_lambda = self.scalars[3 * self.num_layers+2]
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
 
         # set block masks and key shift
         short_bm = ws_short * args.block_size
@@ -1223,6 +1227,7 @@ class GPT(nn.Module):
 
         # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
         x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
         
         # Value embeddings - always computed (not precomputed)
         ve = [value_embed(input_seq) for value_embed in self.value_embeds]
@@ -1265,9 +1270,9 @@ class GPT(nn.Module):
                 skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
                 x = x + skip_gate_out * skip_connections.pop()
             if i == 0:
-                x = (resid_lambdas[0] + x0_lambdas[0]) * x
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
             else:
-                x = resid_lambdas[i] * x + x0_lambdas[i] * x0
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
             
             # Get weights for this layer from banks
             qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
@@ -1398,6 +1403,21 @@ class DataPreloader:
             self.thread.join()
         return self.data
 
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
 def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
     # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -1459,11 +1479,13 @@ def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_l
         _inputs = _inputs.to(dtype=torch.int32)
         _targets = _targets.to(dtype=torch.int64)
         _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
 
         new_params = yield (
             _inputs.to(device="cuda", non_blocking=True),
             _targets.to(device="cuda", non_blocking=True),
-            _cum_lengths.to(device="cuda", non_blocking=True)
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
         )
 
         if new_params is not None:
@@ -1557,6 +1579,7 @@ class TrainingManager():
             "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
             "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
             "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
             "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
             "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
             "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
@@ -1570,7 +1593,7 @@ class TrainingManager():
         # - lm_head must complete before embed sync (when tied)
         self.work_order = [
             "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
-            "ve0", "ve1", "ve2",  # Medium
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
             "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
             "attn", "mlp",        # Large, polar express - process last to maximize overlap
         ]
@@ -1705,10 +1728,10 @@ class Hyperparameters:
     train_max_seq_len: int = 128 * 16
     val_batch_size: int = 4 * 64 * 1024 * 8
     # optimization
-    num_scheduled_iterations: int = 1725  # number of steps to complete lr and ws schedule
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
     num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
     num_iterations: int = num_scheduled_iterations + num_extension_iterations
-    cooldown_frac: float = 0.50  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
     split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
     # evaluation and logging
     run_id: str = f"{uuid.uuid4()}"
@@ -1719,6 +1742,8 @@ class Hyperparameters:
     ws_schedule: tuple = (3, 7, 11)
     ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
     ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
 
 args = Hyperparameters()
 
@@ -1805,13 +1830,13 @@ for step in warmup_steps:
     training_manager.advance_schedule(step)
     model.eval()
     with torch.no_grad():
-        inputs, targets, cum_seqlens = next(val_loader)
-        model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
     model.train()
     for idx in range(grad_accum_steps):
         send_args = training_manager.train_loader_send_args
-        inputs, targets, cum_seqlens = train_loader.send(send_args)
-        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
     training_manager.step_optimizers(step)
 print0("Resetting Model", console=True)
 model.zero_grad(set_to_none=True)
@@ -1850,8 +1875,8 @@ for step in range(train_steps + 1):
         val_loss = 0
         with torch.no_grad():
             for _ in range(val_steps):
-                inputs, targets, cum_seqlens = next(val_loader)
-                val_loss += model(inputs, targets, cum_seqlens, training_manager.get_forward_args())
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
         val_loss /= val_steps
         del val_loader
         dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
@@ -1871,8 +1896,8 @@ for step in range(train_steps + 1):
 
     # --------------- TRAINING SECTION -----------------
     for idx in range(grad_accum_steps):
-        inputs, targets, cum_seqlens = train_loader.send(training_manager.train_loader_send_args)
-        (model(inputs, targets, cum_seqlens, training_manager.get_forward_args()) / grad_accum_steps).backward()
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
     training_manager.step_optimizers(step)
 
     # logging


### PR DESCRIPTION
Updates in PR:
* Bigram Hash Embedding (-5.1s)
* Fix partial key offset to apply to stationary dims instead of 50/50 stationary/rotating (-0.5s) [bug was introduced in paired head PR]
* Reduce step count from 1765 to 1600
* Increase cooldown frac from 0.5 to 0.55 (I find it works to increase this as step count decreases)

Bigram hash code which runs on CPU during each dataloader iteration:
```
args.bigram_vocab_size = 5 * vocab_size
def get_bigram_hash(x):
    """
    Computes bigram hash for each position using [prev_token, curr_token].
    Multiply by arbitary large ints to get even spread over int32 range.
    Position 0 is mapped to the reserved index (vocab_size - 1).
    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
    """
    rand_int_1 = 36313
    rand_int_2 = 27191
    mod = args.bigram_vocab_size-1
    x = x.to(torch.int32).clone()
    x[0] = mod
    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
    return x
```

Model structure:
```
# model args
embed = nn.Embedding(vocab_size, model_dim)
bigram_embed = nn.Embedding(bigram_vocab_size, model_dim).zero_init()
x0_lambdas = nn.Parameter(torch.zeros(num_layers))
bigram_lambdas = nn.Parameter(0.1*torch.ones(num_layers))

# model forward pass
x = x0 = norm(nn.Embedding(input))
x0_bigram = nn.Embedding(get_bigram_hash(input))
for i in range(num_layers):
    x = x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
    x = block(x)
logits = lm_head(x)
```

Recent discussion on Deepseek's Engram got me looking into hash embeddings, and this 2017 paper: https://arxiv.org/abs/1709.03933. Meaningful hash collisions are rare due to token distribution, so hashing seems good. 

I did some of testing on more advanced ways to integrate the hashed embeddings with gating, trigrams, and multiple hashes. Very simple direct addition to the residual stream outperformed by a decent margin.

### Ideas
Interestingly, the model now has more parameters than training tokens. Typically when a feature gets added the step count is reduced. At some point it may be better to drop an attn/mlp.

Now that we have an additional 5*50304 params getting communicated across GPUs and the bottleneck is overwhelmingly on comms, it could be worthwhile to build a sparse communication approach to only send embeds with nonzero grads. I did not look at the profiler here or try other comms orderings. Due to stepping Adam every other step, early step times alternate between 31ms and 37ms. (Could be other ideas like step bigram embed once every 4 steps)

There is an average of 0.4s extra due to a stall on step 6. Chris pointed this out and I believe Varun has been working on a fix. I may have also gotten a worse machine here that was making the issue more pronounced.

## Timing and Validation
```
import scipy.stats
import torch

losses = [3.2756, 3.2786, 3.2773, 3.2791, 3.2778, 3.277]
times = [98.065, 98.017, 99.201, 99.151, 98.112, 98.031]

print("p=%.4f" % scipy.stats.ttest_1samp(losses, 3.28, alternative="less").pvalue)
# p=0.0025

print("losses:", torch.std_mean(torch.tensor(losses)))
# losses: (tensor(0.0012), tensor(3.2776))

print("time:", torch.std_mean(torch.tensor(times)))
# time: (tensor(0.5794), tensor(98.4295))
```

retiming prior record: 104.062 [104.129, 103.995]

If no changes, will merge at 99.3s to be consistent with 5.6s improvement over 104.9s.
