### PR TITLE
New Record: Untie Value Embeddings (-0.4s, -25 steps)

### DIFF
--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/05a8537d-2283-42f6-8564-cf0cae2c39bd.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/05a8537d-2283-42f6-8564-cf0cae2c39bd.txt
@@ -1,0 +1,4119 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 03:06:40 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            131W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          285231      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          285232      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          285233      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          285234      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          285235      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          285236      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          285237      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          285238      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8293 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:78ms step_avg:77.80ms
+step:2/1600 train_time:100ms step_avg:49.91ms
+step:3/1600 train_time:119ms step_avg:39.79ms
+step:4/1600 train_time:144ms step_avg:36.07ms
+step:5/1600 train_time:175ms step_avg:34.94ms
+step:6/1600 train_time:291ms step_avg:48.58ms
+step:7/1600 train_time:310ms step_avg:44.22ms
+step:8/1600 train_time:329ms step_avg:41.14ms
+step:9/1600 train_time:358ms step_avg:39.81ms
+step:10/1600 train_time:395ms step_avg:39.53ms
+step:11/1600 train_time:426ms step_avg:38.76ms
+step:12/1600 train_time:464ms step_avg:38.65ms
+step:13/1600 train_time:495ms step_avg:38.05ms
+step:14/1600 train_time:532ms step_avg:37.99ms
+step:15/1600 train_time:563ms step_avg:37.52ms
+step:16/1600 train_time:601ms step_avg:37.53ms
+step:17/1600 train_time:631ms step_avg:37.13ms
+step:18/1600 train_time:669ms step_avg:37.16ms
+step:19/1600 train_time:699ms step_avg:36.80ms
+step:20/1600 train_time:736ms step_avg:36.81ms
+step:21/1600 train_time:767ms step_avg:36.52ms
+step:22/1600 train_time:805ms step_avg:36.57ms
+step:23/1600 train_time:836ms step_avg:36.33ms
+step:24/1600 train_time:873ms step_avg:36.37ms
+step:25/1600 train_time:903ms step_avg:36.13ms
+step:26/1600 train_time:940ms step_avg:36.16ms
+step:27/1600 train_time:971ms step_avg:35.96ms
+step:28/1600 train_time:1008ms step_avg:36.00ms
+step:29/1600 train_time:1039ms step_avg:35.81ms
+step:30/1600 train_time:1076ms step_avg:35.86ms
+step:31/1600 train_time:1106ms step_avg:35.69ms
+step:32/1600 train_time:1144ms step_avg:35.74ms
+step:33/1600 train_time:1174ms step_avg:35.58ms
+step:34/1600 train_time:1211ms step_avg:35.62ms
+step:35/1600 train_time:1242ms step_avg:35.49ms
+step:36/1600 train_time:1279ms step_avg:35.54ms
+step:37/1600 train_time:1310ms step_avg:35.41ms
+step:38/1600 train_time:1348ms step_avg:35.47ms
+step:39/1600 train_time:1378ms step_avg:35.34ms
+step:40/1600 train_time:1415ms step_avg:35.39ms
+step:41/1600 train_time:1447ms step_avg:35.28ms
+step:42/1600 train_time:1484ms step_avg:35.33ms
+step:43/1600 train_time:1514ms step_avg:35.22ms
+step:44/1600 train_time:1552ms step_avg:35.27ms
+step:45/1600 train_time:1582ms step_avg:35.16ms
+step:46/1600 train_time:1619ms step_avg:35.20ms
+step:47/1600 train_time:1650ms step_avg:35.11ms
+step:48/1600 train_time:1688ms step_avg:35.16ms
+step:49/1600 train_time:1718ms step_avg:35.06ms
+step:50/1600 train_time:1756ms step_avg:35.11ms
+step:51/1600 train_time:1786ms step_avg:35.02ms
+step:52/1600 train_time:1824ms step_avg:35.07ms
+step:53/1600 train_time:1854ms step_avg:34.98ms
+step:54/1600 train_time:1891ms step_avg:35.03ms
+step:55/1600 train_time:1922ms step_avg:34.94ms
+step:56/1600 train_time:1959ms step_avg:34.98ms
+step:57/1600 train_time:1990ms step_avg:34.91ms
+step:58/1600 train_time:2027ms step_avg:34.95ms
+step:59/1600 train_time:2058ms step_avg:34.88ms
+step:60/1600 train_time:2095ms step_avg:34.92ms
+step:61/1600 train_time:2126ms step_avg:34.85ms
+step:62/1600 train_time:2164ms step_avg:34.91ms
+step:63/1600 train_time:2195ms step_avg:34.84ms
+step:64/1600 train_time:2232ms step_avg:34.88ms
+step:65/1600 train_time:2263ms step_avg:34.82ms
+step:66/1600 train_time:2300ms step_avg:34.85ms
+step:67/1600 train_time:2331ms step_avg:34.79ms
+step:68/1600 train_time:2369ms step_avg:34.84ms
+step:69/1600 train_time:2399ms step_avg:34.77ms
+step:70/1600 train_time:2436ms step_avg:34.81ms
+step:71/1600 train_time:2467ms step_avg:34.75ms
+step:72/1600 train_time:2505ms step_avg:34.79ms
+step:73/1600 train_time:2536ms step_avg:34.73ms
+step:74/1600 train_time:2573ms step_avg:34.77ms
+step:75/1600 train_time:2604ms step_avg:34.72ms
+step:76/1600 train_time:2641ms step_avg:34.75ms
+step:77/1600 train_time:2672ms step_avg:34.70ms
+step:78/1600 train_time:2709ms step_avg:34.74ms
+step:79/1600 train_time:2740ms step_avg:34.68ms
+step:80/1600 train_time:2777ms step_avg:34.71ms
+step:81/1600 train_time:2807ms step_avg:34.66ms
+step:82/1600 train_time:2845ms step_avg:34.69ms
+step:83/1600 train_time:2875ms step_avg:34.64ms
+step:84/1600 train_time:2912ms step_avg:34.67ms
+step:85/1600 train_time:2943ms step_avg:34.62ms
+step:86/1600 train_time:2980ms step_avg:34.66ms
+step:87/1600 train_time:3011ms step_avg:34.61ms
+step:88/1600 train_time:3049ms step_avg:34.64ms
+step:89/1600 train_time:3079ms step_avg:34.59ms
+step:90/1600 train_time:3116ms step_avg:34.62ms
+step:91/1600 train_time:3147ms step_avg:34.58ms
+step:92/1600 train_time:3185ms step_avg:34.61ms
+step:93/1600 train_time:3215ms step_avg:34.57ms
+step:94/1600 train_time:3253ms step_avg:34.60ms
+step:95/1600 train_time:3283ms step_avg:34.56ms
+step:96/1600 train_time:3321ms step_avg:34.59ms
+step:97/1600 train_time:3351ms step_avg:34.55ms
+step:98/1600 train_time:3389ms step_avg:34.58ms
+step:99/1600 train_time:3420ms step_avg:34.54ms
+step:100/1600 train_time:3458ms step_avg:34.58ms
+step:101/1600 train_time:3488ms step_avg:34.54ms
+step:102/1600 train_time:3525ms step_avg:34.56ms
+step:103/1600 train_time:3556ms step_avg:34.52ms
+step:104/1600 train_time:3593ms step_avg:34.55ms
+step:105/1600 train_time:3624ms step_avg:34.51ms
+step:106/1600 train_time:3661ms step_avg:34.54ms
+step:107/1600 train_time:3692ms step_avg:34.50ms
+step:108/1600 train_time:3729ms step_avg:34.53ms
+step:109/1600 train_time:3759ms step_avg:34.49ms
+step:110/1600 train_time:3797ms step_avg:34.52ms
+step:111/1600 train_time:3828ms step_avg:34.48ms
+step:112/1600 train_time:3865ms step_avg:34.51ms
+step:113/1600 train_time:3896ms step_avg:34.48ms
+step:114/1600 train_time:3933ms step_avg:34.50ms
+step:115/1600 train_time:3964ms step_avg:34.47ms
+step:116/1600 train_time:4001ms step_avg:34.49ms
+step:117/1600 train_time:4033ms step_avg:34.47ms
+step:118/1600 train_time:4070ms step_avg:34.49ms
+step:119/1600 train_time:4101ms step_avg:34.46ms
+step:120/1600 train_time:4137ms step_avg:34.48ms
+step:121/1600 train_time:4168ms step_avg:34.45ms
+step:122/1600 train_time:4205ms step_avg:34.47ms
+step:123/1600 train_time:4236ms step_avg:34.44ms
+step:124/1600 train_time:4273ms step_avg:34.46ms
+step:125/1600 train_time:4304ms step_avg:34.43ms
+step:126/1600 train_time:4341ms step_avg:34.45ms
+step:127/1600 train_time:4372ms step_avg:34.42ms
+step:128/1600 train_time:4409ms step_avg:34.44ms
+step:129/1600 train_time:4439ms step_avg:34.41ms
+step:130/1600 train_time:4477ms step_avg:34.44ms
+step:131/1600 train_time:4507ms step_avg:34.40ms
+step:132/1600 train_time:4545ms step_avg:34.43ms
+step:133/1600 train_time:4575ms step_avg:34.40ms
+step:134/1600 train_time:4612ms step_avg:34.42ms
+step:135/1600 train_time:4643ms step_avg:34.39ms
+step:136/1600 train_time:4680ms step_avg:34.41ms
+step:137/1600 train_time:4711ms step_avg:34.39ms
+step:138/1600 train_time:4748ms step_avg:34.41ms
+step:139/1600 train_time:4779ms step_avg:34.38ms
+step:140/1600 train_time:4816ms step_avg:34.40ms
+step:141/1600 train_time:4846ms step_avg:34.37ms
+step:142/1600 train_time:4884ms step_avg:34.39ms
+step:143/1600 train_time:4914ms step_avg:34.37ms
+step:144/1600 train_time:4951ms step_avg:34.39ms
+step:145/1600 train_time:4982ms step_avg:34.36ms
+step:146/1600 train_time:5020ms step_avg:34.38ms
+step:147/1600 train_time:5050ms step_avg:34.35ms
+step:148/1600 train_time:5087ms step_avg:34.37ms
+step:149/1600 train_time:5118ms step_avg:34.35ms
+step:150/1600 train_time:5155ms step_avg:34.37ms
+step:151/1600 train_time:5186ms step_avg:34.34ms
+step:152/1600 train_time:5224ms step_avg:34.37ms
+step:153/1600 train_time:5255ms step_avg:34.34ms
+step:154/1600 train_time:5292ms step_avg:34.36ms
+step:155/1600 train_time:5323ms step_avg:34.34ms
+step:156/1600 train_time:5361ms step_avg:34.36ms
+step:157/1600 train_time:5391ms step_avg:34.34ms
+step:158/1600 train_time:5428ms step_avg:34.36ms
+step:159/1600 train_time:5459ms step_avg:34.33ms
+step:160/1600 train_time:5497ms step_avg:34.35ms
+step:161/1600 train_time:5527ms step_avg:34.33ms
+step:162/1600 train_time:5565ms step_avg:34.35ms
+step:163/1600 train_time:5595ms step_avg:34.33ms
+step:164/1600 train_time:5632ms step_avg:34.34ms
+step:165/1600 train_time:5663ms step_avg:34.32ms
+step:166/1600 train_time:5701ms step_avg:34.34ms
+step:167/1600 train_time:5732ms step_avg:34.32ms
+step:168/1600 train_time:5769ms step_avg:34.34ms
+step:169/1600 train_time:5800ms step_avg:34.32ms
+step:170/1600 train_time:5837ms step_avg:34.34ms
+step:171/1600 train_time:5868ms step_avg:34.31ms
+step:172/1600 train_time:5905ms step_avg:34.33ms
+step:173/1600 train_time:5935ms step_avg:34.31ms
+step:174/1600 train_time:5972ms step_avg:34.32ms
+step:175/1600 train_time:6003ms step_avg:34.30ms
+step:176/1600 train_time:6040ms step_avg:34.32ms
+step:177/1600 train_time:6071ms step_avg:34.30ms
+step:178/1600 train_time:6108ms step_avg:34.32ms
+step:179/1600 train_time:6138ms step_avg:34.29ms
+step:180/1600 train_time:6176ms step_avg:34.31ms
+step:181/1600 train_time:6206ms step_avg:34.29ms
+step:182/1600 train_time:6244ms step_avg:34.31ms
+step:183/1600 train_time:6274ms step_avg:34.29ms
+step:184/1600 train_time:6312ms step_avg:34.30ms
+step:185/1600 train_time:6342ms step_avg:34.28ms
+step:186/1600 train_time:6379ms step_avg:34.30ms
+step:187/1600 train_time:6410ms step_avg:34.28ms
+step:188/1600 train_time:6447ms step_avg:34.29ms
+step:189/1600 train_time:6478ms step_avg:34.27ms
+step:190/1600 train_time:6515ms step_avg:34.29ms
+step:191/1600 train_time:6546ms step_avg:34.27ms
+step:192/1600 train_time:6583ms step_avg:34.29ms
+step:193/1600 train_time:6614ms step_avg:34.27ms
+step:194/1600 train_time:6651ms step_avg:34.28ms
+step:195/1600 train_time:6681ms step_avg:34.26ms
+step:196/1600 train_time:6719ms step_avg:34.28ms
+step:197/1600 train_time:6749ms step_avg:34.26ms
+step:198/1600 train_time:6787ms step_avg:34.28ms
+step:199/1600 train_time:6817ms step_avg:34.26ms
+step:200/1600 train_time:6854ms step_avg:34.27ms
+step:201/1600 train_time:6885ms step_avg:34.25ms
+step:202/1600 train_time:6923ms step_avg:34.27ms
+step:203/1600 train_time:6953ms step_avg:34.25ms
+step:204/1600 train_time:6991ms step_avg:34.27ms
+step:205/1600 train_time:7021ms step_avg:34.25ms
+step:206/1600 train_time:7058ms step_avg:34.26ms
+step:207/1600 train_time:7089ms step_avg:34.25ms
+step:208/1600 train_time:7127ms step_avg:34.26ms
+step:209/1600 train_time:7157ms step_avg:34.24ms
+step:210/1600 train_time:7194ms step_avg:34.26ms
+step:211/1600 train_time:7225ms step_avg:34.24ms
+step:212/1600 train_time:7262ms step_avg:34.26ms
+step:213/1600 train_time:7293ms step_avg:34.24ms
+step:214/1600 train_time:7330ms step_avg:34.25ms
+step:215/1600 train_time:7361ms step_avg:34.24ms
+step:216/1600 train_time:7399ms step_avg:34.26ms
+step:217/1600 train_time:7430ms step_avg:34.24ms
+step:218/1600 train_time:7467ms step_avg:34.25ms
+step:219/1600 train_time:7498ms step_avg:34.24ms
+step:220/1600 train_time:7535ms step_avg:34.25ms
+step:221/1600 train_time:7565ms step_avg:34.23ms
+step:222/1600 train_time:7603ms step_avg:34.25ms
+step:223/1600 train_time:7633ms step_avg:34.23ms
+step:224/1600 train_time:7671ms step_avg:34.24ms
+step:225/1600 train_time:7701ms step_avg:34.23ms
+step:226/1600 train_time:7738ms step_avg:34.24ms
+step:227/1600 train_time:7769ms step_avg:34.22ms
+step:228/1600 train_time:7806ms step_avg:34.24ms
+step:229/1600 train_time:7836ms step_avg:34.22ms
+step:230/1600 train_time:7873ms step_avg:34.23ms
+step:231/1600 train_time:7904ms step_avg:34.22ms
+step:232/1600 train_time:7942ms step_avg:34.23ms
+step:233/1600 train_time:7973ms step_avg:34.22ms
+step:234/1600 train_time:8010ms step_avg:34.23ms
+step:235/1600 train_time:8040ms step_avg:34.21ms
+step:236/1600 train_time:8077ms step_avg:34.23ms
+step:237/1600 train_time:8108ms step_avg:34.21ms
+step:238/1600 train_time:8145ms step_avg:34.22ms
+step:239/1600 train_time:8175ms step_avg:34.21ms
+step:240/1600 train_time:8213ms step_avg:34.22ms
+step:241/1600 train_time:8243ms step_avg:34.20ms
+step:242/1600 train_time:8281ms step_avg:34.22ms
+step:243/1600 train_time:8311ms step_avg:34.20ms
+step:244/1600 train_time:8348ms step_avg:34.21ms
+step:245/1600 train_time:8379ms step_avg:34.20ms
+step:246/1600 train_time:8416ms step_avg:34.21ms
+step:247/1600 train_time:8447ms step_avg:34.20ms
+step:248/1600 train_time:8485ms step_avg:34.21ms
+step:249/1600 train_time:8516ms step_avg:34.20ms
+step:250/1600 train_time:8553ms step_avg:34.21ms
+step:250/1600 val_loss:4.5848 train_time:8601ms step_avg:34.40ms
+step:251/1600 train_time:8621ms step_avg:34.35ms
+step:252/1600 train_time:8641ms step_avg:34.29ms
+step:253/1600 train_time:8659ms step_avg:34.22ms
+step:254/1600 train_time:8695ms step_avg:34.23ms
+step:255/1600 train_time:8728ms step_avg:34.23ms
+step:256/1600 train_time:8768ms step_avg:34.25ms
+step:257/1600 train_time:8799ms step_avg:34.24ms
+step:258/1600 train_time:8837ms step_avg:34.25ms
+step:259/1600 train_time:8868ms step_avg:34.24ms
+step:260/1600 train_time:8906ms step_avg:34.25ms
+step:261/1600 train_time:8936ms step_avg:34.24ms
+step:262/1600 train_time:8973ms step_avg:34.25ms
+step:263/1600 train_time:9004ms step_avg:34.24ms
+step:264/1600 train_time:9041ms step_avg:34.25ms
+step:265/1600 train_time:9071ms step_avg:34.23ms
+step:266/1600 train_time:9109ms step_avg:34.24ms
+step:267/1600 train_time:9139ms step_avg:34.23ms
+step:268/1600 train_time:9176ms step_avg:34.24ms
+step:269/1600 train_time:9207ms step_avg:34.23ms
+step:270/1600 train_time:9244ms step_avg:34.24ms
+step:271/1600 train_time:9275ms step_avg:34.22ms
+step:272/1600 train_time:9312ms step_avg:34.23ms
+step:273/1600 train_time:9342ms step_avg:34.22ms
+step:274/1600 train_time:9379ms step_avg:34.23ms
+step:275/1600 train_time:9410ms step_avg:34.22ms
+step:276/1600 train_time:9447ms step_avg:34.23ms
+step:277/1600 train_time:9477ms step_avg:34.21ms
+step:278/1600 train_time:9514ms step_avg:34.22ms
+step:279/1600 train_time:9545ms step_avg:34.21ms
+step:280/1600 train_time:9582ms step_avg:34.22ms
+step:281/1600 train_time:9612ms step_avg:34.21ms
+step:282/1600 train_time:9650ms step_avg:34.22ms
+step:283/1600 train_time:9680ms step_avg:34.21ms
+step:284/1600 train_time:9717ms step_avg:34.22ms
+step:285/1600 train_time:9748ms step_avg:34.20ms
+step:286/1600 train_time:9786ms step_avg:34.22ms
+step:287/1600 train_time:9816ms step_avg:34.20ms
+step:288/1600 train_time:9854ms step_avg:34.22ms
+step:289/1600 train_time:9885ms step_avg:34.20ms
+step:290/1600 train_time:9922ms step_avg:34.21ms
+step:291/1600 train_time:9953ms step_avg:34.20ms
+step:292/1600 train_time:9990ms step_avg:34.21ms
+step:293/1600 train_time:10021ms step_avg:34.20ms
+step:294/1600 train_time:10058ms step_avg:34.21ms
+step:295/1600 train_time:10088ms step_avg:34.20ms
+step:296/1600 train_time:10126ms step_avg:34.21ms
+step:297/1600 train_time:10156ms step_avg:34.20ms
+step:298/1600 train_time:10193ms step_avg:34.21ms
+step:299/1600 train_time:10224ms step_avg:34.19ms
+step:300/1600 train_time:10261ms step_avg:34.20ms
+step:301/1600 train_time:10292ms step_avg:34.19ms
+step:302/1600 train_time:10329ms step_avg:34.20ms
+step:303/1600 train_time:10360ms step_avg:34.19ms
+step:304/1600 train_time:10396ms step_avg:34.20ms
+step:305/1600 train_time:10427ms step_avg:34.19ms
+step:306/1600 train_time:10465ms step_avg:34.20ms
+step:307/1600 train_time:10495ms step_avg:34.19ms
+step:308/1600 train_time:10533ms step_avg:34.20ms
+step:309/1600 train_time:10563ms step_avg:34.18ms
+step:310/1600 train_time:10600ms step_avg:34.19ms
+step:311/1600 train_time:10630ms step_avg:34.18ms
+step:312/1600 train_time:10667ms step_avg:34.19ms
+step:313/1600 train_time:10698ms step_avg:34.18ms
+step:314/1600 train_time:10735ms step_avg:34.19ms
+step:315/1600 train_time:10765ms step_avg:34.18ms
+step:316/1600 train_time:10803ms step_avg:34.19ms
+step:317/1600 train_time:10833ms step_avg:34.17ms
+step:318/1600 train_time:10871ms step_avg:34.18ms
+step:319/1600 train_time:10901ms step_avg:34.17ms
+step:320/1600 train_time:10939ms step_avg:34.18ms
+step:321/1600 train_time:10969ms step_avg:34.17ms
+step:322/1600 train_time:11007ms step_avg:34.18ms
+step:323/1600 train_time:11038ms step_avg:34.17ms
+step:324/1600 train_time:11075ms step_avg:34.18ms
+step:325/1600 train_time:11106ms step_avg:34.17ms
+step:326/1600 train_time:11143ms step_avg:34.18ms
+step:327/1600 train_time:11174ms step_avg:34.17ms
+step:328/1600 train_time:11211ms step_avg:34.18ms
+step:329/1600 train_time:11241ms step_avg:34.17ms
+step:330/1600 train_time:11278ms step_avg:34.18ms
+step:331/1600 train_time:11309ms step_avg:34.17ms
+step:332/1600 train_time:11346ms step_avg:34.18ms
+step:333/1600 train_time:11377ms step_avg:34.16ms
+step:334/1600 train_time:11414ms step_avg:34.17ms
+step:335/1600 train_time:11445ms step_avg:34.16ms
+step:336/1600 train_time:11482ms step_avg:34.17ms
+step:337/1600 train_time:11513ms step_avg:34.16ms
+step:338/1600 train_time:11550ms step_avg:34.17ms
+step:339/1600 train_time:11581ms step_avg:34.16ms
+step:340/1600 train_time:11619ms step_avg:34.17ms
+step:341/1600 train_time:11649ms step_avg:34.16ms
+step:342/1600 train_time:11687ms step_avg:34.17ms
+step:343/1600 train_time:11717ms step_avg:34.16ms
+step:344/1600 train_time:11754ms step_avg:34.17ms
+step:345/1600 train_time:11784ms step_avg:34.16ms
+step:346/1600 train_time:11821ms step_avg:34.17ms
+step:347/1600 train_time:11852ms step_avg:34.15ms
+step:348/1600 train_time:11889ms step_avg:34.16ms
+step:349/1600 train_time:11919ms step_avg:34.15ms
+step:350/1600 train_time:11956ms step_avg:34.16ms
+step:351/1600 train_time:11987ms step_avg:34.15ms
+step:352/1600 train_time:12024ms step_avg:34.16ms
+step:353/1600 train_time:12055ms step_avg:34.15ms
+step:354/1600 train_time:12093ms step_avg:34.16ms
+step:355/1600 train_time:12123ms step_avg:34.15ms
+step:356/1600 train_time:12160ms step_avg:34.16ms
+step:357/1600 train_time:12190ms step_avg:34.15ms
+step:358/1600 train_time:12228ms step_avg:34.16ms
+step:359/1600 train_time:12258ms step_avg:34.14ms
+step:360/1600 train_time:12295ms step_avg:34.15ms
+step:361/1600 train_time:12326ms step_avg:34.14ms
+step:362/1600 train_time:12363ms step_avg:34.15ms
+step:363/1600 train_time:12394ms step_avg:34.14ms
+step:364/1600 train_time:12431ms step_avg:34.15ms
+step:365/1600 train_time:12461ms step_avg:34.14ms
+step:366/1600 train_time:12498ms step_avg:34.15ms
+step:367/1600 train_time:12529ms step_avg:34.14ms
+step:368/1600 train_time:12566ms step_avg:34.15ms
+step:369/1600 train_time:12596ms step_avg:34.14ms
+step:370/1600 train_time:12633ms step_avg:34.14ms
+step:371/1600 train_time:12664ms step_avg:34.13ms
+step:372/1600 train_time:12700ms step_avg:34.14ms
+step:373/1600 train_time:12731ms step_avg:34.13ms
+step:374/1600 train_time:12768ms step_avg:34.14ms
+step:375/1600 train_time:12799ms step_avg:34.13ms
+step:376/1600 train_time:12836ms step_avg:34.14ms
+step:377/1600 train_time:12867ms step_avg:34.13ms
+step:378/1600 train_time:12904ms step_avg:34.14ms
+step:379/1600 train_time:12934ms step_avg:34.13ms
+step:380/1600 train_time:12972ms step_avg:34.14ms
+step:381/1600 train_time:13002ms step_avg:34.13ms
+step:382/1600 train_time:13039ms step_avg:34.13ms
+step:383/1600 train_time:13070ms step_avg:34.12ms
+step:384/1600 train_time:13107ms step_avg:34.13ms
+step:385/1600 train_time:13138ms step_avg:34.13ms
+step:386/1600 train_time:13175ms step_avg:34.13ms
+step:387/1600 train_time:13206ms step_avg:34.12ms
+step:388/1600 train_time:13243ms step_avg:34.13ms
+step:389/1600 train_time:13274ms step_avg:34.12ms
+step:390/1600 train_time:13311ms step_avg:34.13ms
+step:391/1600 train_time:13342ms step_avg:34.12ms
+step:392/1600 train_time:13379ms step_avg:34.13ms
+step:393/1600 train_time:13409ms step_avg:34.12ms
+step:394/1600 train_time:13447ms step_avg:34.13ms
+step:395/1600 train_time:13477ms step_avg:34.12ms
+step:396/1600 train_time:13514ms step_avg:34.13ms
+step:397/1600 train_time:13545ms step_avg:34.12ms
+step:398/1600 train_time:13582ms step_avg:34.13ms
+step:399/1600 train_time:13613ms step_avg:34.12ms
+step:400/1600 train_time:13650ms step_avg:34.12ms
+step:401/1600 train_time:13680ms step_avg:34.11ms
+step:402/1600 train_time:13717ms step_avg:34.12ms
+step:403/1600 train_time:13748ms step_avg:34.11ms
+step:404/1600 train_time:13785ms step_avg:34.12ms
+step:405/1600 train_time:13815ms step_avg:34.11ms
+step:406/1600 train_time:13853ms step_avg:34.12ms
+step:407/1600 train_time:13883ms step_avg:34.11ms
+step:408/1600 train_time:13920ms step_avg:34.12ms
+step:409/1600 train_time:13951ms step_avg:34.11ms
+step:410/1600 train_time:13988ms step_avg:34.12ms
+step:411/1600 train_time:14019ms step_avg:34.11ms
+step:412/1600 train_time:14056ms step_avg:34.12ms
+step:413/1600 train_time:14086ms step_avg:34.11ms
+step:414/1600 train_time:14124ms step_avg:34.11ms
+step:415/1600 train_time:14154ms step_avg:34.11ms
+step:416/1600 train_time:14192ms step_avg:34.11ms
+step:417/1600 train_time:14222ms step_avg:34.11ms
+step:418/1600 train_time:14259ms step_avg:34.11ms
+step:419/1600 train_time:14290ms step_avg:34.10ms
+step:420/1600 train_time:14327ms step_avg:34.11ms
+step:421/1600 train_time:14358ms step_avg:34.10ms
+step:422/1600 train_time:14395ms step_avg:34.11ms
+step:423/1600 train_time:14426ms step_avg:34.10ms
+step:424/1600 train_time:14463ms step_avg:34.11ms
+step:425/1600 train_time:14493ms step_avg:34.10ms
+step:426/1600 train_time:14531ms step_avg:34.11ms
+step:427/1600 train_time:14561ms step_avg:34.10ms
+step:428/1600 train_time:14599ms step_avg:34.11ms
+step:429/1600 train_time:14629ms step_avg:34.10ms
+step:430/1600 train_time:14666ms step_avg:34.11ms
+step:431/1600 train_time:14697ms step_avg:34.10ms
+step:432/1600 train_time:14734ms step_avg:34.11ms
+step:433/1600 train_time:14765ms step_avg:34.10ms
+step:434/1600 train_time:14802ms step_avg:34.11ms
+step:435/1600 train_time:14832ms step_avg:34.10ms
+step:436/1600 train_time:14870ms step_avg:34.11ms
+step:437/1600 train_time:14900ms step_avg:34.10ms
+step:438/1600 train_time:14937ms step_avg:34.10ms
+step:439/1600 train_time:14968ms step_avg:34.10ms
+step:440/1600 train_time:15005ms step_avg:34.10ms
+step:441/1600 train_time:15036ms step_avg:34.10ms
+step:442/1600 train_time:15073ms step_avg:34.10ms
+step:443/1600 train_time:15104ms step_avg:34.09ms
+step:444/1600 train_time:15141ms step_avg:34.10ms
+step:445/1600 train_time:15171ms step_avg:34.09ms
+step:446/1600 train_time:15208ms step_avg:34.10ms
+step:447/1600 train_time:15239ms step_avg:34.09ms
+step:448/1600 train_time:15276ms step_avg:34.10ms
+step:449/1600 train_time:15306ms step_avg:34.09ms
+step:450/1600 train_time:15343ms step_avg:34.10ms
+step:451/1600 train_time:15374ms step_avg:34.09ms
+step:452/1600 train_time:15411ms step_avg:34.09ms
+step:453/1600 train_time:15441ms step_avg:34.09ms
+step:454/1600 train_time:15478ms step_avg:34.09ms
+step:455/1600 train_time:15509ms step_avg:34.09ms
+step:456/1600 train_time:15547ms step_avg:34.09ms
+step:457/1600 train_time:15577ms step_avg:34.09ms
+step:458/1600 train_time:15614ms step_avg:34.09ms
+step:459/1600 train_time:15645ms step_avg:34.09ms
+step:460/1600 train_time:15683ms step_avg:34.09ms
+step:461/1600 train_time:15713ms step_avg:34.09ms
+step:462/1600 train_time:15751ms step_avg:34.09ms
+step:463/1600 train_time:15781ms step_avg:34.09ms
+step:464/1600 train_time:15819ms step_avg:34.09ms
+step:465/1600 train_time:15849ms step_avg:34.08ms
+step:466/1600 train_time:15886ms step_avg:34.09ms
+step:467/1600 train_time:15917ms step_avg:34.08ms
+step:468/1600 train_time:15954ms step_avg:34.09ms
+step:469/1600 train_time:15984ms step_avg:34.08ms
+step:470/1600 train_time:16021ms step_avg:34.09ms
+step:471/1600 train_time:16052ms step_avg:34.08ms
+step:472/1600 train_time:16089ms step_avg:34.09ms
+step:473/1600 train_time:16119ms step_avg:34.08ms
+step:474/1600 train_time:16156ms step_avg:34.09ms
+step:475/1600 train_time:16187ms step_avg:34.08ms
+step:476/1600 train_time:16224ms step_avg:34.08ms
+step:477/1600 train_time:16255ms step_avg:34.08ms
+step:478/1600 train_time:16292ms step_avg:34.08ms
+step:479/1600 train_time:16322ms step_avg:34.08ms
+step:480/1600 train_time:16360ms step_avg:34.08ms
+step:481/1600 train_time:16390ms step_avg:34.07ms
+step:482/1600 train_time:16427ms step_avg:34.08ms
+step:483/1600 train_time:16458ms step_avg:34.07ms
+step:484/1600 train_time:16496ms step_avg:34.08ms
+step:485/1600 train_time:16526ms step_avg:34.07ms
+step:486/1600 train_time:16563ms step_avg:34.08ms
+step:487/1600 train_time:16594ms step_avg:34.07ms
+step:488/1600 train_time:16632ms step_avg:34.08ms
+step:489/1600 train_time:16662ms step_avg:34.07ms
+step:490/1600 train_time:16698ms step_avg:34.08ms
+step:491/1600 train_time:16729ms step_avg:34.07ms
+step:492/1600 train_time:16767ms step_avg:34.08ms
+step:493/1600 train_time:16798ms step_avg:34.07ms
+step:494/1600 train_time:16835ms step_avg:34.08ms
+step:495/1600 train_time:16865ms step_avg:34.07ms
+step:496/1600 train_time:16902ms step_avg:34.08ms
+step:497/1600 train_time:16932ms step_avg:34.07ms
+step:498/1600 train_time:16970ms step_avg:34.08ms
+step:499/1600 train_time:17000ms step_avg:34.07ms
+step:500/1600 train_time:17037ms step_avg:34.07ms
+step:500/1600 val_loss:4.2420 train_time:17085ms step_avg:34.17ms
+step:501/1600 train_time:17105ms step_avg:34.14ms
+step:502/1600 train_time:17125ms step_avg:34.11ms
+step:503/1600 train_time:17142ms step_avg:34.08ms
+step:504/1600 train_time:17176ms step_avg:34.08ms
+step:505/1600 train_time:17208ms step_avg:34.08ms
+step:506/1600 train_time:17246ms step_avg:34.08ms
+step:507/1600 train_time:17277ms step_avg:34.08ms
+step:508/1600 train_time:17315ms step_avg:34.08ms
+step:509/1600 train_time:17345ms step_avg:34.08ms
+step:510/1600 train_time:17382ms step_avg:34.08ms
+step:511/1600 train_time:17413ms step_avg:34.08ms
+step:512/1600 train_time:17450ms step_avg:34.08ms
+step:513/1600 train_time:17481ms step_avg:34.08ms
+step:514/1600 train_time:17517ms step_avg:34.08ms
+step:515/1600 train_time:17548ms step_avg:34.07ms
+step:516/1600 train_time:17585ms step_avg:34.08ms
+step:517/1600 train_time:17616ms step_avg:34.07ms
+step:518/1600 train_time:17653ms step_avg:34.08ms
+step:519/1600 train_time:17683ms step_avg:34.07ms
+step:520/1600 train_time:17720ms step_avg:34.08ms
+step:521/1600 train_time:17794ms step_avg:34.15ms
+step:522/1600 train_time:17849ms step_avg:34.19ms
+step:523/1600 train_time:17910ms step_avg:34.24ms
+step:524/1600 train_time:17968ms step_avg:34.29ms
+step:525/1600 train_time:18029ms step_avg:34.34ms
+step:526/1600 train_time:18087ms step_avg:34.39ms
+step:527/1600 train_time:18149ms step_avg:34.44ms
+step:528/1600 train_time:18208ms step_avg:34.49ms
+step:529/1600 train_time:18272ms step_avg:34.54ms
+step:530/1600 train_time:18331ms step_avg:34.59ms
+step:531/1600 train_time:18394ms step_avg:34.64ms
+step:532/1600 train_time:18454ms step_avg:34.69ms
+step:533/1600 train_time:18516ms step_avg:34.74ms
+step:534/1600 train_time:18576ms step_avg:34.79ms
+step:535/1600 train_time:18639ms step_avg:34.84ms
+step:536/1600 train_time:18698ms step_avg:34.88ms
+step:537/1600 train_time:18760ms step_avg:34.94ms
+step:538/1600 train_time:18819ms step_avg:34.98ms
+step:539/1600 train_time:18881ms step_avg:35.03ms
+step:540/1600 train_time:18940ms step_avg:35.07ms
+step:541/1600 train_time:19003ms step_avg:35.13ms
+step:542/1600 train_time:19062ms step_avg:35.17ms
+step:543/1600 train_time:19124ms step_avg:35.22ms
+step:544/1600 train_time:19184ms step_avg:35.26ms
+step:545/1600 train_time:19246ms step_avg:35.31ms
+step:546/1600 train_time:19305ms step_avg:35.36ms
+step:547/1600 train_time:19367ms step_avg:35.41ms
+step:548/1600 train_time:19425ms step_avg:35.45ms
+step:549/1600 train_time:19487ms step_avg:35.50ms
+step:550/1600 train_time:19546ms step_avg:35.54ms
+step:551/1600 train_time:19608ms step_avg:35.59ms
+step:552/1600 train_time:19667ms step_avg:35.63ms
+step:553/1600 train_time:19728ms step_avg:35.68ms
+step:554/1600 train_time:19787ms step_avg:35.72ms
+step:555/1600 train_time:19849ms step_avg:35.76ms
+step:556/1600 train_time:19907ms step_avg:35.80ms
+step:557/1600 train_time:19969ms step_avg:35.85ms
+step:558/1600 train_time:20028ms step_avg:35.89ms
+step:559/1600 train_time:20089ms step_avg:35.94ms
+step:560/1600 train_time:20148ms step_avg:35.98ms
+step:561/1600 train_time:20210ms step_avg:36.02ms
+step:562/1600 train_time:20268ms step_avg:36.06ms
+step:563/1600 train_time:20331ms step_avg:36.11ms
+step:564/1600 train_time:20390ms step_avg:36.15ms
+step:565/1600 train_time:20453ms step_avg:36.20ms
+step:566/1600 train_time:20512ms step_avg:36.24ms
+step:567/1600 train_time:20577ms step_avg:36.29ms
+step:568/1600 train_time:20636ms step_avg:36.33ms
+step:569/1600 train_time:20697ms step_avg:36.37ms
+step:570/1600 train_time:20756ms step_avg:36.41ms
+step:571/1600 train_time:20820ms step_avg:36.46ms
+step:572/1600 train_time:20877ms step_avg:36.50ms
+step:573/1600 train_time:20944ms step_avg:36.55ms
+step:574/1600 train_time:21002ms step_avg:36.59ms
+step:575/1600 train_time:21064ms step_avg:36.63ms
+step:576/1600 train_time:21123ms step_avg:36.67ms
+step:577/1600 train_time:21185ms step_avg:36.72ms
+step:578/1600 train_time:21243ms step_avg:36.75ms
+step:579/1600 train_time:21306ms step_avg:36.80ms
+step:580/1600 train_time:21364ms step_avg:36.83ms
+step:581/1600 train_time:21427ms step_avg:36.88ms
+step:582/1600 train_time:21486ms step_avg:36.92ms
+step:583/1600 train_time:21549ms step_avg:36.96ms
+step:584/1600 train_time:21609ms step_avg:37.00ms
+step:585/1600 train_time:21670ms step_avg:37.04ms
+step:586/1600 train_time:21729ms step_avg:37.08ms
+step:587/1600 train_time:21790ms step_avg:37.12ms
+step:588/1600 train_time:21848ms step_avg:37.16ms
+step:589/1600 train_time:21911ms step_avg:37.20ms
+step:590/1600 train_time:21970ms step_avg:37.24ms
+step:591/1600 train_time:22034ms step_avg:37.28ms
+step:592/1600 train_time:22092ms step_avg:37.32ms
+step:593/1600 train_time:22154ms step_avg:37.36ms
+step:594/1600 train_time:22214ms step_avg:37.40ms
+step:595/1600 train_time:22277ms step_avg:37.44ms
+step:596/1600 train_time:22336ms step_avg:37.48ms
+step:597/1600 train_time:22399ms step_avg:37.52ms
+step:598/1600 train_time:22458ms step_avg:37.56ms
+step:599/1600 train_time:22521ms step_avg:37.60ms
+step:600/1600 train_time:22580ms step_avg:37.63ms
+step:601/1600 train_time:22643ms step_avg:37.68ms
+step:602/1600 train_time:22703ms step_avg:37.71ms
+step:603/1600 train_time:22765ms step_avg:37.75ms
+step:604/1600 train_time:22823ms step_avg:37.79ms
+step:605/1600 train_time:22885ms step_avg:37.83ms
+step:606/1600 train_time:22944ms step_avg:37.86ms
+step:607/1600 train_time:23007ms step_avg:37.90ms
+step:608/1600 train_time:23065ms step_avg:37.94ms
+step:609/1600 train_time:23127ms step_avg:37.98ms
+step:610/1600 train_time:23185ms step_avg:38.01ms
+step:611/1600 train_time:23248ms step_avg:38.05ms
+step:612/1600 train_time:23306ms step_avg:38.08ms
+step:613/1600 train_time:23368ms step_avg:38.12ms
+step:614/1600 train_time:23427ms step_avg:38.15ms
+step:615/1600 train_time:23488ms step_avg:38.19ms
+step:616/1600 train_time:23548ms step_avg:38.23ms
+step:617/1600 train_time:23609ms step_avg:38.26ms
+step:618/1600 train_time:23668ms step_avg:38.30ms
+step:619/1600 train_time:23730ms step_avg:38.34ms
+step:620/1600 train_time:23789ms step_avg:38.37ms
+step:621/1600 train_time:23851ms step_avg:38.41ms
+step:622/1600 train_time:23910ms step_avg:38.44ms
+step:623/1600 train_time:23973ms step_avg:38.48ms
+step:624/1600 train_time:24032ms step_avg:38.51ms
+step:625/1600 train_time:24094ms step_avg:38.55ms
+step:626/1600 train_time:24154ms step_avg:38.58ms
+step:627/1600 train_time:24216ms step_avg:38.62ms
+step:628/1600 train_time:24275ms step_avg:38.65ms
+step:629/1600 train_time:24338ms step_avg:38.69ms
+step:630/1600 train_time:24397ms step_avg:38.72ms
+step:631/1600 train_time:24459ms step_avg:38.76ms
+step:632/1600 train_time:24518ms step_avg:38.79ms
+step:633/1600 train_time:24582ms step_avg:38.83ms
+step:634/1600 train_time:24640ms step_avg:38.87ms
+step:635/1600 train_time:24702ms step_avg:38.90ms
+step:636/1600 train_time:24761ms step_avg:38.93ms
+step:637/1600 train_time:24823ms step_avg:38.97ms
+step:638/1600 train_time:24882ms step_avg:39.00ms
+step:639/1600 train_time:24945ms step_avg:39.04ms
+step:640/1600 train_time:25005ms step_avg:39.07ms
+step:641/1600 train_time:25067ms step_avg:39.11ms
+step:642/1600 train_time:25125ms step_avg:39.14ms
+step:643/1600 train_time:25188ms step_avg:39.17ms
+step:644/1600 train_time:25246ms step_avg:39.20ms
+step:645/1600 train_time:25308ms step_avg:39.24ms
+step:646/1600 train_time:25367ms step_avg:39.27ms
+step:647/1600 train_time:25428ms step_avg:39.30ms
+step:648/1600 train_time:25486ms step_avg:39.33ms
+step:649/1600 train_time:25549ms step_avg:39.37ms
+step:650/1600 train_time:25607ms step_avg:39.39ms
+step:651/1600 train_time:25671ms step_avg:39.43ms
+step:652/1600 train_time:25730ms step_avg:39.46ms
+step:653/1600 train_time:25793ms step_avg:39.50ms
+step:654/1600 train_time:25850ms step_avg:39.53ms
+step:655/1600 train_time:25915ms step_avg:39.56ms
+step:656/1600 train_time:25973ms step_avg:39.59ms
+step:657/1600 train_time:26036ms step_avg:39.63ms
+step:658/1600 train_time:26094ms step_avg:39.66ms
+step:659/1600 train_time:26156ms step_avg:39.69ms
+step:660/1600 train_time:26216ms step_avg:39.72ms
+step:661/1600 train_time:26277ms step_avg:39.75ms
+step:662/1600 train_time:26337ms step_avg:39.78ms
+step:663/1600 train_time:26399ms step_avg:39.82ms
+step:664/1600 train_time:26458ms step_avg:39.85ms
+step:665/1600 train_time:26520ms step_avg:39.88ms
+step:666/1600 train_time:26579ms step_avg:39.91ms
+step:667/1600 train_time:26641ms step_avg:39.94ms
+step:668/1600 train_time:26703ms step_avg:39.98ms
+step:669/1600 train_time:26764ms step_avg:40.01ms
+step:670/1600 train_time:26823ms step_avg:40.03ms
+step:671/1600 train_time:26886ms step_avg:40.07ms
+step:672/1600 train_time:26945ms step_avg:40.10ms
+step:673/1600 train_time:27007ms step_avg:40.13ms
+step:674/1600 train_time:27066ms step_avg:40.16ms
+step:675/1600 train_time:27127ms step_avg:40.19ms
+step:676/1600 train_time:27185ms step_avg:40.21ms
+step:677/1600 train_time:27248ms step_avg:40.25ms
+step:678/1600 train_time:27307ms step_avg:40.28ms
+step:679/1600 train_time:27368ms step_avg:40.31ms
+step:680/1600 train_time:27427ms step_avg:40.33ms
+step:681/1600 train_time:27487ms step_avg:40.36ms
+step:682/1600 train_time:27548ms step_avg:40.39ms
+step:683/1600 train_time:27608ms step_avg:40.42ms
+step:684/1600 train_time:27667ms step_avg:40.45ms
+step:685/1600 train_time:27729ms step_avg:40.48ms
+step:686/1600 train_time:27787ms step_avg:40.51ms
+step:687/1600 train_time:27849ms step_avg:40.54ms
+step:688/1600 train_time:27908ms step_avg:40.56ms
+step:689/1600 train_time:27971ms step_avg:40.60ms
+step:690/1600 train_time:28029ms step_avg:40.62ms
+step:691/1600 train_time:28092ms step_avg:40.65ms
+step:692/1600 train_time:28151ms step_avg:40.68ms
+step:693/1600 train_time:28214ms step_avg:40.71ms
+step:694/1600 train_time:28273ms step_avg:40.74ms
+step:695/1600 train_time:28335ms step_avg:40.77ms
+step:696/1600 train_time:28394ms step_avg:40.80ms
+step:697/1600 train_time:28457ms step_avg:40.83ms
+step:698/1600 train_time:28516ms step_avg:40.85ms
+step:699/1600 train_time:28579ms step_avg:40.89ms
+step:700/1600 train_time:28638ms step_avg:40.91ms
+step:701/1600 train_time:28701ms step_avg:40.94ms
+step:702/1600 train_time:28760ms step_avg:40.97ms
+step:703/1600 train_time:28823ms step_avg:41.00ms
+step:704/1600 train_time:28881ms step_avg:41.02ms
+step:705/1600 train_time:28944ms step_avg:41.06ms
+step:706/1600 train_time:29004ms step_avg:41.08ms
+step:707/1600 train_time:29066ms step_avg:41.11ms
+step:708/1600 train_time:29125ms step_avg:41.14ms
+step:709/1600 train_time:29187ms step_avg:41.17ms
+step:710/1600 train_time:29246ms step_avg:41.19ms
+step:711/1600 train_time:29309ms step_avg:41.22ms
+step:712/1600 train_time:29367ms step_avg:41.25ms
+step:713/1600 train_time:29428ms step_avg:41.27ms
+step:714/1600 train_time:29486ms step_avg:41.30ms
+step:715/1600 train_time:29549ms step_avg:41.33ms
+step:716/1600 train_time:29606ms step_avg:41.35ms
+step:717/1600 train_time:29668ms step_avg:41.38ms
+step:718/1600 train_time:29727ms step_avg:41.40ms
+step:719/1600 train_time:29788ms step_avg:41.43ms
+step:720/1600 train_time:29848ms step_avg:41.46ms
+step:721/1600 train_time:29909ms step_avg:41.48ms
+step:722/1600 train_time:29969ms step_avg:41.51ms
+step:723/1600 train_time:30031ms step_avg:41.54ms
+step:724/1600 train_time:30090ms step_avg:41.56ms
+step:725/1600 train_time:30153ms step_avg:41.59ms
+step:726/1600 train_time:30212ms step_avg:41.61ms
+step:727/1600 train_time:30274ms step_avg:41.64ms
+step:728/1600 train_time:30333ms step_avg:41.67ms
+step:729/1600 train_time:30394ms step_avg:41.69ms
+step:730/1600 train_time:30454ms step_avg:41.72ms
+step:731/1600 train_time:30516ms step_avg:41.75ms
+step:732/1600 train_time:30575ms step_avg:41.77ms
+step:733/1600 train_time:30637ms step_avg:41.80ms
+step:734/1600 train_time:30697ms step_avg:41.82ms
+step:735/1600 train_time:30760ms step_avg:41.85ms
+step:736/1600 train_time:30821ms step_avg:41.88ms
+step:737/1600 train_time:30883ms step_avg:41.90ms
+step:738/1600 train_time:30942ms step_avg:41.93ms
+step:739/1600 train_time:31005ms step_avg:41.95ms
+step:740/1600 train_time:31063ms step_avg:41.98ms
+step:741/1600 train_time:31125ms step_avg:42.00ms
+step:742/1600 train_time:31184ms step_avg:42.03ms
+step:743/1600 train_time:31246ms step_avg:42.05ms
+step:744/1600 train_time:31305ms step_avg:42.08ms
+step:745/1600 train_time:31367ms step_avg:42.10ms
+step:746/1600 train_time:31425ms step_avg:42.13ms
+step:747/1600 train_time:31488ms step_avg:42.15ms
+step:748/1600 train_time:31547ms step_avg:42.18ms
+step:749/1600 train_time:31609ms step_avg:42.20ms
+step:750/1600 train_time:31668ms step_avg:42.22ms
+step:750/1600 val_loss:3.8936 train_time:31712ms step_avg:42.28ms
+step:751/1600 train_time:31733ms step_avg:42.25ms
+step:752/1600 train_time:31793ms step_avg:42.28ms
+step:753/1600 train_time:31855ms step_avg:42.30ms
+step:754/1600 train_time:31916ms step_avg:42.33ms
+step:755/1600 train_time:31981ms step_avg:42.36ms
+step:756/1600 train_time:32040ms step_avg:42.38ms
+step:757/1600 train_time:32102ms step_avg:42.41ms
+step:758/1600 train_time:32160ms step_avg:42.43ms
+step:759/1600 train_time:32222ms step_avg:42.45ms
+step:760/1600 train_time:32281ms step_avg:42.47ms
+step:761/1600 train_time:32342ms step_avg:42.50ms
+step:762/1600 train_time:32401ms step_avg:42.52ms
+step:763/1600 train_time:32463ms step_avg:42.55ms
+step:764/1600 train_time:32523ms step_avg:42.57ms
+step:765/1600 train_time:32586ms step_avg:42.60ms
+step:766/1600 train_time:32645ms step_avg:42.62ms
+step:767/1600 train_time:32709ms step_avg:42.65ms
+step:768/1600 train_time:32769ms step_avg:42.67ms
+step:769/1600 train_time:32832ms step_avg:42.69ms
+step:770/1600 train_time:32892ms step_avg:42.72ms
+step:771/1600 train_time:32953ms step_avg:42.74ms
+step:772/1600 train_time:33012ms step_avg:42.76ms
+step:773/1600 train_time:33076ms step_avg:42.79ms
+step:774/1600 train_time:33135ms step_avg:42.81ms
+step:775/1600 train_time:33197ms step_avg:42.83ms
+step:776/1600 train_time:33255ms step_avg:42.85ms
+step:777/1600 train_time:33317ms step_avg:42.88ms
+step:778/1600 train_time:33376ms step_avg:42.90ms
+step:779/1600 train_time:33439ms step_avg:42.93ms
+step:780/1600 train_time:33498ms step_avg:42.95ms
+step:781/1600 train_time:33561ms step_avg:42.97ms
+step:782/1600 train_time:33620ms step_avg:42.99ms
+step:783/1600 train_time:33684ms step_avg:43.02ms
+step:784/1600 train_time:33743ms step_avg:43.04ms
+step:785/1600 train_time:33805ms step_avg:43.06ms
+step:786/1600 train_time:33865ms step_avg:43.08ms
+step:787/1600 train_time:33927ms step_avg:43.11ms
+step:788/1600 train_time:33986ms step_avg:43.13ms
+step:789/1600 train_time:34049ms step_avg:43.16ms
+step:790/1600 train_time:34109ms step_avg:43.18ms
+step:791/1600 train_time:34171ms step_avg:43.20ms
+step:792/1600 train_time:34228ms step_avg:43.22ms
+step:793/1600 train_time:34290ms step_avg:43.24ms
+step:794/1600 train_time:34349ms step_avg:43.26ms
+step:795/1600 train_time:34410ms step_avg:43.28ms
+step:796/1600 train_time:34469ms step_avg:43.30ms
+step:797/1600 train_time:34531ms step_avg:43.33ms
+step:798/1600 train_time:34590ms step_avg:43.35ms
+step:799/1600 train_time:34652ms step_avg:43.37ms
+step:800/1600 train_time:34710ms step_avg:43.39ms
+step:801/1600 train_time:34771ms step_avg:43.41ms
+step:802/1600 train_time:34830ms step_avg:43.43ms
+step:803/1600 train_time:34892ms step_avg:43.45ms
+step:804/1600 train_time:34951ms step_avg:43.47ms
+step:805/1600 train_time:35014ms step_avg:43.50ms
+step:806/1600 train_time:35075ms step_avg:43.52ms
+step:807/1600 train_time:35137ms step_avg:43.54ms
+step:808/1600 train_time:35196ms step_avg:43.56ms
+step:809/1600 train_time:35257ms step_avg:43.58ms
+step:810/1600 train_time:35317ms step_avg:43.60ms
+step:811/1600 train_time:35379ms step_avg:43.62ms
+step:812/1600 train_time:35438ms step_avg:43.64ms
+step:813/1600 train_time:35500ms step_avg:43.67ms
+step:814/1600 train_time:35559ms step_avg:43.68ms
+step:815/1600 train_time:35621ms step_avg:43.71ms
+step:816/1600 train_time:35681ms step_avg:43.73ms
+step:817/1600 train_time:35742ms step_avg:43.75ms
+step:818/1600 train_time:35802ms step_avg:43.77ms
+step:819/1600 train_time:35863ms step_avg:43.79ms
+step:820/1600 train_time:35923ms step_avg:43.81ms
+step:821/1600 train_time:35987ms step_avg:43.83ms
+step:822/1600 train_time:36046ms step_avg:43.85ms
+step:823/1600 train_time:36109ms step_avg:43.87ms
+step:824/1600 train_time:36167ms step_avg:43.89ms
+step:825/1600 train_time:36230ms step_avg:43.92ms
+step:826/1600 train_time:36290ms step_avg:43.93ms
+step:827/1600 train_time:36351ms step_avg:43.95ms
+step:828/1600 train_time:36409ms step_avg:43.97ms
+step:829/1600 train_time:36471ms step_avg:43.99ms
+step:830/1600 train_time:36529ms step_avg:44.01ms
+step:831/1600 train_time:36591ms step_avg:44.03ms
+step:832/1600 train_time:36650ms step_avg:44.05ms
+step:833/1600 train_time:36711ms step_avg:44.07ms
+step:834/1600 train_time:36770ms step_avg:44.09ms
+step:835/1600 train_time:36831ms step_avg:44.11ms
+step:836/1600 train_time:36890ms step_avg:44.13ms
+step:837/1600 train_time:36953ms step_avg:44.15ms
+step:838/1600 train_time:37011ms step_avg:44.17ms
+step:839/1600 train_time:37074ms step_avg:44.19ms
+step:840/1600 train_time:37132ms step_avg:44.20ms
+step:841/1600 train_time:37195ms step_avg:44.23ms
+step:842/1600 train_time:37255ms step_avg:44.25ms
+step:843/1600 train_time:37316ms step_avg:44.27ms
+step:844/1600 train_time:37375ms step_avg:44.28ms
+step:845/1600 train_time:37437ms step_avg:44.30ms
+step:846/1600 train_time:37496ms step_avg:44.32ms
+step:847/1600 train_time:37560ms step_avg:44.34ms
+step:848/1600 train_time:37618ms step_avg:44.36ms
+step:849/1600 train_time:37682ms step_avg:44.38ms
+step:850/1600 train_time:37741ms step_avg:44.40ms
+step:851/1600 train_time:37802ms step_avg:44.42ms
+step:852/1600 train_time:37861ms step_avg:44.44ms
+step:853/1600 train_time:37924ms step_avg:44.46ms
+step:854/1600 train_time:37984ms step_avg:44.48ms
+step:855/1600 train_time:38046ms step_avg:44.50ms
+step:856/1600 train_time:38105ms step_avg:44.51ms
+step:857/1600 train_time:38168ms step_avg:44.54ms
+step:858/1600 train_time:38227ms step_avg:44.55ms
+step:859/1600 train_time:38290ms step_avg:44.57ms
+step:860/1600 train_time:38348ms step_avg:44.59ms
+step:861/1600 train_time:38410ms step_avg:44.61ms
+step:862/1600 train_time:38469ms step_avg:44.63ms
+step:863/1600 train_time:38530ms step_avg:44.65ms
+step:864/1600 train_time:38590ms step_avg:44.66ms
+step:865/1600 train_time:38650ms step_avg:44.68ms
+step:866/1600 train_time:38709ms step_avg:44.70ms
+step:867/1600 train_time:38770ms step_avg:44.72ms
+step:868/1600 train_time:38828ms step_avg:44.73ms
+step:869/1600 train_time:38890ms step_avg:44.75ms
+step:870/1600 train_time:38949ms step_avg:44.77ms
+step:871/1600 train_time:39011ms step_avg:44.79ms
+step:872/1600 train_time:39071ms step_avg:44.81ms
+step:873/1600 train_time:39133ms step_avg:44.83ms
+step:874/1600 train_time:39192ms step_avg:44.84ms
+step:875/1600 train_time:39254ms step_avg:44.86ms
+step:876/1600 train_time:39313ms step_avg:44.88ms
+step:877/1600 train_time:39376ms step_avg:44.90ms
+step:878/1600 train_time:39435ms step_avg:44.91ms
+step:879/1600 train_time:39498ms step_avg:44.93ms
+step:880/1600 train_time:39556ms step_avg:44.95ms
+step:881/1600 train_time:39619ms step_avg:44.97ms
+step:882/1600 train_time:39680ms step_avg:44.99ms
+step:883/1600 train_time:39742ms step_avg:45.01ms
+step:884/1600 train_time:39801ms step_avg:45.02ms
+step:885/1600 train_time:39863ms step_avg:45.04ms
+step:886/1600 train_time:39922ms step_avg:45.06ms
+step:887/1600 train_time:39986ms step_avg:45.08ms
+step:888/1600 train_time:40045ms step_avg:45.10ms
+step:889/1600 train_time:40107ms step_avg:45.11ms
+step:890/1600 train_time:40172ms step_avg:45.14ms
+step:891/1600 train_time:40232ms step_avg:45.15ms
+step:892/1600 train_time:40289ms step_avg:45.17ms
+step:893/1600 train_time:40350ms step_avg:45.18ms
+step:894/1600 train_time:40409ms step_avg:45.20ms
+step:895/1600 train_time:40470ms step_avg:45.22ms
+step:896/1600 train_time:40530ms step_avg:45.23ms
+step:897/1600 train_time:40594ms step_avg:45.25ms
+step:898/1600 train_time:40652ms step_avg:45.27ms
+step:899/1600 train_time:40712ms step_avg:45.29ms
+step:900/1600 train_time:40771ms step_avg:45.30ms
+step:901/1600 train_time:40832ms step_avg:45.32ms
+step:902/1600 train_time:40891ms step_avg:45.33ms
+step:903/1600 train_time:40954ms step_avg:45.35ms
+step:904/1600 train_time:41013ms step_avg:45.37ms
+step:905/1600 train_time:41075ms step_avg:45.39ms
+step:906/1600 train_time:41135ms step_avg:45.40ms
+step:907/1600 train_time:41198ms step_avg:45.42ms
+step:908/1600 train_time:41257ms step_avg:45.44ms
+step:909/1600 train_time:41319ms step_avg:45.46ms
+step:910/1600 train_time:41379ms step_avg:45.47ms
+step:911/1600 train_time:41441ms step_avg:45.49ms
+step:912/1600 train_time:41500ms step_avg:45.50ms
+step:913/1600 train_time:41563ms step_avg:45.52ms
+step:914/1600 train_time:41622ms step_avg:45.54ms
+step:915/1600 train_time:41685ms step_avg:45.56ms
+step:916/1600 train_time:41743ms step_avg:45.57ms
+step:917/1600 train_time:41806ms step_avg:45.59ms
+step:918/1600 train_time:41866ms step_avg:45.61ms
+step:919/1600 train_time:41928ms step_avg:45.62ms
+step:920/1600 train_time:41986ms step_avg:45.64ms
+step:921/1600 train_time:42048ms step_avg:45.65ms
+step:922/1600 train_time:42107ms step_avg:45.67ms
+step:923/1600 train_time:42169ms step_avg:45.69ms
+step:924/1600 train_time:42228ms step_avg:45.70ms
+step:925/1600 train_time:42290ms step_avg:45.72ms
+step:926/1600 train_time:42349ms step_avg:45.73ms
+step:927/1600 train_time:42412ms step_avg:45.75ms
+step:928/1600 train_time:42470ms step_avg:45.76ms
+step:929/1600 train_time:42532ms step_avg:45.78ms
+step:930/1600 train_time:42590ms step_avg:45.80ms
+step:931/1600 train_time:42655ms step_avg:45.82ms
+step:932/1600 train_time:42712ms step_avg:45.83ms
+step:933/1600 train_time:42773ms step_avg:45.84ms
+step:934/1600 train_time:42831ms step_avg:45.86ms
+step:935/1600 train_time:42893ms step_avg:45.87ms
+step:936/1600 train_time:42952ms step_avg:45.89ms
+step:937/1600 train_time:43014ms step_avg:45.91ms
+step:938/1600 train_time:43073ms step_avg:45.92ms
+step:939/1600 train_time:43136ms step_avg:45.94ms
+step:940/1600 train_time:43196ms step_avg:45.95ms
+step:941/1600 train_time:43259ms step_avg:45.97ms
+step:942/1600 train_time:43317ms step_avg:45.98ms
+step:943/1600 train_time:43380ms step_avg:46.00ms
+step:944/1600 train_time:43439ms step_avg:46.02ms
+step:945/1600 train_time:43502ms step_avg:46.03ms
+step:946/1600 train_time:43561ms step_avg:46.05ms
+step:947/1600 train_time:43624ms step_avg:46.07ms
+step:948/1600 train_time:43683ms step_avg:46.08ms
+step:949/1600 train_time:43744ms step_avg:46.09ms
+step:950/1600 train_time:43803ms step_avg:46.11ms
+step:951/1600 train_time:43866ms step_avg:46.13ms
+step:952/1600 train_time:43924ms step_avg:46.14ms
+step:953/1600 train_time:43986ms step_avg:46.16ms
+step:954/1600 train_time:44046ms step_avg:46.17ms
+step:955/1600 train_time:44109ms step_avg:46.19ms
+step:956/1600 train_time:44169ms step_avg:46.20ms
+step:957/1600 train_time:44231ms step_avg:46.22ms
+step:958/1600 train_time:44289ms step_avg:46.23ms
+step:959/1600 train_time:44351ms step_avg:46.25ms
+step:960/1600 train_time:44410ms step_avg:46.26ms
+step:961/1600 train_time:44471ms step_avg:46.28ms
+step:962/1600 train_time:44530ms step_avg:46.29ms
+step:963/1600 train_time:44592ms step_avg:46.30ms
+step:964/1600 train_time:44650ms step_avg:46.32ms
+step:965/1600 train_time:44712ms step_avg:46.33ms
+step:966/1600 train_time:44772ms step_avg:46.35ms
+step:967/1600 train_time:44834ms step_avg:46.36ms
+step:968/1600 train_time:44891ms step_avg:46.38ms
+step:969/1600 train_time:44955ms step_avg:46.39ms
+step:970/1600 train_time:45013ms step_avg:46.40ms
+step:971/1600 train_time:45075ms step_avg:46.42ms
+step:972/1600 train_time:45134ms step_avg:46.43ms
+step:973/1600 train_time:45196ms step_avg:46.45ms
+step:974/1600 train_time:45256ms step_avg:46.46ms
+step:975/1600 train_time:45320ms step_avg:46.48ms
+step:976/1600 train_time:45379ms step_avg:46.50ms
+step:977/1600 train_time:45439ms step_avg:46.51ms
+step:978/1600 train_time:45498ms step_avg:46.52ms
+step:979/1600 train_time:45560ms step_avg:46.54ms
+step:980/1600 train_time:45620ms step_avg:46.55ms
+step:981/1600 train_time:45684ms step_avg:46.57ms
+step:982/1600 train_time:45742ms step_avg:46.58ms
+step:983/1600 train_time:45805ms step_avg:46.60ms
+step:984/1600 train_time:45864ms step_avg:46.61ms
+step:985/1600 train_time:45926ms step_avg:46.63ms
+step:986/1600 train_time:45986ms step_avg:46.64ms
+step:987/1600 train_time:46048ms step_avg:46.65ms
+step:988/1600 train_time:46107ms step_avg:46.67ms
+step:989/1600 train_time:46169ms step_avg:46.68ms
+step:990/1600 train_time:46229ms step_avg:46.70ms
+step:991/1600 train_time:46291ms step_avg:46.71ms
+step:992/1600 train_time:46351ms step_avg:46.72ms
+step:993/1600 train_time:46413ms step_avg:46.74ms
+step:994/1600 train_time:46471ms step_avg:46.75ms
+step:995/1600 train_time:46532ms step_avg:46.77ms
+step:996/1600 train_time:46591ms step_avg:46.78ms
+step:997/1600 train_time:46653ms step_avg:46.79ms
+step:998/1600 train_time:46711ms step_avg:46.80ms
+step:999/1600 train_time:46773ms step_avg:46.82ms
+step:1000/1600 train_time:46832ms step_avg:46.83ms
+step:1000/1600 val_loss:3.5958 train_time:46877ms step_avg:46.88ms
+step:1001/1600 train_time:46898ms step_avg:46.85ms
+step:1002/1600 train_time:46959ms step_avg:46.87ms
+step:1003/1600 train_time:47021ms step_avg:46.88ms
+step:1004/1600 train_time:47081ms step_avg:46.89ms
+step:1005/1600 train_time:47143ms step_avg:46.91ms
+step:1006/1600 train_time:47202ms step_avg:46.92ms
+step:1007/1600 train_time:47264ms step_avg:46.94ms
+step:1008/1600 train_time:47323ms step_avg:46.95ms
+step:1009/1600 train_time:47384ms step_avg:46.96ms
+step:1010/1600 train_time:47442ms step_avg:46.97ms
+step:1011/1600 train_time:47506ms step_avg:46.99ms
+step:1012/1600 train_time:47564ms step_avg:47.00ms
+step:1013/1600 train_time:47626ms step_avg:47.01ms
+step:1014/1600 train_time:47685ms step_avg:47.03ms
+step:1015/1600 train_time:47747ms step_avg:47.04ms
+step:1016/1600 train_time:47806ms step_avg:47.05ms
+step:1017/1600 train_time:47871ms step_avg:47.07ms
+step:1018/1600 train_time:47931ms step_avg:47.08ms
+step:1019/1600 train_time:47994ms step_avg:47.10ms
+step:1020/1600 train_time:48054ms step_avg:47.11ms
+step:1021/1600 train_time:48116ms step_avg:47.13ms
+step:1022/1600 train_time:48175ms step_avg:47.14ms
+step:1023/1600 train_time:48238ms step_avg:47.15ms
+step:1024/1600 train_time:48296ms step_avg:47.16ms
+step:1025/1600 train_time:48358ms step_avg:47.18ms
+step:1026/1600 train_time:48417ms step_avg:47.19ms
+step:1027/1600 train_time:48479ms step_avg:47.20ms
+step:1028/1600 train_time:48538ms step_avg:47.22ms
+step:1029/1600 train_time:48600ms step_avg:47.23ms
+step:1030/1600 train_time:48658ms step_avg:47.24ms
+step:1031/1600 train_time:48719ms step_avg:47.25ms
+step:1032/1600 train_time:48778ms step_avg:47.27ms
+step:1033/1600 train_time:48840ms step_avg:47.28ms
+step:1034/1600 train_time:48899ms step_avg:47.29ms
+step:1035/1600 train_time:48961ms step_avg:47.31ms
+step:1036/1600 train_time:49022ms step_avg:47.32ms
+step:1037/1600 train_time:49084ms step_avg:47.33ms
+step:1038/1600 train_time:49145ms step_avg:47.35ms
+step:1039/1600 train_time:49206ms step_avg:47.36ms
+step:1040/1600 train_time:49265ms step_avg:47.37ms
+step:1041/1600 train_time:49337ms step_avg:47.39ms
+step:1042/1600 train_time:49421ms step_avg:47.43ms
+step:1043/1600 train_time:49509ms step_avg:47.47ms
+step:1044/1600 train_time:49596ms step_avg:47.51ms
+step:1045/1600 train_time:49681ms step_avg:47.54ms
+step:1046/1600 train_time:49765ms step_avg:47.58ms
+step:1047/1600 train_time:49853ms step_avg:47.62ms
+step:1048/1600 train_time:49939ms step_avg:47.65ms
+step:1049/1600 train_time:50028ms step_avg:47.69ms
+step:1050/1600 train_time:50114ms step_avg:47.73ms
+step:1051/1600 train_time:50201ms step_avg:47.77ms
+step:1052/1600 train_time:50287ms step_avg:47.80ms
+step:1053/1600 train_time:50374ms step_avg:47.84ms
+step:1054/1600 train_time:50460ms step_avg:47.87ms
+step:1055/1600 train_time:50548ms step_avg:47.91ms
+step:1056/1600 train_time:50632ms step_avg:47.95ms
+step:1057/1600 train_time:50720ms step_avg:47.99ms
+step:1058/1600 train_time:50804ms step_avg:48.02ms
+step:1059/1600 train_time:50892ms step_avg:48.06ms
+step:1060/1600 train_time:50979ms step_avg:48.09ms
+step:1061/1600 train_time:51066ms step_avg:48.13ms
+step:1062/1600 train_time:51151ms step_avg:48.16ms
+step:1063/1600 train_time:51240ms step_avg:48.20ms
+step:1064/1600 train_time:51326ms step_avg:48.24ms
+step:1065/1600 train_time:51413ms step_avg:48.27ms
+step:1066/1600 train_time:51497ms step_avg:48.31ms
+step:1067/1600 train_time:51587ms step_avg:48.35ms
+step:1068/1600 train_time:51670ms step_avg:48.38ms
+step:1069/1600 train_time:51758ms step_avg:48.42ms
+step:1070/1600 train_time:51842ms step_avg:48.45ms
+step:1071/1600 train_time:51931ms step_avg:48.49ms
+step:1072/1600 train_time:52016ms step_avg:48.52ms
+step:1073/1600 train_time:52105ms step_avg:48.56ms
+step:1074/1600 train_time:52190ms step_avg:48.59ms
+step:1075/1600 train_time:52278ms step_avg:48.63ms
+step:1076/1600 train_time:52362ms step_avg:48.66ms
+step:1077/1600 train_time:52451ms step_avg:48.70ms
+step:1078/1600 train_time:52536ms step_avg:48.73ms
+step:1079/1600 train_time:52624ms step_avg:48.77ms
+step:1080/1600 train_time:52709ms step_avg:48.80ms
+step:1081/1600 train_time:52796ms step_avg:48.84ms
+step:1082/1600 train_time:52881ms step_avg:48.87ms
+step:1083/1600 train_time:52969ms step_avg:48.91ms
+step:1084/1600 train_time:53054ms step_avg:48.94ms
+step:1085/1600 train_time:53143ms step_avg:48.98ms
+step:1086/1600 train_time:53228ms step_avg:49.01ms
+step:1087/1600 train_time:53317ms step_avg:49.05ms
+step:1088/1600 train_time:53401ms step_avg:49.08ms
+step:1089/1600 train_time:53488ms step_avg:49.12ms
+step:1090/1600 train_time:53574ms step_avg:49.15ms
+step:1091/1600 train_time:53663ms step_avg:49.19ms
+step:1092/1600 train_time:53747ms step_avg:49.22ms
+step:1093/1600 train_time:53836ms step_avg:49.26ms
+step:1094/1600 train_time:53921ms step_avg:49.29ms
+step:1095/1600 train_time:54009ms step_avg:49.32ms
+step:1096/1600 train_time:54094ms step_avg:49.36ms
+step:1097/1600 train_time:54182ms step_avg:49.39ms
+step:1098/1600 train_time:54266ms step_avg:49.42ms
+step:1099/1600 train_time:54354ms step_avg:49.46ms
+step:1100/1600 train_time:54440ms step_avg:49.49ms
+step:1101/1600 train_time:54528ms step_avg:49.53ms
+step:1102/1600 train_time:54612ms step_avg:49.56ms
+step:1103/1600 train_time:54702ms step_avg:49.59ms
+step:1104/1600 train_time:54785ms step_avg:49.62ms
+step:1105/1600 train_time:54873ms step_avg:49.66ms
+step:1106/1600 train_time:54958ms step_avg:49.69ms
+step:1107/1600 train_time:55047ms step_avg:49.73ms
+step:1108/1600 train_time:55132ms step_avg:49.76ms
+step:1109/1600 train_time:55220ms step_avg:49.79ms
+step:1110/1600 train_time:55305ms step_avg:49.82ms
+step:1111/1600 train_time:55392ms step_avg:49.86ms
+step:1112/1600 train_time:55478ms step_avg:49.89ms
+step:1113/1600 train_time:55566ms step_avg:49.92ms
+step:1114/1600 train_time:55651ms step_avg:49.96ms
+step:1115/1600 train_time:55740ms step_avg:49.99ms
+step:1116/1600 train_time:55826ms step_avg:50.02ms
+step:1117/1600 train_time:55913ms step_avg:50.06ms
+step:1118/1600 train_time:56004ms step_avg:50.09ms
+step:1119/1600 train_time:56089ms step_avg:50.12ms
+step:1120/1600 train_time:56174ms step_avg:50.16ms
+step:1121/1600 train_time:56262ms step_avg:50.19ms
+step:1122/1600 train_time:56346ms step_avg:50.22ms
+step:1123/1600 train_time:56434ms step_avg:50.25ms
+step:1124/1600 train_time:56520ms step_avg:50.28ms
+step:1125/1600 train_time:56608ms step_avg:50.32ms
+step:1126/1600 train_time:56693ms step_avg:50.35ms
+step:1127/1600 train_time:56781ms step_avg:50.38ms
+step:1128/1600 train_time:56866ms step_avg:50.41ms
+step:1129/1600 train_time:56954ms step_avg:50.45ms
+step:1130/1600 train_time:57039ms step_avg:50.48ms
+step:1131/1600 train_time:57127ms step_avg:50.51ms
+step:1132/1600 train_time:57213ms step_avg:50.54ms
+step:1133/1600 train_time:57301ms step_avg:50.57ms
+step:1134/1600 train_time:57386ms step_avg:50.61ms
+step:1135/1600 train_time:57474ms step_avg:50.64ms
+step:1136/1600 train_time:57560ms step_avg:50.67ms
+step:1137/1600 train_time:57649ms step_avg:50.70ms
+step:1138/1600 train_time:57733ms step_avg:50.73ms
+step:1139/1600 train_time:57827ms step_avg:50.77ms
+step:1140/1600 train_time:57910ms step_avg:50.80ms
+step:1141/1600 train_time:58001ms step_avg:50.83ms
+step:1142/1600 train_time:58083ms step_avg:50.86ms
+step:1143/1600 train_time:58170ms step_avg:50.89ms
+step:1144/1600 train_time:58255ms step_avg:50.92ms
+step:1145/1600 train_time:58344ms step_avg:50.96ms
+step:1146/1600 train_time:58429ms step_avg:50.98ms
+step:1147/1600 train_time:58517ms step_avg:51.02ms
+step:1148/1600 train_time:58602ms step_avg:51.05ms
+step:1149/1600 train_time:58690ms step_avg:51.08ms
+step:1150/1600 train_time:58775ms step_avg:51.11ms
+step:1151/1600 train_time:58863ms step_avg:51.14ms
+step:1152/1600 train_time:58950ms step_avg:51.17ms
+step:1153/1600 train_time:59037ms step_avg:51.20ms
+step:1154/1600 train_time:59126ms step_avg:51.24ms
+step:1155/1600 train_time:59211ms step_avg:51.27ms
+step:1156/1600 train_time:59297ms step_avg:51.29ms
+step:1157/1600 train_time:59385ms step_avg:51.33ms
+step:1158/1600 train_time:59470ms step_avg:51.36ms
+step:1159/1600 train_time:59558ms step_avg:51.39ms
+step:1160/1600 train_time:59643ms step_avg:51.42ms
+step:1161/1600 train_time:59731ms step_avg:51.45ms
+step:1162/1600 train_time:59817ms step_avg:51.48ms
+step:1163/1600 train_time:59904ms step_avg:51.51ms
+step:1164/1600 train_time:59989ms step_avg:51.54ms
+step:1165/1600 train_time:60077ms step_avg:51.57ms
+step:1166/1600 train_time:60163ms step_avg:51.60ms
+step:1167/1600 train_time:60251ms step_avg:51.63ms
+step:1168/1600 train_time:60337ms step_avg:51.66ms
+step:1169/1600 train_time:60425ms step_avg:51.69ms
+step:1170/1600 train_time:60510ms step_avg:51.72ms
+step:1171/1600 train_time:60598ms step_avg:51.75ms
+step:1172/1600 train_time:60683ms step_avg:51.78ms
+step:1173/1600 train_time:60770ms step_avg:51.81ms
+step:1174/1600 train_time:60855ms step_avg:51.84ms
+step:1175/1600 train_time:60944ms step_avg:51.87ms
+step:1176/1600 train_time:61029ms step_avg:51.90ms
+step:1177/1600 train_time:61117ms step_avg:51.93ms
+step:1178/1600 train_time:61202ms step_avg:51.95ms
+step:1179/1600 train_time:61290ms step_avg:51.98ms
+step:1180/1600 train_time:61375ms step_avg:52.01ms
+step:1181/1600 train_time:61464ms step_avg:52.04ms
+step:1182/1600 train_time:61549ms step_avg:52.07ms
+step:1183/1600 train_time:61638ms step_avg:52.10ms
+step:1184/1600 train_time:61722ms step_avg:52.13ms
+step:1185/1600 train_time:61810ms step_avg:52.16ms
+step:1186/1600 train_time:61895ms step_avg:52.19ms
+step:1187/1600 train_time:61984ms step_avg:52.22ms
+step:1188/1600 train_time:62069ms step_avg:52.25ms
+step:1189/1600 train_time:62157ms step_avg:52.28ms
+step:1190/1600 train_time:62242ms step_avg:52.30ms
+step:1191/1600 train_time:62331ms step_avg:52.33ms
+step:1192/1600 train_time:62415ms step_avg:52.36ms
+step:1193/1600 train_time:62503ms step_avg:52.39ms
+step:1194/1600 train_time:62588ms step_avg:52.42ms
+step:1195/1600 train_time:62676ms step_avg:52.45ms
+step:1196/1600 train_time:62762ms step_avg:52.48ms
+step:1197/1600 train_time:62849ms step_avg:52.51ms
+step:1198/1600 train_time:62934ms step_avg:52.53ms
+step:1199/1600 train_time:63022ms step_avg:52.56ms
+step:1200/1600 train_time:63107ms step_avg:52.59ms
+step:1201/1600 train_time:63194ms step_avg:52.62ms
+step:1202/1600 train_time:63280ms step_avg:52.65ms
+step:1203/1600 train_time:63367ms step_avg:52.67ms
+step:1204/1600 train_time:63452ms step_avg:52.70ms
+step:1205/1600 train_time:63541ms step_avg:52.73ms
+step:1206/1600 train_time:63625ms step_avg:52.76ms
+step:1207/1600 train_time:63714ms step_avg:52.79ms
+step:1208/1600 train_time:63799ms step_avg:52.81ms
+step:1209/1600 train_time:63887ms step_avg:52.84ms
+step:1210/1600 train_time:63972ms step_avg:52.87ms
+step:1211/1600 train_time:64060ms step_avg:52.90ms
+step:1212/1600 train_time:64145ms step_avg:52.92ms
+step:1213/1600 train_time:64233ms step_avg:52.95ms
+step:1214/1600 train_time:64318ms step_avg:52.98ms
+step:1215/1600 train_time:64406ms step_avg:53.01ms
+step:1216/1600 train_time:64491ms step_avg:53.04ms
+step:1217/1600 train_time:64579ms step_avg:53.06ms
+step:1218/1600 train_time:64664ms step_avg:53.09ms
+step:1219/1600 train_time:64753ms step_avg:53.12ms
+step:1220/1600 train_time:64840ms step_avg:53.15ms
+step:1221/1600 train_time:64936ms step_avg:53.18ms
+step:1222/1600 train_time:65012ms step_avg:53.20ms
+step:1223/1600 train_time:65100ms step_avg:53.23ms
+step:1224/1600 train_time:65185ms step_avg:53.26ms
+step:1225/1600 train_time:65274ms step_avg:53.28ms
+step:1226/1600 train_time:65360ms step_avg:53.31ms
+step:1227/1600 train_time:65448ms step_avg:53.34ms
+step:1228/1600 train_time:65533ms step_avg:53.37ms
+step:1229/1600 train_time:65623ms step_avg:53.40ms
+step:1230/1600 train_time:65708ms step_avg:53.42ms
+step:1231/1600 train_time:65795ms step_avg:53.45ms
+step:1232/1600 train_time:65880ms step_avg:53.47ms
+step:1233/1600 train_time:65967ms step_avg:53.50ms
+step:1234/1600 train_time:66053ms step_avg:53.53ms
+step:1235/1600 train_time:66141ms step_avg:53.56ms
+step:1236/1600 train_time:66226ms step_avg:53.58ms
+step:1237/1600 train_time:66314ms step_avg:53.61ms
+step:1238/1600 train_time:66399ms step_avg:53.63ms
+step:1239/1600 train_time:66487ms step_avg:53.66ms
+step:1240/1600 train_time:66572ms step_avg:53.69ms
+step:1241/1600 train_time:66661ms step_avg:53.72ms
+step:1242/1600 train_time:66746ms step_avg:53.74ms
+step:1243/1600 train_time:66835ms step_avg:53.77ms
+step:1244/1600 train_time:66918ms step_avg:53.79ms
+step:1245/1600 train_time:67006ms step_avg:53.82ms
+step:1246/1600 train_time:67091ms step_avg:53.84ms
+step:1247/1600 train_time:67179ms step_avg:53.87ms
+step:1248/1600 train_time:67264ms step_avg:53.90ms
+step:1249/1600 train_time:67352ms step_avg:53.92ms
+step:1250/1600 train_time:67438ms step_avg:53.95ms
+step:1250/1600 val_loss:3.4162 train_time:67509ms step_avg:54.01ms
+step:1251/1600 train_time:67530ms step_avg:53.98ms
+step:1252/1600 train_time:67616ms step_avg:54.01ms
+step:1253/1600 train_time:67709ms step_avg:54.04ms
+step:1254/1600 train_time:67794ms step_avg:54.06ms
+step:1255/1600 train_time:67881ms step_avg:54.09ms
+step:1256/1600 train_time:67966ms step_avg:54.11ms
+step:1257/1600 train_time:68052ms step_avg:54.14ms
+step:1258/1600 train_time:68137ms step_avg:54.16ms
+step:1259/1600 train_time:68224ms step_avg:54.19ms
+step:1260/1600 train_time:68310ms step_avg:54.21ms
+step:1261/1600 train_time:68396ms step_avg:54.24ms
+step:1262/1600 train_time:68483ms step_avg:54.27ms
+step:1263/1600 train_time:68571ms step_avg:54.29ms
+step:1264/1600 train_time:68659ms step_avg:54.32ms
+step:1265/1600 train_time:68748ms step_avg:54.35ms
+step:1266/1600 train_time:68833ms step_avg:54.37ms
+step:1267/1600 train_time:68921ms step_avg:54.40ms
+step:1268/1600 train_time:69005ms step_avg:54.42ms
+step:1269/1600 train_time:69093ms step_avg:54.45ms
+step:1270/1600 train_time:69179ms step_avg:54.47ms
+step:1271/1600 train_time:69264ms step_avg:54.50ms
+step:1272/1600 train_time:69349ms step_avg:54.52ms
+step:1273/1600 train_time:69437ms step_avg:54.55ms
+step:1274/1600 train_time:69523ms step_avg:54.57ms
+step:1275/1600 train_time:69613ms step_avg:54.60ms
+step:1276/1600 train_time:69699ms step_avg:54.62ms
+step:1277/1600 train_time:69788ms step_avg:54.65ms
+step:1278/1600 train_time:69873ms step_avg:54.67ms
+step:1279/1600 train_time:69963ms step_avg:54.70ms
+step:1280/1600 train_time:70046ms step_avg:54.72ms
+step:1281/1600 train_time:70134ms step_avg:54.75ms
+step:1282/1600 train_time:70218ms step_avg:54.77ms
+step:1283/1600 train_time:70306ms step_avg:54.80ms
+step:1284/1600 train_time:70390ms step_avg:54.82ms
+step:1285/1600 train_time:70479ms step_avg:54.85ms
+step:1286/1600 train_time:70565ms step_avg:54.87ms
+step:1287/1600 train_time:70654ms step_avg:54.90ms
+step:1288/1600 train_time:70740ms step_avg:54.92ms
+step:1289/1600 train_time:70828ms step_avg:54.95ms
+step:1290/1600 train_time:70913ms step_avg:54.97ms
+step:1291/1600 train_time:71002ms step_avg:55.00ms
+step:1292/1600 train_time:71086ms step_avg:55.02ms
+step:1293/1600 train_time:71174ms step_avg:55.05ms
+step:1294/1600 train_time:71258ms step_avg:55.07ms
+step:1295/1600 train_time:71346ms step_avg:55.09ms
+step:1296/1600 train_time:71431ms step_avg:55.12ms
+step:1297/1600 train_time:71520ms step_avg:55.14ms
+step:1298/1600 train_time:71606ms step_avg:55.17ms
+step:1299/1600 train_time:71694ms step_avg:55.19ms
+step:1300/1600 train_time:71779ms step_avg:55.21ms
+step:1301/1600 train_time:71867ms step_avg:55.24ms
+step:1302/1600 train_time:71953ms step_avg:55.26ms
+step:1303/1600 train_time:72041ms step_avg:55.29ms
+step:1304/1600 train_time:72126ms step_avg:55.31ms
+step:1305/1600 train_time:72213ms step_avg:55.34ms
+step:1306/1600 train_time:72298ms step_avg:55.36ms
+step:1307/1600 train_time:72386ms step_avg:55.38ms
+step:1308/1600 train_time:72473ms step_avg:55.41ms
+step:1309/1600 train_time:72561ms step_avg:55.43ms
+step:1310/1600 train_time:72647ms step_avg:55.46ms
+step:1311/1600 train_time:72735ms step_avg:55.48ms
+step:1312/1600 train_time:72820ms step_avg:55.50ms
+step:1313/1600 train_time:72908ms step_avg:55.53ms
+step:1314/1600 train_time:72995ms step_avg:55.55ms
+step:1315/1600 train_time:73083ms step_avg:55.58ms
+step:1316/1600 train_time:73168ms step_avg:55.60ms
+step:1317/1600 train_time:73254ms step_avg:55.62ms
+step:1318/1600 train_time:73339ms step_avg:55.64ms
+step:1319/1600 train_time:73426ms step_avg:55.67ms
+step:1320/1600 train_time:73511ms step_avg:55.69ms
+step:1321/1600 train_time:73600ms step_avg:55.72ms
+step:1322/1600 train_time:73686ms step_avg:55.74ms
+step:1323/1600 train_time:73774ms step_avg:55.76ms
+step:1324/1600 train_time:73859ms step_avg:55.78ms
+step:1325/1600 train_time:73947ms step_avg:55.81ms
+step:1326/1600 train_time:74031ms step_avg:55.83ms
+step:1327/1600 train_time:74120ms step_avg:55.86ms
+step:1328/1600 train_time:74204ms step_avg:55.88ms
+step:1329/1600 train_time:74294ms step_avg:55.90ms
+step:1330/1600 train_time:74377ms step_avg:55.92ms
+step:1331/1600 train_time:74467ms step_avg:55.95ms
+step:1332/1600 train_time:74551ms step_avg:55.97ms
+step:1333/1600 train_time:74640ms step_avg:55.99ms
+step:1334/1600 train_time:74724ms step_avg:56.02ms
+step:1335/1600 train_time:74813ms step_avg:56.04ms
+step:1336/1600 train_time:74899ms step_avg:56.06ms
+step:1337/1600 train_time:74986ms step_avg:56.09ms
+step:1338/1600 train_time:75071ms step_avg:56.11ms
+step:1339/1600 train_time:75159ms step_avg:56.13ms
+step:1340/1600 train_time:75244ms step_avg:56.15ms
+step:1341/1600 train_time:75331ms step_avg:56.18ms
+step:1342/1600 train_time:75416ms step_avg:56.20ms
+step:1343/1600 train_time:75504ms step_avg:56.22ms
+step:1344/1600 train_time:75589ms step_avg:56.24ms
+step:1345/1600 train_time:75678ms step_avg:56.27ms
+step:1346/1600 train_time:75762ms step_avg:56.29ms
+step:1347/1600 train_time:75850ms step_avg:56.31ms
+step:1348/1600 train_time:75936ms step_avg:56.33ms
+step:1349/1600 train_time:76025ms step_avg:56.36ms
+step:1350/1600 train_time:76109ms step_avg:56.38ms
+step:1351/1600 train_time:76198ms step_avg:56.40ms
+step:1352/1600 train_time:76282ms step_avg:56.42ms
+step:1353/1600 train_time:76371ms step_avg:56.45ms
+step:1354/1600 train_time:76455ms step_avg:56.47ms
+step:1355/1600 train_time:76544ms step_avg:56.49ms
+step:1356/1600 train_time:76630ms step_avg:56.51ms
+step:1357/1600 train_time:76718ms step_avg:56.54ms
+step:1358/1600 train_time:76802ms step_avg:56.56ms
+step:1359/1600 train_time:76891ms step_avg:56.58ms
+step:1360/1600 train_time:76976ms step_avg:56.60ms
+step:1361/1600 train_time:77063ms step_avg:56.62ms
+step:1362/1600 train_time:77148ms step_avg:56.64ms
+step:1363/1600 train_time:77236ms step_avg:56.67ms
+step:1364/1600 train_time:77321ms step_avg:56.69ms
+step:1365/1600 train_time:77408ms step_avg:56.71ms
+step:1366/1600 train_time:77499ms step_avg:56.73ms
+step:1367/1600 train_time:77584ms step_avg:56.76ms
+step:1368/1600 train_time:77668ms step_avg:56.78ms
+step:1369/1600 train_time:77757ms step_avg:56.80ms
+step:1370/1600 train_time:77841ms step_avg:56.82ms
+step:1371/1600 train_time:77930ms step_avg:56.84ms
+step:1372/1600 train_time:78015ms step_avg:56.86ms
+step:1373/1600 train_time:78103ms step_avg:56.89ms
+step:1374/1600 train_time:78189ms step_avg:56.91ms
+step:1375/1600 train_time:78279ms step_avg:56.93ms
+step:1376/1600 train_time:78364ms step_avg:56.95ms
+step:1377/1600 train_time:78451ms step_avg:56.97ms
+step:1378/1600 train_time:78535ms step_avg:56.99ms
+step:1379/1600 train_time:78623ms step_avg:57.01ms
+step:1380/1600 train_time:78708ms step_avg:57.03ms
+step:1381/1600 train_time:78796ms step_avg:57.06ms
+step:1382/1600 train_time:78881ms step_avg:57.08ms
+step:1383/1600 train_time:78970ms step_avg:57.10ms
+step:1384/1600 train_time:79055ms step_avg:57.12ms
+step:1385/1600 train_time:79144ms step_avg:57.14ms
+step:1386/1600 train_time:79229ms step_avg:57.16ms
+step:1387/1600 train_time:79319ms step_avg:57.19ms
+step:1388/1600 train_time:79405ms step_avg:57.21ms
+step:1389/1600 train_time:79491ms step_avg:57.23ms
+step:1390/1600 train_time:79576ms step_avg:57.25ms
+step:1391/1600 train_time:79664ms step_avg:57.27ms
+step:1392/1600 train_time:79749ms step_avg:57.29ms
+step:1393/1600 train_time:79838ms step_avg:57.31ms
+step:1394/1600 train_time:79922ms step_avg:57.33ms
+step:1395/1600 train_time:80011ms step_avg:57.36ms
+step:1396/1600 train_time:80097ms step_avg:57.38ms
+step:1397/1600 train_time:80185ms step_avg:57.40ms
+step:1398/1600 train_time:80271ms step_avg:57.42ms
+step:1399/1600 train_time:80360ms step_avg:57.44ms
+step:1400/1600 train_time:80445ms step_avg:57.46ms
+step:1401/1600 train_time:80533ms step_avg:57.48ms
+step:1402/1600 train_time:80618ms step_avg:57.50ms
+step:1403/1600 train_time:80705ms step_avg:57.52ms
+step:1404/1600 train_time:80790ms step_avg:57.54ms
+step:1405/1600 train_time:80879ms step_avg:57.56ms
+step:1406/1600 train_time:80964ms step_avg:57.58ms
+step:1407/1600 train_time:81052ms step_avg:57.61ms
+step:1408/1600 train_time:81137ms step_avg:57.63ms
+step:1409/1600 train_time:81225ms step_avg:57.65ms
+step:1410/1600 train_time:81311ms step_avg:57.67ms
+step:1411/1600 train_time:81400ms step_avg:57.69ms
+step:1412/1600 train_time:81485ms step_avg:57.71ms
+step:1413/1600 train_time:81572ms step_avg:57.73ms
+step:1414/1600 train_time:81657ms step_avg:57.75ms
+step:1415/1600 train_time:81745ms step_avg:57.77ms
+step:1416/1600 train_time:81829ms step_avg:57.79ms
+step:1417/1600 train_time:81919ms step_avg:57.81ms
+step:1418/1600 train_time:82003ms step_avg:57.83ms
+step:1419/1600 train_time:82091ms step_avg:57.85ms
+step:1420/1600 train_time:82176ms step_avg:57.87ms
+step:1421/1600 train_time:82264ms step_avg:57.89ms
+step:1422/1600 train_time:82350ms step_avg:57.91ms
+step:1423/1600 train_time:82438ms step_avg:57.93ms
+step:1424/1600 train_time:82524ms step_avg:57.95ms
+step:1425/1600 train_time:82611ms step_avg:57.97ms
+step:1426/1600 train_time:82696ms step_avg:57.99ms
+step:1427/1600 train_time:82784ms step_avg:58.01ms
+step:1428/1600 train_time:82869ms step_avg:58.03ms
+step:1429/1600 train_time:82957ms step_avg:58.05ms
+step:1430/1600 train_time:83042ms step_avg:58.07ms
+step:1431/1600 train_time:83130ms step_avg:58.09ms
+step:1432/1600 train_time:83218ms step_avg:58.11ms
+step:1433/1600 train_time:83305ms step_avg:58.13ms
+step:1434/1600 train_time:83390ms step_avg:58.15ms
+step:1435/1600 train_time:83480ms step_avg:58.17ms
+step:1436/1600 train_time:83565ms step_avg:58.19ms
+step:1437/1600 train_time:83653ms step_avg:58.21ms
+step:1438/1600 train_time:83738ms step_avg:58.23ms
+step:1439/1600 train_time:83825ms step_avg:58.25ms
+step:1440/1600 train_time:83912ms step_avg:58.27ms
+step:1441/1600 train_time:84000ms step_avg:58.29ms
+step:1442/1600 train_time:84084ms step_avg:58.31ms
+step:1443/1600 train_time:84173ms step_avg:58.33ms
+step:1444/1600 train_time:84259ms step_avg:58.35ms
+step:1445/1600 train_time:84347ms step_avg:58.37ms
+step:1446/1600 train_time:84433ms step_avg:58.39ms
+step:1447/1600 train_time:84523ms step_avg:58.41ms
+step:1448/1600 train_time:84607ms step_avg:58.43ms
+step:1449/1600 train_time:84695ms step_avg:58.45ms
+step:1450/1600 train_time:84780ms step_avg:58.47ms
+step:1451/1600 train_time:84868ms step_avg:58.49ms
+step:1452/1600 train_time:84954ms step_avg:58.51ms
+step:1453/1600 train_time:85042ms step_avg:58.53ms
+step:1454/1600 train_time:85127ms step_avg:58.55ms
+step:1455/1600 train_time:85215ms step_avg:58.57ms
+step:1456/1600 train_time:85301ms step_avg:58.59ms
+step:1457/1600 train_time:85388ms step_avg:58.61ms
+step:1458/1600 train_time:85476ms step_avg:58.63ms
+step:1459/1600 train_time:85563ms step_avg:58.64ms
+step:1460/1600 train_time:85648ms step_avg:58.66ms
+step:1461/1600 train_time:85736ms step_avg:58.68ms
+step:1462/1600 train_time:85821ms step_avg:58.70ms
+step:1463/1600 train_time:85909ms step_avg:58.72ms
+step:1464/1600 train_time:85996ms step_avg:58.74ms
+step:1465/1600 train_time:86083ms step_avg:58.76ms
+step:1466/1600 train_time:86168ms step_avg:58.78ms
+step:1467/1600 train_time:86257ms step_avg:58.80ms
+step:1468/1600 train_time:86345ms step_avg:58.82ms
+step:1469/1600 train_time:86431ms step_avg:58.84ms
+step:1470/1600 train_time:86516ms step_avg:58.85ms
+step:1471/1600 train_time:86606ms step_avg:58.88ms
+step:1472/1600 train_time:86690ms step_avg:58.89ms
+step:1473/1600 train_time:86779ms step_avg:58.91ms
+step:1474/1600 train_time:86864ms step_avg:58.93ms
+step:1475/1600 train_time:86952ms step_avg:58.95ms
+step:1476/1600 train_time:87037ms step_avg:58.97ms
+step:1477/1600 train_time:87126ms step_avg:58.99ms
+step:1478/1600 train_time:87211ms step_avg:59.01ms
+step:1479/1600 train_time:87300ms step_avg:59.03ms
+step:1480/1600 train_time:87386ms step_avg:59.04ms
+step:1481/1600 train_time:87475ms step_avg:59.06ms
+step:1482/1600 train_time:87559ms step_avg:59.08ms
+step:1483/1600 train_time:87647ms step_avg:59.10ms
+step:1484/1600 train_time:87733ms step_avg:59.12ms
+step:1485/1600 train_time:87821ms step_avg:59.14ms
+step:1486/1600 train_time:87905ms step_avg:59.16ms
+step:1487/1600 train_time:87994ms step_avg:59.18ms
+step:1488/1600 train_time:88083ms step_avg:59.20ms
+step:1489/1600 train_time:88167ms step_avg:59.21ms
+step:1490/1600 train_time:88252ms step_avg:59.23ms
+step:1491/1600 train_time:88341ms step_avg:59.25ms
+step:1492/1600 train_time:88426ms step_avg:59.27ms
+step:1493/1600 train_time:88514ms step_avg:59.29ms
+step:1494/1600 train_time:88598ms step_avg:59.30ms
+step:1495/1600 train_time:88686ms step_avg:59.32ms
+step:1496/1600 train_time:88772ms step_avg:59.34ms
+step:1497/1600 train_time:88860ms step_avg:59.36ms
+step:1498/1600 train_time:88945ms step_avg:59.38ms
+step:1499/1600 train_time:89033ms step_avg:59.39ms
+step:1500/1600 train_time:89117ms step_avg:59.41ms
+step:1500/1600 val_loss:3.3065 train_time:89189ms step_avg:59.46ms
+step:1501/1600 train_time:89210ms step_avg:59.43ms
+step:1502/1600 train_time:89297ms step_avg:59.45ms
+step:1503/1600 train_time:89390ms step_avg:59.47ms
+step:1504/1600 train_time:89476ms step_avg:59.49ms
+step:1505/1600 train_time:89564ms step_avg:59.51ms
+step:1506/1600 train_time:89648ms step_avg:59.53ms
+step:1507/1600 train_time:89735ms step_avg:59.55ms
+step:1508/1600 train_time:89820ms step_avg:59.56ms
+step:1509/1600 train_time:89906ms step_avg:59.58ms
+step:1510/1600 train_time:89990ms step_avg:59.60ms
+step:1511/1600 train_time:90078ms step_avg:59.61ms
+step:1512/1600 train_time:90164ms step_avg:59.63ms
+step:1513/1600 train_time:90255ms step_avg:59.65ms
+step:1514/1600 train_time:90343ms step_avg:59.67ms
+step:1515/1600 train_time:90432ms step_avg:59.69ms
+step:1516/1600 train_time:90518ms step_avg:59.71ms
+step:1517/1600 train_time:90607ms step_avg:59.73ms
+step:1518/1600 train_time:90690ms step_avg:59.74ms
+step:1519/1600 train_time:90778ms step_avg:59.76ms
+step:1520/1600 train_time:90862ms step_avg:59.78ms
+step:1521/1600 train_time:90948ms step_avg:59.80ms
+step:1522/1600 train_time:91032ms step_avg:59.81ms
+step:1523/1600 train_time:91121ms step_avg:59.83ms
+step:1524/1600 train_time:91206ms step_avg:59.85ms
+step:1525/1600 train_time:91295ms step_avg:59.87ms
+step:1526/1600 train_time:91381ms step_avg:59.88ms
+step:1527/1600 train_time:91469ms step_avg:59.90ms
+step:1528/1600 train_time:91555ms step_avg:59.92ms
+step:1529/1600 train_time:91643ms step_avg:59.94ms
+step:1530/1600 train_time:91728ms step_avg:59.95ms
+step:1531/1600 train_time:91815ms step_avg:59.97ms
+step:1532/1600 train_time:91900ms step_avg:59.99ms
+step:1533/1600 train_time:91988ms step_avg:60.01ms
+step:1534/1600 train_time:92074ms step_avg:60.02ms
+step:1535/1600 train_time:92163ms step_avg:60.04ms
+step:1536/1600 train_time:92248ms step_avg:60.06ms
+step:1537/1600 train_time:92337ms step_avg:60.08ms
+step:1538/1600 train_time:92423ms step_avg:60.09ms
+step:1539/1600 train_time:92512ms step_avg:60.11ms
+step:1540/1600 train_time:92597ms step_avg:60.13ms
+step:1541/1600 train_time:92685ms step_avg:60.15ms
+step:1542/1600 train_time:92770ms step_avg:60.16ms
+step:1543/1600 train_time:92858ms step_avg:60.18ms
+step:1544/1600 train_time:92942ms step_avg:60.20ms
+step:1545/1600 train_time:93030ms step_avg:60.21ms
+step:1546/1600 train_time:93116ms step_avg:60.23ms
+step:1547/1600 train_time:93204ms step_avg:60.25ms
+step:1548/1600 train_time:93290ms step_avg:60.26ms
+step:1549/1600 train_time:93379ms step_avg:60.28ms
+step:1550/1600 train_time:93464ms step_avg:60.30ms
+step:1551/1600 train_time:93553ms step_avg:60.32ms
+step:1552/1600 train_time:93638ms step_avg:60.33ms
+step:1553/1600 train_time:93726ms step_avg:60.35ms
+step:1554/1600 train_time:93813ms step_avg:60.37ms
+step:1555/1600 train_time:93902ms step_avg:60.39ms
+step:1556/1600 train_time:93986ms step_avg:60.40ms
+step:1557/1600 train_time:94073ms step_avg:60.42ms
+step:1558/1600 train_time:94158ms step_avg:60.44ms
+step:1559/1600 train_time:94248ms step_avg:60.45ms
+step:1560/1600 train_time:94332ms step_avg:60.47ms
+step:1561/1600 train_time:94430ms step_avg:60.49ms
+step:1562/1600 train_time:94512ms step_avg:60.51ms
+step:1563/1600 train_time:94600ms step_avg:60.52ms
+step:1564/1600 train_time:94686ms step_avg:60.54ms
+step:1565/1600 train_time:94773ms step_avg:60.56ms
+step:1566/1600 train_time:94859ms step_avg:60.57ms
+step:1567/1600 train_time:94947ms step_avg:60.59ms
+step:1568/1600 train_time:95033ms step_avg:60.61ms
+step:1569/1600 train_time:95122ms step_avg:60.63ms
+step:1570/1600 train_time:95206ms step_avg:60.64ms
+step:1571/1600 train_time:95296ms step_avg:60.66ms
+step:1572/1600 train_time:95383ms step_avg:60.68ms
+step:1573/1600 train_time:95471ms step_avg:60.69ms
+step:1574/1600 train_time:95558ms step_avg:60.71ms
+step:1575/1600 train_time:95646ms step_avg:60.73ms
+step:1576/1600 train_time:95732ms step_avg:60.74ms
+step:1577/1600 train_time:95823ms step_avg:60.76ms
+step:1578/1600 train_time:95907ms step_avg:60.78ms
+step:1579/1600 train_time:95995ms step_avg:60.79ms
+step:1580/1600 train_time:96080ms step_avg:60.81ms
+step:1581/1600 train_time:96168ms step_avg:60.83ms
+step:1582/1600 train_time:96254ms step_avg:60.84ms
+step:1583/1600 train_time:96344ms step_avg:60.86ms
+step:1584/1600 train_time:96430ms step_avg:60.88ms
+step:1585/1600 train_time:96518ms step_avg:60.89ms
+step:1586/1600 train_time:96604ms step_avg:60.91ms
+step:1587/1600 train_time:96692ms step_avg:60.93ms
+step:1588/1600 train_time:96780ms step_avg:60.94ms
+step:1589/1600 train_time:96867ms step_avg:60.96ms
+step:1590/1600 train_time:96953ms step_avg:60.98ms
+step:1591/1600 train_time:97041ms step_avg:60.99ms
+step:1592/1600 train_time:97129ms step_avg:61.01ms
+step:1593/1600 train_time:97215ms step_avg:61.03ms
+step:1594/1600 train_time:97304ms step_avg:61.04ms
+step:1595/1600 train_time:97391ms step_avg:61.06ms
+step:1596/1600 train_time:97475ms step_avg:61.07ms
+step:1597/1600 train_time:97564ms step_avg:61.09ms
+step:1598/1600 train_time:97649ms step_avg:61.11ms
+step:1599/1600 train_time:97738ms step_avg:61.12ms
+step:1600/1600 train_time:97824ms step_avg:61.14ms
+step:1600/1600 val_loss:3.2770 train_time:97895ms step_avg:61.18ms
+peak memory allocated: 30789 MiB reserved: 46138 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/1de5cd1b-9690-4157-8fc0-ef0f4f395c29.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/1de5cd1b-9690-4157-8fc0-ef0f4f395c29.txt
@@ -1,0 +1,4096 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 01 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # shifting first layer updates this to 01 ... 01 @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:36:55 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   40C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            132W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          257483      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          257484      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          257485      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          257486      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          257487      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          257488      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          257489      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          257490      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 511, 512, 513, 1023, 1024, 1025, 1534, 1535, 1536] for warmup
+Resetting Model
+step:0/1575 val_loss:10.8298 train_time:0ms step_avg:0.03ms
+step:1/1575 train_time:76ms step_avg:75.52ms
+step:2/1575 train_time:96ms step_avg:48.21ms
+step:3/1575 train_time:114ms step_avg:38.15ms
+step:4/1575 train_time:157ms step_avg:39.27ms
+step:5/1575 train_time:188ms step_avg:37.50ms
+step:6/1575 train_time:269ms step_avg:44.78ms
+step:7/1575 train_time:285ms step_avg:40.71ms
+step:8/1575 train_time:325ms step_avg:40.62ms
+step:9/1575 train_time:356ms step_avg:39.51ms
+step:10/1575 train_time:394ms step_avg:39.42ms
+step:11/1575 train_time:425ms step_avg:38.62ms
+step:12/1575 train_time:463ms step_avg:38.61ms
+step:13/1575 train_time:495ms step_avg:38.08ms
+step:14/1575 train_time:533ms step_avg:38.10ms
+step:15/1575 train_time:565ms step_avg:37.65ms
+step:16/1575 train_time:603ms step_avg:37.71ms
+step:17/1575 train_time:635ms step_avg:37.34ms
+step:18/1575 train_time:673ms step_avg:37.39ms
+step:19/1575 train_time:704ms step_avg:37.07ms
+step:20/1575 train_time:743ms step_avg:37.16ms
+step:21/1575 train_time:774ms step_avg:36.87ms
+step:22/1575 train_time:813ms step_avg:36.93ms
+step:23/1575 train_time:844ms step_avg:36.68ms
+step:24/1575 train_time:882ms step_avg:36.74ms
+step:25/1575 train_time:913ms step_avg:36.53ms
+step:26/1575 train_time:952ms step_avg:36.60ms
+step:27/1575 train_time:983ms step_avg:36.41ms
+step:28/1575 train_time:1022ms step_avg:36.48ms
+step:29/1575 train_time:1053ms step_avg:36.31ms
+step:30/1575 train_time:1091ms step_avg:36.38ms
+step:31/1575 train_time:1122ms step_avg:36.21ms
+step:32/1575 train_time:1161ms step_avg:36.27ms
+step:33/1575 train_time:1192ms step_avg:36.13ms
+step:34/1575 train_time:1231ms step_avg:36.20ms
+step:35/1575 train_time:1262ms step_avg:36.06ms
+step:36/1575 train_time:1301ms step_avg:36.14ms
+step:37/1575 train_time:1332ms step_avg:36.01ms
+step:38/1575 train_time:1371ms step_avg:36.07ms
+step:39/1575 train_time:1402ms step_avg:35.94ms
+step:40/1575 train_time:1440ms step_avg:36.00ms
+step:41/1575 train_time:1471ms step_avg:35.89ms
+step:42/1575 train_time:1510ms step_avg:35.96ms
+step:43/1575 train_time:1541ms step_avg:35.84ms
+step:44/1575 train_time:1580ms step_avg:35.91ms
+step:45/1575 train_time:1611ms step_avg:35.81ms
+step:46/1575 train_time:1649ms step_avg:35.86ms
+step:47/1575 train_time:1681ms step_avg:35.76ms
+step:48/1575 train_time:1719ms step_avg:35.82ms
+step:49/1575 train_time:1751ms step_avg:35.74ms
+step:50/1575 train_time:1789ms step_avg:35.79ms
+step:51/1575 train_time:1820ms step_avg:35.69ms
+step:52/1575 train_time:1858ms step_avg:35.74ms
+step:53/1575 train_time:1890ms step_avg:35.66ms
+step:54/1575 train_time:1928ms step_avg:35.70ms
+step:55/1575 train_time:1960ms step_avg:35.63ms
+step:56/1575 train_time:1998ms step_avg:35.68ms
+step:57/1575 train_time:2030ms step_avg:35.61ms
+step:58/1575 train_time:2068ms step_avg:35.66ms
+step:59/1575 train_time:2099ms step_avg:35.58ms
+step:60/1575 train_time:2138ms step_avg:35.63ms
+step:61/1575 train_time:2169ms step_avg:35.55ms
+step:62/1575 train_time:2207ms step_avg:35.60ms
+step:63/1575 train_time:2239ms step_avg:35.53ms
+step:64/1575 train_time:2277ms step_avg:35.57ms
+step:65/1575 train_time:2308ms step_avg:35.51ms
+step:66/1575 train_time:2346ms step_avg:35.55ms
+step:67/1575 train_time:2378ms step_avg:35.49ms
+step:68/1575 train_time:2416ms step_avg:35.53ms
+step:69/1575 train_time:2447ms step_avg:35.47ms
+step:70/1575 train_time:2486ms step_avg:35.51ms
+step:71/1575 train_time:2517ms step_avg:35.46ms
+step:72/1575 train_time:2556ms step_avg:35.50ms
+step:73/1575 train_time:2588ms step_avg:35.45ms
+step:74/1575 train_time:2626ms step_avg:35.48ms
+step:75/1575 train_time:2657ms step_avg:35.43ms
+step:76/1575 train_time:2696ms step_avg:35.47ms
+step:77/1575 train_time:2727ms step_avg:35.42ms
+step:78/1575 train_time:2766ms step_avg:35.46ms
+step:79/1575 train_time:2797ms step_avg:35.41ms
+step:80/1575 train_time:2836ms step_avg:35.45ms
+step:81/1575 train_time:2867ms step_avg:35.39ms
+step:82/1575 train_time:2905ms step_avg:35.43ms
+step:83/1575 train_time:2936ms step_avg:35.38ms
+step:84/1575 train_time:2975ms step_avg:35.41ms
+step:85/1575 train_time:3006ms step_avg:35.37ms
+step:86/1575 train_time:3045ms step_avg:35.41ms
+step:87/1575 train_time:3076ms step_avg:35.36ms
+step:88/1575 train_time:3114ms step_avg:35.39ms
+step:89/1575 train_time:3146ms step_avg:35.34ms
+step:90/1575 train_time:3184ms step_avg:35.38ms
+step:91/1575 train_time:3215ms step_avg:35.33ms
+step:92/1575 train_time:3254ms step_avg:35.37ms
+step:93/1575 train_time:3285ms step_avg:35.32ms
+step:94/1575 train_time:3323ms step_avg:35.36ms
+step:95/1575 train_time:3355ms step_avg:35.32ms
+step:96/1575 train_time:3394ms step_avg:35.35ms
+step:97/1575 train_time:3424ms step_avg:35.30ms
+step:98/1575 train_time:3463ms step_avg:35.33ms
+step:99/1575 train_time:3494ms step_avg:35.29ms
+step:100/1575 train_time:3532ms step_avg:35.32ms
+step:101/1575 train_time:3563ms step_avg:35.28ms
+step:102/1575 train_time:3602ms step_avg:35.31ms
+step:103/1575 train_time:3634ms step_avg:35.28ms
+step:104/1575 train_time:3672ms step_avg:35.31ms
+step:105/1575 train_time:3703ms step_avg:35.27ms
+step:106/1575 train_time:3741ms step_avg:35.29ms
+step:107/1575 train_time:3773ms step_avg:35.26ms
+step:108/1575 train_time:3811ms step_avg:35.29ms
+step:109/1575 train_time:3842ms step_avg:35.25ms
+step:110/1575 train_time:3880ms step_avg:35.27ms
+step:111/1575 train_time:3912ms step_avg:35.24ms
+step:112/1575 train_time:3950ms step_avg:35.27ms
+step:113/1575 train_time:3982ms step_avg:35.24ms
+step:114/1575 train_time:4020ms step_avg:35.26ms
+step:115/1575 train_time:4051ms step_avg:35.23ms
+step:116/1575 train_time:4090ms step_avg:35.26ms
+step:117/1575 train_time:4121ms step_avg:35.22ms
+step:118/1575 train_time:4161ms step_avg:35.26ms
+step:119/1575 train_time:4191ms step_avg:35.22ms
+step:120/1575 train_time:4229ms step_avg:35.24ms
+step:121/1575 train_time:4260ms step_avg:35.21ms
+step:122/1575 train_time:4299ms step_avg:35.24ms
+step:123/1575 train_time:4331ms step_avg:35.21ms
+step:124/1575 train_time:4369ms step_avg:35.24ms
+step:125/1575 train_time:4400ms step_avg:35.20ms
+step:126/1575 train_time:4439ms step_avg:35.23ms
+step:127/1575 train_time:4470ms step_avg:35.20ms
+step:128/1575 train_time:4508ms step_avg:35.22ms
+step:129/1575 train_time:4540ms step_avg:35.19ms
+step:130/1575 train_time:4579ms step_avg:35.22ms
+step:131/1575 train_time:4611ms step_avg:35.20ms
+step:132/1575 train_time:4649ms step_avg:35.22ms
+step:133/1575 train_time:4680ms step_avg:35.18ms
+step:134/1575 train_time:4718ms step_avg:35.21ms
+step:135/1575 train_time:4749ms step_avg:35.18ms
+step:136/1575 train_time:4787ms step_avg:35.20ms
+step:137/1575 train_time:4819ms step_avg:35.17ms
+step:138/1575 train_time:4857ms step_avg:35.20ms
+step:139/1575 train_time:4888ms step_avg:35.17ms
+step:140/1575 train_time:4927ms step_avg:35.19ms
+step:141/1575 train_time:4958ms step_avg:35.16ms
+step:142/1575 train_time:4996ms step_avg:35.19ms
+step:143/1575 train_time:5028ms step_avg:35.16ms
+step:144/1575 train_time:5067ms step_avg:35.18ms
+step:145/1575 train_time:5098ms step_avg:35.16ms
+step:146/1575 train_time:5136ms step_avg:35.18ms
+step:147/1575 train_time:5167ms step_avg:35.15ms
+step:148/1575 train_time:5206ms step_avg:35.18ms
+step:149/1575 train_time:5237ms step_avg:35.15ms
+step:150/1575 train_time:5275ms step_avg:35.17ms
+step:151/1575 train_time:5307ms step_avg:35.14ms
+step:152/1575 train_time:5345ms step_avg:35.17ms
+step:153/1575 train_time:5377ms step_avg:35.14ms
+step:154/1575 train_time:5415ms step_avg:35.16ms
+step:155/1575 train_time:5446ms step_avg:35.14ms
+step:156/1575 train_time:5484ms step_avg:35.16ms
+step:157/1575 train_time:5515ms step_avg:35.13ms
+step:158/1575 train_time:5554ms step_avg:35.15ms
+step:159/1575 train_time:5585ms step_avg:35.13ms
+step:160/1575 train_time:5624ms step_avg:35.15ms
+step:161/1575 train_time:5654ms step_avg:35.12ms
+step:162/1575 train_time:5693ms step_avg:35.14ms
+step:163/1575 train_time:5724ms step_avg:35.12ms
+step:164/1575 train_time:5762ms step_avg:35.14ms
+step:165/1575 train_time:5793ms step_avg:35.11ms
+step:166/1575 train_time:5832ms step_avg:35.13ms
+step:167/1575 train_time:5863ms step_avg:35.11ms
+step:168/1575 train_time:5902ms step_avg:35.13ms
+step:169/1575 train_time:5933ms step_avg:35.11ms
+step:170/1575 train_time:5971ms step_avg:35.12ms
+step:171/1575 train_time:6002ms step_avg:35.10ms
+step:172/1575 train_time:6040ms step_avg:35.12ms
+step:173/1575 train_time:6072ms step_avg:35.10ms
+step:174/1575 train_time:6110ms step_avg:35.11ms
+step:175/1575 train_time:6141ms step_avg:35.09ms
+step:176/1575 train_time:6179ms step_avg:35.11ms
+step:177/1575 train_time:6210ms step_avg:35.09ms
+step:178/1575 train_time:6248ms step_avg:35.10ms
+step:179/1575 train_time:6280ms step_avg:35.08ms
+step:180/1575 train_time:6318ms step_avg:35.10ms
+step:181/1575 train_time:6349ms step_avg:35.08ms
+step:182/1575 train_time:6387ms step_avg:35.10ms
+step:183/1575 train_time:6418ms step_avg:35.07ms
+step:184/1575 train_time:6457ms step_avg:35.09ms
+step:185/1575 train_time:6488ms step_avg:35.07ms
+step:186/1575 train_time:6526ms step_avg:35.09ms
+step:187/1575 train_time:6557ms step_avg:35.07ms
+step:188/1575 train_time:6596ms step_avg:35.08ms
+step:189/1575 train_time:6627ms step_avg:35.06ms
+step:190/1575 train_time:6665ms step_avg:35.08ms
+step:191/1575 train_time:6697ms step_avg:35.06ms
+step:192/1575 train_time:6735ms step_avg:35.08ms
+step:193/1575 train_time:6766ms step_avg:35.06ms
+step:194/1575 train_time:6805ms step_avg:35.08ms
+step:195/1575 train_time:6836ms step_avg:35.06ms
+step:196/1575 train_time:6874ms step_avg:35.07ms
+step:197/1575 train_time:6906ms step_avg:35.05ms
+step:198/1575 train_time:6944ms step_avg:35.07ms
+step:199/1575 train_time:6975ms step_avg:35.05ms
+step:200/1575 train_time:7013ms step_avg:35.07ms
+step:201/1575 train_time:7044ms step_avg:35.05ms
+step:202/1575 train_time:7083ms step_avg:35.06ms
+step:203/1575 train_time:7114ms step_avg:35.04ms
+step:204/1575 train_time:7152ms step_avg:35.06ms
+step:205/1575 train_time:7183ms step_avg:35.04ms
+step:206/1575 train_time:7222ms step_avg:35.06ms
+step:207/1575 train_time:7253ms step_avg:35.04ms
+step:208/1575 train_time:7291ms step_avg:35.05ms
+step:209/1575 train_time:7322ms step_avg:35.03ms
+step:210/1575 train_time:7361ms step_avg:35.05ms
+step:211/1575 train_time:7392ms step_avg:35.03ms
+step:212/1575 train_time:7430ms step_avg:35.05ms
+step:213/1575 train_time:7461ms step_avg:35.03ms
+step:214/1575 train_time:7499ms step_avg:35.04ms
+step:215/1575 train_time:7531ms step_avg:35.03ms
+step:216/1575 train_time:7569ms step_avg:35.04ms
+step:217/1575 train_time:7601ms step_avg:35.03ms
+step:218/1575 train_time:7639ms step_avg:35.04ms
+step:219/1575 train_time:7671ms step_avg:35.03ms
+step:220/1575 train_time:7709ms step_avg:35.04ms
+step:221/1575 train_time:7740ms step_avg:35.02ms
+step:222/1575 train_time:7778ms step_avg:35.04ms
+step:223/1575 train_time:7810ms step_avg:35.02ms
+step:224/1575 train_time:7848ms step_avg:35.04ms
+step:225/1575 train_time:7879ms step_avg:35.02ms
+step:226/1575 train_time:7918ms step_avg:35.04ms
+step:227/1575 train_time:7949ms step_avg:35.02ms
+step:228/1575 train_time:7988ms step_avg:35.03ms
+step:229/1575 train_time:8019ms step_avg:35.02ms
+step:230/1575 train_time:8057ms step_avg:35.03ms
+step:231/1575 train_time:8089ms step_avg:35.02ms
+step:232/1575 train_time:8128ms step_avg:35.03ms
+step:233/1575 train_time:8159ms step_avg:35.02ms
+step:234/1575 train_time:8197ms step_avg:35.03ms
+step:235/1575 train_time:8228ms step_avg:35.01ms
+step:236/1575 train_time:8267ms step_avg:35.03ms
+step:237/1575 train_time:8298ms step_avg:35.01ms
+step:238/1575 train_time:8337ms step_avg:35.03ms
+step:239/1575 train_time:8368ms step_avg:35.01ms
+step:240/1575 train_time:8406ms step_avg:35.03ms
+step:241/1575 train_time:8437ms step_avg:35.01ms
+step:242/1575 train_time:8476ms step_avg:35.02ms
+step:243/1575 train_time:8507ms step_avg:35.01ms
+step:244/1575 train_time:8545ms step_avg:35.02ms
+step:245/1575 train_time:8576ms step_avg:35.00ms
+step:246/1575 train_time:8614ms step_avg:35.02ms
+step:247/1575 train_time:8645ms step_avg:35.00ms
+step:248/1575 train_time:8684ms step_avg:35.01ms
+step:249/1575 train_time:8715ms step_avg:35.00ms
+step:250/1575 train_time:8753ms step_avg:35.01ms
+step:250/1575 val_loss:4.5756 train_time:8802ms step_avg:35.21ms
+step:251/1575 train_time:8820ms step_avg:35.14ms
+step:252/1575 train_time:8838ms step_avg:35.07ms
+step:253/1575 train_time:8858ms step_avg:35.01ms
+step:254/1575 train_time:8897ms step_avg:35.03ms
+step:255/1575 train_time:8929ms step_avg:35.02ms
+step:256/1575 train_time:8969ms step_avg:35.03ms
+step:257/1575 train_time:9001ms step_avg:35.02ms
+step:258/1575 train_time:9040ms step_avg:35.04ms
+step:259/1575 train_time:9071ms step_avg:35.02ms
+step:260/1575 train_time:9110ms step_avg:35.04ms
+step:261/1575 train_time:9141ms step_avg:35.02ms
+step:262/1575 train_time:9180ms step_avg:35.04ms
+step:263/1575 train_time:9211ms step_avg:35.02ms
+step:264/1575 train_time:9249ms step_avg:35.03ms
+step:265/1575 train_time:9280ms step_avg:35.02ms
+step:266/1575 train_time:9318ms step_avg:35.03ms
+step:267/1575 train_time:9349ms step_avg:35.02ms
+step:268/1575 train_time:9387ms step_avg:35.03ms
+step:269/1575 train_time:9419ms step_avg:35.01ms
+step:270/1575 train_time:9458ms step_avg:35.03ms
+step:271/1575 train_time:9488ms step_avg:35.01ms
+step:272/1575 train_time:9526ms step_avg:35.02ms
+step:273/1575 train_time:9557ms step_avg:35.01ms
+step:274/1575 train_time:9596ms step_avg:35.02ms
+step:275/1575 train_time:9627ms step_avg:35.01ms
+step:276/1575 train_time:9665ms step_avg:35.02ms
+step:277/1575 train_time:9697ms step_avg:35.01ms
+step:278/1575 train_time:9735ms step_avg:35.02ms
+step:279/1575 train_time:9766ms step_avg:35.00ms
+step:280/1575 train_time:9805ms step_avg:35.02ms
+step:281/1575 train_time:9836ms step_avg:35.00ms
+step:282/1575 train_time:9874ms step_avg:35.01ms
+step:283/1575 train_time:9905ms step_avg:35.00ms
+step:284/1575 train_time:9943ms step_avg:35.01ms
+step:285/1575 train_time:9974ms step_avg:35.00ms
+step:286/1575 train_time:10012ms step_avg:35.01ms
+step:287/1575 train_time:10044ms step_avg:35.00ms
+step:288/1575 train_time:10083ms step_avg:35.01ms
+step:289/1575 train_time:10114ms step_avg:35.00ms
+step:290/1575 train_time:10153ms step_avg:35.01ms
+step:291/1575 train_time:10184ms step_avg:35.00ms
+step:292/1575 train_time:10222ms step_avg:35.01ms
+step:293/1575 train_time:10253ms step_avg:34.99ms
+step:294/1575 train_time:10292ms step_avg:35.01ms
+step:295/1575 train_time:10322ms step_avg:34.99ms
+step:296/1575 train_time:10361ms step_avg:35.00ms
+step:297/1575 train_time:10392ms step_avg:34.99ms
+step:298/1575 train_time:10430ms step_avg:35.00ms
+step:299/1575 train_time:10461ms step_avg:34.99ms
+step:300/1575 train_time:10499ms step_avg:35.00ms
+step:301/1575 train_time:10530ms step_avg:34.98ms
+step:302/1575 train_time:10569ms step_avg:35.00ms
+step:303/1575 train_time:10600ms step_avg:34.98ms
+step:304/1575 train_time:10638ms step_avg:34.99ms
+step:305/1575 train_time:10669ms step_avg:34.98ms
+step:306/1575 train_time:10707ms step_avg:34.99ms
+step:307/1575 train_time:10738ms step_avg:34.98ms
+step:308/1575 train_time:10777ms step_avg:34.99ms
+step:309/1575 train_time:10808ms step_avg:34.98ms
+step:310/1575 train_time:10846ms step_avg:34.99ms
+step:311/1575 train_time:10877ms step_avg:34.97ms
+step:312/1575 train_time:10915ms step_avg:34.98ms
+step:313/1575 train_time:10946ms step_avg:34.97ms
+step:314/1575 train_time:10984ms step_avg:34.98ms
+step:315/1575 train_time:11015ms step_avg:34.97ms
+step:316/1575 train_time:11054ms step_avg:34.98ms
+step:317/1575 train_time:11085ms step_avg:34.97ms
+step:318/1575 train_time:11123ms step_avg:34.98ms
+step:319/1575 train_time:11154ms step_avg:34.97ms
+step:320/1575 train_time:11193ms step_avg:34.98ms
+step:321/1575 train_time:11223ms step_avg:34.96ms
+step:322/1575 train_time:11262ms step_avg:34.98ms
+step:323/1575 train_time:11293ms step_avg:34.96ms
+step:324/1575 train_time:11331ms step_avg:34.97ms
+step:325/1575 train_time:11362ms step_avg:34.96ms
+step:326/1575 train_time:11400ms step_avg:34.97ms
+step:327/1575 train_time:11431ms step_avg:34.96ms
+step:328/1575 train_time:11470ms step_avg:34.97ms
+step:329/1575 train_time:11501ms step_avg:34.96ms
+step:330/1575 train_time:11539ms step_avg:34.97ms
+step:331/1575 train_time:11570ms step_avg:34.96ms
+step:332/1575 train_time:11608ms step_avg:34.96ms
+step:333/1575 train_time:11639ms step_avg:34.95ms
+step:334/1575 train_time:11677ms step_avg:34.96ms
+step:335/1575 train_time:11708ms step_avg:34.95ms
+step:336/1575 train_time:11747ms step_avg:34.96ms
+step:337/1575 train_time:11778ms step_avg:34.95ms
+step:338/1575 train_time:11816ms step_avg:34.96ms
+step:339/1575 train_time:11847ms step_avg:34.95ms
+step:340/1575 train_time:11886ms step_avg:34.96ms
+step:341/1575 train_time:11917ms step_avg:34.95ms
+step:342/1575 train_time:11955ms step_avg:34.96ms
+step:343/1575 train_time:11986ms step_avg:34.94ms
+step:344/1575 train_time:12024ms step_avg:34.95ms
+step:345/1575 train_time:12056ms step_avg:34.94ms
+step:346/1575 train_time:12094ms step_avg:34.95ms
+step:347/1575 train_time:12125ms step_avg:34.94ms
+step:348/1575 train_time:12164ms step_avg:34.95ms
+step:349/1575 train_time:12195ms step_avg:34.94ms
+step:350/1575 train_time:12233ms step_avg:34.95ms
+step:351/1575 train_time:12264ms step_avg:34.94ms
+step:352/1575 train_time:12302ms step_avg:34.95ms
+step:353/1575 train_time:12333ms step_avg:34.94ms
+step:354/1575 train_time:12372ms step_avg:34.95ms
+step:355/1575 train_time:12402ms step_avg:34.94ms
+step:356/1575 train_time:12441ms step_avg:34.95ms
+step:357/1575 train_time:12472ms step_avg:34.94ms
+step:358/1575 train_time:12510ms step_avg:34.94ms
+step:359/1575 train_time:12541ms step_avg:34.93ms
+step:360/1575 train_time:12579ms step_avg:34.94ms
+step:361/1575 train_time:12610ms step_avg:34.93ms
+step:362/1575 train_time:12649ms step_avg:34.94ms
+step:363/1575 train_time:12680ms step_avg:34.93ms
+step:364/1575 train_time:12718ms step_avg:34.94ms
+step:365/1575 train_time:12749ms step_avg:34.93ms
+step:366/1575 train_time:12788ms step_avg:34.94ms
+step:367/1575 train_time:12819ms step_avg:34.93ms
+step:368/1575 train_time:12857ms step_avg:34.94ms
+step:369/1575 train_time:12888ms step_avg:34.93ms
+step:370/1575 train_time:12926ms step_avg:34.94ms
+step:371/1575 train_time:12958ms step_avg:34.93ms
+step:372/1575 train_time:12996ms step_avg:34.93ms
+step:373/1575 train_time:13027ms step_avg:34.92ms
+step:374/1575 train_time:13065ms step_avg:34.93ms
+step:375/1575 train_time:13096ms step_avg:34.92ms
+step:376/1575 train_time:13135ms step_avg:34.93ms
+step:377/1575 train_time:13166ms step_avg:34.92ms
+step:378/1575 train_time:13204ms step_avg:34.93ms
+step:379/1575 train_time:13236ms step_avg:34.92ms
+step:380/1575 train_time:13274ms step_avg:34.93ms
+step:381/1575 train_time:13305ms step_avg:34.92ms
+step:382/1575 train_time:13343ms step_avg:34.93ms
+step:383/1575 train_time:13375ms step_avg:34.92ms
+step:384/1575 train_time:13413ms step_avg:34.93ms
+step:385/1575 train_time:13444ms step_avg:34.92ms
+step:386/1575 train_time:13482ms step_avg:34.93ms
+step:387/1575 train_time:13513ms step_avg:34.92ms
+step:388/1575 train_time:13551ms step_avg:34.93ms
+step:389/1575 train_time:13582ms step_avg:34.92ms
+step:390/1575 train_time:13621ms step_avg:34.93ms
+step:391/1575 train_time:13652ms step_avg:34.92ms
+step:392/1575 train_time:13690ms step_avg:34.92ms
+step:393/1575 train_time:13721ms step_avg:34.91ms
+step:394/1575 train_time:13760ms step_avg:34.92ms
+step:395/1575 train_time:13791ms step_avg:34.91ms
+step:396/1575 train_time:13829ms step_avg:34.92ms
+step:397/1575 train_time:13860ms step_avg:34.91ms
+step:398/1575 train_time:13898ms step_avg:34.92ms
+step:399/1575 train_time:13929ms step_avg:34.91ms
+step:400/1575 train_time:13968ms step_avg:34.92ms
+step:401/1575 train_time:13999ms step_avg:34.91ms
+step:402/1575 train_time:14038ms step_avg:34.92ms
+step:403/1575 train_time:14069ms step_avg:34.91ms
+step:404/1575 train_time:14107ms step_avg:34.92ms
+step:405/1575 train_time:14138ms step_avg:34.91ms
+step:406/1575 train_time:14176ms step_avg:34.92ms
+step:407/1575 train_time:14207ms step_avg:34.91ms
+step:408/1575 train_time:14246ms step_avg:34.92ms
+step:409/1575 train_time:14277ms step_avg:34.91ms
+step:410/1575 train_time:14315ms step_avg:34.91ms
+step:411/1575 train_time:14346ms step_avg:34.91ms
+step:412/1575 train_time:14385ms step_avg:34.92ms
+step:413/1575 train_time:14416ms step_avg:34.91ms
+step:414/1575 train_time:14454ms step_avg:34.91ms
+step:415/1575 train_time:14485ms step_avg:34.90ms
+step:416/1575 train_time:14524ms step_avg:34.91ms
+step:417/1575 train_time:14555ms step_avg:34.90ms
+step:418/1575 train_time:14594ms step_avg:34.91ms
+step:419/1575 train_time:14624ms step_avg:34.90ms
+step:420/1575 train_time:14663ms step_avg:34.91ms
+step:421/1575 train_time:14694ms step_avg:34.90ms
+step:422/1575 train_time:14732ms step_avg:34.91ms
+step:423/1575 train_time:14763ms step_avg:34.90ms
+step:424/1575 train_time:14802ms step_avg:34.91ms
+step:425/1575 train_time:14833ms step_avg:34.90ms
+step:426/1575 train_time:14871ms step_avg:34.91ms
+step:427/1575 train_time:14902ms step_avg:34.90ms
+step:428/1575 train_time:14940ms step_avg:34.91ms
+step:429/1575 train_time:14971ms step_avg:34.90ms
+step:430/1575 train_time:15010ms step_avg:34.91ms
+step:431/1575 train_time:15041ms step_avg:34.90ms
+step:432/1575 train_time:15080ms step_avg:34.91ms
+step:433/1575 train_time:15110ms step_avg:34.90ms
+step:434/1575 train_time:15149ms step_avg:34.90ms
+step:435/1575 train_time:15180ms step_avg:34.90ms
+step:436/1575 train_time:15218ms step_avg:34.90ms
+step:437/1575 train_time:15249ms step_avg:34.90ms
+step:438/1575 train_time:15287ms step_avg:34.90ms
+step:439/1575 train_time:15318ms step_avg:34.89ms
+step:440/1575 train_time:15357ms step_avg:34.90ms
+step:441/1575 train_time:15388ms step_avg:34.89ms
+step:442/1575 train_time:15426ms step_avg:34.90ms
+step:443/1575 train_time:15457ms step_avg:34.89ms
+step:444/1575 train_time:15495ms step_avg:34.90ms
+step:445/1575 train_time:15526ms step_avg:34.89ms
+step:446/1575 train_time:15564ms step_avg:34.90ms
+step:447/1575 train_time:15596ms step_avg:34.89ms
+step:448/1575 train_time:15634ms step_avg:34.90ms
+step:449/1575 train_time:15665ms step_avg:34.89ms
+step:450/1575 train_time:15703ms step_avg:34.90ms
+step:451/1575 train_time:15735ms step_avg:34.89ms
+step:452/1575 train_time:15773ms step_avg:34.90ms
+step:453/1575 train_time:15804ms step_avg:34.89ms
+step:454/1575 train_time:15842ms step_avg:34.90ms
+step:455/1575 train_time:15873ms step_avg:34.89ms
+step:456/1575 train_time:15912ms step_avg:34.89ms
+step:457/1575 train_time:15943ms step_avg:34.89ms
+step:458/1575 train_time:15981ms step_avg:34.89ms
+step:459/1575 train_time:16012ms step_avg:34.88ms
+step:460/1575 train_time:16050ms step_avg:34.89ms
+step:461/1575 train_time:16081ms step_avg:34.88ms
+step:462/1575 train_time:16119ms step_avg:34.89ms
+step:463/1575 train_time:16150ms step_avg:34.88ms
+step:464/1575 train_time:16189ms step_avg:34.89ms
+step:465/1575 train_time:16220ms step_avg:34.88ms
+step:466/1575 train_time:16258ms step_avg:34.89ms
+step:467/1575 train_time:16290ms step_avg:34.88ms
+step:468/1575 train_time:16328ms step_avg:34.89ms
+step:469/1575 train_time:16359ms step_avg:34.88ms
+step:470/1575 train_time:16398ms step_avg:34.89ms
+step:471/1575 train_time:16429ms step_avg:34.88ms
+step:472/1575 train_time:16468ms step_avg:34.89ms
+step:473/1575 train_time:16499ms step_avg:34.88ms
+step:474/1575 train_time:16537ms step_avg:34.89ms
+step:475/1575 train_time:16568ms step_avg:34.88ms
+step:476/1575 train_time:16606ms step_avg:34.89ms
+step:477/1575 train_time:16638ms step_avg:34.88ms
+step:478/1575 train_time:16675ms step_avg:34.89ms
+step:479/1575 train_time:16707ms step_avg:34.88ms
+step:480/1575 train_time:16745ms step_avg:34.89ms
+step:481/1575 train_time:16776ms step_avg:34.88ms
+step:482/1575 train_time:16815ms step_avg:34.88ms
+step:483/1575 train_time:16846ms step_avg:34.88ms
+step:484/1575 train_time:16885ms step_avg:34.89ms
+step:485/1575 train_time:16916ms step_avg:34.88ms
+step:486/1575 train_time:16955ms step_avg:34.89ms
+step:487/1575 train_time:16986ms step_avg:34.88ms
+step:488/1575 train_time:17024ms step_avg:34.89ms
+step:489/1575 train_time:17055ms step_avg:34.88ms
+step:490/1575 train_time:17093ms step_avg:34.88ms
+step:491/1575 train_time:17124ms step_avg:34.88ms
+step:492/1575 train_time:17162ms step_avg:34.88ms
+step:493/1575 train_time:17194ms step_avg:34.88ms
+step:494/1575 train_time:17232ms step_avg:34.88ms
+step:495/1575 train_time:17264ms step_avg:34.88ms
+step:496/1575 train_time:17302ms step_avg:34.88ms
+step:497/1575 train_time:17333ms step_avg:34.88ms
+step:498/1575 train_time:17371ms step_avg:34.88ms
+step:499/1575 train_time:17402ms step_avg:34.87ms
+step:500/1575 train_time:17441ms step_avg:34.88ms
+step:500/1575 val_loss:4.2375 train_time:17489ms step_avg:34.98ms
+step:501/1575 train_time:17507ms step_avg:34.94ms
+step:502/1575 train_time:17525ms step_avg:34.91ms
+step:503/1575 train_time:17544ms step_avg:34.88ms
+step:504/1575 train_time:17584ms step_avg:34.89ms
+step:505/1575 train_time:17617ms step_avg:34.89ms
+step:506/1575 train_time:17656ms step_avg:34.89ms
+step:507/1575 train_time:17688ms step_avg:34.89ms
+step:508/1575 train_time:17726ms step_avg:34.89ms
+step:509/1575 train_time:17757ms step_avg:34.89ms
+step:510/1575 train_time:17796ms step_avg:34.89ms
+step:511/1575 train_time:17827ms step_avg:34.89ms
+step:512/1575 train_time:17865ms step_avg:34.89ms
+step:513/1575 train_time:17935ms step_avg:34.96ms
+step:514/1575 train_time:17992ms step_avg:35.00ms
+step:515/1575 train_time:18055ms step_avg:35.06ms
+step:516/1575 train_time:18113ms step_avg:35.10ms
+step:517/1575 train_time:18176ms step_avg:35.16ms
+step:518/1575 train_time:18236ms step_avg:35.20ms
+step:519/1575 train_time:18299ms step_avg:35.26ms
+step:520/1575 train_time:18357ms step_avg:35.30ms
+step:521/1575 train_time:18420ms step_avg:35.36ms
+step:522/1575 train_time:18480ms step_avg:35.40ms
+step:523/1575 train_time:18545ms step_avg:35.46ms
+step:524/1575 train_time:18605ms step_avg:35.51ms
+step:525/1575 train_time:18669ms step_avg:35.56ms
+step:526/1575 train_time:18729ms step_avg:35.61ms
+step:527/1575 train_time:18795ms step_avg:35.66ms
+step:528/1575 train_time:18854ms step_avg:35.71ms
+step:529/1575 train_time:18918ms step_avg:35.76ms
+step:530/1575 train_time:18977ms step_avg:35.81ms
+step:531/1575 train_time:19041ms step_avg:35.86ms
+step:532/1575 train_time:19099ms step_avg:35.90ms
+step:533/1575 train_time:19162ms step_avg:35.95ms
+step:534/1575 train_time:19222ms step_avg:36.00ms
+step:535/1575 train_time:19285ms step_avg:36.05ms
+step:536/1575 train_time:19344ms step_avg:36.09ms
+step:537/1575 train_time:19406ms step_avg:36.14ms
+step:538/1575 train_time:19465ms step_avg:36.18ms
+step:539/1575 train_time:19529ms step_avg:36.23ms
+step:540/1575 train_time:19588ms step_avg:36.27ms
+step:541/1575 train_time:19651ms step_avg:36.32ms
+step:542/1575 train_time:19711ms step_avg:36.37ms
+step:543/1575 train_time:19775ms step_avg:36.42ms
+step:544/1575 train_time:19835ms step_avg:36.46ms
+step:545/1575 train_time:19899ms step_avg:36.51ms
+step:546/1575 train_time:19958ms step_avg:36.55ms
+step:547/1575 train_time:20022ms step_avg:36.60ms
+step:548/1575 train_time:20080ms step_avg:36.64ms
+step:549/1575 train_time:20144ms step_avg:36.69ms
+step:550/1575 train_time:20203ms step_avg:36.73ms
+step:551/1575 train_time:20265ms step_avg:36.78ms
+step:552/1575 train_time:20324ms step_avg:36.82ms
+step:553/1575 train_time:20387ms step_avg:36.87ms
+step:554/1575 train_time:20447ms step_avg:36.91ms
+step:555/1575 train_time:20510ms step_avg:36.95ms
+step:556/1575 train_time:20569ms step_avg:36.99ms
+step:557/1575 train_time:20632ms step_avg:37.04ms
+step:558/1575 train_time:20691ms step_avg:37.08ms
+step:559/1575 train_time:20755ms step_avg:37.13ms
+step:560/1575 train_time:20815ms step_avg:37.17ms
+step:561/1575 train_time:20880ms step_avg:37.22ms
+step:562/1575 train_time:20939ms step_avg:37.26ms
+step:563/1575 train_time:21002ms step_avg:37.30ms
+step:564/1575 train_time:21062ms step_avg:37.34ms
+step:565/1575 train_time:21124ms step_avg:37.39ms
+step:566/1575 train_time:21183ms step_avg:37.43ms
+step:567/1575 train_time:21246ms step_avg:37.47ms
+step:568/1575 train_time:21305ms step_avg:37.51ms
+step:569/1575 train_time:21373ms step_avg:37.56ms
+step:570/1575 train_time:21430ms step_avg:37.60ms
+step:571/1575 train_time:21492ms step_avg:37.64ms
+step:572/1575 train_time:21551ms step_avg:37.68ms
+step:573/1575 train_time:21614ms step_avg:37.72ms
+step:574/1575 train_time:21673ms step_avg:37.76ms
+step:575/1575 train_time:21737ms step_avg:37.80ms
+step:576/1575 train_time:21796ms step_avg:37.84ms
+step:577/1575 train_time:21859ms step_avg:37.88ms
+step:578/1575 train_time:21919ms step_avg:37.92ms
+step:579/1575 train_time:21982ms step_avg:37.97ms
+step:580/1575 train_time:22042ms step_avg:38.00ms
+step:581/1575 train_time:22105ms step_avg:38.05ms
+step:582/1575 train_time:22164ms step_avg:38.08ms
+step:583/1575 train_time:22228ms step_avg:38.13ms
+step:584/1575 train_time:22287ms step_avg:38.16ms
+step:585/1575 train_time:22350ms step_avg:38.20ms
+step:586/1575 train_time:22409ms step_avg:38.24ms
+step:587/1575 train_time:22472ms step_avg:38.28ms
+step:588/1575 train_time:22531ms step_avg:38.32ms
+step:589/1575 train_time:22594ms step_avg:38.36ms
+step:590/1575 train_time:22654ms step_avg:38.40ms
+step:591/1575 train_time:22717ms step_avg:38.44ms
+step:592/1575 train_time:22776ms step_avg:38.47ms
+step:593/1575 train_time:22840ms step_avg:38.52ms
+step:594/1575 train_time:22899ms step_avg:38.55ms
+step:595/1575 train_time:22962ms step_avg:38.59ms
+step:596/1575 train_time:23022ms step_avg:38.63ms
+step:597/1575 train_time:23085ms step_avg:38.67ms
+step:598/1575 train_time:23147ms step_avg:38.71ms
+step:599/1575 train_time:23209ms step_avg:38.75ms
+step:600/1575 train_time:23268ms step_avg:38.78ms
+step:601/1575 train_time:23331ms step_avg:38.82ms
+step:602/1575 train_time:23389ms step_avg:38.85ms
+step:603/1575 train_time:23453ms step_avg:38.89ms
+step:604/1575 train_time:23513ms step_avg:38.93ms
+step:605/1575 train_time:23575ms step_avg:38.97ms
+step:606/1575 train_time:23635ms step_avg:39.00ms
+step:607/1575 train_time:23698ms step_avg:39.04ms
+step:608/1575 train_time:23758ms step_avg:39.07ms
+step:609/1575 train_time:23821ms step_avg:39.11ms
+step:610/1575 train_time:23880ms step_avg:39.15ms
+step:611/1575 train_time:23944ms step_avg:39.19ms
+step:612/1575 train_time:24004ms step_avg:39.22ms
+step:613/1575 train_time:24067ms step_avg:39.26ms
+step:614/1575 train_time:24127ms step_avg:39.29ms
+step:615/1575 train_time:24190ms step_avg:39.33ms
+step:616/1575 train_time:24250ms step_avg:39.37ms
+step:617/1575 train_time:24313ms step_avg:39.41ms
+step:618/1575 train_time:24373ms step_avg:39.44ms
+step:619/1575 train_time:24436ms step_avg:39.48ms
+step:620/1575 train_time:24495ms step_avg:39.51ms
+step:621/1575 train_time:24558ms step_avg:39.55ms
+step:622/1575 train_time:24617ms step_avg:39.58ms
+step:623/1575 train_time:24680ms step_avg:39.61ms
+step:624/1575 train_time:24739ms step_avg:39.65ms
+step:625/1575 train_time:24803ms step_avg:39.68ms
+step:626/1575 train_time:24862ms step_avg:39.72ms
+step:627/1575 train_time:24925ms step_avg:39.75ms
+step:628/1575 train_time:24984ms step_avg:39.78ms
+step:629/1575 train_time:25048ms step_avg:39.82ms
+step:630/1575 train_time:25107ms step_avg:39.85ms
+step:631/1575 train_time:25170ms step_avg:39.89ms
+step:632/1575 train_time:25230ms step_avg:39.92ms
+step:633/1575 train_time:25294ms step_avg:39.96ms
+step:634/1575 train_time:25353ms step_avg:39.99ms
+step:635/1575 train_time:25416ms step_avg:40.03ms
+step:636/1575 train_time:25475ms step_avg:40.06ms
+step:637/1575 train_time:25539ms step_avg:40.09ms
+step:638/1575 train_time:25598ms step_avg:40.12ms
+step:639/1575 train_time:25662ms step_avg:40.16ms
+step:640/1575 train_time:25722ms step_avg:40.19ms
+step:641/1575 train_time:25785ms step_avg:40.23ms
+step:642/1575 train_time:25845ms step_avg:40.26ms
+step:643/1575 train_time:25908ms step_avg:40.29ms
+step:644/1575 train_time:25967ms step_avg:40.32ms
+step:645/1575 train_time:26031ms step_avg:40.36ms
+step:646/1575 train_time:26090ms step_avg:40.39ms
+step:647/1575 train_time:26154ms step_avg:40.42ms
+step:648/1575 train_time:26215ms step_avg:40.46ms
+step:649/1575 train_time:26278ms step_avg:40.49ms
+step:650/1575 train_time:26339ms step_avg:40.52ms
+step:651/1575 train_time:26401ms step_avg:40.55ms
+step:652/1575 train_time:26460ms step_avg:40.58ms
+step:653/1575 train_time:26523ms step_avg:40.62ms
+step:654/1575 train_time:26582ms step_avg:40.65ms
+step:655/1575 train_time:26646ms step_avg:40.68ms
+step:656/1575 train_time:26705ms step_avg:40.71ms
+step:657/1575 train_time:26768ms step_avg:40.74ms
+step:658/1575 train_time:26827ms step_avg:40.77ms
+step:659/1575 train_time:26891ms step_avg:40.81ms
+step:660/1575 train_time:26950ms step_avg:40.83ms
+step:661/1575 train_time:27013ms step_avg:40.87ms
+step:662/1575 train_time:27072ms step_avg:40.89ms
+step:663/1575 train_time:27135ms step_avg:40.93ms
+step:664/1575 train_time:27195ms step_avg:40.96ms
+step:665/1575 train_time:27259ms step_avg:40.99ms
+step:666/1575 train_time:27318ms step_avg:41.02ms
+step:667/1575 train_time:27382ms step_avg:41.05ms
+step:668/1575 train_time:27442ms step_avg:41.08ms
+step:669/1575 train_time:27504ms step_avg:41.11ms
+step:670/1575 train_time:27564ms step_avg:41.14ms
+step:671/1575 train_time:27627ms step_avg:41.17ms
+step:672/1575 train_time:27692ms step_avg:41.21ms
+step:673/1575 train_time:27750ms step_avg:41.23ms
+step:674/1575 train_time:27809ms step_avg:41.26ms
+step:675/1575 train_time:27872ms step_avg:41.29ms
+step:676/1575 train_time:27931ms step_avg:41.32ms
+step:677/1575 train_time:27994ms step_avg:41.35ms
+step:678/1575 train_time:28054ms step_avg:41.38ms
+step:679/1575 train_time:28118ms step_avg:41.41ms
+step:680/1575 train_time:28177ms step_avg:41.44ms
+step:681/1575 train_time:28241ms step_avg:41.47ms
+step:682/1575 train_time:28301ms step_avg:41.50ms
+step:683/1575 train_time:28364ms step_avg:41.53ms
+step:684/1575 train_time:28423ms step_avg:41.55ms
+step:685/1575 train_time:28486ms step_avg:41.59ms
+step:686/1575 train_time:28546ms step_avg:41.61ms
+step:687/1575 train_time:28609ms step_avg:41.64ms
+step:688/1575 train_time:28670ms step_avg:41.67ms
+step:689/1575 train_time:28732ms step_avg:41.70ms
+step:690/1575 train_time:28791ms step_avg:41.73ms
+step:691/1575 train_time:28854ms step_avg:41.76ms
+step:692/1575 train_time:28914ms step_avg:41.78ms
+step:693/1575 train_time:28977ms step_avg:41.81ms
+step:694/1575 train_time:29036ms step_avg:41.84ms
+step:695/1575 train_time:29101ms step_avg:41.87ms
+step:696/1575 train_time:29160ms step_avg:41.90ms
+step:697/1575 train_time:29223ms step_avg:41.93ms
+step:698/1575 train_time:29282ms step_avg:41.95ms
+step:699/1575 train_time:29346ms step_avg:41.98ms
+step:700/1575 train_time:29405ms step_avg:42.01ms
+step:701/1575 train_time:29468ms step_avg:42.04ms
+step:702/1575 train_time:29527ms step_avg:42.06ms
+step:703/1575 train_time:29590ms step_avg:42.09ms
+step:704/1575 train_time:29649ms step_avg:42.11ms
+step:705/1575 train_time:29712ms step_avg:42.14ms
+step:706/1575 train_time:29771ms step_avg:42.17ms
+step:707/1575 train_time:29834ms step_avg:42.20ms
+step:708/1575 train_time:29894ms step_avg:42.22ms
+step:709/1575 train_time:29957ms step_avg:42.25ms
+step:710/1575 train_time:30017ms step_avg:42.28ms
+step:711/1575 train_time:30081ms step_avg:42.31ms
+step:712/1575 train_time:30141ms step_avg:42.33ms
+step:713/1575 train_time:30204ms step_avg:42.36ms
+step:714/1575 train_time:30263ms step_avg:42.39ms
+step:715/1575 train_time:30327ms step_avg:42.42ms
+step:716/1575 train_time:30387ms step_avg:42.44ms
+step:717/1575 train_time:30450ms step_avg:42.47ms
+step:718/1575 train_time:30509ms step_avg:42.49ms
+step:719/1575 train_time:30572ms step_avg:42.52ms
+step:720/1575 train_time:30631ms step_avg:42.54ms
+step:721/1575 train_time:30694ms step_avg:42.57ms
+step:722/1575 train_time:30754ms step_avg:42.60ms
+step:723/1575 train_time:30818ms step_avg:42.62ms
+step:724/1575 train_time:30877ms step_avg:42.65ms
+step:725/1575 train_time:30940ms step_avg:42.68ms
+step:726/1575 train_time:30999ms step_avg:42.70ms
+step:727/1575 train_time:31064ms step_avg:42.73ms
+step:728/1575 train_time:31125ms step_avg:42.75ms
+step:729/1575 train_time:31186ms step_avg:42.78ms
+step:730/1575 train_time:31245ms step_avg:42.80ms
+step:731/1575 train_time:31308ms step_avg:42.83ms
+step:732/1575 train_time:31368ms step_avg:42.85ms
+step:733/1575 train_time:31431ms step_avg:42.88ms
+step:734/1575 train_time:31490ms step_avg:42.90ms
+step:735/1575 train_time:31554ms step_avg:42.93ms
+step:736/1575 train_time:31613ms step_avg:42.95ms
+step:737/1575 train_time:31677ms step_avg:42.98ms
+step:738/1575 train_time:31736ms step_avg:43.00ms
+step:739/1575 train_time:31799ms step_avg:43.03ms
+step:740/1575 train_time:31859ms step_avg:43.05ms
+step:741/1575 train_time:31922ms step_avg:43.08ms
+step:742/1575 train_time:31982ms step_avg:43.10ms
+step:743/1575 train_time:32044ms step_avg:43.13ms
+step:744/1575 train_time:32103ms step_avg:43.15ms
+step:745/1575 train_time:32167ms step_avg:43.18ms
+step:746/1575 train_time:32226ms step_avg:43.20ms
+step:747/1575 train_time:32289ms step_avg:43.23ms
+step:748/1575 train_time:32350ms step_avg:43.25ms
+step:749/1575 train_time:32412ms step_avg:43.27ms
+step:750/1575 train_time:32471ms step_avg:43.29ms
+step:750/1575 val_loss:3.8927 train_time:32519ms step_avg:43.36ms
+step:751/1575 train_time:32537ms step_avg:43.33ms
+step:752/1575 train_time:32597ms step_avg:43.35ms
+step:753/1575 train_time:32664ms step_avg:43.38ms
+step:754/1575 train_time:32725ms step_avg:43.40ms
+step:755/1575 train_time:32789ms step_avg:43.43ms
+step:756/1575 train_time:32848ms step_avg:43.45ms
+step:757/1575 train_time:32910ms step_avg:43.47ms
+step:758/1575 train_time:32969ms step_avg:43.49ms
+step:759/1575 train_time:33032ms step_avg:43.52ms
+step:760/1575 train_time:33091ms step_avg:43.54ms
+step:761/1575 train_time:33154ms step_avg:43.57ms
+step:762/1575 train_time:33213ms step_avg:43.59ms
+step:763/1575 train_time:33275ms step_avg:43.61ms
+step:764/1575 train_time:33334ms step_avg:43.63ms
+step:765/1575 train_time:33398ms step_avg:43.66ms
+step:766/1575 train_time:33457ms step_avg:43.68ms
+step:767/1575 train_time:33521ms step_avg:43.70ms
+step:768/1575 train_time:33582ms step_avg:43.73ms
+step:769/1575 train_time:33647ms step_avg:43.75ms
+step:770/1575 train_time:33706ms step_avg:43.77ms
+step:771/1575 train_time:33770ms step_avg:43.80ms
+step:772/1575 train_time:33830ms step_avg:43.82ms
+step:773/1575 train_time:33893ms step_avg:43.85ms
+step:774/1575 train_time:33952ms step_avg:43.87ms
+step:775/1575 train_time:34015ms step_avg:43.89ms
+step:776/1575 train_time:34074ms step_avg:43.91ms
+step:777/1575 train_time:34137ms step_avg:43.93ms
+step:778/1575 train_time:34196ms step_avg:43.95ms
+step:779/1575 train_time:34259ms step_avg:43.98ms
+step:780/1575 train_time:34318ms step_avg:44.00ms
+step:781/1575 train_time:34381ms step_avg:44.02ms
+step:782/1575 train_time:34441ms step_avg:44.04ms
+step:783/1575 train_time:34504ms step_avg:44.07ms
+step:784/1575 train_time:34564ms step_avg:44.09ms
+step:785/1575 train_time:34628ms step_avg:44.11ms
+step:786/1575 train_time:34688ms step_avg:44.13ms
+step:787/1575 train_time:34751ms step_avg:44.16ms
+step:788/1575 train_time:34810ms step_avg:44.18ms
+step:789/1575 train_time:34873ms step_avg:44.20ms
+step:790/1575 train_time:34932ms step_avg:44.22ms
+step:791/1575 train_time:34995ms step_avg:44.24ms
+step:792/1575 train_time:35054ms step_avg:44.26ms
+step:793/1575 train_time:35118ms step_avg:44.28ms
+step:794/1575 train_time:35176ms step_avg:44.30ms
+step:795/1575 train_time:35239ms step_avg:44.33ms
+step:796/1575 train_time:35298ms step_avg:44.34ms
+step:797/1575 train_time:35362ms step_avg:44.37ms
+step:798/1575 train_time:35421ms step_avg:44.39ms
+step:799/1575 train_time:35486ms step_avg:44.41ms
+step:800/1575 train_time:35546ms step_avg:44.43ms
+step:801/1575 train_time:35609ms step_avg:44.46ms
+step:802/1575 train_time:35669ms step_avg:44.47ms
+step:803/1575 train_time:35732ms step_avg:44.50ms
+step:804/1575 train_time:35791ms step_avg:44.52ms
+step:805/1575 train_time:35855ms step_avg:44.54ms
+step:806/1575 train_time:35915ms step_avg:44.56ms
+step:807/1575 train_time:35979ms step_avg:44.58ms
+step:808/1575 train_time:36037ms step_avg:44.60ms
+step:809/1575 train_time:36100ms step_avg:44.62ms
+step:810/1575 train_time:36160ms step_avg:44.64ms
+step:811/1575 train_time:36224ms step_avg:44.67ms
+step:812/1575 train_time:36282ms step_avg:44.68ms
+step:813/1575 train_time:36345ms step_avg:44.71ms
+step:814/1575 train_time:36404ms step_avg:44.72ms
+step:815/1575 train_time:36468ms step_avg:44.75ms
+step:816/1575 train_time:36528ms step_avg:44.76ms
+step:817/1575 train_time:36590ms step_avg:44.79ms
+step:818/1575 train_time:36650ms step_avg:44.80ms
+step:819/1575 train_time:36713ms step_avg:44.83ms
+step:820/1575 train_time:36772ms step_avg:44.84ms
+step:821/1575 train_time:36835ms step_avg:44.87ms
+step:822/1575 train_time:36894ms step_avg:44.88ms
+step:823/1575 train_time:36958ms step_avg:44.91ms
+step:824/1575 train_time:37016ms step_avg:44.92ms
+step:825/1575 train_time:37080ms step_avg:44.95ms
+step:826/1575 train_time:37139ms step_avg:44.96ms
+step:827/1575 train_time:37202ms step_avg:44.98ms
+step:828/1575 train_time:37262ms step_avg:45.00ms
+step:829/1575 train_time:37326ms step_avg:45.02ms
+step:830/1575 train_time:37385ms step_avg:45.04ms
+step:831/1575 train_time:37448ms step_avg:45.06ms
+step:832/1575 train_time:37507ms step_avg:45.08ms
+step:833/1575 train_time:37571ms step_avg:45.10ms
+step:834/1575 train_time:37630ms step_avg:45.12ms
+step:835/1575 train_time:37694ms step_avg:45.14ms
+step:836/1575 train_time:37754ms step_avg:45.16ms
+step:837/1575 train_time:37816ms step_avg:45.18ms
+step:838/1575 train_time:37875ms step_avg:45.20ms
+step:839/1575 train_time:37938ms step_avg:45.22ms
+step:840/1575 train_time:37997ms step_avg:45.23ms
+step:841/1575 train_time:38061ms step_avg:45.26ms
+step:842/1575 train_time:38120ms step_avg:45.27ms
+step:843/1575 train_time:38184ms step_avg:45.30ms
+step:844/1575 train_time:38243ms step_avg:45.31ms
+step:845/1575 train_time:38307ms step_avg:45.33ms
+step:846/1575 train_time:38366ms step_avg:45.35ms
+step:847/1575 train_time:38429ms step_avg:45.37ms
+step:848/1575 train_time:38489ms step_avg:45.39ms
+step:849/1575 train_time:38552ms step_avg:45.41ms
+step:850/1575 train_time:38611ms step_avg:45.43ms
+step:851/1575 train_time:38674ms step_avg:45.45ms
+step:852/1575 train_time:38735ms step_avg:45.46ms
+step:853/1575 train_time:38798ms step_avg:45.48ms
+step:854/1575 train_time:38855ms step_avg:45.50ms
+step:855/1575 train_time:38918ms step_avg:45.52ms
+step:856/1575 train_time:38978ms step_avg:45.54ms
+step:857/1575 train_time:39041ms step_avg:45.56ms
+step:858/1575 train_time:39101ms step_avg:45.57ms
+step:859/1575 train_time:39165ms step_avg:45.59ms
+step:860/1575 train_time:39224ms step_avg:45.61ms
+step:861/1575 train_time:39287ms step_avg:45.63ms
+step:862/1575 train_time:39347ms step_avg:45.65ms
+step:863/1575 train_time:39411ms step_avg:45.67ms
+step:864/1575 train_time:39470ms step_avg:45.68ms
+step:865/1575 train_time:39533ms step_avg:45.70ms
+step:866/1575 train_time:39593ms step_avg:45.72ms
+step:867/1575 train_time:39656ms step_avg:45.74ms
+step:868/1575 train_time:39716ms step_avg:45.76ms
+step:869/1575 train_time:39779ms step_avg:45.78ms
+step:870/1575 train_time:39838ms step_avg:45.79ms
+step:871/1575 train_time:39902ms step_avg:45.81ms
+step:872/1575 train_time:39962ms step_avg:45.83ms
+step:873/1575 train_time:40025ms step_avg:45.85ms
+step:874/1575 train_time:40084ms step_avg:45.86ms
+step:875/1575 train_time:40147ms step_avg:45.88ms
+step:876/1575 train_time:40206ms step_avg:45.90ms
+step:877/1575 train_time:40270ms step_avg:45.92ms
+step:878/1575 train_time:40329ms step_avg:45.93ms
+step:879/1575 train_time:40395ms step_avg:45.96ms
+step:880/1575 train_time:40454ms step_avg:45.97ms
+step:881/1575 train_time:40515ms step_avg:45.99ms
+step:882/1575 train_time:40575ms step_avg:46.00ms
+step:883/1575 train_time:40638ms step_avg:46.02ms
+step:884/1575 train_time:40697ms step_avg:46.04ms
+step:885/1575 train_time:40761ms step_avg:46.06ms
+step:886/1575 train_time:40825ms step_avg:46.08ms
+step:887/1575 train_time:40886ms step_avg:46.09ms
+step:888/1575 train_time:40945ms step_avg:46.11ms
+step:889/1575 train_time:41008ms step_avg:46.13ms
+step:890/1575 train_time:41067ms step_avg:46.14ms
+step:891/1575 train_time:41130ms step_avg:46.16ms
+step:892/1575 train_time:41188ms step_avg:46.18ms
+step:893/1575 train_time:41251ms step_avg:46.19ms
+step:894/1575 train_time:41311ms step_avg:46.21ms
+step:895/1575 train_time:41374ms step_avg:46.23ms
+step:896/1575 train_time:41433ms step_avg:46.24ms
+step:897/1575 train_time:41496ms step_avg:46.26ms
+step:898/1575 train_time:41555ms step_avg:46.27ms
+step:899/1575 train_time:41618ms step_avg:46.29ms
+step:900/1575 train_time:41678ms step_avg:46.31ms
+step:901/1575 train_time:41741ms step_avg:46.33ms
+step:902/1575 train_time:41800ms step_avg:46.34ms
+step:903/1575 train_time:41864ms step_avg:46.36ms
+step:904/1575 train_time:41923ms step_avg:46.37ms
+step:905/1575 train_time:41986ms step_avg:46.39ms
+step:906/1575 train_time:42046ms step_avg:46.41ms
+step:907/1575 train_time:42109ms step_avg:46.43ms
+step:908/1575 train_time:42169ms step_avg:46.44ms
+step:909/1575 train_time:42232ms step_avg:46.46ms
+step:910/1575 train_time:42291ms step_avg:46.47ms
+step:911/1575 train_time:42354ms step_avg:46.49ms
+step:912/1575 train_time:42413ms step_avg:46.51ms
+step:913/1575 train_time:42477ms step_avg:46.52ms
+step:914/1575 train_time:42536ms step_avg:46.54ms
+step:915/1575 train_time:42600ms step_avg:46.56ms
+step:916/1575 train_time:42659ms step_avg:46.57ms
+step:917/1575 train_time:42722ms step_avg:46.59ms
+step:918/1575 train_time:42781ms step_avg:46.60ms
+step:919/1575 train_time:42845ms step_avg:46.62ms
+step:920/1575 train_time:42904ms step_avg:46.63ms
+step:921/1575 train_time:42967ms step_avg:46.65ms
+step:922/1575 train_time:43026ms step_avg:46.67ms
+step:923/1575 train_time:43089ms step_avg:46.68ms
+step:924/1575 train_time:43149ms step_avg:46.70ms
+step:925/1575 train_time:43212ms step_avg:46.72ms
+step:926/1575 train_time:43271ms step_avg:46.73ms
+step:927/1575 train_time:43335ms step_avg:46.75ms
+step:928/1575 train_time:43394ms step_avg:46.76ms
+step:929/1575 train_time:43458ms step_avg:46.78ms
+step:930/1575 train_time:43517ms step_avg:46.79ms
+step:931/1575 train_time:43580ms step_avg:46.81ms
+step:932/1575 train_time:43640ms step_avg:46.82ms
+step:933/1575 train_time:43703ms step_avg:46.84ms
+step:934/1575 train_time:43763ms step_avg:46.86ms
+step:935/1575 train_time:43827ms step_avg:46.87ms
+step:936/1575 train_time:43885ms step_avg:46.89ms
+step:937/1575 train_time:43949ms step_avg:46.90ms
+step:938/1575 train_time:44008ms step_avg:46.92ms
+step:939/1575 train_time:44072ms step_avg:46.93ms
+step:940/1575 train_time:44131ms step_avg:46.95ms
+step:941/1575 train_time:44194ms step_avg:46.97ms
+step:942/1575 train_time:44253ms step_avg:46.98ms
+step:943/1575 train_time:44317ms step_avg:47.00ms
+step:944/1575 train_time:44376ms step_avg:47.01ms
+step:945/1575 train_time:44439ms step_avg:47.03ms
+step:946/1575 train_time:44498ms step_avg:47.04ms
+step:947/1575 train_time:44562ms step_avg:47.06ms
+step:948/1575 train_time:44621ms step_avg:47.07ms
+step:949/1575 train_time:44685ms step_avg:47.09ms
+step:950/1575 train_time:44744ms step_avg:47.10ms
+step:951/1575 train_time:44808ms step_avg:47.12ms
+step:952/1575 train_time:44867ms step_avg:47.13ms
+step:953/1575 train_time:44930ms step_avg:47.15ms
+step:954/1575 train_time:44989ms step_avg:47.16ms
+step:955/1575 train_time:45052ms step_avg:47.17ms
+step:956/1575 train_time:45111ms step_avg:47.19ms
+step:957/1575 train_time:45176ms step_avg:47.21ms
+step:958/1575 train_time:45236ms step_avg:47.22ms
+step:959/1575 train_time:45299ms step_avg:47.24ms
+step:960/1575 train_time:45358ms step_avg:47.25ms
+step:961/1575 train_time:45420ms step_avg:47.26ms
+step:962/1575 train_time:45479ms step_avg:47.28ms
+step:963/1575 train_time:45543ms step_avg:47.29ms
+step:964/1575 train_time:45602ms step_avg:47.30ms
+step:965/1575 train_time:45666ms step_avg:47.32ms
+step:966/1575 train_time:45725ms step_avg:47.33ms
+step:967/1575 train_time:45788ms step_avg:47.35ms
+step:968/1575 train_time:45847ms step_avg:47.36ms
+step:969/1575 train_time:45911ms step_avg:47.38ms
+step:970/1575 train_time:45970ms step_avg:47.39ms
+step:971/1575 train_time:46033ms step_avg:47.41ms
+step:972/1575 train_time:46093ms step_avg:47.42ms
+step:973/1575 train_time:46157ms step_avg:47.44ms
+step:974/1575 train_time:46216ms step_avg:47.45ms
+step:975/1575 train_time:46279ms step_avg:47.47ms
+step:976/1575 train_time:46338ms step_avg:47.48ms
+step:977/1575 train_time:46402ms step_avg:47.49ms
+step:978/1575 train_time:46461ms step_avg:47.51ms
+step:979/1575 train_time:46526ms step_avg:47.52ms
+step:980/1575 train_time:46585ms step_avg:47.54ms
+step:981/1575 train_time:46648ms step_avg:47.55ms
+step:982/1575 train_time:46707ms step_avg:47.56ms
+step:983/1575 train_time:46771ms step_avg:47.58ms
+step:984/1575 train_time:46831ms step_avg:47.59ms
+step:985/1575 train_time:46894ms step_avg:47.61ms
+step:986/1575 train_time:46953ms step_avg:47.62ms
+step:987/1575 train_time:47017ms step_avg:47.64ms
+step:988/1575 train_time:47076ms step_avg:47.65ms
+step:989/1575 train_time:47140ms step_avg:47.66ms
+step:990/1575 train_time:47199ms step_avg:47.68ms
+step:991/1575 train_time:47263ms step_avg:47.69ms
+step:992/1575 train_time:47322ms step_avg:47.70ms
+step:993/1575 train_time:47386ms step_avg:47.72ms
+step:994/1575 train_time:47445ms step_avg:47.73ms
+step:995/1575 train_time:47508ms step_avg:47.75ms
+step:996/1575 train_time:47567ms step_avg:47.76ms
+step:997/1575 train_time:47630ms step_avg:47.77ms
+step:998/1575 train_time:47690ms step_avg:47.79ms
+step:999/1575 train_time:47753ms step_avg:47.80ms
+step:1000/1575 train_time:47812ms step_avg:47.81ms
+step:1000/1575 val_loss:3.5812 train_time:47861ms step_avg:47.86ms
+step:1001/1575 train_time:47879ms step_avg:47.83ms
+step:1002/1575 train_time:47937ms step_avg:47.84ms
+step:1003/1575 train_time:48003ms step_avg:47.86ms
+step:1004/1575 train_time:48064ms step_avg:47.87ms
+step:1005/1575 train_time:48127ms step_avg:47.89ms
+step:1006/1575 train_time:48186ms step_avg:47.90ms
+step:1007/1575 train_time:48250ms step_avg:47.91ms
+step:1008/1575 train_time:48309ms step_avg:47.93ms
+step:1009/1575 train_time:48372ms step_avg:47.94ms
+step:1010/1575 train_time:48431ms step_avg:47.95ms
+step:1011/1575 train_time:48494ms step_avg:47.97ms
+step:1012/1575 train_time:48553ms step_avg:47.98ms
+step:1013/1575 train_time:48615ms step_avg:47.99ms
+step:1014/1575 train_time:48674ms step_avg:48.00ms
+step:1015/1575 train_time:48736ms step_avg:48.02ms
+step:1016/1575 train_time:48796ms step_avg:48.03ms
+step:1017/1575 train_time:48859ms step_avg:48.04ms
+step:1018/1575 train_time:48919ms step_avg:48.05ms
+step:1019/1575 train_time:48984ms step_avg:48.07ms
+step:1020/1575 train_time:49043ms step_avg:48.08ms
+step:1021/1575 train_time:49108ms step_avg:48.10ms
+step:1022/1575 train_time:49167ms step_avg:48.11ms
+step:1023/1575 train_time:49230ms step_avg:48.12ms
+step:1024/1575 train_time:49289ms step_avg:48.13ms
+step:1025/1575 train_time:49361ms step_avg:48.16ms
+step:1026/1575 train_time:49444ms step_avg:48.19ms
+step:1027/1575 train_time:49535ms step_avg:48.23ms
+step:1028/1575 train_time:49621ms step_avg:48.27ms
+step:1029/1575 train_time:49711ms step_avg:48.31ms
+step:1030/1575 train_time:49796ms step_avg:48.35ms
+step:1031/1575 train_time:49888ms step_avg:48.39ms
+step:1032/1575 train_time:49974ms step_avg:48.42ms
+step:1033/1575 train_time:50064ms step_avg:48.46ms
+step:1034/1575 train_time:50150ms step_avg:48.50ms
+step:1035/1575 train_time:50239ms step_avg:48.54ms
+step:1036/1575 train_time:50325ms step_avg:48.58ms
+step:1037/1575 train_time:50414ms step_avg:48.62ms
+step:1038/1575 train_time:50499ms step_avg:48.65ms
+step:1039/1575 train_time:50589ms step_avg:48.69ms
+step:1040/1575 train_time:50675ms step_avg:48.73ms
+step:1041/1575 train_time:50765ms step_avg:48.77ms
+step:1042/1575 train_time:50851ms step_avg:48.80ms
+step:1043/1575 train_time:50941ms step_avg:48.84ms
+step:1044/1575 train_time:51026ms step_avg:48.88ms
+step:1045/1575 train_time:51116ms step_avg:48.92ms
+step:1046/1575 train_time:51202ms step_avg:48.95ms
+step:1047/1575 train_time:51292ms step_avg:48.99ms
+step:1048/1575 train_time:51378ms step_avg:49.02ms
+step:1049/1575 train_time:51467ms step_avg:49.06ms
+step:1050/1575 train_time:51552ms step_avg:49.10ms
+step:1051/1575 train_time:51642ms step_avg:49.14ms
+step:1052/1575 train_time:51727ms step_avg:49.17ms
+step:1053/1575 train_time:51817ms step_avg:49.21ms
+step:1054/1575 train_time:51903ms step_avg:49.24ms
+step:1055/1575 train_time:51993ms step_avg:49.28ms
+step:1056/1575 train_time:52079ms step_avg:49.32ms
+step:1057/1575 train_time:52168ms step_avg:49.36ms
+step:1058/1575 train_time:52255ms step_avg:49.39ms
+step:1059/1575 train_time:52345ms step_avg:49.43ms
+step:1060/1575 train_time:52430ms step_avg:49.46ms
+step:1061/1575 train_time:52520ms step_avg:49.50ms
+step:1062/1575 train_time:52605ms step_avg:49.53ms
+step:1063/1575 train_time:52694ms step_avg:49.57ms
+step:1064/1575 train_time:52780ms step_avg:49.61ms
+step:1065/1575 train_time:52869ms step_avg:49.64ms
+step:1066/1575 train_time:52955ms step_avg:49.68ms
+step:1067/1575 train_time:53045ms step_avg:49.71ms
+step:1068/1575 train_time:53130ms step_avg:49.75ms
+step:1069/1575 train_time:53220ms step_avg:49.78ms
+step:1070/1575 train_time:53306ms step_avg:49.82ms
+step:1071/1575 train_time:53395ms step_avg:49.86ms
+step:1072/1575 train_time:53481ms step_avg:49.89ms
+step:1073/1575 train_time:53570ms step_avg:49.92ms
+step:1074/1575 train_time:53656ms step_avg:49.96ms
+step:1075/1575 train_time:53746ms step_avg:50.00ms
+step:1076/1575 train_time:53832ms step_avg:50.03ms
+step:1077/1575 train_time:53922ms step_avg:50.07ms
+step:1078/1575 train_time:54008ms step_avg:50.10ms
+step:1079/1575 train_time:54098ms step_avg:50.14ms
+step:1080/1575 train_time:54184ms step_avg:50.17ms
+step:1081/1575 train_time:54273ms step_avg:50.21ms
+step:1082/1575 train_time:54359ms step_avg:50.24ms
+step:1083/1575 train_time:54448ms step_avg:50.28ms
+step:1084/1575 train_time:54538ms step_avg:50.31ms
+step:1085/1575 train_time:54626ms step_avg:50.35ms
+step:1086/1575 train_time:54711ms step_avg:50.38ms
+step:1087/1575 train_time:54801ms step_avg:50.41ms
+step:1088/1575 train_time:54886ms step_avg:50.45ms
+step:1089/1575 train_time:54975ms step_avg:50.48ms
+step:1090/1575 train_time:55061ms step_avg:50.51ms
+step:1091/1575 train_time:55151ms step_avg:50.55ms
+step:1092/1575 train_time:55237ms step_avg:50.58ms
+step:1093/1575 train_time:55327ms step_avg:50.62ms
+step:1094/1575 train_time:55412ms step_avg:50.65ms
+step:1095/1575 train_time:55502ms step_avg:50.69ms
+step:1096/1575 train_time:55587ms step_avg:50.72ms
+step:1097/1575 train_time:55677ms step_avg:50.75ms
+step:1098/1575 train_time:55763ms step_avg:50.79ms
+step:1099/1575 train_time:55852ms step_avg:50.82ms
+step:1100/1575 train_time:55938ms step_avg:50.85ms
+step:1101/1575 train_time:56028ms step_avg:50.89ms
+step:1102/1575 train_time:56113ms step_avg:50.92ms
+step:1103/1575 train_time:56203ms step_avg:50.95ms
+step:1104/1575 train_time:56289ms step_avg:50.99ms
+step:1105/1575 train_time:56378ms step_avg:51.02ms
+step:1106/1575 train_time:56464ms step_avg:51.05ms
+step:1107/1575 train_time:56554ms step_avg:51.09ms
+step:1108/1575 train_time:56640ms step_avg:51.12ms
+step:1109/1575 train_time:56730ms step_avg:51.15ms
+step:1110/1575 train_time:56816ms step_avg:51.19ms
+step:1111/1575 train_time:56906ms step_avg:51.22ms
+step:1112/1575 train_time:56991ms step_avg:51.25ms
+step:1113/1575 train_time:57081ms step_avg:51.29ms
+step:1114/1575 train_time:57167ms step_avg:51.32ms
+step:1115/1575 train_time:57256ms step_avg:51.35ms
+step:1116/1575 train_time:57342ms step_avg:51.38ms
+step:1117/1575 train_time:57431ms step_avg:51.42ms
+step:1118/1575 train_time:57517ms step_avg:51.45ms
+step:1119/1575 train_time:57606ms step_avg:51.48ms
+step:1120/1575 train_time:57693ms step_avg:51.51ms
+step:1121/1575 train_time:57782ms step_avg:51.55ms
+step:1122/1575 train_time:57868ms step_avg:51.58ms
+step:1123/1575 train_time:57957ms step_avg:51.61ms
+step:1124/1575 train_time:58043ms step_avg:51.64ms
+step:1125/1575 train_time:58132ms step_avg:51.67ms
+step:1126/1575 train_time:58221ms step_avg:51.71ms
+step:1127/1575 train_time:58309ms step_avg:51.74ms
+step:1128/1575 train_time:58400ms step_avg:51.77ms
+step:1129/1575 train_time:58489ms step_avg:51.81ms
+step:1130/1575 train_time:58570ms step_avg:51.83ms
+step:1131/1575 train_time:58659ms step_avg:51.86ms
+step:1132/1575 train_time:58744ms step_avg:51.89ms
+step:1133/1575 train_time:58833ms step_avg:51.93ms
+step:1134/1575 train_time:58919ms step_avg:51.96ms
+step:1135/1575 train_time:59008ms step_avg:51.99ms
+step:1136/1575 train_time:59093ms step_avg:52.02ms
+step:1137/1575 train_time:59183ms step_avg:52.05ms
+step:1138/1575 train_time:59269ms step_avg:52.08ms
+step:1139/1575 train_time:59361ms step_avg:52.12ms
+step:1140/1575 train_time:59445ms step_avg:52.14ms
+step:1141/1575 train_time:59536ms step_avg:52.18ms
+step:1142/1575 train_time:59620ms step_avg:52.21ms
+step:1143/1575 train_time:59709ms step_avg:52.24ms
+step:1144/1575 train_time:59794ms step_avg:52.27ms
+step:1145/1575 train_time:59884ms step_avg:52.30ms
+step:1146/1575 train_time:59975ms step_avg:52.33ms
+step:1147/1575 train_time:60063ms step_avg:52.37ms
+step:1148/1575 train_time:60148ms step_avg:52.39ms
+step:1149/1575 train_time:60237ms step_avg:52.43ms
+step:1150/1575 train_time:60322ms step_avg:52.45ms
+step:1151/1575 train_time:60411ms step_avg:52.49ms
+step:1152/1575 train_time:60497ms step_avg:52.52ms
+step:1153/1575 train_time:60587ms step_avg:52.55ms
+step:1154/1575 train_time:60672ms step_avg:52.58ms
+step:1155/1575 train_time:60761ms step_avg:52.61ms
+step:1156/1575 train_time:60847ms step_avg:52.64ms
+step:1157/1575 train_time:60937ms step_avg:52.67ms
+step:1158/1575 train_time:61023ms step_avg:52.70ms
+step:1159/1575 train_time:61113ms step_avg:52.73ms
+step:1160/1575 train_time:61198ms step_avg:52.76ms
+step:1161/1575 train_time:61288ms step_avg:52.79ms
+step:1162/1575 train_time:61374ms step_avg:52.82ms
+step:1163/1575 train_time:61463ms step_avg:52.85ms
+step:1164/1575 train_time:61549ms step_avg:52.88ms
+step:1165/1575 train_time:61638ms step_avg:52.91ms
+step:1166/1575 train_time:61724ms step_avg:52.94ms
+step:1167/1575 train_time:61813ms step_avg:52.97ms
+step:1168/1575 train_time:61899ms step_avg:53.00ms
+step:1169/1575 train_time:61989ms step_avg:53.03ms
+step:1170/1575 train_time:62075ms step_avg:53.06ms
+step:1171/1575 train_time:62164ms step_avg:53.09ms
+step:1172/1575 train_time:62249ms step_avg:53.11ms
+step:1173/1575 train_time:62339ms step_avg:53.15ms
+step:1174/1575 train_time:62425ms step_avg:53.17ms
+step:1175/1575 train_time:62514ms step_avg:53.20ms
+step:1176/1575 train_time:62600ms step_avg:53.23ms
+step:1177/1575 train_time:62688ms step_avg:53.26ms
+step:1178/1575 train_time:62774ms step_avg:53.29ms
+step:1179/1575 train_time:62864ms step_avg:53.32ms
+step:1180/1575 train_time:62950ms step_avg:53.35ms
+step:1181/1575 train_time:63039ms step_avg:53.38ms
+step:1182/1575 train_time:63124ms step_avg:53.40ms
+step:1183/1575 train_time:63214ms step_avg:53.44ms
+step:1184/1575 train_time:63301ms step_avg:53.46ms
+step:1185/1575 train_time:63389ms step_avg:53.49ms
+step:1186/1575 train_time:63475ms step_avg:53.52ms
+step:1187/1575 train_time:63565ms step_avg:53.55ms
+step:1188/1575 train_time:63651ms step_avg:53.58ms
+step:1189/1575 train_time:63742ms step_avg:53.61ms
+step:1190/1575 train_time:63827ms step_avg:53.64ms
+step:1191/1575 train_time:63916ms step_avg:53.67ms
+step:1192/1575 train_time:64002ms step_avg:53.69ms
+step:1193/1575 train_time:64090ms step_avg:53.72ms
+step:1194/1575 train_time:64177ms step_avg:53.75ms
+step:1195/1575 train_time:64266ms step_avg:53.78ms
+step:1196/1575 train_time:64352ms step_avg:53.81ms
+step:1197/1575 train_time:64443ms step_avg:53.84ms
+step:1198/1575 train_time:64528ms step_avg:53.86ms
+step:1199/1575 train_time:64618ms step_avg:53.89ms
+step:1200/1575 train_time:64703ms step_avg:53.92ms
+step:1201/1575 train_time:64792ms step_avg:53.95ms
+step:1202/1575 train_time:64879ms step_avg:53.98ms
+step:1203/1575 train_time:64968ms step_avg:54.01ms
+step:1204/1575 train_time:65054ms step_avg:54.03ms
+step:1205/1575 train_time:65143ms step_avg:54.06ms
+step:1206/1575 train_time:65230ms step_avg:54.09ms
+step:1207/1575 train_time:65320ms step_avg:54.12ms
+step:1208/1575 train_time:65405ms step_avg:54.14ms
+step:1209/1575 train_time:65496ms step_avg:54.17ms
+step:1210/1575 train_time:65582ms step_avg:54.20ms
+step:1211/1575 train_time:65671ms step_avg:54.23ms
+step:1212/1575 train_time:65758ms step_avg:54.26ms
+step:1213/1575 train_time:65847ms step_avg:54.28ms
+step:1214/1575 train_time:65932ms step_avg:54.31ms
+step:1215/1575 train_time:66023ms step_avg:54.34ms
+step:1216/1575 train_time:66108ms step_avg:54.37ms
+step:1217/1575 train_time:66197ms step_avg:54.39ms
+step:1218/1575 train_time:66284ms step_avg:54.42ms
+step:1219/1575 train_time:66373ms step_avg:54.45ms
+step:1220/1575 train_time:66459ms step_avg:54.47ms
+step:1221/1575 train_time:66548ms step_avg:54.50ms
+step:1222/1575 train_time:66634ms step_avg:54.53ms
+step:1223/1575 train_time:66724ms step_avg:54.56ms
+step:1224/1575 train_time:66809ms step_avg:54.58ms
+step:1225/1575 train_time:66900ms step_avg:54.61ms
+step:1226/1575 train_time:66985ms step_avg:54.64ms
+step:1227/1575 train_time:67074ms step_avg:54.66ms
+step:1228/1575 train_time:67161ms step_avg:54.69ms
+step:1229/1575 train_time:67250ms step_avg:54.72ms
+step:1230/1575 train_time:67335ms step_avg:54.74ms
+step:1231/1575 train_time:67425ms step_avg:54.77ms
+step:1232/1575 train_time:67510ms step_avg:54.80ms
+step:1233/1575 train_time:67599ms step_avg:54.83ms
+step:1234/1575 train_time:67685ms step_avg:54.85ms
+step:1235/1575 train_time:67775ms step_avg:54.88ms
+step:1236/1575 train_time:67861ms step_avg:54.90ms
+step:1237/1575 train_time:67950ms step_avg:54.93ms
+step:1238/1575 train_time:68036ms step_avg:54.96ms
+step:1239/1575 train_time:68126ms step_avg:54.99ms
+step:1240/1575 train_time:68212ms step_avg:55.01ms
+step:1241/1575 train_time:68301ms step_avg:55.04ms
+step:1242/1575 train_time:68387ms step_avg:55.06ms
+step:1243/1575 train_time:68477ms step_avg:55.09ms
+step:1244/1575 train_time:68562ms step_avg:55.11ms
+step:1245/1575 train_time:68652ms step_avg:55.14ms
+step:1246/1575 train_time:68738ms step_avg:55.17ms
+step:1247/1575 train_time:68828ms step_avg:55.19ms
+step:1248/1575 train_time:68914ms step_avg:55.22ms
+step:1249/1575 train_time:69004ms step_avg:55.25ms
+step:1250/1575 train_time:69089ms step_avg:55.27ms
+step:1250/1575 val_loss:3.4062 train_time:69165ms step_avg:55.33ms
+step:1251/1575 train_time:69184ms step_avg:55.30ms
+step:1252/1575 train_time:69269ms step_avg:55.33ms
+step:1253/1575 train_time:69363ms step_avg:55.36ms
+step:1254/1575 train_time:69449ms step_avg:55.38ms
+step:1255/1575 train_time:69538ms step_avg:55.41ms
+step:1256/1575 train_time:69623ms step_avg:55.43ms
+step:1257/1575 train_time:69711ms step_avg:55.46ms
+step:1258/1575 train_time:69796ms step_avg:55.48ms
+step:1259/1575 train_time:69884ms step_avg:55.51ms
+step:1260/1575 train_time:69970ms step_avg:55.53ms
+step:1261/1575 train_time:70059ms step_avg:55.56ms
+step:1262/1575 train_time:70145ms step_avg:55.58ms
+step:1263/1575 train_time:70240ms step_avg:55.61ms
+step:1264/1575 train_time:70327ms step_avg:55.64ms
+step:1265/1575 train_time:70417ms step_avg:55.67ms
+step:1266/1575 train_time:70503ms step_avg:55.69ms
+step:1267/1575 train_time:70591ms step_avg:55.72ms
+step:1268/1575 train_time:70676ms step_avg:55.74ms
+step:1269/1575 train_time:70765ms step_avg:55.76ms
+step:1270/1575 train_time:70849ms step_avg:55.79ms
+step:1271/1575 train_time:70938ms step_avg:55.81ms
+step:1272/1575 train_time:71023ms step_avg:55.84ms
+step:1273/1575 train_time:71113ms step_avg:55.86ms
+step:1274/1575 train_time:71200ms step_avg:55.89ms
+step:1275/1575 train_time:71291ms step_avg:55.91ms
+step:1276/1575 train_time:71378ms step_avg:55.94ms
+step:1277/1575 train_time:71468ms step_avg:55.97ms
+step:1278/1575 train_time:71553ms step_avg:55.99ms
+step:1279/1575 train_time:71643ms step_avg:56.01ms
+step:1280/1575 train_time:71728ms step_avg:56.04ms
+step:1281/1575 train_time:71816ms step_avg:56.06ms
+step:1282/1575 train_time:71901ms step_avg:56.08ms
+step:1283/1575 train_time:71990ms step_avg:56.11ms
+step:1284/1575 train_time:72076ms step_avg:56.13ms
+step:1285/1575 train_time:72166ms step_avg:56.16ms
+step:1286/1575 train_time:72253ms step_avg:56.18ms
+step:1287/1575 train_time:72343ms step_avg:56.21ms
+step:1288/1575 train_time:72430ms step_avg:56.23ms
+step:1289/1575 train_time:72520ms step_avg:56.26ms
+step:1290/1575 train_time:72606ms step_avg:56.28ms
+step:1291/1575 train_time:72695ms step_avg:56.31ms
+step:1292/1575 train_time:72780ms step_avg:56.33ms
+step:1293/1575 train_time:72868ms step_avg:56.36ms
+step:1294/1575 train_time:72954ms step_avg:56.38ms
+step:1295/1575 train_time:73043ms step_avg:56.40ms
+step:1296/1575 train_time:73129ms step_avg:56.43ms
+step:1297/1575 train_time:73220ms step_avg:56.45ms
+step:1298/1575 train_time:73306ms step_avg:56.48ms
+step:1299/1575 train_time:73397ms step_avg:56.50ms
+step:1300/1575 train_time:73484ms step_avg:56.53ms
+step:1301/1575 train_time:73574ms step_avg:56.55ms
+step:1302/1575 train_time:73658ms step_avg:56.57ms
+step:1303/1575 train_time:73748ms step_avg:56.60ms
+step:1304/1575 train_time:73832ms step_avg:56.62ms
+step:1305/1575 train_time:73921ms step_avg:56.64ms
+step:1306/1575 train_time:74006ms step_avg:56.67ms
+step:1307/1575 train_time:74095ms step_avg:56.69ms
+step:1308/1575 train_time:74181ms step_avg:56.71ms
+step:1309/1575 train_time:74271ms step_avg:56.74ms
+step:1310/1575 train_time:74357ms step_avg:56.76ms
+step:1311/1575 train_time:74447ms step_avg:56.79ms
+step:1312/1575 train_time:74533ms step_avg:56.81ms
+step:1313/1575 train_time:74623ms step_avg:56.83ms
+step:1314/1575 train_time:74709ms step_avg:56.86ms
+step:1315/1575 train_time:74799ms step_avg:56.88ms
+step:1316/1575 train_time:74884ms step_avg:56.90ms
+step:1317/1575 train_time:74972ms step_avg:56.93ms
+step:1318/1575 train_time:75058ms step_avg:56.95ms
+step:1319/1575 train_time:75148ms step_avg:56.97ms
+step:1320/1575 train_time:75234ms step_avg:57.00ms
+step:1321/1575 train_time:75323ms step_avg:57.02ms
+step:1322/1575 train_time:75410ms step_avg:57.04ms
+step:1323/1575 train_time:75500ms step_avg:57.07ms
+step:1324/1575 train_time:75586ms step_avg:57.09ms
+step:1325/1575 train_time:75676ms step_avg:57.11ms
+step:1326/1575 train_time:75761ms step_avg:57.14ms
+step:1327/1575 train_time:75850ms step_avg:57.16ms
+step:1328/1575 train_time:75936ms step_avg:57.18ms
+step:1329/1575 train_time:76025ms step_avg:57.20ms
+step:1330/1575 train_time:76110ms step_avg:57.23ms
+step:1331/1575 train_time:76200ms step_avg:57.25ms
+step:1332/1575 train_time:76286ms step_avg:57.27ms
+step:1333/1575 train_time:76377ms step_avg:57.30ms
+step:1334/1575 train_time:76462ms step_avg:57.32ms
+step:1335/1575 train_time:76552ms step_avg:57.34ms
+step:1336/1575 train_time:76638ms step_avg:57.36ms
+step:1337/1575 train_time:76728ms step_avg:57.39ms
+step:1338/1575 train_time:76813ms step_avg:57.41ms
+step:1339/1575 train_time:76903ms step_avg:57.43ms
+step:1340/1575 train_time:76988ms step_avg:57.45ms
+step:1341/1575 train_time:77078ms step_avg:57.48ms
+step:1342/1575 train_time:77163ms step_avg:57.50ms
+step:1343/1575 train_time:77252ms step_avg:57.52ms
+step:1344/1575 train_time:77338ms step_avg:57.54ms
+step:1345/1575 train_time:77428ms step_avg:57.57ms
+step:1346/1575 train_time:77514ms step_avg:57.59ms
+step:1347/1575 train_time:77604ms step_avg:57.61ms
+step:1348/1575 train_time:77690ms step_avg:57.63ms
+step:1349/1575 train_time:77779ms step_avg:57.66ms
+step:1350/1575 train_time:77864ms step_avg:57.68ms
+step:1351/1575 train_time:77953ms step_avg:57.70ms
+step:1352/1575 train_time:78039ms step_avg:57.72ms
+step:1353/1575 train_time:78128ms step_avg:57.74ms
+step:1354/1575 train_time:78214ms step_avg:57.77ms
+step:1355/1575 train_time:78304ms step_avg:57.79ms
+step:1356/1575 train_time:78389ms step_avg:57.81ms
+step:1357/1575 train_time:78480ms step_avg:57.83ms
+step:1358/1575 train_time:78570ms step_avg:57.86ms
+step:1359/1575 train_time:78658ms step_avg:57.88ms
+step:1360/1575 train_time:78744ms step_avg:57.90ms
+step:1361/1575 train_time:78833ms step_avg:57.92ms
+step:1362/1575 train_time:78918ms step_avg:57.94ms
+step:1363/1575 train_time:79007ms step_avg:57.97ms
+step:1364/1575 train_time:79093ms step_avg:57.99ms
+step:1365/1575 train_time:79182ms step_avg:58.01ms
+step:1366/1575 train_time:79267ms step_avg:58.03ms
+step:1367/1575 train_time:79358ms step_avg:58.05ms
+step:1368/1575 train_time:79443ms step_avg:58.07ms
+step:1369/1575 train_time:79533ms step_avg:58.10ms
+step:1370/1575 train_time:79618ms step_avg:58.12ms
+step:1371/1575 train_time:79708ms step_avg:58.14ms
+step:1372/1575 train_time:79794ms step_avg:58.16ms
+step:1373/1575 train_time:79884ms step_avg:58.18ms
+step:1374/1575 train_time:79970ms step_avg:58.20ms
+step:1375/1575 train_time:80060ms step_avg:58.23ms
+step:1376/1575 train_time:80145ms step_avg:58.25ms
+step:1377/1575 train_time:80235ms step_avg:58.27ms
+step:1378/1575 train_time:80320ms step_avg:58.29ms
+step:1379/1575 train_time:80410ms step_avg:58.31ms
+step:1380/1575 train_time:80496ms step_avg:58.33ms
+step:1381/1575 train_time:80586ms step_avg:58.35ms
+step:1382/1575 train_time:80671ms step_avg:58.37ms
+step:1383/1575 train_time:80761ms step_avg:58.40ms
+step:1384/1575 train_time:80847ms step_avg:58.42ms
+step:1385/1575 train_time:80937ms step_avg:58.44ms
+step:1386/1575 train_time:81023ms step_avg:58.46ms
+step:1387/1575 train_time:81113ms step_avg:58.48ms
+step:1388/1575 train_time:81198ms step_avg:58.50ms
+step:1389/1575 train_time:81288ms step_avg:58.52ms
+step:1390/1575 train_time:81374ms step_avg:58.54ms
+step:1391/1575 train_time:81463ms step_avg:58.56ms
+step:1392/1575 train_time:81549ms step_avg:58.58ms
+step:1393/1575 train_time:81640ms step_avg:58.61ms
+step:1394/1575 train_time:81725ms step_avg:58.63ms
+step:1395/1575 train_time:81815ms step_avg:58.65ms
+step:1396/1575 train_time:81900ms step_avg:58.67ms
+step:1397/1575 train_time:81990ms step_avg:58.69ms
+step:1398/1575 train_time:82076ms step_avg:58.71ms
+step:1399/1575 train_time:82165ms step_avg:58.73ms
+step:1400/1575 train_time:82250ms step_avg:58.75ms
+step:1401/1575 train_time:82340ms step_avg:58.77ms
+step:1402/1575 train_time:82426ms step_avg:58.79ms
+step:1403/1575 train_time:82515ms step_avg:58.81ms
+step:1404/1575 train_time:82601ms step_avg:58.83ms
+step:1405/1575 train_time:82691ms step_avg:58.85ms
+step:1406/1575 train_time:82776ms step_avg:58.87ms
+step:1407/1575 train_time:82866ms step_avg:58.90ms
+step:1408/1575 train_time:82951ms step_avg:58.91ms
+step:1409/1575 train_time:83041ms step_avg:58.94ms
+step:1410/1575 train_time:83127ms step_avg:58.96ms
+step:1411/1575 train_time:83217ms step_avg:58.98ms
+step:1412/1575 train_time:83302ms step_avg:59.00ms
+step:1413/1575 train_time:83391ms step_avg:59.02ms
+step:1414/1575 train_time:83477ms step_avg:59.04ms
+step:1415/1575 train_time:83567ms step_avg:59.06ms
+step:1416/1575 train_time:83655ms step_avg:59.08ms
+step:1417/1575 train_time:83742ms step_avg:59.10ms
+step:1418/1575 train_time:83828ms step_avg:59.12ms
+step:1419/1575 train_time:83917ms step_avg:59.14ms
+step:1420/1575 train_time:84003ms step_avg:59.16ms
+step:1421/1575 train_time:84093ms step_avg:59.18ms
+step:1422/1575 train_time:84179ms step_avg:59.20ms
+step:1423/1575 train_time:84268ms step_avg:59.22ms
+step:1424/1575 train_time:84354ms step_avg:59.24ms
+step:1425/1575 train_time:84443ms step_avg:59.26ms
+step:1426/1575 train_time:84529ms step_avg:59.28ms
+step:1427/1575 train_time:84620ms step_avg:59.30ms
+step:1428/1575 train_time:84705ms step_avg:59.32ms
+step:1429/1575 train_time:84795ms step_avg:59.34ms
+step:1430/1575 train_time:84881ms step_avg:59.36ms
+step:1431/1575 train_time:84970ms step_avg:59.38ms
+step:1432/1575 train_time:85057ms step_avg:59.40ms
+step:1433/1575 train_time:85146ms step_avg:59.42ms
+step:1434/1575 train_time:85232ms step_avg:59.44ms
+step:1435/1575 train_time:85322ms step_avg:59.46ms
+step:1436/1575 train_time:85407ms step_avg:59.48ms
+step:1437/1575 train_time:85497ms step_avg:59.50ms
+step:1438/1575 train_time:85583ms step_avg:59.52ms
+step:1439/1575 train_time:85674ms step_avg:59.54ms
+step:1440/1575 train_time:85759ms step_avg:59.55ms
+step:1441/1575 train_time:85849ms step_avg:59.58ms
+step:1442/1575 train_time:85935ms step_avg:59.59ms
+step:1443/1575 train_time:86025ms step_avg:59.62ms
+step:1444/1575 train_time:86110ms step_avg:59.63ms
+step:1445/1575 train_time:86200ms step_avg:59.65ms
+step:1446/1575 train_time:86285ms step_avg:59.67ms
+step:1447/1575 train_time:86375ms step_avg:59.69ms
+step:1448/1575 train_time:86460ms step_avg:59.71ms
+step:1449/1575 train_time:86550ms step_avg:59.73ms
+step:1450/1575 train_time:86636ms step_avg:59.75ms
+step:1451/1575 train_time:86725ms step_avg:59.77ms
+step:1452/1575 train_time:86812ms step_avg:59.79ms
+step:1453/1575 train_time:86902ms step_avg:59.81ms
+step:1454/1575 train_time:86988ms step_avg:59.83ms
+step:1455/1575 train_time:87077ms step_avg:59.85ms
+step:1456/1575 train_time:87162ms step_avg:59.86ms
+step:1457/1575 train_time:87251ms step_avg:59.88ms
+step:1458/1575 train_time:87337ms step_avg:59.90ms
+step:1459/1575 train_time:87426ms step_avg:59.92ms
+step:1460/1575 train_time:87512ms step_avg:59.94ms
+step:1461/1575 train_time:87602ms step_avg:59.96ms
+step:1462/1575 train_time:87687ms step_avg:59.98ms
+step:1463/1575 train_time:87778ms step_avg:60.00ms
+step:1464/1575 train_time:87864ms step_avg:60.02ms
+step:1465/1575 train_time:87953ms step_avg:60.04ms
+step:1466/1575 train_time:88039ms step_avg:60.05ms
+step:1467/1575 train_time:88129ms step_avg:60.07ms
+step:1468/1575 train_time:88214ms step_avg:60.09ms
+step:1469/1575 train_time:88303ms step_avg:60.11ms
+step:1470/1575 train_time:88388ms step_avg:60.13ms
+step:1471/1575 train_time:88479ms step_avg:60.15ms
+step:1472/1575 train_time:88565ms step_avg:60.17ms
+step:1473/1575 train_time:88655ms step_avg:60.19ms
+step:1474/1575 train_time:88740ms step_avg:60.20ms
+step:1475/1575 train_time:88831ms step_avg:60.22ms
+step:1476/1575 train_time:88916ms step_avg:60.24ms
+step:1477/1575 train_time:89007ms step_avg:60.26ms
+step:1478/1575 train_time:89091ms step_avg:60.28ms
+step:1479/1575 train_time:89180ms step_avg:60.30ms
+step:1480/1575 train_time:89265ms step_avg:60.31ms
+step:1481/1575 train_time:89354ms step_avg:60.33ms
+step:1482/1575 train_time:89439ms step_avg:60.35ms
+step:1483/1575 train_time:89529ms step_avg:60.37ms
+step:1484/1575 train_time:89615ms step_avg:60.39ms
+step:1485/1575 train_time:89704ms step_avg:60.41ms
+step:1486/1575 train_time:89791ms step_avg:60.42ms
+step:1487/1575 train_time:89882ms step_avg:60.44ms
+step:1488/1575 train_time:89967ms step_avg:60.46ms
+step:1489/1575 train_time:90057ms step_avg:60.48ms
+step:1490/1575 train_time:90143ms step_avg:60.50ms
+step:1491/1575 train_time:90232ms step_avg:60.52ms
+step:1492/1575 train_time:90318ms step_avg:60.53ms
+step:1493/1575 train_time:90407ms step_avg:60.55ms
+step:1494/1575 train_time:90493ms step_avg:60.57ms
+step:1495/1575 train_time:90582ms step_avg:60.59ms
+step:1496/1575 train_time:90668ms step_avg:60.61ms
+step:1497/1575 train_time:90758ms step_avg:60.63ms
+step:1498/1575 train_time:90844ms step_avg:60.64ms
+step:1499/1575 train_time:90935ms step_avg:60.66ms
+step:1500/1575 train_time:91020ms step_avg:60.68ms
+step:1500/1575 val_loss:3.2992 train_time:91094ms step_avg:60.73ms
+step:1501/1575 train_time:91113ms step_avg:60.70ms
+step:1502/1575 train_time:91201ms step_avg:60.72ms
+step:1503/1575 train_time:91293ms step_avg:60.74ms
+step:1504/1575 train_time:91380ms step_avg:60.76ms
+step:1505/1575 train_time:91469ms step_avg:60.78ms
+step:1506/1575 train_time:91554ms step_avg:60.79ms
+step:1507/1575 train_time:91642ms step_avg:60.81ms
+step:1508/1575 train_time:91727ms step_avg:60.83ms
+step:1509/1575 train_time:91815ms step_avg:60.85ms
+step:1510/1575 train_time:91900ms step_avg:60.86ms
+step:1511/1575 train_time:91988ms step_avg:60.88ms
+step:1512/1575 train_time:92074ms step_avg:60.90ms
+step:1513/1575 train_time:92166ms step_avg:60.92ms
+step:1514/1575 train_time:92255ms step_avg:60.93ms
+step:1515/1575 train_time:92344ms step_avg:60.95ms
+step:1516/1575 train_time:92430ms step_avg:60.97ms
+step:1517/1575 train_time:92520ms step_avg:60.99ms
+step:1518/1575 train_time:92605ms step_avg:61.00ms
+step:1519/1575 train_time:92694ms step_avg:61.02ms
+step:1520/1575 train_time:92778ms step_avg:61.04ms
+step:1521/1575 train_time:92867ms step_avg:61.06ms
+step:1522/1575 train_time:92952ms step_avg:61.07ms
+step:1523/1575 train_time:93042ms step_avg:61.09ms
+step:1524/1575 train_time:93129ms step_avg:61.11ms
+step:1525/1575 train_time:93222ms step_avg:61.13ms
+step:1526/1575 train_time:93308ms step_avg:61.15ms
+step:1527/1575 train_time:93399ms step_avg:61.16ms
+step:1528/1575 train_time:93484ms step_avg:61.18ms
+step:1529/1575 train_time:93574ms step_avg:61.20ms
+step:1530/1575 train_time:93659ms step_avg:61.21ms
+step:1531/1575 train_time:93748ms step_avg:61.23ms
+step:1532/1575 train_time:93832ms step_avg:61.25ms
+step:1533/1575 train_time:93921ms step_avg:61.27ms
+step:1534/1575 train_time:94007ms step_avg:61.28ms
+step:1535/1575 train_time:94097ms step_avg:61.30ms
+step:1536/1575 train_time:94191ms step_avg:61.32ms
+step:1537/1575 train_time:94280ms step_avg:61.34ms
+step:1538/1575 train_time:94366ms step_avg:61.36ms
+step:1539/1575 train_time:94456ms step_avg:61.37ms
+step:1540/1575 train_time:94542ms step_avg:61.39ms
+step:1541/1575 train_time:94632ms step_avg:61.41ms
+step:1542/1575 train_time:94718ms step_avg:61.43ms
+step:1543/1575 train_time:94807ms step_avg:61.44ms
+step:1544/1575 train_time:94892ms step_avg:61.46ms
+step:1545/1575 train_time:94982ms step_avg:61.48ms
+step:1546/1575 train_time:95067ms step_avg:61.49ms
+step:1547/1575 train_time:95158ms step_avg:61.51ms
+step:1548/1575 train_time:95245ms step_avg:61.53ms
+step:1549/1575 train_time:95336ms step_avg:61.55ms
+step:1550/1575 train_time:95421ms step_avg:61.56ms
+step:1551/1575 train_time:95513ms step_avg:61.58ms
+step:1552/1575 train_time:95598ms step_avg:61.60ms
+step:1553/1575 train_time:95689ms step_avg:61.62ms
+step:1554/1575 train_time:95775ms step_avg:61.63ms
+step:1555/1575 train_time:95863ms step_avg:61.65ms
+step:1556/1575 train_time:95949ms step_avg:61.66ms
+step:1557/1575 train_time:96039ms step_avg:61.68ms
+step:1558/1575 train_time:96125ms step_avg:61.70ms
+step:1559/1575 train_time:96215ms step_avg:61.72ms
+step:1560/1575 train_time:96302ms step_avg:61.73ms
+step:1561/1575 train_time:96392ms step_avg:61.75ms
+step:1562/1575 train_time:96478ms step_avg:61.77ms
+step:1563/1575 train_time:96569ms step_avg:61.78ms
+step:1564/1575 train_time:96655ms step_avg:61.80ms
+step:1565/1575 train_time:96745ms step_avg:61.82ms
+step:1566/1575 train_time:96831ms step_avg:61.83ms
+step:1567/1575 train_time:96920ms step_avg:61.85ms
+step:1568/1575 train_time:97007ms step_avg:61.87ms
+step:1569/1575 train_time:97101ms step_avg:61.89ms
+step:1570/1575 train_time:97185ms step_avg:61.90ms
+step:1571/1575 train_time:97275ms step_avg:61.92ms
+step:1572/1575 train_time:97361ms step_avg:61.93ms
+step:1573/1575 train_time:97451ms step_avg:61.95ms
+step:1574/1575 train_time:97537ms step_avg:61.97ms
+step:1575/1575 train_time:97627ms step_avg:61.99ms
+step:1575/1575 val_loss:3.2775 train_time:97697ms step_avg:62.03ms
+peak memory allocated: 31016 MiB reserved: 46998 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/43955d93-6914-40cb-bdf8-786ace93784f.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/43955d93-6914-40cb-bdf8-786ace93784f.txt
@@ -1,0 +1,4096 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 01 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # shifting first layer updates this to 01 ... 01 @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:23:31 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   39C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   41C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            130W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          243976      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          243977      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          243978      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          243979      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          243980      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          243981      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          243982      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          243983      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 511, 512, 513, 1023, 1024, 1025, 1534, 1535, 1536] for warmup
+Resetting Model
+step:0/1575 val_loss:10.8300 train_time:0ms step_avg:0.03ms
+step:1/1575 train_time:75ms step_avg:74.68ms
+step:2/1575 train_time:98ms step_avg:48.76ms
+step:3/1575 train_time:117ms step_avg:39.10ms
+step:4/1575 train_time:144ms step_avg:36.06ms
+step:5/1575 train_time:174ms step_avg:34.90ms
+step:6/1575 train_time:272ms step_avg:45.27ms
+step:7/1575 train_time:291ms step_avg:41.52ms
+step:8/1575 train_time:311ms step_avg:38.84ms
+step:9/1575 train_time:342ms step_avg:37.95ms
+step:10/1575 train_time:380ms step_avg:37.99ms
+step:11/1575 train_time:411ms step_avg:37.34ms
+step:12/1575 train_time:450ms step_avg:37.49ms
+step:13/1575 train_time:481ms step_avg:36.97ms
+step:14/1575 train_time:519ms step_avg:37.08ms
+step:15/1575 train_time:550ms step_avg:36.69ms
+step:16/1575 train_time:589ms step_avg:36.81ms
+step:17/1575 train_time:620ms step_avg:36.47ms
+step:18/1575 train_time:658ms step_avg:36.57ms
+step:19/1575 train_time:689ms step_avg:36.27ms
+step:20/1575 train_time:728ms step_avg:36.41ms
+step:21/1575 train_time:759ms step_avg:36.15ms
+step:22/1575 train_time:798ms step_avg:36.25ms
+step:23/1575 train_time:828ms step_avg:36.01ms
+step:24/1575 train_time:867ms step_avg:36.13ms
+step:25/1575 train_time:898ms step_avg:35.92ms
+step:26/1575 train_time:937ms step_avg:36.03ms
+step:27/1575 train_time:968ms step_avg:35.84ms
+step:28/1575 train_time:1007ms step_avg:35.95ms
+step:29/1575 train_time:1038ms step_avg:35.78ms
+step:30/1575 train_time:1076ms step_avg:35.86ms
+step:31/1575 train_time:1107ms step_avg:35.70ms
+step:32/1575 train_time:1146ms step_avg:35.80ms
+step:33/1575 train_time:1177ms step_avg:35.66ms
+step:34/1575 train_time:1215ms step_avg:35.75ms
+step:35/1575 train_time:1246ms step_avg:35.60ms
+step:36/1575 train_time:1285ms step_avg:35.69ms
+step:37/1575 train_time:1316ms step_avg:35.57ms
+step:38/1575 train_time:1355ms step_avg:35.66ms
+step:39/1575 train_time:1386ms step_avg:35.54ms
+step:40/1575 train_time:1425ms step_avg:35.62ms
+step:41/1575 train_time:1457ms step_avg:35.53ms
+step:42/1575 train_time:1495ms step_avg:35.61ms
+step:43/1575 train_time:1526ms step_avg:35.50ms
+step:44/1575 train_time:1565ms step_avg:35.58ms
+step:45/1575 train_time:1597ms step_avg:35.48ms
+step:46/1575 train_time:1636ms step_avg:35.56ms
+step:47/1575 train_time:1666ms step_avg:35.45ms
+step:48/1575 train_time:1705ms step_avg:35.52ms
+step:49/1575 train_time:1736ms step_avg:35.43ms
+step:50/1575 train_time:1775ms step_avg:35.50ms
+step:51/1575 train_time:1806ms step_avg:35.40ms
+step:52/1575 train_time:1845ms step_avg:35.48ms
+step:53/1575 train_time:1876ms step_avg:35.40ms
+step:54/1575 train_time:1915ms step_avg:35.45ms
+step:55/1575 train_time:1946ms step_avg:35.38ms
+step:56/1575 train_time:1985ms step_avg:35.44ms
+step:57/1575 train_time:2016ms step_avg:35.37ms
+step:58/1575 train_time:2055ms step_avg:35.43ms
+step:59/1575 train_time:2086ms step_avg:35.35ms
+step:60/1575 train_time:2124ms step_avg:35.41ms
+step:61/1575 train_time:2155ms step_avg:35.33ms
+step:62/1575 train_time:2194ms step_avg:35.39ms
+step:63/1575 train_time:2225ms step_avg:35.32ms
+step:64/1575 train_time:2264ms step_avg:35.38ms
+step:65/1575 train_time:2296ms step_avg:35.32ms
+step:66/1575 train_time:2334ms step_avg:35.37ms
+step:67/1575 train_time:2365ms step_avg:35.30ms
+step:68/1575 train_time:2404ms step_avg:35.35ms
+step:69/1575 train_time:2435ms step_avg:35.29ms
+step:70/1575 train_time:2473ms step_avg:35.33ms
+step:71/1575 train_time:2504ms step_avg:35.27ms
+step:72/1575 train_time:2543ms step_avg:35.32ms
+step:73/1575 train_time:2574ms step_avg:35.26ms
+step:74/1575 train_time:2613ms step_avg:35.31ms
+step:75/1575 train_time:2644ms step_avg:35.25ms
+step:76/1575 train_time:2682ms step_avg:35.29ms
+step:77/1575 train_time:2713ms step_avg:35.24ms
+step:78/1575 train_time:2753ms step_avg:35.29ms
+step:79/1575 train_time:2783ms step_avg:35.23ms
+step:80/1575 train_time:2822ms step_avg:35.28ms
+step:81/1575 train_time:2853ms step_avg:35.23ms
+step:82/1575 train_time:2892ms step_avg:35.27ms
+step:83/1575 train_time:2924ms step_avg:35.22ms
+step:84/1575 train_time:2962ms step_avg:35.27ms
+step:85/1575 train_time:2993ms step_avg:35.22ms
+step:86/1575 train_time:3032ms step_avg:35.26ms
+step:87/1575 train_time:3063ms step_avg:35.21ms
+step:88/1575 train_time:3102ms step_avg:35.25ms
+step:89/1575 train_time:3133ms step_avg:35.20ms
+step:90/1575 train_time:3171ms step_avg:35.23ms
+step:91/1575 train_time:3202ms step_avg:35.19ms
+step:92/1575 train_time:3241ms step_avg:35.22ms
+step:93/1575 train_time:3271ms step_avg:35.18ms
+step:94/1575 train_time:3310ms step_avg:35.22ms
+step:95/1575 train_time:3341ms step_avg:35.17ms
+step:96/1575 train_time:3379ms step_avg:35.20ms
+step:97/1575 train_time:3411ms step_avg:35.16ms
+step:98/1575 train_time:3449ms step_avg:35.20ms
+step:99/1575 train_time:3480ms step_avg:35.15ms
+step:100/1575 train_time:3519ms step_avg:35.19ms
+step:101/1575 train_time:3550ms step_avg:35.15ms
+step:102/1575 train_time:3589ms step_avg:35.19ms
+step:103/1575 train_time:3620ms step_avg:35.14ms
+step:104/1575 train_time:3658ms step_avg:35.18ms
+step:105/1575 train_time:3689ms step_avg:35.14ms
+step:106/1575 train_time:3728ms step_avg:35.17ms
+step:107/1575 train_time:3759ms step_avg:35.13ms
+step:108/1575 train_time:3798ms step_avg:35.16ms
+step:109/1575 train_time:3829ms step_avg:35.13ms
+step:110/1575 train_time:3867ms step_avg:35.16ms
+step:111/1575 train_time:3898ms step_avg:35.12ms
+step:112/1575 train_time:3937ms step_avg:35.15ms
+step:113/1575 train_time:3967ms step_avg:35.11ms
+step:114/1575 train_time:4006ms step_avg:35.14ms
+step:115/1575 train_time:4037ms step_avg:35.10ms
+step:116/1575 train_time:4075ms step_avg:35.13ms
+step:117/1575 train_time:4106ms step_avg:35.10ms
+step:118/1575 train_time:4145ms step_avg:35.13ms
+step:119/1575 train_time:4176ms step_avg:35.09ms
+step:120/1575 train_time:4215ms step_avg:35.12ms
+step:121/1575 train_time:4246ms step_avg:35.09ms
+step:122/1575 train_time:4285ms step_avg:35.12ms
+step:123/1575 train_time:4316ms step_avg:35.09ms
+step:124/1575 train_time:4355ms step_avg:35.12ms
+step:125/1575 train_time:4385ms step_avg:35.08ms
+step:126/1575 train_time:4424ms step_avg:35.11ms
+step:127/1575 train_time:4456ms step_avg:35.08ms
+step:128/1575 train_time:4495ms step_avg:35.11ms
+step:129/1575 train_time:4526ms step_avg:35.08ms
+step:130/1575 train_time:4565ms step_avg:35.12ms
+step:131/1575 train_time:4596ms step_avg:35.08ms
+step:132/1575 train_time:4635ms step_avg:35.11ms
+step:133/1575 train_time:4666ms step_avg:35.08ms
+step:134/1575 train_time:4705ms step_avg:35.11ms
+step:135/1575 train_time:4737ms step_avg:35.09ms
+step:136/1575 train_time:4775ms step_avg:35.11ms
+step:137/1575 train_time:4806ms step_avg:35.08ms
+step:138/1575 train_time:4845ms step_avg:35.11ms
+step:139/1575 train_time:4876ms step_avg:35.08ms
+step:140/1575 train_time:4916ms step_avg:35.12ms
+step:141/1575 train_time:4945ms step_avg:35.07ms
+step:142/1575 train_time:4986ms step_avg:35.11ms
+step:143/1575 train_time:5015ms step_avg:35.07ms
+step:144/1575 train_time:5056ms step_avg:35.11ms
+step:145/1575 train_time:5085ms step_avg:35.07ms
+step:146/1575 train_time:5125ms step_avg:35.10ms
+step:147/1575 train_time:5154ms step_avg:35.06ms
+step:148/1575 train_time:5194ms step_avg:35.10ms
+step:149/1575 train_time:5224ms step_avg:35.06ms
+step:150/1575 train_time:5263ms step_avg:35.09ms
+step:151/1575 train_time:5294ms step_avg:35.06ms
+step:152/1575 train_time:5332ms step_avg:35.08ms
+step:153/1575 train_time:5363ms step_avg:35.05ms
+step:154/1575 train_time:5402ms step_avg:35.07ms
+step:155/1575 train_time:5432ms step_avg:35.05ms
+step:156/1575 train_time:5471ms step_avg:35.07ms
+step:157/1575 train_time:5502ms step_avg:35.04ms
+step:158/1575 train_time:5540ms step_avg:35.07ms
+step:159/1575 train_time:5571ms step_avg:35.04ms
+step:160/1575 train_time:5610ms step_avg:35.06ms
+step:161/1575 train_time:5641ms step_avg:35.04ms
+step:162/1575 train_time:5679ms step_avg:35.06ms
+step:163/1575 train_time:5710ms step_avg:35.03ms
+step:164/1575 train_time:5749ms step_avg:35.06ms
+step:165/1575 train_time:5780ms step_avg:35.03ms
+step:166/1575 train_time:5818ms step_avg:35.05ms
+step:167/1575 train_time:5850ms step_avg:35.03ms
+step:168/1575 train_time:5888ms step_avg:35.05ms
+step:169/1575 train_time:5919ms step_avg:35.02ms
+step:170/1575 train_time:5957ms step_avg:35.04ms
+step:171/1575 train_time:5988ms step_avg:35.02ms
+step:172/1575 train_time:6027ms step_avg:35.04ms
+step:173/1575 train_time:6058ms step_avg:35.02ms
+step:174/1575 train_time:6097ms step_avg:35.04ms
+step:175/1575 train_time:6128ms step_avg:35.02ms
+step:176/1575 train_time:6167ms step_avg:35.04ms
+step:177/1575 train_time:6198ms step_avg:35.02ms
+step:178/1575 train_time:6236ms step_avg:35.03ms
+step:179/1575 train_time:6267ms step_avg:35.01ms
+step:180/1575 train_time:6306ms step_avg:35.03ms
+step:181/1575 train_time:6337ms step_avg:35.01ms
+step:182/1575 train_time:6376ms step_avg:35.03ms
+step:183/1575 train_time:6406ms step_avg:35.01ms
+step:184/1575 train_time:6445ms step_avg:35.03ms
+step:185/1575 train_time:6476ms step_avg:35.00ms
+step:186/1575 train_time:6514ms step_avg:35.02ms
+step:187/1575 train_time:6545ms step_avg:35.00ms
+step:188/1575 train_time:6584ms step_avg:35.02ms
+step:189/1575 train_time:6615ms step_avg:35.00ms
+step:190/1575 train_time:6653ms step_avg:35.02ms
+step:191/1575 train_time:6684ms step_avg:34.99ms
+step:192/1575 train_time:6723ms step_avg:35.01ms
+step:193/1575 train_time:6754ms step_avg:34.99ms
+step:194/1575 train_time:6793ms step_avg:35.01ms
+step:195/1575 train_time:6823ms step_avg:34.99ms
+step:196/1575 train_time:6862ms step_avg:35.01ms
+step:197/1575 train_time:6893ms step_avg:34.99ms
+step:198/1575 train_time:6931ms step_avg:35.01ms
+step:199/1575 train_time:6962ms step_avg:34.98ms
+step:200/1575 train_time:7001ms step_avg:35.00ms
+step:201/1575 train_time:7032ms step_avg:34.99ms
+step:202/1575 train_time:7071ms step_avg:35.00ms
+step:203/1575 train_time:7102ms step_avg:34.98ms
+step:204/1575 train_time:7140ms step_avg:35.00ms
+step:205/1575 train_time:7171ms step_avg:34.98ms
+step:206/1575 train_time:7210ms step_avg:35.00ms
+step:207/1575 train_time:7241ms step_avg:34.98ms
+step:208/1575 train_time:7280ms step_avg:35.00ms
+step:209/1575 train_time:7311ms step_avg:34.98ms
+step:210/1575 train_time:7350ms step_avg:35.00ms
+step:211/1575 train_time:7381ms step_avg:34.98ms
+step:212/1575 train_time:7419ms step_avg:34.99ms
+step:213/1575 train_time:7450ms step_avg:34.98ms
+step:214/1575 train_time:7489ms step_avg:35.00ms
+step:215/1575 train_time:7520ms step_avg:34.98ms
+step:216/1575 train_time:7559ms step_avg:34.99ms
+step:217/1575 train_time:7589ms step_avg:34.97ms
+step:218/1575 train_time:7628ms step_avg:34.99ms
+step:219/1575 train_time:7659ms step_avg:34.97ms
+step:220/1575 train_time:7698ms step_avg:34.99ms
+step:221/1575 train_time:7729ms step_avg:34.97ms
+step:222/1575 train_time:7768ms step_avg:34.99ms
+step:223/1575 train_time:7799ms step_avg:34.97ms
+step:224/1575 train_time:7837ms step_avg:34.99ms
+step:225/1575 train_time:7868ms step_avg:34.97ms
+step:226/1575 train_time:7907ms step_avg:34.99ms
+step:227/1575 train_time:7938ms step_avg:34.97ms
+step:228/1575 train_time:7976ms step_avg:34.98ms
+step:229/1575 train_time:8007ms step_avg:34.97ms
+step:230/1575 train_time:8046ms step_avg:34.98ms
+step:231/1575 train_time:8077ms step_avg:34.97ms
+step:232/1575 train_time:8115ms step_avg:34.98ms
+step:233/1575 train_time:8146ms step_avg:34.96ms
+step:234/1575 train_time:8185ms step_avg:34.98ms
+step:235/1575 train_time:8215ms step_avg:34.96ms
+step:236/1575 train_time:8254ms step_avg:34.98ms
+step:237/1575 train_time:8285ms step_avg:34.96ms
+step:238/1575 train_time:8323ms step_avg:34.97ms
+step:239/1575 train_time:8354ms step_avg:34.95ms
+step:240/1575 train_time:8393ms step_avg:34.97ms
+step:241/1575 train_time:8424ms step_avg:34.95ms
+step:242/1575 train_time:8463ms step_avg:34.97ms
+step:243/1575 train_time:8494ms step_avg:34.95ms
+step:244/1575 train_time:8532ms step_avg:34.97ms
+step:245/1575 train_time:8563ms step_avg:34.95ms
+step:246/1575 train_time:8602ms step_avg:34.97ms
+step:247/1575 train_time:8632ms step_avg:34.95ms
+step:248/1575 train_time:8671ms step_avg:34.96ms
+step:249/1575 train_time:8702ms step_avg:34.95ms
+step:250/1575 train_time:8740ms step_avg:34.96ms
+step:250/1575 val_loss:4.5690 train_time:8789ms step_avg:35.16ms
+step:251/1575 train_time:8809ms step_avg:35.10ms
+step:252/1575 train_time:8830ms step_avg:35.04ms
+step:253/1575 train_time:8847ms step_avg:34.97ms
+step:254/1575 train_time:8884ms step_avg:34.98ms
+step:255/1575 train_time:8916ms step_avg:34.96ms
+step:256/1575 train_time:8956ms step_avg:34.98ms
+step:257/1575 train_time:8987ms step_avg:34.97ms
+step:258/1575 train_time:9027ms step_avg:34.99ms
+step:259/1575 train_time:9058ms step_avg:34.97ms
+step:260/1575 train_time:9097ms step_avg:34.99ms
+step:261/1575 train_time:9128ms step_avg:34.97ms
+step:262/1575 train_time:9167ms step_avg:34.99ms
+step:263/1575 train_time:9198ms step_avg:34.97ms
+step:264/1575 train_time:9240ms step_avg:35.00ms
+step:265/1575 train_time:9267ms step_avg:34.97ms
+step:266/1575 train_time:9307ms step_avg:34.99ms
+step:267/1575 train_time:9337ms step_avg:34.97ms
+step:268/1575 train_time:9376ms step_avg:34.98ms
+step:269/1575 train_time:9406ms step_avg:34.97ms
+step:270/1575 train_time:9445ms step_avg:34.98ms
+step:271/1575 train_time:9476ms step_avg:34.97ms
+step:272/1575 train_time:9514ms step_avg:34.98ms
+step:273/1575 train_time:9545ms step_avg:34.96ms
+step:274/1575 train_time:9583ms step_avg:34.98ms
+step:275/1575 train_time:9614ms step_avg:34.96ms
+step:276/1575 train_time:9653ms step_avg:34.97ms
+step:277/1575 train_time:9683ms step_avg:34.96ms
+step:278/1575 train_time:9722ms step_avg:34.97ms
+step:279/1575 train_time:9753ms step_avg:34.96ms
+step:280/1575 train_time:9792ms step_avg:34.97ms
+step:281/1575 train_time:9822ms step_avg:34.96ms
+step:282/1575 train_time:9861ms step_avg:34.97ms
+step:283/1575 train_time:9892ms step_avg:34.95ms
+step:284/1575 train_time:9930ms step_avg:34.97ms
+step:285/1575 train_time:9961ms step_avg:34.95ms
+step:286/1575 train_time:10000ms step_avg:34.97ms
+step:287/1575 train_time:10031ms step_avg:34.95ms
+step:288/1575 train_time:10069ms step_avg:34.96ms
+step:289/1575 train_time:10100ms step_avg:34.95ms
+step:290/1575 train_time:10139ms step_avg:34.96ms
+step:291/1575 train_time:10170ms step_avg:34.95ms
+step:292/1575 train_time:10209ms step_avg:34.96ms
+step:293/1575 train_time:10240ms step_avg:34.95ms
+step:294/1575 train_time:10279ms step_avg:34.96ms
+step:295/1575 train_time:10310ms step_avg:34.95ms
+step:296/1575 train_time:10348ms step_avg:34.96ms
+step:297/1575 train_time:10379ms step_avg:34.95ms
+step:298/1575 train_time:10418ms step_avg:34.96ms
+step:299/1575 train_time:10449ms step_avg:34.95ms
+step:300/1575 train_time:10489ms step_avg:34.96ms
+step:301/1575 train_time:10519ms step_avg:34.95ms
+step:302/1575 train_time:10558ms step_avg:34.96ms
+step:303/1575 train_time:10589ms step_avg:34.95ms
+step:304/1575 train_time:10628ms step_avg:34.96ms
+step:305/1575 train_time:10658ms step_avg:34.95ms
+step:306/1575 train_time:10698ms step_avg:34.96ms
+step:307/1575 train_time:10728ms step_avg:34.95ms
+step:308/1575 train_time:10767ms step_avg:34.96ms
+step:309/1575 train_time:10798ms step_avg:34.95ms
+step:310/1575 train_time:10837ms step_avg:34.96ms
+step:311/1575 train_time:10868ms step_avg:34.94ms
+step:312/1575 train_time:10907ms step_avg:34.96ms
+step:313/1575 train_time:10938ms step_avg:34.94ms
+step:314/1575 train_time:10976ms step_avg:34.96ms
+step:315/1575 train_time:11007ms step_avg:34.94ms
+step:316/1575 train_time:11046ms step_avg:34.95ms
+step:317/1575 train_time:11076ms step_avg:34.94ms
+step:318/1575 train_time:11115ms step_avg:34.95ms
+step:319/1575 train_time:11146ms step_avg:34.94ms
+step:320/1575 train_time:11184ms step_avg:34.95ms
+step:321/1575 train_time:11215ms step_avg:34.94ms
+step:322/1575 train_time:11254ms step_avg:34.95ms
+step:323/1575 train_time:11286ms step_avg:34.94ms
+step:324/1575 train_time:11324ms step_avg:34.95ms
+step:325/1575 train_time:11355ms step_avg:34.94ms
+step:326/1575 train_time:11393ms step_avg:34.95ms
+step:327/1575 train_time:11424ms step_avg:34.94ms
+step:328/1575 train_time:11463ms step_avg:34.95ms
+step:329/1575 train_time:11494ms step_avg:34.94ms
+step:330/1575 train_time:11532ms step_avg:34.95ms
+step:331/1575 train_time:11563ms step_avg:34.93ms
+step:332/1575 train_time:11602ms step_avg:34.94ms
+step:333/1575 train_time:11633ms step_avg:34.93ms
+step:334/1575 train_time:11671ms step_avg:34.94ms
+step:335/1575 train_time:11702ms step_avg:34.93ms
+step:336/1575 train_time:11740ms step_avg:34.94ms
+step:337/1575 train_time:11771ms step_avg:34.93ms
+step:338/1575 train_time:11809ms step_avg:34.94ms
+step:339/1575 train_time:11840ms step_avg:34.93ms
+step:340/1575 train_time:11879ms step_avg:34.94ms
+step:341/1575 train_time:11909ms step_avg:34.93ms
+step:342/1575 train_time:11949ms step_avg:34.94ms
+step:343/1575 train_time:11980ms step_avg:34.93ms
+step:344/1575 train_time:12019ms step_avg:34.94ms
+step:345/1575 train_time:12049ms step_avg:34.93ms
+step:346/1575 train_time:12088ms step_avg:34.94ms
+step:347/1575 train_time:12119ms step_avg:34.92ms
+step:348/1575 train_time:12157ms step_avg:34.94ms
+step:349/1575 train_time:12188ms step_avg:34.92ms
+step:350/1575 train_time:12227ms step_avg:34.93ms
+step:351/1575 train_time:12258ms step_avg:34.92ms
+step:352/1575 train_time:12296ms step_avg:34.93ms
+step:353/1575 train_time:12327ms step_avg:34.92ms
+step:354/1575 train_time:12366ms step_avg:34.93ms
+step:355/1575 train_time:12397ms step_avg:34.92ms
+step:356/1575 train_time:12436ms step_avg:34.93ms
+step:357/1575 train_time:12466ms step_avg:34.92ms
+step:358/1575 train_time:12505ms step_avg:34.93ms
+step:359/1575 train_time:12535ms step_avg:34.92ms
+step:360/1575 train_time:12574ms step_avg:34.93ms
+step:361/1575 train_time:12605ms step_avg:34.92ms
+step:362/1575 train_time:12643ms step_avg:34.93ms
+step:363/1575 train_time:12674ms step_avg:34.91ms
+step:364/1575 train_time:12713ms step_avg:34.93ms
+step:365/1575 train_time:12744ms step_avg:34.91ms
+step:366/1575 train_time:12782ms step_avg:34.92ms
+step:367/1575 train_time:12813ms step_avg:34.91ms
+step:368/1575 train_time:12851ms step_avg:34.92ms
+step:369/1575 train_time:12882ms step_avg:34.91ms
+step:370/1575 train_time:12921ms step_avg:34.92ms
+step:371/1575 train_time:12951ms step_avg:34.91ms
+step:372/1575 train_time:12990ms step_avg:34.92ms
+step:373/1575 train_time:13021ms step_avg:34.91ms
+step:374/1575 train_time:13059ms step_avg:34.92ms
+step:375/1575 train_time:13090ms step_avg:34.91ms
+step:376/1575 train_time:13129ms step_avg:34.92ms
+step:377/1575 train_time:13160ms step_avg:34.91ms
+step:378/1575 train_time:13198ms step_avg:34.92ms
+step:379/1575 train_time:13229ms step_avg:34.91ms
+step:380/1575 train_time:13268ms step_avg:34.92ms
+step:381/1575 train_time:13299ms step_avg:34.90ms
+step:382/1575 train_time:13337ms step_avg:34.91ms
+step:383/1575 train_time:13368ms step_avg:34.90ms
+step:384/1575 train_time:13406ms step_avg:34.91ms
+step:385/1575 train_time:13437ms step_avg:34.90ms
+step:386/1575 train_time:13476ms step_avg:34.91ms
+step:387/1575 train_time:13507ms step_avg:34.90ms
+step:388/1575 train_time:13545ms step_avg:34.91ms
+step:389/1575 train_time:13576ms step_avg:34.90ms
+step:390/1575 train_time:13615ms step_avg:34.91ms
+step:391/1575 train_time:13646ms step_avg:34.90ms
+step:392/1575 train_time:13684ms step_avg:34.91ms
+step:393/1575 train_time:13715ms step_avg:34.90ms
+step:394/1575 train_time:13753ms step_avg:34.91ms
+step:395/1575 train_time:13784ms step_avg:34.90ms
+step:396/1575 train_time:13823ms step_avg:34.91ms
+step:397/1575 train_time:13854ms step_avg:34.90ms
+step:398/1575 train_time:13892ms step_avg:34.90ms
+step:399/1575 train_time:13923ms step_avg:34.89ms
+step:400/1575 train_time:13962ms step_avg:34.90ms
+step:401/1575 train_time:13993ms step_avg:34.89ms
+step:402/1575 train_time:14031ms step_avg:34.90ms
+step:403/1575 train_time:14062ms step_avg:34.89ms
+step:404/1575 train_time:14101ms step_avg:34.90ms
+step:405/1575 train_time:14131ms step_avg:34.89ms
+step:406/1575 train_time:14170ms step_avg:34.90ms
+step:407/1575 train_time:14202ms step_avg:34.89ms
+step:408/1575 train_time:14240ms step_avg:34.90ms
+step:409/1575 train_time:14270ms step_avg:34.89ms
+step:410/1575 train_time:14309ms step_avg:34.90ms
+step:411/1575 train_time:14340ms step_avg:34.89ms
+step:412/1575 train_time:14379ms step_avg:34.90ms
+step:413/1575 train_time:14409ms step_avg:34.89ms
+step:414/1575 train_time:14448ms step_avg:34.90ms
+step:415/1575 train_time:14479ms step_avg:34.89ms
+step:416/1575 train_time:14518ms step_avg:34.90ms
+step:417/1575 train_time:14548ms step_avg:34.89ms
+step:418/1575 train_time:14587ms step_avg:34.90ms
+step:419/1575 train_time:14618ms step_avg:34.89ms
+step:420/1575 train_time:14657ms step_avg:34.90ms
+step:421/1575 train_time:14688ms step_avg:34.89ms
+step:422/1575 train_time:14727ms step_avg:34.90ms
+step:423/1575 train_time:14757ms step_avg:34.89ms
+step:424/1575 train_time:14796ms step_avg:34.90ms
+step:425/1575 train_time:14827ms step_avg:34.89ms
+step:426/1575 train_time:14865ms step_avg:34.89ms
+step:427/1575 train_time:14896ms step_avg:34.89ms
+step:428/1575 train_time:14935ms step_avg:34.90ms
+step:429/1575 train_time:14966ms step_avg:34.89ms
+step:430/1575 train_time:15005ms step_avg:34.89ms
+step:431/1575 train_time:15036ms step_avg:34.89ms
+step:432/1575 train_time:15074ms step_avg:34.89ms
+step:433/1575 train_time:15105ms step_avg:34.88ms
+step:434/1575 train_time:15143ms step_avg:34.89ms
+step:435/1575 train_time:15174ms step_avg:34.88ms
+step:436/1575 train_time:15213ms step_avg:34.89ms
+step:437/1575 train_time:15244ms step_avg:34.88ms
+step:438/1575 train_time:15282ms step_avg:34.89ms
+step:439/1575 train_time:15314ms step_avg:34.88ms
+step:440/1575 train_time:15352ms step_avg:34.89ms
+step:441/1575 train_time:15383ms step_avg:34.88ms
+step:442/1575 train_time:15422ms step_avg:34.89ms
+step:443/1575 train_time:15452ms step_avg:34.88ms
+step:444/1575 train_time:15491ms step_avg:34.89ms
+step:445/1575 train_time:15522ms step_avg:34.88ms
+step:446/1575 train_time:15560ms step_avg:34.89ms
+step:447/1575 train_time:15591ms step_avg:34.88ms
+step:448/1575 train_time:15630ms step_avg:34.89ms
+step:449/1575 train_time:15660ms step_avg:34.88ms
+step:450/1575 train_time:15699ms step_avg:34.89ms
+step:451/1575 train_time:15730ms step_avg:34.88ms
+step:452/1575 train_time:15769ms step_avg:34.89ms
+step:453/1575 train_time:15800ms step_avg:34.88ms
+step:454/1575 train_time:15838ms step_avg:34.89ms
+step:455/1575 train_time:15869ms step_avg:34.88ms
+step:456/1575 train_time:15908ms step_avg:34.89ms
+step:457/1575 train_time:15939ms step_avg:34.88ms
+step:458/1575 train_time:15977ms step_avg:34.89ms
+step:459/1575 train_time:16008ms step_avg:34.88ms
+step:460/1575 train_time:16047ms step_avg:34.89ms
+step:461/1575 train_time:16078ms step_avg:34.88ms
+step:462/1575 train_time:16117ms step_avg:34.88ms
+step:463/1575 train_time:16147ms step_avg:34.88ms
+step:464/1575 train_time:16186ms step_avg:34.88ms
+step:465/1575 train_time:16217ms step_avg:34.88ms
+step:466/1575 train_time:16256ms step_avg:34.88ms
+step:467/1575 train_time:16287ms step_avg:34.88ms
+step:468/1575 train_time:16325ms step_avg:34.88ms
+step:469/1575 train_time:16357ms step_avg:34.88ms
+step:470/1575 train_time:16395ms step_avg:34.88ms
+step:471/1575 train_time:16426ms step_avg:34.88ms
+step:472/1575 train_time:16465ms step_avg:34.88ms
+step:473/1575 train_time:16496ms step_avg:34.87ms
+step:474/1575 train_time:16535ms step_avg:34.88ms
+step:475/1575 train_time:16566ms step_avg:34.88ms
+step:476/1575 train_time:16604ms step_avg:34.88ms
+step:477/1575 train_time:16635ms step_avg:34.87ms
+step:478/1575 train_time:16673ms step_avg:34.88ms
+step:479/1575 train_time:16704ms step_avg:34.87ms
+step:480/1575 train_time:16743ms step_avg:34.88ms
+step:481/1575 train_time:16773ms step_avg:34.87ms
+step:482/1575 train_time:16812ms step_avg:34.88ms
+step:483/1575 train_time:16842ms step_avg:34.87ms
+step:484/1575 train_time:16881ms step_avg:34.88ms
+step:485/1575 train_time:16911ms step_avg:34.87ms
+step:486/1575 train_time:16950ms step_avg:34.88ms
+step:487/1575 train_time:16981ms step_avg:34.87ms
+step:488/1575 train_time:17020ms step_avg:34.88ms
+step:489/1575 train_time:17050ms step_avg:34.87ms
+step:490/1575 train_time:17089ms step_avg:34.87ms
+step:491/1575 train_time:17120ms step_avg:34.87ms
+step:492/1575 train_time:17158ms step_avg:34.87ms
+step:493/1575 train_time:17189ms step_avg:34.87ms
+step:494/1575 train_time:17228ms step_avg:34.87ms
+step:495/1575 train_time:17259ms step_avg:34.87ms
+step:496/1575 train_time:17298ms step_avg:34.87ms
+step:497/1575 train_time:17328ms step_avg:34.87ms
+step:498/1575 train_time:17367ms step_avg:34.87ms
+step:499/1575 train_time:17398ms step_avg:34.87ms
+step:500/1575 train_time:17437ms step_avg:34.87ms
+step:500/1575 val_loss:4.2346 train_time:17485ms step_avg:34.97ms
+step:501/1575 train_time:17505ms step_avg:34.94ms
+step:502/1575 train_time:17525ms step_avg:34.91ms
+step:503/1575 train_time:17543ms step_avg:34.88ms
+step:504/1575 train_time:17580ms step_avg:34.88ms
+step:505/1575 train_time:17610ms step_avg:34.87ms
+step:506/1575 train_time:17650ms step_avg:34.88ms
+step:507/1575 train_time:17681ms step_avg:34.87ms
+step:508/1575 train_time:17720ms step_avg:34.88ms
+step:509/1575 train_time:17751ms step_avg:34.87ms
+step:510/1575 train_time:17790ms step_avg:34.88ms
+step:511/1575 train_time:17821ms step_avg:34.87ms
+step:512/1575 train_time:17859ms step_avg:34.88ms
+step:513/1575 train_time:17938ms step_avg:34.97ms
+step:514/1575 train_time:17989ms step_avg:35.00ms
+step:515/1575 train_time:18052ms step_avg:35.05ms
+step:516/1575 train_time:18110ms step_avg:35.10ms
+step:517/1575 train_time:18173ms step_avg:35.15ms
+step:518/1575 train_time:18231ms step_avg:35.20ms
+step:519/1575 train_time:18293ms step_avg:35.25ms
+step:520/1575 train_time:18352ms step_avg:35.29ms
+step:521/1575 train_time:18415ms step_avg:35.35ms
+step:522/1575 train_time:18477ms step_avg:35.40ms
+step:523/1575 train_time:18543ms step_avg:35.45ms
+step:524/1575 train_time:18604ms step_avg:35.50ms
+step:525/1575 train_time:18668ms step_avg:35.56ms
+step:526/1575 train_time:18727ms step_avg:35.60ms
+step:527/1575 train_time:18791ms step_avg:35.66ms
+step:528/1575 train_time:18851ms step_avg:35.70ms
+step:529/1575 train_time:18914ms step_avg:35.75ms
+step:530/1575 train_time:18973ms step_avg:35.80ms
+step:531/1575 train_time:19037ms step_avg:35.85ms
+step:532/1575 train_time:19097ms step_avg:35.90ms
+step:533/1575 train_time:19160ms step_avg:35.95ms
+step:534/1575 train_time:19219ms step_avg:35.99ms
+step:535/1575 train_time:19283ms step_avg:36.04ms
+step:536/1575 train_time:19342ms step_avg:36.09ms
+step:537/1575 train_time:19406ms step_avg:36.14ms
+step:538/1575 train_time:19466ms step_avg:36.18ms
+step:539/1575 train_time:19529ms step_avg:36.23ms
+step:540/1575 train_time:19589ms step_avg:36.28ms
+step:541/1575 train_time:19652ms step_avg:36.33ms
+step:542/1575 train_time:19712ms step_avg:36.37ms
+step:543/1575 train_time:19776ms step_avg:36.42ms
+step:544/1575 train_time:19837ms step_avg:36.47ms
+step:545/1575 train_time:19900ms step_avg:36.51ms
+step:546/1575 train_time:19959ms step_avg:36.56ms
+step:547/1575 train_time:20023ms step_avg:36.61ms
+step:548/1575 train_time:20083ms step_avg:36.65ms
+step:549/1575 train_time:20147ms step_avg:36.70ms
+step:550/1575 train_time:20206ms step_avg:36.74ms
+step:551/1575 train_time:20269ms step_avg:36.78ms
+step:552/1575 train_time:20327ms step_avg:36.83ms
+step:553/1575 train_time:20391ms step_avg:36.87ms
+step:554/1575 train_time:20450ms step_avg:36.91ms
+step:555/1575 train_time:20513ms step_avg:36.96ms
+step:556/1575 train_time:20573ms step_avg:37.00ms
+step:557/1575 train_time:20636ms step_avg:37.05ms
+step:558/1575 train_time:20695ms step_avg:37.09ms
+step:559/1575 train_time:20760ms step_avg:37.14ms
+step:560/1575 train_time:20819ms step_avg:37.18ms
+step:561/1575 train_time:20883ms step_avg:37.22ms
+step:562/1575 train_time:20942ms step_avg:37.26ms
+step:563/1575 train_time:21006ms step_avg:37.31ms
+step:564/1575 train_time:21065ms step_avg:37.35ms
+step:565/1575 train_time:21128ms step_avg:37.39ms
+step:566/1575 train_time:21188ms step_avg:37.43ms
+step:567/1575 train_time:21250ms step_avg:37.48ms
+step:568/1575 train_time:21309ms step_avg:37.52ms
+step:569/1575 train_time:21377ms step_avg:37.57ms
+step:570/1575 train_time:21435ms step_avg:37.60ms
+step:571/1575 train_time:21497ms step_avg:37.65ms
+step:572/1575 train_time:21556ms step_avg:37.69ms
+step:573/1575 train_time:21619ms step_avg:37.73ms
+step:574/1575 train_time:21677ms step_avg:37.77ms
+step:575/1575 train_time:21742ms step_avg:37.81ms
+step:576/1575 train_time:21801ms step_avg:37.85ms
+step:577/1575 train_time:21864ms step_avg:37.89ms
+step:578/1575 train_time:21923ms step_avg:37.93ms
+step:579/1575 train_time:21987ms step_avg:37.97ms
+step:580/1575 train_time:22046ms step_avg:38.01ms
+step:581/1575 train_time:22109ms step_avg:38.05ms
+step:582/1575 train_time:22169ms step_avg:38.09ms
+step:583/1575 train_time:22232ms step_avg:38.13ms
+step:584/1575 train_time:22290ms step_avg:38.17ms
+step:585/1575 train_time:22353ms step_avg:38.21ms
+step:586/1575 train_time:22413ms step_avg:38.25ms
+step:587/1575 train_time:22476ms step_avg:38.29ms
+step:588/1575 train_time:22535ms step_avg:38.33ms
+step:589/1575 train_time:22599ms step_avg:38.37ms
+step:590/1575 train_time:22658ms step_avg:38.40ms
+step:591/1575 train_time:22722ms step_avg:38.45ms
+step:592/1575 train_time:22781ms step_avg:38.48ms
+step:593/1575 train_time:22844ms step_avg:38.52ms
+step:594/1575 train_time:22904ms step_avg:38.56ms
+step:595/1575 train_time:22967ms step_avg:38.60ms
+step:596/1575 train_time:23027ms step_avg:38.64ms
+step:597/1575 train_time:23091ms step_avg:38.68ms
+step:598/1575 train_time:23149ms step_avg:38.71ms
+step:599/1575 train_time:23212ms step_avg:38.75ms
+step:600/1575 train_time:23271ms step_avg:38.79ms
+step:601/1575 train_time:23334ms step_avg:38.83ms
+step:602/1575 train_time:23395ms step_avg:38.86ms
+step:603/1575 train_time:23458ms step_avg:38.90ms
+step:604/1575 train_time:23516ms step_avg:38.93ms
+step:605/1575 train_time:23579ms step_avg:38.97ms
+step:606/1575 train_time:23639ms step_avg:39.01ms
+step:607/1575 train_time:23702ms step_avg:39.05ms
+step:608/1575 train_time:23761ms step_avg:39.08ms
+step:609/1575 train_time:23826ms step_avg:39.12ms
+step:610/1575 train_time:23885ms step_avg:39.16ms
+step:611/1575 train_time:23949ms step_avg:39.20ms
+step:612/1575 train_time:24008ms step_avg:39.23ms
+step:613/1575 train_time:24071ms step_avg:39.27ms
+step:614/1575 train_time:24130ms step_avg:39.30ms
+step:615/1575 train_time:24193ms step_avg:39.34ms
+step:616/1575 train_time:24253ms step_avg:39.37ms
+step:617/1575 train_time:24316ms step_avg:39.41ms
+step:618/1575 train_time:24375ms step_avg:39.44ms
+step:619/1575 train_time:24438ms step_avg:39.48ms
+step:620/1575 train_time:24497ms step_avg:39.51ms
+step:621/1575 train_time:24560ms step_avg:39.55ms
+step:622/1575 train_time:24620ms step_avg:39.58ms
+step:623/1575 train_time:24683ms step_avg:39.62ms
+step:624/1575 train_time:24743ms step_avg:39.65ms
+step:625/1575 train_time:24807ms step_avg:39.69ms
+step:626/1575 train_time:24866ms step_avg:39.72ms
+step:627/1575 train_time:24930ms step_avg:39.76ms
+step:628/1575 train_time:24989ms step_avg:39.79ms
+step:629/1575 train_time:25053ms step_avg:39.83ms
+step:630/1575 train_time:25112ms step_avg:39.86ms
+step:631/1575 train_time:25174ms step_avg:39.90ms
+step:632/1575 train_time:25234ms step_avg:39.93ms
+step:633/1575 train_time:25297ms step_avg:39.96ms
+step:634/1575 train_time:25356ms step_avg:39.99ms
+step:635/1575 train_time:25419ms step_avg:40.03ms
+step:636/1575 train_time:25479ms step_avg:40.06ms
+step:637/1575 train_time:25541ms step_avg:40.10ms
+step:638/1575 train_time:25602ms step_avg:40.13ms
+step:639/1575 train_time:25664ms step_avg:40.16ms
+step:640/1575 train_time:25723ms step_avg:40.19ms
+step:641/1575 train_time:25787ms step_avg:40.23ms
+step:642/1575 train_time:25847ms step_avg:40.26ms
+step:643/1575 train_time:25910ms step_avg:40.30ms
+step:644/1575 train_time:25969ms step_avg:40.33ms
+step:645/1575 train_time:26033ms step_avg:40.36ms
+step:646/1575 train_time:26093ms step_avg:40.39ms
+step:647/1575 train_time:26155ms step_avg:40.43ms
+step:648/1575 train_time:26214ms step_avg:40.45ms
+step:649/1575 train_time:26277ms step_avg:40.49ms
+step:650/1575 train_time:26337ms step_avg:40.52ms
+step:651/1575 train_time:26399ms step_avg:40.55ms
+step:652/1575 train_time:26458ms step_avg:40.58ms
+step:653/1575 train_time:26522ms step_avg:40.62ms
+step:654/1575 train_time:26581ms step_avg:40.64ms
+step:655/1575 train_time:26644ms step_avg:40.68ms
+step:656/1575 train_time:26704ms step_avg:40.71ms
+step:657/1575 train_time:26767ms step_avg:40.74ms
+step:658/1575 train_time:26827ms step_avg:40.77ms
+step:659/1575 train_time:26891ms step_avg:40.81ms
+step:660/1575 train_time:26950ms step_avg:40.83ms
+step:661/1575 train_time:27013ms step_avg:40.87ms
+step:662/1575 train_time:27072ms step_avg:40.89ms
+step:663/1575 train_time:27135ms step_avg:40.93ms
+step:664/1575 train_time:27195ms step_avg:40.96ms
+step:665/1575 train_time:27258ms step_avg:40.99ms
+step:666/1575 train_time:27317ms step_avg:41.02ms
+step:667/1575 train_time:27380ms step_avg:41.05ms
+step:668/1575 train_time:27439ms step_avg:41.08ms
+step:669/1575 train_time:27503ms step_avg:41.11ms
+step:670/1575 train_time:27562ms step_avg:41.14ms
+step:671/1575 train_time:27625ms step_avg:41.17ms
+step:672/1575 train_time:27687ms step_avg:41.20ms
+step:673/1575 train_time:27749ms step_avg:41.23ms
+step:674/1575 train_time:27811ms step_avg:41.26ms
+step:675/1575 train_time:27873ms step_avg:41.29ms
+step:676/1575 train_time:27932ms step_avg:41.32ms
+step:677/1575 train_time:27994ms step_avg:41.35ms
+step:678/1575 train_time:28055ms step_avg:41.38ms
+step:679/1575 train_time:28117ms step_avg:41.41ms
+step:680/1575 train_time:28176ms step_avg:41.43ms
+step:681/1575 train_time:28239ms step_avg:41.47ms
+step:682/1575 train_time:28298ms step_avg:41.49ms
+step:683/1575 train_time:28361ms step_avg:41.52ms
+step:684/1575 train_time:28420ms step_avg:41.55ms
+step:685/1575 train_time:28484ms step_avg:41.58ms
+step:686/1575 train_time:28544ms step_avg:41.61ms
+step:687/1575 train_time:28608ms step_avg:41.64ms
+step:688/1575 train_time:28667ms step_avg:41.67ms
+step:689/1575 train_time:28730ms step_avg:41.70ms
+step:690/1575 train_time:28789ms step_avg:41.72ms
+step:691/1575 train_time:28853ms step_avg:41.76ms
+step:692/1575 train_time:28913ms step_avg:41.78ms
+step:693/1575 train_time:28975ms step_avg:41.81ms
+step:694/1575 train_time:29034ms step_avg:41.84ms
+step:695/1575 train_time:29099ms step_avg:41.87ms
+step:696/1575 train_time:29157ms step_avg:41.89ms
+step:697/1575 train_time:29220ms step_avg:41.92ms
+step:698/1575 train_time:29279ms step_avg:41.95ms
+step:699/1575 train_time:29343ms step_avg:41.98ms
+step:700/1575 train_time:29402ms step_avg:42.00ms
+step:701/1575 train_time:29465ms step_avg:42.03ms
+step:702/1575 train_time:29524ms step_avg:42.06ms
+step:703/1575 train_time:29588ms step_avg:42.09ms
+step:704/1575 train_time:29648ms step_avg:42.11ms
+step:705/1575 train_time:29711ms step_avg:42.14ms
+step:706/1575 train_time:29771ms step_avg:42.17ms
+step:707/1575 train_time:29834ms step_avg:42.20ms
+step:708/1575 train_time:29893ms step_avg:42.22ms
+step:709/1575 train_time:29956ms step_avg:42.25ms
+step:710/1575 train_time:30015ms step_avg:42.28ms
+step:711/1575 train_time:30079ms step_avg:42.30ms
+step:712/1575 train_time:30138ms step_avg:42.33ms
+step:713/1575 train_time:30201ms step_avg:42.36ms
+step:714/1575 train_time:30261ms step_avg:42.38ms
+step:715/1575 train_time:30324ms step_avg:42.41ms
+step:716/1575 train_time:30382ms step_avg:42.43ms
+step:717/1575 train_time:30446ms step_avg:42.46ms
+step:718/1575 train_time:30505ms step_avg:42.49ms
+step:719/1575 train_time:30569ms step_avg:42.52ms
+step:720/1575 train_time:30628ms step_avg:42.54ms
+step:721/1575 train_time:30691ms step_avg:42.57ms
+step:722/1575 train_time:30750ms step_avg:42.59ms
+step:723/1575 train_time:30814ms step_avg:42.62ms
+step:724/1575 train_time:30873ms step_avg:42.64ms
+step:725/1575 train_time:30936ms step_avg:42.67ms
+step:726/1575 train_time:30995ms step_avg:42.69ms
+step:727/1575 train_time:31059ms step_avg:42.72ms
+step:728/1575 train_time:31118ms step_avg:42.74ms
+step:729/1575 train_time:31181ms step_avg:42.77ms
+step:730/1575 train_time:31241ms step_avg:42.80ms
+step:731/1575 train_time:31304ms step_avg:42.82ms
+step:732/1575 train_time:31363ms step_avg:42.85ms
+step:733/1575 train_time:31428ms step_avg:42.88ms
+step:734/1575 train_time:31487ms step_avg:42.90ms
+step:735/1575 train_time:31550ms step_avg:42.93ms
+step:736/1575 train_time:31611ms step_avg:42.95ms
+step:737/1575 train_time:31673ms step_avg:42.98ms
+step:738/1575 train_time:31732ms step_avg:43.00ms
+step:739/1575 train_time:31795ms step_avg:43.03ms
+step:740/1575 train_time:31854ms step_avg:43.05ms
+step:741/1575 train_time:31918ms step_avg:43.07ms
+step:742/1575 train_time:31976ms step_avg:43.10ms
+step:743/1575 train_time:32040ms step_avg:43.12ms
+step:744/1575 train_time:32099ms step_avg:43.14ms
+step:745/1575 train_time:32162ms step_avg:43.17ms
+step:746/1575 train_time:32221ms step_avg:43.19ms
+step:747/1575 train_time:32285ms step_avg:43.22ms
+step:748/1575 train_time:32344ms step_avg:43.24ms
+step:749/1575 train_time:32408ms step_avg:43.27ms
+step:750/1575 train_time:32468ms step_avg:43.29ms
+step:750/1575 val_loss:3.8832 train_time:32513ms step_avg:43.35ms
+step:751/1575 train_time:32534ms step_avg:43.32ms
+step:752/1575 train_time:32594ms step_avg:43.34ms
+step:753/1575 train_time:32660ms step_avg:43.37ms
+step:754/1575 train_time:32721ms step_avg:43.40ms
+step:755/1575 train_time:32783ms step_avg:43.42ms
+step:756/1575 train_time:32842ms step_avg:43.44ms
+step:757/1575 train_time:32905ms step_avg:43.47ms
+step:758/1575 train_time:32964ms step_avg:43.49ms
+step:759/1575 train_time:33027ms step_avg:43.51ms
+step:760/1575 train_time:33086ms step_avg:43.53ms
+step:761/1575 train_time:33149ms step_avg:43.56ms
+step:762/1575 train_time:33208ms step_avg:43.58ms
+step:763/1575 train_time:33271ms step_avg:43.61ms
+step:764/1575 train_time:33330ms step_avg:43.63ms
+step:765/1575 train_time:33393ms step_avg:43.65ms
+step:766/1575 train_time:33452ms step_avg:43.67ms
+step:767/1575 train_time:33517ms step_avg:43.70ms
+step:768/1575 train_time:33578ms step_avg:43.72ms
+step:769/1575 train_time:33642ms step_avg:43.75ms
+step:770/1575 train_time:33703ms step_avg:43.77ms
+step:771/1575 train_time:33767ms step_avg:43.80ms
+step:772/1575 train_time:33826ms step_avg:43.82ms
+step:773/1575 train_time:33889ms step_avg:43.84ms
+step:774/1575 train_time:33949ms step_avg:43.86ms
+step:775/1575 train_time:34012ms step_avg:43.89ms
+step:776/1575 train_time:34072ms step_avg:43.91ms
+step:777/1575 train_time:34135ms step_avg:43.93ms
+step:778/1575 train_time:34196ms step_avg:43.95ms
+step:779/1575 train_time:34258ms step_avg:43.98ms
+step:780/1575 train_time:34316ms step_avg:43.99ms
+step:781/1575 train_time:34379ms step_avg:44.02ms
+step:782/1575 train_time:34438ms step_avg:44.04ms
+step:783/1575 train_time:34501ms step_avg:44.06ms
+step:784/1575 train_time:34561ms step_avg:44.08ms
+step:785/1575 train_time:34626ms step_avg:44.11ms
+step:786/1575 train_time:34686ms step_avg:44.13ms
+step:787/1575 train_time:34750ms step_avg:44.15ms
+step:788/1575 train_time:34809ms step_avg:44.17ms
+step:789/1575 train_time:34873ms step_avg:44.20ms
+step:790/1575 train_time:34933ms step_avg:44.22ms
+step:791/1575 train_time:34996ms step_avg:44.24ms
+step:792/1575 train_time:35055ms step_avg:44.26ms
+step:793/1575 train_time:35118ms step_avg:44.28ms
+step:794/1575 train_time:35177ms step_avg:44.30ms
+step:795/1575 train_time:35240ms step_avg:44.33ms
+step:796/1575 train_time:35299ms step_avg:44.34ms
+step:797/1575 train_time:35361ms step_avg:44.37ms
+step:798/1575 train_time:35420ms step_avg:44.39ms
+step:799/1575 train_time:35484ms step_avg:44.41ms
+step:800/1575 train_time:35543ms step_avg:44.43ms
+step:801/1575 train_time:35607ms step_avg:44.45ms
+step:802/1575 train_time:35667ms step_avg:44.47ms
+step:803/1575 train_time:35731ms step_avg:44.50ms
+step:804/1575 train_time:35791ms step_avg:44.52ms
+step:805/1575 train_time:35854ms step_avg:44.54ms
+step:806/1575 train_time:35914ms step_avg:44.56ms
+step:807/1575 train_time:35978ms step_avg:44.58ms
+step:808/1575 train_time:36037ms step_avg:44.60ms
+step:809/1575 train_time:36100ms step_avg:44.62ms
+step:810/1575 train_time:36159ms step_avg:44.64ms
+step:811/1575 train_time:36221ms step_avg:44.66ms
+step:812/1575 train_time:36281ms step_avg:44.68ms
+step:813/1575 train_time:36343ms step_avg:44.70ms
+step:814/1575 train_time:36403ms step_avg:44.72ms
+step:815/1575 train_time:36466ms step_avg:44.74ms
+step:816/1575 train_time:36526ms step_avg:44.76ms
+step:817/1575 train_time:36590ms step_avg:44.79ms
+step:818/1575 train_time:36650ms step_avg:44.80ms
+step:819/1575 train_time:36713ms step_avg:44.83ms
+step:820/1575 train_time:36773ms step_avg:44.85ms
+step:821/1575 train_time:36837ms step_avg:44.87ms
+step:822/1575 train_time:36897ms step_avg:44.89ms
+step:823/1575 train_time:36960ms step_avg:44.91ms
+step:824/1575 train_time:37019ms step_avg:44.93ms
+step:825/1575 train_time:37082ms step_avg:44.95ms
+step:826/1575 train_time:37141ms step_avg:44.96ms
+step:827/1575 train_time:37206ms step_avg:44.99ms
+step:828/1575 train_time:37265ms step_avg:45.01ms
+step:829/1575 train_time:37327ms step_avg:45.03ms
+step:830/1575 train_time:37387ms step_avg:45.04ms
+step:831/1575 train_time:37451ms step_avg:45.07ms
+step:832/1575 train_time:37512ms step_avg:45.09ms
+step:833/1575 train_time:37575ms step_avg:45.11ms
+step:834/1575 train_time:37633ms step_avg:45.12ms
+step:835/1575 train_time:37696ms step_avg:45.15ms
+step:836/1575 train_time:37756ms step_avg:45.16ms
+step:837/1575 train_time:37819ms step_avg:45.18ms
+step:838/1575 train_time:37879ms step_avg:45.20ms
+step:839/1575 train_time:37942ms step_avg:45.22ms
+step:840/1575 train_time:38005ms step_avg:45.24ms
+step:841/1575 train_time:38066ms step_avg:45.26ms
+step:842/1575 train_time:38125ms step_avg:45.28ms
+step:843/1575 train_time:38188ms step_avg:45.30ms
+step:844/1575 train_time:38249ms step_avg:45.32ms
+step:845/1575 train_time:38311ms step_avg:45.34ms
+step:846/1575 train_time:38370ms step_avg:45.35ms
+step:847/1575 train_time:38433ms step_avg:45.38ms
+step:848/1575 train_time:38492ms step_avg:45.39ms
+step:849/1575 train_time:38555ms step_avg:45.41ms
+step:850/1575 train_time:38614ms step_avg:45.43ms
+step:851/1575 train_time:38678ms step_avg:45.45ms
+step:852/1575 train_time:38738ms step_avg:45.47ms
+step:853/1575 train_time:38802ms step_avg:45.49ms
+step:854/1575 train_time:38862ms step_avg:45.51ms
+step:855/1575 train_time:38925ms step_avg:45.53ms
+step:856/1575 train_time:38985ms step_avg:45.54ms
+step:857/1575 train_time:39048ms step_avg:45.56ms
+step:858/1575 train_time:39107ms step_avg:45.58ms
+step:859/1575 train_time:39170ms step_avg:45.60ms
+step:860/1575 train_time:39230ms step_avg:45.62ms
+step:861/1575 train_time:39294ms step_avg:45.64ms
+step:862/1575 train_time:39353ms step_avg:45.65ms
+step:863/1575 train_time:39416ms step_avg:45.67ms
+step:864/1575 train_time:39476ms step_avg:45.69ms
+step:865/1575 train_time:39539ms step_avg:45.71ms
+step:866/1575 train_time:39598ms step_avg:45.73ms
+step:867/1575 train_time:39662ms step_avg:45.75ms
+step:868/1575 train_time:39722ms step_avg:45.76ms
+step:869/1575 train_time:39786ms step_avg:45.78ms
+step:870/1575 train_time:39845ms step_avg:45.80ms
+step:871/1575 train_time:39909ms step_avg:45.82ms
+step:872/1575 train_time:39968ms step_avg:45.83ms
+step:873/1575 train_time:40033ms step_avg:45.86ms
+step:874/1575 train_time:40092ms step_avg:45.87ms
+step:875/1575 train_time:40156ms step_avg:45.89ms
+step:876/1575 train_time:40215ms step_avg:45.91ms
+step:877/1575 train_time:40278ms step_avg:45.93ms
+step:878/1575 train_time:40337ms step_avg:45.94ms
+step:879/1575 train_time:40400ms step_avg:45.96ms
+step:880/1575 train_time:40460ms step_avg:45.98ms
+step:881/1575 train_time:40523ms step_avg:46.00ms
+step:882/1575 train_time:40582ms step_avg:46.01ms
+step:883/1575 train_time:40645ms step_avg:46.03ms
+step:884/1575 train_time:40704ms step_avg:46.05ms
+step:885/1575 train_time:40768ms step_avg:46.07ms
+step:886/1575 train_time:40832ms step_avg:46.09ms
+step:887/1575 train_time:40893ms step_avg:46.10ms
+step:888/1575 train_time:40952ms step_avg:46.12ms
+step:889/1575 train_time:41015ms step_avg:46.14ms
+step:890/1575 train_time:41075ms step_avg:46.15ms
+step:891/1575 train_time:41139ms step_avg:46.17ms
+step:892/1575 train_time:41197ms step_avg:46.18ms
+step:893/1575 train_time:41260ms step_avg:46.20ms
+step:894/1575 train_time:41319ms step_avg:46.22ms
+step:895/1575 train_time:41382ms step_avg:46.24ms
+step:896/1575 train_time:41441ms step_avg:46.25ms
+step:897/1575 train_time:41505ms step_avg:46.27ms
+step:898/1575 train_time:41565ms step_avg:46.29ms
+step:899/1575 train_time:41628ms step_avg:46.30ms
+step:900/1575 train_time:41688ms step_avg:46.32ms
+step:901/1575 train_time:41752ms step_avg:46.34ms
+step:902/1575 train_time:41810ms step_avg:46.35ms
+step:903/1575 train_time:41874ms step_avg:46.37ms
+step:904/1575 train_time:41933ms step_avg:46.39ms
+step:905/1575 train_time:41997ms step_avg:46.41ms
+step:906/1575 train_time:42056ms step_avg:46.42ms
+step:907/1575 train_time:42120ms step_avg:46.44ms
+step:908/1575 train_time:42179ms step_avg:46.45ms
+step:909/1575 train_time:42242ms step_avg:46.47ms
+step:910/1575 train_time:42303ms step_avg:46.49ms
+step:911/1575 train_time:42366ms step_avg:46.50ms
+step:912/1575 train_time:42424ms step_avg:46.52ms
+step:913/1575 train_time:42487ms step_avg:46.54ms
+step:914/1575 train_time:42545ms step_avg:46.55ms
+step:915/1575 train_time:42609ms step_avg:46.57ms
+step:916/1575 train_time:42668ms step_avg:46.58ms
+step:917/1575 train_time:42732ms step_avg:46.60ms
+step:918/1575 train_time:42792ms step_avg:46.61ms
+step:919/1575 train_time:42855ms step_avg:46.63ms
+step:920/1575 train_time:42914ms step_avg:46.65ms
+step:921/1575 train_time:42978ms step_avg:46.66ms
+step:922/1575 train_time:43037ms step_avg:46.68ms
+step:923/1575 train_time:43100ms step_avg:46.70ms
+step:924/1575 train_time:43160ms step_avg:46.71ms
+step:925/1575 train_time:43223ms step_avg:46.73ms
+step:926/1575 train_time:43282ms step_avg:46.74ms
+step:927/1575 train_time:43345ms step_avg:46.76ms
+step:928/1575 train_time:43404ms step_avg:46.77ms
+step:929/1575 train_time:43467ms step_avg:46.79ms
+step:930/1575 train_time:43526ms step_avg:46.80ms
+step:931/1575 train_time:43590ms step_avg:46.82ms
+step:932/1575 train_time:43649ms step_avg:46.83ms
+step:933/1575 train_time:43713ms step_avg:46.85ms
+step:934/1575 train_time:43774ms step_avg:46.87ms
+step:935/1575 train_time:43837ms step_avg:46.88ms
+step:936/1575 train_time:43896ms step_avg:46.90ms
+step:937/1575 train_time:43959ms step_avg:46.91ms
+step:938/1575 train_time:44019ms step_avg:46.93ms
+step:939/1575 train_time:44083ms step_avg:46.95ms
+step:940/1575 train_time:44142ms step_avg:46.96ms
+step:941/1575 train_time:44205ms step_avg:46.98ms
+step:942/1575 train_time:44265ms step_avg:46.99ms
+step:943/1575 train_time:44328ms step_avg:47.01ms
+step:944/1575 train_time:44388ms step_avg:47.02ms
+step:945/1575 train_time:44450ms step_avg:47.04ms
+step:946/1575 train_time:44509ms step_avg:47.05ms
+step:947/1575 train_time:44573ms step_avg:47.07ms
+step:948/1575 train_time:44632ms step_avg:47.08ms
+step:949/1575 train_time:44695ms step_avg:47.10ms
+step:950/1575 train_time:44755ms step_avg:47.11ms
+step:951/1575 train_time:44818ms step_avg:47.13ms
+step:952/1575 train_time:44877ms step_avg:47.14ms
+step:953/1575 train_time:44940ms step_avg:47.16ms
+step:954/1575 train_time:45000ms step_avg:47.17ms
+step:955/1575 train_time:45063ms step_avg:47.19ms
+step:956/1575 train_time:45123ms step_avg:47.20ms
+step:957/1575 train_time:45187ms step_avg:47.22ms
+step:958/1575 train_time:45245ms step_avg:47.23ms
+step:959/1575 train_time:45308ms step_avg:47.25ms
+step:960/1575 train_time:45368ms step_avg:47.26ms
+step:961/1575 train_time:45432ms step_avg:47.28ms
+step:962/1575 train_time:45490ms step_avg:47.29ms
+step:963/1575 train_time:45555ms step_avg:47.31ms
+step:964/1575 train_time:45614ms step_avg:47.32ms
+step:965/1575 train_time:45677ms step_avg:47.33ms
+step:966/1575 train_time:45740ms step_avg:47.35ms
+step:967/1575 train_time:45799ms step_avg:47.36ms
+step:968/1575 train_time:45858ms step_avg:47.37ms
+step:969/1575 train_time:45922ms step_avg:47.39ms
+step:970/1575 train_time:45982ms step_avg:47.40ms
+step:971/1575 train_time:46046ms step_avg:47.42ms
+step:972/1575 train_time:46104ms step_avg:47.43ms
+step:973/1575 train_time:46168ms step_avg:47.45ms
+step:974/1575 train_time:46228ms step_avg:47.46ms
+step:975/1575 train_time:46291ms step_avg:47.48ms
+step:976/1575 train_time:46350ms step_avg:47.49ms
+step:977/1575 train_time:46414ms step_avg:47.51ms
+step:978/1575 train_time:46474ms step_avg:47.52ms
+step:979/1575 train_time:46536ms step_avg:47.53ms
+step:980/1575 train_time:46596ms step_avg:47.55ms
+step:981/1575 train_time:46658ms step_avg:47.56ms
+step:982/1575 train_time:46717ms step_avg:47.57ms
+step:983/1575 train_time:46780ms step_avg:47.59ms
+step:984/1575 train_time:46840ms step_avg:47.60ms
+step:985/1575 train_time:46903ms step_avg:47.62ms
+step:986/1575 train_time:46963ms step_avg:47.63ms
+step:987/1575 train_time:47026ms step_avg:47.65ms
+step:988/1575 train_time:47086ms step_avg:47.66ms
+step:989/1575 train_time:47149ms step_avg:47.67ms
+step:990/1575 train_time:47208ms step_avg:47.68ms
+step:991/1575 train_time:47272ms step_avg:47.70ms
+step:992/1575 train_time:47331ms step_avg:47.71ms
+step:993/1575 train_time:47395ms step_avg:47.73ms
+step:994/1575 train_time:47457ms step_avg:47.74ms
+step:995/1575 train_time:47519ms step_avg:47.76ms
+step:996/1575 train_time:47577ms step_avg:47.77ms
+step:997/1575 train_time:47640ms step_avg:47.78ms
+step:998/1575 train_time:47701ms step_avg:47.80ms
+step:999/1575 train_time:47764ms step_avg:47.81ms
+step:1000/1575 train_time:47822ms step_avg:47.82ms
+step:1000/1575 val_loss:3.5827 train_time:47867ms step_avg:47.87ms
+step:1001/1575 train_time:47889ms step_avg:47.84ms
+step:1002/1575 train_time:47945ms step_avg:47.85ms
+step:1003/1575 train_time:48012ms step_avg:47.87ms
+step:1004/1575 train_time:48073ms step_avg:47.88ms
+step:1005/1575 train_time:48136ms step_avg:47.90ms
+step:1006/1575 train_time:48196ms step_avg:47.91ms
+step:1007/1575 train_time:48259ms step_avg:47.92ms
+step:1008/1575 train_time:48318ms step_avg:47.93ms
+step:1009/1575 train_time:48382ms step_avg:47.95ms
+step:1010/1575 train_time:48440ms step_avg:47.96ms
+step:1011/1575 train_time:48504ms step_avg:47.98ms
+step:1012/1575 train_time:48565ms step_avg:47.99ms
+step:1013/1575 train_time:48626ms step_avg:48.00ms
+step:1014/1575 train_time:48684ms step_avg:48.01ms
+step:1015/1575 train_time:48747ms step_avg:48.03ms
+step:1016/1575 train_time:48805ms step_avg:48.04ms
+step:1017/1575 train_time:48869ms step_avg:48.05ms
+step:1018/1575 train_time:48929ms step_avg:48.06ms
+step:1019/1575 train_time:48993ms step_avg:48.08ms
+step:1020/1575 train_time:49054ms step_avg:48.09ms
+step:1021/1575 train_time:49118ms step_avg:48.11ms
+step:1022/1575 train_time:49178ms step_avg:48.12ms
+step:1023/1575 train_time:49242ms step_avg:48.13ms
+step:1024/1575 train_time:49300ms step_avg:48.14ms
+step:1025/1575 train_time:49377ms step_avg:48.17ms
+step:1026/1575 train_time:49456ms step_avg:48.20ms
+step:1027/1575 train_time:49545ms step_avg:48.24ms
+step:1028/1575 train_time:49631ms step_avg:48.28ms
+step:1029/1575 train_time:49719ms step_avg:48.32ms
+step:1030/1575 train_time:49804ms step_avg:48.35ms
+step:1031/1575 train_time:49896ms step_avg:48.40ms
+step:1032/1575 train_time:49982ms step_avg:48.43ms
+step:1033/1575 train_time:50073ms step_avg:48.47ms
+step:1034/1575 train_time:50159ms step_avg:48.51ms
+step:1035/1575 train_time:50249ms step_avg:48.55ms
+step:1036/1575 train_time:50334ms step_avg:48.59ms
+step:1037/1575 train_time:50423ms step_avg:48.62ms
+step:1038/1575 train_time:50508ms step_avg:48.66ms
+step:1039/1575 train_time:50598ms step_avg:48.70ms
+step:1040/1575 train_time:50683ms step_avg:48.73ms
+step:1041/1575 train_time:50773ms step_avg:48.77ms
+step:1042/1575 train_time:50858ms step_avg:48.81ms
+step:1043/1575 train_time:50948ms step_avg:48.85ms
+step:1044/1575 train_time:51035ms step_avg:48.88ms
+step:1045/1575 train_time:51126ms step_avg:48.92ms
+step:1046/1575 train_time:51211ms step_avg:48.96ms
+step:1047/1575 train_time:51302ms step_avg:49.00ms
+step:1048/1575 train_time:51387ms step_avg:49.03ms
+step:1049/1575 train_time:51476ms step_avg:49.07ms
+step:1050/1575 train_time:51562ms step_avg:49.11ms
+step:1051/1575 train_time:51651ms step_avg:49.14ms
+step:1052/1575 train_time:51739ms step_avg:49.18ms
+step:1053/1575 train_time:51825ms step_avg:49.22ms
+step:1054/1575 train_time:51911ms step_avg:49.25ms
+step:1055/1575 train_time:52003ms step_avg:49.29ms
+step:1056/1575 train_time:52089ms step_avg:49.33ms
+step:1057/1575 train_time:52179ms step_avg:49.36ms
+step:1058/1575 train_time:52266ms step_avg:49.40ms
+step:1059/1575 train_time:52354ms step_avg:49.44ms
+step:1060/1575 train_time:52440ms step_avg:49.47ms
+step:1061/1575 train_time:52528ms step_avg:49.51ms
+step:1062/1575 train_time:52614ms step_avg:49.54ms
+step:1063/1575 train_time:52703ms step_avg:49.58ms
+step:1064/1575 train_time:52789ms step_avg:49.61ms
+step:1065/1575 train_time:52878ms step_avg:49.65ms
+step:1066/1575 train_time:52964ms step_avg:49.68ms
+step:1067/1575 train_time:53054ms step_avg:49.72ms
+step:1068/1575 train_time:53140ms step_avg:49.76ms
+step:1069/1575 train_time:53229ms step_avg:49.79ms
+step:1070/1575 train_time:53315ms step_avg:49.83ms
+step:1071/1575 train_time:53404ms step_avg:49.86ms
+step:1072/1575 train_time:53490ms step_avg:49.90ms
+step:1073/1575 train_time:53578ms step_avg:49.93ms
+step:1074/1575 train_time:53664ms step_avg:49.97ms
+step:1075/1575 train_time:53754ms step_avg:50.00ms
+step:1076/1575 train_time:53840ms step_avg:50.04ms
+step:1077/1575 train_time:53930ms step_avg:50.07ms
+step:1078/1575 train_time:54015ms step_avg:50.11ms
+step:1079/1575 train_time:54105ms step_avg:50.14ms
+step:1080/1575 train_time:54192ms step_avg:50.18ms
+step:1081/1575 train_time:54281ms step_avg:50.21ms
+step:1082/1575 train_time:54367ms step_avg:50.25ms
+step:1083/1575 train_time:54457ms step_avg:50.28ms
+step:1084/1575 train_time:54543ms step_avg:50.32ms
+step:1085/1575 train_time:54632ms step_avg:50.35ms
+step:1086/1575 train_time:54717ms step_avg:50.38ms
+step:1087/1575 train_time:54808ms step_avg:50.42ms
+step:1088/1575 train_time:54895ms step_avg:50.46ms
+step:1089/1575 train_time:54983ms step_avg:50.49ms
+step:1090/1575 train_time:55069ms step_avg:50.52ms
+step:1091/1575 train_time:55160ms step_avg:50.56ms
+step:1092/1575 train_time:55246ms step_avg:50.59ms
+step:1093/1575 train_time:55336ms step_avg:50.63ms
+step:1094/1575 train_time:55422ms step_avg:50.66ms
+step:1095/1575 train_time:55511ms step_avg:50.69ms
+step:1096/1575 train_time:55596ms step_avg:50.73ms
+step:1097/1575 train_time:55684ms step_avg:50.76ms
+step:1098/1575 train_time:55771ms step_avg:50.79ms
+step:1099/1575 train_time:55862ms step_avg:50.83ms
+step:1100/1575 train_time:55946ms step_avg:50.86ms
+step:1101/1575 train_time:56035ms step_avg:50.89ms
+step:1102/1575 train_time:56120ms step_avg:50.93ms
+step:1103/1575 train_time:56210ms step_avg:50.96ms
+step:1104/1575 train_time:56297ms step_avg:50.99ms
+step:1105/1575 train_time:56386ms step_avg:51.03ms
+step:1106/1575 train_time:56472ms step_avg:51.06ms
+step:1107/1575 train_time:56562ms step_avg:51.09ms
+step:1108/1575 train_time:56648ms step_avg:51.13ms
+step:1109/1575 train_time:56738ms step_avg:51.16ms
+step:1110/1575 train_time:56825ms step_avg:51.19ms
+step:1111/1575 train_time:56914ms step_avg:51.23ms
+step:1112/1575 train_time:56999ms step_avg:51.26ms
+step:1113/1575 train_time:57094ms step_avg:51.30ms
+step:1114/1575 train_time:57183ms step_avg:51.33ms
+step:1115/1575 train_time:57266ms step_avg:51.36ms
+step:1116/1575 train_time:57351ms step_avg:51.39ms
+step:1117/1575 train_time:57440ms step_avg:51.42ms
+step:1118/1575 train_time:57526ms step_avg:51.45ms
+step:1119/1575 train_time:57615ms step_avg:51.49ms
+step:1120/1575 train_time:57700ms step_avg:51.52ms
+step:1121/1575 train_time:57789ms step_avg:51.55ms
+step:1122/1575 train_time:57875ms step_avg:51.58ms
+step:1123/1575 train_time:57964ms step_avg:51.62ms
+step:1124/1575 train_time:58050ms step_avg:51.65ms
+step:1125/1575 train_time:58140ms step_avg:51.68ms
+step:1126/1575 train_time:58226ms step_avg:51.71ms
+step:1127/1575 train_time:58316ms step_avg:51.74ms
+step:1128/1575 train_time:58402ms step_avg:51.77ms
+step:1129/1575 train_time:58490ms step_avg:51.81ms
+step:1130/1575 train_time:58576ms step_avg:51.84ms
+step:1131/1575 train_time:58665ms step_avg:51.87ms
+step:1132/1575 train_time:58750ms step_avg:51.90ms
+step:1133/1575 train_time:58840ms step_avg:51.93ms
+step:1134/1575 train_time:58925ms step_avg:51.96ms
+step:1135/1575 train_time:59015ms step_avg:52.00ms
+step:1136/1575 train_time:59100ms step_avg:52.03ms
+step:1137/1575 train_time:59191ms step_avg:52.06ms
+step:1138/1575 train_time:59277ms step_avg:52.09ms
+step:1139/1575 train_time:59366ms step_avg:52.12ms
+step:1140/1575 train_time:59453ms step_avg:52.15ms
+step:1141/1575 train_time:59542ms step_avg:52.18ms
+step:1142/1575 train_time:59628ms step_avg:52.21ms
+step:1143/1575 train_time:59717ms step_avg:52.25ms
+step:1144/1575 train_time:59802ms step_avg:52.27ms
+step:1145/1575 train_time:59893ms step_avg:52.31ms
+step:1146/1575 train_time:59983ms step_avg:52.34ms
+step:1147/1575 train_time:60070ms step_avg:52.37ms
+step:1148/1575 train_time:60156ms step_avg:52.40ms
+step:1149/1575 train_time:60244ms step_avg:52.43ms
+step:1150/1575 train_time:60330ms step_avg:52.46ms
+step:1151/1575 train_time:60420ms step_avg:52.49ms
+step:1152/1575 train_time:60506ms step_avg:52.52ms
+step:1153/1575 train_time:60595ms step_avg:52.55ms
+step:1154/1575 train_time:60680ms step_avg:52.58ms
+step:1155/1575 train_time:60770ms step_avg:52.61ms
+step:1156/1575 train_time:60856ms step_avg:52.64ms
+step:1157/1575 train_time:60945ms step_avg:52.68ms
+step:1158/1575 train_time:61031ms step_avg:52.70ms
+step:1159/1575 train_time:61122ms step_avg:52.74ms
+step:1160/1575 train_time:61207ms step_avg:52.76ms
+step:1161/1575 train_time:61298ms step_avg:52.80ms
+step:1162/1575 train_time:61383ms step_avg:52.83ms
+step:1163/1575 train_time:61474ms step_avg:52.86ms
+step:1164/1575 train_time:61559ms step_avg:52.89ms
+step:1165/1575 train_time:61648ms step_avg:52.92ms
+step:1166/1575 train_time:61735ms step_avg:52.95ms
+step:1167/1575 train_time:61825ms step_avg:52.98ms
+step:1168/1575 train_time:61912ms step_avg:53.01ms
+step:1169/1575 train_time:62002ms step_avg:53.04ms
+step:1170/1575 train_time:62087ms step_avg:53.07ms
+step:1171/1575 train_time:62177ms step_avg:53.10ms
+step:1172/1575 train_time:62263ms step_avg:53.13ms
+step:1173/1575 train_time:62352ms step_avg:53.16ms
+step:1174/1575 train_time:62438ms step_avg:53.18ms
+step:1175/1575 train_time:62527ms step_avg:53.21ms
+step:1176/1575 train_time:62612ms step_avg:53.24ms
+step:1177/1575 train_time:62702ms step_avg:53.27ms
+step:1178/1575 train_time:62788ms step_avg:53.30ms
+step:1179/1575 train_time:62877ms step_avg:53.33ms
+step:1180/1575 train_time:62963ms step_avg:53.36ms
+step:1181/1575 train_time:63052ms step_avg:53.39ms
+step:1182/1575 train_time:63138ms step_avg:53.42ms
+step:1183/1575 train_time:63227ms step_avg:53.45ms
+step:1184/1575 train_time:63313ms step_avg:53.47ms
+step:1185/1575 train_time:63404ms step_avg:53.51ms
+step:1186/1575 train_time:63488ms step_avg:53.53ms
+step:1187/1575 train_time:63578ms step_avg:53.56ms
+step:1188/1575 train_time:63664ms step_avg:53.59ms
+step:1189/1575 train_time:63753ms step_avg:53.62ms
+step:1190/1575 train_time:63839ms step_avg:53.65ms
+step:1191/1575 train_time:63928ms step_avg:53.68ms
+step:1192/1575 train_time:64015ms step_avg:53.70ms
+step:1193/1575 train_time:64104ms step_avg:53.73ms
+step:1194/1575 train_time:64190ms step_avg:53.76ms
+step:1195/1575 train_time:64280ms step_avg:53.79ms
+step:1196/1575 train_time:64366ms step_avg:53.82ms
+step:1197/1575 train_time:64457ms step_avg:53.85ms
+step:1198/1575 train_time:64541ms step_avg:53.87ms
+step:1199/1575 train_time:64631ms step_avg:53.90ms
+step:1200/1575 train_time:64717ms step_avg:53.93ms
+step:1201/1575 train_time:64807ms step_avg:53.96ms
+step:1202/1575 train_time:64893ms step_avg:53.99ms
+step:1203/1575 train_time:64982ms step_avg:54.02ms
+step:1204/1575 train_time:65068ms step_avg:54.04ms
+step:1205/1575 train_time:65158ms step_avg:54.07ms
+step:1206/1575 train_time:65244ms step_avg:54.10ms
+step:1207/1575 train_time:65334ms step_avg:54.13ms
+step:1208/1575 train_time:65419ms step_avg:54.16ms
+step:1209/1575 train_time:65509ms step_avg:54.18ms
+step:1210/1575 train_time:65594ms step_avg:54.21ms
+step:1211/1575 train_time:65683ms step_avg:54.24ms
+step:1212/1575 train_time:65770ms step_avg:54.27ms
+step:1213/1575 train_time:65859ms step_avg:54.29ms
+step:1214/1575 train_time:65945ms step_avg:54.32ms
+step:1215/1575 train_time:66034ms step_avg:54.35ms
+step:1216/1575 train_time:66120ms step_avg:54.37ms
+step:1217/1575 train_time:66209ms step_avg:54.40ms
+step:1218/1575 train_time:66294ms step_avg:54.43ms
+step:1219/1575 train_time:66384ms step_avg:54.46ms
+step:1220/1575 train_time:66470ms step_avg:54.48ms
+step:1221/1575 train_time:66560ms step_avg:54.51ms
+step:1222/1575 train_time:66650ms step_avg:54.54ms
+step:1223/1575 train_time:66737ms step_avg:54.57ms
+step:1224/1575 train_time:66823ms step_avg:54.59ms
+step:1225/1575 train_time:66913ms step_avg:54.62ms
+step:1226/1575 train_time:66999ms step_avg:54.65ms
+step:1227/1575 train_time:67088ms step_avg:54.68ms
+step:1228/1575 train_time:67173ms step_avg:54.70ms
+step:1229/1575 train_time:67262ms step_avg:54.73ms
+step:1230/1575 train_time:67348ms step_avg:54.75ms
+step:1231/1575 train_time:67439ms step_avg:54.78ms
+step:1232/1575 train_time:67524ms step_avg:54.81ms
+step:1233/1575 train_time:67613ms step_avg:54.84ms
+step:1234/1575 train_time:67699ms step_avg:54.86ms
+step:1235/1575 train_time:67788ms step_avg:54.89ms
+step:1236/1575 train_time:67874ms step_avg:54.91ms
+step:1237/1575 train_time:67964ms step_avg:54.94ms
+step:1238/1575 train_time:68049ms step_avg:54.97ms
+step:1239/1575 train_time:68140ms step_avg:55.00ms
+step:1240/1575 train_time:68226ms step_avg:55.02ms
+step:1241/1575 train_time:68315ms step_avg:55.05ms
+step:1242/1575 train_time:68401ms step_avg:55.07ms
+step:1243/1575 train_time:68492ms step_avg:55.10ms
+step:1244/1575 train_time:68577ms step_avg:55.13ms
+step:1245/1575 train_time:68666ms step_avg:55.15ms
+step:1246/1575 train_time:68752ms step_avg:55.18ms
+step:1247/1575 train_time:68842ms step_avg:55.21ms
+step:1248/1575 train_time:68927ms step_avg:55.23ms
+step:1249/1575 train_time:69017ms step_avg:55.26ms
+step:1250/1575 train_time:69102ms step_avg:55.28ms
+step:1250/1575 val_loss:3.4062 train_time:69175ms step_avg:55.34ms
+step:1251/1575 train_time:69196ms step_avg:55.31ms
+step:1252/1575 train_time:69284ms step_avg:55.34ms
+step:1253/1575 train_time:69379ms step_avg:55.37ms
+step:1254/1575 train_time:69465ms step_avg:55.40ms
+step:1255/1575 train_time:69554ms step_avg:55.42ms
+step:1256/1575 train_time:69639ms step_avg:55.45ms
+step:1257/1575 train_time:69729ms step_avg:55.47ms
+step:1258/1575 train_time:69812ms step_avg:55.49ms
+step:1259/1575 train_time:69901ms step_avg:55.52ms
+step:1260/1575 train_time:69986ms step_avg:55.54ms
+step:1261/1575 train_time:70074ms step_avg:55.57ms
+step:1262/1575 train_time:70161ms step_avg:55.60ms
+step:1263/1575 train_time:70252ms step_avg:55.62ms
+step:1264/1575 train_time:70341ms step_avg:55.65ms
+step:1265/1575 train_time:70432ms step_avg:55.68ms
+step:1266/1575 train_time:70519ms step_avg:55.70ms
+step:1267/1575 train_time:70608ms step_avg:55.73ms
+step:1268/1575 train_time:70693ms step_avg:55.75ms
+step:1269/1575 train_time:70782ms step_avg:55.78ms
+step:1270/1575 train_time:70866ms step_avg:55.80ms
+step:1271/1575 train_time:70956ms step_avg:55.83ms
+step:1272/1575 train_time:71042ms step_avg:55.85ms
+step:1273/1575 train_time:71130ms step_avg:55.88ms
+step:1274/1575 train_time:71217ms step_avg:55.90ms
+step:1275/1575 train_time:71309ms step_avg:55.93ms
+step:1276/1575 train_time:71395ms step_avg:55.95ms
+step:1277/1575 train_time:71486ms step_avg:55.98ms
+step:1278/1575 train_time:71572ms step_avg:56.00ms
+step:1279/1575 train_time:71661ms step_avg:56.03ms
+step:1280/1575 train_time:71747ms step_avg:56.05ms
+step:1281/1575 train_time:71835ms step_avg:56.08ms
+step:1282/1575 train_time:71920ms step_avg:56.10ms
+step:1283/1575 train_time:72009ms step_avg:56.13ms
+step:1284/1575 train_time:72095ms step_avg:56.15ms
+step:1285/1575 train_time:72184ms step_avg:56.17ms
+step:1286/1575 train_time:72271ms step_avg:56.20ms
+step:1287/1575 train_time:72363ms step_avg:56.23ms
+step:1288/1575 train_time:72450ms step_avg:56.25ms
+step:1289/1575 train_time:72541ms step_avg:56.28ms
+step:1290/1575 train_time:72626ms step_avg:56.30ms
+step:1291/1575 train_time:72714ms step_avg:56.32ms
+step:1292/1575 train_time:72800ms step_avg:56.35ms
+step:1293/1575 train_time:72888ms step_avg:56.37ms
+step:1294/1575 train_time:72974ms step_avg:56.39ms
+step:1295/1575 train_time:73063ms step_avg:56.42ms
+step:1296/1575 train_time:73149ms step_avg:56.44ms
+step:1297/1575 train_time:73239ms step_avg:56.47ms
+step:1298/1575 train_time:73325ms step_avg:56.49ms
+step:1299/1575 train_time:73415ms step_avg:56.52ms
+step:1300/1575 train_time:73501ms step_avg:56.54ms
+step:1301/1575 train_time:73591ms step_avg:56.56ms
+step:1302/1575 train_time:73676ms step_avg:56.59ms
+step:1303/1575 train_time:73766ms step_avg:56.61ms
+step:1304/1575 train_time:73852ms step_avg:56.63ms
+step:1305/1575 train_time:73940ms step_avg:56.66ms
+step:1306/1575 train_time:74026ms step_avg:56.68ms
+step:1307/1575 train_time:74115ms step_avg:56.71ms
+step:1308/1575 train_time:74201ms step_avg:56.73ms
+step:1309/1575 train_time:74290ms step_avg:56.75ms
+step:1310/1575 train_time:74377ms step_avg:56.78ms
+step:1311/1575 train_time:74466ms step_avg:56.80ms
+step:1312/1575 train_time:74553ms step_avg:56.82ms
+step:1313/1575 train_time:74643ms step_avg:56.85ms
+step:1314/1575 train_time:74728ms step_avg:56.87ms
+step:1315/1575 train_time:74819ms step_avg:56.90ms
+step:1316/1575 train_time:74904ms step_avg:56.92ms
+step:1317/1575 train_time:74993ms step_avg:56.94ms
+step:1318/1575 train_time:75079ms step_avg:56.96ms
+step:1319/1575 train_time:75168ms step_avg:56.99ms
+step:1320/1575 train_time:75254ms step_avg:57.01ms
+step:1321/1575 train_time:75344ms step_avg:57.04ms
+step:1322/1575 train_time:75430ms step_avg:57.06ms
+step:1323/1575 train_time:75520ms step_avg:57.08ms
+step:1324/1575 train_time:75605ms step_avg:57.10ms
+step:1325/1575 train_time:75696ms step_avg:57.13ms
+step:1326/1575 train_time:75781ms step_avg:57.15ms
+step:1327/1575 train_time:75869ms step_avg:57.17ms
+step:1328/1575 train_time:75957ms step_avg:57.20ms
+step:1329/1575 train_time:76047ms step_avg:57.22ms
+step:1330/1575 train_time:76131ms step_avg:57.24ms
+step:1331/1575 train_time:76220ms step_avg:57.27ms
+step:1332/1575 train_time:76306ms step_avg:57.29ms
+step:1333/1575 train_time:76397ms step_avg:57.31ms
+step:1334/1575 train_time:76483ms step_avg:57.33ms
+step:1335/1575 train_time:76571ms step_avg:57.36ms
+step:1336/1575 train_time:76657ms step_avg:57.38ms
+step:1337/1575 train_time:76746ms step_avg:57.40ms
+step:1338/1575 train_time:76832ms step_avg:57.42ms
+step:1339/1575 train_time:76922ms step_avg:57.45ms
+step:1340/1575 train_time:77007ms step_avg:57.47ms
+step:1341/1575 train_time:77097ms step_avg:57.49ms
+step:1342/1575 train_time:77182ms step_avg:57.51ms
+step:1343/1575 train_time:77272ms step_avg:57.54ms
+step:1344/1575 train_time:77358ms step_avg:57.56ms
+step:1345/1575 train_time:77447ms step_avg:57.58ms
+step:1346/1575 train_time:77533ms step_avg:57.60ms
+step:1347/1575 train_time:77623ms step_avg:57.63ms
+step:1348/1575 train_time:77709ms step_avg:57.65ms
+step:1349/1575 train_time:77798ms step_avg:57.67ms
+step:1350/1575 train_time:77884ms step_avg:57.69ms
+step:1351/1575 train_time:77973ms step_avg:57.72ms
+step:1352/1575 train_time:78060ms step_avg:57.74ms
+step:1353/1575 train_time:78148ms step_avg:57.76ms
+step:1354/1575 train_time:78234ms step_avg:57.78ms
+step:1355/1575 train_time:78324ms step_avg:57.80ms
+step:1356/1575 train_time:78409ms step_avg:57.82ms
+step:1357/1575 train_time:78500ms step_avg:57.85ms
+step:1358/1575 train_time:78590ms step_avg:57.87ms
+step:1359/1575 train_time:78677ms step_avg:57.89ms
+step:1360/1575 train_time:78763ms step_avg:57.91ms
+step:1361/1575 train_time:78851ms step_avg:57.94ms
+step:1362/1575 train_time:78937ms step_avg:57.96ms
+step:1363/1575 train_time:79026ms step_avg:57.98ms
+step:1364/1575 train_time:79113ms step_avg:58.00ms
+step:1365/1575 train_time:79201ms step_avg:58.02ms
+step:1366/1575 train_time:79287ms step_avg:58.04ms
+step:1367/1575 train_time:79377ms step_avg:58.07ms
+step:1368/1575 train_time:79463ms step_avg:58.09ms
+step:1369/1575 train_time:79554ms step_avg:58.11ms
+step:1370/1575 train_time:79639ms step_avg:58.13ms
+step:1371/1575 train_time:79728ms step_avg:58.15ms
+step:1372/1575 train_time:79816ms step_avg:58.17ms
+step:1373/1575 train_time:79905ms step_avg:58.20ms
+step:1374/1575 train_time:79991ms step_avg:58.22ms
+step:1375/1575 train_time:80080ms step_avg:58.24ms
+step:1376/1575 train_time:80166ms step_avg:58.26ms
+step:1377/1575 train_time:80256ms step_avg:58.28ms
+step:1378/1575 train_time:80342ms step_avg:58.30ms
+step:1379/1575 train_time:80431ms step_avg:58.33ms
+step:1380/1575 train_time:80517ms step_avg:58.35ms
+step:1381/1575 train_time:80606ms step_avg:58.37ms
+step:1382/1575 train_time:80692ms step_avg:58.39ms
+step:1383/1575 train_time:80784ms step_avg:58.41ms
+step:1384/1575 train_time:80868ms step_avg:58.43ms
+step:1385/1575 train_time:80957ms step_avg:58.45ms
+step:1386/1575 train_time:81043ms step_avg:58.47ms
+step:1387/1575 train_time:81132ms step_avg:58.49ms
+step:1388/1575 train_time:81218ms step_avg:58.51ms
+step:1389/1575 train_time:81307ms step_avg:58.54ms
+step:1390/1575 train_time:81393ms step_avg:58.56ms
+step:1391/1575 train_time:81483ms step_avg:58.58ms
+step:1392/1575 train_time:81570ms step_avg:58.60ms
+step:1393/1575 train_time:81659ms step_avg:58.62ms
+step:1394/1575 train_time:81745ms step_avg:58.64ms
+step:1395/1575 train_time:81834ms step_avg:58.66ms
+step:1396/1575 train_time:81920ms step_avg:58.68ms
+step:1397/1575 train_time:82010ms step_avg:58.70ms
+step:1398/1575 train_time:82096ms step_avg:58.72ms
+step:1399/1575 train_time:82185ms step_avg:58.75ms
+step:1400/1575 train_time:82271ms step_avg:58.77ms
+step:1401/1575 train_time:82361ms step_avg:58.79ms
+step:1402/1575 train_time:82447ms step_avg:58.81ms
+step:1403/1575 train_time:82536ms step_avg:58.83ms
+step:1404/1575 train_time:82622ms step_avg:58.85ms
+step:1405/1575 train_time:82712ms step_avg:58.87ms
+step:1406/1575 train_time:82798ms step_avg:58.89ms
+step:1407/1575 train_time:82888ms step_avg:58.91ms
+step:1408/1575 train_time:82973ms step_avg:58.93ms
+step:1409/1575 train_time:83064ms step_avg:58.95ms
+step:1410/1575 train_time:83149ms step_avg:58.97ms
+step:1411/1575 train_time:83238ms step_avg:58.99ms
+step:1412/1575 train_time:83325ms step_avg:59.01ms
+step:1413/1575 train_time:83415ms step_avg:59.03ms
+step:1414/1575 train_time:83504ms step_avg:59.06ms
+step:1415/1575 train_time:83591ms step_avg:59.07ms
+step:1416/1575 train_time:83677ms step_avg:59.09ms
+step:1417/1575 train_time:83766ms step_avg:59.12ms
+step:1418/1575 train_time:83852ms step_avg:59.13ms
+step:1419/1575 train_time:83941ms step_avg:59.16ms
+step:1420/1575 train_time:84028ms step_avg:59.17ms
+step:1421/1575 train_time:84117ms step_avg:59.20ms
+step:1422/1575 train_time:84202ms step_avg:59.21ms
+step:1423/1575 train_time:84292ms step_avg:59.24ms
+step:1424/1575 train_time:84377ms step_avg:59.25ms
+step:1425/1575 train_time:84467ms step_avg:59.27ms
+step:1426/1575 train_time:84553ms step_avg:59.29ms
+step:1427/1575 train_time:84643ms step_avg:59.32ms
+step:1428/1575 train_time:84729ms step_avg:59.33ms
+step:1429/1575 train_time:84818ms step_avg:59.35ms
+step:1430/1575 train_time:84904ms step_avg:59.37ms
+step:1431/1575 train_time:84994ms step_avg:59.39ms
+step:1432/1575 train_time:85080ms step_avg:59.41ms
+step:1433/1575 train_time:85169ms step_avg:59.43ms
+step:1434/1575 train_time:85256ms step_avg:59.45ms
+step:1435/1575 train_time:85345ms step_avg:59.47ms
+step:1436/1575 train_time:85432ms step_avg:59.49ms
+step:1437/1575 train_time:85522ms step_avg:59.51ms
+step:1438/1575 train_time:85607ms step_avg:59.53ms
+step:1439/1575 train_time:85697ms step_avg:59.55ms
+step:1440/1575 train_time:85783ms step_avg:59.57ms
+step:1441/1575 train_time:85872ms step_avg:59.59ms
+step:1442/1575 train_time:85959ms step_avg:59.61ms
+step:1443/1575 train_time:86048ms step_avg:59.63ms
+step:1444/1575 train_time:86133ms step_avg:59.65ms
+step:1445/1575 train_time:86223ms step_avg:59.67ms
+step:1446/1575 train_time:86308ms step_avg:59.69ms
+step:1447/1575 train_time:86399ms step_avg:59.71ms
+step:1448/1575 train_time:86482ms step_avg:59.73ms
+step:1449/1575 train_time:86572ms step_avg:59.75ms
+step:1450/1575 train_time:86659ms step_avg:59.77ms
+step:1451/1575 train_time:86748ms step_avg:59.78ms
+step:1452/1575 train_time:86834ms step_avg:59.80ms
+step:1453/1575 train_time:86924ms step_avg:59.82ms
+step:1454/1575 train_time:87009ms step_avg:59.84ms
+step:1455/1575 train_time:87100ms step_avg:59.86ms
+step:1456/1575 train_time:87185ms step_avg:59.88ms
+step:1457/1575 train_time:87275ms step_avg:59.90ms
+step:1458/1575 train_time:87360ms step_avg:59.92ms
+step:1459/1575 train_time:87450ms step_avg:59.94ms
+step:1460/1575 train_time:87536ms step_avg:59.96ms
+step:1461/1575 train_time:87624ms step_avg:59.98ms
+step:1462/1575 train_time:87710ms step_avg:59.99ms
+step:1463/1575 train_time:87801ms step_avg:60.01ms
+step:1464/1575 train_time:87886ms step_avg:60.03ms
+step:1465/1575 train_time:87979ms step_avg:60.05ms
+step:1466/1575 train_time:88063ms step_avg:60.07ms
+step:1467/1575 train_time:88150ms step_avg:60.09ms
+step:1468/1575 train_time:88237ms step_avg:60.11ms
+step:1469/1575 train_time:88326ms step_avg:60.13ms
+step:1470/1575 train_time:88412ms step_avg:60.14ms
+step:1471/1575 train_time:88502ms step_avg:60.16ms
+step:1472/1575 train_time:88587ms step_avg:60.18ms
+step:1473/1575 train_time:88676ms step_avg:60.20ms
+step:1474/1575 train_time:88763ms step_avg:60.22ms
+step:1475/1575 train_time:88852ms step_avg:60.24ms
+step:1476/1575 train_time:88939ms step_avg:60.26ms
+step:1477/1575 train_time:89028ms step_avg:60.28ms
+step:1478/1575 train_time:89114ms step_avg:60.29ms
+step:1479/1575 train_time:89203ms step_avg:60.31ms
+step:1480/1575 train_time:89289ms step_avg:60.33ms
+step:1481/1575 train_time:89379ms step_avg:60.35ms
+step:1482/1575 train_time:89464ms step_avg:60.37ms
+step:1483/1575 train_time:89554ms step_avg:60.39ms
+step:1484/1575 train_time:89640ms step_avg:60.40ms
+step:1485/1575 train_time:89729ms step_avg:60.42ms
+step:1486/1575 train_time:89816ms step_avg:60.44ms
+step:1487/1575 train_time:89906ms step_avg:60.46ms
+step:1488/1575 train_time:89992ms step_avg:60.48ms
+step:1489/1575 train_time:90081ms step_avg:60.50ms
+step:1490/1575 train_time:90167ms step_avg:60.51ms
+step:1491/1575 train_time:90257ms step_avg:60.53ms
+step:1492/1575 train_time:90342ms step_avg:60.55ms
+step:1493/1575 train_time:90432ms step_avg:60.57ms
+step:1494/1575 train_time:90517ms step_avg:60.59ms
+step:1495/1575 train_time:90607ms step_avg:60.61ms
+step:1496/1575 train_time:90692ms step_avg:60.62ms
+step:1497/1575 train_time:90782ms step_avg:60.64ms
+step:1498/1575 train_time:90868ms step_avg:60.66ms
+step:1499/1575 train_time:90961ms step_avg:60.68ms
+step:1500/1575 train_time:91045ms step_avg:60.70ms
+step:1500/1575 val_loss:3.2995 train_time:91117ms step_avg:60.74ms
+step:1501/1575 train_time:91138ms step_avg:60.72ms
+step:1502/1575 train_time:91225ms step_avg:60.74ms
+step:1503/1575 train_time:91322ms step_avg:60.76ms
+step:1504/1575 train_time:91409ms step_avg:60.78ms
+step:1505/1575 train_time:91501ms step_avg:60.80ms
+step:1506/1575 train_time:91584ms step_avg:60.81ms
+step:1507/1575 train_time:91672ms step_avg:60.83ms
+step:1508/1575 train_time:91757ms step_avg:60.85ms
+step:1509/1575 train_time:91845ms step_avg:60.86ms
+step:1510/1575 train_time:91930ms step_avg:60.88ms
+step:1511/1575 train_time:92018ms step_avg:60.90ms
+step:1512/1575 train_time:92104ms step_avg:60.92ms
+step:1513/1575 train_time:92197ms step_avg:60.94ms
+step:1514/1575 train_time:92285ms step_avg:60.95ms
+step:1515/1575 train_time:92375ms step_avg:60.97ms
+step:1516/1575 train_time:92461ms step_avg:60.99ms
+step:1517/1575 train_time:92550ms step_avg:61.01ms
+step:1518/1575 train_time:92635ms step_avg:61.02ms
+step:1519/1575 train_time:92724ms step_avg:61.04ms
+step:1520/1575 train_time:92810ms step_avg:61.06ms
+step:1521/1575 train_time:92899ms step_avg:61.08ms
+step:1522/1575 train_time:92984ms step_avg:61.09ms
+step:1523/1575 train_time:93074ms step_avg:61.11ms
+step:1524/1575 train_time:93160ms step_avg:61.13ms
+step:1525/1575 train_time:93251ms step_avg:61.15ms
+step:1526/1575 train_time:93339ms step_avg:61.17ms
+step:1527/1575 train_time:93429ms step_avg:61.18ms
+step:1528/1575 train_time:93516ms step_avg:61.20ms
+step:1529/1575 train_time:93605ms step_avg:61.22ms
+step:1530/1575 train_time:93691ms step_avg:61.24ms
+step:1531/1575 train_time:93779ms step_avg:61.25ms
+step:1532/1575 train_time:93864ms step_avg:61.27ms
+step:1533/1575 train_time:93952ms step_avg:61.29ms
+step:1534/1575 train_time:94038ms step_avg:61.30ms
+step:1535/1575 train_time:94127ms step_avg:61.32ms
+step:1536/1575 train_time:94222ms step_avg:61.34ms
+step:1537/1575 train_time:94309ms step_avg:61.36ms
+step:1538/1575 train_time:94397ms step_avg:61.38ms
+step:1539/1575 train_time:94488ms step_avg:61.40ms
+step:1540/1575 train_time:94574ms step_avg:61.41ms
+step:1541/1575 train_time:94664ms step_avg:61.43ms
+step:1542/1575 train_time:94749ms step_avg:61.45ms
+step:1543/1575 train_time:94838ms step_avg:61.46ms
+step:1544/1575 train_time:94924ms step_avg:61.48ms
+step:1545/1575 train_time:95014ms step_avg:61.50ms
+step:1546/1575 train_time:95100ms step_avg:61.51ms
+step:1547/1575 train_time:95191ms step_avg:61.53ms
+step:1548/1575 train_time:95277ms step_avg:61.55ms
+step:1549/1575 train_time:95368ms step_avg:61.57ms
+step:1550/1575 train_time:95454ms step_avg:61.58ms
+step:1551/1575 train_time:95546ms step_avg:61.60ms
+step:1552/1575 train_time:95632ms step_avg:61.62ms
+step:1553/1575 train_time:95721ms step_avg:61.64ms
+step:1554/1575 train_time:95806ms step_avg:61.65ms
+step:1555/1575 train_time:95896ms step_avg:61.67ms
+step:1556/1575 train_time:95983ms step_avg:61.69ms
+step:1557/1575 train_time:96072ms step_avg:61.70ms
+step:1558/1575 train_time:96157ms step_avg:61.72ms
+step:1559/1575 train_time:96247ms step_avg:61.74ms
+step:1560/1575 train_time:96334ms step_avg:61.75ms
+step:1561/1575 train_time:96424ms step_avg:61.77ms
+step:1562/1575 train_time:96511ms step_avg:61.79ms
+step:1563/1575 train_time:96601ms step_avg:61.80ms
+step:1564/1575 train_time:96687ms step_avg:61.82ms
+step:1565/1575 train_time:96777ms step_avg:61.84ms
+step:1566/1575 train_time:96863ms step_avg:61.85ms
+step:1567/1575 train_time:96953ms step_avg:61.87ms
+step:1568/1575 train_time:97039ms step_avg:61.89ms
+step:1569/1575 train_time:97132ms step_avg:61.91ms
+step:1570/1575 train_time:97217ms step_avg:61.92ms
+step:1571/1575 train_time:97306ms step_avg:61.94ms
+step:1572/1575 train_time:97392ms step_avg:61.95ms
+step:1573/1575 train_time:97483ms step_avg:61.97ms
+step:1574/1575 train_time:97568ms step_avg:61.99ms
+step:1575/1575 train_time:97658ms step_avg:62.01ms
+step:1575/1575 val_loss:3.2776 train_time:97725ms step_avg:62.05ms
+peak memory allocated: 31016 MiB reserved: 46998 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/57d707c1-8b51-446f-8cb1-c80f6640cb75.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/57d707c1-8b51-446f-8cb1-c80f6640cb75.txt
@@ -1,0 +1,4119 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 03:00:00 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            132W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          278027      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          278028      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          278029      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          278030      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          278031      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          278032      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          278033      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          278034      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8321 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:89ms step_avg:88.71ms
+step:2/1600 train_time:116ms step_avg:57.85ms
+step:3/1600 train_time:141ms step_avg:47.06ms
+step:4/1600 train_time:163ms step_avg:40.78ms
+step:5/1600 train_time:192ms step_avg:38.33ms
+step:6/1600 train_time:300ms step_avg:49.92ms
+step:7/1600 train_time:323ms step_avg:46.19ms
+step:8/1600 train_time:431ms step_avg:53.89ms
+step:9/1600 train_time:461ms step_avg:51.22ms
+step:10/1600 train_time:498ms step_avg:49.83ms
+step:11/1600 train_time:529ms step_avg:48.06ms
+step:12/1600 train_time:566ms step_avg:47.19ms
+step:13/1600 train_time:597ms step_avg:45.90ms
+step:14/1600 train_time:634ms step_avg:45.29ms
+step:15/1600 train_time:665ms step_avg:44.33ms
+step:16/1600 train_time:702ms step_avg:43.89ms
+step:17/1600 train_time:733ms step_avg:43.11ms
+step:18/1600 train_time:770ms step_avg:42.78ms
+step:19/1600 train_time:800ms step_avg:42.12ms
+step:20/1600 train_time:838ms step_avg:41.88ms
+step:21/1600 train_time:868ms step_avg:41.34ms
+step:22/1600 train_time:906ms step_avg:41.17ms
+step:23/1600 train_time:936ms step_avg:40.71ms
+step:24/1600 train_time:973ms step_avg:40.56ms
+step:25/1600 train_time:1004ms step_avg:40.15ms
+step:26/1600 train_time:1042ms step_avg:40.07ms
+step:27/1600 train_time:1072ms step_avg:39.71ms
+step:28/1600 train_time:1109ms step_avg:39.62ms
+step:29/1600 train_time:1140ms step_avg:39.31ms
+step:30/1600 train_time:1177ms step_avg:39.24ms
+step:31/1600 train_time:1208ms step_avg:38.96ms
+step:32/1600 train_time:1245ms step_avg:38.92ms
+step:33/1600 train_time:1276ms step_avg:38.65ms
+step:34/1600 train_time:1313ms step_avg:38.62ms
+step:35/1600 train_time:1344ms step_avg:38.41ms
+step:36/1600 train_time:1382ms step_avg:38.39ms
+step:37/1600 train_time:1413ms step_avg:38.18ms
+step:38/1600 train_time:1451ms step_avg:38.19ms
+step:39/1600 train_time:1481ms step_avg:37.98ms
+step:40/1600 train_time:1519ms step_avg:37.98ms
+step:41/1600 train_time:1550ms step_avg:37.80ms
+step:42/1600 train_time:1587ms step_avg:37.79ms
+step:43/1600 train_time:1618ms step_avg:37.62ms
+step:44/1600 train_time:1655ms step_avg:37.62ms
+step:45/1600 train_time:1685ms step_avg:37.45ms
+step:46/1600 train_time:1723ms step_avg:37.46ms
+step:47/1600 train_time:1754ms step_avg:37.31ms
+step:48/1600 train_time:1791ms step_avg:37.31ms
+step:49/1600 train_time:1822ms step_avg:37.17ms
+step:50/1600 train_time:1859ms step_avg:37.18ms
+step:51/1600 train_time:1890ms step_avg:37.05ms
+step:52/1600 train_time:1927ms step_avg:37.06ms
+step:53/1600 train_time:1958ms step_avg:36.94ms
+step:54/1600 train_time:1995ms step_avg:36.94ms
+step:55/1600 train_time:2026ms step_avg:36.83ms
+step:56/1600 train_time:2064ms step_avg:36.85ms
+step:57/1600 train_time:2094ms step_avg:36.74ms
+step:58/1600 train_time:2132ms step_avg:36.75ms
+step:59/1600 train_time:2162ms step_avg:36.65ms
+step:60/1600 train_time:2200ms step_avg:36.67ms
+step:61/1600 train_time:2232ms step_avg:36.58ms
+step:62/1600 train_time:2269ms step_avg:36.59ms
+step:63/1600 train_time:2299ms step_avg:36.49ms
+step:64/1600 train_time:2337ms step_avg:36.51ms
+step:65/1600 train_time:2367ms step_avg:36.42ms
+step:66/1600 train_time:2405ms step_avg:36.44ms
+step:67/1600 train_time:2436ms step_avg:36.36ms
+step:68/1600 train_time:2473ms step_avg:36.37ms
+step:69/1600 train_time:2504ms step_avg:36.29ms
+step:70/1600 train_time:2542ms step_avg:36.31ms
+step:71/1600 train_time:2572ms step_avg:36.23ms
+step:72/1600 train_time:2610ms step_avg:36.25ms
+step:73/1600 train_time:2641ms step_avg:36.17ms
+step:74/1600 train_time:2678ms step_avg:36.19ms
+step:75/1600 train_time:2709ms step_avg:36.11ms
+step:76/1600 train_time:2747ms step_avg:36.14ms
+step:77/1600 train_time:2777ms step_avg:36.06ms
+step:78/1600 train_time:2814ms step_avg:36.07ms
+step:79/1600 train_time:2845ms step_avg:36.01ms
+step:80/1600 train_time:2884ms step_avg:36.05ms
+step:81/1600 train_time:2913ms step_avg:35.97ms
+step:82/1600 train_time:2951ms step_avg:35.99ms
+step:83/1600 train_time:2981ms step_avg:35.92ms
+step:84/1600 train_time:3019ms step_avg:35.93ms
+step:85/1600 train_time:3049ms step_avg:35.87ms
+step:86/1600 train_time:3086ms step_avg:35.89ms
+step:87/1600 train_time:3117ms step_avg:35.82ms
+step:88/1600 train_time:3154ms step_avg:35.84ms
+step:89/1600 train_time:3185ms step_avg:35.78ms
+step:90/1600 train_time:3222ms step_avg:35.80ms
+step:91/1600 train_time:3253ms step_avg:35.75ms
+step:92/1600 train_time:3290ms step_avg:35.77ms
+step:93/1600 train_time:3321ms step_avg:35.71ms
+step:94/1600 train_time:3359ms step_avg:35.73ms
+step:95/1600 train_time:3389ms step_avg:35.68ms
+step:96/1600 train_time:3427ms step_avg:35.70ms
+step:97/1600 train_time:3457ms step_avg:35.64ms
+step:98/1600 train_time:3494ms step_avg:35.66ms
+step:99/1600 train_time:3525ms step_avg:35.61ms
+step:100/1600 train_time:3563ms step_avg:35.63ms
+step:101/1600 train_time:3594ms step_avg:35.58ms
+step:102/1600 train_time:3631ms step_avg:35.60ms
+step:103/1600 train_time:3662ms step_avg:35.55ms
+step:104/1600 train_time:3700ms step_avg:35.57ms
+step:105/1600 train_time:3730ms step_avg:35.53ms
+step:106/1600 train_time:3768ms step_avg:35.54ms
+step:107/1600 train_time:3798ms step_avg:35.50ms
+step:108/1600 train_time:3835ms step_avg:35.51ms
+step:109/1600 train_time:3866ms step_avg:35.47ms
+step:110/1600 train_time:3903ms step_avg:35.48ms
+step:111/1600 train_time:3934ms step_avg:35.44ms
+step:112/1600 train_time:3972ms step_avg:35.46ms
+step:113/1600 train_time:4002ms step_avg:35.41ms
+step:114/1600 train_time:4039ms step_avg:35.43ms
+step:115/1600 train_time:4070ms step_avg:35.39ms
+step:116/1600 train_time:4107ms step_avg:35.41ms
+step:117/1600 train_time:4138ms step_avg:35.36ms
+step:118/1600 train_time:4175ms step_avg:35.38ms
+step:119/1600 train_time:4206ms step_avg:35.34ms
+step:120/1600 train_time:4244ms step_avg:35.37ms
+step:121/1600 train_time:4274ms step_avg:35.32ms
+step:122/1600 train_time:4311ms step_avg:35.34ms
+step:123/1600 train_time:4342ms step_avg:35.30ms
+step:124/1600 train_time:4379ms step_avg:35.32ms
+step:125/1600 train_time:4410ms step_avg:35.28ms
+step:126/1600 train_time:4447ms step_avg:35.30ms
+step:127/1600 train_time:4478ms step_avg:35.26ms
+step:128/1600 train_time:4515ms step_avg:35.27ms
+step:129/1600 train_time:4545ms step_avg:35.23ms
+step:130/1600 train_time:4583ms step_avg:35.25ms
+step:131/1600 train_time:4613ms step_avg:35.21ms
+step:132/1600 train_time:4651ms step_avg:35.23ms
+step:133/1600 train_time:4681ms step_avg:35.19ms
+step:134/1600 train_time:4718ms step_avg:35.21ms
+step:135/1600 train_time:4748ms step_avg:35.17ms
+step:136/1600 train_time:4786ms step_avg:35.19ms
+step:137/1600 train_time:4816ms step_avg:35.16ms
+step:138/1600 train_time:4854ms step_avg:35.17ms
+step:139/1600 train_time:4885ms step_avg:35.14ms
+step:140/1600 train_time:4922ms step_avg:35.16ms
+step:141/1600 train_time:4953ms step_avg:35.13ms
+step:142/1600 train_time:4990ms step_avg:35.14ms
+step:143/1600 train_time:5021ms step_avg:35.11ms
+step:144/1600 train_time:5058ms step_avg:35.13ms
+step:145/1600 train_time:5088ms step_avg:35.09ms
+step:146/1600 train_time:5126ms step_avg:35.11ms
+step:147/1600 train_time:5156ms step_avg:35.08ms
+step:148/1600 train_time:5194ms step_avg:35.09ms
+step:149/1600 train_time:5224ms step_avg:35.06ms
+step:150/1600 train_time:5261ms step_avg:35.07ms
+step:151/1600 train_time:5292ms step_avg:35.04ms
+step:152/1600 train_time:5329ms step_avg:35.06ms
+step:153/1600 train_time:5360ms step_avg:35.03ms
+step:154/1600 train_time:5397ms step_avg:35.05ms
+step:155/1600 train_time:5427ms step_avg:35.01ms
+step:156/1600 train_time:5465ms step_avg:35.03ms
+step:157/1600 train_time:5495ms step_avg:35.00ms
+step:158/1600 train_time:5532ms step_avg:35.01ms
+step:159/1600 train_time:5563ms step_avg:34.99ms
+step:160/1600 train_time:5601ms step_avg:35.01ms
+step:161/1600 train_time:5632ms step_avg:34.98ms
+step:162/1600 train_time:5670ms step_avg:35.00ms
+step:163/1600 train_time:5700ms step_avg:34.97ms
+step:164/1600 train_time:5738ms step_avg:34.99ms
+step:165/1600 train_time:5768ms step_avg:34.96ms
+step:166/1600 train_time:5806ms step_avg:34.98ms
+step:167/1600 train_time:5837ms step_avg:34.95ms
+step:168/1600 train_time:5874ms step_avg:34.96ms
+step:169/1600 train_time:5904ms step_avg:34.94ms
+step:170/1600 train_time:5942ms step_avg:34.95ms
+step:171/1600 train_time:5972ms step_avg:34.93ms
+step:172/1600 train_time:6010ms step_avg:34.94ms
+step:173/1600 train_time:6040ms step_avg:34.92ms
+step:174/1600 train_time:6078ms step_avg:34.93ms
+step:175/1600 train_time:6108ms step_avg:34.90ms
+step:176/1600 train_time:6146ms step_avg:34.92ms
+step:177/1600 train_time:6177ms step_avg:34.90ms
+step:178/1600 train_time:6214ms step_avg:34.91ms
+step:179/1600 train_time:6245ms step_avg:34.89ms
+step:180/1600 train_time:6282ms step_avg:34.90ms
+step:181/1600 train_time:6313ms step_avg:34.88ms
+step:182/1600 train_time:6350ms step_avg:34.89ms
+step:183/1600 train_time:6380ms step_avg:34.86ms
+step:184/1600 train_time:6417ms step_avg:34.88ms
+step:185/1600 train_time:6448ms step_avg:34.85ms
+step:186/1600 train_time:6485ms step_avg:34.87ms
+step:187/1600 train_time:6515ms step_avg:34.84ms
+step:188/1600 train_time:6553ms step_avg:34.86ms
+step:189/1600 train_time:6584ms step_avg:34.84ms
+step:190/1600 train_time:6622ms step_avg:34.85ms
+step:191/1600 train_time:6652ms step_avg:34.83ms
+step:192/1600 train_time:6689ms step_avg:34.84ms
+step:193/1600 train_time:6720ms step_avg:34.82ms
+step:194/1600 train_time:6757ms step_avg:34.83ms
+step:195/1600 train_time:6787ms step_avg:34.81ms
+step:196/1600 train_time:6825ms step_avg:34.82ms
+step:197/1600 train_time:6856ms step_avg:34.80ms
+step:198/1600 train_time:6893ms step_avg:34.81ms
+step:199/1600 train_time:6924ms step_avg:34.79ms
+step:200/1600 train_time:6962ms step_avg:34.81ms
+step:201/1600 train_time:6992ms step_avg:34.79ms
+step:202/1600 train_time:7029ms step_avg:34.80ms
+step:203/1600 train_time:7060ms step_avg:34.78ms
+step:204/1600 train_time:7097ms step_avg:34.79ms
+step:205/1600 train_time:7127ms step_avg:34.77ms
+step:206/1600 train_time:7165ms step_avg:34.78ms
+step:207/1600 train_time:7196ms step_avg:34.76ms
+step:208/1600 train_time:7233ms step_avg:34.77ms
+step:209/1600 train_time:7264ms step_avg:34.76ms
+step:210/1600 train_time:7302ms step_avg:34.77ms
+step:211/1600 train_time:7332ms step_avg:34.75ms
+step:212/1600 train_time:7370ms step_avg:34.76ms
+step:213/1600 train_time:7400ms step_avg:34.74ms
+step:214/1600 train_time:7437ms step_avg:34.75ms
+step:215/1600 train_time:7468ms step_avg:34.73ms
+step:216/1600 train_time:7506ms step_avg:34.75ms
+step:217/1600 train_time:7536ms step_avg:34.73ms
+step:218/1600 train_time:7573ms step_avg:34.74ms
+step:219/1600 train_time:7604ms step_avg:34.72ms
+step:220/1600 train_time:7642ms step_avg:34.74ms
+step:221/1600 train_time:7673ms step_avg:34.72ms
+step:222/1600 train_time:7710ms step_avg:34.73ms
+step:223/1600 train_time:7740ms step_avg:34.71ms
+step:224/1600 train_time:7778ms step_avg:34.72ms
+step:225/1600 train_time:7808ms step_avg:34.70ms
+step:226/1600 train_time:7845ms step_avg:34.71ms
+step:227/1600 train_time:7876ms step_avg:34.69ms
+step:228/1600 train_time:7913ms step_avg:34.71ms
+step:229/1600 train_time:7943ms step_avg:34.69ms
+step:230/1600 train_time:7981ms step_avg:34.70ms
+step:231/1600 train_time:8011ms step_avg:34.68ms
+step:232/1600 train_time:8048ms step_avg:34.69ms
+step:233/1600 train_time:8078ms step_avg:34.67ms
+step:234/1600 train_time:8115ms step_avg:34.68ms
+step:235/1600 train_time:8146ms step_avg:34.66ms
+step:236/1600 train_time:8184ms step_avg:34.68ms
+step:237/1600 train_time:8214ms step_avg:34.66ms
+step:238/1600 train_time:8251ms step_avg:34.67ms
+step:239/1600 train_time:8281ms step_avg:34.65ms
+step:240/1600 train_time:8319ms step_avg:34.66ms
+step:241/1600 train_time:8349ms step_avg:34.64ms
+step:242/1600 train_time:8387ms step_avg:34.66ms
+step:243/1600 train_time:8417ms step_avg:34.64ms
+step:244/1600 train_time:8454ms step_avg:34.65ms
+step:245/1600 train_time:8485ms step_avg:34.63ms
+step:246/1600 train_time:8523ms step_avg:34.64ms
+step:247/1600 train_time:8553ms step_avg:34.63ms
+step:248/1600 train_time:8590ms step_avg:34.64ms
+step:249/1600 train_time:8621ms step_avg:34.62ms
+step:250/1600 train_time:8659ms step_avg:34.63ms
+step:250/1600 val_loss:4.5832 train_time:8706ms step_avg:34.82ms
+step:251/1600 train_time:8729ms step_avg:34.77ms
+step:252/1600 train_time:8749ms step_avg:34.72ms
+step:253/1600 train_time:8766ms step_avg:34.65ms
+step:254/1600 train_time:8799ms step_avg:34.64ms
+step:255/1600 train_time:8831ms step_avg:34.63ms
+step:256/1600 train_time:8870ms step_avg:34.65ms
+step:257/1600 train_time:8902ms step_avg:34.64ms
+step:258/1600 train_time:8939ms step_avg:34.65ms
+step:259/1600 train_time:8970ms step_avg:34.63ms
+step:260/1600 train_time:9008ms step_avg:34.65ms
+step:261/1600 train_time:9039ms step_avg:34.63ms
+step:262/1600 train_time:9076ms step_avg:34.64ms
+step:263/1600 train_time:9106ms step_avg:34.63ms
+step:264/1600 train_time:9144ms step_avg:34.64ms
+step:265/1600 train_time:9174ms step_avg:34.62ms
+step:266/1600 train_time:9212ms step_avg:34.63ms
+step:267/1600 train_time:9242ms step_avg:34.62ms
+step:268/1600 train_time:9279ms step_avg:34.62ms
+step:269/1600 train_time:9310ms step_avg:34.61ms
+step:270/1600 train_time:9347ms step_avg:34.62ms
+step:271/1600 train_time:9377ms step_avg:34.60ms
+step:272/1600 train_time:9415ms step_avg:34.61ms
+step:273/1600 train_time:9445ms step_avg:34.60ms
+step:274/1600 train_time:9482ms step_avg:34.61ms
+step:275/1600 train_time:9513ms step_avg:34.59ms
+step:276/1600 train_time:9550ms step_avg:34.60ms
+step:277/1600 train_time:9580ms step_avg:34.58ms
+step:278/1600 train_time:9617ms step_avg:34.59ms
+step:279/1600 train_time:9647ms step_avg:34.58ms
+step:280/1600 train_time:9685ms step_avg:34.59ms
+step:281/1600 train_time:9715ms step_avg:34.57ms
+step:282/1600 train_time:9753ms step_avg:34.58ms
+step:283/1600 train_time:9783ms step_avg:34.57ms
+step:284/1600 train_time:9821ms step_avg:34.58ms
+step:285/1600 train_time:9851ms step_avg:34.56ms
+step:286/1600 train_time:9888ms step_avg:34.58ms
+step:287/1600 train_time:9919ms step_avg:34.56ms
+step:288/1600 train_time:9957ms step_avg:34.57ms
+step:289/1600 train_time:9987ms step_avg:34.56ms
+step:290/1600 train_time:10025ms step_avg:34.57ms
+step:291/1600 train_time:10055ms step_avg:34.55ms
+step:292/1600 train_time:10093ms step_avg:34.57ms
+step:293/1600 train_time:10124ms step_avg:34.55ms
+step:294/1600 train_time:10161ms step_avg:34.56ms
+step:295/1600 train_time:10192ms step_avg:34.55ms
+step:296/1600 train_time:10229ms step_avg:34.56ms
+step:297/1600 train_time:10259ms step_avg:34.54ms
+step:298/1600 train_time:10297ms step_avg:34.55ms
+step:299/1600 train_time:10327ms step_avg:34.54ms
+step:300/1600 train_time:10364ms step_avg:34.55ms
+step:301/1600 train_time:10395ms step_avg:34.54ms
+step:302/1600 train_time:10433ms step_avg:34.54ms
+step:303/1600 train_time:10463ms step_avg:34.53ms
+step:304/1600 train_time:10501ms step_avg:34.54ms
+step:305/1600 train_time:10531ms step_avg:34.53ms
+step:306/1600 train_time:10568ms step_avg:34.54ms
+step:307/1600 train_time:10599ms step_avg:34.52ms
+step:308/1600 train_time:10636ms step_avg:34.53ms
+step:309/1600 train_time:10666ms step_avg:34.52ms
+step:310/1600 train_time:10704ms step_avg:34.53ms
+step:311/1600 train_time:10734ms step_avg:34.52ms
+step:312/1600 train_time:10772ms step_avg:34.53ms
+step:313/1600 train_time:10802ms step_avg:34.51ms
+step:314/1600 train_time:10840ms step_avg:34.52ms
+step:315/1600 train_time:10870ms step_avg:34.51ms
+step:316/1600 train_time:10908ms step_avg:34.52ms
+step:317/1600 train_time:10938ms step_avg:34.50ms
+step:318/1600 train_time:10975ms step_avg:34.51ms
+step:319/1600 train_time:11005ms step_avg:34.50ms
+step:320/1600 train_time:11042ms step_avg:34.51ms
+step:321/1600 train_time:11073ms step_avg:34.49ms
+step:322/1600 train_time:11111ms step_avg:34.50ms
+step:323/1600 train_time:11141ms step_avg:34.49ms
+step:324/1600 train_time:11178ms step_avg:34.50ms
+step:325/1600 train_time:11209ms step_avg:34.49ms
+step:326/1600 train_time:11246ms step_avg:34.50ms
+step:327/1600 train_time:11277ms step_avg:34.49ms
+step:328/1600 train_time:11314ms step_avg:34.50ms
+step:329/1600 train_time:11345ms step_avg:34.48ms
+step:330/1600 train_time:11382ms step_avg:34.49ms
+step:331/1600 train_time:11412ms step_avg:34.48ms
+step:332/1600 train_time:11450ms step_avg:34.49ms
+step:333/1600 train_time:11480ms step_avg:34.47ms
+step:334/1600 train_time:11517ms step_avg:34.48ms
+step:335/1600 train_time:11551ms step_avg:34.48ms
+step:336/1600 train_time:11586ms step_avg:34.48ms
+step:337/1600 train_time:11616ms step_avg:34.47ms
+step:338/1600 train_time:11654ms step_avg:34.48ms
+step:339/1600 train_time:11684ms step_avg:34.47ms
+step:340/1600 train_time:11721ms step_avg:34.47ms
+step:341/1600 train_time:11752ms step_avg:34.46ms
+step:342/1600 train_time:11789ms step_avg:34.47ms
+step:343/1600 train_time:11820ms step_avg:34.46ms
+step:344/1600 train_time:11857ms step_avg:34.47ms
+step:345/1600 train_time:11887ms step_avg:34.46ms
+step:346/1600 train_time:11925ms step_avg:34.46ms
+step:347/1600 train_time:11955ms step_avg:34.45ms
+step:348/1600 train_time:11993ms step_avg:34.46ms
+step:349/1600 train_time:12023ms step_avg:34.45ms
+step:350/1600 train_time:12061ms step_avg:34.46ms
+step:351/1600 train_time:12091ms step_avg:34.45ms
+step:352/1600 train_time:12129ms step_avg:34.46ms
+step:353/1600 train_time:12159ms step_avg:34.44ms
+step:354/1600 train_time:12196ms step_avg:34.45ms
+step:355/1600 train_time:12227ms step_avg:34.44ms
+step:356/1600 train_time:12264ms step_avg:34.45ms
+step:357/1600 train_time:12294ms step_avg:34.44ms
+step:358/1600 train_time:12332ms step_avg:34.45ms
+step:359/1600 train_time:12362ms step_avg:34.43ms
+step:360/1600 train_time:12399ms step_avg:34.44ms
+step:361/1600 train_time:12430ms step_avg:34.43ms
+step:362/1600 train_time:12468ms step_avg:34.44ms
+step:363/1600 train_time:12498ms step_avg:34.43ms
+step:364/1600 train_time:12535ms step_avg:34.44ms
+step:365/1600 train_time:12566ms step_avg:34.43ms
+step:366/1600 train_time:12603ms step_avg:34.43ms
+step:367/1600 train_time:12633ms step_avg:34.42ms
+step:368/1600 train_time:12671ms step_avg:34.43ms
+step:369/1600 train_time:12701ms step_avg:34.42ms
+step:370/1600 train_time:12738ms step_avg:34.43ms
+step:371/1600 train_time:12769ms step_avg:34.42ms
+step:372/1600 train_time:12807ms step_avg:34.43ms
+step:373/1600 train_time:12837ms step_avg:34.42ms
+step:374/1600 train_time:12874ms step_avg:34.42ms
+step:375/1600 train_time:12905ms step_avg:34.41ms
+step:376/1600 train_time:12943ms step_avg:34.42ms
+step:377/1600 train_time:12974ms step_avg:34.41ms
+step:378/1600 train_time:13011ms step_avg:34.42ms
+step:379/1600 train_time:13042ms step_avg:34.41ms
+step:380/1600 train_time:13080ms step_avg:34.42ms
+step:381/1600 train_time:13110ms step_avg:34.41ms
+step:382/1600 train_time:13147ms step_avg:34.42ms
+step:383/1600 train_time:13178ms step_avg:34.41ms
+step:384/1600 train_time:13215ms step_avg:34.42ms
+step:385/1600 train_time:13246ms step_avg:34.41ms
+step:386/1600 train_time:13284ms step_avg:34.41ms
+step:387/1600 train_time:13314ms step_avg:34.40ms
+step:388/1600 train_time:13351ms step_avg:34.41ms
+step:389/1600 train_time:13382ms step_avg:34.40ms
+step:390/1600 train_time:13419ms step_avg:34.41ms
+step:391/1600 train_time:13449ms step_avg:34.40ms
+step:392/1600 train_time:13487ms step_avg:34.40ms
+step:393/1600 train_time:13518ms step_avg:34.40ms
+step:394/1600 train_time:13555ms step_avg:34.40ms
+step:395/1600 train_time:13586ms step_avg:34.39ms
+step:396/1600 train_time:13623ms step_avg:34.40ms
+step:397/1600 train_time:13653ms step_avg:34.39ms
+step:398/1600 train_time:13691ms step_avg:34.40ms
+step:399/1600 train_time:13721ms step_avg:34.39ms
+step:400/1600 train_time:13758ms step_avg:34.40ms
+step:401/1600 train_time:13788ms step_avg:34.39ms
+step:402/1600 train_time:13827ms step_avg:34.39ms
+step:403/1600 train_time:13856ms step_avg:34.38ms
+step:404/1600 train_time:13894ms step_avg:34.39ms
+step:405/1600 train_time:13924ms step_avg:34.38ms
+step:406/1600 train_time:13962ms step_avg:34.39ms
+step:407/1600 train_time:13992ms step_avg:34.38ms
+step:408/1600 train_time:14030ms step_avg:34.39ms
+step:409/1600 train_time:14060ms step_avg:34.38ms
+step:410/1600 train_time:14097ms step_avg:34.38ms
+step:411/1600 train_time:14128ms step_avg:34.37ms
+step:412/1600 train_time:14165ms step_avg:34.38ms
+step:413/1600 train_time:14195ms step_avg:34.37ms
+step:414/1600 train_time:14233ms step_avg:34.38ms
+step:415/1600 train_time:14263ms step_avg:34.37ms
+step:416/1600 train_time:14301ms step_avg:34.38ms
+step:417/1600 train_time:14331ms step_avg:34.37ms
+step:418/1600 train_time:14369ms step_avg:34.37ms
+step:419/1600 train_time:14399ms step_avg:34.36ms
+step:420/1600 train_time:14436ms step_avg:34.37ms
+step:421/1600 train_time:14466ms step_avg:34.36ms
+step:422/1600 train_time:14504ms step_avg:34.37ms
+step:423/1600 train_time:14535ms step_avg:34.36ms
+step:424/1600 train_time:14572ms step_avg:34.37ms
+step:425/1600 train_time:14602ms step_avg:34.36ms
+step:426/1600 train_time:14640ms step_avg:34.37ms
+step:427/1600 train_time:14670ms step_avg:34.35ms
+step:428/1600 train_time:14708ms step_avg:34.36ms
+step:429/1600 train_time:14737ms step_avg:34.35ms
+step:430/1600 train_time:14774ms step_avg:34.36ms
+step:431/1600 train_time:14805ms step_avg:34.35ms
+step:432/1600 train_time:14842ms step_avg:34.36ms
+step:433/1600 train_time:14872ms step_avg:34.35ms
+step:434/1600 train_time:14910ms step_avg:34.36ms
+step:435/1600 train_time:14940ms step_avg:34.35ms
+step:436/1600 train_time:14978ms step_avg:34.35ms
+step:437/1600 train_time:15008ms step_avg:34.34ms
+step:438/1600 train_time:15046ms step_avg:34.35ms
+step:439/1600 train_time:15076ms step_avg:34.34ms
+step:440/1600 train_time:15114ms step_avg:34.35ms
+step:441/1600 train_time:15145ms step_avg:34.34ms
+step:442/1600 train_time:15182ms step_avg:34.35ms
+step:443/1600 train_time:15212ms step_avg:34.34ms
+step:444/1600 train_time:15249ms step_avg:34.34ms
+step:445/1600 train_time:15279ms step_avg:34.34ms
+step:446/1600 train_time:15316ms step_avg:34.34ms
+step:447/1600 train_time:15346ms step_avg:34.33ms
+step:448/1600 train_time:15384ms step_avg:34.34ms
+step:449/1600 train_time:15414ms step_avg:34.33ms
+step:450/1600 train_time:15452ms step_avg:34.34ms
+step:451/1600 train_time:15482ms step_avg:34.33ms
+step:452/1600 train_time:15520ms step_avg:34.34ms
+step:453/1600 train_time:15550ms step_avg:34.33ms
+step:454/1600 train_time:15588ms step_avg:34.33ms
+step:455/1600 train_time:15618ms step_avg:34.33ms
+step:456/1600 train_time:15656ms step_avg:34.33ms
+step:457/1600 train_time:15686ms step_avg:34.32ms
+step:458/1600 train_time:15724ms step_avg:34.33ms
+step:459/1600 train_time:15754ms step_avg:34.32ms
+step:460/1600 train_time:15791ms step_avg:34.33ms
+step:461/1600 train_time:15822ms step_avg:34.32ms
+step:462/1600 train_time:15859ms step_avg:34.33ms
+step:463/1600 train_time:15889ms step_avg:34.32ms
+step:464/1600 train_time:15927ms step_avg:34.32ms
+step:465/1600 train_time:15957ms step_avg:34.32ms
+step:466/1600 train_time:15994ms step_avg:34.32ms
+step:467/1600 train_time:16025ms step_avg:34.31ms
+step:468/1600 train_time:16063ms step_avg:34.32ms
+step:469/1600 train_time:16094ms step_avg:34.31ms
+step:470/1600 train_time:16131ms step_avg:34.32ms
+step:471/1600 train_time:16161ms step_avg:34.31ms
+step:472/1600 train_time:16199ms step_avg:34.32ms
+step:473/1600 train_time:16229ms step_avg:34.31ms
+step:474/1600 train_time:16267ms step_avg:34.32ms
+step:475/1600 train_time:16297ms step_avg:34.31ms
+step:476/1600 train_time:16335ms step_avg:34.32ms
+step:477/1600 train_time:16365ms step_avg:34.31ms
+step:478/1600 train_time:16403ms step_avg:34.32ms
+step:479/1600 train_time:16433ms step_avg:34.31ms
+step:480/1600 train_time:16471ms step_avg:34.31ms
+step:481/1600 train_time:16501ms step_avg:34.31ms
+step:482/1600 train_time:16538ms step_avg:34.31ms
+step:483/1600 train_time:16569ms step_avg:34.30ms
+step:484/1600 train_time:16606ms step_avg:34.31ms
+step:485/1600 train_time:16636ms step_avg:34.30ms
+step:486/1600 train_time:16674ms step_avg:34.31ms
+step:487/1600 train_time:16705ms step_avg:34.30ms
+step:488/1600 train_time:16742ms step_avg:34.31ms
+step:489/1600 train_time:16772ms step_avg:34.30ms
+step:490/1600 train_time:16810ms step_avg:34.31ms
+step:491/1600 train_time:16840ms step_avg:34.30ms
+step:492/1600 train_time:16877ms step_avg:34.30ms
+step:493/1600 train_time:16908ms step_avg:34.30ms
+step:494/1600 train_time:16945ms step_avg:34.30ms
+step:495/1600 train_time:16975ms step_avg:34.29ms
+step:496/1600 train_time:17013ms step_avg:34.30ms
+step:497/1600 train_time:17053ms step_avg:34.31ms
+step:498/1600 train_time:17081ms step_avg:34.30ms
+step:499/1600 train_time:17111ms step_avg:34.29ms
+step:500/1600 train_time:17149ms step_avg:34.30ms
+step:500/1600 val_loss:4.2359 train_time:17196ms step_avg:34.39ms
+step:501/1600 train_time:17216ms step_avg:34.36ms
+step:502/1600 train_time:17236ms step_avg:34.33ms
+step:503/1600 train_time:17254ms step_avg:34.30ms
+step:504/1600 train_time:17288ms step_avg:34.30ms
+step:505/1600 train_time:17320ms step_avg:34.30ms
+step:506/1600 train_time:17359ms step_avg:34.31ms
+step:507/1600 train_time:17390ms step_avg:34.30ms
+step:508/1600 train_time:17428ms step_avg:34.31ms
+step:509/1600 train_time:17459ms step_avg:34.30ms
+step:510/1600 train_time:17496ms step_avg:34.31ms
+step:511/1600 train_time:17527ms step_avg:34.30ms
+step:512/1600 train_time:17564ms step_avg:34.30ms
+step:513/1600 train_time:17594ms step_avg:34.30ms
+step:514/1600 train_time:17631ms step_avg:34.30ms
+step:515/1600 train_time:17661ms step_avg:34.29ms
+step:516/1600 train_time:17698ms step_avg:34.30ms
+step:517/1600 train_time:17728ms step_avg:34.29ms
+step:518/1600 train_time:17765ms step_avg:34.30ms
+step:519/1600 train_time:17795ms step_avg:34.29ms
+step:520/1600 train_time:17832ms step_avg:34.29ms
+step:521/1600 train_time:17906ms step_avg:34.37ms
+step:522/1600 train_time:17960ms step_avg:34.41ms
+step:523/1600 train_time:18021ms step_avg:34.46ms
+step:524/1600 train_time:18080ms step_avg:34.50ms
+step:525/1600 train_time:18141ms step_avg:34.55ms
+step:526/1600 train_time:18201ms step_avg:34.60ms
+step:527/1600 train_time:18265ms step_avg:34.66ms
+step:528/1600 train_time:18325ms step_avg:34.71ms
+step:529/1600 train_time:18388ms step_avg:34.76ms
+step:530/1600 train_time:18447ms step_avg:34.81ms
+step:531/1600 train_time:18509ms step_avg:34.86ms
+step:532/1600 train_time:18568ms step_avg:34.90ms
+step:533/1600 train_time:18631ms step_avg:34.96ms
+step:534/1600 train_time:18691ms step_avg:35.00ms
+step:535/1600 train_time:18753ms step_avg:35.05ms
+step:536/1600 train_time:18813ms step_avg:35.10ms
+step:537/1600 train_time:18875ms step_avg:35.15ms
+step:538/1600 train_time:18934ms step_avg:35.19ms
+step:539/1600 train_time:18996ms step_avg:35.24ms
+step:540/1600 train_time:19054ms step_avg:35.29ms
+step:541/1600 train_time:19117ms step_avg:35.34ms
+step:542/1600 train_time:19177ms step_avg:35.38ms
+step:543/1600 train_time:19239ms step_avg:35.43ms
+step:544/1600 train_time:19299ms step_avg:35.48ms
+step:545/1600 train_time:19362ms step_avg:35.53ms
+step:546/1600 train_time:19421ms step_avg:35.57ms
+step:547/1600 train_time:19485ms step_avg:35.62ms
+step:548/1600 train_time:19543ms step_avg:35.66ms
+step:549/1600 train_time:19607ms step_avg:35.71ms
+step:550/1600 train_time:19665ms step_avg:35.76ms
+step:551/1600 train_time:19728ms step_avg:35.80ms
+step:552/1600 train_time:19786ms step_avg:35.84ms
+step:553/1600 train_time:19848ms step_avg:35.89ms
+step:554/1600 train_time:19907ms step_avg:35.93ms
+step:555/1600 train_time:19969ms step_avg:35.98ms
+step:556/1600 train_time:20027ms step_avg:36.02ms
+step:557/1600 train_time:20090ms step_avg:36.07ms
+step:558/1600 train_time:20149ms step_avg:36.11ms
+step:559/1600 train_time:20212ms step_avg:36.16ms
+step:560/1600 train_time:20272ms step_avg:36.20ms
+step:561/1600 train_time:20334ms step_avg:36.25ms
+step:562/1600 train_time:20395ms step_avg:36.29ms
+step:563/1600 train_time:20457ms step_avg:36.34ms
+step:564/1600 train_time:20516ms step_avg:36.38ms
+step:565/1600 train_time:20579ms step_avg:36.42ms
+step:566/1600 train_time:20638ms step_avg:36.46ms
+step:567/1600 train_time:20701ms step_avg:36.51ms
+step:568/1600 train_time:20761ms step_avg:36.55ms
+step:569/1600 train_time:20824ms step_avg:36.60ms
+step:570/1600 train_time:20883ms step_avg:36.64ms
+step:571/1600 train_time:20945ms step_avg:36.68ms
+step:572/1600 train_time:21004ms step_avg:36.72ms
+step:573/1600 train_time:21071ms step_avg:36.77ms
+step:574/1600 train_time:21127ms step_avg:36.81ms
+step:575/1600 train_time:21188ms step_avg:36.85ms
+step:576/1600 train_time:21248ms step_avg:36.89ms
+step:577/1600 train_time:21311ms step_avg:36.93ms
+step:578/1600 train_time:21369ms step_avg:36.97ms
+step:579/1600 train_time:21430ms step_avg:37.01ms
+step:580/1600 train_time:21490ms step_avg:37.05ms
+step:581/1600 train_time:21551ms step_avg:37.09ms
+step:582/1600 train_time:21611ms step_avg:37.13ms
+step:583/1600 train_time:21675ms step_avg:37.18ms
+step:584/1600 train_time:21735ms step_avg:37.22ms
+step:585/1600 train_time:21797ms step_avg:37.26ms
+step:586/1600 train_time:21856ms step_avg:37.30ms
+step:587/1600 train_time:21919ms step_avg:37.34ms
+step:588/1600 train_time:21979ms step_avg:37.38ms
+step:589/1600 train_time:22040ms step_avg:37.42ms
+step:590/1600 train_time:22100ms step_avg:37.46ms
+step:591/1600 train_time:22162ms step_avg:37.50ms
+step:592/1600 train_time:22221ms step_avg:37.54ms
+step:593/1600 train_time:22283ms step_avg:37.58ms
+step:594/1600 train_time:22343ms step_avg:37.61ms
+step:595/1600 train_time:22406ms step_avg:37.66ms
+step:596/1600 train_time:22465ms step_avg:37.69ms
+step:597/1600 train_time:22527ms step_avg:37.73ms
+step:598/1600 train_time:22585ms step_avg:37.77ms
+step:599/1600 train_time:22647ms step_avg:37.81ms
+step:600/1600 train_time:22706ms step_avg:37.84ms
+step:601/1600 train_time:22768ms step_avg:37.88ms
+step:602/1600 train_time:22827ms step_avg:37.92ms
+step:603/1600 train_time:22890ms step_avg:37.96ms
+step:604/1600 train_time:22949ms step_avg:37.99ms
+step:605/1600 train_time:23011ms step_avg:38.03ms
+step:606/1600 train_time:23071ms step_avg:38.07ms
+step:607/1600 train_time:23134ms step_avg:38.11ms
+step:608/1600 train_time:23194ms step_avg:38.15ms
+step:609/1600 train_time:23257ms step_avg:38.19ms
+step:610/1600 train_time:23316ms step_avg:38.22ms
+step:611/1600 train_time:23379ms step_avg:38.26ms
+step:612/1600 train_time:23439ms step_avg:38.30ms
+step:613/1600 train_time:23502ms step_avg:38.34ms
+step:614/1600 train_time:23561ms step_avg:38.37ms
+step:615/1600 train_time:23623ms step_avg:38.41ms
+step:616/1600 train_time:23684ms step_avg:38.45ms
+step:617/1600 train_time:23745ms step_avg:38.48ms
+step:618/1600 train_time:23804ms step_avg:38.52ms
+step:619/1600 train_time:23865ms step_avg:38.55ms
+step:620/1600 train_time:23924ms step_avg:38.59ms
+step:621/1600 train_time:23987ms step_avg:38.63ms
+step:622/1600 train_time:24045ms step_avg:38.66ms
+step:623/1600 train_time:24107ms step_avg:38.70ms
+step:624/1600 train_time:24165ms step_avg:38.73ms
+step:625/1600 train_time:24227ms step_avg:38.76ms
+step:626/1600 train_time:24286ms step_avg:38.80ms
+step:627/1600 train_time:24348ms step_avg:38.83ms
+step:628/1600 train_time:24408ms step_avg:38.87ms
+step:629/1600 train_time:24470ms step_avg:38.90ms
+step:630/1600 train_time:24529ms step_avg:38.94ms
+step:631/1600 train_time:24593ms step_avg:38.97ms
+step:632/1600 train_time:24651ms step_avg:39.01ms
+step:633/1600 train_time:24715ms step_avg:39.04ms
+step:634/1600 train_time:24774ms step_avg:39.08ms
+step:635/1600 train_time:24837ms step_avg:39.11ms
+step:636/1600 train_time:24896ms step_avg:39.15ms
+step:637/1600 train_time:24958ms step_avg:39.18ms
+step:638/1600 train_time:25017ms step_avg:39.21ms
+step:639/1600 train_time:25081ms step_avg:39.25ms
+step:640/1600 train_time:25141ms step_avg:39.28ms
+step:641/1600 train_time:25203ms step_avg:39.32ms
+step:642/1600 train_time:25262ms step_avg:39.35ms
+step:643/1600 train_time:25324ms step_avg:39.38ms
+step:644/1600 train_time:25382ms step_avg:39.41ms
+step:645/1600 train_time:25444ms step_avg:39.45ms
+step:646/1600 train_time:25504ms step_avg:39.48ms
+step:647/1600 train_time:25566ms step_avg:39.51ms
+step:648/1600 train_time:25625ms step_avg:39.54ms
+step:649/1600 train_time:25687ms step_avg:39.58ms
+step:650/1600 train_time:25745ms step_avg:39.61ms
+step:651/1600 train_time:25807ms step_avg:39.64ms
+step:652/1600 train_time:25865ms step_avg:39.67ms
+step:653/1600 train_time:25927ms step_avg:39.70ms
+step:654/1600 train_time:25986ms step_avg:39.73ms
+step:655/1600 train_time:26047ms step_avg:39.77ms
+step:656/1600 train_time:26110ms step_avg:39.80ms
+step:657/1600 train_time:26169ms step_avg:39.83ms
+step:658/1600 train_time:26228ms step_avg:39.86ms
+step:659/1600 train_time:26291ms step_avg:39.90ms
+step:660/1600 train_time:26349ms step_avg:39.92ms
+step:661/1600 train_time:26412ms step_avg:39.96ms
+step:662/1600 train_time:26471ms step_avg:39.99ms
+step:663/1600 train_time:26534ms step_avg:40.02ms
+step:664/1600 train_time:26593ms step_avg:40.05ms
+step:665/1600 train_time:26656ms step_avg:40.08ms
+step:666/1600 train_time:26715ms step_avg:40.11ms
+step:667/1600 train_time:26778ms step_avg:40.15ms
+step:668/1600 train_time:26838ms step_avg:40.18ms
+step:669/1600 train_time:26898ms step_avg:40.21ms
+step:670/1600 train_time:26958ms step_avg:40.24ms
+step:671/1600 train_time:27020ms step_avg:40.27ms
+step:672/1600 train_time:27079ms step_avg:40.30ms
+step:673/1600 train_time:27142ms step_avg:40.33ms
+step:674/1600 train_time:27202ms step_avg:40.36ms
+step:675/1600 train_time:27264ms step_avg:40.39ms
+step:676/1600 train_time:27323ms step_avg:40.42ms
+step:677/1600 train_time:27385ms step_avg:40.45ms
+step:678/1600 train_time:27444ms step_avg:40.48ms
+step:679/1600 train_time:27506ms step_avg:40.51ms
+step:680/1600 train_time:27565ms step_avg:40.54ms
+step:681/1600 train_time:27627ms step_avg:40.57ms
+step:682/1600 train_time:27686ms step_avg:40.59ms
+step:683/1600 train_time:27747ms step_avg:40.63ms
+step:684/1600 train_time:27806ms step_avg:40.65ms
+step:685/1600 train_time:27868ms step_avg:40.68ms
+step:686/1600 train_time:27927ms step_avg:40.71ms
+step:687/1600 train_time:27989ms step_avg:40.74ms
+step:688/1600 train_time:28048ms step_avg:40.77ms
+step:689/1600 train_time:28111ms step_avg:40.80ms
+step:690/1600 train_time:28170ms step_avg:40.83ms
+step:691/1600 train_time:28233ms step_avg:40.86ms
+step:692/1600 train_time:28292ms step_avg:40.88ms
+step:693/1600 train_time:28355ms step_avg:40.92ms
+step:694/1600 train_time:28414ms step_avg:40.94ms
+step:695/1600 train_time:28476ms step_avg:40.97ms
+step:696/1600 train_time:28535ms step_avg:41.00ms
+step:697/1600 train_time:28597ms step_avg:41.03ms
+step:698/1600 train_time:28656ms step_avg:41.05ms
+step:699/1600 train_time:28718ms step_avg:41.08ms
+step:700/1600 train_time:28778ms step_avg:41.11ms
+step:701/1600 train_time:28841ms step_avg:41.14ms
+step:702/1600 train_time:28900ms step_avg:41.17ms
+step:703/1600 train_time:28964ms step_avg:41.20ms
+step:704/1600 train_time:29022ms step_avg:41.22ms
+step:705/1600 train_time:29084ms step_avg:41.25ms
+step:706/1600 train_time:29143ms step_avg:41.28ms
+step:707/1600 train_time:29206ms step_avg:41.31ms
+step:708/1600 train_time:29265ms step_avg:41.33ms
+step:709/1600 train_time:29327ms step_avg:41.36ms
+step:710/1600 train_time:29385ms step_avg:41.39ms
+step:711/1600 train_time:29447ms step_avg:41.42ms
+step:712/1600 train_time:29505ms step_avg:41.44ms
+step:713/1600 train_time:29566ms step_avg:41.47ms
+step:714/1600 train_time:29625ms step_avg:41.49ms
+step:715/1600 train_time:29687ms step_avg:41.52ms
+step:716/1600 train_time:29746ms step_avg:41.54ms
+step:717/1600 train_time:29808ms step_avg:41.57ms
+step:718/1600 train_time:29867ms step_avg:41.60ms
+step:719/1600 train_time:29930ms step_avg:41.63ms
+step:720/1600 train_time:29991ms step_avg:41.65ms
+step:721/1600 train_time:30051ms step_avg:41.68ms
+step:722/1600 train_time:30110ms step_avg:41.70ms
+step:723/1600 train_time:30174ms step_avg:41.73ms
+step:724/1600 train_time:30233ms step_avg:41.76ms
+step:725/1600 train_time:30295ms step_avg:41.79ms
+step:726/1600 train_time:30354ms step_avg:41.81ms
+step:727/1600 train_time:30416ms step_avg:41.84ms
+step:728/1600 train_time:30475ms step_avg:41.86ms
+step:729/1600 train_time:30537ms step_avg:41.89ms
+step:730/1600 train_time:30596ms step_avg:41.91ms
+step:731/1600 train_time:30658ms step_avg:41.94ms
+step:732/1600 train_time:30718ms step_avg:41.96ms
+step:733/1600 train_time:30781ms step_avg:41.99ms
+step:734/1600 train_time:30841ms step_avg:42.02ms
+step:735/1600 train_time:30904ms step_avg:42.05ms
+step:736/1600 train_time:30962ms step_avg:42.07ms
+step:737/1600 train_time:31025ms step_avg:42.10ms
+step:738/1600 train_time:31084ms step_avg:42.12ms
+step:739/1600 train_time:31146ms step_avg:42.15ms
+step:740/1600 train_time:31205ms step_avg:42.17ms
+step:741/1600 train_time:31267ms step_avg:42.20ms
+step:742/1600 train_time:31326ms step_avg:42.22ms
+step:743/1600 train_time:31388ms step_avg:42.25ms
+step:744/1600 train_time:31446ms step_avg:42.27ms
+step:745/1600 train_time:31509ms step_avg:42.29ms
+step:746/1600 train_time:31567ms step_avg:42.31ms
+step:747/1600 train_time:31630ms step_avg:42.34ms
+step:748/1600 train_time:31689ms step_avg:42.37ms
+step:749/1600 train_time:31752ms step_avg:42.39ms
+step:750/1600 train_time:31812ms step_avg:42.42ms
+step:750/1600 val_loss:3.8932 train_time:31857ms step_avg:42.48ms
+step:751/1600 train_time:31878ms step_avg:42.45ms
+step:752/1600 train_time:31936ms step_avg:42.47ms
+step:753/1600 train_time:31999ms step_avg:42.49ms
+step:754/1600 train_time:32060ms step_avg:42.52ms
+step:755/1600 train_time:32122ms step_avg:42.55ms
+step:756/1600 train_time:32181ms step_avg:42.57ms
+step:757/1600 train_time:32243ms step_avg:42.59ms
+step:758/1600 train_time:32303ms step_avg:42.62ms
+step:759/1600 train_time:32364ms step_avg:42.64ms
+step:760/1600 train_time:32422ms step_avg:42.66ms
+step:761/1600 train_time:32484ms step_avg:42.69ms
+step:762/1600 train_time:32542ms step_avg:42.71ms
+step:763/1600 train_time:32603ms step_avg:42.73ms
+step:764/1600 train_time:32662ms step_avg:42.75ms
+step:765/1600 train_time:32723ms step_avg:42.78ms
+step:766/1600 train_time:32782ms step_avg:42.80ms
+step:767/1600 train_time:32845ms step_avg:42.82ms
+step:768/1600 train_time:32906ms step_avg:42.85ms
+step:769/1600 train_time:32970ms step_avg:42.87ms
+step:770/1600 train_time:33029ms step_avg:42.90ms
+step:771/1600 train_time:33094ms step_avg:42.92ms
+step:772/1600 train_time:33157ms step_avg:42.95ms
+step:773/1600 train_time:33217ms step_avg:42.97ms
+step:774/1600 train_time:33276ms step_avg:42.99ms
+step:775/1600 train_time:33338ms step_avg:43.02ms
+step:776/1600 train_time:33397ms step_avg:43.04ms
+step:777/1600 train_time:33458ms step_avg:43.06ms
+step:778/1600 train_time:33516ms step_avg:43.08ms
+step:779/1600 train_time:33578ms step_avg:43.10ms
+step:780/1600 train_time:33637ms step_avg:43.12ms
+step:781/1600 train_time:33697ms step_avg:43.15ms
+step:782/1600 train_time:33755ms step_avg:43.17ms
+step:783/1600 train_time:33817ms step_avg:43.19ms
+step:784/1600 train_time:33877ms step_avg:43.21ms
+step:785/1600 train_time:33942ms step_avg:43.24ms
+step:786/1600 train_time:34004ms step_avg:43.26ms
+step:787/1600 train_time:34067ms step_avg:43.29ms
+step:788/1600 train_time:34128ms step_avg:43.31ms
+step:789/1600 train_time:34190ms step_avg:43.33ms
+step:790/1600 train_time:34248ms step_avg:43.35ms
+step:791/1600 train_time:34311ms step_avg:43.38ms
+step:792/1600 train_time:34370ms step_avg:43.40ms
+step:793/1600 train_time:34433ms step_avg:43.42ms
+step:794/1600 train_time:34491ms step_avg:43.44ms
+step:795/1600 train_time:34554ms step_avg:43.46ms
+step:796/1600 train_time:34613ms step_avg:43.48ms
+step:797/1600 train_time:34676ms step_avg:43.51ms
+step:798/1600 train_time:34734ms step_avg:43.53ms
+step:799/1600 train_time:34795ms step_avg:43.55ms
+step:800/1600 train_time:34855ms step_avg:43.57ms
+step:801/1600 train_time:34917ms step_avg:43.59ms
+step:802/1600 train_time:34976ms step_avg:43.61ms
+step:803/1600 train_time:35038ms step_avg:43.63ms
+step:804/1600 train_time:35097ms step_avg:43.65ms
+step:805/1600 train_time:35160ms step_avg:43.68ms
+step:806/1600 train_time:35220ms step_avg:43.70ms
+step:807/1600 train_time:35282ms step_avg:43.72ms
+step:808/1600 train_time:35341ms step_avg:43.74ms
+step:809/1600 train_time:35404ms step_avg:43.76ms
+step:810/1600 train_time:35463ms step_avg:43.78ms
+step:811/1600 train_time:35526ms step_avg:43.81ms
+step:812/1600 train_time:35584ms step_avg:43.82ms
+step:813/1600 train_time:35647ms step_avg:43.85ms
+step:814/1600 train_time:35705ms step_avg:43.86ms
+step:815/1600 train_time:35767ms step_avg:43.89ms
+step:816/1600 train_time:35827ms step_avg:43.91ms
+step:817/1600 train_time:35889ms step_avg:43.93ms
+step:818/1600 train_time:35949ms step_avg:43.95ms
+step:819/1600 train_time:36012ms step_avg:43.97ms
+step:820/1600 train_time:36071ms step_avg:43.99ms
+step:821/1600 train_time:36135ms step_avg:44.01ms
+step:822/1600 train_time:36194ms step_avg:44.03ms
+step:823/1600 train_time:36256ms step_avg:44.05ms
+step:824/1600 train_time:36315ms step_avg:44.07ms
+step:825/1600 train_time:36377ms step_avg:44.09ms
+step:826/1600 train_time:36435ms step_avg:44.11ms
+step:827/1600 train_time:36497ms step_avg:44.13ms
+step:828/1600 train_time:36556ms step_avg:44.15ms
+step:829/1600 train_time:36618ms step_avg:44.17ms
+step:830/1600 train_time:36677ms step_avg:44.19ms
+step:831/1600 train_time:36739ms step_avg:44.21ms
+step:832/1600 train_time:36798ms step_avg:44.23ms
+step:833/1600 train_time:36860ms step_avg:44.25ms
+step:834/1600 train_time:36919ms step_avg:44.27ms
+step:835/1600 train_time:36982ms step_avg:44.29ms
+step:836/1600 train_time:37041ms step_avg:44.31ms
+step:837/1600 train_time:37104ms step_avg:44.33ms
+step:838/1600 train_time:37163ms step_avg:44.35ms
+step:839/1600 train_time:37226ms step_avg:44.37ms
+step:840/1600 train_time:37285ms step_avg:44.39ms
+step:841/1600 train_time:37348ms step_avg:44.41ms
+step:842/1600 train_time:37407ms step_avg:44.43ms
+step:843/1600 train_time:37471ms step_avg:44.45ms
+step:844/1600 train_time:37530ms step_avg:44.47ms
+step:845/1600 train_time:37592ms step_avg:44.49ms
+step:846/1600 train_time:37651ms step_avg:44.50ms
+step:847/1600 train_time:37713ms step_avg:44.53ms
+step:848/1600 train_time:37772ms step_avg:44.54ms
+step:849/1600 train_time:37835ms step_avg:44.56ms
+step:850/1600 train_time:37893ms step_avg:44.58ms
+step:851/1600 train_time:37956ms step_avg:44.60ms
+step:852/1600 train_time:38015ms step_avg:44.62ms
+step:853/1600 train_time:38077ms step_avg:44.64ms
+step:854/1600 train_time:38136ms step_avg:44.66ms
+step:855/1600 train_time:38198ms step_avg:44.68ms
+step:856/1600 train_time:38256ms step_avg:44.69ms
+step:857/1600 train_time:38319ms step_avg:44.71ms
+step:858/1600 train_time:38378ms step_avg:44.73ms
+step:859/1600 train_time:38440ms step_avg:44.75ms
+step:860/1600 train_time:38500ms step_avg:44.77ms
+step:861/1600 train_time:38563ms step_avg:44.79ms
+step:862/1600 train_time:38622ms step_avg:44.81ms
+step:863/1600 train_time:38685ms step_avg:44.83ms
+step:864/1600 train_time:38743ms step_avg:44.84ms
+step:865/1600 train_time:38806ms step_avg:44.86ms
+step:866/1600 train_time:38865ms step_avg:44.88ms
+step:867/1600 train_time:38927ms step_avg:44.90ms
+step:868/1600 train_time:38987ms step_avg:44.92ms
+step:869/1600 train_time:39050ms step_avg:44.94ms
+step:870/1600 train_time:39110ms step_avg:44.95ms
+step:871/1600 train_time:39173ms step_avg:44.97ms
+step:872/1600 train_time:39232ms step_avg:44.99ms
+step:873/1600 train_time:39295ms step_avg:45.01ms
+step:874/1600 train_time:39354ms step_avg:45.03ms
+step:875/1600 train_time:39416ms step_avg:45.05ms
+step:876/1600 train_time:39476ms step_avg:45.06ms
+step:877/1600 train_time:39537ms step_avg:45.08ms
+step:878/1600 train_time:39596ms step_avg:45.10ms
+step:879/1600 train_time:39658ms step_avg:45.12ms
+step:880/1600 train_time:39717ms step_avg:45.13ms
+step:881/1600 train_time:39778ms step_avg:45.15ms
+step:882/1600 train_time:39837ms step_avg:45.17ms
+step:883/1600 train_time:39900ms step_avg:45.19ms
+step:884/1600 train_time:39959ms step_avg:45.20ms
+step:885/1600 train_time:40021ms step_avg:45.22ms
+step:886/1600 train_time:40081ms step_avg:45.24ms
+step:887/1600 train_time:40144ms step_avg:45.26ms
+step:888/1600 train_time:40203ms step_avg:45.27ms
+step:889/1600 train_time:40267ms step_avg:45.29ms
+step:890/1600 train_time:40331ms step_avg:45.32ms
+step:891/1600 train_time:40391ms step_avg:45.33ms
+step:892/1600 train_time:40449ms step_avg:45.35ms
+step:893/1600 train_time:40512ms step_avg:45.37ms
+step:894/1600 train_time:40571ms step_avg:45.38ms
+step:895/1600 train_time:40634ms step_avg:45.40ms
+step:896/1600 train_time:40692ms step_avg:45.42ms
+step:897/1600 train_time:40755ms step_avg:45.43ms
+step:898/1600 train_time:40814ms step_avg:45.45ms
+step:899/1600 train_time:40877ms step_avg:45.47ms
+step:900/1600 train_time:40935ms step_avg:45.48ms
+step:901/1600 train_time:40997ms step_avg:45.50ms
+step:902/1600 train_time:41055ms step_avg:45.52ms
+step:903/1600 train_time:41117ms step_avg:45.53ms
+step:904/1600 train_time:41176ms step_avg:45.55ms
+step:905/1600 train_time:41239ms step_avg:45.57ms
+step:906/1600 train_time:41299ms step_avg:45.58ms
+step:907/1600 train_time:41362ms step_avg:45.60ms
+step:908/1600 train_time:41421ms step_avg:45.62ms
+step:909/1600 train_time:41483ms step_avg:45.64ms
+step:910/1600 train_time:41543ms step_avg:45.65ms
+step:911/1600 train_time:41605ms step_avg:45.67ms
+step:912/1600 train_time:41664ms step_avg:45.68ms
+step:913/1600 train_time:41726ms step_avg:45.70ms
+step:914/1600 train_time:41786ms step_avg:45.72ms
+step:915/1600 train_time:41849ms step_avg:45.74ms
+step:916/1600 train_time:41908ms step_avg:45.75ms
+step:917/1600 train_time:41971ms step_avg:45.77ms
+step:918/1600 train_time:42031ms step_avg:45.78ms
+step:919/1600 train_time:42093ms step_avg:45.80ms
+step:920/1600 train_time:42153ms step_avg:45.82ms
+step:921/1600 train_time:42215ms step_avg:45.84ms
+step:922/1600 train_time:42274ms step_avg:45.85ms
+step:923/1600 train_time:42335ms step_avg:45.87ms
+step:924/1600 train_time:42394ms step_avg:45.88ms
+step:925/1600 train_time:42456ms step_avg:45.90ms
+step:926/1600 train_time:42516ms step_avg:45.91ms
+step:927/1600 train_time:42576ms step_avg:45.93ms
+step:928/1600 train_time:42636ms step_avg:45.94ms
+step:929/1600 train_time:42697ms step_avg:45.96ms
+step:930/1600 train_time:42756ms step_avg:45.97ms
+step:931/1600 train_time:42818ms step_avg:45.99ms
+step:932/1600 train_time:42877ms step_avg:46.01ms
+step:933/1600 train_time:42939ms step_avg:46.02ms
+step:934/1600 train_time:42999ms step_avg:46.04ms
+step:935/1600 train_time:43062ms step_avg:46.06ms
+step:936/1600 train_time:43121ms step_avg:46.07ms
+step:937/1600 train_time:43184ms step_avg:46.09ms
+step:938/1600 train_time:43244ms step_avg:46.10ms
+step:939/1600 train_time:43306ms step_avg:46.12ms
+step:940/1600 train_time:43365ms step_avg:46.13ms
+step:941/1600 train_time:43427ms step_avg:46.15ms
+step:942/1600 train_time:43487ms step_avg:46.16ms
+step:943/1600 train_time:43549ms step_avg:46.18ms
+step:944/1600 train_time:43608ms step_avg:46.19ms
+step:945/1600 train_time:43670ms step_avg:46.21ms
+step:946/1600 train_time:43728ms step_avg:46.22ms
+step:947/1600 train_time:43792ms step_avg:46.24ms
+step:948/1600 train_time:43851ms step_avg:46.26ms
+step:949/1600 train_time:43912ms step_avg:46.27ms
+step:950/1600 train_time:43972ms step_avg:46.29ms
+step:951/1600 train_time:44035ms step_avg:46.30ms
+step:952/1600 train_time:44093ms step_avg:46.32ms
+step:953/1600 train_time:44155ms step_avg:46.33ms
+step:954/1600 train_time:44213ms step_avg:46.35ms
+step:955/1600 train_time:44276ms step_avg:46.36ms
+step:956/1600 train_time:44335ms step_avg:46.38ms
+step:957/1600 train_time:44397ms step_avg:46.39ms
+step:958/1600 train_time:44455ms step_avg:46.40ms
+step:959/1600 train_time:44517ms step_avg:46.42ms
+step:960/1600 train_time:44576ms step_avg:46.43ms
+step:961/1600 train_time:44638ms step_avg:46.45ms
+step:962/1600 train_time:44696ms step_avg:46.46ms
+step:963/1600 train_time:44759ms step_avg:46.48ms
+step:964/1600 train_time:44819ms step_avg:46.49ms
+step:965/1600 train_time:44882ms step_avg:46.51ms
+step:966/1600 train_time:44941ms step_avg:46.52ms
+step:967/1600 train_time:45003ms step_avg:46.54ms
+step:968/1600 train_time:45063ms step_avg:46.55ms
+step:969/1600 train_time:45127ms step_avg:46.57ms
+step:970/1600 train_time:45185ms step_avg:46.58ms
+step:971/1600 train_time:45248ms step_avg:46.60ms
+step:972/1600 train_time:45306ms step_avg:46.61ms
+step:973/1600 train_time:45368ms step_avg:46.63ms
+step:974/1600 train_time:45428ms step_avg:46.64ms
+step:975/1600 train_time:45491ms step_avg:46.66ms
+step:976/1600 train_time:45550ms step_avg:46.67ms
+step:977/1600 train_time:45613ms step_avg:46.69ms
+step:978/1600 train_time:45671ms step_avg:46.70ms
+step:979/1600 train_time:45734ms step_avg:46.71ms
+step:980/1600 train_time:45793ms step_avg:46.73ms
+step:981/1600 train_time:45856ms step_avg:46.74ms
+step:982/1600 train_time:45914ms step_avg:46.76ms
+step:983/1600 train_time:45976ms step_avg:46.77ms
+step:984/1600 train_time:46034ms step_avg:46.78ms
+step:985/1600 train_time:46097ms step_avg:46.80ms
+step:986/1600 train_time:46156ms step_avg:46.81ms
+step:987/1600 train_time:46218ms step_avg:46.83ms
+step:988/1600 train_time:46276ms step_avg:46.84ms
+step:989/1600 train_time:46338ms step_avg:46.85ms
+step:990/1600 train_time:46400ms step_avg:46.87ms
+step:991/1600 train_time:46462ms step_avg:46.88ms
+step:992/1600 train_time:46521ms step_avg:46.90ms
+step:993/1600 train_time:46583ms step_avg:46.91ms
+step:994/1600 train_time:46644ms step_avg:46.93ms
+step:995/1600 train_time:46705ms step_avg:46.94ms
+step:996/1600 train_time:46764ms step_avg:46.95ms
+step:997/1600 train_time:46826ms step_avg:46.97ms
+step:998/1600 train_time:46886ms step_avg:46.98ms
+step:999/1600 train_time:46948ms step_avg:46.99ms
+step:1000/1600 train_time:47008ms step_avg:47.01ms
+step:1000/1600 val_loss:3.5975 train_time:47053ms step_avg:47.05ms
+step:1001/1600 train_time:47074ms step_avg:47.03ms
+step:1002/1600 train_time:47131ms step_avg:47.04ms
+step:1003/1600 train_time:47195ms step_avg:47.05ms
+step:1004/1600 train_time:47256ms step_avg:47.07ms
+step:1005/1600 train_time:47318ms step_avg:47.08ms
+step:1006/1600 train_time:47377ms step_avg:47.09ms
+step:1007/1600 train_time:47438ms step_avg:47.11ms
+step:1008/1600 train_time:47497ms step_avg:47.12ms
+step:1009/1600 train_time:47559ms step_avg:47.13ms
+step:1010/1600 train_time:47617ms step_avg:47.15ms
+step:1011/1600 train_time:47679ms step_avg:47.16ms
+step:1012/1600 train_time:47738ms step_avg:47.17ms
+step:1013/1600 train_time:47800ms step_avg:47.19ms
+step:1014/1600 train_time:47858ms step_avg:47.20ms
+step:1015/1600 train_time:47919ms step_avg:47.21ms
+step:1016/1600 train_time:47978ms step_avg:47.22ms
+step:1017/1600 train_time:48041ms step_avg:47.24ms
+step:1018/1600 train_time:48102ms step_avg:47.25ms
+step:1019/1600 train_time:48165ms step_avg:47.27ms
+step:1020/1600 train_time:48224ms step_avg:47.28ms
+step:1021/1600 train_time:48286ms step_avg:47.29ms
+step:1022/1600 train_time:48345ms step_avg:47.30ms
+step:1023/1600 train_time:48408ms step_avg:47.32ms
+step:1024/1600 train_time:48466ms step_avg:47.33ms
+step:1025/1600 train_time:48528ms step_avg:47.34ms
+step:1026/1600 train_time:48588ms step_avg:47.36ms
+step:1027/1600 train_time:48651ms step_avg:47.37ms
+step:1028/1600 train_time:48710ms step_avg:47.38ms
+step:1029/1600 train_time:48773ms step_avg:47.40ms
+step:1030/1600 train_time:48832ms step_avg:47.41ms
+step:1031/1600 train_time:48894ms step_avg:47.42ms
+step:1032/1600 train_time:48952ms step_avg:47.43ms
+step:1033/1600 train_time:49015ms step_avg:47.45ms
+step:1034/1600 train_time:49074ms step_avg:47.46ms
+step:1035/1600 train_time:49137ms step_avg:47.48ms
+step:1036/1600 train_time:49197ms step_avg:47.49ms
+step:1037/1600 train_time:49260ms step_avg:47.50ms
+step:1038/1600 train_time:49319ms step_avg:47.51ms
+step:1039/1600 train_time:49381ms step_avg:47.53ms
+step:1040/1600 train_time:49439ms step_avg:47.54ms
+step:1041/1600 train_time:49512ms step_avg:47.56ms
+step:1042/1600 train_time:49595ms step_avg:47.60ms
+step:1043/1600 train_time:49682ms step_avg:47.63ms
+step:1044/1600 train_time:49767ms step_avg:47.67ms
+step:1045/1600 train_time:49854ms step_avg:47.71ms
+step:1046/1600 train_time:49940ms step_avg:47.74ms
+step:1047/1600 train_time:50029ms step_avg:47.78ms
+step:1048/1600 train_time:50115ms step_avg:47.82ms
+step:1049/1600 train_time:50203ms step_avg:47.86ms
+step:1050/1600 train_time:50289ms step_avg:47.89ms
+step:1051/1600 train_time:50377ms step_avg:47.93ms
+step:1052/1600 train_time:50463ms step_avg:47.97ms
+step:1053/1600 train_time:50551ms step_avg:48.01ms
+step:1054/1600 train_time:50637ms step_avg:48.04ms
+step:1055/1600 train_time:50725ms step_avg:48.08ms
+step:1056/1600 train_time:50808ms step_avg:48.11ms
+step:1057/1600 train_time:50896ms step_avg:48.15ms
+step:1058/1600 train_time:50983ms step_avg:48.19ms
+step:1059/1600 train_time:51071ms step_avg:48.23ms
+step:1060/1600 train_time:51156ms step_avg:48.26ms
+step:1061/1600 train_time:51244ms step_avg:48.30ms
+step:1062/1600 train_time:51330ms step_avg:48.33ms
+step:1063/1600 train_time:51417ms step_avg:48.37ms
+step:1064/1600 train_time:51504ms step_avg:48.41ms
+step:1065/1600 train_time:51591ms step_avg:48.44ms
+step:1066/1600 train_time:51676ms step_avg:48.48ms
+step:1067/1600 train_time:51764ms step_avg:48.51ms
+step:1068/1600 train_time:51849ms step_avg:48.55ms
+step:1069/1600 train_time:51939ms step_avg:48.59ms
+step:1070/1600 train_time:52022ms step_avg:48.62ms
+step:1071/1600 train_time:52110ms step_avg:48.66ms
+step:1072/1600 train_time:52196ms step_avg:48.69ms
+step:1073/1600 train_time:52284ms step_avg:48.73ms
+step:1074/1600 train_time:52368ms step_avg:48.76ms
+step:1075/1600 train_time:52456ms step_avg:48.80ms
+step:1076/1600 train_time:52542ms step_avg:48.83ms
+step:1077/1600 train_time:52630ms step_avg:48.87ms
+step:1078/1600 train_time:52715ms step_avg:48.90ms
+step:1079/1600 train_time:52803ms step_avg:48.94ms
+step:1080/1600 train_time:52888ms step_avg:48.97ms
+step:1081/1600 train_time:52976ms step_avg:49.01ms
+step:1082/1600 train_time:53061ms step_avg:49.04ms
+step:1083/1600 train_time:53150ms step_avg:49.08ms
+step:1084/1600 train_time:53236ms step_avg:49.11ms
+step:1085/1600 train_time:53325ms step_avg:49.15ms
+step:1086/1600 train_time:53410ms step_avg:49.18ms
+step:1087/1600 train_time:53497ms step_avg:49.22ms
+step:1088/1600 train_time:53582ms step_avg:49.25ms
+step:1089/1600 train_time:53670ms step_avg:49.28ms
+step:1090/1600 train_time:53756ms step_avg:49.32ms
+step:1091/1600 train_time:53844ms step_avg:49.35ms
+step:1092/1600 train_time:53929ms step_avg:49.39ms
+step:1093/1600 train_time:54016ms step_avg:49.42ms
+step:1094/1600 train_time:54102ms step_avg:49.45ms
+step:1095/1600 train_time:54191ms step_avg:49.49ms
+step:1096/1600 train_time:54276ms step_avg:49.52ms
+step:1097/1600 train_time:54364ms step_avg:49.56ms
+step:1098/1600 train_time:54449ms step_avg:49.59ms
+step:1099/1600 train_time:54538ms step_avg:49.62ms
+step:1100/1600 train_time:54623ms step_avg:49.66ms
+step:1101/1600 train_time:54711ms step_avg:49.69ms
+step:1102/1600 train_time:54797ms step_avg:49.73ms
+step:1103/1600 train_time:54885ms step_avg:49.76ms
+step:1104/1600 train_time:54969ms step_avg:49.79ms
+step:1105/1600 train_time:55060ms step_avg:49.83ms
+step:1106/1600 train_time:55143ms step_avg:49.86ms
+step:1107/1600 train_time:55232ms step_avg:49.89ms
+step:1108/1600 train_time:55317ms step_avg:49.93ms
+step:1109/1600 train_time:55407ms step_avg:49.96ms
+step:1110/1600 train_time:55492ms step_avg:49.99ms
+step:1111/1600 train_time:55580ms step_avg:50.03ms
+step:1112/1600 train_time:55664ms step_avg:50.06ms
+step:1113/1600 train_time:55754ms step_avg:50.09ms
+step:1114/1600 train_time:55839ms step_avg:50.12ms
+step:1115/1600 train_time:55927ms step_avg:50.16ms
+step:1116/1600 train_time:56011ms step_avg:50.19ms
+step:1117/1600 train_time:56100ms step_avg:50.22ms
+step:1118/1600 train_time:56186ms step_avg:50.26ms
+step:1119/1600 train_time:56273ms step_avg:50.29ms
+step:1120/1600 train_time:56359ms step_avg:50.32ms
+step:1121/1600 train_time:56447ms step_avg:50.35ms
+step:1122/1600 train_time:56532ms step_avg:50.39ms
+step:1123/1600 train_time:56622ms step_avg:50.42ms
+step:1124/1600 train_time:56706ms step_avg:50.45ms
+step:1125/1600 train_time:56796ms step_avg:50.49ms
+step:1126/1600 train_time:56880ms step_avg:50.51ms
+step:1127/1600 train_time:56968ms step_avg:50.55ms
+step:1128/1600 train_time:57053ms step_avg:50.58ms
+step:1129/1600 train_time:57140ms step_avg:50.61ms
+step:1130/1600 train_time:57225ms step_avg:50.64ms
+step:1131/1600 train_time:57314ms step_avg:50.68ms
+step:1132/1600 train_time:57399ms step_avg:50.71ms
+step:1133/1600 train_time:57488ms step_avg:50.74ms
+step:1134/1600 train_time:57573ms step_avg:50.77ms
+step:1135/1600 train_time:57661ms step_avg:50.80ms
+step:1136/1600 train_time:57745ms step_avg:50.83ms
+step:1137/1600 train_time:57833ms step_avg:50.86ms
+step:1138/1600 train_time:57919ms step_avg:50.90ms
+step:1139/1600 train_time:58007ms step_avg:50.93ms
+step:1140/1600 train_time:58093ms step_avg:50.96ms
+step:1141/1600 train_time:58181ms step_avg:50.99ms
+step:1142/1600 train_time:58266ms step_avg:51.02ms
+step:1143/1600 train_time:58353ms step_avg:51.05ms
+step:1144/1600 train_time:58442ms step_avg:51.09ms
+step:1145/1600 train_time:58530ms step_avg:51.12ms
+step:1146/1600 train_time:58617ms step_avg:51.15ms
+step:1147/1600 train_time:58707ms step_avg:51.18ms
+step:1148/1600 train_time:58791ms step_avg:51.21ms
+step:1149/1600 train_time:58875ms step_avg:51.24ms
+step:1150/1600 train_time:58960ms step_avg:51.27ms
+step:1151/1600 train_time:59049ms step_avg:51.30ms
+step:1152/1600 train_time:59133ms step_avg:51.33ms
+step:1153/1600 train_time:59221ms step_avg:51.36ms
+step:1154/1600 train_time:59311ms step_avg:51.40ms
+step:1155/1600 train_time:59397ms step_avg:51.43ms
+step:1156/1600 train_time:59483ms step_avg:51.46ms
+step:1157/1600 train_time:59571ms step_avg:51.49ms
+step:1158/1600 train_time:59657ms step_avg:51.52ms
+step:1159/1600 train_time:59746ms step_avg:51.55ms
+step:1160/1600 train_time:59831ms step_avg:51.58ms
+step:1161/1600 train_time:59918ms step_avg:51.61ms
+step:1162/1600 train_time:60003ms step_avg:51.64ms
+step:1163/1600 train_time:60090ms step_avg:51.67ms
+step:1164/1600 train_time:60176ms step_avg:51.70ms
+step:1165/1600 train_time:60263ms step_avg:51.73ms
+step:1166/1600 train_time:60348ms step_avg:51.76ms
+step:1167/1600 train_time:60436ms step_avg:51.79ms
+step:1168/1600 train_time:60522ms step_avg:51.82ms
+step:1169/1600 train_time:60610ms step_avg:51.85ms
+step:1170/1600 train_time:60696ms step_avg:51.88ms
+step:1171/1600 train_time:60784ms step_avg:51.91ms
+step:1172/1600 train_time:60871ms step_avg:51.94ms
+step:1173/1600 train_time:60957ms step_avg:51.97ms
+step:1174/1600 train_time:61042ms step_avg:52.00ms
+step:1175/1600 train_time:61131ms step_avg:52.03ms
+step:1176/1600 train_time:61216ms step_avg:52.05ms
+step:1177/1600 train_time:61305ms step_avg:52.09ms
+step:1178/1600 train_time:61389ms step_avg:52.11ms
+step:1179/1600 train_time:61477ms step_avg:52.14ms
+step:1180/1600 train_time:61562ms step_avg:52.17ms
+step:1181/1600 train_time:61650ms step_avg:52.20ms
+step:1182/1600 train_time:61734ms step_avg:52.23ms
+step:1183/1600 train_time:61823ms step_avg:52.26ms
+step:1184/1600 train_time:61907ms step_avg:52.29ms
+step:1185/1600 train_time:61996ms step_avg:52.32ms
+step:1186/1600 train_time:62082ms step_avg:52.35ms
+step:1187/1600 train_time:62169ms step_avg:52.38ms
+step:1188/1600 train_time:62255ms step_avg:52.40ms
+step:1189/1600 train_time:62343ms step_avg:52.43ms
+step:1190/1600 train_time:62428ms step_avg:52.46ms
+step:1191/1600 train_time:62517ms step_avg:52.49ms
+step:1192/1600 train_time:62602ms step_avg:52.52ms
+step:1193/1600 train_time:62690ms step_avg:52.55ms
+step:1194/1600 train_time:62777ms step_avg:52.58ms
+step:1195/1600 train_time:62864ms step_avg:52.61ms
+step:1196/1600 train_time:62949ms step_avg:52.63ms
+step:1197/1600 train_time:63037ms step_avg:52.66ms
+step:1198/1600 train_time:63123ms step_avg:52.69ms
+step:1199/1600 train_time:63211ms step_avg:52.72ms
+step:1200/1600 train_time:63298ms step_avg:52.75ms
+step:1201/1600 train_time:63386ms step_avg:52.78ms
+step:1202/1600 train_time:63470ms step_avg:52.80ms
+step:1203/1600 train_time:63558ms step_avg:52.83ms
+step:1204/1600 train_time:63644ms step_avg:52.86ms
+step:1205/1600 train_time:63734ms step_avg:52.89ms
+step:1206/1600 train_time:63818ms step_avg:52.92ms
+step:1207/1600 train_time:63907ms step_avg:52.95ms
+step:1208/1600 train_time:63992ms step_avg:52.97ms
+step:1209/1600 train_time:64080ms step_avg:53.00ms
+step:1210/1600 train_time:64165ms step_avg:53.03ms
+step:1211/1600 train_time:64254ms step_avg:53.06ms
+step:1212/1600 train_time:64339ms step_avg:53.09ms
+step:1213/1600 train_time:64428ms step_avg:53.11ms
+step:1214/1600 train_time:64515ms step_avg:53.14ms
+step:1215/1600 train_time:64601ms step_avg:53.17ms
+step:1216/1600 train_time:64687ms step_avg:53.20ms
+step:1217/1600 train_time:64774ms step_avg:53.22ms
+step:1218/1600 train_time:64859ms step_avg:53.25ms
+step:1219/1600 train_time:64947ms step_avg:53.28ms
+step:1220/1600 train_time:65032ms step_avg:53.30ms
+step:1221/1600 train_time:65121ms step_avg:53.33ms
+step:1222/1600 train_time:65205ms step_avg:53.36ms
+step:1223/1600 train_time:65294ms step_avg:53.39ms
+step:1224/1600 train_time:65379ms step_avg:53.41ms
+step:1225/1600 train_time:65467ms step_avg:53.44ms
+step:1226/1600 train_time:65553ms step_avg:53.47ms
+step:1227/1600 train_time:65640ms step_avg:53.50ms
+step:1228/1600 train_time:65726ms step_avg:53.52ms
+step:1229/1600 train_time:65814ms step_avg:53.55ms
+step:1230/1600 train_time:65899ms step_avg:53.58ms
+step:1231/1600 train_time:65990ms step_avg:53.61ms
+step:1232/1600 train_time:66074ms step_avg:53.63ms
+step:1233/1600 train_time:66160ms step_avg:53.66ms
+step:1234/1600 train_time:66245ms step_avg:53.68ms
+step:1235/1600 train_time:66333ms step_avg:53.71ms
+step:1236/1600 train_time:66418ms step_avg:53.74ms
+step:1237/1600 train_time:66506ms step_avg:53.76ms
+step:1238/1600 train_time:66591ms step_avg:53.79ms
+step:1239/1600 train_time:66679ms step_avg:53.82ms
+step:1240/1600 train_time:66765ms step_avg:53.84ms
+step:1241/1600 train_time:66853ms step_avg:53.87ms
+step:1242/1600 train_time:66940ms step_avg:53.90ms
+step:1243/1600 train_time:67027ms step_avg:53.92ms
+step:1244/1600 train_time:67111ms step_avg:53.95ms
+step:1245/1600 train_time:67199ms step_avg:53.98ms
+step:1246/1600 train_time:67284ms step_avg:54.00ms
+step:1247/1600 train_time:67372ms step_avg:54.03ms
+step:1248/1600 train_time:67457ms step_avg:54.05ms
+step:1249/1600 train_time:67547ms step_avg:54.08ms
+step:1250/1600 train_time:67631ms step_avg:54.11ms
+step:1250/1600 val_loss:3.4160 train_time:67703ms step_avg:54.16ms
+step:1251/1600 train_time:67724ms step_avg:54.14ms
+step:1252/1600 train_time:67810ms step_avg:54.16ms
+step:1253/1600 train_time:67902ms step_avg:54.19ms
+step:1254/1600 train_time:67987ms step_avg:54.22ms
+step:1255/1600 train_time:68074ms step_avg:54.24ms
+step:1256/1600 train_time:68159ms step_avg:54.27ms
+step:1257/1600 train_time:68245ms step_avg:54.29ms
+step:1258/1600 train_time:68330ms step_avg:54.32ms
+step:1259/1600 train_time:68418ms step_avg:54.34ms
+step:1260/1600 train_time:68503ms step_avg:54.37ms
+step:1261/1600 train_time:68589ms step_avg:54.39ms
+step:1262/1600 train_time:68675ms step_avg:54.42ms
+step:1263/1600 train_time:68766ms step_avg:54.45ms
+step:1264/1600 train_time:68854ms step_avg:54.47ms
+step:1265/1600 train_time:68944ms step_avg:54.50ms
+step:1266/1600 train_time:69029ms step_avg:54.53ms
+step:1267/1600 train_time:69118ms step_avg:54.55ms
+step:1268/1600 train_time:69202ms step_avg:54.58ms
+step:1269/1600 train_time:69289ms step_avg:54.60ms
+step:1270/1600 train_time:69374ms step_avg:54.63ms
+step:1271/1600 train_time:69461ms step_avg:54.65ms
+step:1272/1600 train_time:69545ms step_avg:54.67ms
+step:1273/1600 train_time:69633ms step_avg:54.70ms
+step:1274/1600 train_time:69719ms step_avg:54.72ms
+step:1275/1600 train_time:69809ms step_avg:54.75ms
+step:1276/1600 train_time:69895ms step_avg:54.78ms
+step:1277/1600 train_time:69985ms step_avg:54.80ms
+step:1278/1600 train_time:70071ms step_avg:54.83ms
+step:1279/1600 train_time:70160ms step_avg:54.86ms
+step:1280/1600 train_time:70247ms step_avg:54.88ms
+step:1281/1600 train_time:70332ms step_avg:54.90ms
+step:1282/1600 train_time:70417ms step_avg:54.93ms
+step:1283/1600 train_time:70504ms step_avg:54.95ms
+step:1284/1600 train_time:70588ms step_avg:54.97ms
+step:1285/1600 train_time:70676ms step_avg:55.00ms
+step:1286/1600 train_time:70762ms step_avg:55.02ms
+step:1287/1600 train_time:70852ms step_avg:55.05ms
+step:1288/1600 train_time:70939ms step_avg:55.08ms
+step:1289/1600 train_time:71027ms step_avg:55.10ms
+step:1290/1600 train_time:71113ms step_avg:55.13ms
+step:1291/1600 train_time:71201ms step_avg:55.15ms
+step:1292/1600 train_time:71285ms step_avg:55.17ms
+step:1293/1600 train_time:71373ms step_avg:55.20ms
+step:1294/1600 train_time:71458ms step_avg:55.22ms
+step:1295/1600 train_time:71546ms step_avg:55.25ms
+step:1296/1600 train_time:71631ms step_avg:55.27ms
+step:1297/1600 train_time:71721ms step_avg:55.30ms
+step:1298/1600 train_time:71806ms step_avg:55.32ms
+step:1299/1600 train_time:71895ms step_avg:55.35ms
+step:1300/1600 train_time:71982ms step_avg:55.37ms
+step:1301/1600 train_time:72071ms step_avg:55.40ms
+step:1302/1600 train_time:72156ms step_avg:55.42ms
+step:1303/1600 train_time:72245ms step_avg:55.45ms
+step:1304/1600 train_time:72330ms step_avg:55.47ms
+step:1305/1600 train_time:72419ms step_avg:55.49ms
+step:1306/1600 train_time:72502ms step_avg:55.51ms
+step:1307/1600 train_time:72590ms step_avg:55.54ms
+step:1308/1600 train_time:72676ms step_avg:55.56ms
+step:1309/1600 train_time:72765ms step_avg:55.59ms
+step:1310/1600 train_time:72851ms step_avg:55.61ms
+step:1311/1600 train_time:72940ms step_avg:55.64ms
+step:1312/1600 train_time:73025ms step_avg:55.66ms
+step:1313/1600 train_time:73113ms step_avg:55.68ms
+step:1314/1600 train_time:73199ms step_avg:55.71ms
+step:1315/1600 train_time:73287ms step_avg:55.73ms
+step:1316/1600 train_time:73372ms step_avg:55.75ms
+step:1317/1600 train_time:73459ms step_avg:55.78ms
+step:1318/1600 train_time:73543ms step_avg:55.80ms
+step:1319/1600 train_time:73631ms step_avg:55.82ms
+step:1320/1600 train_time:73717ms step_avg:55.85ms
+step:1321/1600 train_time:73807ms step_avg:55.87ms
+step:1322/1600 train_time:73893ms step_avg:55.89ms
+step:1323/1600 train_time:73981ms step_avg:55.92ms
+step:1324/1600 train_time:74066ms step_avg:55.94ms
+step:1325/1600 train_time:74154ms step_avg:55.97ms
+step:1326/1600 train_time:74240ms step_avg:55.99ms
+step:1327/1600 train_time:74327ms step_avg:56.01ms
+step:1328/1600 train_time:74413ms step_avg:56.03ms
+step:1329/1600 train_time:74500ms step_avg:56.06ms
+step:1330/1600 train_time:74586ms step_avg:56.08ms
+step:1331/1600 train_time:74674ms step_avg:56.10ms
+step:1332/1600 train_time:74760ms step_avg:56.13ms
+step:1333/1600 train_time:74849ms step_avg:56.15ms
+step:1334/1600 train_time:74934ms step_avg:56.17ms
+step:1335/1600 train_time:75023ms step_avg:56.20ms
+step:1336/1600 train_time:75108ms step_avg:56.22ms
+step:1337/1600 train_time:75197ms step_avg:56.24ms
+step:1338/1600 train_time:75281ms step_avg:56.26ms
+step:1339/1600 train_time:75371ms step_avg:56.29ms
+step:1340/1600 train_time:75455ms step_avg:56.31ms
+step:1341/1600 train_time:75544ms step_avg:56.33ms
+step:1342/1600 train_time:75627ms step_avg:56.35ms
+step:1343/1600 train_time:75715ms step_avg:56.38ms
+step:1344/1600 train_time:75801ms step_avg:56.40ms
+step:1345/1600 train_time:75889ms step_avg:56.42ms
+step:1346/1600 train_time:75975ms step_avg:56.44ms
+step:1347/1600 train_time:76064ms step_avg:56.47ms
+step:1348/1600 train_time:76149ms step_avg:56.49ms
+step:1349/1600 train_time:76238ms step_avg:56.51ms
+step:1350/1600 train_time:76323ms step_avg:56.54ms
+step:1351/1600 train_time:76411ms step_avg:56.56ms
+step:1352/1600 train_time:76496ms step_avg:56.58ms
+step:1353/1600 train_time:76585ms step_avg:56.60ms
+step:1354/1600 train_time:76670ms step_avg:56.62ms
+step:1355/1600 train_time:76759ms step_avg:56.65ms
+step:1356/1600 train_time:76845ms step_avg:56.67ms
+step:1357/1600 train_time:76933ms step_avg:56.69ms
+step:1358/1600 train_time:77018ms step_avg:56.71ms
+step:1359/1600 train_time:77106ms step_avg:56.74ms
+step:1360/1600 train_time:77192ms step_avg:56.76ms
+step:1361/1600 train_time:77280ms step_avg:56.78ms
+step:1362/1600 train_time:77366ms step_avg:56.80ms
+step:1363/1600 train_time:77454ms step_avg:56.83ms
+step:1364/1600 train_time:77538ms step_avg:56.85ms
+step:1365/1600 train_time:77627ms step_avg:56.87ms
+step:1366/1600 train_time:77722ms step_avg:56.90ms
+step:1367/1600 train_time:77806ms step_avg:56.92ms
+step:1368/1600 train_time:77889ms step_avg:56.94ms
+step:1369/1600 train_time:77976ms step_avg:56.96ms
+step:1370/1600 train_time:78061ms step_avg:56.98ms
+step:1371/1600 train_time:78151ms step_avg:57.00ms
+step:1372/1600 train_time:78235ms step_avg:57.02ms
+step:1373/1600 train_time:78323ms step_avg:57.05ms
+step:1374/1600 train_time:78409ms step_avg:57.07ms
+step:1375/1600 train_time:78497ms step_avg:57.09ms
+step:1376/1600 train_time:78582ms step_avg:57.11ms
+step:1377/1600 train_time:78673ms step_avg:57.13ms
+step:1378/1600 train_time:78756ms step_avg:57.15ms
+step:1379/1600 train_time:78845ms step_avg:57.18ms
+step:1380/1600 train_time:78931ms step_avg:57.20ms
+step:1381/1600 train_time:79018ms step_avg:57.22ms
+step:1382/1600 train_time:79103ms step_avg:57.24ms
+step:1383/1600 train_time:79192ms step_avg:57.26ms
+step:1384/1600 train_time:79279ms step_avg:57.28ms
+step:1385/1600 train_time:79366ms step_avg:57.30ms
+step:1386/1600 train_time:79452ms step_avg:57.32ms
+step:1387/1600 train_time:79539ms step_avg:57.35ms
+step:1388/1600 train_time:79624ms step_avg:57.37ms
+step:1389/1600 train_time:79711ms step_avg:57.39ms
+step:1390/1600 train_time:79796ms step_avg:57.41ms
+step:1391/1600 train_time:79886ms step_avg:57.43ms
+step:1392/1600 train_time:79972ms step_avg:57.45ms
+step:1393/1600 train_time:80059ms step_avg:57.47ms
+step:1394/1600 train_time:80146ms step_avg:57.49ms
+step:1395/1600 train_time:80233ms step_avg:57.51ms
+step:1396/1600 train_time:80319ms step_avg:57.54ms
+step:1397/1600 train_time:80408ms step_avg:57.56ms
+step:1398/1600 train_time:80495ms step_avg:57.58ms
+step:1399/1600 train_time:80582ms step_avg:57.60ms
+step:1400/1600 train_time:80667ms step_avg:57.62ms
+step:1401/1600 train_time:80755ms step_avg:57.64ms
+step:1402/1600 train_time:80840ms step_avg:57.66ms
+step:1403/1600 train_time:80930ms step_avg:57.68ms
+step:1404/1600 train_time:81014ms step_avg:57.70ms
+step:1405/1600 train_time:81103ms step_avg:57.72ms
+step:1406/1600 train_time:81188ms step_avg:57.74ms
+step:1407/1600 train_time:81276ms step_avg:57.77ms
+step:1408/1600 train_time:81362ms step_avg:57.79ms
+step:1409/1600 train_time:81451ms step_avg:57.81ms
+step:1410/1600 train_time:81536ms step_avg:57.83ms
+step:1411/1600 train_time:81624ms step_avg:57.85ms
+step:1412/1600 train_time:81709ms step_avg:57.87ms
+step:1413/1600 train_time:81798ms step_avg:57.89ms
+step:1414/1600 train_time:81883ms step_avg:57.91ms
+step:1415/1600 train_time:81971ms step_avg:57.93ms
+step:1416/1600 train_time:82056ms step_avg:57.95ms
+step:1417/1600 train_time:82145ms step_avg:57.97ms
+step:1418/1600 train_time:82229ms step_avg:57.99ms
+step:1419/1600 train_time:82318ms step_avg:58.01ms
+step:1420/1600 train_time:82403ms step_avg:58.03ms
+step:1421/1600 train_time:82491ms step_avg:58.05ms
+step:1422/1600 train_time:82576ms step_avg:58.07ms
+step:1423/1600 train_time:82666ms step_avg:58.09ms
+step:1424/1600 train_time:82750ms step_avg:58.11ms
+step:1425/1600 train_time:82840ms step_avg:58.13ms
+step:1426/1600 train_time:82924ms step_avg:58.15ms
+step:1427/1600 train_time:83012ms step_avg:58.17ms
+step:1428/1600 train_time:83098ms step_avg:58.19ms
+step:1429/1600 train_time:83187ms step_avg:58.21ms
+step:1430/1600 train_time:83272ms step_avg:58.23ms
+step:1431/1600 train_time:83364ms step_avg:58.26ms
+step:1432/1600 train_time:83448ms step_avg:58.27ms
+step:1433/1600 train_time:83534ms step_avg:58.29ms
+step:1434/1600 train_time:83619ms step_avg:58.31ms
+step:1435/1600 train_time:83708ms step_avg:58.33ms
+step:1436/1600 train_time:83794ms step_avg:58.35ms
+step:1437/1600 train_time:83882ms step_avg:58.37ms
+step:1438/1600 train_time:83967ms step_avg:58.39ms
+step:1439/1600 train_time:84055ms step_avg:58.41ms
+step:1440/1600 train_time:84141ms step_avg:58.43ms
+step:1441/1600 train_time:84230ms step_avg:58.45ms
+step:1442/1600 train_time:84315ms step_avg:58.47ms
+step:1443/1600 train_time:84404ms step_avg:58.49ms
+step:1444/1600 train_time:84490ms step_avg:58.51ms
+step:1445/1600 train_time:84579ms step_avg:58.53ms
+step:1446/1600 train_time:84664ms step_avg:58.55ms
+step:1447/1600 train_time:84752ms step_avg:58.57ms
+step:1448/1600 train_time:84837ms step_avg:58.59ms
+step:1449/1600 train_time:84926ms step_avg:58.61ms
+step:1450/1600 train_time:85010ms step_avg:58.63ms
+step:1451/1600 train_time:85099ms step_avg:58.65ms
+step:1452/1600 train_time:85185ms step_avg:58.67ms
+step:1453/1600 train_time:85273ms step_avg:58.69ms
+step:1454/1600 train_time:85359ms step_avg:58.71ms
+step:1455/1600 train_time:85447ms step_avg:58.73ms
+step:1456/1600 train_time:85532ms step_avg:58.74ms
+step:1457/1600 train_time:85622ms step_avg:58.77ms
+step:1458/1600 train_time:85707ms step_avg:58.78ms
+step:1459/1600 train_time:85795ms step_avg:58.80ms
+step:1460/1600 train_time:85880ms step_avg:58.82ms
+step:1461/1600 train_time:85968ms step_avg:58.84ms
+step:1462/1600 train_time:86054ms step_avg:58.86ms
+step:1463/1600 train_time:86143ms step_avg:58.88ms
+step:1464/1600 train_time:86228ms step_avg:58.90ms
+step:1465/1600 train_time:86316ms step_avg:58.92ms
+step:1466/1600 train_time:86402ms step_avg:58.94ms
+step:1467/1600 train_time:86491ms step_avg:58.96ms
+step:1468/1600 train_time:86575ms step_avg:58.97ms
+step:1469/1600 train_time:86664ms step_avg:59.00ms
+step:1470/1600 train_time:86749ms step_avg:59.01ms
+step:1471/1600 train_time:86837ms step_avg:59.03ms
+step:1472/1600 train_time:86922ms step_avg:59.05ms
+step:1473/1600 train_time:87009ms step_avg:59.07ms
+step:1474/1600 train_time:87095ms step_avg:59.09ms
+step:1475/1600 train_time:87184ms step_avg:59.11ms
+step:1476/1600 train_time:87270ms step_avg:59.13ms
+step:1477/1600 train_time:87358ms step_avg:59.15ms
+step:1478/1600 train_time:87444ms step_avg:59.16ms
+step:1479/1600 train_time:87531ms step_avg:59.18ms
+step:1480/1600 train_time:87617ms step_avg:59.20ms
+step:1481/1600 train_time:87706ms step_avg:59.22ms
+step:1482/1600 train_time:87791ms step_avg:59.24ms
+step:1483/1600 train_time:87879ms step_avg:59.26ms
+step:1484/1600 train_time:87965ms step_avg:59.28ms
+step:1485/1600 train_time:88053ms step_avg:59.30ms
+step:1486/1600 train_time:88140ms step_avg:59.31ms
+step:1487/1600 train_time:88228ms step_avg:59.33ms
+step:1488/1600 train_time:88312ms step_avg:59.35ms
+step:1489/1600 train_time:88400ms step_avg:59.37ms
+step:1490/1600 train_time:88486ms step_avg:59.39ms
+step:1491/1600 train_time:88574ms step_avg:59.41ms
+step:1492/1600 train_time:88660ms step_avg:59.42ms
+step:1493/1600 train_time:88749ms step_avg:59.44ms
+step:1494/1600 train_time:88833ms step_avg:59.46ms
+step:1495/1600 train_time:88922ms step_avg:59.48ms
+step:1496/1600 train_time:89007ms step_avg:59.50ms
+step:1497/1600 train_time:89095ms step_avg:59.52ms
+step:1498/1600 train_time:89181ms step_avg:59.53ms
+step:1499/1600 train_time:89268ms step_avg:59.55ms
+step:1500/1600 train_time:89353ms step_avg:59.57ms
+step:1500/1600 val_loss:3.3081 train_time:89425ms step_avg:59.62ms
+step:1501/1600 train_time:89446ms step_avg:59.59ms
+step:1502/1600 train_time:89532ms step_avg:59.61ms
+step:1503/1600 train_time:89624ms step_avg:59.63ms
+step:1504/1600 train_time:89711ms step_avg:59.65ms
+step:1505/1600 train_time:89798ms step_avg:59.67ms
+step:1506/1600 train_time:89883ms step_avg:59.68ms
+step:1507/1600 train_time:89968ms step_avg:59.70ms
+step:1508/1600 train_time:90054ms step_avg:59.72ms
+step:1509/1600 train_time:90140ms step_avg:59.73ms
+step:1510/1600 train_time:90224ms step_avg:59.75ms
+step:1511/1600 train_time:90311ms step_avg:59.77ms
+step:1512/1600 train_time:90397ms step_avg:59.79ms
+step:1513/1600 train_time:90487ms step_avg:59.81ms
+step:1514/1600 train_time:90575ms step_avg:59.82ms
+step:1515/1600 train_time:90664ms step_avg:59.84ms
+step:1516/1600 train_time:90751ms step_avg:59.86ms
+step:1517/1600 train_time:90839ms step_avg:59.88ms
+step:1518/1600 train_time:90924ms step_avg:59.90ms
+step:1519/1600 train_time:91010ms step_avg:59.91ms
+step:1520/1600 train_time:91094ms step_avg:59.93ms
+step:1521/1600 train_time:91182ms step_avg:59.95ms
+step:1522/1600 train_time:91266ms step_avg:59.96ms
+step:1523/1600 train_time:91354ms step_avg:59.98ms
+step:1524/1600 train_time:91440ms step_avg:60.00ms
+step:1525/1600 train_time:91530ms step_avg:60.02ms
+step:1526/1600 train_time:91617ms step_avg:60.04ms
+step:1527/1600 train_time:91707ms step_avg:60.06ms
+step:1528/1600 train_time:91792ms step_avg:60.07ms
+step:1529/1600 train_time:91881ms step_avg:60.09ms
+step:1530/1600 train_time:91967ms step_avg:60.11ms
+step:1531/1600 train_time:92054ms step_avg:60.13ms
+step:1532/1600 train_time:92138ms step_avg:60.14ms
+step:1533/1600 train_time:92226ms step_avg:60.16ms
+step:1534/1600 train_time:92311ms step_avg:60.18ms
+step:1535/1600 train_time:92398ms step_avg:60.19ms
+step:1536/1600 train_time:92485ms step_avg:60.21ms
+step:1537/1600 train_time:92575ms step_avg:60.23ms
+step:1538/1600 train_time:92661ms step_avg:60.25ms
+step:1539/1600 train_time:92750ms step_avg:60.27ms
+step:1540/1600 train_time:92836ms step_avg:60.28ms
+step:1541/1600 train_time:92924ms step_avg:60.30ms
+step:1542/1600 train_time:93010ms step_avg:60.32ms
+step:1543/1600 train_time:93096ms step_avg:60.33ms
+step:1544/1600 train_time:93181ms step_avg:60.35ms
+step:1545/1600 train_time:93270ms step_avg:60.37ms
+step:1546/1600 train_time:93354ms step_avg:60.38ms
+step:1547/1600 train_time:93442ms step_avg:60.40ms
+step:1548/1600 train_time:93528ms step_avg:60.42ms
+step:1549/1600 train_time:93617ms step_avg:60.44ms
+step:1550/1600 train_time:93703ms step_avg:60.45ms
+step:1551/1600 train_time:93791ms step_avg:60.47ms
+step:1552/1600 train_time:93877ms step_avg:60.49ms
+step:1553/1600 train_time:93972ms step_avg:60.51ms
+step:1554/1600 train_time:94052ms step_avg:60.52ms
+step:1555/1600 train_time:94138ms step_avg:60.54ms
+step:1556/1600 train_time:94222ms step_avg:60.55ms
+step:1557/1600 train_time:94310ms step_avg:60.57ms
+step:1558/1600 train_time:94395ms step_avg:60.59ms
+step:1559/1600 train_time:94484ms step_avg:60.61ms
+step:1560/1600 train_time:94571ms step_avg:60.62ms
+step:1561/1600 train_time:94666ms step_avg:60.64ms
+step:1562/1600 train_time:94750ms step_avg:60.66ms
+step:1563/1600 train_time:94839ms step_avg:60.68ms
+step:1564/1600 train_time:94925ms step_avg:60.69ms
+step:1565/1600 train_time:95013ms step_avg:60.71ms
+step:1566/1600 train_time:95098ms step_avg:60.73ms
+step:1567/1600 train_time:95187ms step_avg:60.74ms
+step:1568/1600 train_time:95273ms step_avg:60.76ms
+step:1569/1600 train_time:95362ms step_avg:60.78ms
+step:1570/1600 train_time:95448ms step_avg:60.79ms
+step:1571/1600 train_time:95536ms step_avg:60.81ms
+step:1572/1600 train_time:95623ms step_avg:60.83ms
+step:1573/1600 train_time:95713ms step_avg:60.85ms
+step:1574/1600 train_time:95799ms step_avg:60.86ms
+step:1575/1600 train_time:95888ms step_avg:60.88ms
+step:1576/1600 train_time:95977ms step_avg:60.90ms
+step:1577/1600 train_time:96070ms step_avg:60.92ms
+step:1578/1600 train_time:96150ms step_avg:60.93ms
+step:1579/1600 train_time:96237ms step_avg:60.95ms
+step:1580/1600 train_time:96322ms step_avg:60.96ms
+step:1581/1600 train_time:96410ms step_avg:60.98ms
+step:1582/1600 train_time:96496ms step_avg:61.00ms
+step:1583/1600 train_time:96585ms step_avg:61.01ms
+step:1584/1600 train_time:96671ms step_avg:61.03ms
+step:1585/1600 train_time:96759ms step_avg:61.05ms
+step:1586/1600 train_time:96845ms step_avg:61.06ms
+step:1587/1600 train_time:96933ms step_avg:61.08ms
+step:1588/1600 train_time:97020ms step_avg:61.10ms
+step:1589/1600 train_time:97108ms step_avg:61.11ms
+step:1590/1600 train_time:97194ms step_avg:61.13ms
+step:1591/1600 train_time:97283ms step_avg:61.15ms
+step:1592/1600 train_time:97368ms step_avg:61.16ms
+step:1593/1600 train_time:97457ms step_avg:61.18ms
+step:1594/1600 train_time:97543ms step_avg:61.19ms
+step:1595/1600 train_time:97633ms step_avg:61.21ms
+step:1596/1600 train_time:97718ms step_avg:61.23ms
+step:1597/1600 train_time:97806ms step_avg:61.24ms
+step:1598/1600 train_time:97891ms step_avg:61.26ms
+step:1599/1600 train_time:97979ms step_avg:61.28ms
+step:1600/1600 train_time:98066ms step_avg:61.29ms
+step:1600/1600 val_loss:3.2788 train_time:98136ms step_avg:61.34ms
+peak memory allocated: 30264 MiB reserved: 46378 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/5f1dcf6f-93ac-4f63-b44c-1016ecd36c2d.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/5f1dcf6f-93ac-4f63-b44c-1016ecd36c2d.txt
@@ -1,0 +1,4119 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 03:19:58 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   41C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            131W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   37C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          299489      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          299490      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          299491      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          299492      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          299493      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          299494      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          299495      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          299496      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8300 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:86ms step_avg:86.02ms
+step:2/1600 train_time:107ms step_avg:53.40ms
+step:3/1600 train_time:126ms step_avg:41.83ms
+step:4/1600 train_time:154ms step_avg:38.61ms
+step:5/1600 train_time:184ms step_avg:36.90ms
+step:6/1600 train_time:297ms step_avg:49.47ms
+step:7/1600 train_time:313ms step_avg:44.78ms
+step:8/1600 train_time:432ms step_avg:53.99ms
+step:9/1600 train_time:462ms step_avg:51.35ms
+step:10/1600 train_time:499ms step_avg:49.90ms
+step:11/1600 train_time:530ms step_avg:48.16ms
+step:12/1600 train_time:567ms step_avg:47.23ms
+step:13/1600 train_time:597ms step_avg:45.96ms
+step:14/1600 train_time:635ms step_avg:45.34ms
+step:15/1600 train_time:666ms step_avg:44.38ms
+step:16/1600 train_time:703ms step_avg:43.94ms
+step:17/1600 train_time:734ms step_avg:43.18ms
+step:18/1600 train_time:771ms step_avg:42.85ms
+step:19/1600 train_time:802ms step_avg:42.22ms
+step:20/1600 train_time:839ms step_avg:41.96ms
+step:21/1600 train_time:870ms step_avg:41.41ms
+step:22/1600 train_time:906ms step_avg:41.20ms
+step:23/1600 train_time:938ms step_avg:40.76ms
+step:24/1600 train_time:975ms step_avg:40.63ms
+step:25/1600 train_time:1006ms step_avg:40.24ms
+step:26/1600 train_time:1043ms step_avg:40.13ms
+step:27/1600 train_time:1074ms step_avg:39.77ms
+step:28/1600 train_time:1111ms step_avg:39.66ms
+step:29/1600 train_time:1142ms step_avg:39.37ms
+step:30/1600 train_time:1179ms step_avg:39.29ms
+step:31/1600 train_time:1209ms step_avg:39.01ms
+step:32/1600 train_time:1247ms step_avg:38.97ms
+step:33/1600 train_time:1278ms step_avg:38.72ms
+step:34/1600 train_time:1315ms step_avg:38.68ms
+step:35/1600 train_time:1346ms step_avg:38.46ms
+step:36/1600 train_time:1383ms step_avg:38.43ms
+step:37/1600 train_time:1414ms step_avg:38.22ms
+step:38/1600 train_time:1452ms step_avg:38.20ms
+step:39/1600 train_time:1482ms step_avg:38.01ms
+step:40/1600 train_time:1519ms step_avg:37.98ms
+step:41/1600 train_time:1550ms step_avg:37.80ms
+step:42/1600 train_time:1587ms step_avg:37.78ms
+step:43/1600 train_time:1618ms step_avg:37.62ms
+step:44/1600 train_time:1655ms step_avg:37.62ms
+step:45/1600 train_time:1685ms step_avg:37.45ms
+step:46/1600 train_time:1723ms step_avg:37.46ms
+step:47/1600 train_time:1753ms step_avg:37.31ms
+step:48/1600 train_time:1791ms step_avg:37.31ms
+step:49/1600 train_time:1822ms step_avg:37.18ms
+step:50/1600 train_time:1859ms step_avg:37.18ms
+step:51/1600 train_time:1889ms step_avg:37.05ms
+step:52/1600 train_time:1927ms step_avg:37.06ms
+step:53/1600 train_time:1958ms step_avg:36.94ms
+step:54/1600 train_time:1995ms step_avg:36.94ms
+step:55/1600 train_time:2026ms step_avg:36.84ms
+step:56/1600 train_time:2064ms step_avg:36.86ms
+step:57/1600 train_time:2095ms step_avg:36.75ms
+step:58/1600 train_time:2132ms step_avg:36.75ms
+step:59/1600 train_time:2163ms step_avg:36.65ms
+step:60/1600 train_time:2199ms step_avg:36.66ms
+step:61/1600 train_time:2230ms step_avg:36.56ms
+step:62/1600 train_time:2268ms step_avg:36.57ms
+step:63/1600 train_time:2299ms step_avg:36.49ms
+step:64/1600 train_time:2336ms step_avg:36.50ms
+step:65/1600 train_time:2367ms step_avg:36.41ms
+step:66/1600 train_time:2404ms step_avg:36.42ms
+step:67/1600 train_time:2435ms step_avg:36.34ms
+step:68/1600 train_time:2472ms step_avg:36.36ms
+step:69/1600 train_time:2503ms step_avg:36.28ms
+step:70/1600 train_time:2540ms step_avg:36.29ms
+step:71/1600 train_time:2571ms step_avg:36.21ms
+step:72/1600 train_time:2608ms step_avg:36.23ms
+step:73/1600 train_time:2640ms step_avg:36.17ms
+step:74/1600 train_time:2678ms step_avg:36.18ms
+step:75/1600 train_time:2708ms step_avg:36.11ms
+step:76/1600 train_time:2745ms step_avg:36.12ms
+step:77/1600 train_time:2776ms step_avg:36.05ms
+step:78/1600 train_time:2813ms step_avg:36.07ms
+step:79/1600 train_time:2844ms step_avg:36.00ms
+step:80/1600 train_time:2881ms step_avg:36.02ms
+step:81/1600 train_time:2913ms step_avg:35.96ms
+step:82/1600 train_time:2950ms step_avg:35.98ms
+step:83/1600 train_time:2981ms step_avg:35.92ms
+step:84/1600 train_time:3018ms step_avg:35.93ms
+step:85/1600 train_time:3049ms step_avg:35.87ms
+step:86/1600 train_time:3086ms step_avg:35.88ms
+step:87/1600 train_time:3117ms step_avg:35.82ms
+step:88/1600 train_time:3154ms step_avg:35.84ms
+step:89/1600 train_time:3184ms step_avg:35.78ms
+step:90/1600 train_time:3221ms step_avg:35.79ms
+step:91/1600 train_time:3252ms step_avg:35.74ms
+step:92/1600 train_time:3289ms step_avg:35.75ms
+step:93/1600 train_time:3321ms step_avg:35.71ms
+step:94/1600 train_time:3358ms step_avg:35.72ms
+step:95/1600 train_time:3389ms step_avg:35.67ms
+step:96/1600 train_time:3426ms step_avg:35.69ms
+step:97/1600 train_time:3457ms step_avg:35.64ms
+step:98/1600 train_time:3494ms step_avg:35.65ms
+step:99/1600 train_time:3525ms step_avg:35.60ms
+step:100/1600 train_time:3562ms step_avg:35.62ms
+step:101/1600 train_time:3593ms step_avg:35.57ms
+step:102/1600 train_time:3630ms step_avg:35.59ms
+step:103/1600 train_time:3661ms step_avg:35.54ms
+step:104/1600 train_time:3697ms step_avg:35.55ms
+step:105/1600 train_time:3728ms step_avg:35.51ms
+step:106/1600 train_time:3766ms step_avg:35.53ms
+step:107/1600 train_time:3797ms step_avg:35.49ms
+step:108/1600 train_time:3835ms step_avg:35.51ms
+step:109/1600 train_time:3866ms step_avg:35.47ms
+step:110/1600 train_time:3903ms step_avg:35.48ms
+step:111/1600 train_time:3934ms step_avg:35.44ms
+step:112/1600 train_time:3971ms step_avg:35.46ms
+step:113/1600 train_time:4002ms step_avg:35.42ms
+step:114/1600 train_time:4039ms step_avg:35.43ms
+step:115/1600 train_time:4070ms step_avg:35.39ms
+step:116/1600 train_time:4107ms step_avg:35.41ms
+step:117/1600 train_time:4138ms step_avg:35.37ms
+step:118/1600 train_time:4176ms step_avg:35.39ms
+step:119/1600 train_time:4207ms step_avg:35.35ms
+step:120/1600 train_time:4244ms step_avg:35.37ms
+step:121/1600 train_time:4275ms step_avg:35.33ms
+step:122/1600 train_time:4312ms step_avg:35.34ms
+step:123/1600 train_time:4343ms step_avg:35.31ms
+step:124/1600 train_time:4380ms step_avg:35.32ms
+step:125/1600 train_time:4411ms step_avg:35.29ms
+step:126/1600 train_time:4448ms step_avg:35.31ms
+step:127/1600 train_time:4479ms step_avg:35.27ms
+step:128/1600 train_time:4516ms step_avg:35.28ms
+step:129/1600 train_time:4548ms step_avg:35.25ms
+step:130/1600 train_time:4585ms step_avg:35.27ms
+step:131/1600 train_time:4615ms step_avg:35.23ms
+step:132/1600 train_time:4653ms step_avg:35.25ms
+step:133/1600 train_time:4683ms step_avg:35.21ms
+step:134/1600 train_time:4720ms step_avg:35.23ms
+step:135/1600 train_time:4751ms step_avg:35.19ms
+step:136/1600 train_time:4789ms step_avg:35.21ms
+step:137/1600 train_time:4820ms step_avg:35.18ms
+step:138/1600 train_time:4857ms step_avg:35.20ms
+step:139/1600 train_time:4887ms step_avg:35.16ms
+step:140/1600 train_time:4925ms step_avg:35.18ms
+step:141/1600 train_time:4956ms step_avg:35.15ms
+step:142/1600 train_time:4993ms step_avg:35.16ms
+step:143/1600 train_time:5024ms step_avg:35.13ms
+step:144/1600 train_time:5061ms step_avg:35.15ms
+step:145/1600 train_time:5092ms step_avg:35.12ms
+step:146/1600 train_time:5129ms step_avg:35.13ms
+step:147/1600 train_time:5160ms step_avg:35.10ms
+step:148/1600 train_time:5197ms step_avg:35.12ms
+step:149/1600 train_time:5228ms step_avg:35.09ms
+step:150/1600 train_time:5265ms step_avg:35.10ms
+step:151/1600 train_time:5296ms step_avg:35.07ms
+step:152/1600 train_time:5333ms step_avg:35.09ms
+step:153/1600 train_time:5364ms step_avg:35.06ms
+step:154/1600 train_time:5401ms step_avg:35.07ms
+step:155/1600 train_time:5433ms step_avg:35.05ms
+step:156/1600 train_time:5470ms step_avg:35.06ms
+step:157/1600 train_time:5500ms step_avg:35.03ms
+step:158/1600 train_time:5537ms step_avg:35.05ms
+step:159/1600 train_time:5568ms step_avg:35.02ms
+step:160/1600 train_time:5605ms step_avg:35.03ms
+step:161/1600 train_time:5636ms step_avg:35.01ms
+step:162/1600 train_time:5674ms step_avg:35.02ms
+step:163/1600 train_time:5704ms step_avg:34.99ms
+step:164/1600 train_time:5741ms step_avg:35.01ms
+step:165/1600 train_time:5772ms step_avg:34.98ms
+step:166/1600 train_time:5810ms step_avg:35.00ms
+step:167/1600 train_time:5841ms step_avg:34.97ms
+step:168/1600 train_time:5878ms step_avg:34.99ms
+step:169/1600 train_time:5909ms step_avg:34.96ms
+step:170/1600 train_time:5946ms step_avg:34.97ms
+step:171/1600 train_time:5977ms step_avg:34.95ms
+step:172/1600 train_time:6014ms step_avg:34.96ms
+step:173/1600 train_time:6045ms step_avg:34.94ms
+step:174/1600 train_time:6082ms step_avg:34.95ms
+step:175/1600 train_time:6113ms step_avg:34.93ms
+step:176/1600 train_time:6149ms step_avg:34.94ms
+step:177/1600 train_time:6180ms step_avg:34.92ms
+step:178/1600 train_time:6218ms step_avg:34.93ms
+step:179/1600 train_time:6249ms step_avg:34.91ms
+step:180/1600 train_time:6286ms step_avg:34.92ms
+step:181/1600 train_time:6317ms step_avg:34.90ms
+step:182/1600 train_time:6353ms step_avg:34.91ms
+step:183/1600 train_time:6384ms step_avg:34.89ms
+step:184/1600 train_time:6421ms step_avg:34.90ms
+step:185/1600 train_time:6452ms step_avg:34.88ms
+step:186/1600 train_time:6489ms step_avg:34.89ms
+step:187/1600 train_time:6520ms step_avg:34.87ms
+step:188/1600 train_time:6557ms step_avg:34.88ms
+step:189/1600 train_time:6587ms step_avg:34.85ms
+step:190/1600 train_time:6624ms step_avg:34.87ms
+step:191/1600 train_time:6655ms step_avg:34.84ms
+step:192/1600 train_time:6692ms step_avg:34.86ms
+step:193/1600 train_time:6723ms step_avg:34.83ms
+step:194/1600 train_time:6760ms step_avg:34.85ms
+step:195/1600 train_time:6790ms step_avg:34.82ms
+step:196/1600 train_time:6828ms step_avg:34.84ms
+step:197/1600 train_time:6858ms step_avg:34.81ms
+step:198/1600 train_time:6895ms step_avg:34.82ms
+step:199/1600 train_time:6926ms step_avg:34.80ms
+step:200/1600 train_time:6963ms step_avg:34.82ms
+step:201/1600 train_time:6994ms step_avg:34.80ms
+step:202/1600 train_time:7032ms step_avg:34.81ms
+step:203/1600 train_time:7062ms step_avg:34.79ms
+step:204/1600 train_time:7100ms step_avg:34.80ms
+step:205/1600 train_time:7130ms step_avg:34.78ms
+step:206/1600 train_time:7167ms step_avg:34.79ms
+step:207/1600 train_time:7198ms step_avg:34.77ms
+step:208/1600 train_time:7235ms step_avg:34.78ms
+step:209/1600 train_time:7266ms step_avg:34.76ms
+step:210/1600 train_time:7303ms step_avg:34.78ms
+step:211/1600 train_time:7334ms step_avg:34.76ms
+step:212/1600 train_time:7371ms step_avg:34.77ms
+step:213/1600 train_time:7402ms step_avg:34.75ms
+step:214/1600 train_time:7439ms step_avg:34.76ms
+step:215/1600 train_time:7470ms step_avg:34.75ms
+step:216/1600 train_time:7507ms step_avg:34.76ms
+step:217/1600 train_time:7538ms step_avg:34.74ms
+step:218/1600 train_time:7575ms step_avg:34.75ms
+step:219/1600 train_time:7606ms step_avg:34.73ms
+step:220/1600 train_time:7644ms step_avg:34.74ms
+step:221/1600 train_time:7674ms step_avg:34.73ms
+step:222/1600 train_time:7711ms step_avg:34.74ms
+step:223/1600 train_time:7742ms step_avg:34.72ms
+step:224/1600 train_time:7779ms step_avg:34.73ms
+step:225/1600 train_time:7811ms step_avg:34.71ms
+step:226/1600 train_time:7848ms step_avg:34.73ms
+step:227/1600 train_time:7879ms step_avg:34.71ms
+step:228/1600 train_time:7916ms step_avg:34.72ms
+step:229/1600 train_time:7947ms step_avg:34.70ms
+step:230/1600 train_time:7984ms step_avg:34.71ms
+step:231/1600 train_time:8015ms step_avg:34.70ms
+step:232/1600 train_time:8052ms step_avg:34.71ms
+step:233/1600 train_time:8083ms step_avg:34.69ms
+step:234/1600 train_time:8120ms step_avg:34.70ms
+step:235/1600 train_time:8151ms step_avg:34.69ms
+step:236/1600 train_time:8190ms step_avg:34.70ms
+step:237/1600 train_time:8220ms step_avg:34.68ms
+step:238/1600 train_time:8257ms step_avg:34.69ms
+step:239/1600 train_time:8288ms step_avg:34.68ms
+step:240/1600 train_time:8325ms step_avg:34.69ms
+step:241/1600 train_time:8355ms step_avg:34.67ms
+step:242/1600 train_time:8392ms step_avg:34.68ms
+step:243/1600 train_time:8423ms step_avg:34.66ms
+step:244/1600 train_time:8460ms step_avg:34.67ms
+step:245/1600 train_time:8491ms step_avg:34.66ms
+step:246/1600 train_time:8528ms step_avg:34.67ms
+step:247/1600 train_time:8558ms step_avg:34.65ms
+step:248/1600 train_time:8595ms step_avg:34.66ms
+step:249/1600 train_time:8626ms step_avg:34.64ms
+step:250/1600 train_time:8664ms step_avg:34.66ms
+step:250/1600 val_loss:4.5841 train_time:8711ms step_avg:34.84ms
+step:251/1600 train_time:8729ms step_avg:34.78ms
+step:252/1600 train_time:8748ms step_avg:34.71ms
+step:253/1600 train_time:8765ms step_avg:34.65ms
+step:254/1600 train_time:8803ms step_avg:34.66ms
+step:255/1600 train_time:8835ms step_avg:34.65ms
+step:256/1600 train_time:8873ms step_avg:34.66ms
+step:257/1600 train_time:8905ms step_avg:34.65ms
+step:258/1600 train_time:8942ms step_avg:34.66ms
+step:259/1600 train_time:8973ms step_avg:34.64ms
+step:260/1600 train_time:9011ms step_avg:34.66ms
+step:261/1600 train_time:9041ms step_avg:34.64ms
+step:262/1600 train_time:9078ms step_avg:34.65ms
+step:263/1600 train_time:9109ms step_avg:34.63ms
+step:264/1600 train_time:9145ms step_avg:34.64ms
+step:265/1600 train_time:9176ms step_avg:34.63ms
+step:266/1600 train_time:9213ms step_avg:34.64ms
+step:267/1600 train_time:9244ms step_avg:34.62ms
+step:268/1600 train_time:9281ms step_avg:34.63ms
+step:269/1600 train_time:9311ms step_avg:34.61ms
+step:270/1600 train_time:9348ms step_avg:34.62ms
+step:271/1600 train_time:9379ms step_avg:34.61ms
+step:272/1600 train_time:9416ms step_avg:34.62ms
+step:273/1600 train_time:9446ms step_avg:34.60ms
+step:274/1600 train_time:9484ms step_avg:34.61ms
+step:275/1600 train_time:9514ms step_avg:34.60ms
+step:276/1600 train_time:9551ms step_avg:34.61ms
+step:277/1600 train_time:9582ms step_avg:34.59ms
+step:278/1600 train_time:9619ms step_avg:34.60ms
+step:279/1600 train_time:9649ms step_avg:34.59ms
+step:280/1600 train_time:9686ms step_avg:34.59ms
+step:281/1600 train_time:9717ms step_avg:34.58ms
+step:282/1600 train_time:9754ms step_avg:34.59ms
+step:283/1600 train_time:9784ms step_avg:34.57ms
+step:284/1600 train_time:9822ms step_avg:34.58ms
+step:285/1600 train_time:9852ms step_avg:34.57ms
+step:286/1600 train_time:9890ms step_avg:34.58ms
+step:287/1600 train_time:9921ms step_avg:34.57ms
+step:288/1600 train_time:9958ms step_avg:34.58ms
+step:289/1600 train_time:9989ms step_avg:34.57ms
+step:290/1600 train_time:10026ms step_avg:34.57ms
+step:291/1600 train_time:10057ms step_avg:34.56ms
+step:292/1600 train_time:10094ms step_avg:34.57ms
+step:293/1600 train_time:10125ms step_avg:34.56ms
+step:294/1600 train_time:10162ms step_avg:34.56ms
+step:295/1600 train_time:10192ms step_avg:34.55ms
+step:296/1600 train_time:10230ms step_avg:34.56ms
+step:297/1600 train_time:10260ms step_avg:34.55ms
+step:298/1600 train_time:10297ms step_avg:34.56ms
+step:299/1600 train_time:10328ms step_avg:34.54ms
+step:300/1600 train_time:10365ms step_avg:34.55ms
+step:301/1600 train_time:10396ms step_avg:34.54ms
+step:302/1600 train_time:10433ms step_avg:34.55ms
+step:303/1600 train_time:10464ms step_avg:34.53ms
+step:304/1600 train_time:10500ms step_avg:34.54ms
+step:305/1600 train_time:10531ms step_avg:34.53ms
+step:306/1600 train_time:10568ms step_avg:34.54ms
+step:307/1600 train_time:10598ms step_avg:34.52ms
+step:308/1600 train_time:10635ms step_avg:34.53ms
+step:309/1600 train_time:10666ms step_avg:34.52ms
+step:310/1600 train_time:10703ms step_avg:34.53ms
+step:311/1600 train_time:10734ms step_avg:34.51ms
+step:312/1600 train_time:10771ms step_avg:34.52ms
+step:313/1600 train_time:10801ms step_avg:34.51ms
+step:314/1600 train_time:10839ms step_avg:34.52ms
+step:315/1600 train_time:10869ms step_avg:34.51ms
+step:316/1600 train_time:10906ms step_avg:34.51ms
+step:317/1600 train_time:10937ms step_avg:34.50ms
+step:318/1600 train_time:10974ms step_avg:34.51ms
+step:319/1600 train_time:11005ms step_avg:34.50ms
+step:320/1600 train_time:11043ms step_avg:34.51ms
+step:321/1600 train_time:11073ms step_avg:34.50ms
+step:322/1600 train_time:11111ms step_avg:34.51ms
+step:323/1600 train_time:11141ms step_avg:34.49ms
+step:324/1600 train_time:11179ms step_avg:34.50ms
+step:325/1600 train_time:11210ms step_avg:34.49ms
+step:326/1600 train_time:11247ms step_avg:34.50ms
+step:327/1600 train_time:11278ms step_avg:34.49ms
+step:328/1600 train_time:11315ms step_avg:34.50ms
+step:329/1600 train_time:11346ms step_avg:34.48ms
+step:330/1600 train_time:11382ms step_avg:34.49ms
+step:331/1600 train_time:11413ms step_avg:34.48ms
+step:332/1600 train_time:11450ms step_avg:34.49ms
+step:333/1600 train_time:11481ms step_avg:34.48ms
+step:334/1600 train_time:11519ms step_avg:34.49ms
+step:335/1600 train_time:11549ms step_avg:34.47ms
+step:336/1600 train_time:11586ms step_avg:34.48ms
+step:337/1600 train_time:11616ms step_avg:34.47ms
+step:338/1600 train_time:11653ms step_avg:34.48ms
+step:339/1600 train_time:11684ms step_avg:34.46ms
+step:340/1600 train_time:11720ms step_avg:34.47ms
+step:341/1600 train_time:11751ms step_avg:34.46ms
+step:342/1600 train_time:11788ms step_avg:34.47ms
+step:343/1600 train_time:11819ms step_avg:34.46ms
+step:344/1600 train_time:11856ms step_avg:34.46ms
+step:345/1600 train_time:11886ms step_avg:34.45ms
+step:346/1600 train_time:11923ms step_avg:34.46ms
+step:347/1600 train_time:11954ms step_avg:34.45ms
+step:348/1600 train_time:11991ms step_avg:34.46ms
+step:349/1600 train_time:12022ms step_avg:34.45ms
+step:350/1600 train_time:12059ms step_avg:34.45ms
+step:351/1600 train_time:12089ms step_avg:34.44ms
+step:352/1600 train_time:12126ms step_avg:34.45ms
+step:353/1600 train_time:12157ms step_avg:34.44ms
+step:354/1600 train_time:12194ms step_avg:34.45ms
+step:355/1600 train_time:12225ms step_avg:34.44ms
+step:356/1600 train_time:12261ms step_avg:34.44ms
+step:357/1600 train_time:12292ms step_avg:34.43ms
+step:358/1600 train_time:12329ms step_avg:34.44ms
+step:359/1600 train_time:12360ms step_avg:34.43ms
+step:360/1600 train_time:12397ms step_avg:34.44ms
+step:361/1600 train_time:12427ms step_avg:34.42ms
+step:362/1600 train_time:12464ms step_avg:34.43ms
+step:363/1600 train_time:12495ms step_avg:34.42ms
+step:364/1600 train_time:12532ms step_avg:34.43ms
+step:365/1600 train_time:12562ms step_avg:34.42ms
+step:366/1600 train_time:12599ms step_avg:34.42ms
+step:367/1600 train_time:12630ms step_avg:34.41ms
+step:368/1600 train_time:12667ms step_avg:34.42ms
+step:369/1600 train_time:12698ms step_avg:34.41ms
+step:370/1600 train_time:12735ms step_avg:34.42ms
+step:371/1600 train_time:12765ms step_avg:34.41ms
+step:372/1600 train_time:12802ms step_avg:34.41ms
+step:373/1600 train_time:12833ms step_avg:34.40ms
+step:374/1600 train_time:12870ms step_avg:34.41ms
+step:375/1600 train_time:12901ms step_avg:34.40ms
+step:376/1600 train_time:12938ms step_avg:34.41ms
+step:377/1600 train_time:12969ms step_avg:34.40ms
+step:378/1600 train_time:13006ms step_avg:34.41ms
+step:379/1600 train_time:13036ms step_avg:34.40ms
+step:380/1600 train_time:13074ms step_avg:34.40ms
+step:381/1600 train_time:13104ms step_avg:34.39ms
+step:382/1600 train_time:13141ms step_avg:34.40ms
+step:383/1600 train_time:13172ms step_avg:34.39ms
+step:384/1600 train_time:13209ms step_avg:34.40ms
+step:385/1600 train_time:13239ms step_avg:34.39ms
+step:386/1600 train_time:13277ms step_avg:34.40ms
+step:387/1600 train_time:13307ms step_avg:34.39ms
+step:388/1600 train_time:13344ms step_avg:34.39ms
+step:389/1600 train_time:13375ms step_avg:34.38ms
+step:390/1600 train_time:13412ms step_avg:34.39ms
+step:391/1600 train_time:13443ms step_avg:34.38ms
+step:392/1600 train_time:13480ms step_avg:34.39ms
+step:393/1600 train_time:13511ms step_avg:34.38ms
+step:394/1600 train_time:13548ms step_avg:34.39ms
+step:395/1600 train_time:13579ms step_avg:34.38ms
+step:396/1600 train_time:13616ms step_avg:34.38ms
+step:397/1600 train_time:13647ms step_avg:34.37ms
+step:398/1600 train_time:13684ms step_avg:34.38ms
+step:399/1600 train_time:13714ms step_avg:34.37ms
+step:400/1600 train_time:13752ms step_avg:34.38ms
+step:401/1600 train_time:13782ms step_avg:34.37ms
+step:402/1600 train_time:13819ms step_avg:34.38ms
+step:403/1600 train_time:13850ms step_avg:34.37ms
+step:404/1600 train_time:13887ms step_avg:34.37ms
+step:405/1600 train_time:13918ms step_avg:34.37ms
+step:406/1600 train_time:13955ms step_avg:34.37ms
+step:407/1600 train_time:13985ms step_avg:34.36ms
+step:408/1600 train_time:14022ms step_avg:34.37ms
+step:409/1600 train_time:14053ms step_avg:34.36ms
+step:410/1600 train_time:14091ms step_avg:34.37ms
+step:411/1600 train_time:14121ms step_avg:34.36ms
+step:412/1600 train_time:14158ms step_avg:34.36ms
+step:413/1600 train_time:14189ms step_avg:34.36ms
+step:414/1600 train_time:14226ms step_avg:34.36ms
+step:415/1600 train_time:14257ms step_avg:34.35ms
+step:416/1600 train_time:14294ms step_avg:34.36ms
+step:417/1600 train_time:14325ms step_avg:34.35ms
+step:418/1600 train_time:14361ms step_avg:34.36ms
+step:419/1600 train_time:14392ms step_avg:34.35ms
+step:420/1600 train_time:14429ms step_avg:34.36ms
+step:421/1600 train_time:14460ms step_avg:34.35ms
+step:422/1600 train_time:14497ms step_avg:34.35ms
+step:423/1600 train_time:14528ms step_avg:34.34ms
+step:424/1600 train_time:14564ms step_avg:34.35ms
+step:425/1600 train_time:14595ms step_avg:34.34ms
+step:426/1600 train_time:14632ms step_avg:34.35ms
+step:427/1600 train_time:14663ms step_avg:34.34ms
+step:428/1600 train_time:14700ms step_avg:34.35ms
+step:429/1600 train_time:14731ms step_avg:34.34ms
+step:430/1600 train_time:14769ms step_avg:34.35ms
+step:431/1600 train_time:14799ms step_avg:34.34ms
+step:432/1600 train_time:14836ms step_avg:34.34ms
+step:433/1600 train_time:14867ms step_avg:34.33ms
+step:434/1600 train_time:14903ms step_avg:34.34ms
+step:435/1600 train_time:14934ms step_avg:34.33ms
+step:436/1600 train_time:14972ms step_avg:34.34ms
+step:437/1600 train_time:15002ms step_avg:34.33ms
+step:438/1600 train_time:15039ms step_avg:34.34ms
+step:439/1600 train_time:15070ms step_avg:34.33ms
+step:440/1600 train_time:15108ms step_avg:34.34ms
+step:441/1600 train_time:15139ms step_avg:34.33ms
+step:442/1600 train_time:15176ms step_avg:34.33ms
+step:443/1600 train_time:15206ms step_avg:34.33ms
+step:444/1600 train_time:15243ms step_avg:34.33ms
+step:445/1600 train_time:15274ms step_avg:34.32ms
+step:446/1600 train_time:15311ms step_avg:34.33ms
+step:447/1600 train_time:15342ms step_avg:34.32ms
+step:448/1600 train_time:15379ms step_avg:34.33ms
+step:449/1600 train_time:15410ms step_avg:34.32ms
+step:450/1600 train_time:15447ms step_avg:34.33ms
+step:451/1600 train_time:15478ms step_avg:34.32ms
+step:452/1600 train_time:15515ms step_avg:34.33ms
+step:453/1600 train_time:15546ms step_avg:34.32ms
+step:454/1600 train_time:15583ms step_avg:34.32ms
+step:455/1600 train_time:15613ms step_avg:34.31ms
+step:456/1600 train_time:15650ms step_avg:34.32ms
+step:457/1600 train_time:15681ms step_avg:34.31ms
+step:458/1600 train_time:15718ms step_avg:34.32ms
+step:459/1600 train_time:15748ms step_avg:34.31ms
+step:460/1600 train_time:15785ms step_avg:34.32ms
+step:461/1600 train_time:15816ms step_avg:34.31ms
+step:462/1600 train_time:15853ms step_avg:34.31ms
+step:463/1600 train_time:15884ms step_avg:34.31ms
+step:464/1600 train_time:15921ms step_avg:34.31ms
+step:465/1600 train_time:15952ms step_avg:34.30ms
+step:466/1600 train_time:15988ms step_avg:34.31ms
+step:467/1600 train_time:16020ms step_avg:34.30ms
+step:468/1600 train_time:16057ms step_avg:34.31ms
+step:469/1600 train_time:16087ms step_avg:34.30ms
+step:470/1600 train_time:16125ms step_avg:34.31ms
+step:471/1600 train_time:16155ms step_avg:34.30ms
+step:472/1600 train_time:16192ms step_avg:34.31ms
+step:473/1600 train_time:16223ms step_avg:34.30ms
+step:474/1600 train_time:16260ms step_avg:34.30ms
+step:475/1600 train_time:16291ms step_avg:34.30ms
+step:476/1600 train_time:16328ms step_avg:34.30ms
+step:477/1600 train_time:16358ms step_avg:34.29ms
+step:478/1600 train_time:16396ms step_avg:34.30ms
+step:479/1600 train_time:16426ms step_avg:34.29ms
+step:480/1600 train_time:16463ms step_avg:34.30ms
+step:481/1600 train_time:16494ms step_avg:34.29ms
+step:482/1600 train_time:16532ms step_avg:34.30ms
+step:483/1600 train_time:16563ms step_avg:34.29ms
+step:484/1600 train_time:16599ms step_avg:34.30ms
+step:485/1600 train_time:16630ms step_avg:34.29ms
+step:486/1600 train_time:16667ms step_avg:34.30ms
+step:487/1600 train_time:16698ms step_avg:34.29ms
+step:488/1600 train_time:16736ms step_avg:34.29ms
+step:489/1600 train_time:16766ms step_avg:34.29ms
+step:490/1600 train_time:16803ms step_avg:34.29ms
+step:491/1600 train_time:16833ms step_avg:34.28ms
+step:492/1600 train_time:16871ms step_avg:34.29ms
+step:493/1600 train_time:16902ms step_avg:34.28ms
+step:494/1600 train_time:16939ms step_avg:34.29ms
+step:495/1600 train_time:16970ms step_avg:34.28ms
+step:496/1600 train_time:17007ms step_avg:34.29ms
+step:497/1600 train_time:17038ms step_avg:34.28ms
+step:498/1600 train_time:17075ms step_avg:34.29ms
+step:499/1600 train_time:17105ms step_avg:34.28ms
+step:500/1600 train_time:17142ms step_avg:34.28ms
+step:500/1600 val_loss:4.2321 train_time:17190ms step_avg:34.38ms
+step:501/1600 train_time:17208ms step_avg:34.35ms
+step:502/1600 train_time:17227ms step_avg:34.32ms
+step:503/1600 train_time:17243ms step_avg:34.28ms
+step:504/1600 train_time:17280ms step_avg:34.29ms
+step:505/1600 train_time:17312ms step_avg:34.28ms
+step:506/1600 train_time:17349ms step_avg:34.29ms
+step:507/1600 train_time:17380ms step_avg:34.28ms
+step:508/1600 train_time:17417ms step_avg:34.29ms
+step:509/1600 train_time:17448ms step_avg:34.28ms
+step:510/1600 train_time:17486ms step_avg:34.29ms
+step:511/1600 train_time:17516ms step_avg:34.28ms
+step:512/1600 train_time:17553ms step_avg:34.28ms
+step:513/1600 train_time:17584ms step_avg:34.28ms
+step:514/1600 train_time:17620ms step_avg:34.28ms
+step:515/1600 train_time:17651ms step_avg:34.27ms
+step:516/1600 train_time:17688ms step_avg:34.28ms
+step:517/1600 train_time:17718ms step_avg:34.27ms
+step:518/1600 train_time:17756ms step_avg:34.28ms
+step:519/1600 train_time:17786ms step_avg:34.27ms
+step:520/1600 train_time:17823ms step_avg:34.27ms
+step:521/1600 train_time:17893ms step_avg:34.34ms
+step:522/1600 train_time:17950ms step_avg:34.39ms
+step:523/1600 train_time:18011ms step_avg:34.44ms
+step:524/1600 train_time:18069ms step_avg:34.48ms
+step:525/1600 train_time:18131ms step_avg:34.54ms
+step:526/1600 train_time:18191ms step_avg:34.58ms
+step:527/1600 train_time:18255ms step_avg:34.64ms
+step:528/1600 train_time:18315ms step_avg:34.69ms
+step:529/1600 train_time:18378ms step_avg:34.74ms
+step:530/1600 train_time:18437ms step_avg:34.79ms
+step:531/1600 train_time:18500ms step_avg:34.84ms
+step:532/1600 train_time:18558ms step_avg:34.88ms
+step:533/1600 train_time:18621ms step_avg:34.94ms
+step:534/1600 train_time:18680ms step_avg:34.98ms
+step:535/1600 train_time:18743ms step_avg:35.03ms
+step:536/1600 train_time:18802ms step_avg:35.08ms
+step:537/1600 train_time:18864ms step_avg:35.13ms
+step:538/1600 train_time:18923ms step_avg:35.17ms
+step:539/1600 train_time:18985ms step_avg:35.22ms
+step:540/1600 train_time:19044ms step_avg:35.27ms
+step:541/1600 train_time:19106ms step_avg:35.32ms
+step:542/1600 train_time:19165ms step_avg:35.36ms
+step:543/1600 train_time:19227ms step_avg:35.41ms
+step:544/1600 train_time:19287ms step_avg:35.45ms
+step:545/1600 train_time:19349ms step_avg:35.50ms
+step:546/1600 train_time:19408ms step_avg:35.55ms
+step:547/1600 train_time:19470ms step_avg:35.59ms
+step:548/1600 train_time:19530ms step_avg:35.64ms
+step:549/1600 train_time:19592ms step_avg:35.69ms
+step:550/1600 train_time:19651ms step_avg:35.73ms
+step:551/1600 train_time:19714ms step_avg:35.78ms
+step:552/1600 train_time:19774ms step_avg:35.82ms
+step:553/1600 train_time:19835ms step_avg:35.87ms
+step:554/1600 train_time:19895ms step_avg:35.91ms
+step:555/1600 train_time:19957ms step_avg:35.96ms
+step:556/1600 train_time:20017ms step_avg:36.00ms
+step:557/1600 train_time:20079ms step_avg:36.05ms
+step:558/1600 train_time:20138ms step_avg:36.09ms
+step:559/1600 train_time:20201ms step_avg:36.14ms
+step:560/1600 train_time:20260ms step_avg:36.18ms
+step:561/1600 train_time:20323ms step_avg:36.23ms
+step:562/1600 train_time:20386ms step_avg:36.27ms
+step:563/1600 train_time:20447ms step_avg:36.32ms
+step:564/1600 train_time:20507ms step_avg:36.36ms
+step:565/1600 train_time:20566ms step_avg:36.40ms
+step:566/1600 train_time:20625ms step_avg:36.44ms
+step:567/1600 train_time:20687ms step_avg:36.49ms
+step:568/1600 train_time:20746ms step_avg:36.52ms
+step:569/1600 train_time:20808ms step_avg:36.57ms
+step:570/1600 train_time:20866ms step_avg:36.61ms
+step:571/1600 train_time:20929ms step_avg:36.65ms
+step:572/1600 train_time:20988ms step_avg:36.69ms
+step:573/1600 train_time:21054ms step_avg:36.74ms
+step:574/1600 train_time:21112ms step_avg:36.78ms
+step:575/1600 train_time:21174ms step_avg:36.82ms
+step:576/1600 train_time:21233ms step_avg:36.86ms
+step:577/1600 train_time:21295ms step_avg:36.91ms
+step:578/1600 train_time:21354ms step_avg:36.95ms
+step:579/1600 train_time:21418ms step_avg:36.99ms
+step:580/1600 train_time:21476ms step_avg:37.03ms
+step:581/1600 train_time:21538ms step_avg:37.07ms
+step:582/1600 train_time:21597ms step_avg:37.11ms
+step:583/1600 train_time:21659ms step_avg:37.15ms
+step:584/1600 train_time:21719ms step_avg:37.19ms
+step:585/1600 train_time:21781ms step_avg:37.23ms
+step:586/1600 train_time:21841ms step_avg:37.27ms
+step:587/1600 train_time:21906ms step_avg:37.32ms
+step:588/1600 train_time:21964ms step_avg:37.35ms
+step:589/1600 train_time:22026ms step_avg:37.39ms
+step:590/1600 train_time:22084ms step_avg:37.43ms
+step:591/1600 train_time:22147ms step_avg:37.47ms
+step:592/1600 train_time:22206ms step_avg:37.51ms
+step:593/1600 train_time:22268ms step_avg:37.55ms
+step:594/1600 train_time:22327ms step_avg:37.59ms
+step:595/1600 train_time:22389ms step_avg:37.63ms
+step:596/1600 train_time:22448ms step_avg:37.66ms
+step:597/1600 train_time:22510ms step_avg:37.71ms
+step:598/1600 train_time:22569ms step_avg:37.74ms
+step:599/1600 train_time:22633ms step_avg:37.78ms
+step:600/1600 train_time:22691ms step_avg:37.82ms
+step:601/1600 train_time:22754ms step_avg:37.86ms
+step:602/1600 train_time:22813ms step_avg:37.90ms
+step:603/1600 train_time:22876ms step_avg:37.94ms
+step:604/1600 train_time:22935ms step_avg:37.97ms
+step:605/1600 train_time:22998ms step_avg:38.01ms
+step:606/1600 train_time:23057ms step_avg:38.05ms
+step:607/1600 train_time:23119ms step_avg:38.09ms
+step:608/1600 train_time:23178ms step_avg:38.12ms
+step:609/1600 train_time:23241ms step_avg:38.16ms
+step:610/1600 train_time:23301ms step_avg:38.20ms
+step:611/1600 train_time:23363ms step_avg:38.24ms
+step:612/1600 train_time:23424ms step_avg:38.27ms
+step:613/1600 train_time:23485ms step_avg:38.31ms
+step:614/1600 train_time:23544ms step_avg:38.35ms
+step:615/1600 train_time:23607ms step_avg:38.38ms
+step:616/1600 train_time:23665ms step_avg:38.42ms
+step:617/1600 train_time:23726ms step_avg:38.45ms
+step:618/1600 train_time:23785ms step_avg:38.49ms
+step:619/1600 train_time:23848ms step_avg:38.53ms
+step:620/1600 train_time:23906ms step_avg:38.56ms
+step:621/1600 train_time:23969ms step_avg:38.60ms
+step:622/1600 train_time:24029ms step_avg:38.63ms
+step:623/1600 train_time:24092ms step_avg:38.67ms
+step:624/1600 train_time:24151ms step_avg:38.70ms
+step:625/1600 train_time:24213ms step_avg:38.74ms
+step:626/1600 train_time:24273ms step_avg:38.77ms
+step:627/1600 train_time:24336ms step_avg:38.81ms
+step:628/1600 train_time:24395ms step_avg:38.84ms
+step:629/1600 train_time:24458ms step_avg:38.88ms
+step:630/1600 train_time:24517ms step_avg:38.92ms
+step:631/1600 train_time:24579ms step_avg:38.95ms
+step:632/1600 train_time:24638ms step_avg:38.98ms
+step:633/1600 train_time:24701ms step_avg:39.02ms
+step:634/1600 train_time:24760ms step_avg:39.05ms
+step:635/1600 train_time:24823ms step_avg:39.09ms
+step:636/1600 train_time:24882ms step_avg:39.12ms
+step:637/1600 train_time:24944ms step_avg:39.16ms
+step:638/1600 train_time:25004ms step_avg:39.19ms
+step:639/1600 train_time:25066ms step_avg:39.23ms
+step:640/1600 train_time:25125ms step_avg:39.26ms
+step:641/1600 train_time:25188ms step_avg:39.29ms
+step:642/1600 train_time:25246ms step_avg:39.32ms
+step:643/1600 train_time:25308ms step_avg:39.36ms
+step:644/1600 train_time:25367ms step_avg:39.39ms
+step:645/1600 train_time:25430ms step_avg:39.43ms
+step:646/1600 train_time:25489ms step_avg:39.46ms
+step:647/1600 train_time:25550ms step_avg:39.49ms
+step:648/1600 train_time:25609ms step_avg:39.52ms
+step:649/1600 train_time:25672ms step_avg:39.56ms
+step:650/1600 train_time:25734ms step_avg:39.59ms
+step:651/1600 train_time:25798ms step_avg:39.63ms
+step:652/1600 train_time:25854ms step_avg:39.65ms
+step:653/1600 train_time:25916ms step_avg:39.69ms
+step:654/1600 train_time:25975ms step_avg:39.72ms
+step:655/1600 train_time:26038ms step_avg:39.75ms
+step:656/1600 train_time:26097ms step_avg:39.78ms
+step:657/1600 train_time:26159ms step_avg:39.82ms
+step:658/1600 train_time:26219ms step_avg:39.85ms
+step:659/1600 train_time:26281ms step_avg:39.88ms
+step:660/1600 train_time:26340ms step_avg:39.91ms
+step:661/1600 train_time:26403ms step_avg:39.94ms
+step:662/1600 train_time:26462ms step_avg:39.97ms
+step:663/1600 train_time:26525ms step_avg:40.01ms
+step:664/1600 train_time:26584ms step_avg:40.04ms
+step:665/1600 train_time:26646ms step_avg:40.07ms
+step:666/1600 train_time:26706ms step_avg:40.10ms
+step:667/1600 train_time:26768ms step_avg:40.13ms
+step:668/1600 train_time:26827ms step_avg:40.16ms
+step:669/1600 train_time:26889ms step_avg:40.19ms
+step:670/1600 train_time:26947ms step_avg:40.22ms
+step:671/1600 train_time:27010ms step_avg:40.25ms
+step:672/1600 train_time:27071ms step_avg:40.28ms
+step:673/1600 train_time:27132ms step_avg:40.31ms
+step:674/1600 train_time:27192ms step_avg:40.34ms
+step:675/1600 train_time:27254ms step_avg:40.38ms
+step:676/1600 train_time:27313ms step_avg:40.40ms
+step:677/1600 train_time:27375ms step_avg:40.44ms
+step:678/1600 train_time:27434ms step_avg:40.46ms
+step:679/1600 train_time:27496ms step_avg:40.50ms
+step:680/1600 train_time:27556ms step_avg:40.52ms
+step:681/1600 train_time:27619ms step_avg:40.56ms
+step:682/1600 train_time:27677ms step_avg:40.58ms
+step:683/1600 train_time:27740ms step_avg:40.61ms
+step:684/1600 train_time:27799ms step_avg:40.64ms
+step:685/1600 train_time:27861ms step_avg:40.67ms
+step:686/1600 train_time:27921ms step_avg:40.70ms
+step:687/1600 train_time:27983ms step_avg:40.73ms
+step:688/1600 train_time:28043ms step_avg:40.76ms
+step:689/1600 train_time:28105ms step_avg:40.79ms
+step:690/1600 train_time:28164ms step_avg:40.82ms
+step:691/1600 train_time:28227ms step_avg:40.85ms
+step:692/1600 train_time:28286ms step_avg:40.88ms
+step:693/1600 train_time:28348ms step_avg:40.91ms
+step:694/1600 train_time:28407ms step_avg:40.93ms
+step:695/1600 train_time:28469ms step_avg:40.96ms
+step:696/1600 train_time:28528ms step_avg:40.99ms
+step:697/1600 train_time:28590ms step_avg:41.02ms
+step:698/1600 train_time:28649ms step_avg:41.05ms
+step:699/1600 train_time:28712ms step_avg:41.08ms
+step:700/1600 train_time:28771ms step_avg:41.10ms
+step:701/1600 train_time:28833ms step_avg:41.13ms
+step:702/1600 train_time:28892ms step_avg:41.16ms
+step:703/1600 train_time:28956ms step_avg:41.19ms
+step:704/1600 train_time:29014ms step_avg:41.21ms
+step:705/1600 train_time:29076ms step_avg:41.24ms
+step:706/1600 train_time:29135ms step_avg:41.27ms
+step:707/1600 train_time:29198ms step_avg:41.30ms
+step:708/1600 train_time:29257ms step_avg:41.32ms
+step:709/1600 train_time:29320ms step_avg:41.35ms
+step:710/1600 train_time:29378ms step_avg:41.38ms
+step:711/1600 train_time:29441ms step_avg:41.41ms
+step:712/1600 train_time:29500ms step_avg:41.43ms
+step:713/1600 train_time:29563ms step_avg:41.46ms
+step:714/1600 train_time:29622ms step_avg:41.49ms
+step:715/1600 train_time:29685ms step_avg:41.52ms
+step:716/1600 train_time:29745ms step_avg:41.54ms
+step:717/1600 train_time:29807ms step_avg:41.57ms
+step:718/1600 train_time:29866ms step_avg:41.60ms
+step:719/1600 train_time:29928ms step_avg:41.62ms
+step:720/1600 train_time:29986ms step_avg:41.65ms
+step:721/1600 train_time:30048ms step_avg:41.68ms
+step:722/1600 train_time:30107ms step_avg:41.70ms
+step:723/1600 train_time:30169ms step_avg:41.73ms
+step:724/1600 train_time:30228ms step_avg:41.75ms
+step:725/1600 train_time:30291ms step_avg:41.78ms
+step:726/1600 train_time:30351ms step_avg:41.81ms
+step:727/1600 train_time:30413ms step_avg:41.83ms
+step:728/1600 train_time:30472ms step_avg:41.86ms
+step:729/1600 train_time:30534ms step_avg:41.89ms
+step:730/1600 train_time:30594ms step_avg:41.91ms
+step:731/1600 train_time:30656ms step_avg:41.94ms
+step:732/1600 train_time:30716ms step_avg:41.96ms
+step:733/1600 train_time:30778ms step_avg:41.99ms
+step:734/1600 train_time:30837ms step_avg:42.01ms
+step:735/1600 train_time:30900ms step_avg:42.04ms
+step:736/1600 train_time:30959ms step_avg:42.06ms
+step:737/1600 train_time:31021ms step_avg:42.09ms
+step:738/1600 train_time:31081ms step_avg:42.11ms
+step:739/1600 train_time:31143ms step_avg:42.14ms
+step:740/1600 train_time:31202ms step_avg:42.17ms
+step:741/1600 train_time:31265ms step_avg:42.19ms
+step:742/1600 train_time:31324ms step_avg:42.22ms
+step:743/1600 train_time:31387ms step_avg:42.24ms
+step:744/1600 train_time:31446ms step_avg:42.27ms
+step:745/1600 train_time:31508ms step_avg:42.29ms
+step:746/1600 train_time:31566ms step_avg:42.31ms
+step:747/1600 train_time:31628ms step_avg:42.34ms
+step:748/1600 train_time:31687ms step_avg:42.36ms
+step:749/1600 train_time:31749ms step_avg:42.39ms
+step:750/1600 train_time:31808ms step_avg:42.41ms
+step:750/1600 val_loss:3.8944 train_time:31856ms step_avg:42.47ms
+step:751/1600 train_time:31876ms step_avg:42.44ms
+step:752/1600 train_time:31934ms step_avg:42.47ms
+step:753/1600 train_time:31999ms step_avg:42.49ms
+step:754/1600 train_time:32060ms step_avg:42.52ms
+step:755/1600 train_time:32122ms step_avg:42.55ms
+step:756/1600 train_time:32182ms step_avg:42.57ms
+step:757/1600 train_time:32244ms step_avg:42.59ms
+step:758/1600 train_time:32303ms step_avg:42.62ms
+step:759/1600 train_time:32364ms step_avg:42.64ms
+step:760/1600 train_time:32423ms step_avg:42.66ms
+step:761/1600 train_time:32487ms step_avg:42.69ms
+step:762/1600 train_time:32545ms step_avg:42.71ms
+step:763/1600 train_time:32606ms step_avg:42.73ms
+step:764/1600 train_time:32664ms step_avg:42.75ms
+step:765/1600 train_time:32725ms step_avg:42.78ms
+step:766/1600 train_time:32784ms step_avg:42.80ms
+step:767/1600 train_time:32848ms step_avg:42.83ms
+step:768/1600 train_time:32907ms step_avg:42.85ms
+step:769/1600 train_time:32972ms step_avg:42.88ms
+step:770/1600 train_time:33031ms step_avg:42.90ms
+step:771/1600 train_time:33094ms step_avg:42.92ms
+step:772/1600 train_time:33154ms step_avg:42.95ms
+step:773/1600 train_time:33216ms step_avg:42.97ms
+step:774/1600 train_time:33275ms step_avg:42.99ms
+step:775/1600 train_time:33337ms step_avg:43.02ms
+step:776/1600 train_time:33396ms step_avg:43.04ms
+step:777/1600 train_time:33458ms step_avg:43.06ms
+step:778/1600 train_time:33516ms step_avg:43.08ms
+step:779/1600 train_time:33578ms step_avg:43.10ms
+step:780/1600 train_time:33636ms step_avg:43.12ms
+step:781/1600 train_time:33698ms step_avg:43.15ms
+step:782/1600 train_time:33757ms step_avg:43.17ms
+step:783/1600 train_time:33819ms step_avg:43.19ms
+step:784/1600 train_time:33880ms step_avg:43.21ms
+step:785/1600 train_time:33944ms step_avg:43.24ms
+step:786/1600 train_time:34004ms step_avg:43.26ms
+step:787/1600 train_time:34067ms step_avg:43.29ms
+step:788/1600 train_time:34126ms step_avg:43.31ms
+step:789/1600 train_time:34188ms step_avg:43.33ms
+step:790/1600 train_time:34247ms step_avg:43.35ms
+step:791/1600 train_time:34310ms step_avg:43.38ms
+step:792/1600 train_time:34370ms step_avg:43.40ms
+step:793/1600 train_time:34432ms step_avg:43.42ms
+step:794/1600 train_time:34492ms step_avg:43.44ms
+step:795/1600 train_time:34556ms step_avg:43.47ms
+step:796/1600 train_time:34615ms step_avg:43.49ms
+step:797/1600 train_time:34676ms step_avg:43.51ms
+step:798/1600 train_time:34735ms step_avg:43.53ms
+step:799/1600 train_time:34797ms step_avg:43.55ms
+step:800/1600 train_time:34856ms step_avg:43.57ms
+step:801/1600 train_time:34920ms step_avg:43.59ms
+step:802/1600 train_time:34980ms step_avg:43.62ms
+step:803/1600 train_time:35040ms step_avg:43.64ms
+step:804/1600 train_time:35100ms step_avg:43.66ms
+step:805/1600 train_time:35162ms step_avg:43.68ms
+step:806/1600 train_time:35221ms step_avg:43.70ms
+step:807/1600 train_time:35283ms step_avg:43.72ms
+step:808/1600 train_time:35343ms step_avg:43.74ms
+step:809/1600 train_time:35405ms step_avg:43.76ms
+step:810/1600 train_time:35464ms step_avg:43.78ms
+step:811/1600 train_time:35527ms step_avg:43.81ms
+step:812/1600 train_time:35586ms step_avg:43.83ms
+step:813/1600 train_time:35649ms step_avg:43.85ms
+step:814/1600 train_time:35708ms step_avg:43.87ms
+step:815/1600 train_time:35770ms step_avg:43.89ms
+step:816/1600 train_time:35830ms step_avg:43.91ms
+step:817/1600 train_time:35892ms step_avg:43.93ms
+step:818/1600 train_time:35954ms step_avg:43.95ms
+step:819/1600 train_time:36016ms step_avg:43.98ms
+step:820/1600 train_time:36076ms step_avg:44.00ms
+step:821/1600 train_time:36139ms step_avg:44.02ms
+step:822/1600 train_time:36196ms step_avg:44.03ms
+step:823/1600 train_time:36257ms step_avg:44.06ms
+step:824/1600 train_time:36316ms step_avg:44.07ms
+step:825/1600 train_time:36379ms step_avg:44.10ms
+step:826/1600 train_time:36438ms step_avg:44.11ms
+step:827/1600 train_time:36500ms step_avg:44.14ms
+step:828/1600 train_time:36560ms step_avg:44.15ms
+step:829/1600 train_time:36622ms step_avg:44.18ms
+step:830/1600 train_time:36681ms step_avg:44.19ms
+step:831/1600 train_time:36744ms step_avg:44.22ms
+step:832/1600 train_time:36803ms step_avg:44.23ms
+step:833/1600 train_time:36867ms step_avg:44.26ms
+step:834/1600 train_time:36926ms step_avg:44.28ms
+step:835/1600 train_time:36989ms step_avg:44.30ms
+step:836/1600 train_time:37047ms step_avg:44.32ms
+step:837/1600 train_time:37111ms step_avg:44.34ms
+step:838/1600 train_time:37170ms step_avg:44.36ms
+step:839/1600 train_time:37233ms step_avg:44.38ms
+step:840/1600 train_time:37292ms step_avg:44.40ms
+step:841/1600 train_time:37355ms step_avg:44.42ms
+step:842/1600 train_time:37414ms step_avg:44.43ms
+step:843/1600 train_time:37477ms step_avg:44.46ms
+step:844/1600 train_time:37536ms step_avg:44.47ms
+step:845/1600 train_time:37598ms step_avg:44.49ms
+step:846/1600 train_time:37657ms step_avg:44.51ms
+step:847/1600 train_time:37719ms step_avg:44.53ms
+step:848/1600 train_time:37778ms step_avg:44.55ms
+step:849/1600 train_time:37841ms step_avg:44.57ms
+step:850/1600 train_time:37900ms step_avg:44.59ms
+step:851/1600 train_time:37963ms step_avg:44.61ms
+step:852/1600 train_time:38022ms step_avg:44.63ms
+step:853/1600 train_time:38085ms step_avg:44.65ms
+step:854/1600 train_time:38144ms step_avg:44.67ms
+step:855/1600 train_time:38208ms step_avg:44.69ms
+step:856/1600 train_time:38267ms step_avg:44.70ms
+step:857/1600 train_time:38330ms step_avg:44.73ms
+step:858/1600 train_time:38388ms step_avg:44.74ms
+step:859/1600 train_time:38451ms step_avg:44.76ms
+step:860/1600 train_time:38509ms step_avg:44.78ms
+step:861/1600 train_time:38572ms step_avg:44.80ms
+step:862/1600 train_time:38631ms step_avg:44.82ms
+step:863/1600 train_time:38694ms step_avg:44.84ms
+step:864/1600 train_time:38752ms step_avg:44.85ms
+step:865/1600 train_time:38815ms step_avg:44.87ms
+step:866/1600 train_time:38874ms step_avg:44.89ms
+step:867/1600 train_time:38938ms step_avg:44.91ms
+step:868/1600 train_time:38997ms step_avg:44.93ms
+step:869/1600 train_time:39059ms step_avg:44.95ms
+step:870/1600 train_time:39117ms step_avg:44.96ms
+step:871/1600 train_time:39180ms step_avg:44.98ms
+step:872/1600 train_time:39239ms step_avg:45.00ms
+step:873/1600 train_time:39302ms step_avg:45.02ms
+step:874/1600 train_time:39361ms step_avg:45.04ms
+step:875/1600 train_time:39424ms step_avg:45.06ms
+step:876/1600 train_time:39484ms step_avg:45.07ms
+step:877/1600 train_time:39546ms step_avg:45.09ms
+step:878/1600 train_time:39605ms step_avg:45.11ms
+step:879/1600 train_time:39667ms step_avg:45.13ms
+step:880/1600 train_time:39726ms step_avg:45.14ms
+step:881/1600 train_time:39788ms step_avg:45.16ms
+step:882/1600 train_time:39848ms step_avg:45.18ms
+step:883/1600 train_time:39910ms step_avg:45.20ms
+step:884/1600 train_time:39969ms step_avg:45.21ms
+step:885/1600 train_time:40034ms step_avg:45.24ms
+step:886/1600 train_time:40094ms step_avg:45.25ms
+step:887/1600 train_time:40154ms step_avg:45.27ms
+step:888/1600 train_time:40213ms step_avg:45.28ms
+step:889/1600 train_time:40276ms step_avg:45.30ms
+step:890/1600 train_time:40341ms step_avg:45.33ms
+step:891/1600 train_time:40399ms step_avg:45.34ms
+step:892/1600 train_time:40457ms step_avg:45.36ms
+step:893/1600 train_time:40520ms step_avg:45.37ms
+step:894/1600 train_time:40577ms step_avg:45.39ms
+step:895/1600 train_time:40639ms step_avg:45.41ms
+step:896/1600 train_time:40698ms step_avg:45.42ms
+step:897/1600 train_time:40760ms step_avg:45.44ms
+step:898/1600 train_time:40819ms step_avg:45.46ms
+step:899/1600 train_time:40882ms step_avg:45.48ms
+step:900/1600 train_time:40944ms step_avg:45.49ms
+step:901/1600 train_time:41004ms step_avg:45.51ms
+step:902/1600 train_time:41064ms step_avg:45.53ms
+step:903/1600 train_time:41126ms step_avg:45.54ms
+step:904/1600 train_time:41185ms step_avg:45.56ms
+step:905/1600 train_time:41248ms step_avg:45.58ms
+step:906/1600 train_time:41307ms step_avg:45.59ms
+step:907/1600 train_time:41369ms step_avg:45.61ms
+step:908/1600 train_time:41428ms step_avg:45.63ms
+step:909/1600 train_time:41491ms step_avg:45.64ms
+step:910/1600 train_time:41551ms step_avg:45.66ms
+step:911/1600 train_time:41613ms step_avg:45.68ms
+step:912/1600 train_time:41672ms step_avg:45.69ms
+step:913/1600 train_time:41735ms step_avg:45.71ms
+step:914/1600 train_time:41793ms step_avg:45.73ms
+step:915/1600 train_time:41856ms step_avg:45.74ms
+step:916/1600 train_time:41915ms step_avg:45.76ms
+step:917/1600 train_time:41977ms step_avg:45.78ms
+step:918/1600 train_time:42036ms step_avg:45.79ms
+step:919/1600 train_time:42099ms step_avg:45.81ms
+step:920/1600 train_time:42157ms step_avg:45.82ms
+step:921/1600 train_time:42219ms step_avg:45.84ms
+step:922/1600 train_time:42278ms step_avg:45.85ms
+step:923/1600 train_time:42341ms step_avg:45.87ms
+step:924/1600 train_time:42401ms step_avg:45.89ms
+step:925/1600 train_time:42463ms step_avg:45.91ms
+step:926/1600 train_time:42522ms step_avg:45.92ms
+step:927/1600 train_time:42584ms step_avg:45.94ms
+step:928/1600 train_time:42643ms step_avg:45.95ms
+step:929/1600 train_time:42707ms step_avg:45.97ms
+step:930/1600 train_time:42766ms step_avg:45.98ms
+step:931/1600 train_time:42828ms step_avg:46.00ms
+step:932/1600 train_time:42887ms step_avg:46.02ms
+step:933/1600 train_time:42950ms step_avg:46.03ms
+step:934/1600 train_time:43009ms step_avg:46.05ms
+step:935/1600 train_time:43071ms step_avg:46.06ms
+step:936/1600 train_time:43129ms step_avg:46.08ms
+step:937/1600 train_time:43193ms step_avg:46.10ms
+step:938/1600 train_time:43250ms step_avg:46.11ms
+step:939/1600 train_time:43313ms step_avg:46.13ms
+step:940/1600 train_time:43372ms step_avg:46.14ms
+step:941/1600 train_time:43435ms step_avg:46.16ms
+step:942/1600 train_time:43494ms step_avg:46.17ms
+step:943/1600 train_time:43555ms step_avg:46.19ms
+step:944/1600 train_time:43614ms step_avg:46.20ms
+step:945/1600 train_time:43677ms step_avg:46.22ms
+step:946/1600 train_time:43736ms step_avg:46.23ms
+step:947/1600 train_time:43798ms step_avg:46.25ms
+step:948/1600 train_time:43857ms step_avg:46.26ms
+step:949/1600 train_time:43920ms step_avg:46.28ms
+step:950/1600 train_time:43979ms step_avg:46.29ms
+step:951/1600 train_time:44042ms step_avg:46.31ms
+step:952/1600 train_time:44101ms step_avg:46.32ms
+step:953/1600 train_time:44163ms step_avg:46.34ms
+step:954/1600 train_time:44222ms step_avg:46.35ms
+step:955/1600 train_time:44284ms step_avg:46.37ms
+step:956/1600 train_time:44343ms step_avg:46.38ms
+step:957/1600 train_time:44406ms step_avg:46.40ms
+step:958/1600 train_time:44465ms step_avg:46.41ms
+step:959/1600 train_time:44527ms step_avg:46.43ms
+step:960/1600 train_time:44586ms step_avg:46.44ms
+step:961/1600 train_time:44648ms step_avg:46.46ms
+step:962/1600 train_time:44708ms step_avg:46.47ms
+step:963/1600 train_time:44770ms step_avg:46.49ms
+step:964/1600 train_time:44829ms step_avg:46.50ms
+step:965/1600 train_time:44892ms step_avg:46.52ms
+step:966/1600 train_time:44952ms step_avg:46.53ms
+step:967/1600 train_time:45015ms step_avg:46.55ms
+step:968/1600 train_time:45074ms step_avg:46.56ms
+step:969/1600 train_time:45139ms step_avg:46.58ms
+step:970/1600 train_time:45197ms step_avg:46.59ms
+step:971/1600 train_time:45256ms step_avg:46.61ms
+step:972/1600 train_time:45315ms step_avg:46.62ms
+step:973/1600 train_time:45378ms step_avg:46.64ms
+step:974/1600 train_time:45437ms step_avg:46.65ms
+step:975/1600 train_time:45500ms step_avg:46.67ms
+step:976/1600 train_time:45559ms step_avg:46.68ms
+step:977/1600 train_time:45621ms step_avg:46.70ms
+step:978/1600 train_time:45680ms step_avg:46.71ms
+step:979/1600 train_time:45742ms step_avg:46.72ms
+step:980/1600 train_time:45802ms step_avg:46.74ms
+step:981/1600 train_time:45865ms step_avg:46.75ms
+step:982/1600 train_time:45924ms step_avg:46.77ms
+step:983/1600 train_time:45987ms step_avg:46.78ms
+step:984/1600 train_time:46045ms step_avg:46.79ms
+step:985/1600 train_time:46108ms step_avg:46.81ms
+step:986/1600 train_time:46167ms step_avg:46.82ms
+step:987/1600 train_time:46229ms step_avg:46.84ms
+step:988/1600 train_time:46288ms step_avg:46.85ms
+step:989/1600 train_time:46351ms step_avg:46.87ms
+step:990/1600 train_time:46411ms step_avg:46.88ms
+step:991/1600 train_time:46474ms step_avg:46.90ms
+step:992/1600 train_time:46534ms step_avg:46.91ms
+step:993/1600 train_time:46596ms step_avg:46.92ms
+step:994/1600 train_time:46654ms step_avg:46.94ms
+step:995/1600 train_time:46717ms step_avg:46.95ms
+step:996/1600 train_time:46775ms step_avg:46.96ms
+step:997/1600 train_time:46837ms step_avg:46.98ms
+step:998/1600 train_time:46897ms step_avg:46.99ms
+step:999/1600 train_time:46960ms step_avg:47.01ms
+step:1000/1600 train_time:47019ms step_avg:47.02ms
+step:1000/1600 val_loss:3.5962 train_time:47066ms step_avg:47.07ms
+step:1001/1600 train_time:47085ms step_avg:47.04ms
+step:1002/1600 train_time:47144ms step_avg:47.05ms
+step:1003/1600 train_time:47208ms step_avg:47.07ms
+step:1004/1600 train_time:47270ms step_avg:47.08ms
+step:1005/1600 train_time:47332ms step_avg:47.10ms
+step:1006/1600 train_time:47390ms step_avg:47.11ms
+step:1007/1600 train_time:47452ms step_avg:47.12ms
+step:1008/1600 train_time:47513ms step_avg:47.14ms
+step:1009/1600 train_time:47574ms step_avg:47.15ms
+step:1010/1600 train_time:47632ms step_avg:47.16ms
+step:1011/1600 train_time:47694ms step_avg:47.18ms
+step:1012/1600 train_time:47752ms step_avg:47.19ms
+step:1013/1600 train_time:47814ms step_avg:47.20ms
+step:1014/1600 train_time:47874ms step_avg:47.21ms
+step:1015/1600 train_time:47936ms step_avg:47.23ms
+step:1016/1600 train_time:47995ms step_avg:47.24ms
+step:1017/1600 train_time:48058ms step_avg:47.25ms
+step:1018/1600 train_time:48120ms step_avg:47.27ms
+step:1019/1600 train_time:48183ms step_avg:47.28ms
+step:1020/1600 train_time:48243ms step_avg:47.30ms
+step:1021/1600 train_time:48306ms step_avg:47.31ms
+step:1022/1600 train_time:48365ms step_avg:47.32ms
+step:1023/1600 train_time:48428ms step_avg:47.34ms
+step:1024/1600 train_time:48486ms step_avg:47.35ms
+step:1025/1600 train_time:48548ms step_avg:47.36ms
+step:1026/1600 train_time:48606ms step_avg:47.37ms
+step:1027/1600 train_time:48667ms step_avg:47.39ms
+step:1028/1600 train_time:48726ms step_avg:47.40ms
+step:1029/1600 train_time:48788ms step_avg:47.41ms
+step:1030/1600 train_time:48846ms step_avg:47.42ms
+step:1031/1600 train_time:48908ms step_avg:47.44ms
+step:1032/1600 train_time:48966ms step_avg:47.45ms
+step:1033/1600 train_time:49030ms step_avg:47.46ms
+step:1034/1600 train_time:49090ms step_avg:47.48ms
+step:1035/1600 train_time:49153ms step_avg:47.49ms
+step:1036/1600 train_time:49214ms step_avg:47.50ms
+step:1037/1600 train_time:49277ms step_avg:47.52ms
+step:1038/1600 train_time:49336ms step_avg:47.53ms
+step:1039/1600 train_time:49401ms step_avg:47.55ms
+step:1040/1600 train_time:49458ms step_avg:47.56ms
+step:1041/1600 train_time:49528ms step_avg:47.58ms
+step:1042/1600 train_time:49612ms step_avg:47.61ms
+step:1043/1600 train_time:49700ms step_avg:47.65ms
+step:1044/1600 train_time:49785ms step_avg:47.69ms
+step:1045/1600 train_time:49873ms step_avg:47.73ms
+step:1046/1600 train_time:49958ms step_avg:47.76ms
+step:1047/1600 train_time:50047ms step_avg:47.80ms
+step:1048/1600 train_time:50134ms step_avg:47.84ms
+step:1049/1600 train_time:50226ms step_avg:47.88ms
+step:1050/1600 train_time:50308ms step_avg:47.91ms
+step:1051/1600 train_time:50396ms step_avg:47.95ms
+step:1052/1600 train_time:50482ms step_avg:47.99ms
+step:1053/1600 train_time:50571ms step_avg:48.03ms
+step:1054/1600 train_time:50655ms step_avg:48.06ms
+step:1055/1600 train_time:50743ms step_avg:48.10ms
+step:1056/1600 train_time:50828ms step_avg:48.13ms
+step:1057/1600 train_time:50917ms step_avg:48.17ms
+step:1058/1600 train_time:51001ms step_avg:48.20ms
+step:1059/1600 train_time:51089ms step_avg:48.24ms
+step:1060/1600 train_time:51175ms step_avg:48.28ms
+step:1061/1600 train_time:51263ms step_avg:48.32ms
+step:1062/1600 train_time:51348ms step_avg:48.35ms
+step:1063/1600 train_time:51436ms step_avg:48.39ms
+step:1064/1600 train_time:51521ms step_avg:48.42ms
+step:1065/1600 train_time:51609ms step_avg:48.46ms
+step:1066/1600 train_time:51694ms step_avg:48.49ms
+step:1067/1600 train_time:51781ms step_avg:48.53ms
+step:1068/1600 train_time:51866ms step_avg:48.56ms
+step:1069/1600 train_time:51955ms step_avg:48.60ms
+step:1070/1600 train_time:52038ms step_avg:48.63ms
+step:1071/1600 train_time:52129ms step_avg:48.67ms
+step:1072/1600 train_time:52212ms step_avg:48.71ms
+step:1073/1600 train_time:52301ms step_avg:48.74ms
+step:1074/1600 train_time:52387ms step_avg:48.78ms
+step:1075/1600 train_time:52475ms step_avg:48.81ms
+step:1076/1600 train_time:52559ms step_avg:48.85ms
+step:1077/1600 train_time:52648ms step_avg:48.88ms
+step:1078/1600 train_time:52733ms step_avg:48.92ms
+step:1079/1600 train_time:52820ms step_avg:48.95ms
+step:1080/1600 train_time:52906ms step_avg:48.99ms
+step:1081/1600 train_time:52995ms step_avg:49.02ms
+step:1082/1600 train_time:53079ms step_avg:49.06ms
+step:1083/1600 train_time:53171ms step_avg:49.10ms
+step:1084/1600 train_time:53254ms step_avg:49.13ms
+step:1085/1600 train_time:53342ms step_avg:49.16ms
+step:1086/1600 train_time:53428ms step_avg:49.20ms
+step:1087/1600 train_time:53516ms step_avg:49.23ms
+step:1088/1600 train_time:53600ms step_avg:49.26ms
+step:1089/1600 train_time:53689ms step_avg:49.30ms
+step:1090/1600 train_time:53774ms step_avg:49.33ms
+step:1091/1600 train_time:53862ms step_avg:49.37ms
+step:1092/1600 train_time:53948ms step_avg:49.40ms
+step:1093/1600 train_time:54036ms step_avg:49.44ms
+step:1094/1600 train_time:54121ms step_avg:49.47ms
+step:1095/1600 train_time:54209ms step_avg:49.51ms
+step:1096/1600 train_time:54295ms step_avg:49.54ms
+step:1097/1600 train_time:54385ms step_avg:49.58ms
+step:1098/1600 train_time:54471ms step_avg:49.61ms
+step:1099/1600 train_time:54560ms step_avg:49.65ms
+step:1100/1600 train_time:54643ms step_avg:49.68ms
+step:1101/1600 train_time:54731ms step_avg:49.71ms
+step:1102/1600 train_time:54817ms step_avg:49.74ms
+step:1103/1600 train_time:54905ms step_avg:49.78ms
+step:1104/1600 train_time:54991ms step_avg:49.81ms
+step:1105/1600 train_time:55079ms step_avg:49.84ms
+step:1106/1600 train_time:55165ms step_avg:49.88ms
+step:1107/1600 train_time:55253ms step_avg:49.91ms
+step:1108/1600 train_time:55338ms step_avg:49.94ms
+step:1109/1600 train_time:55428ms step_avg:49.98ms
+step:1110/1600 train_time:55512ms step_avg:50.01ms
+step:1111/1600 train_time:55599ms step_avg:50.04ms
+step:1112/1600 train_time:55686ms step_avg:50.08ms
+step:1113/1600 train_time:55774ms step_avg:50.11ms
+step:1114/1600 train_time:55859ms step_avg:50.14ms
+step:1115/1600 train_time:55948ms step_avg:50.18ms
+step:1116/1600 train_time:56033ms step_avg:50.21ms
+step:1117/1600 train_time:56121ms step_avg:50.24ms
+step:1118/1600 train_time:56207ms step_avg:50.27ms
+step:1119/1600 train_time:56295ms step_avg:50.31ms
+step:1120/1600 train_time:56380ms step_avg:50.34ms
+step:1121/1600 train_time:56467ms step_avg:50.37ms
+step:1122/1600 train_time:56553ms step_avg:50.40ms
+step:1123/1600 train_time:56640ms step_avg:50.44ms
+step:1124/1600 train_time:56726ms step_avg:50.47ms
+step:1125/1600 train_time:56813ms step_avg:50.50ms
+step:1126/1600 train_time:56898ms step_avg:50.53ms
+step:1127/1600 train_time:56987ms step_avg:50.57ms
+step:1128/1600 train_time:57073ms step_avg:50.60ms
+step:1129/1600 train_time:57161ms step_avg:50.63ms
+step:1130/1600 train_time:57246ms step_avg:50.66ms
+step:1131/1600 train_time:57334ms step_avg:50.69ms
+step:1132/1600 train_time:57420ms step_avg:50.72ms
+step:1133/1600 train_time:57507ms step_avg:50.76ms
+step:1134/1600 train_time:57593ms step_avg:50.79ms
+step:1135/1600 train_time:57680ms step_avg:50.82ms
+step:1136/1600 train_time:57766ms step_avg:50.85ms
+step:1137/1600 train_time:57854ms step_avg:50.88ms
+step:1138/1600 train_time:57942ms step_avg:50.92ms
+step:1139/1600 train_time:58032ms step_avg:50.95ms
+step:1140/1600 train_time:58114ms step_avg:50.98ms
+step:1141/1600 train_time:58201ms step_avg:51.01ms
+step:1142/1600 train_time:58286ms step_avg:51.04ms
+step:1143/1600 train_time:58373ms step_avg:51.07ms
+step:1144/1600 train_time:58458ms step_avg:51.10ms
+step:1145/1600 train_time:58546ms step_avg:51.13ms
+step:1146/1600 train_time:58631ms step_avg:51.16ms
+step:1147/1600 train_time:58719ms step_avg:51.19ms
+step:1148/1600 train_time:58803ms step_avg:51.22ms
+step:1149/1600 train_time:58891ms step_avg:51.25ms
+step:1150/1600 train_time:58976ms step_avg:51.28ms
+step:1151/1600 train_time:59065ms step_avg:51.32ms
+step:1152/1600 train_time:59149ms step_avg:51.34ms
+step:1153/1600 train_time:59238ms step_avg:51.38ms
+step:1154/1600 train_time:59327ms step_avg:51.41ms
+step:1155/1600 train_time:59412ms step_avg:51.44ms
+step:1156/1600 train_time:59497ms step_avg:51.47ms
+step:1157/1600 train_time:59585ms step_avg:51.50ms
+step:1158/1600 train_time:59670ms step_avg:51.53ms
+step:1159/1600 train_time:59758ms step_avg:51.56ms
+step:1160/1600 train_time:59843ms step_avg:51.59ms
+step:1161/1600 train_time:59932ms step_avg:51.62ms
+step:1162/1600 train_time:60017ms step_avg:51.65ms
+step:1163/1600 train_time:60105ms step_avg:51.68ms
+step:1164/1600 train_time:60191ms step_avg:51.71ms
+step:1165/1600 train_time:60279ms step_avg:51.74ms
+step:1166/1600 train_time:60364ms step_avg:51.77ms
+step:1167/1600 train_time:60453ms step_avg:51.80ms
+step:1168/1600 train_time:60537ms step_avg:51.83ms
+step:1169/1600 train_time:60625ms step_avg:51.86ms
+step:1170/1600 train_time:60709ms step_avg:51.89ms
+step:1171/1600 train_time:60798ms step_avg:51.92ms
+step:1172/1600 train_time:60883ms step_avg:51.95ms
+step:1173/1600 train_time:60971ms step_avg:51.98ms
+step:1174/1600 train_time:61056ms step_avg:52.01ms
+step:1175/1600 train_time:61145ms step_avg:52.04ms
+step:1176/1600 train_time:61231ms step_avg:52.07ms
+step:1177/1600 train_time:61319ms step_avg:52.10ms
+step:1178/1600 train_time:61404ms step_avg:52.13ms
+step:1179/1600 train_time:61492ms step_avg:52.16ms
+step:1180/1600 train_time:61576ms step_avg:52.18ms
+step:1181/1600 train_time:61665ms step_avg:52.21ms
+step:1182/1600 train_time:61750ms step_avg:52.24ms
+step:1183/1600 train_time:61838ms step_avg:52.27ms
+step:1184/1600 train_time:61924ms step_avg:52.30ms
+step:1185/1600 train_time:62014ms step_avg:52.33ms
+step:1186/1600 train_time:62099ms step_avg:52.36ms
+step:1187/1600 train_time:62185ms step_avg:52.39ms
+step:1188/1600 train_time:62270ms step_avg:52.42ms
+step:1189/1600 train_time:62358ms step_avg:52.45ms
+step:1190/1600 train_time:62443ms step_avg:52.47ms
+step:1191/1600 train_time:62531ms step_avg:52.50ms
+step:1192/1600 train_time:62617ms step_avg:52.53ms
+step:1193/1600 train_time:62704ms step_avg:52.56ms
+step:1194/1600 train_time:62790ms step_avg:52.59ms
+step:1195/1600 train_time:62878ms step_avg:52.62ms
+step:1196/1600 train_time:62964ms step_avg:52.65ms
+step:1197/1600 train_time:63052ms step_avg:52.68ms
+step:1198/1600 train_time:63137ms step_avg:52.70ms
+step:1199/1600 train_time:63224ms step_avg:52.73ms
+step:1200/1600 train_time:63309ms step_avg:52.76ms
+step:1201/1600 train_time:63398ms step_avg:52.79ms
+step:1202/1600 train_time:63483ms step_avg:52.81ms
+step:1203/1600 train_time:63572ms step_avg:52.84ms
+step:1204/1600 train_time:63656ms step_avg:52.87ms
+step:1205/1600 train_time:63743ms step_avg:52.90ms
+step:1206/1600 train_time:63829ms step_avg:52.93ms
+step:1207/1600 train_time:63916ms step_avg:52.95ms
+step:1208/1600 train_time:64001ms step_avg:52.98ms
+step:1209/1600 train_time:64090ms step_avg:53.01ms
+step:1210/1600 train_time:64175ms step_avg:53.04ms
+step:1211/1600 train_time:64263ms step_avg:53.07ms
+step:1212/1600 train_time:64348ms step_avg:53.09ms
+step:1213/1600 train_time:64436ms step_avg:53.12ms
+step:1214/1600 train_time:64521ms step_avg:53.15ms
+step:1215/1600 train_time:64610ms step_avg:53.18ms
+step:1216/1600 train_time:64695ms step_avg:53.20ms
+step:1217/1600 train_time:64784ms step_avg:53.23ms
+step:1218/1600 train_time:64869ms step_avg:53.26ms
+step:1219/1600 train_time:64958ms step_avg:53.29ms
+step:1220/1600 train_time:65042ms step_avg:53.31ms
+step:1221/1600 train_time:65131ms step_avg:53.34ms
+step:1222/1600 train_time:65217ms step_avg:53.37ms
+step:1223/1600 train_time:65305ms step_avg:53.40ms
+step:1224/1600 train_time:65390ms step_avg:53.42ms
+step:1225/1600 train_time:65477ms step_avg:53.45ms
+step:1226/1600 train_time:65562ms step_avg:53.48ms
+step:1227/1600 train_time:65650ms step_avg:53.50ms
+step:1228/1600 train_time:65735ms step_avg:53.53ms
+step:1229/1600 train_time:65823ms step_avg:53.56ms
+step:1230/1600 train_time:65908ms step_avg:53.58ms
+step:1231/1600 train_time:65997ms step_avg:53.61ms
+step:1232/1600 train_time:66082ms step_avg:53.64ms
+step:1233/1600 train_time:66171ms step_avg:53.67ms
+step:1234/1600 train_time:66256ms step_avg:53.69ms
+step:1235/1600 train_time:66343ms step_avg:53.72ms
+step:1236/1600 train_time:66430ms step_avg:53.75ms
+step:1237/1600 train_time:66517ms step_avg:53.77ms
+step:1238/1600 train_time:66602ms step_avg:53.80ms
+step:1239/1600 train_time:66691ms step_avg:53.83ms
+step:1240/1600 train_time:66775ms step_avg:53.85ms
+step:1241/1600 train_time:66863ms step_avg:53.88ms
+step:1242/1600 train_time:66948ms step_avg:53.90ms
+step:1243/1600 train_time:67036ms step_avg:53.93ms
+step:1244/1600 train_time:67121ms step_avg:53.96ms
+step:1245/1600 train_time:67211ms step_avg:53.98ms
+step:1246/1600 train_time:67296ms step_avg:54.01ms
+step:1247/1600 train_time:67384ms step_avg:54.04ms
+step:1248/1600 train_time:67469ms step_avg:54.06ms
+step:1249/1600 train_time:67557ms step_avg:54.09ms
+step:1250/1600 train_time:67642ms step_avg:54.11ms
+step:1250/1600 val_loss:3.4146 train_time:67715ms step_avg:54.17ms
+step:1251/1600 train_time:67734ms step_avg:54.14ms
+step:1252/1600 train_time:67819ms step_avg:54.17ms
+step:1253/1600 train_time:67908ms step_avg:54.20ms
+step:1254/1600 train_time:67993ms step_avg:54.22ms
+step:1255/1600 train_time:68082ms step_avg:54.25ms
+step:1256/1600 train_time:68166ms step_avg:54.27ms
+step:1257/1600 train_time:68254ms step_avg:54.30ms
+step:1258/1600 train_time:68339ms step_avg:54.32ms
+step:1259/1600 train_time:68426ms step_avg:54.35ms
+step:1260/1600 train_time:68510ms step_avg:54.37ms
+step:1261/1600 train_time:68599ms step_avg:54.40ms
+step:1262/1600 train_time:68685ms step_avg:54.43ms
+step:1263/1600 train_time:68776ms step_avg:54.45ms
+step:1264/1600 train_time:68862ms step_avg:54.48ms
+step:1265/1600 train_time:68952ms step_avg:54.51ms
+step:1266/1600 train_time:69037ms step_avg:54.53ms
+step:1267/1600 train_time:69126ms step_avg:54.56ms
+step:1268/1600 train_time:69210ms step_avg:54.58ms
+step:1269/1600 train_time:69296ms step_avg:54.61ms
+step:1270/1600 train_time:69381ms step_avg:54.63ms
+step:1271/1600 train_time:69468ms step_avg:54.66ms
+step:1272/1600 train_time:69553ms step_avg:54.68ms
+step:1273/1600 train_time:69642ms step_avg:54.71ms
+step:1274/1600 train_time:69729ms step_avg:54.73ms
+step:1275/1600 train_time:69817ms step_avg:54.76ms
+step:1276/1600 train_time:69903ms step_avg:54.78ms
+step:1277/1600 train_time:69992ms step_avg:54.81ms
+step:1278/1600 train_time:70076ms step_avg:54.83ms
+step:1279/1600 train_time:70164ms step_avg:54.86ms
+step:1280/1600 train_time:70249ms step_avg:54.88ms
+step:1281/1600 train_time:70337ms step_avg:54.91ms
+step:1282/1600 train_time:70421ms step_avg:54.93ms
+step:1283/1600 train_time:70509ms step_avg:54.96ms
+step:1284/1600 train_time:70594ms step_avg:54.98ms
+step:1285/1600 train_time:70684ms step_avg:55.01ms
+step:1286/1600 train_time:70770ms step_avg:55.03ms
+step:1287/1600 train_time:70859ms step_avg:55.06ms
+step:1288/1600 train_time:70945ms step_avg:55.08ms
+step:1289/1600 train_time:71032ms step_avg:55.11ms
+step:1290/1600 train_time:71117ms step_avg:55.13ms
+step:1291/1600 train_time:71205ms step_avg:55.16ms
+step:1292/1600 train_time:71290ms step_avg:55.18ms
+step:1293/1600 train_time:71379ms step_avg:55.20ms
+step:1294/1600 train_time:71463ms step_avg:55.23ms
+step:1295/1600 train_time:71551ms step_avg:55.25ms
+step:1296/1600 train_time:71637ms step_avg:55.28ms
+step:1297/1600 train_time:71725ms step_avg:55.30ms
+step:1298/1600 train_time:71811ms step_avg:55.32ms
+step:1299/1600 train_time:71900ms step_avg:55.35ms
+step:1300/1600 train_time:71985ms step_avg:55.37ms
+step:1301/1600 train_time:72072ms step_avg:55.40ms
+step:1302/1600 train_time:72157ms step_avg:55.42ms
+step:1303/1600 train_time:72245ms step_avg:55.45ms
+step:1304/1600 train_time:72329ms step_avg:55.47ms
+step:1305/1600 train_time:72417ms step_avg:55.49ms
+step:1306/1600 train_time:72503ms step_avg:55.51ms
+step:1307/1600 train_time:72591ms step_avg:55.54ms
+step:1308/1600 train_time:72677ms step_avg:55.56ms
+step:1309/1600 train_time:72765ms step_avg:55.59ms
+step:1310/1600 train_time:72851ms step_avg:55.61ms
+step:1311/1600 train_time:72940ms step_avg:55.64ms
+step:1312/1600 train_time:73025ms step_avg:55.66ms
+step:1313/1600 train_time:73113ms step_avg:55.68ms
+step:1314/1600 train_time:73198ms step_avg:55.71ms
+step:1315/1600 train_time:73286ms step_avg:55.73ms
+step:1316/1600 train_time:73370ms step_avg:55.75ms
+step:1317/1600 train_time:73457ms step_avg:55.78ms
+step:1318/1600 train_time:73543ms step_avg:55.80ms
+step:1319/1600 train_time:73632ms step_avg:55.82ms
+step:1320/1600 train_time:73719ms step_avg:55.85ms
+step:1321/1600 train_time:73807ms step_avg:55.87ms
+step:1322/1600 train_time:73892ms step_avg:55.89ms
+step:1323/1600 train_time:73981ms step_avg:55.92ms
+step:1324/1600 train_time:74067ms step_avg:55.94ms
+step:1325/1600 train_time:74155ms step_avg:55.97ms
+step:1326/1600 train_time:74240ms step_avg:55.99ms
+step:1327/1600 train_time:74328ms step_avg:56.01ms
+step:1328/1600 train_time:74412ms step_avg:56.03ms
+step:1329/1600 train_time:74500ms step_avg:56.06ms
+step:1330/1600 train_time:74585ms step_avg:56.08ms
+step:1331/1600 train_time:74673ms step_avg:56.10ms
+step:1332/1600 train_time:74759ms step_avg:56.13ms
+step:1333/1600 train_time:74848ms step_avg:56.15ms
+step:1334/1600 train_time:74934ms step_avg:56.17ms
+step:1335/1600 train_time:75022ms step_avg:56.20ms
+step:1336/1600 train_time:75107ms step_avg:56.22ms
+step:1337/1600 train_time:75195ms step_avg:56.24ms
+step:1338/1600 train_time:75280ms step_avg:56.26ms
+step:1339/1600 train_time:75368ms step_avg:56.29ms
+step:1340/1600 train_time:75453ms step_avg:56.31ms
+step:1341/1600 train_time:75541ms step_avg:56.33ms
+step:1342/1600 train_time:75626ms step_avg:56.35ms
+step:1343/1600 train_time:75715ms step_avg:56.38ms
+step:1344/1600 train_time:75800ms step_avg:56.40ms
+step:1345/1600 train_time:75888ms step_avg:56.42ms
+step:1346/1600 train_time:75973ms step_avg:56.44ms
+step:1347/1600 train_time:76062ms step_avg:56.47ms
+step:1348/1600 train_time:76146ms step_avg:56.49ms
+step:1349/1600 train_time:76234ms step_avg:56.51ms
+step:1350/1600 train_time:76319ms step_avg:56.53ms
+step:1351/1600 train_time:76408ms step_avg:56.56ms
+step:1352/1600 train_time:76492ms step_avg:56.58ms
+step:1353/1600 train_time:76580ms step_avg:56.60ms
+step:1354/1600 train_time:76666ms step_avg:56.62ms
+step:1355/1600 train_time:76754ms step_avg:56.64ms
+step:1356/1600 train_time:76841ms step_avg:56.67ms
+step:1357/1600 train_time:76928ms step_avg:56.69ms
+step:1358/1600 train_time:77013ms step_avg:56.71ms
+step:1359/1600 train_time:77102ms step_avg:56.73ms
+step:1360/1600 train_time:77186ms step_avg:56.75ms
+step:1361/1600 train_time:77275ms step_avg:56.78ms
+step:1362/1600 train_time:77360ms step_avg:56.80ms
+step:1363/1600 train_time:77448ms step_avg:56.82ms
+step:1364/1600 train_time:77532ms step_avg:56.84ms
+step:1365/1600 train_time:77622ms step_avg:56.87ms
+step:1366/1600 train_time:77712ms step_avg:56.89ms
+step:1367/1600 train_time:77798ms step_avg:56.91ms
+step:1368/1600 train_time:77883ms step_avg:56.93ms
+step:1369/1600 train_time:77970ms step_avg:56.95ms
+step:1370/1600 train_time:78056ms step_avg:56.98ms
+step:1371/1600 train_time:78144ms step_avg:57.00ms
+step:1372/1600 train_time:78229ms step_avg:57.02ms
+step:1373/1600 train_time:78318ms step_avg:57.04ms
+step:1374/1600 train_time:78403ms step_avg:57.06ms
+step:1375/1600 train_time:78490ms step_avg:57.08ms
+step:1376/1600 train_time:78576ms step_avg:57.10ms
+step:1377/1600 train_time:78665ms step_avg:57.13ms
+step:1378/1600 train_time:78750ms step_avg:57.15ms
+step:1379/1600 train_time:78838ms step_avg:57.17ms
+step:1380/1600 train_time:78923ms step_avg:57.19ms
+step:1381/1600 train_time:79011ms step_avg:57.21ms
+step:1382/1600 train_time:79097ms step_avg:57.23ms
+step:1383/1600 train_time:79186ms step_avg:57.26ms
+step:1384/1600 train_time:79271ms step_avg:57.28ms
+step:1385/1600 train_time:79360ms step_avg:57.30ms
+step:1386/1600 train_time:79445ms step_avg:57.32ms
+step:1387/1600 train_time:79532ms step_avg:57.34ms
+step:1388/1600 train_time:79617ms step_avg:57.36ms
+step:1389/1600 train_time:79706ms step_avg:57.38ms
+step:1390/1600 train_time:79791ms step_avg:57.40ms
+step:1391/1600 train_time:79879ms step_avg:57.43ms
+step:1392/1600 train_time:79964ms step_avg:57.45ms
+step:1393/1600 train_time:80052ms step_avg:57.47ms
+step:1394/1600 train_time:80138ms step_avg:57.49ms
+step:1395/1600 train_time:80227ms step_avg:57.51ms
+step:1396/1600 train_time:80313ms step_avg:57.53ms
+step:1397/1600 train_time:80401ms step_avg:57.55ms
+step:1398/1600 train_time:80486ms step_avg:57.57ms
+step:1399/1600 train_time:80575ms step_avg:57.59ms
+step:1400/1600 train_time:80660ms step_avg:57.61ms
+step:1401/1600 train_time:80748ms step_avg:57.64ms
+step:1402/1600 train_time:80833ms step_avg:57.66ms
+step:1403/1600 train_time:80922ms step_avg:57.68ms
+step:1404/1600 train_time:81007ms step_avg:57.70ms
+step:1405/1600 train_time:81094ms step_avg:57.72ms
+step:1406/1600 train_time:81180ms step_avg:57.74ms
+step:1407/1600 train_time:81268ms step_avg:57.76ms
+step:1408/1600 train_time:81353ms step_avg:57.78ms
+step:1409/1600 train_time:81441ms step_avg:57.80ms
+step:1410/1600 train_time:81527ms step_avg:57.82ms
+step:1411/1600 train_time:81615ms step_avg:57.84ms
+step:1412/1600 train_time:81701ms step_avg:57.86ms
+step:1413/1600 train_time:81789ms step_avg:57.88ms
+step:1414/1600 train_time:81874ms step_avg:57.90ms
+step:1415/1600 train_time:81962ms step_avg:57.92ms
+step:1416/1600 train_time:82047ms step_avg:57.94ms
+step:1417/1600 train_time:82135ms step_avg:57.96ms
+step:1418/1600 train_time:82220ms step_avg:57.98ms
+step:1419/1600 train_time:82309ms step_avg:58.00ms
+step:1420/1600 train_time:82394ms step_avg:58.02ms
+step:1421/1600 train_time:82482ms step_avg:58.04ms
+step:1422/1600 train_time:82567ms step_avg:58.06ms
+step:1423/1600 train_time:82656ms step_avg:58.09ms
+step:1424/1600 train_time:82741ms step_avg:58.10ms
+step:1425/1600 train_time:82829ms step_avg:58.13ms
+step:1426/1600 train_time:82915ms step_avg:58.14ms
+step:1427/1600 train_time:83003ms step_avg:58.17ms
+step:1428/1600 train_time:83087ms step_avg:58.18ms
+step:1429/1600 train_time:83176ms step_avg:58.21ms
+step:1430/1600 train_time:83262ms step_avg:58.22ms
+step:1431/1600 train_time:83350ms step_avg:58.25ms
+step:1432/1600 train_time:83435ms step_avg:58.26ms
+step:1433/1600 train_time:83524ms step_avg:58.29ms
+step:1434/1600 train_time:83608ms step_avg:58.30ms
+step:1435/1600 train_time:83696ms step_avg:58.32ms
+step:1436/1600 train_time:83781ms step_avg:58.34ms
+step:1437/1600 train_time:83869ms step_avg:58.36ms
+step:1438/1600 train_time:83954ms step_avg:58.38ms
+step:1439/1600 train_time:84042ms step_avg:58.40ms
+step:1440/1600 train_time:84128ms step_avg:58.42ms
+step:1441/1600 train_time:84216ms step_avg:58.44ms
+step:1442/1600 train_time:84301ms step_avg:58.46ms
+step:1443/1600 train_time:84389ms step_avg:58.48ms
+step:1444/1600 train_time:84474ms step_avg:58.50ms
+step:1445/1600 train_time:84563ms step_avg:58.52ms
+step:1446/1600 train_time:84650ms step_avg:58.54ms
+step:1447/1600 train_time:84738ms step_avg:58.56ms
+step:1448/1600 train_time:84823ms step_avg:58.58ms
+step:1449/1600 train_time:84910ms step_avg:58.60ms
+step:1450/1600 train_time:84997ms step_avg:58.62ms
+step:1451/1600 train_time:85084ms step_avg:58.64ms
+step:1452/1600 train_time:85169ms step_avg:58.66ms
+step:1453/1600 train_time:85258ms step_avg:58.68ms
+step:1454/1600 train_time:85343ms step_avg:58.70ms
+step:1455/1600 train_time:85431ms step_avg:58.72ms
+step:1456/1600 train_time:85516ms step_avg:58.73ms
+step:1457/1600 train_time:85604ms step_avg:58.75ms
+step:1458/1600 train_time:85689ms step_avg:58.77ms
+step:1459/1600 train_time:85778ms step_avg:58.79ms
+step:1460/1600 train_time:85864ms step_avg:58.81ms
+step:1461/1600 train_time:85952ms step_avg:58.83ms
+step:1462/1600 train_time:86037ms step_avg:58.85ms
+step:1463/1600 train_time:86125ms step_avg:58.87ms
+step:1464/1600 train_time:86211ms step_avg:58.89ms
+step:1465/1600 train_time:86300ms step_avg:58.91ms
+step:1466/1600 train_time:86385ms step_avg:58.93ms
+step:1467/1600 train_time:86473ms step_avg:58.95ms
+step:1468/1600 train_time:86559ms step_avg:58.96ms
+step:1469/1600 train_time:86647ms step_avg:58.98ms
+step:1470/1600 train_time:86733ms step_avg:59.00ms
+step:1471/1600 train_time:86821ms step_avg:59.02ms
+step:1472/1600 train_time:86907ms step_avg:59.04ms
+step:1473/1600 train_time:86993ms step_avg:59.06ms
+step:1474/1600 train_time:87079ms step_avg:59.08ms
+step:1475/1600 train_time:87168ms step_avg:59.10ms
+step:1476/1600 train_time:87253ms step_avg:59.11ms
+step:1477/1600 train_time:87342ms step_avg:59.13ms
+step:1478/1600 train_time:87428ms step_avg:59.15ms
+step:1479/1600 train_time:87515ms step_avg:59.17ms
+step:1480/1600 train_time:87600ms step_avg:59.19ms
+step:1481/1600 train_time:87689ms step_avg:59.21ms
+step:1482/1600 train_time:87773ms step_avg:59.23ms
+step:1483/1600 train_time:87861ms step_avg:59.25ms
+step:1484/1600 train_time:87946ms step_avg:59.26ms
+step:1485/1600 train_time:88035ms step_avg:59.28ms
+step:1486/1600 train_time:88120ms step_avg:59.30ms
+step:1487/1600 train_time:88209ms step_avg:59.32ms
+step:1488/1600 train_time:88294ms step_avg:59.34ms
+step:1489/1600 train_time:88383ms step_avg:59.36ms
+step:1490/1600 train_time:88468ms step_avg:59.37ms
+step:1491/1600 train_time:88555ms step_avg:59.39ms
+step:1492/1600 train_time:88640ms step_avg:59.41ms
+step:1493/1600 train_time:88728ms step_avg:59.43ms
+step:1494/1600 train_time:88813ms step_avg:59.45ms
+step:1495/1600 train_time:88902ms step_avg:59.47ms
+step:1496/1600 train_time:88988ms step_avg:59.48ms
+step:1497/1600 train_time:89076ms step_avg:59.50ms
+step:1498/1600 train_time:89161ms step_avg:59.52ms
+step:1499/1600 train_time:89249ms step_avg:59.54ms
+step:1500/1600 train_time:89334ms step_avg:59.56ms
+step:1500/1600 val_loss:3.3058 train_time:89408ms step_avg:59.61ms
+step:1501/1600 train_time:89427ms step_avg:59.58ms
+step:1502/1600 train_time:89512ms step_avg:59.60ms
+step:1503/1600 train_time:89607ms step_avg:59.62ms
+step:1504/1600 train_time:89694ms step_avg:59.64ms
+step:1505/1600 train_time:89782ms step_avg:59.66ms
+step:1506/1600 train_time:89866ms step_avg:59.67ms
+step:1507/1600 train_time:89953ms step_avg:59.69ms
+step:1508/1600 train_time:90036ms step_avg:59.71ms
+step:1509/1600 train_time:90123ms step_avg:59.72ms
+step:1510/1600 train_time:90207ms step_avg:59.74ms
+step:1511/1600 train_time:90295ms step_avg:59.76ms
+step:1512/1600 train_time:90381ms step_avg:59.78ms
+step:1513/1600 train_time:90472ms step_avg:59.80ms
+step:1514/1600 train_time:90558ms step_avg:59.81ms
+step:1515/1600 train_time:90648ms step_avg:59.83ms
+step:1516/1600 train_time:90734ms step_avg:59.85ms
+step:1517/1600 train_time:90823ms step_avg:59.87ms
+step:1518/1600 train_time:90907ms step_avg:59.89ms
+step:1519/1600 train_time:90993ms step_avg:59.90ms
+step:1520/1600 train_time:91077ms step_avg:59.92ms
+step:1521/1600 train_time:91165ms step_avg:59.94ms
+step:1522/1600 train_time:91249ms step_avg:59.95ms
+step:1523/1600 train_time:91337ms step_avg:59.97ms
+step:1524/1600 train_time:91423ms step_avg:59.99ms
+step:1525/1600 train_time:91512ms step_avg:60.01ms
+step:1526/1600 train_time:91599ms step_avg:60.03ms
+step:1527/1600 train_time:91688ms step_avg:60.04ms
+step:1528/1600 train_time:91775ms step_avg:60.06ms
+step:1529/1600 train_time:91864ms step_avg:60.08ms
+step:1530/1600 train_time:91948ms step_avg:60.10ms
+step:1531/1600 train_time:92035ms step_avg:60.11ms
+step:1532/1600 train_time:92120ms step_avg:60.13ms
+step:1533/1600 train_time:92208ms step_avg:60.15ms
+step:1534/1600 train_time:92293ms step_avg:60.16ms
+step:1535/1600 train_time:92382ms step_avg:60.18ms
+step:1536/1600 train_time:92466ms step_avg:60.20ms
+step:1537/1600 train_time:92555ms step_avg:60.22ms
+step:1538/1600 train_time:92641ms step_avg:60.23ms
+step:1539/1600 train_time:92730ms step_avg:60.25ms
+step:1540/1600 train_time:92816ms step_avg:60.27ms
+step:1541/1600 train_time:92904ms step_avg:60.29ms
+step:1542/1600 train_time:92989ms step_avg:60.30ms
+step:1543/1600 train_time:93076ms step_avg:60.32ms
+step:1544/1600 train_time:93161ms step_avg:60.34ms
+step:1545/1600 train_time:93248ms step_avg:60.35ms
+step:1546/1600 train_time:93333ms step_avg:60.37ms
+step:1547/1600 train_time:93422ms step_avg:60.39ms
+step:1548/1600 train_time:93508ms step_avg:60.41ms
+step:1549/1600 train_time:93594ms step_avg:60.42ms
+step:1550/1600 train_time:93681ms step_avg:60.44ms
+step:1551/1600 train_time:93769ms step_avg:60.46ms
+step:1552/1600 train_time:93854ms step_avg:60.47ms
+step:1553/1600 train_time:93942ms step_avg:60.49ms
+step:1554/1600 train_time:94028ms step_avg:60.51ms
+step:1555/1600 train_time:94116ms step_avg:60.52ms
+step:1556/1600 train_time:94201ms step_avg:60.54ms
+step:1557/1600 train_time:94289ms step_avg:60.56ms
+step:1558/1600 train_time:94375ms step_avg:60.57ms
+step:1559/1600 train_time:94463ms step_avg:60.59ms
+step:1560/1600 train_time:94548ms step_avg:60.61ms
+step:1561/1600 train_time:94644ms step_avg:60.63ms
+step:1562/1600 train_time:94727ms step_avg:60.64ms
+step:1563/1600 train_time:94814ms step_avg:60.66ms
+step:1564/1600 train_time:94900ms step_avg:60.68ms
+step:1565/1600 train_time:94988ms step_avg:60.70ms
+step:1566/1600 train_time:95075ms step_avg:60.71ms
+step:1567/1600 train_time:95164ms step_avg:60.73ms
+step:1568/1600 train_time:95249ms step_avg:60.75ms
+step:1569/1600 train_time:95337ms step_avg:60.76ms
+step:1570/1600 train_time:95422ms step_avg:60.78ms
+step:1571/1600 train_time:95511ms step_avg:60.80ms
+step:1572/1600 train_time:95598ms step_avg:60.81ms
+step:1573/1600 train_time:95686ms step_avg:60.83ms
+step:1574/1600 train_time:95773ms step_avg:60.85ms
+step:1575/1600 train_time:95862ms step_avg:60.86ms
+step:1576/1600 train_time:95947ms step_avg:60.88ms
+step:1577/1600 train_time:96040ms step_avg:60.90ms
+step:1578/1600 train_time:96123ms step_avg:60.91ms
+step:1579/1600 train_time:96210ms step_avg:60.93ms
+step:1580/1600 train_time:96295ms step_avg:60.95ms
+step:1581/1600 train_time:96383ms step_avg:60.96ms
+step:1582/1600 train_time:96469ms step_avg:60.98ms
+step:1583/1600 train_time:96558ms step_avg:61.00ms
+step:1584/1600 train_time:96644ms step_avg:61.01ms
+step:1585/1600 train_time:96733ms step_avg:61.03ms
+step:1586/1600 train_time:96818ms step_avg:61.05ms
+step:1587/1600 train_time:96907ms step_avg:61.06ms
+step:1588/1600 train_time:96993ms step_avg:61.08ms
+step:1589/1600 train_time:97081ms step_avg:61.10ms
+step:1590/1600 train_time:97166ms step_avg:61.11ms
+step:1591/1600 train_time:97255ms step_avg:61.13ms
+step:1592/1600 train_time:97340ms step_avg:61.14ms
+step:1593/1600 train_time:97429ms step_avg:61.16ms
+step:1594/1600 train_time:97514ms step_avg:61.18ms
+step:1595/1600 train_time:97603ms step_avg:61.19ms
+step:1596/1600 train_time:97688ms step_avg:61.21ms
+step:1597/1600 train_time:97777ms step_avg:61.23ms
+step:1598/1600 train_time:97863ms step_avg:61.24ms
+step:1599/1600 train_time:97951ms step_avg:61.26ms
+step:1600/1600 train_time:98037ms step_avg:61.27ms
+step:1600/1600 val_loss:3.2763 train_time:98110ms step_avg:61.32ms
+peak memory allocated: 30264 MiB reserved: 46338 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/77930ff9-5f0b-48f9-b55e-b08b061d5c36.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/77930ff9-5f0b-48f9-b55e-b08b061d5c36.txt
@@ -1,0 +1,4096 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 01 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # shifting first layer updates this to 01 ... 01 @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:20:09 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   38C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   40C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   41C    P0            130W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   39C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          240581      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          240582      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          240583      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          240584      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          240585      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          240586      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          240587      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          240588      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 511, 512, 513, 1023, 1024, 1025, 1534, 1535, 1536] for warmup
+Resetting Model
+step:0/1575 val_loss:10.8351 train_time:0ms step_avg:0.05ms
+step:1/1575 train_time:84ms step_avg:84.10ms
+step:2/1575 train_time:108ms step_avg:53.87ms
+step:3/1575 train_time:129ms step_avg:42.85ms
+step:4/1575 train_time:155ms step_avg:38.69ms
+step:5/1575 train_time:184ms step_avg:36.79ms
+step:6/1575 train_time:306ms step_avg:50.95ms
+step:7/1575 train_time:325ms step_avg:46.37ms
+step:8/1575 train_time:349ms step_avg:43.58ms
+step:9/1575 train_time:379ms step_avg:42.13ms
+step:10/1575 train_time:418ms step_avg:41.77ms
+step:11/1575 train_time:448ms step_avg:40.76ms
+step:12/1575 train_time:487ms step_avg:40.60ms
+step:13/1575 train_time:518ms step_avg:39.85ms
+step:14/1575 train_time:558ms step_avg:39.85ms
+step:15/1575 train_time:588ms step_avg:39.21ms
+step:16/1575 train_time:627ms step_avg:39.21ms
+step:17/1575 train_time:658ms step_avg:38.73ms
+step:18/1575 train_time:697ms step_avg:38.73ms
+step:19/1575 train_time:728ms step_avg:38.32ms
+step:20/1575 train_time:767ms step_avg:38.35ms
+step:21/1575 train_time:798ms step_avg:38.00ms
+step:22/1575 train_time:837ms step_avg:38.04ms
+step:23/1575 train_time:868ms step_avg:37.72ms
+step:24/1575 train_time:906ms step_avg:37.76ms
+step:25/1575 train_time:937ms step_avg:37.48ms
+step:26/1575 train_time:976ms step_avg:37.54ms
+step:27/1575 train_time:1007ms step_avg:37.30ms
+step:28/1575 train_time:1046ms step_avg:37.35ms
+step:29/1575 train_time:1077ms step_avg:37.13ms
+step:30/1575 train_time:1116ms step_avg:37.19ms
+step:31/1575 train_time:1147ms step_avg:36.99ms
+step:32/1575 train_time:1186ms step_avg:37.07ms
+step:33/1575 train_time:1217ms step_avg:36.87ms
+step:34/1575 train_time:1256ms step_avg:36.94ms
+step:35/1575 train_time:1287ms step_avg:36.78ms
+step:36/1575 train_time:1327ms step_avg:36.85ms
+step:37/1575 train_time:1358ms step_avg:36.69ms
+step:38/1575 train_time:1396ms step_avg:36.75ms
+step:39/1575 train_time:1427ms step_avg:36.59ms
+step:40/1575 train_time:1466ms step_avg:36.64ms
+step:41/1575 train_time:1497ms step_avg:36.50ms
+step:42/1575 train_time:1536ms step_avg:36.57ms
+step:43/1575 train_time:1567ms step_avg:36.44ms
+step:44/1575 train_time:1606ms step_avg:36.49ms
+step:45/1575 train_time:1637ms step_avg:36.38ms
+step:46/1575 train_time:1676ms step_avg:36.43ms
+step:47/1575 train_time:1707ms step_avg:36.31ms
+step:48/1575 train_time:1745ms step_avg:36.36ms
+step:49/1575 train_time:1776ms step_avg:36.25ms
+step:50/1575 train_time:1815ms step_avg:36.31ms
+step:51/1575 train_time:1846ms step_avg:36.19ms
+step:52/1575 train_time:1885ms step_avg:36.25ms
+step:53/1575 train_time:1916ms step_avg:36.15ms
+step:54/1575 train_time:1955ms step_avg:36.21ms
+step:55/1575 train_time:1986ms step_avg:36.11ms
+step:56/1575 train_time:2025ms step_avg:36.15ms
+step:57/1575 train_time:2055ms step_avg:36.06ms
+step:58/1575 train_time:2095ms step_avg:36.12ms
+step:59/1575 train_time:2125ms step_avg:36.03ms
+step:60/1575 train_time:2164ms step_avg:36.07ms
+step:61/1575 train_time:2195ms step_avg:35.98ms
+step:62/1575 train_time:2233ms step_avg:36.02ms
+step:63/1575 train_time:2264ms step_avg:35.94ms
+step:64/1575 train_time:2303ms step_avg:35.98ms
+step:65/1575 train_time:2334ms step_avg:35.91ms
+step:66/1575 train_time:2374ms step_avg:35.96ms
+step:67/1575 train_time:2404ms step_avg:35.88ms
+step:68/1575 train_time:2443ms step_avg:35.92ms
+step:69/1575 train_time:2473ms step_avg:35.84ms
+step:70/1575 train_time:2512ms step_avg:35.89ms
+step:71/1575 train_time:2543ms step_avg:35.81ms
+step:72/1575 train_time:2581ms step_avg:35.85ms
+step:73/1575 train_time:2612ms step_avg:35.78ms
+step:74/1575 train_time:2651ms step_avg:35.82ms
+step:75/1575 train_time:2682ms step_avg:35.75ms
+step:76/1575 train_time:2720ms step_avg:35.79ms
+step:77/1575 train_time:2751ms step_avg:35.73ms
+step:78/1575 train_time:2790ms step_avg:35.77ms
+step:79/1575 train_time:2820ms step_avg:35.70ms
+step:80/1575 train_time:2859ms step_avg:35.74ms
+step:81/1575 train_time:2890ms step_avg:35.68ms
+step:82/1575 train_time:2929ms step_avg:35.71ms
+step:83/1575 train_time:2959ms step_avg:35.65ms
+step:84/1575 train_time:2998ms step_avg:35.69ms
+step:85/1575 train_time:3029ms step_avg:35.63ms
+step:86/1575 train_time:3068ms step_avg:35.67ms
+step:87/1575 train_time:3099ms step_avg:35.62ms
+step:88/1575 train_time:3137ms step_avg:35.65ms
+step:89/1575 train_time:3168ms step_avg:35.60ms
+step:90/1575 train_time:3207ms step_avg:35.64ms
+step:91/1575 train_time:3238ms step_avg:35.58ms
+step:92/1575 train_time:3277ms step_avg:35.62ms
+step:93/1575 train_time:3308ms step_avg:35.57ms
+step:94/1575 train_time:3346ms step_avg:35.60ms
+step:95/1575 train_time:3377ms step_avg:35.55ms
+step:96/1575 train_time:3416ms step_avg:35.59ms
+step:97/1575 train_time:3447ms step_avg:35.54ms
+step:98/1575 train_time:3487ms step_avg:35.58ms
+step:99/1575 train_time:3517ms step_avg:35.52ms
+step:100/1575 train_time:3556ms step_avg:35.56ms
+step:101/1575 train_time:3586ms step_avg:35.50ms
+step:102/1575 train_time:3626ms step_avg:35.54ms
+step:103/1575 train_time:3656ms step_avg:35.49ms
+step:104/1575 train_time:3694ms step_avg:35.52ms
+step:105/1575 train_time:3725ms step_avg:35.48ms
+step:106/1575 train_time:3764ms step_avg:35.51ms
+step:107/1575 train_time:3795ms step_avg:35.46ms
+step:108/1575 train_time:3834ms step_avg:35.50ms
+step:109/1575 train_time:3864ms step_avg:35.45ms
+step:110/1575 train_time:3903ms step_avg:35.48ms
+step:111/1575 train_time:3934ms step_avg:35.44ms
+step:112/1575 train_time:3973ms step_avg:35.48ms
+step:113/1575 train_time:4004ms step_avg:35.43ms
+step:114/1575 train_time:4042ms step_avg:35.46ms
+step:115/1575 train_time:4073ms step_avg:35.42ms
+step:116/1575 train_time:4112ms step_avg:35.45ms
+step:117/1575 train_time:4143ms step_avg:35.41ms
+step:118/1575 train_time:4181ms step_avg:35.44ms
+step:119/1575 train_time:4212ms step_avg:35.39ms
+step:120/1575 train_time:4250ms step_avg:35.42ms
+step:121/1575 train_time:4281ms step_avg:35.38ms
+step:122/1575 train_time:4320ms step_avg:35.41ms
+step:123/1575 train_time:4351ms step_avg:35.37ms
+step:124/1575 train_time:4390ms step_avg:35.40ms
+step:125/1575 train_time:4420ms step_avg:35.36ms
+step:126/1575 train_time:4459ms step_avg:35.39ms
+step:127/1575 train_time:4490ms step_avg:35.36ms
+step:128/1575 train_time:4529ms step_avg:35.39ms
+step:129/1575 train_time:4561ms step_avg:35.35ms
+step:130/1575 train_time:4600ms step_avg:35.38ms
+step:131/1575 train_time:4630ms step_avg:35.35ms
+step:132/1575 train_time:4669ms step_avg:35.37ms
+step:133/1575 train_time:4700ms step_avg:35.34ms
+step:134/1575 train_time:4739ms step_avg:35.36ms
+step:135/1575 train_time:4770ms step_avg:35.33ms
+step:136/1575 train_time:4808ms step_avg:35.35ms
+step:137/1575 train_time:4839ms step_avg:35.32ms
+step:138/1575 train_time:4878ms step_avg:35.35ms
+step:139/1575 train_time:4909ms step_avg:35.31ms
+step:140/1575 train_time:4948ms step_avg:35.34ms
+step:141/1575 train_time:4979ms step_avg:35.31ms
+step:142/1575 train_time:5018ms step_avg:35.34ms
+step:143/1575 train_time:5049ms step_avg:35.31ms
+step:144/1575 train_time:5088ms step_avg:35.33ms
+step:145/1575 train_time:5119ms step_avg:35.30ms
+step:146/1575 train_time:5158ms step_avg:35.33ms
+step:147/1575 train_time:5189ms step_avg:35.30ms
+step:148/1575 train_time:5228ms step_avg:35.32ms
+step:149/1575 train_time:5258ms step_avg:35.29ms
+step:150/1575 train_time:5298ms step_avg:35.32ms
+step:151/1575 train_time:5328ms step_avg:35.29ms
+step:152/1575 train_time:5367ms step_avg:35.31ms
+step:153/1575 train_time:5398ms step_avg:35.28ms
+step:154/1575 train_time:5437ms step_avg:35.30ms
+step:155/1575 train_time:5468ms step_avg:35.27ms
+step:156/1575 train_time:5506ms step_avg:35.29ms
+step:157/1575 train_time:5537ms step_avg:35.27ms
+step:158/1575 train_time:5576ms step_avg:35.29ms
+step:159/1575 train_time:5606ms step_avg:35.26ms
+step:160/1575 train_time:5645ms step_avg:35.28ms
+step:161/1575 train_time:5676ms step_avg:35.25ms
+step:162/1575 train_time:5715ms step_avg:35.28ms
+step:163/1575 train_time:5746ms step_avg:35.25ms
+step:164/1575 train_time:5785ms step_avg:35.27ms
+step:165/1575 train_time:5815ms step_avg:35.24ms
+step:166/1575 train_time:5854ms step_avg:35.26ms
+step:167/1575 train_time:5885ms step_avg:35.24ms
+step:168/1575 train_time:5923ms step_avg:35.26ms
+step:169/1575 train_time:5954ms step_avg:35.23ms
+step:170/1575 train_time:5993ms step_avg:35.25ms
+step:171/1575 train_time:6024ms step_avg:35.23ms
+step:172/1575 train_time:6062ms step_avg:35.25ms
+step:173/1575 train_time:6093ms step_avg:35.22ms
+step:174/1575 train_time:6132ms step_avg:35.24ms
+step:175/1575 train_time:6163ms step_avg:35.21ms
+step:176/1575 train_time:6201ms step_avg:35.23ms
+step:177/1575 train_time:6231ms step_avg:35.21ms
+step:178/1575 train_time:6270ms step_avg:35.23ms
+step:179/1575 train_time:6301ms step_avg:35.20ms
+step:180/1575 train_time:6340ms step_avg:35.22ms
+step:181/1575 train_time:6370ms step_avg:35.20ms
+step:182/1575 train_time:6409ms step_avg:35.21ms
+step:183/1575 train_time:6440ms step_avg:35.19ms
+step:184/1575 train_time:6479ms step_avg:35.21ms
+step:185/1575 train_time:6509ms step_avg:35.18ms
+step:186/1575 train_time:6548ms step_avg:35.20ms
+step:187/1575 train_time:6579ms step_avg:35.18ms
+step:188/1575 train_time:6618ms step_avg:35.20ms
+step:189/1575 train_time:6648ms step_avg:35.18ms
+step:190/1575 train_time:6687ms step_avg:35.20ms
+step:191/1575 train_time:6718ms step_avg:35.17ms
+step:192/1575 train_time:6757ms step_avg:35.19ms
+step:193/1575 train_time:6787ms step_avg:35.17ms
+step:194/1575 train_time:6826ms step_avg:35.18ms
+step:195/1575 train_time:6857ms step_avg:35.16ms
+step:196/1575 train_time:6896ms step_avg:35.18ms
+step:197/1575 train_time:6926ms step_avg:35.16ms
+step:198/1575 train_time:6965ms step_avg:35.18ms
+step:199/1575 train_time:6996ms step_avg:35.16ms
+step:200/1575 train_time:7035ms step_avg:35.17ms
+step:201/1575 train_time:7066ms step_avg:35.15ms
+step:202/1575 train_time:7104ms step_avg:35.17ms
+step:203/1575 train_time:7135ms step_avg:35.15ms
+step:204/1575 train_time:7174ms step_avg:35.17ms
+step:205/1575 train_time:7205ms step_avg:35.14ms
+step:206/1575 train_time:7243ms step_avg:35.16ms
+step:207/1575 train_time:7274ms step_avg:35.14ms
+step:208/1575 train_time:7312ms step_avg:35.16ms
+step:209/1575 train_time:7343ms step_avg:35.13ms
+step:210/1575 train_time:7382ms step_avg:35.15ms
+step:211/1575 train_time:7412ms step_avg:35.13ms
+step:212/1575 train_time:7451ms step_avg:35.15ms
+step:213/1575 train_time:7482ms step_avg:35.12ms
+step:214/1575 train_time:7520ms step_avg:35.14ms
+step:215/1575 train_time:7551ms step_avg:35.12ms
+step:216/1575 train_time:7590ms step_avg:35.14ms
+step:217/1575 train_time:7621ms step_avg:35.12ms
+step:218/1575 train_time:7659ms step_avg:35.13ms
+step:219/1575 train_time:7690ms step_avg:35.11ms
+step:220/1575 train_time:7728ms step_avg:35.13ms
+step:221/1575 train_time:7759ms step_avg:35.11ms
+step:222/1575 train_time:7798ms step_avg:35.13ms
+step:223/1575 train_time:7828ms step_avg:35.11ms
+step:224/1575 train_time:7867ms step_avg:35.12ms
+step:225/1575 train_time:7898ms step_avg:35.10ms
+step:226/1575 train_time:7937ms step_avg:35.12ms
+step:227/1575 train_time:7967ms step_avg:35.10ms
+step:228/1575 train_time:8006ms step_avg:35.11ms
+step:229/1575 train_time:8037ms step_avg:35.10ms
+step:230/1575 train_time:8075ms step_avg:35.11ms
+step:231/1575 train_time:8106ms step_avg:35.09ms
+step:232/1575 train_time:8145ms step_avg:35.11ms
+step:233/1575 train_time:8176ms step_avg:35.09ms
+step:234/1575 train_time:8215ms step_avg:35.11ms
+step:235/1575 train_time:8246ms step_avg:35.09ms
+step:236/1575 train_time:8285ms step_avg:35.11ms
+step:237/1575 train_time:8315ms step_avg:35.09ms
+step:238/1575 train_time:8354ms step_avg:35.10ms
+step:239/1575 train_time:8385ms step_avg:35.08ms
+step:240/1575 train_time:8423ms step_avg:35.10ms
+step:241/1575 train_time:8454ms step_avg:35.08ms
+step:242/1575 train_time:8493ms step_avg:35.09ms
+step:243/1575 train_time:8523ms step_avg:35.08ms
+step:244/1575 train_time:8562ms step_avg:35.09ms
+step:245/1575 train_time:8593ms step_avg:35.07ms
+step:246/1575 train_time:8631ms step_avg:35.09ms
+step:247/1575 train_time:8662ms step_avg:35.07ms
+step:248/1575 train_time:8700ms step_avg:35.08ms
+step:249/1575 train_time:8731ms step_avg:35.06ms
+step:250/1575 train_time:8770ms step_avg:35.08ms
+step:250/1575 val_loss:4.5856 train_time:8818ms step_avg:35.27ms
+step:251/1575 train_time:8838ms step_avg:35.21ms
+step:252/1575 train_time:8858ms step_avg:35.15ms
+step:253/1575 train_time:8876ms step_avg:35.08ms
+step:254/1575 train_time:8911ms step_avg:35.08ms
+step:255/1575 train_time:8943ms step_avg:35.07ms
+step:256/1575 train_time:8984ms step_avg:35.09ms
+step:257/1575 train_time:9016ms step_avg:35.08ms
+step:258/1575 train_time:9055ms step_avg:35.10ms
+step:259/1575 train_time:9086ms step_avg:35.08ms
+step:260/1575 train_time:9125ms step_avg:35.10ms
+step:261/1575 train_time:9156ms step_avg:35.08ms
+step:262/1575 train_time:9195ms step_avg:35.09ms
+step:263/1575 train_time:9225ms step_avg:35.08ms
+step:264/1575 train_time:9264ms step_avg:35.09ms
+step:265/1575 train_time:9294ms step_avg:35.07ms
+step:266/1575 train_time:9333ms step_avg:35.09ms
+step:267/1575 train_time:9364ms step_avg:35.07ms
+step:268/1575 train_time:9402ms step_avg:35.08ms
+step:269/1575 train_time:9433ms step_avg:35.07ms
+step:270/1575 train_time:9472ms step_avg:35.08ms
+step:271/1575 train_time:9502ms step_avg:35.06ms
+step:272/1575 train_time:9542ms step_avg:35.08ms
+step:273/1575 train_time:9572ms step_avg:35.06ms
+step:274/1575 train_time:9610ms step_avg:35.07ms
+step:275/1575 train_time:9641ms step_avg:35.06ms
+step:276/1575 train_time:9680ms step_avg:35.07ms
+step:277/1575 train_time:9710ms step_avg:35.06ms
+step:278/1575 train_time:9749ms step_avg:35.07ms
+step:279/1575 train_time:9780ms step_avg:35.05ms
+step:280/1575 train_time:9818ms step_avg:35.07ms
+step:281/1575 train_time:9849ms step_avg:35.05ms
+step:282/1575 train_time:9887ms step_avg:35.06ms
+step:283/1575 train_time:9918ms step_avg:35.05ms
+step:284/1575 train_time:9957ms step_avg:35.06ms
+step:285/1575 train_time:9987ms step_avg:35.04ms
+step:286/1575 train_time:10026ms step_avg:35.05ms
+step:287/1575 train_time:10056ms step_avg:35.04ms
+step:288/1575 train_time:10095ms step_avg:35.05ms
+step:289/1575 train_time:10126ms step_avg:35.04ms
+step:290/1575 train_time:10165ms step_avg:35.05ms
+step:291/1575 train_time:10196ms step_avg:35.04ms
+step:292/1575 train_time:10235ms step_avg:35.05ms
+step:293/1575 train_time:10265ms step_avg:35.04ms
+step:294/1575 train_time:10304ms step_avg:35.05ms
+step:295/1575 train_time:10335ms step_avg:35.03ms
+step:296/1575 train_time:10373ms step_avg:35.04ms
+step:297/1575 train_time:10404ms step_avg:35.03ms
+step:298/1575 train_time:10443ms step_avg:35.05ms
+step:299/1575 train_time:10473ms step_avg:35.03ms
+step:300/1575 train_time:10512ms step_avg:35.04ms
+step:301/1575 train_time:10543ms step_avg:35.03ms
+step:302/1575 train_time:10582ms step_avg:35.04ms
+step:303/1575 train_time:10612ms step_avg:35.02ms
+step:304/1575 train_time:10651ms step_avg:35.04ms
+step:305/1575 train_time:10681ms step_avg:35.02ms
+step:306/1575 train_time:10720ms step_avg:35.03ms
+step:307/1575 train_time:10750ms step_avg:35.02ms
+step:308/1575 train_time:10789ms step_avg:35.03ms
+step:309/1575 train_time:10820ms step_avg:35.02ms
+step:310/1575 train_time:10859ms step_avg:35.03ms
+step:311/1575 train_time:10889ms step_avg:35.01ms
+step:312/1575 train_time:10928ms step_avg:35.03ms
+step:313/1575 train_time:10959ms step_avg:35.01ms
+step:314/1575 train_time:10997ms step_avg:35.02ms
+step:315/1575 train_time:11028ms step_avg:35.01ms
+step:316/1575 train_time:11066ms step_avg:35.02ms
+step:317/1575 train_time:11097ms step_avg:35.01ms
+step:318/1575 train_time:11135ms step_avg:35.02ms
+step:319/1575 train_time:11166ms step_avg:35.00ms
+step:320/1575 train_time:11205ms step_avg:35.02ms
+step:321/1575 train_time:11236ms step_avg:35.00ms
+step:322/1575 train_time:11274ms step_avg:35.01ms
+step:323/1575 train_time:11305ms step_avg:35.00ms
+step:324/1575 train_time:11343ms step_avg:35.01ms
+step:325/1575 train_time:11374ms step_avg:35.00ms
+step:326/1575 train_time:11413ms step_avg:35.01ms
+step:327/1575 train_time:11444ms step_avg:35.00ms
+step:328/1575 train_time:11483ms step_avg:35.01ms
+step:329/1575 train_time:11514ms step_avg:35.00ms
+step:330/1575 train_time:11552ms step_avg:35.01ms
+step:331/1575 train_time:11583ms step_avg:34.99ms
+step:332/1575 train_time:11622ms step_avg:35.01ms
+step:333/1575 train_time:11653ms step_avg:34.99ms
+step:334/1575 train_time:11691ms step_avg:35.00ms
+step:335/1575 train_time:11722ms step_avg:34.99ms
+step:336/1575 train_time:11761ms step_avg:35.00ms
+step:337/1575 train_time:11791ms step_avg:34.99ms
+step:338/1575 train_time:11830ms step_avg:35.00ms
+step:339/1575 train_time:11861ms step_avg:34.99ms
+step:340/1575 train_time:11899ms step_avg:35.00ms
+step:341/1575 train_time:11930ms step_avg:34.98ms
+step:342/1575 train_time:11968ms step_avg:34.99ms
+step:343/1575 train_time:11999ms step_avg:34.98ms
+step:344/1575 train_time:12038ms step_avg:34.99ms
+step:345/1575 train_time:12069ms step_avg:34.98ms
+step:346/1575 train_time:12107ms step_avg:34.99ms
+step:347/1575 train_time:12138ms step_avg:34.98ms
+step:348/1575 train_time:12177ms step_avg:34.99ms
+step:349/1575 train_time:12207ms step_avg:34.98ms
+step:350/1575 train_time:12246ms step_avg:34.99ms
+step:351/1575 train_time:12277ms step_avg:34.98ms
+step:352/1575 train_time:12316ms step_avg:34.99ms
+step:353/1575 train_time:12347ms step_avg:34.98ms
+step:354/1575 train_time:12386ms step_avg:34.99ms
+step:355/1575 train_time:12416ms step_avg:34.98ms
+step:356/1575 train_time:12455ms step_avg:34.99ms
+step:357/1575 train_time:12486ms step_avg:34.97ms
+step:358/1575 train_time:12524ms step_avg:34.98ms
+step:359/1575 train_time:12555ms step_avg:34.97ms
+step:360/1575 train_time:12594ms step_avg:34.98ms
+step:361/1575 train_time:12624ms step_avg:34.97ms
+step:362/1575 train_time:12663ms step_avg:34.98ms
+step:363/1575 train_time:12693ms step_avg:34.97ms
+step:364/1575 train_time:12732ms step_avg:34.98ms
+step:365/1575 train_time:12763ms step_avg:34.97ms
+step:366/1575 train_time:12801ms step_avg:34.98ms
+step:367/1575 train_time:12832ms step_avg:34.97ms
+step:368/1575 train_time:12872ms step_avg:34.98ms
+step:369/1575 train_time:12902ms step_avg:34.97ms
+step:370/1575 train_time:12941ms step_avg:34.98ms
+step:371/1575 train_time:12972ms step_avg:34.96ms
+step:372/1575 train_time:13010ms step_avg:34.97ms
+step:373/1575 train_time:13041ms step_avg:34.96ms
+step:374/1575 train_time:13080ms step_avg:34.97ms
+step:375/1575 train_time:13110ms step_avg:34.96ms
+step:376/1575 train_time:13149ms step_avg:34.97ms
+step:377/1575 train_time:13179ms step_avg:34.96ms
+step:378/1575 train_time:13218ms step_avg:34.97ms
+step:379/1575 train_time:13249ms step_avg:34.96ms
+step:380/1575 train_time:13287ms step_avg:34.97ms
+step:381/1575 train_time:13318ms step_avg:34.95ms
+step:382/1575 train_time:13357ms step_avg:34.97ms
+step:383/1575 train_time:13387ms step_avg:34.95ms
+step:384/1575 train_time:13426ms step_avg:34.96ms
+step:385/1575 train_time:13457ms step_avg:34.95ms
+step:386/1575 train_time:13496ms step_avg:34.96ms
+step:387/1575 train_time:13527ms step_avg:34.95ms
+step:388/1575 train_time:13565ms step_avg:34.96ms
+step:389/1575 train_time:13596ms step_avg:34.95ms
+step:390/1575 train_time:13635ms step_avg:34.96ms
+step:391/1575 train_time:13666ms step_avg:34.95ms
+step:392/1575 train_time:13704ms step_avg:34.96ms
+step:393/1575 train_time:13735ms step_avg:34.95ms
+step:394/1575 train_time:13774ms step_avg:34.96ms
+step:395/1575 train_time:13805ms step_avg:34.95ms
+step:396/1575 train_time:13843ms step_avg:34.96ms
+step:397/1575 train_time:13874ms step_avg:34.95ms
+step:398/1575 train_time:13913ms step_avg:34.96ms
+step:399/1575 train_time:13944ms step_avg:34.95ms
+step:400/1575 train_time:13982ms step_avg:34.96ms
+step:401/1575 train_time:14013ms step_avg:34.94ms
+step:402/1575 train_time:14051ms step_avg:34.95ms
+step:403/1575 train_time:14082ms step_avg:34.94ms
+step:404/1575 train_time:14121ms step_avg:34.95ms
+step:405/1575 train_time:14152ms step_avg:34.94ms
+step:406/1575 train_time:14190ms step_avg:34.95ms
+step:407/1575 train_time:14221ms step_avg:34.94ms
+step:408/1575 train_time:14260ms step_avg:34.95ms
+step:409/1575 train_time:14290ms step_avg:34.94ms
+step:410/1575 train_time:14329ms step_avg:34.95ms
+step:411/1575 train_time:14359ms step_avg:34.94ms
+step:412/1575 train_time:14398ms step_avg:34.95ms
+step:413/1575 train_time:14429ms step_avg:34.94ms
+step:414/1575 train_time:14468ms step_avg:34.95ms
+step:415/1575 train_time:14498ms step_avg:34.93ms
+step:416/1575 train_time:14537ms step_avg:34.94ms
+step:417/1575 train_time:14568ms step_avg:34.93ms
+step:418/1575 train_time:14606ms step_avg:34.94ms
+step:419/1575 train_time:14636ms step_avg:34.93ms
+step:420/1575 train_time:14676ms step_avg:34.94ms
+step:421/1575 train_time:14706ms step_avg:34.93ms
+step:422/1575 train_time:14745ms step_avg:34.94ms
+step:423/1575 train_time:14775ms step_avg:34.93ms
+step:424/1575 train_time:14814ms step_avg:34.94ms
+step:425/1575 train_time:14845ms step_avg:34.93ms
+step:426/1575 train_time:14883ms step_avg:34.94ms
+step:427/1575 train_time:14914ms step_avg:34.93ms
+step:428/1575 train_time:14953ms step_avg:34.94ms
+step:429/1575 train_time:14983ms step_avg:34.93ms
+step:430/1575 train_time:15022ms step_avg:34.93ms
+step:431/1575 train_time:15052ms step_avg:34.92ms
+step:432/1575 train_time:15091ms step_avg:34.93ms
+step:433/1575 train_time:15122ms step_avg:34.92ms
+step:434/1575 train_time:15161ms step_avg:34.93ms
+step:435/1575 train_time:15192ms step_avg:34.92ms
+step:436/1575 train_time:15230ms step_avg:34.93ms
+step:437/1575 train_time:15261ms step_avg:34.92ms
+step:438/1575 train_time:15300ms step_avg:34.93ms
+step:439/1575 train_time:15331ms step_avg:34.92ms
+step:440/1575 train_time:15369ms step_avg:34.93ms
+step:441/1575 train_time:15400ms step_avg:34.92ms
+step:442/1575 train_time:15439ms step_avg:34.93ms
+step:443/1575 train_time:15469ms step_avg:34.92ms
+step:444/1575 train_time:15507ms step_avg:34.93ms
+step:445/1575 train_time:15538ms step_avg:34.92ms
+step:446/1575 train_time:15577ms step_avg:34.93ms
+step:447/1575 train_time:15607ms step_avg:34.92ms
+step:448/1575 train_time:15645ms step_avg:34.92ms
+step:449/1575 train_time:15676ms step_avg:34.91ms
+step:450/1575 train_time:15715ms step_avg:34.92ms
+step:451/1575 train_time:15746ms step_avg:34.91ms
+step:452/1575 train_time:15785ms step_avg:34.92ms
+step:453/1575 train_time:15816ms step_avg:34.91ms
+step:454/1575 train_time:15854ms step_avg:34.92ms
+step:455/1575 train_time:15885ms step_avg:34.91ms
+step:456/1575 train_time:15924ms step_avg:34.92ms
+step:457/1575 train_time:15955ms step_avg:34.91ms
+step:458/1575 train_time:15993ms step_avg:34.92ms
+step:459/1575 train_time:16024ms step_avg:34.91ms
+step:460/1575 train_time:16063ms step_avg:34.92ms
+step:461/1575 train_time:16093ms step_avg:34.91ms
+step:462/1575 train_time:16132ms step_avg:34.92ms
+step:463/1575 train_time:16163ms step_avg:34.91ms
+step:464/1575 train_time:16201ms step_avg:34.92ms
+step:465/1575 train_time:16232ms step_avg:34.91ms
+step:466/1575 train_time:16270ms step_avg:34.92ms
+step:467/1575 train_time:16301ms step_avg:34.91ms
+step:468/1575 train_time:16340ms step_avg:34.91ms
+step:469/1575 train_time:16371ms step_avg:34.91ms
+step:470/1575 train_time:16409ms step_avg:34.91ms
+step:471/1575 train_time:16440ms step_avg:34.90ms
+step:472/1575 train_time:16479ms step_avg:34.91ms
+step:473/1575 train_time:16509ms step_avg:34.90ms
+step:474/1575 train_time:16548ms step_avg:34.91ms
+step:475/1575 train_time:16578ms step_avg:34.90ms
+step:476/1575 train_time:16617ms step_avg:34.91ms
+step:477/1575 train_time:16648ms step_avg:34.90ms
+step:478/1575 train_time:16686ms step_avg:34.91ms
+step:479/1575 train_time:16717ms step_avg:34.90ms
+step:480/1575 train_time:16756ms step_avg:34.91ms
+step:481/1575 train_time:16786ms step_avg:34.90ms
+step:482/1575 train_time:16825ms step_avg:34.91ms
+step:483/1575 train_time:16856ms step_avg:34.90ms
+step:484/1575 train_time:16894ms step_avg:34.90ms
+step:485/1575 train_time:16925ms step_avg:34.90ms
+step:486/1575 train_time:16964ms step_avg:34.90ms
+step:487/1575 train_time:16994ms step_avg:34.90ms
+step:488/1575 train_time:17033ms step_avg:34.90ms
+step:489/1575 train_time:17064ms step_avg:34.90ms
+step:490/1575 train_time:17103ms step_avg:34.90ms
+step:491/1575 train_time:17134ms step_avg:34.90ms
+step:492/1575 train_time:17173ms step_avg:34.90ms
+step:493/1575 train_time:17203ms step_avg:34.90ms
+step:494/1575 train_time:17242ms step_avg:34.90ms
+step:495/1575 train_time:17273ms step_avg:34.89ms
+step:496/1575 train_time:17312ms step_avg:34.90ms
+step:497/1575 train_time:17343ms step_avg:34.89ms
+step:498/1575 train_time:17381ms step_avg:34.90ms
+step:499/1575 train_time:17412ms step_avg:34.89ms
+step:500/1575 train_time:17451ms step_avg:34.90ms
+step:500/1575 val_loss:4.2306 train_time:17500ms step_avg:35.00ms
+step:501/1575 train_time:17520ms step_avg:34.97ms
+step:502/1575 train_time:17540ms step_avg:34.94ms
+step:503/1575 train_time:17558ms step_avg:34.91ms
+step:504/1575 train_time:17594ms step_avg:34.91ms
+step:505/1575 train_time:17625ms step_avg:34.90ms
+step:506/1575 train_time:17666ms step_avg:34.91ms
+step:507/1575 train_time:17697ms step_avg:34.90ms
+step:508/1575 train_time:17736ms step_avg:34.91ms
+step:509/1575 train_time:17766ms step_avg:34.90ms
+step:510/1575 train_time:17806ms step_avg:34.91ms
+step:511/1575 train_time:17836ms step_avg:34.90ms
+step:512/1575 train_time:17874ms step_avg:34.91ms
+step:513/1575 train_time:17946ms step_avg:34.98ms
+step:514/1575 train_time:18004ms step_avg:35.03ms
+step:515/1575 train_time:18067ms step_avg:35.08ms
+step:516/1575 train_time:18125ms step_avg:35.13ms
+step:517/1575 train_time:18188ms step_avg:35.18ms
+step:518/1575 train_time:18248ms step_avg:35.23ms
+step:519/1575 train_time:18311ms step_avg:35.28ms
+step:520/1575 train_time:18370ms step_avg:35.33ms
+step:521/1575 train_time:18432ms step_avg:35.38ms
+step:522/1575 train_time:18492ms step_avg:35.43ms
+step:523/1575 train_time:18558ms step_avg:35.48ms
+step:524/1575 train_time:18618ms step_avg:35.53ms
+step:525/1575 train_time:18682ms step_avg:35.58ms
+step:526/1575 train_time:18742ms step_avg:35.63ms
+step:527/1575 train_time:18806ms step_avg:35.69ms
+step:528/1575 train_time:18866ms step_avg:35.73ms
+step:529/1575 train_time:18932ms step_avg:35.79ms
+step:530/1575 train_time:18991ms step_avg:35.83ms
+step:531/1575 train_time:19052ms step_avg:35.88ms
+step:532/1575 train_time:19111ms step_avg:35.92ms
+step:533/1575 train_time:19175ms step_avg:35.98ms
+step:534/1575 train_time:19234ms step_avg:36.02ms
+step:535/1575 train_time:19297ms step_avg:36.07ms
+step:536/1575 train_time:19356ms step_avg:36.11ms
+step:537/1575 train_time:19419ms step_avg:36.16ms
+step:538/1575 train_time:19478ms step_avg:36.20ms
+step:539/1575 train_time:19541ms step_avg:36.25ms
+step:540/1575 train_time:19602ms step_avg:36.30ms
+step:541/1575 train_time:19667ms step_avg:36.35ms
+step:542/1575 train_time:19726ms step_avg:36.39ms
+step:543/1575 train_time:19788ms step_avg:36.44ms
+step:544/1575 train_time:19847ms step_avg:36.48ms
+step:545/1575 train_time:19912ms step_avg:36.54ms
+step:546/1575 train_time:19972ms step_avg:36.58ms
+step:547/1575 train_time:20035ms step_avg:36.63ms
+step:548/1575 train_time:20094ms step_avg:36.67ms
+step:549/1575 train_time:20157ms step_avg:36.72ms
+step:550/1575 train_time:20216ms step_avg:36.76ms
+step:551/1575 train_time:20279ms step_avg:36.80ms
+step:552/1575 train_time:20338ms step_avg:36.84ms
+step:553/1575 train_time:20402ms step_avg:36.89ms
+step:554/1575 train_time:20461ms step_avg:36.93ms
+step:555/1575 train_time:20524ms step_avg:36.98ms
+step:556/1575 train_time:20583ms step_avg:37.02ms
+step:557/1575 train_time:20648ms step_avg:37.07ms
+step:558/1575 train_time:20708ms step_avg:37.11ms
+step:559/1575 train_time:20771ms step_avg:37.16ms
+step:560/1575 train_time:20830ms step_avg:37.20ms
+step:561/1575 train_time:20894ms step_avg:37.24ms
+step:562/1575 train_time:20954ms step_avg:37.28ms
+step:563/1575 train_time:21017ms step_avg:37.33ms
+step:564/1575 train_time:21076ms step_avg:37.37ms
+step:565/1575 train_time:21139ms step_avg:37.41ms
+step:566/1575 train_time:21198ms step_avg:37.45ms
+step:567/1575 train_time:21262ms step_avg:37.50ms
+step:568/1575 train_time:21321ms step_avg:37.54ms
+step:569/1575 train_time:21389ms step_avg:37.59ms
+step:570/1575 train_time:21446ms step_avg:37.62ms
+step:571/1575 train_time:21510ms step_avg:37.67ms
+step:572/1575 train_time:21568ms step_avg:37.71ms
+step:573/1575 train_time:21632ms step_avg:37.75ms
+step:574/1575 train_time:21690ms step_avg:37.79ms
+step:575/1575 train_time:21754ms step_avg:37.83ms
+step:576/1575 train_time:21813ms step_avg:37.87ms
+step:577/1575 train_time:21876ms step_avg:37.91ms
+step:578/1575 train_time:21936ms step_avg:37.95ms
+step:579/1575 train_time:21999ms step_avg:37.99ms
+step:580/1575 train_time:22058ms step_avg:38.03ms
+step:581/1575 train_time:22121ms step_avg:38.07ms
+step:582/1575 train_time:22180ms step_avg:38.11ms
+step:583/1575 train_time:22243ms step_avg:38.15ms
+step:584/1575 train_time:22302ms step_avg:38.19ms
+step:585/1575 train_time:22365ms step_avg:38.23ms
+step:586/1575 train_time:22424ms step_avg:38.27ms
+step:587/1575 train_time:22487ms step_avg:38.31ms
+step:588/1575 train_time:22546ms step_avg:38.34ms
+step:589/1575 train_time:22610ms step_avg:38.39ms
+step:590/1575 train_time:22671ms step_avg:38.43ms
+step:591/1575 train_time:22734ms step_avg:38.47ms
+step:592/1575 train_time:22793ms step_avg:38.50ms
+step:593/1575 train_time:22857ms step_avg:38.54ms
+step:594/1575 train_time:22916ms step_avg:38.58ms
+step:595/1575 train_time:22979ms step_avg:38.62ms
+step:596/1575 train_time:23038ms step_avg:38.65ms
+step:597/1575 train_time:23101ms step_avg:38.70ms
+step:598/1575 train_time:23161ms step_avg:38.73ms
+step:599/1575 train_time:23223ms step_avg:38.77ms
+step:600/1575 train_time:23282ms step_avg:38.80ms
+step:601/1575 train_time:23345ms step_avg:38.84ms
+step:602/1575 train_time:23404ms step_avg:38.88ms
+step:603/1575 train_time:23467ms step_avg:38.92ms
+step:604/1575 train_time:23527ms step_avg:38.95ms
+step:605/1575 train_time:23590ms step_avg:38.99ms
+step:606/1575 train_time:23650ms step_avg:39.03ms
+step:607/1575 train_time:23714ms step_avg:39.07ms
+step:608/1575 train_time:23773ms step_avg:39.10ms
+step:609/1575 train_time:23837ms step_avg:39.14ms
+step:610/1575 train_time:23896ms step_avg:39.17ms
+step:611/1575 train_time:23960ms step_avg:39.21ms
+step:612/1575 train_time:24020ms step_avg:39.25ms
+step:613/1575 train_time:24085ms step_avg:39.29ms
+step:614/1575 train_time:24144ms step_avg:39.32ms
+step:615/1575 train_time:24206ms step_avg:39.36ms
+step:616/1575 train_time:24266ms step_avg:39.39ms
+step:617/1575 train_time:24328ms step_avg:39.43ms
+step:618/1575 train_time:24388ms step_avg:39.46ms
+step:619/1575 train_time:24451ms step_avg:39.50ms
+step:620/1575 train_time:24510ms step_avg:39.53ms
+step:621/1575 train_time:24574ms step_avg:39.57ms
+step:622/1575 train_time:24634ms step_avg:39.60ms
+step:623/1575 train_time:24697ms step_avg:39.64ms
+step:624/1575 train_time:24757ms step_avg:39.67ms
+step:625/1575 train_time:24818ms step_avg:39.71ms
+step:626/1575 train_time:24878ms step_avg:39.74ms
+step:627/1575 train_time:24941ms step_avg:39.78ms
+step:628/1575 train_time:25000ms step_avg:39.81ms
+step:629/1575 train_time:25063ms step_avg:39.85ms
+step:630/1575 train_time:25122ms step_avg:39.88ms
+step:631/1575 train_time:25185ms step_avg:39.91ms
+step:632/1575 train_time:25244ms step_avg:39.94ms
+step:633/1575 train_time:25307ms step_avg:39.98ms
+step:634/1575 train_time:25367ms step_avg:40.01ms
+step:635/1575 train_time:25430ms step_avg:40.05ms
+step:636/1575 train_time:25489ms step_avg:40.08ms
+step:637/1575 train_time:25554ms step_avg:40.12ms
+step:638/1575 train_time:25612ms step_avg:40.14ms
+step:639/1575 train_time:25677ms step_avg:40.18ms
+step:640/1575 train_time:25735ms step_avg:40.21ms
+step:641/1575 train_time:25798ms step_avg:40.25ms
+step:642/1575 train_time:25858ms step_avg:40.28ms
+step:643/1575 train_time:25921ms step_avg:40.31ms
+step:644/1575 train_time:25980ms step_avg:40.34ms
+step:645/1575 train_time:26043ms step_avg:40.38ms
+step:646/1575 train_time:26102ms step_avg:40.41ms
+step:647/1575 train_time:26166ms step_avg:40.44ms
+step:648/1575 train_time:26225ms step_avg:40.47ms
+step:649/1575 train_time:26288ms step_avg:40.51ms
+step:650/1575 train_time:26347ms step_avg:40.53ms
+step:651/1575 train_time:26410ms step_avg:40.57ms
+step:652/1575 train_time:26469ms step_avg:40.60ms
+step:653/1575 train_time:26533ms step_avg:40.63ms
+step:654/1575 train_time:26592ms step_avg:40.66ms
+step:655/1575 train_time:26656ms step_avg:40.70ms
+step:656/1575 train_time:26715ms step_avg:40.72ms
+step:657/1575 train_time:26779ms step_avg:40.76ms
+step:658/1575 train_time:26839ms step_avg:40.79ms
+step:659/1575 train_time:26902ms step_avg:40.82ms
+step:660/1575 train_time:26961ms step_avg:40.85ms
+step:661/1575 train_time:27026ms step_avg:40.89ms
+step:662/1575 train_time:27084ms step_avg:40.91ms
+step:663/1575 train_time:27147ms step_avg:40.95ms
+step:664/1575 train_time:27206ms step_avg:40.97ms
+step:665/1575 train_time:27269ms step_avg:41.01ms
+step:666/1575 train_time:27328ms step_avg:41.03ms
+step:667/1575 train_time:27392ms step_avg:41.07ms
+step:668/1575 train_time:27451ms step_avg:41.09ms
+step:669/1575 train_time:27514ms step_avg:41.13ms
+step:670/1575 train_time:27573ms step_avg:41.15ms
+step:671/1575 train_time:27637ms step_avg:41.19ms
+step:672/1575 train_time:27697ms step_avg:41.22ms
+step:673/1575 train_time:27760ms step_avg:41.25ms
+step:674/1575 train_time:27819ms step_avg:41.27ms
+step:675/1575 train_time:27882ms step_avg:41.31ms
+step:676/1575 train_time:27942ms step_avg:41.33ms
+step:677/1575 train_time:28005ms step_avg:41.37ms
+step:678/1575 train_time:28063ms step_avg:41.39ms
+step:679/1575 train_time:28126ms step_avg:41.42ms
+step:680/1575 train_time:28186ms step_avg:41.45ms
+step:681/1575 train_time:28249ms step_avg:41.48ms
+step:682/1575 train_time:28308ms step_avg:41.51ms
+step:683/1575 train_time:28372ms step_avg:41.54ms
+step:684/1575 train_time:28431ms step_avg:41.57ms
+step:685/1575 train_time:28495ms step_avg:41.60ms
+step:686/1575 train_time:28554ms step_avg:41.62ms
+step:687/1575 train_time:28618ms step_avg:41.66ms
+step:688/1575 train_time:28678ms step_avg:41.68ms
+step:689/1575 train_time:28741ms step_avg:41.71ms
+step:690/1575 train_time:28800ms step_avg:41.74ms
+step:691/1575 train_time:28864ms step_avg:41.77ms
+step:692/1575 train_time:28923ms step_avg:41.80ms
+step:693/1575 train_time:28987ms step_avg:41.83ms
+step:694/1575 train_time:29046ms step_avg:41.85ms
+step:695/1575 train_time:29109ms step_avg:41.88ms
+step:696/1575 train_time:29170ms step_avg:41.91ms
+step:697/1575 train_time:29232ms step_avg:41.94ms
+step:698/1575 train_time:29290ms step_avg:41.96ms
+step:699/1575 train_time:29354ms step_avg:41.99ms
+step:700/1575 train_time:29415ms step_avg:42.02ms
+step:701/1575 train_time:29478ms step_avg:42.05ms
+step:702/1575 train_time:29537ms step_avg:42.08ms
+step:703/1575 train_time:29600ms step_avg:42.11ms
+step:704/1575 train_time:29659ms step_avg:42.13ms
+step:705/1575 train_time:29724ms step_avg:42.16ms
+step:706/1575 train_time:29783ms step_avg:42.19ms
+step:707/1575 train_time:29847ms step_avg:42.22ms
+step:708/1575 train_time:29905ms step_avg:42.24ms
+step:709/1575 train_time:29969ms step_avg:42.27ms
+step:710/1575 train_time:30028ms step_avg:42.29ms
+step:711/1575 train_time:30091ms step_avg:42.32ms
+step:712/1575 train_time:30150ms step_avg:42.35ms
+step:713/1575 train_time:30214ms step_avg:42.38ms
+step:714/1575 train_time:30273ms step_avg:42.40ms
+step:715/1575 train_time:30336ms step_avg:42.43ms
+step:716/1575 train_time:30396ms step_avg:42.45ms
+step:717/1575 train_time:30459ms step_avg:42.48ms
+step:718/1575 train_time:30519ms step_avg:42.50ms
+step:719/1575 train_time:30582ms step_avg:42.53ms
+step:720/1575 train_time:30641ms step_avg:42.56ms
+step:721/1575 train_time:30706ms step_avg:42.59ms
+step:722/1575 train_time:30765ms step_avg:42.61ms
+step:723/1575 train_time:30829ms step_avg:42.64ms
+step:724/1575 train_time:30888ms step_avg:42.66ms
+step:725/1575 train_time:30952ms step_avg:42.69ms
+step:726/1575 train_time:31011ms step_avg:42.72ms
+step:727/1575 train_time:31073ms step_avg:42.74ms
+step:728/1575 train_time:31133ms step_avg:42.77ms
+step:729/1575 train_time:31197ms step_avg:42.79ms
+step:730/1575 train_time:31256ms step_avg:42.82ms
+step:731/1575 train_time:31318ms step_avg:42.84ms
+step:732/1575 train_time:31378ms step_avg:42.87ms
+step:733/1575 train_time:31441ms step_avg:42.89ms
+step:734/1575 train_time:31500ms step_avg:42.92ms
+step:735/1575 train_time:31563ms step_avg:42.94ms
+step:736/1575 train_time:31622ms step_avg:42.96ms
+step:737/1575 train_time:31686ms step_avg:42.99ms
+step:738/1575 train_time:31746ms step_avg:43.02ms
+step:739/1575 train_time:31809ms step_avg:43.04ms
+step:740/1575 train_time:31868ms step_avg:43.07ms
+step:741/1575 train_time:31932ms step_avg:43.09ms
+step:742/1575 train_time:31992ms step_avg:43.12ms
+step:743/1575 train_time:32055ms step_avg:43.14ms
+step:744/1575 train_time:32114ms step_avg:43.16ms
+step:745/1575 train_time:32178ms step_avg:43.19ms
+step:746/1575 train_time:32237ms step_avg:43.21ms
+step:747/1575 train_time:32300ms step_avg:43.24ms
+step:748/1575 train_time:32359ms step_avg:43.26ms
+step:749/1575 train_time:32422ms step_avg:43.29ms
+step:750/1575 train_time:32481ms step_avg:43.31ms
+step:750/1575 val_loss:3.8752 train_time:32528ms step_avg:43.37ms
+step:751/1575 train_time:32549ms step_avg:43.34ms
+step:752/1575 train_time:32608ms step_avg:43.36ms
+step:753/1575 train_time:32673ms step_avg:43.39ms
+step:754/1575 train_time:32735ms step_avg:43.41ms
+step:755/1575 train_time:32798ms step_avg:43.44ms
+step:756/1575 train_time:32857ms step_avg:43.46ms
+step:757/1575 train_time:32920ms step_avg:43.49ms
+step:758/1575 train_time:32979ms step_avg:43.51ms
+step:759/1575 train_time:33042ms step_avg:43.53ms
+step:760/1575 train_time:33100ms step_avg:43.55ms
+step:761/1575 train_time:33163ms step_avg:43.58ms
+step:762/1575 train_time:33222ms step_avg:43.60ms
+step:763/1575 train_time:33285ms step_avg:43.62ms
+step:764/1575 train_time:33343ms step_avg:43.64ms
+step:765/1575 train_time:33407ms step_avg:43.67ms
+step:766/1575 train_time:33469ms step_avg:43.69ms
+step:767/1575 train_time:33532ms step_avg:43.72ms
+step:768/1575 train_time:33591ms step_avg:43.74ms
+step:769/1575 train_time:33656ms step_avg:43.77ms
+step:770/1575 train_time:33715ms step_avg:43.79ms
+step:771/1575 train_time:33778ms step_avg:43.81ms
+step:772/1575 train_time:33839ms step_avg:43.83ms
+step:773/1575 train_time:33902ms step_avg:43.86ms
+step:774/1575 train_time:33961ms step_avg:43.88ms
+step:775/1575 train_time:34024ms step_avg:43.90ms
+step:776/1575 train_time:34083ms step_avg:43.92ms
+step:777/1575 train_time:34146ms step_avg:43.95ms
+step:778/1575 train_time:34205ms step_avg:43.96ms
+step:779/1575 train_time:34267ms step_avg:43.99ms
+step:780/1575 train_time:34326ms step_avg:44.01ms
+step:781/1575 train_time:34389ms step_avg:44.03ms
+step:782/1575 train_time:34448ms step_avg:44.05ms
+step:783/1575 train_time:34511ms step_avg:44.08ms
+step:784/1575 train_time:34572ms step_avg:44.10ms
+step:785/1575 train_time:34636ms step_avg:44.12ms
+step:786/1575 train_time:34695ms step_avg:44.14ms
+step:787/1575 train_time:34758ms step_avg:44.17ms
+step:788/1575 train_time:34819ms step_avg:44.19ms
+step:789/1575 train_time:34882ms step_avg:44.21ms
+step:790/1575 train_time:34941ms step_avg:44.23ms
+step:791/1575 train_time:35004ms step_avg:44.25ms
+step:792/1575 train_time:35063ms step_avg:44.27ms
+step:793/1575 train_time:35127ms step_avg:44.30ms
+step:794/1575 train_time:35186ms step_avg:44.31ms
+step:795/1575 train_time:35248ms step_avg:44.34ms
+step:796/1575 train_time:35307ms step_avg:44.36ms
+step:797/1575 train_time:35370ms step_avg:44.38ms
+step:798/1575 train_time:35429ms step_avg:44.40ms
+step:799/1575 train_time:35492ms step_avg:44.42ms
+step:800/1575 train_time:35551ms step_avg:44.44ms
+step:801/1575 train_time:35615ms step_avg:44.46ms
+step:802/1575 train_time:35675ms step_avg:44.48ms
+step:803/1575 train_time:35738ms step_avg:44.51ms
+step:804/1575 train_time:35797ms step_avg:44.52ms
+step:805/1575 train_time:35862ms step_avg:44.55ms
+step:806/1575 train_time:35923ms step_avg:44.57ms
+step:807/1575 train_time:35985ms step_avg:44.59ms
+step:808/1575 train_time:36045ms step_avg:44.61ms
+step:809/1575 train_time:36108ms step_avg:44.63ms
+step:810/1575 train_time:36167ms step_avg:44.65ms
+step:811/1575 train_time:36230ms step_avg:44.67ms
+step:812/1575 train_time:36290ms step_avg:44.69ms
+step:813/1575 train_time:36352ms step_avg:44.71ms
+step:814/1575 train_time:36412ms step_avg:44.73ms
+step:815/1575 train_time:36475ms step_avg:44.75ms
+step:816/1575 train_time:36534ms step_avg:44.77ms
+step:817/1575 train_time:36598ms step_avg:44.80ms
+step:818/1575 train_time:36658ms step_avg:44.81ms
+step:819/1575 train_time:36721ms step_avg:44.84ms
+step:820/1575 train_time:36780ms step_avg:44.85ms
+step:821/1575 train_time:36844ms step_avg:44.88ms
+step:822/1575 train_time:36903ms step_avg:44.89ms
+step:823/1575 train_time:36966ms step_avg:44.92ms
+step:824/1575 train_time:37026ms step_avg:44.93ms
+step:825/1575 train_time:37089ms step_avg:44.96ms
+step:826/1575 train_time:37148ms step_avg:44.97ms
+step:827/1575 train_time:37211ms step_avg:44.99ms
+step:828/1575 train_time:37270ms step_avg:45.01ms
+step:829/1575 train_time:37333ms step_avg:45.03ms
+step:830/1575 train_time:37392ms step_avg:45.05ms
+step:831/1575 train_time:37455ms step_avg:45.07ms
+step:832/1575 train_time:37514ms step_avg:45.09ms
+step:833/1575 train_time:37578ms step_avg:45.11ms
+step:834/1575 train_time:37637ms step_avg:45.13ms
+step:835/1575 train_time:37701ms step_avg:45.15ms
+step:836/1575 train_time:37760ms step_avg:45.17ms
+step:837/1575 train_time:37825ms step_avg:45.19ms
+step:838/1575 train_time:37884ms step_avg:45.21ms
+step:839/1575 train_time:37948ms step_avg:45.23ms
+step:840/1575 train_time:38007ms step_avg:45.25ms
+step:841/1575 train_time:38070ms step_avg:45.27ms
+step:842/1575 train_time:38130ms step_avg:45.28ms
+step:843/1575 train_time:38193ms step_avg:45.31ms
+step:844/1575 train_time:38252ms step_avg:45.32ms
+step:845/1575 train_time:38318ms step_avg:45.35ms
+step:846/1575 train_time:38376ms step_avg:45.36ms
+step:847/1575 train_time:38439ms step_avg:45.38ms
+step:848/1575 train_time:38497ms step_avg:45.40ms
+step:849/1575 train_time:38562ms step_avg:45.42ms
+step:850/1575 train_time:38622ms step_avg:45.44ms
+step:851/1575 train_time:38684ms step_avg:45.46ms
+step:852/1575 train_time:38745ms step_avg:45.48ms
+step:853/1575 train_time:38808ms step_avg:45.50ms
+step:854/1575 train_time:38866ms step_avg:45.51ms
+step:855/1575 train_time:38929ms step_avg:45.53ms
+step:856/1575 train_time:38988ms step_avg:45.55ms
+step:857/1575 train_time:39051ms step_avg:45.57ms
+step:858/1575 train_time:39111ms step_avg:45.58ms
+step:859/1575 train_time:39174ms step_avg:45.60ms
+step:860/1575 train_time:39233ms step_avg:45.62ms
+step:861/1575 train_time:39296ms step_avg:45.64ms
+step:862/1575 train_time:39355ms step_avg:45.66ms
+step:863/1575 train_time:39418ms step_avg:45.68ms
+step:864/1575 train_time:39477ms step_avg:45.69ms
+step:865/1575 train_time:39540ms step_avg:45.71ms
+step:866/1575 train_time:39600ms step_avg:45.73ms
+step:867/1575 train_time:39663ms step_avg:45.75ms
+step:868/1575 train_time:39722ms step_avg:45.76ms
+step:869/1575 train_time:39786ms step_avg:45.78ms
+step:870/1575 train_time:39846ms step_avg:45.80ms
+step:871/1575 train_time:39910ms step_avg:45.82ms
+step:872/1575 train_time:39969ms step_avg:45.84ms
+step:873/1575 train_time:40033ms step_avg:45.86ms
+step:874/1575 train_time:40092ms step_avg:45.87ms
+step:875/1575 train_time:40155ms step_avg:45.89ms
+step:876/1575 train_time:40214ms step_avg:45.91ms
+step:877/1575 train_time:40278ms step_avg:45.93ms
+step:878/1575 train_time:40337ms step_avg:45.94ms
+step:879/1575 train_time:40401ms step_avg:45.96ms
+step:880/1575 train_time:40459ms step_avg:45.98ms
+step:881/1575 train_time:40522ms step_avg:46.00ms
+step:882/1575 train_time:40582ms step_avg:46.01ms
+step:883/1575 train_time:40645ms step_avg:46.03ms
+step:884/1575 train_time:40704ms step_avg:46.05ms
+step:885/1575 train_time:40768ms step_avg:46.07ms
+step:886/1575 train_time:40832ms step_avg:46.09ms
+step:887/1575 train_time:40892ms step_avg:46.10ms
+step:888/1575 train_time:40952ms step_avg:46.12ms
+step:889/1575 train_time:41014ms step_avg:46.13ms
+step:890/1575 train_time:41072ms step_avg:46.15ms
+step:891/1575 train_time:41136ms step_avg:46.17ms
+step:892/1575 train_time:41195ms step_avg:46.18ms
+step:893/1575 train_time:41259ms step_avg:46.20ms
+step:894/1575 train_time:41319ms step_avg:46.22ms
+step:895/1575 train_time:41381ms step_avg:46.24ms
+step:896/1575 train_time:41440ms step_avg:46.25ms
+step:897/1575 train_time:41503ms step_avg:46.27ms
+step:898/1575 train_time:41563ms step_avg:46.28ms
+step:899/1575 train_time:41626ms step_avg:46.30ms
+step:900/1575 train_time:41685ms step_avg:46.32ms
+step:901/1575 train_time:41748ms step_avg:46.34ms
+step:902/1575 train_time:41808ms step_avg:46.35ms
+step:903/1575 train_time:41871ms step_avg:46.37ms
+step:904/1575 train_time:41931ms step_avg:46.38ms
+step:905/1575 train_time:41994ms step_avg:46.40ms
+step:906/1575 train_time:42053ms step_avg:46.42ms
+step:907/1575 train_time:42116ms step_avg:46.43ms
+step:908/1575 train_time:42175ms step_avg:46.45ms
+step:909/1575 train_time:42239ms step_avg:46.47ms
+step:910/1575 train_time:42298ms step_avg:46.48ms
+step:911/1575 train_time:42361ms step_avg:46.50ms
+step:912/1575 train_time:42421ms step_avg:46.51ms
+step:913/1575 train_time:42483ms step_avg:46.53ms
+step:914/1575 train_time:42543ms step_avg:46.55ms
+step:915/1575 train_time:42607ms step_avg:46.57ms
+step:916/1575 train_time:42666ms step_avg:46.58ms
+step:917/1575 train_time:42730ms step_avg:46.60ms
+step:918/1575 train_time:42790ms step_avg:46.61ms
+step:919/1575 train_time:42853ms step_avg:46.63ms
+step:920/1575 train_time:42912ms step_avg:46.64ms
+step:921/1575 train_time:42976ms step_avg:46.66ms
+step:922/1575 train_time:43035ms step_avg:46.68ms
+step:923/1575 train_time:43098ms step_avg:46.69ms
+step:924/1575 train_time:43157ms step_avg:46.71ms
+step:925/1575 train_time:43220ms step_avg:46.72ms
+step:926/1575 train_time:43280ms step_avg:46.74ms
+step:927/1575 train_time:43343ms step_avg:46.76ms
+step:928/1575 train_time:43403ms step_avg:46.77ms
+step:929/1575 train_time:43465ms step_avg:46.79ms
+step:930/1575 train_time:43524ms step_avg:46.80ms
+step:931/1575 train_time:43589ms step_avg:46.82ms
+step:932/1575 train_time:43648ms step_avg:46.83ms
+step:933/1575 train_time:43712ms step_avg:46.85ms
+step:934/1575 train_time:43772ms step_avg:46.86ms
+step:935/1575 train_time:43833ms step_avg:46.88ms
+step:936/1575 train_time:43892ms step_avg:46.89ms
+step:937/1575 train_time:43957ms step_avg:46.91ms
+step:938/1575 train_time:44016ms step_avg:46.93ms
+step:939/1575 train_time:44079ms step_avg:46.94ms
+step:940/1575 train_time:44139ms step_avg:46.96ms
+step:941/1575 train_time:44201ms step_avg:46.97ms
+step:942/1575 train_time:44260ms step_avg:46.99ms
+step:943/1575 train_time:44324ms step_avg:47.00ms
+step:944/1575 train_time:44383ms step_avg:47.02ms
+step:945/1575 train_time:44446ms step_avg:47.03ms
+step:946/1575 train_time:44505ms step_avg:47.05ms
+step:947/1575 train_time:44569ms step_avg:47.06ms
+step:948/1575 train_time:44629ms step_avg:47.08ms
+step:949/1575 train_time:44691ms step_avg:47.09ms
+step:950/1575 train_time:44750ms step_avg:47.11ms
+step:951/1575 train_time:44814ms step_avg:47.12ms
+step:952/1575 train_time:44872ms step_avg:47.13ms
+step:953/1575 train_time:44935ms step_avg:47.15ms
+step:954/1575 train_time:44994ms step_avg:47.16ms
+step:955/1575 train_time:45058ms step_avg:47.18ms
+step:956/1575 train_time:45117ms step_avg:47.19ms
+step:957/1575 train_time:45182ms step_avg:47.21ms
+step:958/1575 train_time:45241ms step_avg:47.22ms
+step:959/1575 train_time:45305ms step_avg:47.24ms
+step:960/1575 train_time:45364ms step_avg:47.25ms
+step:961/1575 train_time:45428ms step_avg:47.27ms
+step:962/1575 train_time:45487ms step_avg:47.28ms
+step:963/1575 train_time:45550ms step_avg:47.30ms
+step:964/1575 train_time:45609ms step_avg:47.31ms
+step:965/1575 train_time:45672ms step_avg:47.33ms
+step:966/1575 train_time:45732ms step_avg:47.34ms
+step:967/1575 train_time:45795ms step_avg:47.36ms
+step:968/1575 train_time:45854ms step_avg:47.37ms
+step:969/1575 train_time:45917ms step_avg:47.39ms
+step:970/1575 train_time:45976ms step_avg:47.40ms
+step:971/1575 train_time:46040ms step_avg:47.41ms
+step:972/1575 train_time:46099ms step_avg:47.43ms
+step:973/1575 train_time:46162ms step_avg:47.44ms
+step:974/1575 train_time:46222ms step_avg:47.46ms
+step:975/1575 train_time:46286ms step_avg:47.47ms
+step:976/1575 train_time:46346ms step_avg:47.49ms
+step:977/1575 train_time:46409ms step_avg:47.50ms
+step:978/1575 train_time:46468ms step_avg:47.51ms
+step:979/1575 train_time:46531ms step_avg:47.53ms
+step:980/1575 train_time:46590ms step_avg:47.54ms
+step:981/1575 train_time:46653ms step_avg:47.56ms
+step:982/1575 train_time:46712ms step_avg:47.57ms
+step:983/1575 train_time:46775ms step_avg:47.58ms
+step:984/1575 train_time:46834ms step_avg:47.60ms
+step:985/1575 train_time:46898ms step_avg:47.61ms
+step:986/1575 train_time:46957ms step_avg:47.62ms
+step:987/1575 train_time:47020ms step_avg:47.64ms
+step:988/1575 train_time:47080ms step_avg:47.65ms
+step:989/1575 train_time:47144ms step_avg:47.67ms
+step:990/1575 train_time:47203ms step_avg:47.68ms
+step:991/1575 train_time:47266ms step_avg:47.70ms
+step:992/1575 train_time:47327ms step_avg:47.71ms
+step:993/1575 train_time:47389ms step_avg:47.72ms
+step:994/1575 train_time:47449ms step_avg:47.74ms
+step:995/1575 train_time:47512ms step_avg:47.75ms
+step:996/1575 train_time:47571ms step_avg:47.76ms
+step:997/1575 train_time:47634ms step_avg:47.78ms
+step:998/1575 train_time:47693ms step_avg:47.79ms
+step:999/1575 train_time:47756ms step_avg:47.80ms
+step:1000/1575 train_time:47815ms step_avg:47.81ms
+step:1000/1575 val_loss:3.5816 train_time:47861ms step_avg:47.86ms
+step:1001/1575 train_time:47882ms step_avg:47.83ms
+step:1002/1575 train_time:47943ms step_avg:47.85ms
+step:1003/1575 train_time:48008ms step_avg:47.86ms
+step:1004/1575 train_time:48070ms step_avg:47.88ms
+step:1005/1575 train_time:48133ms step_avg:47.89ms
+step:1006/1575 train_time:48194ms step_avg:47.91ms
+step:1007/1575 train_time:48257ms step_avg:47.92ms
+step:1008/1575 train_time:48315ms step_avg:47.93ms
+step:1009/1575 train_time:48377ms step_avg:47.95ms
+step:1010/1575 train_time:48436ms step_avg:47.96ms
+step:1011/1575 train_time:48499ms step_avg:47.97ms
+step:1012/1575 train_time:48559ms step_avg:47.98ms
+step:1013/1575 train_time:48622ms step_avg:48.00ms
+step:1014/1575 train_time:48680ms step_avg:48.01ms
+step:1015/1575 train_time:48743ms step_avg:48.02ms
+step:1016/1575 train_time:48802ms step_avg:48.03ms
+step:1017/1575 train_time:48866ms step_avg:48.05ms
+step:1018/1575 train_time:48925ms step_avg:48.06ms
+step:1019/1575 train_time:48990ms step_avg:48.08ms
+step:1020/1575 train_time:49051ms step_avg:48.09ms
+step:1021/1575 train_time:49115ms step_avg:48.10ms
+step:1022/1575 train_time:49174ms step_avg:48.12ms
+step:1023/1575 train_time:49237ms step_avg:48.13ms
+step:1024/1575 train_time:49296ms step_avg:48.14ms
+step:1025/1575 train_time:49366ms step_avg:48.16ms
+step:1026/1575 train_time:49451ms step_avg:48.20ms
+step:1027/1575 train_time:49541ms step_avg:48.24ms
+step:1028/1575 train_time:49625ms step_avg:48.27ms
+step:1029/1575 train_time:49714ms step_avg:48.31ms
+step:1030/1575 train_time:49800ms step_avg:48.35ms
+step:1031/1575 train_time:49889ms step_avg:48.39ms
+step:1032/1575 train_time:49975ms step_avg:48.43ms
+step:1033/1575 train_time:50066ms step_avg:48.47ms
+step:1034/1575 train_time:50152ms step_avg:48.50ms
+step:1035/1575 train_time:50243ms step_avg:48.54ms
+step:1036/1575 train_time:50328ms step_avg:48.58ms
+step:1037/1575 train_time:50417ms step_avg:48.62ms
+step:1038/1575 train_time:50502ms step_avg:48.65ms
+step:1039/1575 train_time:50591ms step_avg:48.69ms
+step:1040/1575 train_time:50677ms step_avg:48.73ms
+step:1041/1575 train_time:50766ms step_avg:48.77ms
+step:1042/1575 train_time:50851ms step_avg:48.80ms
+step:1043/1575 train_time:50941ms step_avg:48.84ms
+step:1044/1575 train_time:51026ms step_avg:48.88ms
+step:1045/1575 train_time:51118ms step_avg:48.92ms
+step:1046/1575 train_time:51203ms step_avg:48.95ms
+step:1047/1575 train_time:51293ms step_avg:48.99ms
+step:1048/1575 train_time:51379ms step_avg:49.03ms
+step:1049/1575 train_time:51468ms step_avg:49.06ms
+step:1050/1575 train_time:51552ms step_avg:49.10ms
+step:1051/1575 train_time:51642ms step_avg:49.14ms
+step:1052/1575 train_time:51727ms step_avg:49.17ms
+step:1053/1575 train_time:51817ms step_avg:49.21ms
+step:1054/1575 train_time:51902ms step_avg:49.24ms
+step:1055/1575 train_time:51991ms step_avg:49.28ms
+step:1056/1575 train_time:52078ms step_avg:49.32ms
+step:1057/1575 train_time:52168ms step_avg:49.35ms
+step:1058/1575 train_time:52254ms step_avg:49.39ms
+step:1059/1575 train_time:52344ms step_avg:49.43ms
+step:1060/1575 train_time:52430ms step_avg:49.46ms
+step:1061/1575 train_time:52519ms step_avg:49.50ms
+step:1062/1575 train_time:52604ms step_avg:49.53ms
+step:1063/1575 train_time:52692ms step_avg:49.57ms
+step:1064/1575 train_time:52779ms step_avg:49.60ms
+step:1065/1575 train_time:52869ms step_avg:49.64ms
+step:1066/1575 train_time:52955ms step_avg:49.68ms
+step:1067/1575 train_time:53046ms step_avg:49.72ms
+step:1068/1575 train_time:53131ms step_avg:49.75ms
+step:1069/1575 train_time:53221ms step_avg:49.79ms
+step:1070/1575 train_time:53306ms step_avg:49.82ms
+step:1071/1575 train_time:53395ms step_avg:49.86ms
+step:1072/1575 train_time:53481ms step_avg:49.89ms
+step:1073/1575 train_time:53570ms step_avg:49.93ms
+step:1074/1575 train_time:53656ms step_avg:49.96ms
+step:1075/1575 train_time:53746ms step_avg:50.00ms
+step:1076/1575 train_time:53831ms step_avg:50.03ms
+step:1077/1575 train_time:53920ms step_avg:50.06ms
+step:1078/1575 train_time:54005ms step_avg:50.10ms
+step:1079/1575 train_time:54094ms step_avg:50.13ms
+step:1080/1575 train_time:54182ms step_avg:50.17ms
+step:1081/1575 train_time:54271ms step_avg:50.20ms
+step:1082/1575 train_time:54356ms step_avg:50.24ms
+step:1083/1575 train_time:54446ms step_avg:50.27ms
+step:1084/1575 train_time:54532ms step_avg:50.31ms
+step:1085/1575 train_time:54621ms step_avg:50.34ms
+step:1086/1575 train_time:54707ms step_avg:50.37ms
+step:1087/1575 train_time:54796ms step_avg:50.41ms
+step:1088/1575 train_time:54882ms step_avg:50.44ms
+step:1089/1575 train_time:54972ms step_avg:50.48ms
+step:1090/1575 train_time:55057ms step_avg:50.51ms
+step:1091/1575 train_time:55146ms step_avg:50.55ms
+step:1092/1575 train_time:55231ms step_avg:50.58ms
+step:1093/1575 train_time:55321ms step_avg:50.61ms
+step:1094/1575 train_time:55406ms step_avg:50.65ms
+step:1095/1575 train_time:55496ms step_avg:50.68ms
+step:1096/1575 train_time:55583ms step_avg:50.71ms
+step:1097/1575 train_time:55671ms step_avg:50.75ms
+step:1098/1575 train_time:55757ms step_avg:50.78ms
+step:1099/1575 train_time:55847ms step_avg:50.82ms
+step:1100/1575 train_time:55933ms step_avg:50.85ms
+step:1101/1575 train_time:56023ms step_avg:50.88ms
+step:1102/1575 train_time:56108ms step_avg:50.92ms
+step:1103/1575 train_time:56198ms step_avg:50.95ms
+step:1104/1575 train_time:56283ms step_avg:50.98ms
+step:1105/1575 train_time:56374ms step_avg:51.02ms
+step:1106/1575 train_time:56459ms step_avg:51.05ms
+step:1107/1575 train_time:56550ms step_avg:51.08ms
+step:1108/1575 train_time:56635ms step_avg:51.11ms
+step:1109/1575 train_time:56730ms step_avg:51.15ms
+step:1110/1575 train_time:56821ms step_avg:51.19ms
+step:1111/1575 train_time:56903ms step_avg:51.22ms
+step:1112/1575 train_time:56988ms step_avg:51.25ms
+step:1113/1575 train_time:57077ms step_avg:51.28ms
+step:1114/1575 train_time:57162ms step_avg:51.31ms
+step:1115/1575 train_time:57252ms step_avg:51.35ms
+step:1116/1575 train_time:57338ms step_avg:51.38ms
+step:1117/1575 train_time:57427ms step_avg:51.41ms
+step:1118/1575 train_time:57514ms step_avg:51.44ms
+step:1119/1575 train_time:57604ms step_avg:51.48ms
+step:1120/1575 train_time:57692ms step_avg:51.51ms
+step:1121/1575 train_time:57780ms step_avg:51.54ms
+step:1122/1575 train_time:57865ms step_avg:51.57ms
+step:1123/1575 train_time:57954ms step_avg:51.61ms
+step:1124/1575 train_time:58039ms step_avg:51.64ms
+step:1125/1575 train_time:58128ms step_avg:51.67ms
+step:1126/1575 train_time:58216ms step_avg:51.70ms
+step:1127/1575 train_time:58305ms step_avg:51.73ms
+step:1128/1575 train_time:58389ms step_avg:51.76ms
+step:1129/1575 train_time:58480ms step_avg:51.80ms
+step:1130/1575 train_time:58565ms step_avg:51.83ms
+step:1131/1575 train_time:58654ms step_avg:51.86ms
+step:1132/1575 train_time:58740ms step_avg:51.89ms
+step:1133/1575 train_time:58829ms step_avg:51.92ms
+step:1134/1575 train_time:58915ms step_avg:51.95ms
+step:1135/1575 train_time:59004ms step_avg:51.99ms
+step:1136/1575 train_time:59090ms step_avg:52.02ms
+step:1137/1575 train_time:59179ms step_avg:52.05ms
+step:1138/1575 train_time:59264ms step_avg:52.08ms
+step:1139/1575 train_time:59353ms step_avg:52.11ms
+step:1140/1575 train_time:59439ms step_avg:52.14ms
+step:1141/1575 train_time:59528ms step_avg:52.17ms
+step:1142/1575 train_time:59614ms step_avg:52.20ms
+step:1143/1575 train_time:59704ms step_avg:52.23ms
+step:1144/1575 train_time:59792ms step_avg:52.27ms
+step:1145/1575 train_time:59880ms step_avg:52.30ms
+step:1146/1575 train_time:59969ms step_avg:52.33ms
+step:1147/1575 train_time:60056ms step_avg:52.36ms
+step:1148/1575 train_time:60142ms step_avg:52.39ms
+step:1149/1575 train_time:60230ms step_avg:52.42ms
+step:1150/1575 train_time:60316ms step_avg:52.45ms
+step:1151/1575 train_time:60406ms step_avg:52.48ms
+step:1152/1575 train_time:60492ms step_avg:52.51ms
+step:1153/1575 train_time:60580ms step_avg:52.54ms
+step:1154/1575 train_time:60666ms step_avg:52.57ms
+step:1155/1575 train_time:60755ms step_avg:52.60ms
+step:1156/1575 train_time:60842ms step_avg:52.63ms
+step:1157/1575 train_time:60930ms step_avg:52.66ms
+step:1158/1575 train_time:61017ms step_avg:52.69ms
+step:1159/1575 train_time:61106ms step_avg:52.72ms
+step:1160/1575 train_time:61192ms step_avg:52.75ms
+step:1161/1575 train_time:61282ms step_avg:52.78ms
+step:1162/1575 train_time:61367ms step_avg:52.81ms
+step:1163/1575 train_time:61457ms step_avg:52.84ms
+step:1164/1575 train_time:61543ms step_avg:52.87ms
+step:1165/1575 train_time:61633ms step_avg:52.90ms
+step:1166/1575 train_time:61717ms step_avg:52.93ms
+step:1167/1575 train_time:61807ms step_avg:52.96ms
+step:1168/1575 train_time:61894ms step_avg:52.99ms
+step:1169/1575 train_time:61983ms step_avg:53.02ms
+step:1170/1575 train_time:62067ms step_avg:53.05ms
+step:1171/1575 train_time:62157ms step_avg:53.08ms
+step:1172/1575 train_time:62243ms step_avg:53.11ms
+step:1173/1575 train_time:62331ms step_avg:53.14ms
+step:1174/1575 train_time:62417ms step_avg:53.17ms
+step:1175/1575 train_time:62507ms step_avg:53.20ms
+step:1176/1575 train_time:62592ms step_avg:53.22ms
+step:1177/1575 train_time:62681ms step_avg:53.25ms
+step:1178/1575 train_time:62767ms step_avg:53.28ms
+step:1179/1575 train_time:62856ms step_avg:53.31ms
+step:1180/1575 train_time:62942ms step_avg:53.34ms
+step:1181/1575 train_time:63031ms step_avg:53.37ms
+step:1182/1575 train_time:63116ms step_avg:53.40ms
+step:1183/1575 train_time:63206ms step_avg:53.43ms
+step:1184/1575 train_time:63293ms step_avg:53.46ms
+step:1185/1575 train_time:63381ms step_avg:53.49ms
+step:1186/1575 train_time:63466ms step_avg:53.51ms
+step:1187/1575 train_time:63555ms step_avg:53.54ms
+step:1188/1575 train_time:63641ms step_avg:53.57ms
+step:1189/1575 train_time:63731ms step_avg:53.60ms
+step:1190/1575 train_time:63816ms step_avg:53.63ms
+step:1191/1575 train_time:63907ms step_avg:53.66ms
+step:1192/1575 train_time:63992ms step_avg:53.68ms
+step:1193/1575 train_time:64081ms step_avg:53.71ms
+step:1194/1575 train_time:64166ms step_avg:53.74ms
+step:1195/1575 train_time:64256ms step_avg:53.77ms
+step:1196/1575 train_time:64341ms step_avg:53.80ms
+step:1197/1575 train_time:64429ms step_avg:53.83ms
+step:1198/1575 train_time:64516ms step_avg:53.85ms
+step:1199/1575 train_time:64606ms step_avg:53.88ms
+step:1200/1575 train_time:64691ms step_avg:53.91ms
+step:1201/1575 train_time:64782ms step_avg:53.94ms
+step:1202/1575 train_time:64866ms step_avg:53.97ms
+step:1203/1575 train_time:64956ms step_avg:53.99ms
+step:1204/1575 train_time:65042ms step_avg:54.02ms
+step:1205/1575 train_time:65132ms step_avg:54.05ms
+step:1206/1575 train_time:65218ms step_avg:54.08ms
+step:1207/1575 train_time:65308ms step_avg:54.11ms
+step:1208/1575 train_time:65393ms step_avg:54.13ms
+step:1209/1575 train_time:65484ms step_avg:54.16ms
+step:1210/1575 train_time:65568ms step_avg:54.19ms
+step:1211/1575 train_time:65658ms step_avg:54.22ms
+step:1212/1575 train_time:65743ms step_avg:54.24ms
+step:1213/1575 train_time:65833ms step_avg:54.27ms
+step:1214/1575 train_time:65920ms step_avg:54.30ms
+step:1215/1575 train_time:66009ms step_avg:54.33ms
+step:1216/1575 train_time:66094ms step_avg:54.35ms
+step:1217/1575 train_time:66184ms step_avg:54.38ms
+step:1218/1575 train_time:66269ms step_avg:54.41ms
+step:1219/1575 train_time:66358ms step_avg:54.44ms
+step:1220/1575 train_time:66444ms step_avg:54.46ms
+step:1221/1575 train_time:66532ms step_avg:54.49ms
+step:1222/1575 train_time:66619ms step_avg:54.52ms
+step:1223/1575 train_time:66708ms step_avg:54.54ms
+step:1224/1575 train_time:66794ms step_avg:54.57ms
+step:1225/1575 train_time:66885ms step_avg:54.60ms
+step:1226/1575 train_time:66970ms step_avg:54.62ms
+step:1227/1575 train_time:67059ms step_avg:54.65ms
+step:1228/1575 train_time:67145ms step_avg:54.68ms
+step:1229/1575 train_time:67234ms step_avg:54.71ms
+step:1230/1575 train_time:67320ms step_avg:54.73ms
+step:1231/1575 train_time:67409ms step_avg:54.76ms
+step:1232/1575 train_time:67495ms step_avg:54.78ms
+step:1233/1575 train_time:67585ms step_avg:54.81ms
+step:1234/1575 train_time:67671ms step_avg:54.84ms
+step:1235/1575 train_time:67761ms step_avg:54.87ms
+step:1236/1575 train_time:67848ms step_avg:54.89ms
+step:1237/1575 train_time:67938ms step_avg:54.92ms
+step:1238/1575 train_time:68022ms step_avg:54.94ms
+step:1239/1575 train_time:68111ms step_avg:54.97ms
+step:1240/1575 train_time:68196ms step_avg:55.00ms
+step:1241/1575 train_time:68286ms step_avg:55.02ms
+step:1242/1575 train_time:68371ms step_avg:55.05ms
+step:1243/1575 train_time:68462ms step_avg:55.08ms
+step:1244/1575 train_time:68546ms step_avg:55.10ms
+step:1245/1575 train_time:68636ms step_avg:55.13ms
+step:1246/1575 train_time:68722ms step_avg:55.15ms
+step:1247/1575 train_time:68811ms step_avg:55.18ms
+step:1248/1575 train_time:68897ms step_avg:55.21ms
+step:1249/1575 train_time:68988ms step_avg:55.23ms
+step:1250/1575 train_time:69074ms step_avg:55.26ms
+step:1250/1575 val_loss:3.4069 train_time:69146ms step_avg:55.32ms
+step:1251/1575 train_time:69167ms step_avg:55.29ms
+step:1252/1575 train_time:69253ms step_avg:55.31ms
+step:1253/1575 train_time:69348ms step_avg:55.35ms
+step:1254/1575 train_time:69434ms step_avg:55.37ms
+step:1255/1575 train_time:69524ms step_avg:55.40ms
+step:1256/1575 train_time:69609ms step_avg:55.42ms
+step:1257/1575 train_time:69697ms step_avg:55.45ms
+step:1258/1575 train_time:69781ms step_avg:55.47ms
+step:1259/1575 train_time:69869ms step_avg:55.50ms
+step:1260/1575 train_time:69954ms step_avg:55.52ms
+step:1261/1575 train_time:70043ms step_avg:55.55ms
+step:1262/1575 train_time:70129ms step_avg:55.57ms
+step:1263/1575 train_time:70222ms step_avg:55.60ms
+step:1264/1575 train_time:70310ms step_avg:55.62ms
+step:1265/1575 train_time:70401ms step_avg:55.65ms
+step:1266/1575 train_time:70486ms step_avg:55.68ms
+step:1267/1575 train_time:70575ms step_avg:55.70ms
+step:1268/1575 train_time:70660ms step_avg:55.73ms
+step:1269/1575 train_time:70748ms step_avg:55.75ms
+step:1270/1575 train_time:70834ms step_avg:55.77ms
+step:1271/1575 train_time:70922ms step_avg:55.80ms
+step:1272/1575 train_time:71007ms step_avg:55.82ms
+step:1273/1575 train_time:71096ms step_avg:55.85ms
+step:1274/1575 train_time:71183ms step_avg:55.87ms
+step:1275/1575 train_time:71274ms step_avg:55.90ms
+step:1276/1575 train_time:71360ms step_avg:55.92ms
+step:1277/1575 train_time:71451ms step_avg:55.95ms
+step:1278/1575 train_time:71537ms step_avg:55.98ms
+step:1279/1575 train_time:71625ms step_avg:56.00ms
+step:1280/1575 train_time:71712ms step_avg:56.02ms
+step:1281/1575 train_time:71802ms step_avg:56.05ms
+step:1282/1575 train_time:71887ms step_avg:56.07ms
+step:1283/1575 train_time:71975ms step_avg:56.10ms
+step:1284/1575 train_time:72060ms step_avg:56.12ms
+step:1285/1575 train_time:72149ms step_avg:56.15ms
+step:1286/1575 train_time:72236ms step_avg:56.17ms
+step:1287/1575 train_time:72327ms step_avg:56.20ms
+step:1288/1575 train_time:72414ms step_avg:56.22ms
+step:1289/1575 train_time:72504ms step_avg:56.25ms
+step:1290/1575 train_time:72590ms step_avg:56.27ms
+step:1291/1575 train_time:72682ms step_avg:56.30ms
+step:1292/1575 train_time:72765ms step_avg:56.32ms
+step:1293/1575 train_time:72854ms step_avg:56.35ms
+step:1294/1575 train_time:72940ms step_avg:56.37ms
+step:1295/1575 train_time:73028ms step_avg:56.39ms
+step:1296/1575 train_time:73116ms step_avg:56.42ms
+step:1297/1575 train_time:73204ms step_avg:56.44ms
+step:1298/1575 train_time:73291ms step_avg:56.46ms
+step:1299/1575 train_time:73381ms step_avg:56.49ms
+step:1300/1575 train_time:73467ms step_avg:56.51ms
+step:1301/1575 train_time:73557ms step_avg:56.54ms
+step:1302/1575 train_time:73643ms step_avg:56.56ms
+step:1303/1575 train_time:73732ms step_avg:56.59ms
+step:1304/1575 train_time:73818ms step_avg:56.61ms
+step:1305/1575 train_time:73906ms step_avg:56.63ms
+step:1306/1575 train_time:73992ms step_avg:56.66ms
+step:1307/1575 train_time:74081ms step_avg:56.68ms
+step:1308/1575 train_time:74166ms step_avg:56.70ms
+step:1309/1575 train_time:74256ms step_avg:56.73ms
+step:1310/1575 train_time:74342ms step_avg:56.75ms
+step:1311/1575 train_time:74432ms step_avg:56.78ms
+step:1312/1575 train_time:74518ms step_avg:56.80ms
+step:1313/1575 train_time:74608ms step_avg:56.82ms
+step:1314/1575 train_time:74693ms step_avg:56.84ms
+step:1315/1575 train_time:74782ms step_avg:56.87ms
+step:1316/1575 train_time:74868ms step_avg:56.89ms
+step:1317/1575 train_time:74957ms step_avg:56.91ms
+step:1318/1575 train_time:75042ms step_avg:56.94ms
+step:1319/1575 train_time:75132ms step_avg:56.96ms
+step:1320/1575 train_time:75218ms step_avg:56.98ms
+step:1321/1575 train_time:75307ms step_avg:57.01ms
+step:1322/1575 train_time:75394ms step_avg:57.03ms
+step:1323/1575 train_time:75483ms step_avg:57.05ms
+step:1324/1575 train_time:75569ms step_avg:57.08ms
+step:1325/1575 train_time:75659ms step_avg:57.10ms
+step:1326/1575 train_time:75745ms step_avg:57.12ms
+step:1327/1575 train_time:75834ms step_avg:57.15ms
+step:1328/1575 train_time:75919ms step_avg:57.17ms
+step:1329/1575 train_time:76008ms step_avg:57.19ms
+step:1330/1575 train_time:76095ms step_avg:57.21ms
+step:1331/1575 train_time:76184ms step_avg:57.24ms
+step:1332/1575 train_time:76270ms step_avg:57.26ms
+step:1333/1575 train_time:76360ms step_avg:57.28ms
+step:1334/1575 train_time:76445ms step_avg:57.31ms
+step:1335/1575 train_time:76534ms step_avg:57.33ms
+step:1336/1575 train_time:76621ms step_avg:57.35ms
+step:1337/1575 train_time:76710ms step_avg:57.37ms
+step:1338/1575 train_time:76795ms step_avg:57.40ms
+step:1339/1575 train_time:76885ms step_avg:57.42ms
+step:1340/1575 train_time:76971ms step_avg:57.44ms
+step:1341/1575 train_time:77061ms step_avg:57.47ms
+step:1342/1575 train_time:77146ms step_avg:57.49ms
+step:1343/1575 train_time:77236ms step_avg:57.51ms
+step:1344/1575 train_time:77321ms step_avg:57.53ms
+step:1345/1575 train_time:77411ms step_avg:57.55ms
+step:1346/1575 train_time:77497ms step_avg:57.58ms
+step:1347/1575 train_time:77587ms step_avg:57.60ms
+step:1348/1575 train_time:77673ms step_avg:57.62ms
+step:1349/1575 train_time:77763ms step_avg:57.65ms
+step:1350/1575 train_time:77848ms step_avg:57.67ms
+step:1351/1575 train_time:77937ms step_avg:57.69ms
+step:1352/1575 train_time:78022ms step_avg:57.71ms
+step:1353/1575 train_time:78111ms step_avg:57.73ms
+step:1354/1575 train_time:78198ms step_avg:57.75ms
+step:1355/1575 train_time:78286ms step_avg:57.78ms
+step:1356/1575 train_time:78372ms step_avg:57.80ms
+step:1357/1575 train_time:78462ms step_avg:57.82ms
+step:1358/1575 train_time:78552ms step_avg:57.84ms
+step:1359/1575 train_time:78639ms step_avg:57.87ms
+step:1360/1575 train_time:78725ms step_avg:57.89ms
+step:1361/1575 train_time:78813ms step_avg:57.91ms
+step:1362/1575 train_time:78900ms step_avg:57.93ms
+step:1363/1575 train_time:78988ms step_avg:57.95ms
+step:1364/1575 train_time:79074ms step_avg:57.97ms
+step:1365/1575 train_time:79163ms step_avg:58.00ms
+step:1366/1575 train_time:79249ms step_avg:58.02ms
+step:1367/1575 train_time:79339ms step_avg:58.04ms
+step:1368/1575 train_time:79425ms step_avg:58.06ms
+step:1369/1575 train_time:79514ms step_avg:58.08ms
+step:1370/1575 train_time:79600ms step_avg:58.10ms
+step:1371/1575 train_time:79689ms step_avg:58.13ms
+step:1372/1575 train_time:79775ms step_avg:58.15ms
+step:1373/1575 train_time:79865ms step_avg:58.17ms
+step:1374/1575 train_time:79950ms step_avg:58.19ms
+step:1375/1575 train_time:80040ms step_avg:58.21ms
+step:1376/1575 train_time:80127ms step_avg:58.23ms
+step:1377/1575 train_time:80215ms step_avg:58.25ms
+step:1378/1575 train_time:80300ms step_avg:58.27ms
+step:1379/1575 train_time:80393ms step_avg:58.30ms
+step:1380/1575 train_time:80478ms step_avg:58.32ms
+step:1381/1575 train_time:80566ms step_avg:58.34ms
+step:1382/1575 train_time:80652ms step_avg:58.36ms
+step:1383/1575 train_time:80741ms step_avg:58.38ms
+step:1384/1575 train_time:80826ms step_avg:58.40ms
+step:1385/1575 train_time:80916ms step_avg:58.42ms
+step:1386/1575 train_time:81002ms step_avg:58.44ms
+step:1387/1575 train_time:81092ms step_avg:58.47ms
+step:1388/1575 train_time:81177ms step_avg:58.49ms
+step:1389/1575 train_time:81266ms step_avg:58.51ms
+step:1390/1575 train_time:81352ms step_avg:58.53ms
+step:1391/1575 train_time:81441ms step_avg:58.55ms
+step:1392/1575 train_time:81527ms step_avg:58.57ms
+step:1393/1575 train_time:81617ms step_avg:58.59ms
+step:1394/1575 train_time:81702ms step_avg:58.61ms
+step:1395/1575 train_time:81791ms step_avg:58.63ms
+step:1396/1575 train_time:81877ms step_avg:58.65ms
+step:1397/1575 train_time:81968ms step_avg:58.67ms
+step:1398/1575 train_time:82053ms step_avg:58.69ms
+step:1399/1575 train_time:82143ms step_avg:58.72ms
+step:1400/1575 train_time:82229ms step_avg:58.74ms
+step:1401/1575 train_time:82319ms step_avg:58.76ms
+step:1402/1575 train_time:82404ms step_avg:58.78ms
+step:1403/1575 train_time:82494ms step_avg:58.80ms
+step:1404/1575 train_time:82579ms step_avg:58.82ms
+step:1405/1575 train_time:82668ms step_avg:58.84ms
+step:1406/1575 train_time:82755ms step_avg:58.86ms
+step:1407/1575 train_time:82845ms step_avg:58.88ms
+step:1408/1575 train_time:82933ms step_avg:58.90ms
+step:1409/1575 train_time:83019ms step_avg:58.92ms
+step:1410/1575 train_time:83104ms step_avg:58.94ms
+step:1411/1575 train_time:83194ms step_avg:58.96ms
+step:1412/1575 train_time:83280ms step_avg:58.98ms
+step:1413/1575 train_time:83369ms step_avg:59.00ms
+step:1414/1575 train_time:83456ms step_avg:59.02ms
+step:1415/1575 train_time:83543ms step_avg:59.04ms
+step:1416/1575 train_time:83630ms step_avg:59.06ms
+step:1417/1575 train_time:83720ms step_avg:59.08ms
+step:1418/1575 train_time:83805ms step_avg:59.10ms
+step:1419/1575 train_time:83895ms step_avg:59.12ms
+step:1420/1575 train_time:83982ms step_avg:59.14ms
+step:1421/1575 train_time:84071ms step_avg:59.16ms
+step:1422/1575 train_time:84157ms step_avg:59.18ms
+step:1423/1575 train_time:84246ms step_avg:59.20ms
+step:1424/1575 train_time:84333ms step_avg:59.22ms
+step:1425/1575 train_time:84422ms step_avg:59.24ms
+step:1426/1575 train_time:84507ms step_avg:59.26ms
+step:1427/1575 train_time:84597ms step_avg:59.28ms
+step:1428/1575 train_time:84682ms step_avg:59.30ms
+step:1429/1575 train_time:84772ms step_avg:59.32ms
+step:1430/1575 train_time:84858ms step_avg:59.34ms
+step:1431/1575 train_time:84947ms step_avg:59.36ms
+step:1432/1575 train_time:85034ms step_avg:59.38ms
+step:1433/1575 train_time:85124ms step_avg:59.40ms
+step:1434/1575 train_time:85209ms step_avg:59.42ms
+step:1435/1575 train_time:85301ms step_avg:59.44ms
+step:1436/1575 train_time:85386ms step_avg:59.46ms
+step:1437/1575 train_time:85475ms step_avg:59.48ms
+step:1438/1575 train_time:85561ms step_avg:59.50ms
+step:1439/1575 train_time:85650ms step_avg:59.52ms
+step:1440/1575 train_time:85736ms step_avg:59.54ms
+step:1441/1575 train_time:85829ms step_avg:59.56ms
+step:1442/1575 train_time:85912ms step_avg:59.58ms
+step:1443/1575 train_time:86000ms step_avg:59.60ms
+step:1444/1575 train_time:86086ms step_avg:59.62ms
+step:1445/1575 train_time:86175ms step_avg:59.64ms
+step:1446/1575 train_time:86261ms step_avg:59.65ms
+step:1447/1575 train_time:86351ms step_avg:59.68ms
+step:1448/1575 train_time:86436ms step_avg:59.69ms
+step:1449/1575 train_time:86525ms step_avg:59.71ms
+step:1450/1575 train_time:86611ms step_avg:59.73ms
+step:1451/1575 train_time:86700ms step_avg:59.75ms
+step:1452/1575 train_time:86786ms step_avg:59.77ms
+step:1453/1575 train_time:86878ms step_avg:59.79ms
+step:1454/1575 train_time:86963ms step_avg:59.81ms
+step:1455/1575 train_time:87051ms step_avg:59.83ms
+step:1456/1575 train_time:87138ms step_avg:59.85ms
+step:1457/1575 train_time:87228ms step_avg:59.87ms
+step:1458/1575 train_time:87314ms step_avg:59.89ms
+step:1459/1575 train_time:87404ms step_avg:59.91ms
+step:1460/1575 train_time:87491ms step_avg:59.93ms
+step:1461/1575 train_time:87579ms step_avg:59.94ms
+step:1462/1575 train_time:87665ms step_avg:59.96ms
+step:1463/1575 train_time:87753ms step_avg:59.98ms
+step:1464/1575 train_time:87839ms step_avg:60.00ms
+step:1465/1575 train_time:87928ms step_avg:60.02ms
+step:1466/1575 train_time:88016ms step_avg:60.04ms
+step:1467/1575 train_time:88104ms step_avg:60.06ms
+step:1468/1575 train_time:88191ms step_avg:60.08ms
+step:1469/1575 train_time:88280ms step_avg:60.10ms
+step:1470/1575 train_time:88365ms step_avg:60.11ms
+step:1471/1575 train_time:88455ms step_avg:60.13ms
+step:1472/1575 train_time:88541ms step_avg:60.15ms
+step:1473/1575 train_time:88631ms step_avg:60.17ms
+step:1474/1575 train_time:88717ms step_avg:60.19ms
+step:1475/1575 train_time:88806ms step_avg:60.21ms
+step:1476/1575 train_time:88892ms step_avg:60.22ms
+step:1477/1575 train_time:88982ms step_avg:60.25ms
+step:1478/1575 train_time:89068ms step_avg:60.26ms
+step:1479/1575 train_time:89158ms step_avg:60.28ms
+step:1480/1575 train_time:89244ms step_avg:60.30ms
+step:1481/1575 train_time:89333ms step_avg:60.32ms
+step:1482/1575 train_time:89419ms step_avg:60.34ms
+step:1483/1575 train_time:89508ms step_avg:60.36ms
+step:1484/1575 train_time:89594ms step_avg:60.37ms
+step:1485/1575 train_time:89684ms step_avg:60.39ms
+step:1486/1575 train_time:89770ms step_avg:60.41ms
+step:1487/1575 train_time:89860ms step_avg:60.43ms
+step:1488/1575 train_time:89945ms step_avg:60.45ms
+step:1489/1575 train_time:90036ms step_avg:60.47ms
+step:1490/1575 train_time:90121ms step_avg:60.48ms
+step:1491/1575 train_time:90212ms step_avg:60.50ms
+step:1492/1575 train_time:90297ms step_avg:60.52ms
+step:1493/1575 train_time:90385ms step_avg:60.54ms
+step:1494/1575 train_time:90472ms step_avg:60.56ms
+step:1495/1575 train_time:90562ms step_avg:60.58ms
+step:1496/1575 train_time:90648ms step_avg:60.59ms
+step:1497/1575 train_time:90737ms step_avg:60.61ms
+step:1498/1575 train_time:90823ms step_avg:60.63ms
+step:1499/1575 train_time:90912ms step_avg:60.65ms
+step:1500/1575 train_time:90998ms step_avg:60.67ms
+step:1500/1575 val_loss:3.3014 train_time:91070ms step_avg:60.71ms
+step:1501/1575 train_time:91091ms step_avg:60.69ms
+step:1502/1575 train_time:91179ms step_avg:60.70ms
+step:1503/1575 train_time:91273ms step_avg:60.73ms
+step:1504/1575 train_time:91359ms step_avg:60.74ms
+step:1505/1575 train_time:91448ms step_avg:60.76ms
+step:1506/1575 train_time:91533ms step_avg:60.78ms
+step:1507/1575 train_time:91622ms step_avg:60.80ms
+step:1508/1575 train_time:91706ms step_avg:60.81ms
+step:1509/1575 train_time:91794ms step_avg:60.83ms
+step:1510/1575 train_time:91879ms step_avg:60.85ms
+step:1511/1575 train_time:91967ms step_avg:60.86ms
+step:1512/1575 train_time:92053ms step_avg:60.88ms
+step:1513/1575 train_time:92145ms step_avg:60.90ms
+step:1514/1575 train_time:92235ms step_avg:60.92ms
+step:1515/1575 train_time:92325ms step_avg:60.94ms
+step:1516/1575 train_time:92411ms step_avg:60.96ms
+step:1517/1575 train_time:92500ms step_avg:60.98ms
+step:1518/1575 train_time:92585ms step_avg:60.99ms
+step:1519/1575 train_time:92674ms step_avg:61.01ms
+step:1520/1575 train_time:92760ms step_avg:61.03ms
+step:1521/1575 train_time:92848ms step_avg:61.04ms
+step:1522/1575 train_time:92933ms step_avg:61.06ms
+step:1523/1575 train_time:93023ms step_avg:61.08ms
+step:1524/1575 train_time:93109ms step_avg:61.09ms
+step:1525/1575 train_time:93200ms step_avg:61.11ms
+step:1526/1575 train_time:93286ms step_avg:61.13ms
+step:1527/1575 train_time:93377ms step_avg:61.15ms
+step:1528/1575 train_time:93462ms step_avg:61.17ms
+step:1529/1575 train_time:93551ms step_avg:61.18ms
+step:1530/1575 train_time:93636ms step_avg:61.20ms
+step:1531/1575 train_time:93727ms step_avg:61.22ms
+step:1532/1575 train_time:93811ms step_avg:61.23ms
+step:1533/1575 train_time:93899ms step_avg:61.25ms
+step:1534/1575 train_time:93984ms step_avg:61.27ms
+step:1535/1575 train_time:94074ms step_avg:61.29ms
+step:1536/1575 train_time:94167ms step_avg:61.31ms
+step:1537/1575 train_time:94257ms step_avg:61.33ms
+step:1538/1575 train_time:94343ms step_avg:61.34ms
+step:1539/1575 train_time:94433ms step_avg:61.36ms
+step:1540/1575 train_time:94519ms step_avg:61.38ms
+step:1541/1575 train_time:94610ms step_avg:61.40ms
+step:1542/1575 train_time:94694ms step_avg:61.41ms
+step:1543/1575 train_time:94784ms step_avg:61.43ms
+step:1544/1575 train_time:94869ms step_avg:61.44ms
+step:1545/1575 train_time:94958ms step_avg:61.46ms
+step:1546/1575 train_time:95043ms step_avg:61.48ms
+step:1547/1575 train_time:95134ms step_avg:61.50ms
+step:1548/1575 train_time:95221ms step_avg:61.51ms
+step:1549/1575 train_time:95311ms step_avg:61.53ms
+step:1550/1575 train_time:95398ms step_avg:61.55ms
+step:1551/1575 train_time:95487ms step_avg:61.57ms
+step:1552/1575 train_time:95573ms step_avg:61.58ms
+step:1553/1575 train_time:95663ms step_avg:61.60ms
+step:1554/1575 train_time:95751ms step_avg:61.62ms
+step:1555/1575 train_time:95838ms step_avg:61.63ms
+step:1556/1575 train_time:95923ms step_avg:61.65ms
+step:1557/1575 train_time:96013ms step_avg:61.67ms
+step:1558/1575 train_time:96102ms step_avg:61.68ms
+step:1559/1575 train_time:96190ms step_avg:61.70ms
+step:1560/1575 train_time:96276ms step_avg:61.72ms
+step:1561/1575 train_time:96366ms step_avg:61.73ms
+step:1562/1575 train_time:96453ms step_avg:61.75ms
+step:1563/1575 train_time:96544ms step_avg:61.77ms
+step:1564/1575 train_time:96629ms step_avg:61.78ms
+step:1565/1575 train_time:96719ms step_avg:61.80ms
+step:1566/1575 train_time:96805ms step_avg:61.82ms
+step:1567/1575 train_time:96895ms step_avg:61.83ms
+step:1568/1575 train_time:96980ms step_avg:61.85ms
+step:1569/1575 train_time:97073ms step_avg:61.87ms
+step:1570/1575 train_time:97158ms step_avg:61.88ms
+step:1571/1575 train_time:97247ms step_avg:61.90ms
+step:1572/1575 train_time:97333ms step_avg:61.92ms
+step:1573/1575 train_time:97424ms step_avg:61.94ms
+step:1574/1575 train_time:97509ms step_avg:61.95ms
+step:1575/1575 train_time:97599ms step_avg:61.97ms
+step:1575/1575 val_loss:3.2799 train_time:97666ms step_avg:62.01ms
+peak memory allocated: 31016 MiB reserved: 46998 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/86ec30c7-06e7-464f-b072-b5313be5e9cd.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/86ec30c7-06e7-464f-b072-b5313be5e9cd.txt
@@ -1,0 +1,4119 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 03:13:19 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   41C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            131W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   39C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          292044      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          292045      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          292046      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          292047      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          292048      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          292049      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          292050      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          292051      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8302 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:82ms step_avg:81.99ms
+step:2/1600 train_time:102ms step_avg:50.78ms
+step:3/1600 train_time:119ms step_avg:39.63ms
+step:4/1600 train_time:153ms step_avg:38.22ms
+step:5/1600 train_time:184ms step_avg:36.70ms
+step:6/1600 train_time:284ms step_avg:47.29ms
+step:7/1600 train_time:300ms step_avg:42.86ms
+step:8/1600 train_time:326ms step_avg:40.69ms
+step:9/1600 train_time:356ms step_avg:39.57ms
+step:10/1600 train_time:393ms step_avg:39.31ms
+step:11/1600 train_time:424ms step_avg:38.57ms
+step:12/1600 train_time:461ms step_avg:38.44ms
+step:13/1600 train_time:492ms step_avg:37.86ms
+step:14/1600 train_time:529ms step_avg:37.79ms
+step:15/1600 train_time:560ms step_avg:37.35ms
+step:16/1600 train_time:597ms step_avg:37.33ms
+step:17/1600 train_time:629ms step_avg:36.97ms
+step:18/1600 train_time:665ms step_avg:36.97ms
+step:19/1600 train_time:696ms step_avg:36.65ms
+step:20/1600 train_time:734ms step_avg:36.71ms
+step:21/1600 train_time:765ms step_avg:36.42ms
+step:22/1600 train_time:802ms step_avg:36.45ms
+step:23/1600 train_time:833ms step_avg:36.21ms
+step:24/1600 train_time:870ms step_avg:36.24ms
+step:25/1600 train_time:901ms step_avg:36.03ms
+step:26/1600 train_time:938ms step_avg:36.08ms
+step:27/1600 train_time:969ms step_avg:35.90ms
+step:28/1600 train_time:1006ms step_avg:35.93ms
+step:29/1600 train_time:1037ms step_avg:35.76ms
+step:30/1600 train_time:1074ms step_avg:35.80ms
+step:31/1600 train_time:1105ms step_avg:35.66ms
+step:32/1600 train_time:1142ms step_avg:35.69ms
+step:33/1600 train_time:1173ms step_avg:35.55ms
+step:34/1600 train_time:1210ms step_avg:35.59ms
+step:35/1600 train_time:1241ms step_avg:35.46ms
+step:36/1600 train_time:1278ms step_avg:35.51ms
+step:37/1600 train_time:1309ms step_avg:35.38ms
+step:38/1600 train_time:1346ms step_avg:35.43ms
+step:39/1600 train_time:1378ms step_avg:35.32ms
+step:40/1600 train_time:1415ms step_avg:35.38ms
+step:41/1600 train_time:1446ms step_avg:35.27ms
+step:42/1600 train_time:1483ms step_avg:35.31ms
+step:43/1600 train_time:1514ms step_avg:35.21ms
+step:44/1600 train_time:1551ms step_avg:35.25ms
+step:45/1600 train_time:1582ms step_avg:35.15ms
+step:46/1600 train_time:1619ms step_avg:35.20ms
+step:47/1600 train_time:1650ms step_avg:35.11ms
+step:48/1600 train_time:1687ms step_avg:35.14ms
+step:49/1600 train_time:1718ms step_avg:35.06ms
+step:50/1600 train_time:1755ms step_avg:35.10ms
+step:51/1600 train_time:1786ms step_avg:35.02ms
+step:52/1600 train_time:1823ms step_avg:35.07ms
+step:53/1600 train_time:1854ms step_avg:34.99ms
+step:54/1600 train_time:1892ms step_avg:35.04ms
+step:55/1600 train_time:1923ms step_avg:34.96ms
+step:56/1600 train_time:1960ms step_avg:35.00ms
+step:57/1600 train_time:1991ms step_avg:34.93ms
+step:58/1600 train_time:2028ms step_avg:34.96ms
+step:59/1600 train_time:2059ms step_avg:34.90ms
+step:60/1600 train_time:2096ms step_avg:34.94ms
+step:61/1600 train_time:2127ms step_avg:34.87ms
+step:62/1600 train_time:2164ms step_avg:34.90ms
+step:63/1600 train_time:2195ms step_avg:34.84ms
+step:64/1600 train_time:2232ms step_avg:34.88ms
+step:65/1600 train_time:2263ms step_avg:34.82ms
+step:66/1600 train_time:2300ms step_avg:34.85ms
+step:67/1600 train_time:2331ms step_avg:34.79ms
+step:68/1600 train_time:2368ms step_avg:34.82ms
+step:69/1600 train_time:2399ms step_avg:34.77ms
+step:70/1600 train_time:2437ms step_avg:34.82ms
+step:71/1600 train_time:2468ms step_avg:34.75ms
+step:72/1600 train_time:2505ms step_avg:34.79ms
+step:73/1600 train_time:2535ms step_avg:34.73ms
+step:74/1600 train_time:2572ms step_avg:34.76ms
+step:75/1600 train_time:2603ms step_avg:34.70ms
+step:76/1600 train_time:2640ms step_avg:34.73ms
+step:77/1600 train_time:2671ms step_avg:34.68ms
+step:78/1600 train_time:2707ms step_avg:34.71ms
+step:79/1600 train_time:2739ms step_avg:34.67ms
+step:80/1600 train_time:2776ms step_avg:34.69ms
+step:81/1600 train_time:2807ms step_avg:34.65ms
+step:82/1600 train_time:2844ms step_avg:34.68ms
+step:83/1600 train_time:2875ms step_avg:34.64ms
+step:84/1600 train_time:2913ms step_avg:34.68ms
+step:85/1600 train_time:2944ms step_avg:34.63ms
+step:86/1600 train_time:2980ms step_avg:34.66ms
+step:87/1600 train_time:3011ms step_avg:34.61ms
+step:88/1600 train_time:3048ms step_avg:34.64ms
+step:89/1600 train_time:3079ms step_avg:34.60ms
+step:90/1600 train_time:3117ms step_avg:34.63ms
+step:91/1600 train_time:3148ms step_avg:34.60ms
+step:92/1600 train_time:3185ms step_avg:34.62ms
+step:93/1600 train_time:3216ms step_avg:34.59ms
+step:94/1600 train_time:3253ms step_avg:34.61ms
+step:95/1600 train_time:3284ms step_avg:34.57ms
+step:96/1600 train_time:3322ms step_avg:34.60ms
+step:97/1600 train_time:3352ms step_avg:34.56ms
+step:98/1600 train_time:3389ms step_avg:34.58ms
+step:99/1600 train_time:3421ms step_avg:34.55ms
+step:100/1600 train_time:3457ms step_avg:34.57ms
+step:101/1600 train_time:3489ms step_avg:34.54ms
+step:102/1600 train_time:3526ms step_avg:34.57ms
+step:103/1600 train_time:3557ms step_avg:34.53ms
+step:104/1600 train_time:3594ms step_avg:34.56ms
+step:105/1600 train_time:3624ms step_avg:34.52ms
+step:106/1600 train_time:3662ms step_avg:34.55ms
+step:107/1600 train_time:3693ms step_avg:34.51ms
+step:108/1600 train_time:3730ms step_avg:34.54ms
+step:109/1600 train_time:3761ms step_avg:34.51ms
+step:110/1600 train_time:3798ms step_avg:34.53ms
+step:111/1600 train_time:3829ms step_avg:34.50ms
+step:112/1600 train_time:3866ms step_avg:34.52ms
+step:113/1600 train_time:3897ms step_avg:34.49ms
+step:114/1600 train_time:3934ms step_avg:34.51ms
+step:115/1600 train_time:3965ms step_avg:34.48ms
+step:116/1600 train_time:4001ms step_avg:34.50ms
+step:117/1600 train_time:4033ms step_avg:34.47ms
+step:118/1600 train_time:4070ms step_avg:34.49ms
+step:119/1600 train_time:4101ms step_avg:34.46ms
+step:120/1600 train_time:4138ms step_avg:34.48ms
+step:121/1600 train_time:4169ms step_avg:34.45ms
+step:122/1600 train_time:4205ms step_avg:34.47ms
+step:123/1600 train_time:4237ms step_avg:34.45ms
+step:124/1600 train_time:4275ms step_avg:34.47ms
+step:125/1600 train_time:4306ms step_avg:34.45ms
+step:126/1600 train_time:4343ms step_avg:34.47ms
+step:127/1600 train_time:4374ms step_avg:34.44ms
+step:128/1600 train_time:4411ms step_avg:34.46ms
+step:129/1600 train_time:4442ms step_avg:34.43ms
+step:130/1600 train_time:4479ms step_avg:34.46ms
+step:131/1600 train_time:4510ms step_avg:34.43ms
+step:132/1600 train_time:4547ms step_avg:34.45ms
+step:133/1600 train_time:4579ms step_avg:34.43ms
+step:134/1600 train_time:4616ms step_avg:34.45ms
+step:135/1600 train_time:4647ms step_avg:34.42ms
+step:136/1600 train_time:4685ms step_avg:34.45ms
+step:137/1600 train_time:4716ms step_avg:34.42ms
+step:138/1600 train_time:4752ms step_avg:34.44ms
+step:139/1600 train_time:4783ms step_avg:34.41ms
+step:140/1600 train_time:4820ms step_avg:34.43ms
+step:141/1600 train_time:4851ms step_avg:34.40ms
+step:142/1600 train_time:4887ms step_avg:34.42ms
+step:143/1600 train_time:4919ms step_avg:34.40ms
+step:144/1600 train_time:4956ms step_avg:34.41ms
+step:145/1600 train_time:4987ms step_avg:34.39ms
+step:146/1600 train_time:5023ms step_avg:34.41ms
+step:147/1600 train_time:5054ms step_avg:34.38ms
+step:148/1600 train_time:5091ms step_avg:34.40ms
+step:149/1600 train_time:5123ms step_avg:34.38ms
+step:150/1600 train_time:5160ms step_avg:34.40ms
+step:151/1600 train_time:5191ms step_avg:34.38ms
+step:152/1600 train_time:5228ms step_avg:34.39ms
+step:153/1600 train_time:5259ms step_avg:34.37ms
+step:154/1600 train_time:5296ms step_avg:34.39ms
+step:155/1600 train_time:5327ms step_avg:34.37ms
+step:156/1600 train_time:5364ms step_avg:34.38ms
+step:157/1600 train_time:5395ms step_avg:34.36ms
+step:158/1600 train_time:5432ms step_avg:34.38ms
+step:159/1600 train_time:5463ms step_avg:34.36ms
+step:160/1600 train_time:5500ms step_avg:34.38ms
+step:161/1600 train_time:5531ms step_avg:34.36ms
+step:162/1600 train_time:5568ms step_avg:34.37ms
+step:163/1600 train_time:5599ms step_avg:34.35ms
+step:164/1600 train_time:5637ms step_avg:34.37ms
+step:165/1600 train_time:5668ms step_avg:34.35ms
+step:166/1600 train_time:5705ms step_avg:34.37ms
+step:167/1600 train_time:5736ms step_avg:34.35ms
+step:168/1600 train_time:5773ms step_avg:34.36ms
+step:169/1600 train_time:5803ms step_avg:34.34ms
+step:170/1600 train_time:5840ms step_avg:34.35ms
+step:171/1600 train_time:5871ms step_avg:34.33ms
+step:172/1600 train_time:5908ms step_avg:34.35ms
+step:173/1600 train_time:5939ms step_avg:34.33ms
+step:174/1600 train_time:5976ms step_avg:34.34ms
+step:175/1600 train_time:6007ms step_avg:34.33ms
+step:176/1600 train_time:6044ms step_avg:34.34ms
+step:177/1600 train_time:6075ms step_avg:34.32ms
+step:178/1600 train_time:6112ms step_avg:34.33ms
+step:179/1600 train_time:6143ms step_avg:34.32ms
+step:180/1600 train_time:6179ms step_avg:34.33ms
+step:181/1600 train_time:6210ms step_avg:34.31ms
+step:182/1600 train_time:6247ms step_avg:34.33ms
+step:183/1600 train_time:6278ms step_avg:34.31ms
+step:184/1600 train_time:6315ms step_avg:34.32ms
+step:185/1600 train_time:6346ms step_avg:34.31ms
+step:186/1600 train_time:6383ms step_avg:34.32ms
+step:187/1600 train_time:6414ms step_avg:34.30ms
+step:188/1600 train_time:6452ms step_avg:34.32ms
+step:189/1600 train_time:6483ms step_avg:34.30ms
+step:190/1600 train_time:6520ms step_avg:34.31ms
+step:191/1600 train_time:6551ms step_avg:34.30ms
+step:192/1600 train_time:6588ms step_avg:34.31ms
+step:193/1600 train_time:6619ms step_avg:34.30ms
+step:194/1600 train_time:6657ms step_avg:34.31ms
+step:195/1600 train_time:6687ms step_avg:34.29ms
+step:196/1600 train_time:6724ms step_avg:34.31ms
+step:197/1600 train_time:6756ms step_avg:34.29ms
+step:198/1600 train_time:6792ms step_avg:34.30ms
+step:199/1600 train_time:6823ms step_avg:34.29ms
+step:200/1600 train_time:6860ms step_avg:34.30ms
+step:201/1600 train_time:6891ms step_avg:34.28ms
+step:202/1600 train_time:6927ms step_avg:34.29ms
+step:203/1600 train_time:6958ms step_avg:34.28ms
+step:204/1600 train_time:6995ms step_avg:34.29ms
+step:205/1600 train_time:7027ms step_avg:34.28ms
+step:206/1600 train_time:7064ms step_avg:34.29ms
+step:207/1600 train_time:7094ms step_avg:34.27ms
+step:208/1600 train_time:7131ms step_avg:34.28ms
+step:209/1600 train_time:7162ms step_avg:34.27ms
+step:210/1600 train_time:7199ms step_avg:34.28ms
+step:211/1600 train_time:7230ms step_avg:34.27ms
+step:212/1600 train_time:7267ms step_avg:34.28ms
+step:213/1600 train_time:7298ms step_avg:34.26ms
+step:214/1600 train_time:7335ms step_avg:34.28ms
+step:215/1600 train_time:7366ms step_avg:34.26ms
+step:216/1600 train_time:7403ms step_avg:34.27ms
+step:217/1600 train_time:7434ms step_avg:34.26ms
+step:218/1600 train_time:7470ms step_avg:34.27ms
+step:219/1600 train_time:7501ms step_avg:34.25ms
+step:220/1600 train_time:7538ms step_avg:34.26ms
+step:221/1600 train_time:7569ms step_avg:34.25ms
+step:222/1600 train_time:7606ms step_avg:34.26ms
+step:223/1600 train_time:7637ms step_avg:34.25ms
+step:224/1600 train_time:7674ms step_avg:34.26ms
+step:225/1600 train_time:7706ms step_avg:34.25ms
+step:226/1600 train_time:7743ms step_avg:34.26ms
+step:227/1600 train_time:7774ms step_avg:34.25ms
+step:228/1600 train_time:7810ms step_avg:34.26ms
+step:229/1600 train_time:7841ms step_avg:34.24ms
+step:230/1600 train_time:7879ms step_avg:34.25ms
+step:231/1600 train_time:7910ms step_avg:34.24ms
+step:232/1600 train_time:7946ms step_avg:34.25ms
+step:233/1600 train_time:7977ms step_avg:34.24ms
+step:234/1600 train_time:8014ms step_avg:34.25ms
+step:235/1600 train_time:8045ms step_avg:34.23ms
+step:236/1600 train_time:8082ms step_avg:34.25ms
+step:237/1600 train_time:8113ms step_avg:34.23ms
+step:238/1600 train_time:8150ms step_avg:34.24ms
+step:239/1600 train_time:8181ms step_avg:34.23ms
+step:240/1600 train_time:8219ms step_avg:34.24ms
+step:241/1600 train_time:8249ms step_avg:34.23ms
+step:242/1600 train_time:8286ms step_avg:34.24ms
+step:243/1600 train_time:8317ms step_avg:34.23ms
+step:244/1600 train_time:8355ms step_avg:34.24ms
+step:245/1600 train_time:8386ms step_avg:34.23ms
+step:246/1600 train_time:8423ms step_avg:34.24ms
+step:247/1600 train_time:8454ms step_avg:34.23ms
+step:248/1600 train_time:8491ms step_avg:34.24ms
+step:249/1600 train_time:8522ms step_avg:34.22ms
+step:250/1600 train_time:8559ms step_avg:34.24ms
+step:250/1600 val_loss:4.5909 train_time:8607ms step_avg:34.43ms
+step:251/1600 train_time:8625ms step_avg:34.36ms
+step:252/1600 train_time:8643ms step_avg:34.30ms
+step:253/1600 train_time:8663ms step_avg:34.24ms
+step:254/1600 train_time:8701ms step_avg:34.25ms
+step:255/1600 train_time:8732ms step_avg:34.25ms
+step:256/1600 train_time:8771ms step_avg:34.26ms
+step:257/1600 train_time:8802ms step_avg:34.25ms
+step:258/1600 train_time:8839ms step_avg:34.26ms
+step:259/1600 train_time:8870ms step_avg:34.25ms
+step:260/1600 train_time:8907ms step_avg:34.26ms
+step:261/1600 train_time:8938ms step_avg:34.24ms
+step:262/1600 train_time:8975ms step_avg:34.25ms
+step:263/1600 train_time:9005ms step_avg:34.24ms
+step:264/1600 train_time:9042ms step_avg:34.25ms
+step:265/1600 train_time:9073ms step_avg:34.24ms
+step:266/1600 train_time:9110ms step_avg:34.25ms
+step:267/1600 train_time:9141ms step_avg:34.24ms
+step:268/1600 train_time:9178ms step_avg:34.25ms
+step:269/1600 train_time:9209ms step_avg:34.23ms
+step:270/1600 train_time:9246ms step_avg:34.24ms
+step:271/1600 train_time:9276ms step_avg:34.23ms
+step:272/1600 train_time:9313ms step_avg:34.24ms
+step:273/1600 train_time:9344ms step_avg:34.23ms
+step:274/1600 train_time:9381ms step_avg:34.24ms
+step:275/1600 train_time:9412ms step_avg:34.22ms
+step:276/1600 train_time:9448ms step_avg:34.23ms
+step:277/1600 train_time:9479ms step_avg:34.22ms
+step:278/1600 train_time:9516ms step_avg:34.23ms
+step:279/1600 train_time:9547ms step_avg:34.22ms
+step:280/1600 train_time:9583ms step_avg:34.23ms
+step:281/1600 train_time:9614ms step_avg:34.21ms
+step:282/1600 train_time:9651ms step_avg:34.22ms
+step:283/1600 train_time:9682ms step_avg:34.21ms
+step:284/1600 train_time:9720ms step_avg:34.22ms
+step:285/1600 train_time:9751ms step_avg:34.21ms
+step:286/1600 train_time:9788ms step_avg:34.22ms
+step:287/1600 train_time:9819ms step_avg:34.21ms
+step:288/1600 train_time:9856ms step_avg:34.22ms
+step:289/1600 train_time:9887ms step_avg:34.21ms
+step:290/1600 train_time:9924ms step_avg:34.22ms
+step:291/1600 train_time:9955ms step_avg:34.21ms
+step:292/1600 train_time:9992ms step_avg:34.22ms
+step:293/1600 train_time:10022ms step_avg:34.21ms
+step:294/1600 train_time:10060ms step_avg:34.22ms
+step:295/1600 train_time:10090ms step_avg:34.20ms
+step:296/1600 train_time:10127ms step_avg:34.21ms
+step:297/1600 train_time:10158ms step_avg:34.20ms
+step:298/1600 train_time:10195ms step_avg:34.21ms
+step:299/1600 train_time:10226ms step_avg:34.20ms
+step:300/1600 train_time:10263ms step_avg:34.21ms
+step:301/1600 train_time:10294ms step_avg:34.20ms
+step:302/1600 train_time:10330ms step_avg:34.21ms
+step:303/1600 train_time:10361ms step_avg:34.20ms
+step:304/1600 train_time:10399ms step_avg:34.21ms
+step:305/1600 train_time:10429ms step_avg:34.19ms
+step:306/1600 train_time:10466ms step_avg:34.20ms
+step:307/1600 train_time:10497ms step_avg:34.19ms
+step:308/1600 train_time:10534ms step_avg:34.20ms
+step:309/1600 train_time:10565ms step_avg:34.19ms
+step:310/1600 train_time:10602ms step_avg:34.20ms
+step:311/1600 train_time:10633ms step_avg:34.19ms
+step:312/1600 train_time:10669ms step_avg:34.20ms
+step:313/1600 train_time:10700ms step_avg:34.19ms
+step:314/1600 train_time:10738ms step_avg:34.20ms
+step:315/1600 train_time:10768ms step_avg:34.19ms
+step:316/1600 train_time:10806ms step_avg:34.20ms
+step:317/1600 train_time:10837ms step_avg:34.19ms
+step:318/1600 train_time:10874ms step_avg:34.19ms
+step:319/1600 train_time:10905ms step_avg:34.19ms
+step:320/1600 train_time:10942ms step_avg:34.19ms
+step:321/1600 train_time:10973ms step_avg:34.18ms
+step:322/1600 train_time:11010ms step_avg:34.19ms
+step:323/1600 train_time:11041ms step_avg:34.18ms
+step:324/1600 train_time:11078ms step_avg:34.19ms
+step:325/1600 train_time:11109ms step_avg:34.18ms
+step:326/1600 train_time:11146ms step_avg:34.19ms
+step:327/1600 train_time:11177ms step_avg:34.18ms
+step:328/1600 train_time:11213ms step_avg:34.19ms
+step:329/1600 train_time:11244ms step_avg:34.18ms
+step:330/1600 train_time:11281ms step_avg:34.18ms
+step:331/1600 train_time:11312ms step_avg:34.17ms
+step:332/1600 train_time:11349ms step_avg:34.18ms
+step:333/1600 train_time:11380ms step_avg:34.17ms
+step:334/1600 train_time:11417ms step_avg:34.18ms
+step:335/1600 train_time:11448ms step_avg:34.17ms
+step:336/1600 train_time:11485ms step_avg:34.18ms
+step:337/1600 train_time:11516ms step_avg:34.17ms
+step:338/1600 train_time:11552ms step_avg:34.18ms
+step:339/1600 train_time:11583ms step_avg:34.17ms
+step:340/1600 train_time:11621ms step_avg:34.18ms
+step:341/1600 train_time:11652ms step_avg:34.17ms
+step:342/1600 train_time:11688ms step_avg:34.18ms
+step:343/1600 train_time:11719ms step_avg:34.17ms
+step:344/1600 train_time:11756ms step_avg:34.17ms
+step:345/1600 train_time:11787ms step_avg:34.17ms
+step:346/1600 train_time:11824ms step_avg:34.17ms
+step:347/1600 train_time:11855ms step_avg:34.16ms
+step:348/1600 train_time:11892ms step_avg:34.17ms
+step:349/1600 train_time:11922ms step_avg:34.16ms
+step:350/1600 train_time:11959ms step_avg:34.17ms
+step:351/1600 train_time:11991ms step_avg:34.16ms
+step:352/1600 train_time:12027ms step_avg:34.17ms
+step:353/1600 train_time:12059ms step_avg:34.16ms
+step:354/1600 train_time:12096ms step_avg:34.17ms
+step:355/1600 train_time:12126ms step_avg:34.16ms
+step:356/1600 train_time:12163ms step_avg:34.17ms
+step:357/1600 train_time:12194ms step_avg:34.16ms
+step:358/1600 train_time:12231ms step_avg:34.16ms
+step:359/1600 train_time:12262ms step_avg:34.16ms
+step:360/1600 train_time:12299ms step_avg:34.16ms
+step:361/1600 train_time:12330ms step_avg:34.15ms
+step:362/1600 train_time:12366ms step_avg:34.16ms
+step:363/1600 train_time:12397ms step_avg:34.15ms
+step:364/1600 train_time:12434ms step_avg:34.16ms
+step:365/1600 train_time:12465ms step_avg:34.15ms
+step:366/1600 train_time:12502ms step_avg:34.16ms
+step:367/1600 train_time:12533ms step_avg:34.15ms
+step:368/1600 train_time:12570ms step_avg:34.16ms
+step:369/1600 train_time:12601ms step_avg:34.15ms
+step:370/1600 train_time:12638ms step_avg:34.16ms
+step:371/1600 train_time:12669ms step_avg:34.15ms
+step:372/1600 train_time:12706ms step_avg:34.16ms
+step:373/1600 train_time:12737ms step_avg:34.15ms
+step:374/1600 train_time:12773ms step_avg:34.15ms
+step:375/1600 train_time:12804ms step_avg:34.14ms
+step:376/1600 train_time:12841ms step_avg:34.15ms
+step:377/1600 train_time:12872ms step_avg:34.14ms
+step:378/1600 train_time:12909ms step_avg:34.15ms
+step:379/1600 train_time:12940ms step_avg:34.14ms
+step:380/1600 train_time:12977ms step_avg:34.15ms
+step:381/1600 train_time:13008ms step_avg:34.14ms
+step:382/1600 train_time:13045ms step_avg:34.15ms
+step:383/1600 train_time:13076ms step_avg:34.14ms
+step:384/1600 train_time:13113ms step_avg:34.15ms
+step:385/1600 train_time:13144ms step_avg:34.14ms
+step:386/1600 train_time:13181ms step_avg:34.15ms
+step:387/1600 train_time:13212ms step_avg:34.14ms
+step:388/1600 train_time:13248ms step_avg:34.14ms
+step:389/1600 train_time:13279ms step_avg:34.14ms
+step:390/1600 train_time:13316ms step_avg:34.14ms
+step:391/1600 train_time:13347ms step_avg:34.14ms
+step:392/1600 train_time:13384ms step_avg:34.14ms
+step:393/1600 train_time:13414ms step_avg:34.13ms
+step:394/1600 train_time:13451ms step_avg:34.14ms
+step:395/1600 train_time:13482ms step_avg:34.13ms
+step:396/1600 train_time:13519ms step_avg:34.14ms
+step:397/1600 train_time:13550ms step_avg:34.13ms
+step:398/1600 train_time:13586ms step_avg:34.14ms
+step:399/1600 train_time:13618ms step_avg:34.13ms
+step:400/1600 train_time:13655ms step_avg:34.14ms
+step:401/1600 train_time:13686ms step_avg:34.13ms
+step:402/1600 train_time:13723ms step_avg:34.14ms
+step:403/1600 train_time:13754ms step_avg:34.13ms
+step:404/1600 train_time:13791ms step_avg:34.14ms
+step:405/1600 train_time:13822ms step_avg:34.13ms
+step:406/1600 train_time:13859ms step_avg:34.13ms
+step:407/1600 train_time:13890ms step_avg:34.13ms
+step:408/1600 train_time:13927ms step_avg:34.13ms
+step:409/1600 train_time:13958ms step_avg:34.13ms
+step:410/1600 train_time:13995ms step_avg:34.13ms
+step:411/1600 train_time:14026ms step_avg:34.13ms
+step:412/1600 train_time:14063ms step_avg:34.13ms
+step:413/1600 train_time:14094ms step_avg:34.13ms
+step:414/1600 train_time:14130ms step_avg:34.13ms
+step:415/1600 train_time:14161ms step_avg:34.12ms
+step:416/1600 train_time:14198ms step_avg:34.13ms
+step:417/1600 train_time:14229ms step_avg:34.12ms
+step:418/1600 train_time:14266ms step_avg:34.13ms
+step:419/1600 train_time:14297ms step_avg:34.12ms
+step:420/1600 train_time:14333ms step_avg:34.13ms
+step:421/1600 train_time:14365ms step_avg:34.12ms
+step:422/1600 train_time:14402ms step_avg:34.13ms
+step:423/1600 train_time:14433ms step_avg:34.12ms
+step:424/1600 train_time:14469ms step_avg:34.13ms
+step:425/1600 train_time:14501ms step_avg:34.12ms
+step:426/1600 train_time:14538ms step_avg:34.13ms
+step:427/1600 train_time:14568ms step_avg:34.12ms
+step:428/1600 train_time:14605ms step_avg:34.12ms
+step:429/1600 train_time:14636ms step_avg:34.12ms
+step:430/1600 train_time:14673ms step_avg:34.12ms
+step:431/1600 train_time:14704ms step_avg:34.12ms
+step:432/1600 train_time:14741ms step_avg:34.12ms
+step:433/1600 train_time:14772ms step_avg:34.11ms
+step:434/1600 train_time:14808ms step_avg:34.12ms
+step:435/1600 train_time:14839ms step_avg:34.11ms
+step:436/1600 train_time:14877ms step_avg:34.12ms
+step:437/1600 train_time:14907ms step_avg:34.11ms
+step:438/1600 train_time:14944ms step_avg:34.12ms
+step:439/1600 train_time:14975ms step_avg:34.11ms
+step:440/1600 train_time:15012ms step_avg:34.12ms
+step:441/1600 train_time:15043ms step_avg:34.11ms
+step:442/1600 train_time:15081ms step_avg:34.12ms
+step:443/1600 train_time:15111ms step_avg:34.11ms
+step:444/1600 train_time:15148ms step_avg:34.12ms
+step:445/1600 train_time:15180ms step_avg:34.11ms
+step:446/1600 train_time:15217ms step_avg:34.12ms
+step:447/1600 train_time:15249ms step_avg:34.11ms
+step:448/1600 train_time:15285ms step_avg:34.12ms
+step:449/1600 train_time:15316ms step_avg:34.11ms
+step:450/1600 train_time:15353ms step_avg:34.12ms
+step:451/1600 train_time:15384ms step_avg:34.11ms
+step:452/1600 train_time:15421ms step_avg:34.12ms
+step:453/1600 train_time:15452ms step_avg:34.11ms
+step:454/1600 train_time:15489ms step_avg:34.12ms
+step:455/1600 train_time:15520ms step_avg:34.11ms
+step:456/1600 train_time:15557ms step_avg:34.12ms
+step:457/1600 train_time:15588ms step_avg:34.11ms
+step:458/1600 train_time:15624ms step_avg:34.11ms
+step:459/1600 train_time:15655ms step_avg:34.11ms
+step:460/1600 train_time:15692ms step_avg:34.11ms
+step:461/1600 train_time:15723ms step_avg:34.11ms
+step:462/1600 train_time:15760ms step_avg:34.11ms
+step:463/1600 train_time:15791ms step_avg:34.11ms
+step:464/1600 train_time:15827ms step_avg:34.11ms
+step:465/1600 train_time:15858ms step_avg:34.10ms
+step:466/1600 train_time:15895ms step_avg:34.11ms
+step:467/1600 train_time:15926ms step_avg:34.10ms
+step:468/1600 train_time:15963ms step_avg:34.11ms
+step:469/1600 train_time:15994ms step_avg:34.10ms
+step:470/1600 train_time:16031ms step_avg:34.11ms
+step:471/1600 train_time:16062ms step_avg:34.10ms
+step:472/1600 train_time:16099ms step_avg:34.11ms
+step:473/1600 train_time:16130ms step_avg:34.10ms
+step:474/1600 train_time:16167ms step_avg:34.11ms
+step:475/1600 train_time:16198ms step_avg:34.10ms
+step:476/1600 train_time:16235ms step_avg:34.11ms
+step:477/1600 train_time:16266ms step_avg:34.10ms
+step:478/1600 train_time:16303ms step_avg:34.11ms
+step:479/1600 train_time:16334ms step_avg:34.10ms
+step:480/1600 train_time:16370ms step_avg:34.11ms
+step:481/1600 train_time:16402ms step_avg:34.10ms
+step:482/1600 train_time:16439ms step_avg:34.11ms
+step:483/1600 train_time:16470ms step_avg:34.10ms
+step:484/1600 train_time:16507ms step_avg:34.10ms
+step:485/1600 train_time:16537ms step_avg:34.10ms
+step:486/1600 train_time:16574ms step_avg:34.10ms
+step:487/1600 train_time:16605ms step_avg:34.10ms
+step:488/1600 train_time:16642ms step_avg:34.10ms
+step:489/1600 train_time:16673ms step_avg:34.10ms
+step:490/1600 train_time:16709ms step_avg:34.10ms
+step:491/1600 train_time:16740ms step_avg:34.09ms
+step:492/1600 train_time:16777ms step_avg:34.10ms
+step:493/1600 train_time:16808ms step_avg:34.09ms
+step:494/1600 train_time:16844ms step_avg:34.10ms
+step:495/1600 train_time:16875ms step_avg:34.09ms
+step:496/1600 train_time:16912ms step_avg:34.10ms
+step:497/1600 train_time:16943ms step_avg:34.09ms
+step:498/1600 train_time:16980ms step_avg:34.10ms
+step:499/1600 train_time:17011ms step_avg:34.09ms
+step:500/1600 train_time:17047ms step_avg:34.09ms
+step:500/1600 val_loss:4.2339 train_time:17095ms step_avg:34.19ms
+step:501/1600 train_time:17113ms step_avg:34.16ms
+step:502/1600 train_time:17133ms step_avg:34.13ms
+step:503/1600 train_time:17152ms step_avg:34.10ms
+step:504/1600 train_time:17186ms step_avg:34.10ms
+step:505/1600 train_time:17218ms step_avg:34.09ms
+step:506/1600 train_time:17256ms step_avg:34.10ms
+step:507/1600 train_time:17288ms step_avg:34.10ms
+step:508/1600 train_time:17325ms step_avg:34.10ms
+step:509/1600 train_time:17356ms step_avg:34.10ms
+step:510/1600 train_time:17393ms step_avg:34.10ms
+step:511/1600 train_time:17424ms step_avg:34.10ms
+step:512/1600 train_time:17461ms step_avg:34.10ms
+step:513/1600 train_time:17492ms step_avg:34.10ms
+step:514/1600 train_time:17529ms step_avg:34.10ms
+step:515/1600 train_time:17560ms step_avg:34.10ms
+step:516/1600 train_time:17596ms step_avg:34.10ms
+step:517/1600 train_time:17627ms step_avg:34.09ms
+step:518/1600 train_time:17664ms step_avg:34.10ms
+step:519/1600 train_time:17695ms step_avg:34.09ms
+step:520/1600 train_time:17731ms step_avg:34.10ms
+step:521/1600 train_time:17801ms step_avg:34.17ms
+step:522/1600 train_time:17857ms step_avg:34.21ms
+step:523/1600 train_time:17918ms step_avg:34.26ms
+step:524/1600 train_time:17976ms step_avg:34.31ms
+step:525/1600 train_time:18038ms step_avg:34.36ms
+step:526/1600 train_time:18097ms step_avg:34.40ms
+step:527/1600 train_time:18160ms step_avg:34.46ms
+step:528/1600 train_time:18219ms step_avg:34.51ms
+step:529/1600 train_time:18283ms step_avg:34.56ms
+step:530/1600 train_time:18343ms step_avg:34.61ms
+step:531/1600 train_time:18405ms step_avg:34.66ms
+step:532/1600 train_time:18465ms step_avg:34.71ms
+step:533/1600 train_time:18529ms step_avg:34.76ms
+step:534/1600 train_time:18586ms step_avg:34.81ms
+step:535/1600 train_time:18649ms step_avg:34.86ms
+step:536/1600 train_time:18708ms step_avg:34.90ms
+step:537/1600 train_time:18772ms step_avg:34.96ms
+step:538/1600 train_time:18831ms step_avg:35.00ms
+step:539/1600 train_time:18894ms step_avg:35.05ms
+step:540/1600 train_time:18952ms step_avg:35.10ms
+step:541/1600 train_time:19014ms step_avg:35.15ms
+step:542/1600 train_time:19072ms step_avg:35.19ms
+step:543/1600 train_time:19135ms step_avg:35.24ms
+step:544/1600 train_time:19194ms step_avg:35.28ms
+step:545/1600 train_time:19256ms step_avg:35.33ms
+step:546/1600 train_time:19315ms step_avg:35.38ms
+step:547/1600 train_time:19378ms step_avg:35.43ms
+step:548/1600 train_time:19438ms step_avg:35.47ms
+step:549/1600 train_time:19501ms step_avg:35.52ms
+step:550/1600 train_time:19560ms step_avg:35.56ms
+step:551/1600 train_time:19621ms step_avg:35.61ms
+step:552/1600 train_time:19680ms step_avg:35.65ms
+step:553/1600 train_time:19743ms step_avg:35.70ms
+step:554/1600 train_time:19802ms step_avg:35.74ms
+step:555/1600 train_time:19864ms step_avg:35.79ms
+step:556/1600 train_time:19923ms step_avg:35.83ms
+step:557/1600 train_time:19986ms step_avg:35.88ms
+step:558/1600 train_time:20045ms step_avg:35.92ms
+step:559/1600 train_time:20108ms step_avg:35.97ms
+step:560/1600 train_time:20167ms step_avg:36.01ms
+step:561/1600 train_time:20229ms step_avg:36.06ms
+step:562/1600 train_time:20288ms step_avg:36.10ms
+step:563/1600 train_time:20351ms step_avg:36.15ms
+step:564/1600 train_time:20411ms step_avg:36.19ms
+step:565/1600 train_time:20474ms step_avg:36.24ms
+step:566/1600 train_time:20533ms step_avg:36.28ms
+step:567/1600 train_time:20595ms step_avg:36.32ms
+step:568/1600 train_time:20654ms step_avg:36.36ms
+step:569/1600 train_time:20716ms step_avg:36.41ms
+step:570/1600 train_time:20774ms step_avg:36.45ms
+step:571/1600 train_time:20837ms step_avg:36.49ms
+step:572/1600 train_time:20896ms step_avg:36.53ms
+step:573/1600 train_time:20963ms step_avg:36.58ms
+step:574/1600 train_time:21019ms step_avg:36.62ms
+step:575/1600 train_time:21080ms step_avg:36.66ms
+step:576/1600 train_time:21138ms step_avg:36.70ms
+step:577/1600 train_time:21202ms step_avg:36.74ms
+step:578/1600 train_time:21260ms step_avg:36.78ms
+step:579/1600 train_time:21321ms step_avg:36.82ms
+step:580/1600 train_time:21380ms step_avg:36.86ms
+step:581/1600 train_time:21443ms step_avg:36.91ms
+step:582/1600 train_time:21502ms step_avg:36.94ms
+step:583/1600 train_time:21564ms step_avg:36.99ms
+step:584/1600 train_time:21623ms step_avg:37.03ms
+step:585/1600 train_time:21685ms step_avg:37.07ms
+step:586/1600 train_time:21744ms step_avg:37.11ms
+step:587/1600 train_time:21806ms step_avg:37.15ms
+step:588/1600 train_time:21866ms step_avg:37.19ms
+step:589/1600 train_time:21928ms step_avg:37.23ms
+step:590/1600 train_time:21990ms step_avg:37.27ms
+step:591/1600 train_time:22050ms step_avg:37.31ms
+step:592/1600 train_time:22111ms step_avg:37.35ms
+step:593/1600 train_time:22173ms step_avg:37.39ms
+step:594/1600 train_time:22232ms step_avg:37.43ms
+step:595/1600 train_time:22294ms step_avg:37.47ms
+step:596/1600 train_time:22353ms step_avg:37.51ms
+step:597/1600 train_time:22416ms step_avg:37.55ms
+step:598/1600 train_time:22474ms step_avg:37.58ms
+step:599/1600 train_time:22537ms step_avg:37.62ms
+step:600/1600 train_time:22596ms step_avg:37.66ms
+step:601/1600 train_time:22658ms step_avg:37.70ms
+step:602/1600 train_time:22718ms step_avg:37.74ms
+step:603/1600 train_time:22780ms step_avg:37.78ms
+step:604/1600 train_time:22838ms step_avg:37.81ms
+step:605/1600 train_time:22901ms step_avg:37.85ms
+step:606/1600 train_time:22960ms step_avg:37.89ms
+step:607/1600 train_time:23021ms step_avg:37.93ms
+step:608/1600 train_time:23080ms step_avg:37.96ms
+step:609/1600 train_time:23142ms step_avg:38.00ms
+step:610/1600 train_time:23201ms step_avg:38.03ms
+step:611/1600 train_time:23265ms step_avg:38.08ms
+step:612/1600 train_time:23323ms step_avg:38.11ms
+step:613/1600 train_time:23386ms step_avg:38.15ms
+step:614/1600 train_time:23446ms step_avg:38.19ms
+step:615/1600 train_time:23508ms step_avg:38.22ms
+step:616/1600 train_time:23567ms step_avg:38.26ms
+step:617/1600 train_time:23629ms step_avg:38.30ms
+step:618/1600 train_time:23689ms step_avg:38.33ms
+step:619/1600 train_time:23751ms step_avg:38.37ms
+step:620/1600 train_time:23813ms step_avg:38.41ms
+step:621/1600 train_time:23877ms step_avg:38.45ms
+step:622/1600 train_time:23934ms step_avg:38.48ms
+step:623/1600 train_time:23996ms step_avg:38.52ms
+step:624/1600 train_time:24054ms step_avg:38.55ms
+step:625/1600 train_time:24117ms step_avg:38.59ms
+step:626/1600 train_time:24176ms step_avg:38.62ms
+step:627/1600 train_time:24238ms step_avg:38.66ms
+step:628/1600 train_time:24296ms step_avg:38.69ms
+step:629/1600 train_time:24359ms step_avg:38.73ms
+step:630/1600 train_time:24417ms step_avg:38.76ms
+step:631/1600 train_time:24479ms step_avg:38.79ms
+step:632/1600 train_time:24537ms step_avg:38.83ms
+step:633/1600 train_time:24600ms step_avg:38.86ms
+step:634/1600 train_time:24659ms step_avg:38.89ms
+step:635/1600 train_time:24721ms step_avg:38.93ms
+step:636/1600 train_time:24780ms step_avg:38.96ms
+step:637/1600 train_time:24843ms step_avg:39.00ms
+step:638/1600 train_time:24902ms step_avg:39.03ms
+step:639/1600 train_time:24964ms step_avg:39.07ms
+step:640/1600 train_time:25023ms step_avg:39.10ms
+step:641/1600 train_time:25086ms step_avg:39.14ms
+step:642/1600 train_time:25145ms step_avg:39.17ms
+step:643/1600 train_time:25208ms step_avg:39.20ms
+step:644/1600 train_time:25267ms step_avg:39.23ms
+step:645/1600 train_time:25329ms step_avg:39.27ms
+step:646/1600 train_time:25389ms step_avg:39.30ms
+step:647/1600 train_time:25451ms step_avg:39.34ms
+step:648/1600 train_time:25511ms step_avg:39.37ms
+step:649/1600 train_time:25573ms step_avg:39.40ms
+step:650/1600 train_time:25632ms step_avg:39.43ms
+step:651/1600 train_time:25695ms step_avg:39.47ms
+step:652/1600 train_time:25754ms step_avg:39.50ms
+step:653/1600 train_time:25816ms step_avg:39.53ms
+step:654/1600 train_time:25875ms step_avg:39.56ms
+step:655/1600 train_time:25938ms step_avg:39.60ms
+step:656/1600 train_time:25997ms step_avg:39.63ms
+step:657/1600 train_time:26059ms step_avg:39.66ms
+step:658/1600 train_time:26117ms step_avg:39.69ms
+step:659/1600 train_time:26179ms step_avg:39.73ms
+step:660/1600 train_time:26238ms step_avg:39.75ms
+step:661/1600 train_time:26300ms step_avg:39.79ms
+step:662/1600 train_time:26359ms step_avg:39.82ms
+step:663/1600 train_time:26422ms step_avg:39.85ms
+step:664/1600 train_time:26481ms step_avg:39.88ms
+step:665/1600 train_time:26543ms step_avg:39.91ms
+step:666/1600 train_time:26602ms step_avg:39.94ms
+step:667/1600 train_time:26665ms step_avg:39.98ms
+step:668/1600 train_time:26724ms step_avg:40.01ms
+step:669/1600 train_time:26786ms step_avg:40.04ms
+step:670/1600 train_time:26845ms step_avg:40.07ms
+step:671/1600 train_time:26908ms step_avg:40.10ms
+step:672/1600 train_time:26967ms step_avg:40.13ms
+step:673/1600 train_time:27029ms step_avg:40.16ms
+step:674/1600 train_time:27089ms step_avg:40.19ms
+step:675/1600 train_time:27151ms step_avg:40.22ms
+step:676/1600 train_time:27210ms step_avg:40.25ms
+step:677/1600 train_time:27272ms step_avg:40.28ms
+step:678/1600 train_time:27331ms step_avg:40.31ms
+step:679/1600 train_time:27394ms step_avg:40.34ms
+step:680/1600 train_time:27453ms step_avg:40.37ms
+step:681/1600 train_time:27515ms step_avg:40.40ms
+step:682/1600 train_time:27574ms step_avg:40.43ms
+step:683/1600 train_time:27636ms step_avg:40.46ms
+step:684/1600 train_time:27696ms step_avg:40.49ms
+step:685/1600 train_time:27758ms step_avg:40.52ms
+step:686/1600 train_time:27817ms step_avg:40.55ms
+step:687/1600 train_time:27880ms step_avg:40.58ms
+step:688/1600 train_time:27939ms step_avg:40.61ms
+step:689/1600 train_time:28002ms step_avg:40.64ms
+step:690/1600 train_time:28060ms step_avg:40.67ms
+step:691/1600 train_time:28123ms step_avg:40.70ms
+step:692/1600 train_time:28181ms step_avg:40.72ms
+step:693/1600 train_time:28243ms step_avg:40.76ms
+step:694/1600 train_time:28303ms step_avg:40.78ms
+step:695/1600 train_time:28366ms step_avg:40.81ms
+step:696/1600 train_time:28425ms step_avg:40.84ms
+step:697/1600 train_time:28487ms step_avg:40.87ms
+step:698/1600 train_time:28546ms step_avg:40.90ms
+step:699/1600 train_time:28609ms step_avg:40.93ms
+step:700/1600 train_time:28668ms step_avg:40.95ms
+step:701/1600 train_time:28731ms step_avg:40.99ms
+step:702/1600 train_time:28792ms step_avg:41.01ms
+step:703/1600 train_time:28855ms step_avg:41.05ms
+step:704/1600 train_time:28913ms step_avg:41.07ms
+step:705/1600 train_time:28976ms step_avg:41.10ms
+step:706/1600 train_time:29036ms step_avg:41.13ms
+step:707/1600 train_time:29097ms step_avg:41.16ms
+step:708/1600 train_time:29156ms step_avg:41.18ms
+step:709/1600 train_time:29217ms step_avg:41.21ms
+step:710/1600 train_time:29276ms step_avg:41.23ms
+step:711/1600 train_time:29338ms step_avg:41.26ms
+step:712/1600 train_time:29397ms step_avg:41.29ms
+step:713/1600 train_time:29460ms step_avg:41.32ms
+step:714/1600 train_time:29518ms step_avg:41.34ms
+step:715/1600 train_time:29580ms step_avg:41.37ms
+step:716/1600 train_time:29639ms step_avg:41.39ms
+step:717/1600 train_time:29701ms step_avg:41.42ms
+step:718/1600 train_time:29761ms step_avg:41.45ms
+step:719/1600 train_time:29824ms step_avg:41.48ms
+step:720/1600 train_time:29883ms step_avg:41.50ms
+step:721/1600 train_time:29946ms step_avg:41.53ms
+step:722/1600 train_time:30005ms step_avg:41.56ms
+step:723/1600 train_time:30067ms step_avg:41.59ms
+step:724/1600 train_time:30127ms step_avg:41.61ms
+step:725/1600 train_time:30190ms step_avg:41.64ms
+step:726/1600 train_time:30249ms step_avg:41.67ms
+step:727/1600 train_time:30313ms step_avg:41.70ms
+step:728/1600 train_time:30372ms step_avg:41.72ms
+step:729/1600 train_time:30435ms step_avg:41.75ms
+step:730/1600 train_time:30494ms step_avg:41.77ms
+step:731/1600 train_time:30556ms step_avg:41.80ms
+step:732/1600 train_time:30614ms step_avg:41.82ms
+step:733/1600 train_time:30677ms step_avg:41.85ms
+step:734/1600 train_time:30736ms step_avg:41.87ms
+step:735/1600 train_time:30799ms step_avg:41.90ms
+step:736/1600 train_time:30857ms step_avg:41.93ms
+step:737/1600 train_time:30920ms step_avg:41.95ms
+step:738/1600 train_time:30978ms step_avg:41.98ms
+step:739/1600 train_time:31040ms step_avg:42.00ms
+step:740/1600 train_time:31100ms step_avg:42.03ms
+step:741/1600 train_time:31163ms step_avg:42.06ms
+step:742/1600 train_time:31222ms step_avg:42.08ms
+step:743/1600 train_time:31285ms step_avg:42.11ms
+step:744/1600 train_time:31344ms step_avg:42.13ms
+step:745/1600 train_time:31407ms step_avg:42.16ms
+step:746/1600 train_time:31466ms step_avg:42.18ms
+step:747/1600 train_time:31528ms step_avg:42.21ms
+step:748/1600 train_time:31587ms step_avg:42.23ms
+step:749/1600 train_time:31651ms step_avg:42.26ms
+step:750/1600 train_time:31710ms step_avg:42.28ms
+step:750/1600 val_loss:3.9002 train_time:31758ms step_avg:42.34ms
+step:751/1600 train_time:31777ms step_avg:42.31ms
+step:752/1600 train_time:31836ms step_avg:42.34ms
+step:753/1600 train_time:31902ms step_avg:42.37ms
+step:754/1600 train_time:31964ms step_avg:42.39ms
+step:755/1600 train_time:32026ms step_avg:42.42ms
+step:756/1600 train_time:32085ms step_avg:42.44ms
+step:757/1600 train_time:32146ms step_avg:42.47ms
+step:758/1600 train_time:32205ms step_avg:42.49ms
+step:759/1600 train_time:32267ms step_avg:42.51ms
+step:760/1600 train_time:32326ms step_avg:42.53ms
+step:761/1600 train_time:32389ms step_avg:42.56ms
+step:762/1600 train_time:32446ms step_avg:42.58ms
+step:763/1600 train_time:32507ms step_avg:42.60ms
+step:764/1600 train_time:32566ms step_avg:42.63ms
+step:765/1600 train_time:32628ms step_avg:42.65ms
+step:766/1600 train_time:32687ms step_avg:42.67ms
+step:767/1600 train_time:32749ms step_avg:42.70ms
+step:768/1600 train_time:32810ms step_avg:42.72ms
+step:769/1600 train_time:32875ms step_avg:42.75ms
+step:770/1600 train_time:32934ms step_avg:42.77ms
+step:771/1600 train_time:32997ms step_avg:42.80ms
+step:772/1600 train_time:33057ms step_avg:42.82ms
+step:773/1600 train_time:33119ms step_avg:42.84ms
+step:774/1600 train_time:33177ms step_avg:42.86ms
+step:775/1600 train_time:33240ms step_avg:42.89ms
+step:776/1600 train_time:33298ms step_avg:42.91ms
+step:777/1600 train_time:33361ms step_avg:42.94ms
+step:778/1600 train_time:33420ms step_avg:42.96ms
+step:779/1600 train_time:33482ms step_avg:42.98ms
+step:780/1600 train_time:33541ms step_avg:43.00ms
+step:781/1600 train_time:33604ms step_avg:43.03ms
+step:782/1600 train_time:33664ms step_avg:43.05ms
+step:783/1600 train_time:33726ms step_avg:43.07ms
+step:784/1600 train_time:33784ms step_avg:43.09ms
+step:785/1600 train_time:33848ms step_avg:43.12ms
+step:786/1600 train_time:33908ms step_avg:43.14ms
+step:787/1600 train_time:33972ms step_avg:43.17ms
+step:788/1600 train_time:34032ms step_avg:43.19ms
+step:789/1600 train_time:34094ms step_avg:43.21ms
+step:790/1600 train_time:34153ms step_avg:43.23ms
+step:791/1600 train_time:34215ms step_avg:43.25ms
+step:792/1600 train_time:34273ms step_avg:43.27ms
+step:793/1600 train_time:34335ms step_avg:43.30ms
+step:794/1600 train_time:34394ms step_avg:43.32ms
+step:795/1600 train_time:34457ms step_avg:43.34ms
+step:796/1600 train_time:34516ms step_avg:43.36ms
+step:797/1600 train_time:34578ms step_avg:43.38ms
+step:798/1600 train_time:34637ms step_avg:43.40ms
+step:799/1600 train_time:34700ms step_avg:43.43ms
+step:800/1600 train_time:34760ms step_avg:43.45ms
+step:801/1600 train_time:34823ms step_avg:43.47ms
+step:802/1600 train_time:34884ms step_avg:43.50ms
+step:803/1600 train_time:34946ms step_avg:43.52ms
+step:804/1600 train_time:35005ms step_avg:43.54ms
+step:805/1600 train_time:35068ms step_avg:43.56ms
+step:806/1600 train_time:35128ms step_avg:43.58ms
+step:807/1600 train_time:35191ms step_avg:43.61ms
+step:808/1600 train_time:35250ms step_avg:43.63ms
+step:809/1600 train_time:35312ms step_avg:43.65ms
+step:810/1600 train_time:35371ms step_avg:43.67ms
+step:811/1600 train_time:35433ms step_avg:43.69ms
+step:812/1600 train_time:35492ms step_avg:43.71ms
+step:813/1600 train_time:35554ms step_avg:43.73ms
+step:814/1600 train_time:35613ms step_avg:43.75ms
+step:815/1600 train_time:35675ms step_avg:43.77ms
+step:816/1600 train_time:35734ms step_avg:43.79ms
+step:817/1600 train_time:35796ms step_avg:43.81ms
+step:818/1600 train_time:35857ms step_avg:43.84ms
+step:819/1600 train_time:35919ms step_avg:43.86ms
+step:820/1600 train_time:35979ms step_avg:43.88ms
+step:821/1600 train_time:36043ms step_avg:43.90ms
+step:822/1600 train_time:36102ms step_avg:43.92ms
+step:823/1600 train_time:36166ms step_avg:43.94ms
+step:824/1600 train_time:36225ms step_avg:43.96ms
+step:825/1600 train_time:36286ms step_avg:43.98ms
+step:826/1600 train_time:36346ms step_avg:44.00ms
+step:827/1600 train_time:36408ms step_avg:44.02ms
+step:828/1600 train_time:36468ms step_avg:44.04ms
+step:829/1600 train_time:36530ms step_avg:44.06ms
+step:830/1600 train_time:36589ms step_avg:44.08ms
+step:831/1600 train_time:36652ms step_avg:44.11ms
+step:832/1600 train_time:36711ms step_avg:44.12ms
+step:833/1600 train_time:36773ms step_avg:44.15ms
+step:834/1600 train_time:36833ms step_avg:44.16ms
+step:835/1600 train_time:36895ms step_avg:44.19ms
+step:836/1600 train_time:36955ms step_avg:44.20ms
+step:837/1600 train_time:37016ms step_avg:44.23ms
+step:838/1600 train_time:37076ms step_avg:44.24ms
+step:839/1600 train_time:37139ms step_avg:44.27ms
+step:840/1600 train_time:37198ms step_avg:44.28ms
+step:841/1600 train_time:37261ms step_avg:44.31ms
+step:842/1600 train_time:37320ms step_avg:44.32ms
+step:843/1600 train_time:37383ms step_avg:44.34ms
+step:844/1600 train_time:37442ms step_avg:44.36ms
+step:845/1600 train_time:37504ms step_avg:44.38ms
+step:846/1600 train_time:37565ms step_avg:44.40ms
+step:847/1600 train_time:37628ms step_avg:44.43ms
+step:848/1600 train_time:37688ms step_avg:44.44ms
+step:849/1600 train_time:37751ms step_avg:44.47ms
+step:850/1600 train_time:37809ms step_avg:44.48ms
+step:851/1600 train_time:37872ms step_avg:44.50ms
+step:852/1600 train_time:37931ms step_avg:44.52ms
+step:853/1600 train_time:37994ms step_avg:44.54ms
+step:854/1600 train_time:38052ms step_avg:44.56ms
+step:855/1600 train_time:38116ms step_avg:44.58ms
+step:856/1600 train_time:38175ms step_avg:44.60ms
+step:857/1600 train_time:38237ms step_avg:44.62ms
+step:858/1600 train_time:38296ms step_avg:44.63ms
+step:859/1600 train_time:38358ms step_avg:44.65ms
+step:860/1600 train_time:38418ms step_avg:44.67ms
+step:861/1600 train_time:38480ms step_avg:44.69ms
+step:862/1600 train_time:38539ms step_avg:44.71ms
+step:863/1600 train_time:38604ms step_avg:44.73ms
+step:864/1600 train_time:38663ms step_avg:44.75ms
+step:865/1600 train_time:38726ms step_avg:44.77ms
+step:866/1600 train_time:38784ms step_avg:44.79ms
+step:867/1600 train_time:38847ms step_avg:44.81ms
+step:868/1600 train_time:38907ms step_avg:44.82ms
+step:869/1600 train_time:38970ms step_avg:44.84ms
+step:870/1600 train_time:39029ms step_avg:44.86ms
+step:871/1600 train_time:39092ms step_avg:44.88ms
+step:872/1600 train_time:39150ms step_avg:44.90ms
+step:873/1600 train_time:39213ms step_avg:44.92ms
+step:874/1600 train_time:39272ms step_avg:44.93ms
+step:875/1600 train_time:39334ms step_avg:44.95ms
+step:876/1600 train_time:39393ms step_avg:44.97ms
+step:877/1600 train_time:39455ms step_avg:44.99ms
+step:878/1600 train_time:39514ms step_avg:45.00ms
+step:879/1600 train_time:39578ms step_avg:45.03ms
+step:880/1600 train_time:39637ms step_avg:45.04ms
+step:881/1600 train_time:39700ms step_avg:45.06ms
+step:882/1600 train_time:39759ms step_avg:45.08ms
+step:883/1600 train_time:39823ms step_avg:45.10ms
+step:884/1600 train_time:39882ms step_avg:45.12ms
+step:885/1600 train_time:39945ms step_avg:45.14ms
+step:886/1600 train_time:40004ms step_avg:45.15ms
+step:887/1600 train_time:40068ms step_avg:45.17ms
+step:888/1600 train_time:40127ms step_avg:45.19ms
+step:889/1600 train_time:40189ms step_avg:45.21ms
+step:890/1600 train_time:40253ms step_avg:45.23ms
+step:891/1600 train_time:40312ms step_avg:45.24ms
+step:892/1600 train_time:40371ms step_avg:45.26ms
+step:893/1600 train_time:40434ms step_avg:45.28ms
+step:894/1600 train_time:40493ms step_avg:45.29ms
+step:895/1600 train_time:40555ms step_avg:45.31ms
+step:896/1600 train_time:40614ms step_avg:45.33ms
+step:897/1600 train_time:40676ms step_avg:45.35ms
+step:898/1600 train_time:40735ms step_avg:45.36ms
+step:899/1600 train_time:40797ms step_avg:45.38ms
+step:900/1600 train_time:40857ms step_avg:45.40ms
+step:901/1600 train_time:40919ms step_avg:45.42ms
+step:902/1600 train_time:40979ms step_avg:45.43ms
+step:903/1600 train_time:41042ms step_avg:45.45ms
+step:904/1600 train_time:41101ms step_avg:45.47ms
+step:905/1600 train_time:41164ms step_avg:45.49ms
+step:906/1600 train_time:41223ms step_avg:45.50ms
+step:907/1600 train_time:41286ms step_avg:45.52ms
+step:908/1600 train_time:41345ms step_avg:45.53ms
+step:909/1600 train_time:41409ms step_avg:45.55ms
+step:910/1600 train_time:41468ms step_avg:45.57ms
+step:911/1600 train_time:41533ms step_avg:45.59ms
+step:912/1600 train_time:41590ms step_avg:45.60ms
+step:913/1600 train_time:41652ms step_avg:45.62ms
+step:914/1600 train_time:41711ms step_avg:45.64ms
+step:915/1600 train_time:41774ms step_avg:45.65ms
+step:916/1600 train_time:41833ms step_avg:45.67ms
+step:917/1600 train_time:41896ms step_avg:45.69ms
+step:918/1600 train_time:41956ms step_avg:45.70ms
+step:919/1600 train_time:42018ms step_avg:45.72ms
+step:920/1600 train_time:42078ms step_avg:45.74ms
+step:921/1600 train_time:42141ms step_avg:45.76ms
+step:922/1600 train_time:42200ms step_avg:45.77ms
+step:923/1600 train_time:42263ms step_avg:45.79ms
+step:924/1600 train_time:42321ms step_avg:45.80ms
+step:925/1600 train_time:42385ms step_avg:45.82ms
+step:926/1600 train_time:42444ms step_avg:45.84ms
+step:927/1600 train_time:42507ms step_avg:45.85ms
+step:928/1600 train_time:42566ms step_avg:45.87ms
+step:929/1600 train_time:42630ms step_avg:45.89ms
+step:930/1600 train_time:42688ms step_avg:45.90ms
+step:931/1600 train_time:42750ms step_avg:45.92ms
+step:932/1600 train_time:42810ms step_avg:45.93ms
+step:933/1600 train_time:42873ms step_avg:45.95ms
+step:934/1600 train_time:42932ms step_avg:45.97ms
+step:935/1600 train_time:42995ms step_avg:45.98ms
+step:936/1600 train_time:43054ms step_avg:46.00ms
+step:937/1600 train_time:43116ms step_avg:46.01ms
+step:938/1600 train_time:43176ms step_avg:46.03ms
+step:939/1600 train_time:43238ms step_avg:46.05ms
+step:940/1600 train_time:43297ms step_avg:46.06ms
+step:941/1600 train_time:43360ms step_avg:46.08ms
+step:942/1600 train_time:43419ms step_avg:46.09ms
+step:943/1600 train_time:43482ms step_avg:46.11ms
+step:944/1600 train_time:43542ms step_avg:46.13ms
+step:945/1600 train_time:43605ms step_avg:46.14ms
+step:946/1600 train_time:43664ms step_avg:46.16ms
+step:947/1600 train_time:43727ms step_avg:46.17ms
+step:948/1600 train_time:43786ms step_avg:46.19ms
+step:949/1600 train_time:43848ms step_avg:46.20ms
+step:950/1600 train_time:43907ms step_avg:46.22ms
+step:951/1600 train_time:43972ms step_avg:46.24ms
+step:952/1600 train_time:44031ms step_avg:46.25ms
+step:953/1600 train_time:44093ms step_avg:46.27ms
+step:954/1600 train_time:44152ms step_avg:46.28ms
+step:955/1600 train_time:44214ms step_avg:46.30ms
+step:956/1600 train_time:44273ms step_avg:46.31ms
+step:957/1600 train_time:44336ms step_avg:46.33ms
+step:958/1600 train_time:44395ms step_avg:46.34ms
+step:959/1600 train_time:44458ms step_avg:46.36ms
+step:960/1600 train_time:44517ms step_avg:46.37ms
+step:961/1600 train_time:44579ms step_avg:46.39ms
+step:962/1600 train_time:44639ms step_avg:46.40ms
+step:963/1600 train_time:44702ms step_avg:46.42ms
+step:964/1600 train_time:44762ms step_avg:46.43ms
+step:965/1600 train_time:44825ms step_avg:46.45ms
+step:966/1600 train_time:44884ms step_avg:46.46ms
+step:967/1600 train_time:44946ms step_avg:46.48ms
+step:968/1600 train_time:45005ms step_avg:46.49ms
+step:969/1600 train_time:45069ms step_avg:46.51ms
+step:970/1600 train_time:45129ms step_avg:46.53ms
+step:971/1600 train_time:45192ms step_avg:46.54ms
+step:972/1600 train_time:45250ms step_avg:46.55ms
+step:973/1600 train_time:45313ms step_avg:46.57ms
+step:974/1600 train_time:45371ms step_avg:46.58ms
+step:975/1600 train_time:45434ms step_avg:46.60ms
+step:976/1600 train_time:45493ms step_avg:46.61ms
+step:977/1600 train_time:45556ms step_avg:46.63ms
+step:978/1600 train_time:45614ms step_avg:46.64ms
+step:979/1600 train_time:45677ms step_avg:46.66ms
+step:980/1600 train_time:45737ms step_avg:46.67ms
+step:981/1600 train_time:45800ms step_avg:46.69ms
+step:982/1600 train_time:45860ms step_avg:46.70ms
+step:983/1600 train_time:45923ms step_avg:46.72ms
+step:984/1600 train_time:45987ms step_avg:46.73ms
+step:985/1600 train_time:46045ms step_avg:46.75ms
+step:986/1600 train_time:46104ms step_avg:46.76ms
+step:987/1600 train_time:46167ms step_avg:46.77ms
+step:988/1600 train_time:46226ms step_avg:46.79ms
+step:989/1600 train_time:46290ms step_avg:46.80ms
+step:990/1600 train_time:46349ms step_avg:46.82ms
+step:991/1600 train_time:46413ms step_avg:46.83ms
+step:992/1600 train_time:46471ms step_avg:46.85ms
+step:993/1600 train_time:46533ms step_avg:46.86ms
+step:994/1600 train_time:46592ms step_avg:46.87ms
+step:995/1600 train_time:46654ms step_avg:46.89ms
+step:996/1600 train_time:46713ms step_avg:46.90ms
+step:997/1600 train_time:46776ms step_avg:46.92ms
+step:998/1600 train_time:46834ms step_avg:46.93ms
+step:999/1600 train_time:46897ms step_avg:46.94ms
+step:1000/1600 train_time:46957ms step_avg:46.96ms
+step:1000/1600 val_loss:3.5958 train_time:47004ms step_avg:47.00ms
+step:1001/1600 train_time:47023ms step_avg:46.98ms
+step:1002/1600 train_time:47081ms step_avg:46.99ms
+step:1003/1600 train_time:47144ms step_avg:47.00ms
+step:1004/1600 train_time:47205ms step_avg:47.02ms
+step:1005/1600 train_time:47268ms step_avg:47.03ms
+step:1006/1600 train_time:47328ms step_avg:47.05ms
+step:1007/1600 train_time:47390ms step_avg:47.06ms
+step:1008/1600 train_time:47449ms step_avg:47.07ms
+step:1009/1600 train_time:47511ms step_avg:47.09ms
+step:1010/1600 train_time:47569ms step_avg:47.10ms
+step:1011/1600 train_time:47633ms step_avg:47.11ms
+step:1012/1600 train_time:47691ms step_avg:47.13ms
+step:1013/1600 train_time:47752ms step_avg:47.14ms
+step:1014/1600 train_time:47811ms step_avg:47.15ms
+step:1015/1600 train_time:47872ms step_avg:47.16ms
+step:1016/1600 train_time:47931ms step_avg:47.18ms
+step:1017/1600 train_time:47994ms step_avg:47.19ms
+step:1018/1600 train_time:48055ms step_avg:47.21ms
+step:1019/1600 train_time:48118ms step_avg:47.22ms
+step:1020/1600 train_time:48178ms step_avg:47.23ms
+step:1021/1600 train_time:48241ms step_avg:47.25ms
+step:1022/1600 train_time:48299ms step_avg:47.26ms
+step:1023/1600 train_time:48362ms step_avg:47.27ms
+step:1024/1600 train_time:48421ms step_avg:47.29ms
+step:1025/1600 train_time:48483ms step_avg:47.30ms
+step:1026/1600 train_time:48542ms step_avg:47.31ms
+step:1027/1600 train_time:48605ms step_avg:47.33ms
+step:1028/1600 train_time:48665ms step_avg:47.34ms
+step:1029/1600 train_time:48726ms step_avg:47.35ms
+step:1030/1600 train_time:48786ms step_avg:47.36ms
+step:1031/1600 train_time:48847ms step_avg:47.38ms
+step:1032/1600 train_time:48907ms step_avg:47.39ms
+step:1033/1600 train_time:48970ms step_avg:47.41ms
+step:1034/1600 train_time:49030ms step_avg:47.42ms
+step:1035/1600 train_time:49094ms step_avg:47.43ms
+step:1036/1600 train_time:49154ms step_avg:47.45ms
+step:1037/1600 train_time:49216ms step_avg:47.46ms
+step:1038/1600 train_time:49275ms step_avg:47.47ms
+step:1039/1600 train_time:49337ms step_avg:47.49ms
+step:1040/1600 train_time:49395ms step_avg:47.50ms
+step:1041/1600 train_time:49466ms step_avg:47.52ms
+step:1042/1600 train_time:49549ms step_avg:47.55ms
+step:1043/1600 train_time:49638ms step_avg:47.59ms
+step:1044/1600 train_time:49722ms step_avg:47.63ms
+step:1045/1600 train_time:49810ms step_avg:47.67ms
+step:1046/1600 train_time:49895ms step_avg:47.70ms
+step:1047/1600 train_time:49983ms step_avg:47.74ms
+step:1048/1600 train_time:50069ms step_avg:47.78ms
+step:1049/1600 train_time:50159ms step_avg:47.82ms
+step:1050/1600 train_time:50245ms step_avg:47.85ms
+step:1051/1600 train_time:50334ms step_avg:47.89ms
+step:1052/1600 train_time:50420ms step_avg:47.93ms
+step:1053/1600 train_time:50508ms step_avg:47.97ms
+step:1054/1600 train_time:50593ms step_avg:48.00ms
+step:1055/1600 train_time:50680ms step_avg:48.04ms
+step:1056/1600 train_time:50764ms step_avg:48.07ms
+step:1057/1600 train_time:50852ms step_avg:48.11ms
+step:1058/1600 train_time:50936ms step_avg:48.14ms
+step:1059/1600 train_time:51026ms step_avg:48.18ms
+step:1060/1600 train_time:51112ms step_avg:48.22ms
+step:1061/1600 train_time:51201ms step_avg:48.26ms
+step:1062/1600 train_time:51286ms step_avg:48.29ms
+step:1063/1600 train_time:51374ms step_avg:48.33ms
+step:1064/1600 train_time:51460ms step_avg:48.36ms
+step:1065/1600 train_time:51548ms step_avg:48.40ms
+step:1066/1600 train_time:51633ms step_avg:48.44ms
+step:1067/1600 train_time:51721ms step_avg:48.47ms
+step:1068/1600 train_time:51805ms step_avg:48.51ms
+step:1069/1600 train_time:51893ms step_avg:48.54ms
+step:1070/1600 train_time:51979ms step_avg:48.58ms
+step:1071/1600 train_time:52067ms step_avg:48.62ms
+step:1072/1600 train_time:52152ms step_avg:48.65ms
+step:1073/1600 train_time:52242ms step_avg:48.69ms
+step:1074/1600 train_time:52327ms step_avg:48.72ms
+step:1075/1600 train_time:52414ms step_avg:48.76ms
+step:1076/1600 train_time:52499ms step_avg:48.79ms
+step:1077/1600 train_time:52588ms step_avg:48.83ms
+step:1078/1600 train_time:52673ms step_avg:48.86ms
+step:1079/1600 train_time:52760ms step_avg:48.90ms
+step:1080/1600 train_time:52846ms step_avg:48.93ms
+step:1081/1600 train_time:52934ms step_avg:48.97ms
+step:1082/1600 train_time:53020ms step_avg:49.00ms
+step:1083/1600 train_time:53108ms step_avg:49.04ms
+step:1084/1600 train_time:53193ms step_avg:49.07ms
+step:1085/1600 train_time:53282ms step_avg:49.11ms
+step:1086/1600 train_time:53367ms step_avg:49.14ms
+step:1087/1600 train_time:53455ms step_avg:49.18ms
+step:1088/1600 train_time:53540ms step_avg:49.21ms
+step:1089/1600 train_time:53628ms step_avg:49.25ms
+step:1090/1600 train_time:53714ms step_avg:49.28ms
+step:1091/1600 train_time:53801ms step_avg:49.31ms
+step:1092/1600 train_time:53886ms step_avg:49.35ms
+step:1093/1600 train_time:53975ms step_avg:49.38ms
+step:1094/1600 train_time:54061ms step_avg:49.42ms
+step:1095/1600 train_time:54151ms step_avg:49.45ms
+step:1096/1600 train_time:54235ms step_avg:49.48ms
+step:1097/1600 train_time:54324ms step_avg:49.52ms
+step:1098/1600 train_time:54409ms step_avg:49.55ms
+step:1099/1600 train_time:54498ms step_avg:49.59ms
+step:1100/1600 train_time:54583ms step_avg:49.62ms
+step:1101/1600 train_time:54671ms step_avg:49.66ms
+step:1102/1600 train_time:54756ms step_avg:49.69ms
+step:1103/1600 train_time:54844ms step_avg:49.72ms
+step:1104/1600 train_time:54928ms step_avg:49.75ms
+step:1105/1600 train_time:55016ms step_avg:49.79ms
+step:1106/1600 train_time:55101ms step_avg:49.82ms
+step:1107/1600 train_time:55190ms step_avg:49.86ms
+step:1108/1600 train_time:55275ms step_avg:49.89ms
+step:1109/1600 train_time:55364ms step_avg:49.92ms
+step:1110/1600 train_time:55450ms step_avg:49.95ms
+step:1111/1600 train_time:55538ms step_avg:49.99ms
+step:1112/1600 train_time:55624ms step_avg:50.02ms
+step:1113/1600 train_time:55712ms step_avg:50.06ms
+step:1114/1600 train_time:55797ms step_avg:50.09ms
+step:1115/1600 train_time:55885ms step_avg:50.12ms
+step:1116/1600 train_time:55969ms step_avg:50.15ms
+step:1117/1600 train_time:56058ms step_avg:50.19ms
+step:1118/1600 train_time:56143ms step_avg:50.22ms
+step:1119/1600 train_time:56231ms step_avg:50.25ms
+step:1120/1600 train_time:56317ms step_avg:50.28ms
+step:1121/1600 train_time:56406ms step_avg:50.32ms
+step:1122/1600 train_time:56491ms step_avg:50.35ms
+step:1123/1600 train_time:56581ms step_avg:50.38ms
+step:1124/1600 train_time:56666ms step_avg:50.41ms
+step:1125/1600 train_time:56754ms step_avg:50.45ms
+step:1126/1600 train_time:56839ms step_avg:50.48ms
+step:1127/1600 train_time:56927ms step_avg:50.51ms
+step:1128/1600 train_time:57012ms step_avg:50.54ms
+step:1129/1600 train_time:57101ms step_avg:50.58ms
+step:1130/1600 train_time:57185ms step_avg:50.61ms
+step:1131/1600 train_time:57273ms step_avg:50.64ms
+step:1132/1600 train_time:57358ms step_avg:50.67ms
+step:1133/1600 train_time:57448ms step_avg:50.70ms
+step:1134/1600 train_time:57534ms step_avg:50.74ms
+step:1135/1600 train_time:57623ms step_avg:50.77ms
+step:1136/1600 train_time:57708ms step_avg:50.80ms
+step:1137/1600 train_time:57796ms step_avg:50.83ms
+step:1138/1600 train_time:57882ms step_avg:50.86ms
+step:1139/1600 train_time:57970ms step_avg:50.90ms
+step:1140/1600 train_time:58054ms step_avg:50.92ms
+step:1141/1600 train_time:58143ms step_avg:50.96ms
+step:1142/1600 train_time:58227ms step_avg:50.99ms
+step:1143/1600 train_time:58316ms step_avg:51.02ms
+step:1144/1600 train_time:58400ms step_avg:51.05ms
+step:1145/1600 train_time:58489ms step_avg:51.08ms
+step:1146/1600 train_time:58580ms step_avg:51.12ms
+step:1147/1600 train_time:58667ms step_avg:51.15ms
+step:1148/1600 train_time:58754ms step_avg:51.18ms
+step:1149/1600 train_time:58837ms step_avg:51.21ms
+step:1150/1600 train_time:58922ms step_avg:51.24ms
+step:1151/1600 train_time:59010ms step_avg:51.27ms
+step:1152/1600 train_time:59096ms step_avg:51.30ms
+step:1153/1600 train_time:59184ms step_avg:51.33ms
+step:1154/1600 train_time:59274ms step_avg:51.36ms
+step:1155/1600 train_time:59361ms step_avg:51.39ms
+step:1156/1600 train_time:59445ms step_avg:51.42ms
+step:1157/1600 train_time:59533ms step_avg:51.45ms
+step:1158/1600 train_time:59618ms step_avg:51.48ms
+step:1159/1600 train_time:59707ms step_avg:51.52ms
+step:1160/1600 train_time:59792ms step_avg:51.54ms
+step:1161/1600 train_time:59881ms step_avg:51.58ms
+step:1162/1600 train_time:59966ms step_avg:51.61ms
+step:1163/1600 train_time:60054ms step_avg:51.64ms
+step:1164/1600 train_time:60139ms step_avg:51.67ms
+step:1165/1600 train_time:60229ms step_avg:51.70ms
+step:1166/1600 train_time:60313ms step_avg:51.73ms
+step:1167/1600 train_time:60403ms step_avg:51.76ms
+step:1168/1600 train_time:60486ms step_avg:51.79ms
+step:1169/1600 train_time:60574ms step_avg:51.82ms
+step:1170/1600 train_time:60660ms step_avg:51.85ms
+step:1171/1600 train_time:60748ms step_avg:51.88ms
+step:1172/1600 train_time:60833ms step_avg:51.91ms
+step:1173/1600 train_time:60922ms step_avg:51.94ms
+step:1174/1600 train_time:61008ms step_avg:51.97ms
+step:1175/1600 train_time:61097ms step_avg:52.00ms
+step:1176/1600 train_time:61181ms step_avg:52.02ms
+step:1177/1600 train_time:61270ms step_avg:52.06ms
+step:1178/1600 train_time:61355ms step_avg:52.08ms
+step:1179/1600 train_time:61444ms step_avg:52.12ms
+step:1180/1600 train_time:61528ms step_avg:52.14ms
+step:1181/1600 train_time:61617ms step_avg:52.17ms
+step:1182/1600 train_time:61702ms step_avg:52.20ms
+step:1183/1600 train_time:61790ms step_avg:52.23ms
+step:1184/1600 train_time:61876ms step_avg:52.26ms
+step:1185/1600 train_time:61965ms step_avg:52.29ms
+step:1186/1600 train_time:62049ms step_avg:52.32ms
+step:1187/1600 train_time:62138ms step_avg:52.35ms
+step:1188/1600 train_time:62222ms step_avg:52.38ms
+step:1189/1600 train_time:62310ms step_avg:52.41ms
+step:1190/1600 train_time:62395ms step_avg:52.43ms
+step:1191/1600 train_time:62484ms step_avg:52.46ms
+step:1192/1600 train_time:62569ms step_avg:52.49ms
+step:1193/1600 train_time:62657ms step_avg:52.52ms
+step:1194/1600 train_time:62743ms step_avg:52.55ms
+step:1195/1600 train_time:62831ms step_avg:52.58ms
+step:1196/1600 train_time:62916ms step_avg:52.61ms
+step:1197/1600 train_time:63005ms step_avg:52.64ms
+step:1198/1600 train_time:63089ms step_avg:52.66ms
+step:1199/1600 train_time:63178ms step_avg:52.69ms
+step:1200/1600 train_time:63263ms step_avg:52.72ms
+step:1201/1600 train_time:63351ms step_avg:52.75ms
+step:1202/1600 train_time:63436ms step_avg:52.78ms
+step:1203/1600 train_time:63524ms step_avg:52.80ms
+step:1204/1600 train_time:63609ms step_avg:52.83ms
+step:1205/1600 train_time:63698ms step_avg:52.86ms
+step:1206/1600 train_time:63783ms step_avg:52.89ms
+step:1207/1600 train_time:63872ms step_avg:52.92ms
+step:1208/1600 train_time:63958ms step_avg:52.95ms
+step:1209/1600 train_time:64047ms step_avg:52.97ms
+step:1210/1600 train_time:64131ms step_avg:53.00ms
+step:1211/1600 train_time:64220ms step_avg:53.03ms
+step:1212/1600 train_time:64304ms step_avg:53.06ms
+step:1213/1600 train_time:64393ms step_avg:53.09ms
+step:1214/1600 train_time:64478ms step_avg:53.11ms
+step:1215/1600 train_time:64566ms step_avg:53.14ms
+step:1216/1600 train_time:64650ms step_avg:53.17ms
+step:1217/1600 train_time:64739ms step_avg:53.20ms
+step:1218/1600 train_time:64824ms step_avg:53.22ms
+step:1219/1600 train_time:64912ms step_avg:53.25ms
+step:1220/1600 train_time:64998ms step_avg:53.28ms
+step:1221/1600 train_time:65086ms step_avg:53.31ms
+step:1222/1600 train_time:65172ms step_avg:53.33ms
+step:1223/1600 train_time:65262ms step_avg:53.36ms
+step:1224/1600 train_time:65344ms step_avg:53.39ms
+step:1225/1600 train_time:65434ms step_avg:53.42ms
+step:1226/1600 train_time:65518ms step_avg:53.44ms
+step:1227/1600 train_time:65607ms step_avg:53.47ms
+step:1228/1600 train_time:65692ms step_avg:53.49ms
+step:1229/1600 train_time:65781ms step_avg:53.52ms
+step:1230/1600 train_time:65865ms step_avg:53.55ms
+step:1231/1600 train_time:65954ms step_avg:53.58ms
+step:1232/1600 train_time:66039ms step_avg:53.60ms
+step:1233/1600 train_time:66128ms step_avg:53.63ms
+step:1234/1600 train_time:66213ms step_avg:53.66ms
+step:1235/1600 train_time:66300ms step_avg:53.68ms
+step:1236/1600 train_time:66385ms step_avg:53.71ms
+step:1237/1600 train_time:66473ms step_avg:53.74ms
+step:1238/1600 train_time:66559ms step_avg:53.76ms
+step:1239/1600 train_time:66647ms step_avg:53.79ms
+step:1240/1600 train_time:66732ms step_avg:53.82ms
+step:1241/1600 train_time:66821ms step_avg:53.84ms
+step:1242/1600 train_time:66906ms step_avg:53.87ms
+step:1243/1600 train_time:66994ms step_avg:53.90ms
+step:1244/1600 train_time:67079ms step_avg:53.92ms
+step:1245/1600 train_time:67168ms step_avg:53.95ms
+step:1246/1600 train_time:67253ms step_avg:53.97ms
+step:1247/1600 train_time:67341ms step_avg:54.00ms
+step:1248/1600 train_time:67426ms step_avg:54.03ms
+step:1249/1600 train_time:67514ms step_avg:54.05ms
+step:1250/1600 train_time:67599ms step_avg:54.08ms
+step:1250/1600 val_loss:3.4145 train_time:67673ms step_avg:54.14ms
+step:1251/1600 train_time:67692ms step_avg:54.11ms
+step:1252/1600 train_time:67778ms step_avg:54.14ms
+step:1253/1600 train_time:67869ms step_avg:54.17ms
+step:1254/1600 train_time:67955ms step_avg:54.19ms
+step:1255/1600 train_time:68043ms step_avg:54.22ms
+step:1256/1600 train_time:68127ms step_avg:54.24ms
+step:1257/1600 train_time:68214ms step_avg:54.27ms
+step:1258/1600 train_time:68298ms step_avg:54.29ms
+step:1259/1600 train_time:68385ms step_avg:54.32ms
+step:1260/1600 train_time:68470ms step_avg:54.34ms
+step:1261/1600 train_time:68557ms step_avg:54.37ms
+step:1262/1600 train_time:68643ms step_avg:54.39ms
+step:1263/1600 train_time:68735ms step_avg:54.42ms
+step:1264/1600 train_time:68821ms step_avg:54.45ms
+step:1265/1600 train_time:68911ms step_avg:54.48ms
+step:1266/1600 train_time:68996ms step_avg:54.50ms
+step:1267/1600 train_time:69084ms step_avg:54.53ms
+step:1268/1600 train_time:69169ms step_avg:54.55ms
+step:1269/1600 train_time:69257ms step_avg:54.58ms
+step:1270/1600 train_time:69341ms step_avg:54.60ms
+step:1271/1600 train_time:69428ms step_avg:54.62ms
+step:1272/1600 train_time:69513ms step_avg:54.65ms
+step:1273/1600 train_time:69601ms step_avg:54.67ms
+step:1274/1600 train_time:69686ms step_avg:54.70ms
+step:1275/1600 train_time:69776ms step_avg:54.73ms
+step:1276/1600 train_time:69863ms step_avg:54.75ms
+step:1277/1600 train_time:69951ms step_avg:54.78ms
+step:1278/1600 train_time:70037ms step_avg:54.80ms
+step:1279/1600 train_time:70126ms step_avg:54.83ms
+step:1280/1600 train_time:70211ms step_avg:54.85ms
+step:1281/1600 train_time:70299ms step_avg:54.88ms
+step:1282/1600 train_time:70383ms step_avg:54.90ms
+step:1283/1600 train_time:70470ms step_avg:54.93ms
+step:1284/1600 train_time:70555ms step_avg:54.95ms
+step:1285/1600 train_time:70644ms step_avg:54.98ms
+step:1286/1600 train_time:70730ms step_avg:55.00ms
+step:1287/1600 train_time:70821ms step_avg:55.03ms
+step:1288/1600 train_time:70907ms step_avg:55.05ms
+step:1289/1600 train_time:70995ms step_avg:55.08ms
+step:1290/1600 train_time:71081ms step_avg:55.10ms
+step:1291/1600 train_time:71169ms step_avg:55.13ms
+step:1292/1600 train_time:71254ms step_avg:55.15ms
+step:1293/1600 train_time:71342ms step_avg:55.18ms
+step:1294/1600 train_time:71426ms step_avg:55.20ms
+step:1295/1600 train_time:71514ms step_avg:55.22ms
+step:1296/1600 train_time:71599ms step_avg:55.25ms
+step:1297/1600 train_time:71687ms step_avg:55.27ms
+step:1298/1600 train_time:71774ms step_avg:55.30ms
+step:1299/1600 train_time:71864ms step_avg:55.32ms
+step:1300/1600 train_time:71949ms step_avg:55.35ms
+step:1301/1600 train_time:72038ms step_avg:55.37ms
+step:1302/1600 train_time:72123ms step_avg:55.39ms
+step:1303/1600 train_time:72211ms step_avg:55.42ms
+step:1304/1600 train_time:72297ms step_avg:55.44ms
+step:1305/1600 train_time:72385ms step_avg:55.47ms
+step:1306/1600 train_time:72469ms step_avg:55.49ms
+step:1307/1600 train_time:72558ms step_avg:55.51ms
+step:1308/1600 train_time:72643ms step_avg:55.54ms
+step:1309/1600 train_time:72731ms step_avg:55.56ms
+step:1310/1600 train_time:72816ms step_avg:55.59ms
+step:1311/1600 train_time:72907ms step_avg:55.61ms
+step:1312/1600 train_time:72992ms step_avg:55.63ms
+step:1313/1600 train_time:73080ms step_avg:55.66ms
+step:1314/1600 train_time:73166ms step_avg:55.68ms
+step:1315/1600 train_time:73253ms step_avg:55.71ms
+step:1316/1600 train_time:73339ms step_avg:55.73ms
+step:1317/1600 train_time:73426ms step_avg:55.75ms
+step:1318/1600 train_time:73511ms step_avg:55.77ms
+step:1319/1600 train_time:73599ms step_avg:55.80ms
+step:1320/1600 train_time:73684ms step_avg:55.82ms
+step:1321/1600 train_time:73773ms step_avg:55.85ms
+step:1322/1600 train_time:73858ms step_avg:55.87ms
+step:1323/1600 train_time:73948ms step_avg:55.89ms
+step:1324/1600 train_time:74033ms step_avg:55.92ms
+step:1325/1600 train_time:74121ms step_avg:55.94ms
+step:1326/1600 train_time:74208ms step_avg:55.96ms
+step:1327/1600 train_time:74296ms step_avg:55.99ms
+step:1328/1600 train_time:74381ms step_avg:56.01ms
+step:1329/1600 train_time:74471ms step_avg:56.04ms
+step:1330/1600 train_time:74561ms step_avg:56.06ms
+step:1331/1600 train_time:74646ms step_avg:56.08ms
+step:1332/1600 train_time:74730ms step_avg:56.10ms
+step:1333/1600 train_time:74818ms step_avg:56.13ms
+step:1334/1600 train_time:74903ms step_avg:56.15ms
+step:1335/1600 train_time:74991ms step_avg:56.17ms
+step:1336/1600 train_time:75077ms step_avg:56.20ms
+step:1337/1600 train_time:75166ms step_avg:56.22ms
+step:1338/1600 train_time:75251ms step_avg:56.24ms
+step:1339/1600 train_time:75340ms step_avg:56.27ms
+step:1340/1600 train_time:75424ms step_avg:56.29ms
+step:1341/1600 train_time:75512ms step_avg:56.31ms
+step:1342/1600 train_time:75598ms step_avg:56.33ms
+step:1343/1600 train_time:75686ms step_avg:56.36ms
+step:1344/1600 train_time:75771ms step_avg:56.38ms
+step:1345/1600 train_time:75860ms step_avg:56.40ms
+step:1346/1600 train_time:75945ms step_avg:56.42ms
+step:1347/1600 train_time:76032ms step_avg:56.45ms
+step:1348/1600 train_time:76117ms step_avg:56.47ms
+step:1349/1600 train_time:76206ms step_avg:56.49ms
+step:1350/1600 train_time:76290ms step_avg:56.51ms
+step:1351/1600 train_time:76379ms step_avg:56.53ms
+step:1352/1600 train_time:76464ms step_avg:56.56ms
+step:1353/1600 train_time:76552ms step_avg:56.58ms
+step:1354/1600 train_time:76637ms step_avg:56.60ms
+step:1355/1600 train_time:76725ms step_avg:56.62ms
+step:1356/1600 train_time:76810ms step_avg:56.64ms
+step:1357/1600 train_time:76899ms step_avg:56.67ms
+step:1358/1600 train_time:76983ms step_avg:56.69ms
+step:1359/1600 train_time:77072ms step_avg:56.71ms
+step:1360/1600 train_time:77157ms step_avg:56.73ms
+step:1361/1600 train_time:77245ms step_avg:56.76ms
+step:1362/1600 train_time:77330ms step_avg:56.78ms
+step:1363/1600 train_time:77419ms step_avg:56.80ms
+step:1364/1600 train_time:77503ms step_avg:56.82ms
+step:1365/1600 train_time:77591ms step_avg:56.84ms
+step:1366/1600 train_time:77681ms step_avg:56.87ms
+step:1367/1600 train_time:77768ms step_avg:56.89ms
+step:1368/1600 train_time:77854ms step_avg:56.91ms
+step:1369/1600 train_time:77941ms step_avg:56.93ms
+step:1370/1600 train_time:78027ms step_avg:56.95ms
+step:1371/1600 train_time:78116ms step_avg:56.98ms
+step:1372/1600 train_time:78201ms step_avg:57.00ms
+step:1373/1600 train_time:78288ms step_avg:57.02ms
+step:1374/1600 train_time:78374ms step_avg:57.04ms
+step:1375/1600 train_time:78462ms step_avg:57.06ms
+step:1376/1600 train_time:78547ms step_avg:57.08ms
+step:1377/1600 train_time:78635ms step_avg:57.11ms
+step:1378/1600 train_time:78720ms step_avg:57.13ms
+step:1379/1600 train_time:78809ms step_avg:57.15ms
+step:1380/1600 train_time:78894ms step_avg:57.17ms
+step:1381/1600 train_time:78983ms step_avg:57.19ms
+step:1382/1600 train_time:79068ms step_avg:57.21ms
+step:1383/1600 train_time:79156ms step_avg:57.24ms
+step:1384/1600 train_time:79241ms step_avg:57.26ms
+step:1385/1600 train_time:79333ms step_avg:57.28ms
+step:1386/1600 train_time:79416ms step_avg:57.30ms
+step:1387/1600 train_time:79506ms step_avg:57.32ms
+step:1388/1600 train_time:79591ms step_avg:57.34ms
+step:1389/1600 train_time:79678ms step_avg:57.36ms
+step:1390/1600 train_time:79764ms step_avg:57.38ms
+step:1391/1600 train_time:79853ms step_avg:57.41ms
+step:1392/1600 train_time:79937ms step_avg:57.43ms
+step:1393/1600 train_time:80025ms step_avg:57.45ms
+step:1394/1600 train_time:80110ms step_avg:57.47ms
+step:1395/1600 train_time:80199ms step_avg:57.49ms
+step:1396/1600 train_time:80283ms step_avg:57.51ms
+step:1397/1600 train_time:80371ms step_avg:57.53ms
+step:1398/1600 train_time:80456ms step_avg:57.55ms
+step:1399/1600 train_time:80545ms step_avg:57.57ms
+step:1400/1600 train_time:80630ms step_avg:57.59ms
+step:1401/1600 train_time:80719ms step_avg:57.62ms
+step:1402/1600 train_time:80804ms step_avg:57.63ms
+step:1403/1600 train_time:80892ms step_avg:57.66ms
+step:1404/1600 train_time:80977ms step_avg:57.68ms
+step:1405/1600 train_time:81066ms step_avg:57.70ms
+step:1406/1600 train_time:81151ms step_avg:57.72ms
+step:1407/1600 train_time:81239ms step_avg:57.74ms
+step:1408/1600 train_time:81323ms step_avg:57.76ms
+step:1409/1600 train_time:81412ms step_avg:57.78ms
+step:1410/1600 train_time:81498ms step_avg:57.80ms
+step:1411/1600 train_time:81585ms step_avg:57.82ms
+step:1412/1600 train_time:81671ms step_avg:57.84ms
+step:1413/1600 train_time:81760ms step_avg:57.86ms
+step:1414/1600 train_time:81845ms step_avg:57.88ms
+step:1415/1600 train_time:81933ms step_avg:57.90ms
+step:1416/1600 train_time:82018ms step_avg:57.92ms
+step:1417/1600 train_time:82107ms step_avg:57.94ms
+step:1418/1600 train_time:82192ms step_avg:57.96ms
+step:1419/1600 train_time:82281ms step_avg:57.99ms
+step:1420/1600 train_time:82366ms step_avg:58.00ms
+step:1421/1600 train_time:82454ms step_avg:58.03ms
+step:1422/1600 train_time:82539ms step_avg:58.04ms
+step:1423/1600 train_time:82628ms step_avg:58.07ms
+step:1424/1600 train_time:82713ms step_avg:58.09ms
+step:1425/1600 train_time:82802ms step_avg:58.11ms
+step:1426/1600 train_time:82887ms step_avg:58.13ms
+step:1427/1600 train_time:82976ms step_avg:58.15ms
+step:1428/1600 train_time:83061ms step_avg:58.17ms
+step:1429/1600 train_time:83149ms step_avg:58.19ms
+step:1430/1600 train_time:83235ms step_avg:58.21ms
+step:1431/1600 train_time:83323ms step_avg:58.23ms
+step:1432/1600 train_time:83408ms step_avg:58.25ms
+step:1433/1600 train_time:83496ms step_avg:58.27ms
+step:1434/1600 train_time:83581ms step_avg:58.28ms
+step:1435/1600 train_time:83669ms step_avg:58.31ms
+step:1436/1600 train_time:83756ms step_avg:58.33ms
+step:1437/1600 train_time:83844ms step_avg:58.35ms
+step:1438/1600 train_time:83930ms step_avg:58.37ms
+step:1439/1600 train_time:84018ms step_avg:58.39ms
+step:1440/1600 train_time:84103ms step_avg:58.40ms
+step:1441/1600 train_time:84190ms step_avg:58.42ms
+step:1442/1600 train_time:84276ms step_avg:58.44ms
+step:1443/1600 train_time:84364ms step_avg:58.46ms
+step:1444/1600 train_time:84449ms step_avg:58.48ms
+step:1445/1600 train_time:84537ms step_avg:58.50ms
+step:1446/1600 train_time:84622ms step_avg:58.52ms
+step:1447/1600 train_time:84711ms step_avg:58.54ms
+step:1448/1600 train_time:84797ms step_avg:58.56ms
+step:1449/1600 train_time:84885ms step_avg:58.58ms
+step:1450/1600 train_time:84971ms step_avg:58.60ms
+step:1451/1600 train_time:85059ms step_avg:58.62ms
+step:1452/1600 train_time:85144ms step_avg:58.64ms
+step:1453/1600 train_time:85232ms step_avg:58.66ms
+step:1454/1600 train_time:85317ms step_avg:58.68ms
+step:1455/1600 train_time:85406ms step_avg:58.70ms
+step:1456/1600 train_time:85491ms step_avg:58.72ms
+step:1457/1600 train_time:85580ms step_avg:58.74ms
+step:1458/1600 train_time:85666ms step_avg:58.76ms
+step:1459/1600 train_time:85754ms step_avg:58.78ms
+step:1460/1600 train_time:85839ms step_avg:58.79ms
+step:1461/1600 train_time:85928ms step_avg:58.81ms
+step:1462/1600 train_time:86013ms step_avg:58.83ms
+step:1463/1600 train_time:86103ms step_avg:58.85ms
+step:1464/1600 train_time:86187ms step_avg:58.87ms
+step:1465/1600 train_time:86275ms step_avg:58.89ms
+step:1466/1600 train_time:86361ms step_avg:58.91ms
+step:1467/1600 train_time:86448ms step_avg:58.93ms
+step:1468/1600 train_time:86534ms step_avg:58.95ms
+step:1469/1600 train_time:86623ms step_avg:58.97ms
+step:1470/1600 train_time:86709ms step_avg:58.99ms
+step:1471/1600 train_time:86795ms step_avg:59.00ms
+step:1472/1600 train_time:86880ms step_avg:59.02ms
+step:1473/1600 train_time:86969ms step_avg:59.04ms
+step:1474/1600 train_time:87054ms step_avg:59.06ms
+step:1475/1600 train_time:87142ms step_avg:59.08ms
+step:1476/1600 train_time:87227ms step_avg:59.10ms
+step:1477/1600 train_time:87315ms step_avg:59.12ms
+step:1478/1600 train_time:87401ms step_avg:59.13ms
+step:1479/1600 train_time:87489ms step_avg:59.15ms
+step:1480/1600 train_time:87575ms step_avg:59.17ms
+step:1481/1600 train_time:87664ms step_avg:59.19ms
+step:1482/1600 train_time:87749ms step_avg:59.21ms
+step:1483/1600 train_time:87837ms step_avg:59.23ms
+step:1484/1600 train_time:87923ms step_avg:59.25ms
+step:1485/1600 train_time:88011ms step_avg:59.27ms
+step:1486/1600 train_time:88096ms step_avg:59.28ms
+step:1487/1600 train_time:88185ms step_avg:59.30ms
+step:1488/1600 train_time:88269ms step_avg:59.32ms
+step:1489/1600 train_time:88359ms step_avg:59.34ms
+step:1490/1600 train_time:88444ms step_avg:59.36ms
+step:1491/1600 train_time:88531ms step_avg:59.38ms
+step:1492/1600 train_time:88617ms step_avg:59.39ms
+step:1493/1600 train_time:88705ms step_avg:59.41ms
+step:1494/1600 train_time:88790ms step_avg:59.43ms
+step:1495/1600 train_time:88878ms step_avg:59.45ms
+step:1496/1600 train_time:88963ms step_avg:59.47ms
+step:1497/1600 train_time:89051ms step_avg:59.49ms
+step:1498/1600 train_time:89137ms step_avg:59.50ms
+step:1499/1600 train_time:89226ms step_avg:59.52ms
+step:1500/1600 train_time:89311ms step_avg:59.54ms
+step:1500/1600 val_loss:3.3058 train_time:89384ms step_avg:59.59ms
+step:1501/1600 train_time:89403ms step_avg:59.56ms
+step:1502/1600 train_time:89487ms step_avg:59.58ms
+step:1503/1600 train_time:89579ms step_avg:59.60ms
+step:1504/1600 train_time:89664ms step_avg:59.62ms
+step:1505/1600 train_time:89752ms step_avg:59.64ms
+step:1506/1600 train_time:89836ms step_avg:59.65ms
+step:1507/1600 train_time:89923ms step_avg:59.67ms
+step:1508/1600 train_time:90008ms step_avg:59.69ms
+step:1509/1600 train_time:90095ms step_avg:59.71ms
+step:1510/1600 train_time:90181ms step_avg:59.72ms
+step:1511/1600 train_time:90268ms step_avg:59.74ms
+step:1512/1600 train_time:90354ms step_avg:59.76ms
+step:1513/1600 train_time:90444ms step_avg:59.78ms
+step:1514/1600 train_time:90531ms step_avg:59.80ms
+step:1515/1600 train_time:90622ms step_avg:59.82ms
+step:1516/1600 train_time:90708ms step_avg:59.83ms
+step:1517/1600 train_time:90796ms step_avg:59.85ms
+step:1518/1600 train_time:90880ms step_avg:59.87ms
+step:1519/1600 train_time:90968ms step_avg:59.89ms
+step:1520/1600 train_time:91052ms step_avg:59.90ms
+step:1521/1600 train_time:91139ms step_avg:59.92ms
+step:1522/1600 train_time:91223ms step_avg:59.94ms
+step:1523/1600 train_time:91311ms step_avg:59.95ms
+step:1524/1600 train_time:91397ms step_avg:59.97ms
+step:1525/1600 train_time:91487ms step_avg:59.99ms
+step:1526/1600 train_time:91573ms step_avg:60.01ms
+step:1527/1600 train_time:91662ms step_avg:60.03ms
+step:1528/1600 train_time:91750ms step_avg:60.05ms
+step:1529/1600 train_time:91837ms step_avg:60.06ms
+step:1530/1600 train_time:91921ms step_avg:60.08ms
+step:1531/1600 train_time:92009ms step_avg:60.10ms
+step:1532/1600 train_time:92092ms step_avg:60.11ms
+step:1533/1600 train_time:92180ms step_avg:60.13ms
+step:1534/1600 train_time:92266ms step_avg:60.15ms
+step:1535/1600 train_time:92355ms step_avg:60.17ms
+step:1536/1600 train_time:92440ms step_avg:60.18ms
+step:1537/1600 train_time:92529ms step_avg:60.20ms
+step:1538/1600 train_time:92615ms step_avg:60.22ms
+step:1539/1600 train_time:92704ms step_avg:60.24ms
+step:1540/1600 train_time:92789ms step_avg:60.25ms
+step:1541/1600 train_time:92877ms step_avg:60.27ms
+step:1542/1600 train_time:92962ms step_avg:60.29ms
+step:1543/1600 train_time:93050ms step_avg:60.30ms
+step:1544/1600 train_time:93135ms step_avg:60.32ms
+step:1545/1600 train_time:93223ms step_avg:60.34ms
+step:1546/1600 train_time:93307ms step_avg:60.35ms
+step:1547/1600 train_time:93397ms step_avg:60.37ms
+step:1548/1600 train_time:93482ms step_avg:60.39ms
+step:1549/1600 train_time:93570ms step_avg:60.41ms
+step:1550/1600 train_time:93656ms step_avg:60.42ms
+step:1551/1600 train_time:93746ms step_avg:60.44ms
+step:1552/1600 train_time:93831ms step_avg:60.46ms
+step:1553/1600 train_time:93920ms step_avg:60.48ms
+step:1554/1600 train_time:94004ms step_avg:60.49ms
+step:1555/1600 train_time:94092ms step_avg:60.51ms
+step:1556/1600 train_time:94177ms step_avg:60.53ms
+step:1557/1600 train_time:94265ms step_avg:60.54ms
+step:1558/1600 train_time:94350ms step_avg:60.56ms
+step:1559/1600 train_time:94439ms step_avg:60.58ms
+step:1560/1600 train_time:94527ms step_avg:60.59ms
+step:1561/1600 train_time:94622ms step_avg:60.62ms
+step:1562/1600 train_time:94704ms step_avg:60.63ms
+step:1563/1600 train_time:94793ms step_avg:60.65ms
+step:1564/1600 train_time:94878ms step_avg:60.66ms
+step:1565/1600 train_time:94966ms step_avg:60.68ms
+step:1566/1600 train_time:95052ms step_avg:60.70ms
+step:1567/1600 train_time:95141ms step_avg:60.72ms
+step:1568/1600 train_time:95227ms step_avg:60.73ms
+step:1569/1600 train_time:95315ms step_avg:60.75ms
+step:1570/1600 train_time:95401ms step_avg:60.76ms
+step:1571/1600 train_time:95490ms step_avg:60.78ms
+step:1572/1600 train_time:95576ms step_avg:60.80ms
+step:1573/1600 train_time:95666ms step_avg:60.82ms
+step:1574/1600 train_time:95752ms step_avg:60.83ms
+step:1575/1600 train_time:95842ms step_avg:60.85ms
+step:1576/1600 train_time:95927ms step_avg:60.87ms
+step:1577/1600 train_time:96018ms step_avg:60.89ms
+step:1578/1600 train_time:96105ms step_avg:60.90ms
+step:1579/1600 train_time:96190ms step_avg:60.92ms
+step:1580/1600 train_time:96277ms step_avg:60.93ms
+step:1581/1600 train_time:96364ms step_avg:60.95ms
+step:1582/1600 train_time:96450ms step_avg:60.97ms
+step:1583/1600 train_time:96540ms step_avg:60.99ms
+step:1584/1600 train_time:96625ms step_avg:61.00ms
+step:1585/1600 train_time:96714ms step_avg:61.02ms
+step:1586/1600 train_time:96799ms step_avg:61.03ms
+step:1587/1600 train_time:96886ms step_avg:61.05ms
+step:1588/1600 train_time:96974ms step_avg:61.07ms
+step:1589/1600 train_time:97062ms step_avg:61.08ms
+step:1590/1600 train_time:97147ms step_avg:61.10ms
+step:1591/1600 train_time:97237ms step_avg:61.12ms
+step:1592/1600 train_time:97322ms step_avg:61.13ms
+step:1593/1600 train_time:97411ms step_avg:61.15ms
+step:1594/1600 train_time:97496ms step_avg:61.16ms
+step:1595/1600 train_time:97586ms step_avg:61.18ms
+step:1596/1600 train_time:97672ms step_avg:61.20ms
+step:1597/1600 train_time:97762ms step_avg:61.22ms
+step:1598/1600 train_time:97846ms step_avg:61.23ms
+step:1599/1600 train_time:97935ms step_avg:61.25ms
+step:1600/1600 train_time:98020ms step_avg:61.26ms
+step:1600/1600 val_loss:3.2764 train_time:98093ms step_avg:61.31ms
+peak memory allocated: 30181 MiB reserved: 46138 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/87907fed-e7b7-4681-bf86-6cffe6139e49.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/87907fed-e7b7-4681-bf86-6cffe6139e49.txt
@@ -1,0 +1,4096 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 01 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # shifting first layer updates this to 01 ... 01 @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:26:52 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   34C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   40C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   41C    P0            130W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          247336      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          247337      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          247338      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          247339      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          247340      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          247341      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          247342      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          247343      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 511, 512, 513, 1023, 1024, 1025, 1534, 1535, 1536] for warmup
+Resetting Model
+step:0/1575 val_loss:10.8282 train_time:0ms step_avg:0.04ms
+step:1/1575 train_time:81ms step_avg:80.72ms
+step:2/1575 train_time:104ms step_avg:52.21ms
+step:3/1575 train_time:125ms step_avg:41.81ms
+step:4/1575 train_time:149ms step_avg:37.35ms
+step:5/1575 train_time:180ms step_avg:35.97ms
+step:6/1575 train_time:286ms step_avg:47.59ms
+step:7/1575 train_time:304ms step_avg:43.47ms
+step:8/1575 train_time:325ms step_avg:40.67ms
+step:9/1575 train_time:356ms step_avg:39.55ms
+step:10/1575 train_time:395ms step_avg:39.49ms
+step:11/1575 train_time:426ms step_avg:38.69ms
+step:12/1575 train_time:464ms step_avg:38.69ms
+step:13/1575 train_time:495ms step_avg:38.10ms
+step:14/1575 train_time:534ms step_avg:38.16ms
+step:15/1575 train_time:565ms step_avg:37.66ms
+step:16/1575 train_time:604ms step_avg:37.72ms
+step:17/1575 train_time:635ms step_avg:37.33ms
+step:18/1575 train_time:674ms step_avg:37.43ms
+step:19/1575 train_time:705ms step_avg:37.10ms
+step:20/1575 train_time:744ms step_avg:37.18ms
+step:21/1575 train_time:774ms step_avg:36.88ms
+step:22/1575 train_time:813ms step_avg:36.96ms
+step:23/1575 train_time:844ms step_avg:36.70ms
+step:24/1575 train_time:883ms step_avg:36.78ms
+step:25/1575 train_time:914ms step_avg:36.55ms
+step:26/1575 train_time:952ms step_avg:36.63ms
+step:27/1575 train_time:984ms step_avg:36.43ms
+step:28/1575 train_time:1023ms step_avg:36.52ms
+step:29/1575 train_time:1053ms step_avg:36.31ms
+step:30/1575 train_time:1092ms step_avg:36.40ms
+step:31/1575 train_time:1123ms step_avg:36.22ms
+step:32/1575 train_time:1162ms step_avg:36.31ms
+step:33/1575 train_time:1193ms step_avg:36.16ms
+step:34/1575 train_time:1232ms step_avg:36.25ms
+step:35/1575 train_time:1264ms step_avg:36.12ms
+step:36/1575 train_time:1303ms step_avg:36.20ms
+step:37/1575 train_time:1334ms step_avg:36.06ms
+step:38/1575 train_time:1373ms step_avg:36.14ms
+step:39/1575 train_time:1405ms step_avg:36.02ms
+step:40/1575 train_time:1444ms step_avg:36.09ms
+step:41/1575 train_time:1474ms step_avg:35.96ms
+step:42/1575 train_time:1513ms step_avg:36.03ms
+step:43/1575 train_time:1544ms step_avg:35.90ms
+step:44/1575 train_time:1582ms step_avg:35.96ms
+step:45/1575 train_time:1613ms step_avg:35.85ms
+step:46/1575 train_time:1652ms step_avg:35.91ms
+step:47/1575 train_time:1683ms step_avg:35.81ms
+step:48/1575 train_time:1722ms step_avg:35.87ms
+step:49/1575 train_time:1753ms step_avg:35.77ms
+step:50/1575 train_time:1791ms step_avg:35.82ms
+step:51/1575 train_time:1822ms step_avg:35.73ms
+step:52/1575 train_time:1861ms step_avg:35.79ms
+step:53/1575 train_time:1892ms step_avg:35.70ms
+step:54/1575 train_time:1931ms step_avg:35.75ms
+step:55/1575 train_time:1962ms step_avg:35.67ms
+step:56/1575 train_time:2000ms step_avg:35.72ms
+step:57/1575 train_time:2031ms step_avg:35.64ms
+step:58/1575 train_time:2070ms step_avg:35.69ms
+step:59/1575 train_time:2101ms step_avg:35.61ms
+step:60/1575 train_time:2140ms step_avg:35.67ms
+step:61/1575 train_time:2171ms step_avg:35.59ms
+step:62/1575 train_time:2209ms step_avg:35.64ms
+step:63/1575 train_time:2240ms step_avg:35.56ms
+step:64/1575 train_time:2279ms step_avg:35.61ms
+step:65/1575 train_time:2310ms step_avg:35.54ms
+step:66/1575 train_time:2348ms step_avg:35.58ms
+step:67/1575 train_time:2380ms step_avg:35.52ms
+step:68/1575 train_time:2419ms step_avg:35.57ms
+step:69/1575 train_time:2449ms step_avg:35.50ms
+step:70/1575 train_time:2488ms step_avg:35.54ms
+step:71/1575 train_time:2519ms step_avg:35.47ms
+step:72/1575 train_time:2558ms step_avg:35.52ms
+step:73/1575 train_time:2589ms step_avg:35.46ms
+step:74/1575 train_time:2628ms step_avg:35.51ms
+step:75/1575 train_time:2658ms step_avg:35.44ms
+step:76/1575 train_time:2696ms step_avg:35.48ms
+step:77/1575 train_time:2727ms step_avg:35.42ms
+step:78/1575 train_time:2766ms step_avg:35.46ms
+step:79/1575 train_time:2797ms step_avg:35.40ms
+step:80/1575 train_time:2836ms step_avg:35.45ms
+step:81/1575 train_time:2867ms step_avg:35.39ms
+step:82/1575 train_time:2905ms step_avg:35.43ms
+step:83/1575 train_time:2936ms step_avg:35.38ms
+step:84/1575 train_time:2975ms step_avg:35.42ms
+step:85/1575 train_time:3006ms step_avg:35.36ms
+step:86/1575 train_time:3044ms step_avg:35.40ms
+step:87/1575 train_time:3075ms step_avg:35.35ms
+step:88/1575 train_time:3114ms step_avg:35.39ms
+step:89/1575 train_time:3145ms step_avg:35.34ms
+step:90/1575 train_time:3185ms step_avg:35.39ms
+step:91/1575 train_time:3215ms step_avg:35.33ms
+step:92/1575 train_time:3253ms step_avg:35.36ms
+step:93/1575 train_time:3284ms step_avg:35.32ms
+step:94/1575 train_time:3323ms step_avg:35.36ms
+step:95/1575 train_time:3354ms step_avg:35.31ms
+step:96/1575 train_time:3393ms step_avg:35.34ms
+step:97/1575 train_time:3424ms step_avg:35.29ms
+step:98/1575 train_time:3462ms step_avg:35.33ms
+step:99/1575 train_time:3493ms step_avg:35.28ms
+step:100/1575 train_time:3532ms step_avg:35.32ms
+step:101/1575 train_time:3562ms step_avg:35.27ms
+step:102/1575 train_time:3601ms step_avg:35.31ms
+step:103/1575 train_time:3632ms step_avg:35.27ms
+step:104/1575 train_time:3671ms step_avg:35.30ms
+step:105/1575 train_time:3702ms step_avg:35.26ms
+step:106/1575 train_time:3741ms step_avg:35.29ms
+step:107/1575 train_time:3772ms step_avg:35.25ms
+step:108/1575 train_time:3810ms step_avg:35.28ms
+step:109/1575 train_time:3842ms step_avg:35.24ms
+step:110/1575 train_time:3880ms step_avg:35.28ms
+step:111/1575 train_time:3911ms step_avg:35.24ms
+step:112/1575 train_time:3950ms step_avg:35.27ms
+step:113/1575 train_time:3981ms step_avg:35.23ms
+step:114/1575 train_time:4020ms step_avg:35.27ms
+step:115/1575 train_time:4051ms step_avg:35.22ms
+step:116/1575 train_time:4089ms step_avg:35.25ms
+step:117/1575 train_time:4120ms step_avg:35.21ms
+step:118/1575 train_time:4159ms step_avg:35.24ms
+step:119/1575 train_time:4189ms step_avg:35.20ms
+step:120/1575 train_time:4228ms step_avg:35.23ms
+step:121/1575 train_time:4259ms step_avg:35.20ms
+step:122/1575 train_time:4297ms step_avg:35.22ms
+step:123/1575 train_time:4328ms step_avg:35.19ms
+step:124/1575 train_time:4367ms step_avg:35.22ms
+step:125/1575 train_time:4398ms step_avg:35.18ms
+step:126/1575 train_time:4437ms step_avg:35.21ms
+step:127/1575 train_time:4468ms step_avg:35.18ms
+step:128/1575 train_time:4506ms step_avg:35.20ms
+step:129/1575 train_time:4537ms step_avg:35.17ms
+step:130/1575 train_time:4576ms step_avg:35.20ms
+step:131/1575 train_time:4607ms step_avg:35.17ms
+step:132/1575 train_time:4646ms step_avg:35.19ms
+step:133/1575 train_time:4676ms step_avg:35.16ms
+step:134/1575 train_time:4715ms step_avg:35.19ms
+step:135/1575 train_time:4746ms step_avg:35.15ms
+step:136/1575 train_time:4784ms step_avg:35.18ms
+step:137/1575 train_time:4815ms step_avg:35.15ms
+step:138/1575 train_time:4854ms step_avg:35.17ms
+step:139/1575 train_time:4884ms step_avg:35.14ms
+step:140/1575 train_time:4923ms step_avg:35.17ms
+step:141/1575 train_time:4954ms step_avg:35.14ms
+step:142/1575 train_time:4993ms step_avg:35.16ms
+step:143/1575 train_time:5025ms step_avg:35.14ms
+step:144/1575 train_time:5063ms step_avg:35.16ms
+step:145/1575 train_time:5094ms step_avg:35.13ms
+step:146/1575 train_time:5133ms step_avg:35.16ms
+step:147/1575 train_time:5164ms step_avg:35.13ms
+step:148/1575 train_time:5203ms step_avg:35.15ms
+step:149/1575 train_time:5233ms step_avg:35.12ms
+step:150/1575 train_time:5272ms step_avg:35.15ms
+step:151/1575 train_time:5303ms step_avg:35.12ms
+step:152/1575 train_time:5342ms step_avg:35.14ms
+step:153/1575 train_time:5373ms step_avg:35.12ms
+step:154/1575 train_time:5411ms step_avg:35.14ms
+step:155/1575 train_time:5442ms step_avg:35.11ms
+step:156/1575 train_time:5481ms step_avg:35.14ms
+step:157/1575 train_time:5512ms step_avg:35.11ms
+step:158/1575 train_time:5551ms step_avg:35.13ms
+step:159/1575 train_time:5582ms step_avg:35.11ms
+step:160/1575 train_time:5621ms step_avg:35.13ms
+step:161/1575 train_time:5651ms step_avg:35.10ms
+step:162/1575 train_time:5690ms step_avg:35.12ms
+step:163/1575 train_time:5721ms step_avg:35.10ms
+step:164/1575 train_time:5759ms step_avg:35.12ms
+step:165/1575 train_time:5791ms step_avg:35.09ms
+step:166/1575 train_time:5829ms step_avg:35.12ms
+step:167/1575 train_time:5860ms step_avg:35.09ms
+step:168/1575 train_time:5899ms step_avg:35.11ms
+step:169/1575 train_time:5929ms step_avg:35.09ms
+step:170/1575 train_time:5968ms step_avg:35.10ms
+step:171/1575 train_time:5999ms step_avg:35.08ms
+step:172/1575 train_time:6037ms step_avg:35.10ms
+step:173/1575 train_time:6068ms step_avg:35.07ms
+step:174/1575 train_time:6106ms step_avg:35.09ms
+step:175/1575 train_time:6137ms step_avg:35.07ms
+step:176/1575 train_time:6176ms step_avg:35.09ms
+step:177/1575 train_time:6207ms step_avg:35.07ms
+step:178/1575 train_time:6245ms step_avg:35.08ms
+step:179/1575 train_time:6276ms step_avg:35.06ms
+step:180/1575 train_time:6314ms step_avg:35.08ms
+step:181/1575 train_time:6345ms step_avg:35.05ms
+step:182/1575 train_time:6383ms step_avg:35.07ms
+step:183/1575 train_time:6414ms step_avg:35.05ms
+step:184/1575 train_time:6453ms step_avg:35.07ms
+step:185/1575 train_time:6484ms step_avg:35.05ms
+step:186/1575 train_time:6522ms step_avg:35.07ms
+step:187/1575 train_time:6553ms step_avg:35.04ms
+step:188/1575 train_time:6592ms step_avg:35.06ms
+step:189/1575 train_time:6623ms step_avg:35.04ms
+step:190/1575 train_time:6661ms step_avg:35.06ms
+step:191/1575 train_time:6692ms step_avg:35.04ms
+step:192/1575 train_time:6730ms step_avg:35.05ms
+step:193/1575 train_time:6761ms step_avg:35.03ms
+step:194/1575 train_time:6800ms step_avg:35.05ms
+step:195/1575 train_time:6831ms step_avg:35.03ms
+step:196/1575 train_time:6869ms step_avg:35.05ms
+step:197/1575 train_time:6900ms step_avg:35.03ms
+step:198/1575 train_time:6939ms step_avg:35.05ms
+step:199/1575 train_time:6970ms step_avg:35.02ms
+step:200/1575 train_time:7008ms step_avg:35.04ms
+step:201/1575 train_time:7039ms step_avg:35.02ms
+step:202/1575 train_time:7077ms step_avg:35.04ms
+step:203/1575 train_time:7108ms step_avg:35.02ms
+step:204/1575 train_time:7147ms step_avg:35.03ms
+step:205/1575 train_time:7178ms step_avg:35.01ms
+step:206/1575 train_time:7216ms step_avg:35.03ms
+step:207/1575 train_time:7247ms step_avg:35.01ms
+step:208/1575 train_time:7286ms step_avg:35.03ms
+step:209/1575 train_time:7316ms step_avg:35.01ms
+step:210/1575 train_time:7356ms step_avg:35.03ms
+step:211/1575 train_time:7386ms step_avg:35.01ms
+step:212/1575 train_time:7425ms step_avg:35.02ms
+step:213/1575 train_time:7455ms step_avg:35.00ms
+step:214/1575 train_time:7494ms step_avg:35.02ms
+step:215/1575 train_time:7525ms step_avg:35.00ms
+step:216/1575 train_time:7563ms step_avg:35.02ms
+step:217/1575 train_time:7594ms step_avg:35.00ms
+step:218/1575 train_time:7633ms step_avg:35.01ms
+step:219/1575 train_time:7664ms step_avg:35.00ms
+step:220/1575 train_time:7703ms step_avg:35.01ms
+step:221/1575 train_time:7734ms step_avg:35.00ms
+step:222/1575 train_time:7772ms step_avg:35.01ms
+step:223/1575 train_time:7803ms step_avg:34.99ms
+step:224/1575 train_time:7841ms step_avg:35.01ms
+step:225/1575 train_time:7872ms step_avg:34.99ms
+step:226/1575 train_time:7911ms step_avg:35.00ms
+step:227/1575 train_time:7942ms step_avg:34.99ms
+step:228/1575 train_time:7981ms step_avg:35.00ms
+step:229/1575 train_time:8011ms step_avg:34.98ms
+step:230/1575 train_time:8050ms step_avg:35.00ms
+step:231/1575 train_time:8081ms step_avg:34.98ms
+step:232/1575 train_time:8119ms step_avg:35.00ms
+step:233/1575 train_time:8150ms step_avg:34.98ms
+step:234/1575 train_time:8189ms step_avg:34.99ms
+step:235/1575 train_time:8220ms step_avg:34.98ms
+step:236/1575 train_time:8259ms step_avg:35.00ms
+step:237/1575 train_time:8290ms step_avg:34.98ms
+step:238/1575 train_time:8328ms step_avg:34.99ms
+step:239/1575 train_time:8359ms step_avg:34.98ms
+step:240/1575 train_time:8398ms step_avg:34.99ms
+step:241/1575 train_time:8429ms step_avg:34.97ms
+step:242/1575 train_time:8467ms step_avg:34.99ms
+step:243/1575 train_time:8498ms step_avg:34.97ms
+step:244/1575 train_time:8537ms step_avg:34.99ms
+step:245/1575 train_time:8568ms step_avg:34.97ms
+step:246/1575 train_time:8606ms step_avg:34.98ms
+step:247/1575 train_time:8637ms step_avg:34.97ms
+step:248/1575 train_time:8676ms step_avg:34.98ms
+step:249/1575 train_time:8706ms step_avg:34.97ms
+step:250/1575 train_time:8745ms step_avg:34.98ms
+step:250/1575 val_loss:4.5749 train_time:8793ms step_avg:35.17ms
+step:251/1575 train_time:8813ms step_avg:35.11ms
+step:252/1575 train_time:8833ms step_avg:35.05ms
+step:253/1575 train_time:8851ms step_avg:34.99ms
+step:254/1575 train_time:8887ms step_avg:34.99ms
+step:255/1575 train_time:8919ms step_avg:34.98ms
+step:256/1575 train_time:8959ms step_avg:34.99ms
+step:257/1575 train_time:8991ms step_avg:34.99ms
+step:258/1575 train_time:9031ms step_avg:35.00ms
+step:259/1575 train_time:9062ms step_avg:34.99ms
+step:260/1575 train_time:9101ms step_avg:35.00ms
+step:261/1575 train_time:9132ms step_avg:34.99ms
+step:262/1575 train_time:9170ms step_avg:35.00ms
+step:263/1575 train_time:9201ms step_avg:34.98ms
+step:264/1575 train_time:9239ms step_avg:35.00ms
+step:265/1575 train_time:9270ms step_avg:34.98ms
+step:266/1575 train_time:9309ms step_avg:34.99ms
+step:267/1575 train_time:9339ms step_avg:34.98ms
+step:268/1575 train_time:9378ms step_avg:34.99ms
+step:269/1575 train_time:9409ms step_avg:34.98ms
+step:270/1575 train_time:9447ms step_avg:34.99ms
+step:271/1575 train_time:9478ms step_avg:34.97ms
+step:272/1575 train_time:9516ms step_avg:34.99ms
+step:273/1575 train_time:9547ms step_avg:34.97ms
+step:274/1575 train_time:9585ms step_avg:34.98ms
+step:275/1575 train_time:9616ms step_avg:34.97ms
+step:276/1575 train_time:9655ms step_avg:34.98ms
+step:277/1575 train_time:9686ms step_avg:34.97ms
+step:278/1575 train_time:9724ms step_avg:34.98ms
+step:279/1575 train_time:9755ms step_avg:34.96ms
+step:280/1575 train_time:9793ms step_avg:34.98ms
+step:281/1575 train_time:9824ms step_avg:34.96ms
+step:282/1575 train_time:9863ms step_avg:34.98ms
+step:283/1575 train_time:9894ms step_avg:34.96ms
+step:284/1575 train_time:9932ms step_avg:34.97ms
+step:285/1575 train_time:9963ms step_avg:34.96ms
+step:286/1575 train_time:10002ms step_avg:34.97ms
+step:287/1575 train_time:10032ms step_avg:34.96ms
+step:288/1575 train_time:10071ms step_avg:34.97ms
+step:289/1575 train_time:10102ms step_avg:34.95ms
+step:290/1575 train_time:10140ms step_avg:34.97ms
+step:291/1575 train_time:10171ms step_avg:34.95ms
+step:292/1575 train_time:10210ms step_avg:34.96ms
+step:293/1575 train_time:10240ms step_avg:34.95ms
+step:294/1575 train_time:10279ms step_avg:34.96ms
+step:295/1575 train_time:10310ms step_avg:34.95ms
+step:296/1575 train_time:10348ms step_avg:34.96ms
+step:297/1575 train_time:10379ms step_avg:34.95ms
+step:298/1575 train_time:10418ms step_avg:34.96ms
+step:299/1575 train_time:10448ms step_avg:34.94ms
+step:300/1575 train_time:10487ms step_avg:34.96ms
+step:301/1575 train_time:10517ms step_avg:34.94ms
+step:302/1575 train_time:10556ms step_avg:34.95ms
+step:303/1575 train_time:10586ms step_avg:34.94ms
+step:304/1575 train_time:10625ms step_avg:34.95ms
+step:305/1575 train_time:10656ms step_avg:34.94ms
+step:306/1575 train_time:10694ms step_avg:34.95ms
+step:307/1575 train_time:10725ms step_avg:34.93ms
+step:308/1575 train_time:10763ms step_avg:34.95ms
+step:309/1575 train_time:10794ms step_avg:34.93ms
+step:310/1575 train_time:10832ms step_avg:34.94ms
+step:311/1575 train_time:10864ms step_avg:34.93ms
+step:312/1575 train_time:10902ms step_avg:34.94ms
+step:313/1575 train_time:10933ms step_avg:34.93ms
+step:314/1575 train_time:10971ms step_avg:34.94ms
+step:315/1575 train_time:11002ms step_avg:34.93ms
+step:316/1575 train_time:11041ms step_avg:34.94ms
+step:317/1575 train_time:11071ms step_avg:34.93ms
+step:318/1575 train_time:11110ms step_avg:34.94ms
+step:319/1575 train_time:11141ms step_avg:34.92ms
+step:320/1575 train_time:11180ms step_avg:34.94ms
+step:321/1575 train_time:11211ms step_avg:34.93ms
+step:322/1575 train_time:11249ms step_avg:34.94ms
+step:323/1575 train_time:11280ms step_avg:34.92ms
+step:324/1575 train_time:11320ms step_avg:34.94ms
+step:325/1575 train_time:11350ms step_avg:34.92ms
+step:326/1575 train_time:11389ms step_avg:34.93ms
+step:327/1575 train_time:11420ms step_avg:34.92ms
+step:328/1575 train_time:11458ms step_avg:34.93ms
+step:329/1575 train_time:11489ms step_avg:34.92ms
+step:330/1575 train_time:11527ms step_avg:34.93ms
+step:331/1575 train_time:11558ms step_avg:34.92ms
+step:332/1575 train_time:11597ms step_avg:34.93ms
+step:333/1575 train_time:11628ms step_avg:34.92ms
+step:334/1575 train_time:11667ms step_avg:34.93ms
+step:335/1575 train_time:11698ms step_avg:34.92ms
+step:336/1575 train_time:11736ms step_avg:34.93ms
+step:337/1575 train_time:11766ms step_avg:34.91ms
+step:338/1575 train_time:11805ms step_avg:34.93ms
+step:339/1575 train_time:11835ms step_avg:34.91ms
+step:340/1575 train_time:11874ms step_avg:34.92ms
+step:341/1575 train_time:11905ms step_avg:34.91ms
+step:342/1575 train_time:11943ms step_avg:34.92ms
+step:343/1575 train_time:11974ms step_avg:34.91ms
+step:344/1575 train_time:12013ms step_avg:34.92ms
+step:345/1575 train_time:12044ms step_avg:34.91ms
+step:346/1575 train_time:12083ms step_avg:34.92ms
+step:347/1575 train_time:12113ms step_avg:34.91ms
+step:348/1575 train_time:12152ms step_avg:34.92ms
+step:349/1575 train_time:12182ms step_avg:34.91ms
+step:350/1575 train_time:12221ms step_avg:34.92ms
+step:351/1575 train_time:12252ms step_avg:34.91ms
+step:352/1575 train_time:12291ms step_avg:34.92ms
+step:353/1575 train_time:12321ms step_avg:34.90ms
+step:354/1575 train_time:12359ms step_avg:34.91ms
+step:355/1575 train_time:12390ms step_avg:34.90ms
+step:356/1575 train_time:12428ms step_avg:34.91ms
+step:357/1575 train_time:12460ms step_avg:34.90ms
+step:358/1575 train_time:12499ms step_avg:34.91ms
+step:359/1575 train_time:12528ms step_avg:34.90ms
+step:360/1575 train_time:12567ms step_avg:34.91ms
+step:361/1575 train_time:12597ms step_avg:34.90ms
+step:362/1575 train_time:12636ms step_avg:34.91ms
+step:363/1575 train_time:12667ms step_avg:34.89ms
+step:364/1575 train_time:12705ms step_avg:34.91ms
+step:365/1575 train_time:12736ms step_avg:34.89ms
+step:366/1575 train_time:12774ms step_avg:34.90ms
+step:367/1575 train_time:12805ms step_avg:34.89ms
+step:368/1575 train_time:12843ms step_avg:34.90ms
+step:369/1575 train_time:12875ms step_avg:34.89ms
+step:370/1575 train_time:12914ms step_avg:34.90ms
+step:371/1575 train_time:12944ms step_avg:34.89ms
+step:372/1575 train_time:12983ms step_avg:34.90ms
+step:373/1575 train_time:13014ms step_avg:34.89ms
+step:374/1575 train_time:13053ms step_avg:34.90ms
+step:375/1575 train_time:13083ms step_avg:34.89ms
+step:376/1575 train_time:13122ms step_avg:34.90ms
+step:377/1575 train_time:13153ms step_avg:34.89ms
+step:378/1575 train_time:13192ms step_avg:34.90ms
+step:379/1575 train_time:13222ms step_avg:34.89ms
+step:380/1575 train_time:13261ms step_avg:34.90ms
+step:381/1575 train_time:13292ms step_avg:34.89ms
+step:382/1575 train_time:13330ms step_avg:34.90ms
+step:383/1575 train_time:13360ms step_avg:34.88ms
+step:384/1575 train_time:13399ms step_avg:34.89ms
+step:385/1575 train_time:13430ms step_avg:34.88ms
+step:386/1575 train_time:13469ms step_avg:34.89ms
+step:387/1575 train_time:13499ms step_avg:34.88ms
+step:388/1575 train_time:13538ms step_avg:34.89ms
+step:389/1575 train_time:13569ms step_avg:34.88ms
+step:390/1575 train_time:13607ms step_avg:34.89ms
+step:391/1575 train_time:13638ms step_avg:34.88ms
+step:392/1575 train_time:13676ms step_avg:34.89ms
+step:393/1575 train_time:13707ms step_avg:34.88ms
+step:394/1575 train_time:13746ms step_avg:34.89ms
+step:395/1575 train_time:13776ms step_avg:34.88ms
+step:396/1575 train_time:13815ms step_avg:34.89ms
+step:397/1575 train_time:13846ms step_avg:34.88ms
+step:398/1575 train_time:13885ms step_avg:34.89ms
+step:399/1575 train_time:13915ms step_avg:34.87ms
+step:400/1575 train_time:13954ms step_avg:34.88ms
+step:401/1575 train_time:13984ms step_avg:34.87ms
+step:402/1575 train_time:14024ms step_avg:34.88ms
+step:403/1575 train_time:14054ms step_avg:34.87ms
+step:404/1575 train_time:14092ms step_avg:34.88ms
+step:405/1575 train_time:14123ms step_avg:34.87ms
+step:406/1575 train_time:14162ms step_avg:34.88ms
+step:407/1575 train_time:14193ms step_avg:34.87ms
+step:408/1575 train_time:14231ms step_avg:34.88ms
+step:409/1575 train_time:14262ms step_avg:34.87ms
+step:410/1575 train_time:14301ms step_avg:34.88ms
+step:411/1575 train_time:14331ms step_avg:34.87ms
+step:412/1575 train_time:14370ms step_avg:34.88ms
+step:413/1575 train_time:14401ms step_avg:34.87ms
+step:414/1575 train_time:14439ms step_avg:34.88ms
+step:415/1575 train_time:14470ms step_avg:34.87ms
+step:416/1575 train_time:14509ms step_avg:34.88ms
+step:417/1575 train_time:14539ms step_avg:34.87ms
+step:418/1575 train_time:14578ms step_avg:34.88ms
+step:419/1575 train_time:14609ms step_avg:34.87ms
+step:420/1575 train_time:14648ms step_avg:34.88ms
+step:421/1575 train_time:14678ms step_avg:34.87ms
+step:422/1575 train_time:14724ms step_avg:34.89ms
+step:423/1575 train_time:14748ms step_avg:34.86ms
+step:424/1575 train_time:14786ms step_avg:34.87ms
+step:425/1575 train_time:14817ms step_avg:34.86ms
+step:426/1575 train_time:14856ms step_avg:34.87ms
+step:427/1575 train_time:14887ms step_avg:34.86ms
+step:428/1575 train_time:14925ms step_avg:34.87ms
+step:429/1575 train_time:14956ms step_avg:34.86ms
+step:430/1575 train_time:14994ms step_avg:34.87ms
+step:431/1575 train_time:15025ms step_avg:34.86ms
+step:432/1575 train_time:15063ms step_avg:34.87ms
+step:433/1575 train_time:15094ms step_avg:34.86ms
+step:434/1575 train_time:15133ms step_avg:34.87ms
+step:435/1575 train_time:15163ms step_avg:34.86ms
+step:436/1575 train_time:15202ms step_avg:34.87ms
+step:437/1575 train_time:15233ms step_avg:34.86ms
+step:438/1575 train_time:15271ms step_avg:34.87ms
+step:439/1575 train_time:15302ms step_avg:34.86ms
+step:440/1575 train_time:15341ms step_avg:34.87ms
+step:441/1575 train_time:15372ms step_avg:34.86ms
+step:442/1575 train_time:15410ms step_avg:34.86ms
+step:443/1575 train_time:15441ms step_avg:34.86ms
+step:444/1575 train_time:15480ms step_avg:34.86ms
+step:445/1575 train_time:15510ms step_avg:34.85ms
+step:446/1575 train_time:15549ms step_avg:34.86ms
+step:447/1575 train_time:15580ms step_avg:34.85ms
+step:448/1575 train_time:15618ms step_avg:34.86ms
+step:449/1575 train_time:15649ms step_avg:34.85ms
+step:450/1575 train_time:15687ms step_avg:34.86ms
+step:451/1575 train_time:15718ms step_avg:34.85ms
+step:452/1575 train_time:15756ms step_avg:34.86ms
+step:453/1575 train_time:15787ms step_avg:34.85ms
+step:454/1575 train_time:15826ms step_avg:34.86ms
+step:455/1575 train_time:15857ms step_avg:34.85ms
+step:456/1575 train_time:15895ms step_avg:34.86ms
+step:457/1575 train_time:15926ms step_avg:34.85ms
+step:458/1575 train_time:15965ms step_avg:34.86ms
+step:459/1575 train_time:15995ms step_avg:34.85ms
+step:460/1575 train_time:16034ms step_avg:34.86ms
+step:461/1575 train_time:16065ms step_avg:34.85ms
+step:462/1575 train_time:16104ms step_avg:34.86ms
+step:463/1575 train_time:16135ms step_avg:34.85ms
+step:464/1575 train_time:16173ms step_avg:34.86ms
+step:465/1575 train_time:16204ms step_avg:34.85ms
+step:466/1575 train_time:16243ms step_avg:34.86ms
+step:467/1575 train_time:16273ms step_avg:34.85ms
+step:468/1575 train_time:16312ms step_avg:34.86ms
+step:469/1575 train_time:16343ms step_avg:34.85ms
+step:470/1575 train_time:16381ms step_avg:34.85ms
+step:471/1575 train_time:16412ms step_avg:34.85ms
+step:472/1575 train_time:16451ms step_avg:34.85ms
+step:473/1575 train_time:16482ms step_avg:34.85ms
+step:474/1575 train_time:16521ms step_avg:34.85ms
+step:475/1575 train_time:16551ms step_avg:34.84ms
+step:476/1575 train_time:16590ms step_avg:34.85ms
+step:477/1575 train_time:16620ms step_avg:34.84ms
+step:478/1575 train_time:16659ms step_avg:34.85ms
+step:479/1575 train_time:16690ms step_avg:34.84ms
+step:480/1575 train_time:16729ms step_avg:34.85ms
+step:481/1575 train_time:16760ms step_avg:34.84ms
+step:482/1575 train_time:16799ms step_avg:34.85ms
+step:483/1575 train_time:16829ms step_avg:34.84ms
+step:484/1575 train_time:16868ms step_avg:34.85ms
+step:485/1575 train_time:16898ms step_avg:34.84ms
+step:486/1575 train_time:16937ms step_avg:34.85ms
+step:487/1575 train_time:16968ms step_avg:34.84ms
+step:488/1575 train_time:17006ms step_avg:34.85ms
+step:489/1575 train_time:17037ms step_avg:34.84ms
+step:490/1575 train_time:17075ms step_avg:34.85ms
+step:491/1575 train_time:17106ms step_avg:34.84ms
+step:492/1575 train_time:17145ms step_avg:34.85ms
+step:493/1575 train_time:17175ms step_avg:34.84ms
+step:494/1575 train_time:17214ms step_avg:34.85ms
+step:495/1575 train_time:17245ms step_avg:34.84ms
+step:496/1575 train_time:17283ms step_avg:34.85ms
+step:497/1575 train_time:17314ms step_avg:34.84ms
+step:498/1575 train_time:17353ms step_avg:34.84ms
+step:499/1575 train_time:17383ms step_avg:34.84ms
+step:500/1575 train_time:17422ms step_avg:34.84ms
+step:500/1575 val_loss:4.2357 train_time:17470ms step_avg:34.94ms
+step:501/1575 train_time:17491ms step_avg:34.91ms
+step:502/1575 train_time:17511ms step_avg:34.88ms
+step:503/1575 train_time:17529ms step_avg:34.85ms
+step:504/1575 train_time:17565ms step_avg:34.85ms
+step:505/1575 train_time:17598ms step_avg:34.85ms
+step:506/1575 train_time:17638ms step_avg:34.86ms
+step:507/1575 train_time:17669ms step_avg:34.85ms
+step:508/1575 train_time:17708ms step_avg:34.86ms
+step:509/1575 train_time:17739ms step_avg:34.85ms
+step:510/1575 train_time:17777ms step_avg:34.86ms
+step:511/1575 train_time:17808ms step_avg:34.85ms
+step:512/1575 train_time:17848ms step_avg:34.86ms
+step:513/1575 train_time:17924ms step_avg:34.94ms
+step:514/1575 train_time:17978ms step_avg:34.98ms
+step:515/1575 train_time:18039ms step_avg:35.03ms
+step:516/1575 train_time:18098ms step_avg:35.07ms
+step:517/1575 train_time:18160ms step_avg:35.13ms
+step:518/1575 train_time:18219ms step_avg:35.17ms
+step:519/1575 train_time:18281ms step_avg:35.22ms
+step:520/1575 train_time:18340ms step_avg:35.27ms
+step:521/1575 train_time:18404ms step_avg:35.32ms
+step:522/1575 train_time:18463ms step_avg:35.37ms
+step:523/1575 train_time:18528ms step_avg:35.43ms
+step:524/1575 train_time:18588ms step_avg:35.47ms
+step:525/1575 train_time:18652ms step_avg:35.53ms
+step:526/1575 train_time:18712ms step_avg:35.57ms
+step:527/1575 train_time:18776ms step_avg:35.63ms
+step:528/1575 train_time:18837ms step_avg:35.68ms
+step:529/1575 train_time:18900ms step_avg:35.73ms
+step:530/1575 train_time:18960ms step_avg:35.77ms
+step:531/1575 train_time:19023ms step_avg:35.82ms
+step:532/1575 train_time:19082ms step_avg:35.87ms
+step:533/1575 train_time:19145ms step_avg:35.92ms
+step:534/1575 train_time:19203ms step_avg:35.96ms
+step:535/1575 train_time:19267ms step_avg:36.01ms
+step:536/1575 train_time:19327ms step_avg:36.06ms
+step:537/1575 train_time:19391ms step_avg:36.11ms
+step:538/1575 train_time:19450ms step_avg:36.15ms
+step:539/1575 train_time:19513ms step_avg:36.20ms
+step:540/1575 train_time:19573ms step_avg:36.25ms
+step:541/1575 train_time:19637ms step_avg:36.30ms
+step:542/1575 train_time:19696ms step_avg:36.34ms
+step:543/1575 train_time:19761ms step_avg:36.39ms
+step:544/1575 train_time:19821ms step_avg:36.44ms
+step:545/1575 train_time:19884ms step_avg:36.49ms
+step:546/1575 train_time:19944ms step_avg:36.53ms
+step:547/1575 train_time:20008ms step_avg:36.58ms
+step:548/1575 train_time:20067ms step_avg:36.62ms
+step:549/1575 train_time:20131ms step_avg:36.67ms
+step:550/1575 train_time:20190ms step_avg:36.71ms
+step:551/1575 train_time:20253ms step_avg:36.76ms
+step:552/1575 train_time:20313ms step_avg:36.80ms
+step:553/1575 train_time:20377ms step_avg:36.85ms
+step:554/1575 train_time:20437ms step_avg:36.89ms
+step:555/1575 train_time:20499ms step_avg:36.94ms
+step:556/1575 train_time:20559ms step_avg:36.98ms
+step:557/1575 train_time:20622ms step_avg:37.02ms
+step:558/1575 train_time:20681ms step_avg:37.06ms
+step:559/1575 train_time:20745ms step_avg:37.11ms
+step:560/1575 train_time:20805ms step_avg:37.15ms
+step:561/1575 train_time:20868ms step_avg:37.20ms
+step:562/1575 train_time:20928ms step_avg:37.24ms
+step:563/1575 train_time:20990ms step_avg:37.28ms
+step:564/1575 train_time:21050ms step_avg:37.32ms
+step:565/1575 train_time:21114ms step_avg:37.37ms
+step:566/1575 train_time:21172ms step_avg:37.41ms
+step:567/1575 train_time:21235ms step_avg:37.45ms
+step:568/1575 train_time:21297ms step_avg:37.49ms
+step:569/1575 train_time:21364ms step_avg:37.55ms
+step:570/1575 train_time:21421ms step_avg:37.58ms
+step:571/1575 train_time:21483ms step_avg:37.62ms
+step:572/1575 train_time:21542ms step_avg:37.66ms
+step:573/1575 train_time:21604ms step_avg:37.70ms
+step:574/1575 train_time:21663ms step_avg:37.74ms
+step:575/1575 train_time:21726ms step_avg:37.78ms
+step:576/1575 train_time:21786ms step_avg:37.82ms
+step:577/1575 train_time:21851ms step_avg:37.87ms
+step:578/1575 train_time:21911ms step_avg:37.91ms
+step:579/1575 train_time:21972ms step_avg:37.95ms
+step:580/1575 train_time:22032ms step_avg:37.99ms
+step:581/1575 train_time:22095ms step_avg:38.03ms
+step:582/1575 train_time:22155ms step_avg:38.07ms
+step:583/1575 train_time:22219ms step_avg:38.11ms
+step:584/1575 train_time:22278ms step_avg:38.15ms
+step:585/1575 train_time:22341ms step_avg:38.19ms
+step:586/1575 train_time:22400ms step_avg:38.23ms
+step:587/1575 train_time:22463ms step_avg:38.27ms
+step:588/1575 train_time:22523ms step_avg:38.30ms
+step:589/1575 train_time:22586ms step_avg:38.35ms
+step:590/1575 train_time:22645ms step_avg:38.38ms
+step:591/1575 train_time:22708ms step_avg:38.42ms
+step:592/1575 train_time:22768ms step_avg:38.46ms
+step:593/1575 train_time:22831ms step_avg:38.50ms
+step:594/1575 train_time:22890ms step_avg:38.54ms
+step:595/1575 train_time:22954ms step_avg:38.58ms
+step:596/1575 train_time:23013ms step_avg:38.61ms
+step:597/1575 train_time:23077ms step_avg:38.65ms
+step:598/1575 train_time:23136ms step_avg:38.69ms
+step:599/1575 train_time:23199ms step_avg:38.73ms
+step:600/1575 train_time:23259ms step_avg:38.76ms
+step:601/1575 train_time:23322ms step_avg:38.81ms
+step:602/1575 train_time:23381ms step_avg:38.84ms
+step:603/1575 train_time:23444ms step_avg:38.88ms
+step:604/1575 train_time:23503ms step_avg:38.91ms
+step:605/1575 train_time:23566ms step_avg:38.95ms
+step:606/1575 train_time:23625ms step_avg:38.99ms
+step:607/1575 train_time:23689ms step_avg:39.03ms
+step:608/1575 train_time:23748ms step_avg:39.06ms
+step:609/1575 train_time:23812ms step_avg:39.10ms
+step:610/1575 train_time:23871ms step_avg:39.13ms
+step:611/1575 train_time:23934ms step_avg:39.17ms
+step:612/1575 train_time:23994ms step_avg:39.21ms
+step:613/1575 train_time:24057ms step_avg:39.25ms
+step:614/1575 train_time:24118ms step_avg:39.28ms
+step:615/1575 train_time:24180ms step_avg:39.32ms
+step:616/1575 train_time:24240ms step_avg:39.35ms
+step:617/1575 train_time:24303ms step_avg:39.39ms
+step:618/1575 train_time:24362ms step_avg:39.42ms
+step:619/1575 train_time:24425ms step_avg:39.46ms
+step:620/1575 train_time:24484ms step_avg:39.49ms
+step:621/1575 train_time:24547ms step_avg:39.53ms
+step:622/1575 train_time:24606ms step_avg:39.56ms
+step:623/1575 train_time:24669ms step_avg:39.60ms
+step:624/1575 train_time:24729ms step_avg:39.63ms
+step:625/1575 train_time:24792ms step_avg:39.67ms
+step:626/1575 train_time:24851ms step_avg:39.70ms
+step:627/1575 train_time:24914ms step_avg:39.74ms
+step:628/1575 train_time:24974ms step_avg:39.77ms
+step:629/1575 train_time:25037ms step_avg:39.80ms
+step:630/1575 train_time:25097ms step_avg:39.84ms
+step:631/1575 train_time:25160ms step_avg:39.87ms
+step:632/1575 train_time:25220ms step_avg:39.90ms
+step:633/1575 train_time:25283ms step_avg:39.94ms
+step:634/1575 train_time:25344ms step_avg:39.97ms
+step:635/1575 train_time:25405ms step_avg:40.01ms
+step:636/1575 train_time:25465ms step_avg:40.04ms
+step:637/1575 train_time:25529ms step_avg:40.08ms
+step:638/1575 train_time:25588ms step_avg:40.11ms
+step:639/1575 train_time:25651ms step_avg:40.14ms
+step:640/1575 train_time:25711ms step_avg:40.17ms
+step:641/1575 train_time:25774ms step_avg:40.21ms
+step:642/1575 train_time:25833ms step_avg:40.24ms
+step:643/1575 train_time:25897ms step_avg:40.27ms
+step:644/1575 train_time:25956ms step_avg:40.30ms
+step:645/1575 train_time:26020ms step_avg:40.34ms
+step:646/1575 train_time:26079ms step_avg:40.37ms
+step:647/1575 train_time:26143ms step_avg:40.41ms
+step:648/1575 train_time:26202ms step_avg:40.44ms
+step:649/1575 train_time:26265ms step_avg:40.47ms
+step:650/1575 train_time:26324ms step_avg:40.50ms
+step:651/1575 train_time:26388ms step_avg:40.53ms
+step:652/1575 train_time:26447ms step_avg:40.56ms
+step:653/1575 train_time:26511ms step_avg:40.60ms
+step:654/1575 train_time:26570ms step_avg:40.63ms
+step:655/1575 train_time:26633ms step_avg:40.66ms
+step:656/1575 train_time:26693ms step_avg:40.69ms
+step:657/1575 train_time:26757ms step_avg:40.73ms
+step:658/1575 train_time:26815ms step_avg:40.75ms
+step:659/1575 train_time:26878ms step_avg:40.79ms
+step:660/1575 train_time:26938ms step_avg:40.81ms
+step:661/1575 train_time:27003ms step_avg:40.85ms
+step:662/1575 train_time:27063ms step_avg:40.88ms
+step:663/1575 train_time:27125ms step_avg:40.91ms
+step:664/1575 train_time:27184ms step_avg:40.94ms
+step:665/1575 train_time:27246ms step_avg:40.97ms
+step:666/1575 train_time:27306ms step_avg:41.00ms
+step:667/1575 train_time:27369ms step_avg:41.03ms
+step:668/1575 train_time:27428ms step_avg:41.06ms
+step:669/1575 train_time:27491ms step_avg:41.09ms
+step:670/1575 train_time:27550ms step_avg:41.12ms
+step:671/1575 train_time:27614ms step_avg:41.15ms
+step:672/1575 train_time:27672ms step_avg:41.18ms
+step:673/1575 train_time:27736ms step_avg:41.21ms
+step:674/1575 train_time:27795ms step_avg:41.24ms
+step:675/1575 train_time:27858ms step_avg:41.27ms
+step:676/1575 train_time:27917ms step_avg:41.30ms
+step:677/1575 train_time:27981ms step_avg:41.33ms
+step:678/1575 train_time:28043ms step_avg:41.36ms
+step:679/1575 train_time:28104ms step_avg:41.39ms
+step:680/1575 train_time:28164ms step_avg:41.42ms
+step:681/1575 train_time:28227ms step_avg:41.45ms
+step:682/1575 train_time:28286ms step_avg:41.48ms
+step:683/1575 train_time:28349ms step_avg:41.51ms
+step:684/1575 train_time:28408ms step_avg:41.53ms
+step:685/1575 train_time:28472ms step_avg:41.56ms
+step:686/1575 train_time:28531ms step_avg:41.59ms
+step:687/1575 train_time:28595ms step_avg:41.62ms
+step:688/1575 train_time:28654ms step_avg:41.65ms
+step:689/1575 train_time:28717ms step_avg:41.68ms
+step:690/1575 train_time:28776ms step_avg:41.70ms
+step:691/1575 train_time:28840ms step_avg:41.74ms
+step:692/1575 train_time:28900ms step_avg:41.76ms
+step:693/1575 train_time:28963ms step_avg:41.79ms
+step:694/1575 train_time:29023ms step_avg:41.82ms
+step:695/1575 train_time:29086ms step_avg:41.85ms
+step:696/1575 train_time:29146ms step_avg:41.88ms
+step:697/1575 train_time:29209ms step_avg:41.91ms
+step:698/1575 train_time:29268ms step_avg:41.93ms
+step:699/1575 train_time:29332ms step_avg:41.96ms
+step:700/1575 train_time:29391ms step_avg:41.99ms
+step:701/1575 train_time:29454ms step_avg:42.02ms
+step:702/1575 train_time:29514ms step_avg:42.04ms
+step:703/1575 train_time:29576ms step_avg:42.07ms
+step:704/1575 train_time:29637ms step_avg:42.10ms
+step:705/1575 train_time:29700ms step_avg:42.13ms
+step:706/1575 train_time:29759ms step_avg:42.15ms
+step:707/1575 train_time:29823ms step_avg:42.18ms
+step:708/1575 train_time:29883ms step_avg:42.21ms
+step:709/1575 train_time:29945ms step_avg:42.24ms
+step:710/1575 train_time:30005ms step_avg:42.26ms
+step:711/1575 train_time:30069ms step_avg:42.29ms
+step:712/1575 train_time:30128ms step_avg:42.31ms
+step:713/1575 train_time:30192ms step_avg:42.34ms
+step:714/1575 train_time:30251ms step_avg:42.37ms
+step:715/1575 train_time:30315ms step_avg:42.40ms
+step:716/1575 train_time:30374ms step_avg:42.42ms
+step:717/1575 train_time:30438ms step_avg:42.45ms
+step:718/1575 train_time:30497ms step_avg:42.47ms
+step:719/1575 train_time:30560ms step_avg:42.50ms
+step:720/1575 train_time:30619ms step_avg:42.53ms
+step:721/1575 train_time:30682ms step_avg:42.55ms
+step:722/1575 train_time:30741ms step_avg:42.58ms
+step:723/1575 train_time:30805ms step_avg:42.61ms
+step:724/1575 train_time:30865ms step_avg:42.63ms
+step:725/1575 train_time:30927ms step_avg:42.66ms
+step:726/1575 train_time:30987ms step_avg:42.68ms
+step:727/1575 train_time:31051ms step_avg:42.71ms
+step:728/1575 train_time:31110ms step_avg:42.73ms
+step:729/1575 train_time:31174ms step_avg:42.76ms
+step:730/1575 train_time:31234ms step_avg:42.79ms
+step:731/1575 train_time:31297ms step_avg:42.81ms
+step:732/1575 train_time:31356ms step_avg:42.84ms
+step:733/1575 train_time:31419ms step_avg:42.86ms
+step:734/1575 train_time:31479ms step_avg:42.89ms
+step:735/1575 train_time:31542ms step_avg:42.91ms
+step:736/1575 train_time:31601ms step_avg:42.94ms
+step:737/1575 train_time:31665ms step_avg:42.96ms
+step:738/1575 train_time:31723ms step_avg:42.99ms
+step:739/1575 train_time:31787ms step_avg:43.01ms
+step:740/1575 train_time:31846ms step_avg:43.04ms
+step:741/1575 train_time:31909ms step_avg:43.06ms
+step:742/1575 train_time:31968ms step_avg:43.08ms
+step:743/1575 train_time:32032ms step_avg:43.11ms
+step:744/1575 train_time:32092ms step_avg:43.13ms
+step:745/1575 train_time:32155ms step_avg:43.16ms
+step:746/1575 train_time:32213ms step_avg:43.18ms
+step:747/1575 train_time:32277ms step_avg:43.21ms
+step:748/1575 train_time:32336ms step_avg:43.23ms
+step:749/1575 train_time:32400ms step_avg:43.26ms
+step:750/1575 train_time:32459ms step_avg:43.28ms
+step:750/1575 val_loss:3.8798 train_time:32505ms step_avg:43.34ms
+step:751/1575 train_time:32526ms step_avg:43.31ms
+step:752/1575 train_time:32584ms step_avg:43.33ms
+step:753/1575 train_time:32650ms step_avg:43.36ms
+step:754/1575 train_time:32710ms step_avg:43.38ms
+step:755/1575 train_time:32773ms step_avg:43.41ms
+step:756/1575 train_time:32832ms step_avg:43.43ms
+step:757/1575 train_time:32894ms step_avg:43.45ms
+step:758/1575 train_time:32954ms step_avg:43.48ms
+step:759/1575 train_time:33017ms step_avg:43.50ms
+step:760/1575 train_time:33076ms step_avg:43.52ms
+step:761/1575 train_time:33139ms step_avg:43.55ms
+step:762/1575 train_time:33198ms step_avg:43.57ms
+step:763/1575 train_time:33261ms step_avg:43.59ms
+step:764/1575 train_time:33320ms step_avg:43.61ms
+step:765/1575 train_time:33383ms step_avg:43.64ms
+step:766/1575 train_time:33443ms step_avg:43.66ms
+step:767/1575 train_time:33506ms step_avg:43.69ms
+step:768/1575 train_time:33567ms step_avg:43.71ms
+step:769/1575 train_time:33632ms step_avg:43.74ms
+step:770/1575 train_time:33693ms step_avg:43.76ms
+step:771/1575 train_time:33756ms step_avg:43.78ms
+step:772/1575 train_time:33816ms step_avg:43.80ms
+step:773/1575 train_time:33880ms step_avg:43.83ms
+step:774/1575 train_time:33939ms step_avg:43.85ms
+step:775/1575 train_time:34002ms step_avg:43.87ms
+step:776/1575 train_time:34061ms step_avg:43.89ms
+step:777/1575 train_time:34123ms step_avg:43.92ms
+step:778/1575 train_time:34183ms step_avg:43.94ms
+step:779/1575 train_time:34246ms step_avg:43.96ms
+step:780/1575 train_time:34304ms step_avg:43.98ms
+step:781/1575 train_time:34367ms step_avg:44.00ms
+step:782/1575 train_time:34426ms step_avg:44.02ms
+step:783/1575 train_time:34489ms step_avg:44.05ms
+step:784/1575 train_time:34549ms step_avg:44.07ms
+step:785/1575 train_time:34613ms step_avg:44.09ms
+step:786/1575 train_time:34673ms step_avg:44.11ms
+step:787/1575 train_time:34736ms step_avg:44.14ms
+step:788/1575 train_time:34795ms step_avg:44.16ms
+step:789/1575 train_time:34858ms step_avg:44.18ms
+step:790/1575 train_time:34917ms step_avg:44.20ms
+step:791/1575 train_time:34981ms step_avg:44.22ms
+step:792/1575 train_time:35041ms step_avg:44.24ms
+step:793/1575 train_time:35104ms step_avg:44.27ms
+step:794/1575 train_time:35164ms step_avg:44.29ms
+step:795/1575 train_time:35226ms step_avg:44.31ms
+step:796/1575 train_time:35285ms step_avg:44.33ms
+step:797/1575 train_time:35348ms step_avg:44.35ms
+step:798/1575 train_time:35407ms step_avg:44.37ms
+step:799/1575 train_time:35471ms step_avg:44.39ms
+step:800/1575 train_time:35529ms step_avg:44.41ms
+step:801/1575 train_time:35593ms step_avg:44.44ms
+step:802/1575 train_time:35652ms step_avg:44.45ms
+step:803/1575 train_time:35716ms step_avg:44.48ms
+step:804/1575 train_time:35776ms step_avg:44.50ms
+step:805/1575 train_time:35839ms step_avg:44.52ms
+step:806/1575 train_time:35899ms step_avg:44.54ms
+step:807/1575 train_time:35963ms step_avg:44.56ms
+step:808/1575 train_time:36022ms step_avg:44.58ms
+step:809/1575 train_time:36085ms step_avg:44.60ms
+step:810/1575 train_time:36144ms step_avg:44.62ms
+step:811/1575 train_time:36208ms step_avg:44.65ms
+step:812/1575 train_time:36267ms step_avg:44.66ms
+step:813/1575 train_time:36329ms step_avg:44.69ms
+step:814/1575 train_time:36390ms step_avg:44.70ms
+step:815/1575 train_time:36451ms step_avg:44.73ms
+step:816/1575 train_time:36511ms step_avg:44.74ms
+step:817/1575 train_time:36573ms step_avg:44.77ms
+step:818/1575 train_time:36633ms step_avg:44.78ms
+step:819/1575 train_time:36697ms step_avg:44.81ms
+step:820/1575 train_time:36756ms step_avg:44.82ms
+step:821/1575 train_time:36820ms step_avg:44.85ms
+step:822/1575 train_time:36879ms step_avg:44.87ms
+step:823/1575 train_time:36943ms step_avg:44.89ms
+step:824/1575 train_time:37002ms step_avg:44.91ms
+step:825/1575 train_time:37065ms step_avg:44.93ms
+step:826/1575 train_time:37124ms step_avg:44.94ms
+step:827/1575 train_time:37188ms step_avg:44.97ms
+step:828/1575 train_time:37247ms step_avg:44.98ms
+step:829/1575 train_time:37310ms step_avg:45.01ms
+step:830/1575 train_time:37370ms step_avg:45.02ms
+step:831/1575 train_time:37433ms step_avg:45.05ms
+step:832/1575 train_time:37493ms step_avg:45.06ms
+step:833/1575 train_time:37556ms step_avg:45.08ms
+step:834/1575 train_time:37615ms step_avg:45.10ms
+step:835/1575 train_time:37679ms step_avg:45.12ms
+step:836/1575 train_time:37738ms step_avg:45.14ms
+step:837/1575 train_time:37801ms step_avg:45.16ms
+step:838/1575 train_time:37860ms step_avg:45.18ms
+step:839/1575 train_time:37926ms step_avg:45.20ms
+step:840/1575 train_time:37985ms step_avg:45.22ms
+step:841/1575 train_time:38048ms step_avg:45.24ms
+step:842/1575 train_time:38107ms step_avg:45.26ms
+step:843/1575 train_time:38171ms step_avg:45.28ms
+step:844/1575 train_time:38229ms step_avg:45.29ms
+step:845/1575 train_time:38292ms step_avg:45.32ms
+step:846/1575 train_time:38351ms step_avg:45.33ms
+step:847/1575 train_time:38414ms step_avg:45.35ms
+step:848/1575 train_time:38473ms step_avg:45.37ms
+step:849/1575 train_time:38536ms step_avg:45.39ms
+step:850/1575 train_time:38596ms step_avg:45.41ms
+step:851/1575 train_time:38660ms step_avg:45.43ms
+step:852/1575 train_time:38719ms step_avg:45.44ms
+step:853/1575 train_time:38782ms step_avg:45.47ms
+step:854/1575 train_time:38841ms step_avg:45.48ms
+step:855/1575 train_time:38904ms step_avg:45.50ms
+step:856/1575 train_time:38964ms step_avg:45.52ms
+step:857/1575 train_time:39027ms step_avg:45.54ms
+step:858/1575 train_time:39088ms step_avg:45.56ms
+step:859/1575 train_time:39150ms step_avg:45.58ms
+step:860/1575 train_time:39209ms step_avg:45.59ms
+step:861/1575 train_time:39271ms step_avg:45.61ms
+step:862/1575 train_time:39332ms step_avg:45.63ms
+step:863/1575 train_time:39395ms step_avg:45.65ms
+step:864/1575 train_time:39454ms step_avg:45.66ms
+step:865/1575 train_time:39524ms step_avg:45.69ms
+step:866/1575 train_time:39576ms step_avg:45.70ms
+step:867/1575 train_time:39642ms step_avg:45.72ms
+step:868/1575 train_time:39700ms step_avg:45.74ms
+step:869/1575 train_time:39763ms step_avg:45.76ms
+step:870/1575 train_time:39823ms step_avg:45.77ms
+step:871/1575 train_time:39887ms step_avg:45.79ms
+step:872/1575 train_time:39946ms step_avg:45.81ms
+step:873/1575 train_time:40014ms step_avg:45.84ms
+step:874/1575 train_time:40069ms step_avg:45.85ms
+step:875/1575 train_time:40132ms step_avg:45.87ms
+step:876/1575 train_time:40191ms step_avg:45.88ms
+step:877/1575 train_time:40254ms step_avg:45.90ms
+step:878/1575 train_time:40313ms step_avg:45.91ms
+step:879/1575 train_time:40376ms step_avg:45.93ms
+step:880/1575 train_time:40435ms step_avg:45.95ms
+step:881/1575 train_time:40498ms step_avg:45.97ms
+step:882/1575 train_time:40558ms step_avg:45.98ms
+step:883/1575 train_time:40621ms step_avg:46.00ms
+step:884/1575 train_time:40680ms step_avg:46.02ms
+step:885/1575 train_time:40743ms step_avg:46.04ms
+step:886/1575 train_time:40808ms step_avg:46.06ms
+step:887/1575 train_time:40869ms step_avg:46.08ms
+step:888/1575 train_time:40928ms step_avg:46.09ms
+step:889/1575 train_time:40992ms step_avg:46.11ms
+step:890/1575 train_time:41051ms step_avg:46.12ms
+step:891/1575 train_time:41113ms step_avg:46.14ms
+step:892/1575 train_time:41173ms step_avg:46.16ms
+step:893/1575 train_time:41235ms step_avg:46.18ms
+step:894/1575 train_time:41294ms step_avg:46.19ms
+step:895/1575 train_time:41357ms step_avg:46.21ms
+step:896/1575 train_time:41416ms step_avg:46.22ms
+step:897/1575 train_time:41481ms step_avg:46.24ms
+step:898/1575 train_time:41540ms step_avg:46.26ms
+step:899/1575 train_time:41603ms step_avg:46.28ms
+step:900/1575 train_time:41661ms step_avg:46.29ms
+step:901/1575 train_time:41724ms step_avg:46.31ms
+step:902/1575 train_time:41784ms step_avg:46.32ms
+step:903/1575 train_time:41847ms step_avg:46.34ms
+step:904/1575 train_time:41907ms step_avg:46.36ms
+step:905/1575 train_time:41970ms step_avg:46.38ms
+step:906/1575 train_time:42030ms step_avg:46.39ms
+step:907/1575 train_time:42092ms step_avg:46.41ms
+step:908/1575 train_time:42152ms step_avg:46.42ms
+step:909/1575 train_time:42216ms step_avg:46.44ms
+step:910/1575 train_time:42274ms step_avg:46.46ms
+step:911/1575 train_time:42336ms step_avg:46.47ms
+step:912/1575 train_time:42395ms step_avg:46.49ms
+step:913/1575 train_time:42459ms step_avg:46.50ms
+step:914/1575 train_time:42518ms step_avg:46.52ms
+step:915/1575 train_time:42582ms step_avg:46.54ms
+step:916/1575 train_time:42641ms step_avg:46.55ms
+step:917/1575 train_time:42704ms step_avg:46.57ms
+step:918/1575 train_time:42764ms step_avg:46.58ms
+step:919/1575 train_time:42828ms step_avg:46.60ms
+step:920/1575 train_time:42888ms step_avg:46.62ms
+step:921/1575 train_time:42951ms step_avg:46.64ms
+step:922/1575 train_time:43011ms step_avg:46.65ms
+step:923/1575 train_time:43074ms step_avg:46.67ms
+step:924/1575 train_time:43133ms step_avg:46.68ms
+step:925/1575 train_time:43196ms step_avg:46.70ms
+step:926/1575 train_time:43255ms step_avg:46.71ms
+step:927/1575 train_time:43318ms step_avg:46.73ms
+step:928/1575 train_time:43378ms step_avg:46.74ms
+step:929/1575 train_time:43440ms step_avg:46.76ms
+step:930/1575 train_time:43499ms step_avg:46.77ms
+step:931/1575 train_time:43563ms step_avg:46.79ms
+step:932/1575 train_time:43622ms step_avg:46.81ms
+step:933/1575 train_time:43685ms step_avg:46.82ms
+step:934/1575 train_time:43745ms step_avg:46.84ms
+step:935/1575 train_time:43809ms step_avg:46.85ms
+step:936/1575 train_time:43869ms step_avg:46.87ms
+step:937/1575 train_time:43932ms step_avg:46.89ms
+step:938/1575 train_time:43991ms step_avg:46.90ms
+step:939/1575 train_time:44054ms step_avg:46.92ms
+step:940/1575 train_time:44113ms step_avg:46.93ms
+step:941/1575 train_time:44177ms step_avg:46.95ms
+step:942/1575 train_time:44235ms step_avg:46.96ms
+step:943/1575 train_time:44299ms step_avg:46.98ms
+step:944/1575 train_time:44358ms step_avg:46.99ms
+step:945/1575 train_time:44421ms step_avg:47.01ms
+step:946/1575 train_time:44480ms step_avg:47.02ms
+step:947/1575 train_time:44543ms step_avg:47.04ms
+step:948/1575 train_time:44604ms step_avg:47.05ms
+step:949/1575 train_time:44666ms step_avg:47.07ms
+step:950/1575 train_time:44725ms step_avg:47.08ms
+step:951/1575 train_time:44789ms step_avg:47.10ms
+step:952/1575 train_time:44848ms step_avg:47.11ms
+step:953/1575 train_time:44911ms step_avg:47.13ms
+step:954/1575 train_time:44971ms step_avg:47.14ms
+step:955/1575 train_time:45033ms step_avg:47.15ms
+step:956/1575 train_time:45092ms step_avg:47.17ms
+step:957/1575 train_time:45155ms step_avg:47.18ms
+step:958/1575 train_time:45214ms step_avg:47.20ms
+step:959/1575 train_time:45277ms step_avg:47.21ms
+step:960/1575 train_time:45336ms step_avg:47.23ms
+step:961/1575 train_time:45403ms step_avg:47.25ms
+step:962/1575 train_time:45461ms step_avg:47.26ms
+step:963/1575 train_time:45523ms step_avg:47.27ms
+step:964/1575 train_time:45583ms step_avg:47.29ms
+step:965/1575 train_time:45646ms step_avg:47.30ms
+step:966/1575 train_time:45705ms step_avg:47.31ms
+step:967/1575 train_time:45770ms step_avg:47.33ms
+step:968/1575 train_time:45829ms step_avg:47.34ms
+step:969/1575 train_time:45892ms step_avg:47.36ms
+step:970/1575 train_time:45953ms step_avg:47.37ms
+step:971/1575 train_time:46015ms step_avg:47.39ms
+step:972/1575 train_time:46074ms step_avg:47.40ms
+step:973/1575 train_time:46138ms step_avg:47.42ms
+step:974/1575 train_time:46196ms step_avg:47.43ms
+step:975/1575 train_time:46261ms step_avg:47.45ms
+step:976/1575 train_time:46319ms step_avg:47.46ms
+step:977/1575 train_time:46382ms step_avg:47.47ms
+step:978/1575 train_time:46441ms step_avg:47.49ms
+step:979/1575 train_time:46506ms step_avg:47.50ms
+step:980/1575 train_time:46565ms step_avg:47.52ms
+step:981/1575 train_time:46630ms step_avg:47.53ms
+step:982/1575 train_time:46689ms step_avg:47.54ms
+step:983/1575 train_time:46751ms step_avg:47.56ms
+step:984/1575 train_time:46810ms step_avg:47.57ms
+step:985/1575 train_time:46874ms step_avg:47.59ms
+step:986/1575 train_time:46933ms step_avg:47.60ms
+step:987/1575 train_time:46996ms step_avg:47.62ms
+step:988/1575 train_time:47057ms step_avg:47.63ms
+step:989/1575 train_time:47120ms step_avg:47.64ms
+step:990/1575 train_time:47180ms step_avg:47.66ms
+step:991/1575 train_time:47241ms step_avg:47.67ms
+step:992/1575 train_time:47301ms step_avg:47.68ms
+step:993/1575 train_time:47364ms step_avg:47.70ms
+step:994/1575 train_time:47423ms step_avg:47.71ms
+step:995/1575 train_time:47487ms step_avg:47.73ms
+step:996/1575 train_time:47546ms step_avg:47.74ms
+step:997/1575 train_time:47610ms step_avg:47.75ms
+step:998/1575 train_time:47669ms step_avg:47.76ms
+step:999/1575 train_time:47732ms step_avg:47.78ms
+step:1000/1575 train_time:47791ms step_avg:47.79ms
+step:1000/1575 val_loss:3.5839 train_time:47837ms step_avg:47.84ms
+step:1001/1575 train_time:47858ms step_avg:47.81ms
+step:1002/1575 train_time:47917ms step_avg:47.82ms
+step:1003/1575 train_time:47983ms step_avg:47.84ms
+step:1004/1575 train_time:48044ms step_avg:47.85ms
+step:1005/1575 train_time:48107ms step_avg:47.87ms
+step:1006/1575 train_time:48167ms step_avg:47.88ms
+step:1007/1575 train_time:48229ms step_avg:47.89ms
+step:1008/1575 train_time:48289ms step_avg:47.91ms
+step:1009/1575 train_time:48351ms step_avg:47.92ms
+step:1010/1575 train_time:48409ms step_avg:47.93ms
+step:1011/1575 train_time:48473ms step_avg:47.95ms
+step:1012/1575 train_time:48532ms step_avg:47.96ms
+step:1013/1575 train_time:48594ms step_avg:47.97ms
+step:1014/1575 train_time:48654ms step_avg:47.98ms
+step:1015/1575 train_time:48717ms step_avg:48.00ms
+step:1016/1575 train_time:48776ms step_avg:48.01ms
+step:1017/1575 train_time:48841ms step_avg:48.02ms
+step:1018/1575 train_time:48901ms step_avg:48.04ms
+step:1019/1575 train_time:48966ms step_avg:48.05ms
+step:1020/1575 train_time:49026ms step_avg:48.06ms
+step:1021/1575 train_time:49089ms step_avg:48.08ms
+step:1022/1575 train_time:49151ms step_avg:48.09ms
+step:1023/1575 train_time:49212ms step_avg:48.11ms
+step:1024/1575 train_time:49270ms step_avg:48.12ms
+step:1025/1575 train_time:49344ms step_avg:48.14ms
+step:1026/1575 train_time:49427ms step_avg:48.17ms
+step:1027/1575 train_time:49515ms step_avg:48.21ms
+step:1028/1575 train_time:49599ms step_avg:48.25ms
+step:1029/1575 train_time:49687ms step_avg:48.29ms
+step:1030/1575 train_time:49773ms step_avg:48.32ms
+step:1031/1575 train_time:49864ms step_avg:48.36ms
+step:1032/1575 train_time:49951ms step_avg:48.40ms
+step:1033/1575 train_time:50041ms step_avg:48.44ms
+step:1034/1575 train_time:50127ms step_avg:48.48ms
+step:1035/1575 train_time:50215ms step_avg:48.52ms
+step:1036/1575 train_time:50301ms step_avg:48.55ms
+step:1037/1575 train_time:50390ms step_avg:48.59ms
+step:1038/1575 train_time:50475ms step_avg:48.63ms
+step:1039/1575 train_time:50564ms step_avg:48.67ms
+step:1040/1575 train_time:50649ms step_avg:48.70ms
+step:1041/1575 train_time:50738ms step_avg:48.74ms
+step:1042/1575 train_time:50826ms step_avg:48.78ms
+step:1043/1575 train_time:50916ms step_avg:48.82ms
+step:1044/1575 train_time:51001ms step_avg:48.85ms
+step:1045/1575 train_time:51093ms step_avg:48.89ms
+step:1046/1575 train_time:51179ms step_avg:48.93ms
+step:1047/1575 train_time:51267ms step_avg:48.97ms
+step:1048/1575 train_time:51353ms step_avg:49.00ms
+step:1049/1575 train_time:51442ms step_avg:49.04ms
+step:1050/1575 train_time:51527ms step_avg:49.07ms
+step:1051/1575 train_time:51615ms step_avg:49.11ms
+step:1052/1575 train_time:51701ms step_avg:49.15ms
+step:1053/1575 train_time:51792ms step_avg:49.19ms
+step:1054/1575 train_time:51877ms step_avg:49.22ms
+step:1055/1575 train_time:51967ms step_avg:49.26ms
+step:1056/1575 train_time:52053ms step_avg:49.29ms
+step:1057/1575 train_time:52143ms step_avg:49.33ms
+step:1058/1575 train_time:52229ms step_avg:49.37ms
+step:1059/1575 train_time:52318ms step_avg:49.40ms
+step:1060/1575 train_time:52403ms step_avg:49.44ms
+step:1061/1575 train_time:52492ms step_avg:49.47ms
+step:1062/1575 train_time:52577ms step_avg:49.51ms
+step:1063/1575 train_time:52667ms step_avg:49.55ms
+step:1064/1575 train_time:52753ms step_avg:49.58ms
+step:1065/1575 train_time:52843ms step_avg:49.62ms
+step:1066/1575 train_time:52929ms step_avg:49.65ms
+step:1067/1575 train_time:53018ms step_avg:49.69ms
+step:1068/1575 train_time:53105ms step_avg:49.72ms
+step:1069/1575 train_time:53195ms step_avg:49.76ms
+step:1070/1575 train_time:53280ms step_avg:49.79ms
+step:1071/1575 train_time:53369ms step_avg:49.83ms
+step:1072/1575 train_time:53455ms step_avg:49.87ms
+step:1073/1575 train_time:53544ms step_avg:49.90ms
+step:1074/1575 train_time:53629ms step_avg:49.93ms
+step:1075/1575 train_time:53717ms step_avg:49.97ms
+step:1076/1575 train_time:53803ms step_avg:50.00ms
+step:1077/1575 train_time:53893ms step_avg:50.04ms
+step:1078/1575 train_time:53979ms step_avg:50.07ms
+step:1079/1575 train_time:54069ms step_avg:50.11ms
+step:1080/1575 train_time:54154ms step_avg:50.14ms
+step:1081/1575 train_time:54243ms step_avg:50.18ms
+step:1082/1575 train_time:54329ms step_avg:50.21ms
+step:1083/1575 train_time:54417ms step_avg:50.25ms
+step:1084/1575 train_time:54503ms step_avg:50.28ms
+step:1085/1575 train_time:54593ms step_avg:50.32ms
+step:1086/1575 train_time:54679ms step_avg:50.35ms
+step:1087/1575 train_time:54768ms step_avg:50.38ms
+step:1088/1575 train_time:54853ms step_avg:50.42ms
+step:1089/1575 train_time:54943ms step_avg:50.45ms
+step:1090/1575 train_time:55029ms step_avg:50.49ms
+step:1091/1575 train_time:55118ms step_avg:50.52ms
+step:1092/1575 train_time:55204ms step_avg:50.55ms
+step:1093/1575 train_time:55293ms step_avg:50.59ms
+step:1094/1575 train_time:55378ms step_avg:50.62ms
+step:1095/1575 train_time:55468ms step_avg:50.66ms
+step:1096/1575 train_time:55552ms step_avg:50.69ms
+step:1097/1575 train_time:55642ms step_avg:50.72ms
+step:1098/1575 train_time:55728ms step_avg:50.75ms
+step:1099/1575 train_time:55817ms step_avg:50.79ms
+step:1100/1575 train_time:55903ms step_avg:50.82ms
+step:1101/1575 train_time:55994ms step_avg:50.86ms
+step:1102/1575 train_time:56079ms step_avg:50.89ms
+step:1103/1575 train_time:56168ms step_avg:50.92ms
+step:1104/1575 train_time:56254ms step_avg:50.95ms
+step:1105/1575 train_time:56345ms step_avg:50.99ms
+step:1106/1575 train_time:56430ms step_avg:51.02ms
+step:1107/1575 train_time:56518ms step_avg:51.06ms
+step:1108/1575 train_time:56604ms step_avg:51.09ms
+step:1109/1575 train_time:56694ms step_avg:51.12ms
+step:1110/1575 train_time:56780ms step_avg:51.15ms
+step:1111/1575 train_time:56868ms step_avg:51.19ms
+step:1112/1575 train_time:56954ms step_avg:51.22ms
+step:1113/1575 train_time:57043ms step_avg:51.25ms
+step:1114/1575 train_time:57129ms step_avg:51.28ms
+step:1115/1575 train_time:57219ms step_avg:51.32ms
+step:1116/1575 train_time:57304ms step_avg:51.35ms
+step:1117/1575 train_time:57394ms step_avg:51.38ms
+step:1118/1575 train_time:57479ms step_avg:51.41ms
+step:1119/1575 train_time:57570ms step_avg:51.45ms
+step:1120/1575 train_time:57659ms step_avg:51.48ms
+step:1121/1575 train_time:57747ms step_avg:51.51ms
+step:1122/1575 train_time:57835ms step_avg:51.55ms
+step:1123/1575 train_time:57921ms step_avg:51.58ms
+step:1124/1575 train_time:58006ms step_avg:51.61ms
+step:1125/1575 train_time:58097ms step_avg:51.64ms
+step:1126/1575 train_time:58181ms step_avg:51.67ms
+step:1127/1575 train_time:58270ms step_avg:51.70ms
+step:1128/1575 train_time:58356ms step_avg:51.73ms
+step:1129/1575 train_time:58445ms step_avg:51.77ms
+step:1130/1575 train_time:58530ms step_avg:51.80ms
+step:1131/1575 train_time:58619ms step_avg:51.83ms
+step:1132/1575 train_time:58705ms step_avg:51.86ms
+step:1133/1575 train_time:58794ms step_avg:51.89ms
+step:1134/1575 train_time:58880ms step_avg:51.92ms
+step:1135/1575 train_time:58969ms step_avg:51.96ms
+step:1136/1575 train_time:59055ms step_avg:51.99ms
+step:1137/1575 train_time:59144ms step_avg:52.02ms
+step:1138/1575 train_time:59229ms step_avg:52.05ms
+step:1139/1575 train_time:59318ms step_avg:52.08ms
+step:1140/1575 train_time:59404ms step_avg:52.11ms
+step:1141/1575 train_time:59493ms step_avg:52.14ms
+step:1142/1575 train_time:59578ms step_avg:52.17ms
+step:1143/1575 train_time:59668ms step_avg:52.20ms
+step:1144/1575 train_time:59753ms step_avg:52.23ms
+step:1145/1575 train_time:59843ms step_avg:52.26ms
+step:1146/1575 train_time:59935ms step_avg:52.30ms
+step:1147/1575 train_time:60020ms step_avg:52.33ms
+step:1148/1575 train_time:60107ms step_avg:52.36ms
+step:1149/1575 train_time:60197ms step_avg:52.39ms
+step:1150/1575 train_time:60282ms step_avg:52.42ms
+step:1151/1575 train_time:60372ms step_avg:52.45ms
+step:1152/1575 train_time:60457ms step_avg:52.48ms
+step:1153/1575 train_time:60547ms step_avg:52.51ms
+step:1154/1575 train_time:60632ms step_avg:52.54ms
+step:1155/1575 train_time:60721ms step_avg:52.57ms
+step:1156/1575 train_time:60807ms step_avg:52.60ms
+step:1157/1575 train_time:60897ms step_avg:52.63ms
+step:1158/1575 train_time:60983ms step_avg:52.66ms
+step:1159/1575 train_time:61076ms step_avg:52.70ms
+step:1160/1575 train_time:61161ms step_avg:52.73ms
+step:1161/1575 train_time:61249ms step_avg:52.76ms
+step:1162/1575 train_time:61334ms step_avg:52.78ms
+step:1163/1575 train_time:61423ms step_avg:52.81ms
+step:1164/1575 train_time:61509ms step_avg:52.84ms
+step:1165/1575 train_time:61598ms step_avg:52.87ms
+step:1166/1575 train_time:61684ms step_avg:52.90ms
+step:1167/1575 train_time:61775ms step_avg:52.93ms
+step:1168/1575 train_time:61862ms step_avg:52.96ms
+step:1169/1575 train_time:61952ms step_avg:53.00ms
+step:1170/1575 train_time:62038ms step_avg:53.02ms
+step:1171/1575 train_time:62128ms step_avg:53.06ms
+step:1172/1575 train_time:62213ms step_avg:53.08ms
+step:1173/1575 train_time:62301ms step_avg:53.11ms
+step:1174/1575 train_time:62387ms step_avg:53.14ms
+step:1175/1575 train_time:62476ms step_avg:53.17ms
+step:1176/1575 train_time:62567ms step_avg:53.20ms
+step:1177/1575 train_time:62652ms step_avg:53.23ms
+step:1178/1575 train_time:62738ms step_avg:53.26ms
+step:1179/1575 train_time:62828ms step_avg:53.29ms
+step:1180/1575 train_time:62913ms step_avg:53.32ms
+step:1181/1575 train_time:63002ms step_avg:53.35ms
+step:1182/1575 train_time:63088ms step_avg:53.37ms
+step:1183/1575 train_time:63177ms step_avg:53.40ms
+step:1184/1575 train_time:63262ms step_avg:53.43ms
+step:1185/1575 train_time:63352ms step_avg:53.46ms
+step:1186/1575 train_time:63437ms step_avg:53.49ms
+step:1187/1575 train_time:63527ms step_avg:53.52ms
+step:1188/1575 train_time:63613ms step_avg:53.55ms
+step:1189/1575 train_time:63703ms step_avg:53.58ms
+step:1190/1575 train_time:63788ms step_avg:53.60ms
+step:1191/1575 train_time:63878ms step_avg:53.63ms
+step:1192/1575 train_time:63964ms step_avg:53.66ms
+step:1193/1575 train_time:64053ms step_avg:53.69ms
+step:1194/1575 train_time:64139ms step_avg:53.72ms
+step:1195/1575 train_time:64228ms step_avg:53.75ms
+step:1196/1575 train_time:64313ms step_avg:53.77ms
+step:1197/1575 train_time:64403ms step_avg:53.80ms
+step:1198/1575 train_time:64488ms step_avg:53.83ms
+step:1199/1575 train_time:64578ms step_avg:53.86ms
+step:1200/1575 train_time:64663ms step_avg:53.89ms
+step:1201/1575 train_time:64753ms step_avg:53.92ms
+step:1202/1575 train_time:64840ms step_avg:53.94ms
+step:1203/1575 train_time:64929ms step_avg:53.97ms
+step:1204/1575 train_time:65014ms step_avg:54.00ms
+step:1205/1575 train_time:65104ms step_avg:54.03ms
+step:1206/1575 train_time:65189ms step_avg:54.05ms
+step:1207/1575 train_time:65278ms step_avg:54.08ms
+step:1208/1575 train_time:65366ms step_avg:54.11ms
+step:1209/1575 train_time:65455ms step_avg:54.14ms
+step:1210/1575 train_time:65540ms step_avg:54.17ms
+step:1211/1575 train_time:65629ms step_avg:54.19ms
+step:1212/1575 train_time:65714ms step_avg:54.22ms
+step:1213/1575 train_time:65803ms step_avg:54.25ms
+step:1214/1575 train_time:65889ms step_avg:54.27ms
+step:1215/1575 train_time:65978ms step_avg:54.30ms
+step:1216/1575 train_time:66064ms step_avg:54.33ms
+step:1217/1575 train_time:66154ms step_avg:54.36ms
+step:1218/1575 train_time:66241ms step_avg:54.39ms
+step:1219/1575 train_time:66330ms step_avg:54.41ms
+step:1220/1575 train_time:66414ms step_avg:54.44ms
+step:1221/1575 train_time:66503ms step_avg:54.47ms
+step:1222/1575 train_time:66589ms step_avg:54.49ms
+step:1223/1575 train_time:66678ms step_avg:54.52ms
+step:1224/1575 train_time:66763ms step_avg:54.54ms
+step:1225/1575 train_time:66852ms step_avg:54.57ms
+step:1226/1575 train_time:66938ms step_avg:54.60ms
+step:1227/1575 train_time:67028ms step_avg:54.63ms
+step:1228/1575 train_time:67119ms step_avg:54.66ms
+step:1229/1575 train_time:67203ms step_avg:54.68ms
+step:1230/1575 train_time:67288ms step_avg:54.71ms
+step:1231/1575 train_time:67379ms step_avg:54.73ms
+step:1232/1575 train_time:67464ms step_avg:54.76ms
+step:1233/1575 train_time:67554ms step_avg:54.79ms
+step:1234/1575 train_time:67639ms step_avg:54.81ms
+step:1235/1575 train_time:67729ms step_avg:54.84ms
+step:1236/1575 train_time:67814ms step_avg:54.87ms
+step:1237/1575 train_time:67904ms step_avg:54.89ms
+step:1238/1575 train_time:67990ms step_avg:54.92ms
+step:1239/1575 train_time:68078ms step_avg:54.95ms
+step:1240/1575 train_time:68165ms step_avg:54.97ms
+step:1241/1575 train_time:68255ms step_avg:55.00ms
+step:1242/1575 train_time:68342ms step_avg:55.03ms
+step:1243/1575 train_time:68431ms step_avg:55.05ms
+step:1244/1575 train_time:68517ms step_avg:55.08ms
+step:1245/1575 train_time:68606ms step_avg:55.11ms
+step:1246/1575 train_time:68691ms step_avg:55.13ms
+step:1247/1575 train_time:68782ms step_avg:55.16ms
+step:1248/1575 train_time:68868ms step_avg:55.18ms
+step:1249/1575 train_time:68957ms step_avg:55.21ms
+step:1250/1575 train_time:69043ms step_avg:55.23ms
+step:1250/1575 val_loss:3.4077 train_time:69115ms step_avg:55.29ms
+step:1251/1575 train_time:69136ms step_avg:55.26ms
+step:1252/1575 train_time:69226ms step_avg:55.29ms
+step:1253/1575 train_time:69318ms step_avg:55.32ms
+step:1254/1575 train_time:69405ms step_avg:55.35ms
+step:1255/1575 train_time:69494ms step_avg:55.37ms
+step:1256/1575 train_time:69579ms step_avg:55.40ms
+step:1257/1575 train_time:69667ms step_avg:55.42ms
+step:1258/1575 train_time:69752ms step_avg:55.45ms
+step:1259/1575 train_time:69840ms step_avg:55.47ms
+step:1260/1575 train_time:69925ms step_avg:55.50ms
+step:1261/1575 train_time:70013ms step_avg:55.52ms
+step:1262/1575 train_time:70099ms step_avg:55.55ms
+step:1263/1575 train_time:70191ms step_avg:55.58ms
+step:1264/1575 train_time:70278ms step_avg:55.60ms
+step:1265/1575 train_time:70369ms step_avg:55.63ms
+step:1266/1575 train_time:70457ms step_avg:55.65ms
+step:1267/1575 train_time:70544ms step_avg:55.68ms
+step:1268/1575 train_time:70630ms step_avg:55.70ms
+step:1269/1575 train_time:70717ms step_avg:55.73ms
+step:1270/1575 train_time:70802ms step_avg:55.75ms
+step:1271/1575 train_time:70890ms step_avg:55.78ms
+step:1272/1575 train_time:70975ms step_avg:55.80ms
+step:1273/1575 train_time:71066ms step_avg:55.83ms
+step:1274/1575 train_time:71152ms step_avg:55.85ms
+step:1275/1575 train_time:71242ms step_avg:55.88ms
+step:1276/1575 train_time:71329ms step_avg:55.90ms
+step:1277/1575 train_time:71418ms step_avg:55.93ms
+step:1278/1575 train_time:71505ms step_avg:55.95ms
+step:1279/1575 train_time:71594ms step_avg:55.98ms
+step:1280/1575 train_time:71679ms step_avg:56.00ms
+step:1281/1575 train_time:71769ms step_avg:56.03ms
+step:1282/1575 train_time:71854ms step_avg:56.05ms
+step:1283/1575 train_time:71943ms step_avg:56.07ms
+step:1284/1575 train_time:72029ms step_avg:56.10ms
+step:1285/1575 train_time:72118ms step_avg:56.12ms
+step:1286/1575 train_time:72206ms step_avg:56.15ms
+step:1287/1575 train_time:72295ms step_avg:56.17ms
+step:1288/1575 train_time:72381ms step_avg:56.20ms
+step:1289/1575 train_time:72471ms step_avg:56.22ms
+step:1290/1575 train_time:72556ms step_avg:56.25ms
+step:1291/1575 train_time:72646ms step_avg:56.27ms
+step:1292/1575 train_time:72731ms step_avg:56.29ms
+step:1293/1575 train_time:72819ms step_avg:56.32ms
+step:1294/1575 train_time:72905ms step_avg:56.34ms
+step:1295/1575 train_time:72994ms step_avg:56.37ms
+step:1296/1575 train_time:73080ms step_avg:56.39ms
+step:1297/1575 train_time:73170ms step_avg:56.41ms
+step:1298/1575 train_time:73255ms step_avg:56.44ms
+step:1299/1575 train_time:73345ms step_avg:56.46ms
+step:1300/1575 train_time:73431ms step_avg:56.49ms
+step:1301/1575 train_time:73520ms step_avg:56.51ms
+step:1302/1575 train_time:73606ms step_avg:56.53ms
+step:1303/1575 train_time:73695ms step_avg:56.56ms
+step:1304/1575 train_time:73781ms step_avg:56.58ms
+step:1305/1575 train_time:73870ms step_avg:56.61ms
+step:1306/1575 train_time:73955ms step_avg:56.63ms
+step:1307/1575 train_time:74045ms step_avg:56.65ms
+step:1308/1575 train_time:74130ms step_avg:56.67ms
+step:1309/1575 train_time:74220ms step_avg:56.70ms
+step:1310/1575 train_time:74307ms step_avg:56.72ms
+step:1311/1575 train_time:74397ms step_avg:56.75ms
+step:1312/1575 train_time:74483ms step_avg:56.77ms
+step:1313/1575 train_time:74573ms step_avg:56.80ms
+step:1314/1575 train_time:74659ms step_avg:56.82ms
+step:1315/1575 train_time:74748ms step_avg:56.84ms
+step:1316/1575 train_time:74833ms step_avg:56.86ms
+step:1317/1575 train_time:74922ms step_avg:56.89ms
+step:1318/1575 train_time:75008ms step_avg:56.91ms
+step:1319/1575 train_time:75097ms step_avg:56.93ms
+step:1320/1575 train_time:75183ms step_avg:56.96ms
+step:1321/1575 train_time:75275ms step_avg:56.98ms
+step:1322/1575 train_time:75360ms step_avg:57.00ms
+step:1323/1575 train_time:75450ms step_avg:57.03ms
+step:1324/1575 train_time:75535ms step_avg:57.05ms
+step:1325/1575 train_time:75626ms step_avg:57.08ms
+step:1326/1575 train_time:75711ms step_avg:57.10ms
+step:1327/1575 train_time:75799ms step_avg:57.12ms
+step:1328/1575 train_time:75885ms step_avg:57.14ms
+step:1329/1575 train_time:75975ms step_avg:57.17ms
+step:1330/1575 train_time:76060ms step_avg:57.19ms
+step:1331/1575 train_time:76149ms step_avg:57.21ms
+step:1332/1575 train_time:76234ms step_avg:57.23ms
+step:1333/1575 train_time:76324ms step_avg:57.26ms
+step:1334/1575 train_time:76411ms step_avg:57.28ms
+step:1335/1575 train_time:76499ms step_avg:57.30ms
+step:1336/1575 train_time:76585ms step_avg:57.32ms
+step:1337/1575 train_time:76675ms step_avg:57.35ms
+step:1338/1575 train_time:76759ms step_avg:57.37ms
+step:1339/1575 train_time:76849ms step_avg:57.39ms
+step:1340/1575 train_time:76935ms step_avg:57.41ms
+step:1341/1575 train_time:77024ms step_avg:57.44ms
+step:1342/1575 train_time:77110ms step_avg:57.46ms
+step:1343/1575 train_time:77199ms step_avg:57.48ms
+step:1344/1575 train_time:77285ms step_avg:57.50ms
+step:1345/1575 train_time:77375ms step_avg:57.53ms
+step:1346/1575 train_time:77461ms step_avg:57.55ms
+step:1347/1575 train_time:77551ms step_avg:57.57ms
+step:1348/1575 train_time:77636ms step_avg:57.59ms
+step:1349/1575 train_time:77725ms step_avg:57.62ms
+step:1350/1575 train_time:77810ms step_avg:57.64ms
+step:1351/1575 train_time:77900ms step_avg:57.66ms
+step:1352/1575 train_time:77985ms step_avg:57.68ms
+step:1353/1575 train_time:78075ms step_avg:57.71ms
+step:1354/1575 train_time:78161ms step_avg:57.73ms
+step:1355/1575 train_time:78250ms step_avg:57.75ms
+step:1356/1575 train_time:78337ms step_avg:57.77ms
+step:1357/1575 train_time:78426ms step_avg:57.79ms
+step:1358/1575 train_time:78516ms step_avg:57.82ms
+step:1359/1575 train_time:78603ms step_avg:57.84ms
+step:1360/1575 train_time:78689ms step_avg:57.86ms
+step:1361/1575 train_time:78778ms step_avg:57.88ms
+step:1362/1575 train_time:78863ms step_avg:57.90ms
+step:1363/1575 train_time:78953ms step_avg:57.93ms
+step:1364/1575 train_time:79040ms step_avg:57.95ms
+step:1365/1575 train_time:79128ms step_avg:57.97ms
+step:1366/1575 train_time:79213ms step_avg:57.99ms
+step:1367/1575 train_time:79303ms step_avg:58.01ms
+step:1368/1575 train_time:79390ms step_avg:58.03ms
+step:1369/1575 train_time:79479ms step_avg:58.06ms
+step:1370/1575 train_time:79564ms step_avg:58.08ms
+step:1371/1575 train_time:79654ms step_avg:58.10ms
+step:1372/1575 train_time:79740ms step_avg:58.12ms
+step:1373/1575 train_time:79829ms step_avg:58.14ms
+step:1374/1575 train_time:79915ms step_avg:58.16ms
+step:1375/1575 train_time:80003ms step_avg:58.18ms
+step:1376/1575 train_time:80089ms step_avg:58.20ms
+step:1377/1575 train_time:80178ms step_avg:58.23ms
+step:1378/1575 train_time:80264ms step_avg:58.25ms
+step:1379/1575 train_time:80355ms step_avg:58.27ms
+step:1380/1575 train_time:80440ms step_avg:58.29ms
+step:1381/1575 train_time:80530ms step_avg:58.31ms
+step:1382/1575 train_time:80616ms step_avg:58.33ms
+step:1383/1575 train_time:80707ms step_avg:58.36ms
+step:1384/1575 train_time:80791ms step_avg:58.38ms
+step:1385/1575 train_time:80880ms step_avg:58.40ms
+step:1386/1575 train_time:80966ms step_avg:58.42ms
+step:1387/1575 train_time:81056ms step_avg:58.44ms
+step:1388/1575 train_time:81141ms step_avg:58.46ms
+step:1389/1575 train_time:81231ms step_avg:58.48ms
+step:1390/1575 train_time:81316ms step_avg:58.50ms
+step:1391/1575 train_time:81406ms step_avg:58.52ms
+step:1392/1575 train_time:81491ms step_avg:58.54ms
+step:1393/1575 train_time:81580ms step_avg:58.56ms
+step:1394/1575 train_time:81666ms step_avg:58.58ms
+step:1395/1575 train_time:81756ms step_avg:58.61ms
+step:1396/1575 train_time:81842ms step_avg:58.63ms
+step:1397/1575 train_time:81932ms step_avg:58.65ms
+step:1398/1575 train_time:82017ms step_avg:58.67ms
+step:1399/1575 train_time:82106ms step_avg:58.69ms
+step:1400/1575 train_time:82191ms step_avg:58.71ms
+step:1401/1575 train_time:82281ms step_avg:58.73ms
+step:1402/1575 train_time:82367ms step_avg:58.75ms
+step:1403/1575 train_time:82456ms step_avg:58.77ms
+step:1404/1575 train_time:82542ms step_avg:58.79ms
+step:1405/1575 train_time:82632ms step_avg:58.81ms
+step:1406/1575 train_time:82717ms step_avg:58.83ms
+step:1407/1575 train_time:82807ms step_avg:58.85ms
+step:1408/1575 train_time:82894ms step_avg:58.87ms
+step:1409/1575 train_time:82983ms step_avg:58.89ms
+step:1410/1575 train_time:83069ms step_avg:58.91ms
+step:1411/1575 train_time:83158ms step_avg:58.94ms
+step:1412/1575 train_time:83243ms step_avg:58.95ms
+step:1413/1575 train_time:83333ms step_avg:58.98ms
+step:1414/1575 train_time:83420ms step_avg:59.00ms
+step:1415/1575 train_time:83508ms step_avg:59.02ms
+step:1416/1575 train_time:83594ms step_avg:59.04ms
+step:1417/1575 train_time:83684ms step_avg:59.06ms
+step:1418/1575 train_time:83770ms step_avg:59.08ms
+step:1419/1575 train_time:83859ms step_avg:59.10ms
+step:1420/1575 train_time:83945ms step_avg:59.12ms
+step:1421/1575 train_time:84036ms step_avg:59.14ms
+step:1422/1575 train_time:84120ms step_avg:59.16ms
+step:1423/1575 train_time:84211ms step_avg:59.18ms
+step:1424/1575 train_time:84297ms step_avg:59.20ms
+step:1425/1575 train_time:84387ms step_avg:59.22ms
+step:1426/1575 train_time:84472ms step_avg:59.24ms
+step:1427/1575 train_time:84561ms step_avg:59.26ms
+step:1428/1575 train_time:84646ms step_avg:59.28ms
+step:1429/1575 train_time:84736ms step_avg:59.30ms
+step:1430/1575 train_time:84822ms step_avg:59.32ms
+step:1431/1575 train_time:84912ms step_avg:59.34ms
+step:1432/1575 train_time:84998ms step_avg:59.36ms
+step:1433/1575 train_time:85087ms step_avg:59.38ms
+step:1434/1575 train_time:85172ms step_avg:59.39ms
+step:1435/1575 train_time:85262ms step_avg:59.42ms
+step:1436/1575 train_time:85349ms step_avg:59.43ms
+step:1437/1575 train_time:85440ms step_avg:59.46ms
+step:1438/1575 train_time:85524ms step_avg:59.47ms
+step:1439/1575 train_time:85615ms step_avg:59.50ms
+step:1440/1575 train_time:85699ms step_avg:59.51ms
+step:1441/1575 train_time:85790ms step_avg:59.54ms
+step:1442/1575 train_time:85876ms step_avg:59.55ms
+step:1443/1575 train_time:85964ms step_avg:59.57ms
+step:1444/1575 train_time:86050ms step_avg:59.59ms
+step:1445/1575 train_time:86139ms step_avg:59.61ms
+step:1446/1575 train_time:86225ms step_avg:59.63ms
+step:1447/1575 train_time:86315ms step_avg:59.65ms
+step:1448/1575 train_time:86401ms step_avg:59.67ms
+step:1449/1575 train_time:86490ms step_avg:59.69ms
+step:1450/1575 train_time:86576ms step_avg:59.71ms
+step:1451/1575 train_time:86665ms step_avg:59.73ms
+step:1452/1575 train_time:86750ms step_avg:59.75ms
+step:1453/1575 train_time:86839ms step_avg:59.77ms
+step:1454/1575 train_time:86926ms step_avg:59.78ms
+step:1455/1575 train_time:87015ms step_avg:59.80ms
+step:1456/1575 train_time:87100ms step_avg:59.82ms
+step:1457/1575 train_time:87189ms step_avg:59.84ms
+step:1458/1575 train_time:87275ms step_avg:59.86ms
+step:1459/1575 train_time:87365ms step_avg:59.88ms
+step:1460/1575 train_time:87451ms step_avg:59.90ms
+step:1461/1575 train_time:87540ms step_avg:59.92ms
+step:1462/1575 train_time:87627ms step_avg:59.94ms
+step:1463/1575 train_time:87716ms step_avg:59.96ms
+step:1464/1575 train_time:87802ms step_avg:59.97ms
+step:1465/1575 train_time:87892ms step_avg:59.99ms
+step:1466/1575 train_time:87978ms step_avg:60.01ms
+step:1467/1575 train_time:88067ms step_avg:60.03ms
+step:1468/1575 train_time:88152ms step_avg:60.05ms
+step:1469/1575 train_time:88242ms step_avg:60.07ms
+step:1470/1575 train_time:88328ms step_avg:60.09ms
+step:1471/1575 train_time:88417ms step_avg:60.11ms
+step:1472/1575 train_time:88505ms step_avg:60.13ms
+step:1473/1575 train_time:88593ms step_avg:60.14ms
+step:1474/1575 train_time:88679ms step_avg:60.16ms
+step:1475/1575 train_time:88768ms step_avg:60.18ms
+step:1476/1575 train_time:88853ms step_avg:60.20ms
+step:1477/1575 train_time:88943ms step_avg:60.22ms
+step:1478/1575 train_time:89029ms step_avg:60.24ms
+step:1479/1575 train_time:89118ms step_avg:60.26ms
+step:1480/1575 train_time:89203ms step_avg:60.27ms
+step:1481/1575 train_time:89293ms step_avg:60.29ms
+step:1482/1575 train_time:89379ms step_avg:60.31ms
+step:1483/1575 train_time:89468ms step_avg:60.33ms
+step:1484/1575 train_time:89554ms step_avg:60.35ms
+step:1485/1575 train_time:89644ms step_avg:60.37ms
+step:1486/1575 train_time:89729ms step_avg:60.38ms
+step:1487/1575 train_time:89819ms step_avg:60.40ms
+step:1488/1575 train_time:89905ms step_avg:60.42ms
+step:1489/1575 train_time:89994ms step_avg:60.44ms
+step:1490/1575 train_time:90080ms step_avg:60.46ms
+step:1491/1575 train_time:90170ms step_avg:60.48ms
+step:1492/1575 train_time:90255ms step_avg:60.49ms
+step:1493/1575 train_time:90346ms step_avg:60.51ms
+step:1494/1575 train_time:90432ms step_avg:60.53ms
+step:1495/1575 train_time:90519ms step_avg:60.55ms
+step:1496/1575 train_time:90605ms step_avg:60.56ms
+step:1497/1575 train_time:90695ms step_avg:60.58ms
+step:1498/1575 train_time:90781ms step_avg:60.60ms
+step:1499/1575 train_time:90871ms step_avg:60.62ms
+step:1500/1575 train_time:90957ms step_avg:60.64ms
+step:1500/1575 val_loss:3.3004 train_time:91028ms step_avg:60.69ms
+step:1501/1575 train_time:91050ms step_avg:60.66ms
+step:1502/1575 train_time:91137ms step_avg:60.68ms
+step:1503/1575 train_time:91231ms step_avg:60.70ms
+step:1504/1575 train_time:91318ms step_avg:60.72ms
+step:1505/1575 train_time:91408ms step_avg:60.74ms
+step:1506/1575 train_time:91493ms step_avg:60.75ms
+step:1507/1575 train_time:91581ms step_avg:60.77ms
+step:1508/1575 train_time:91666ms step_avg:60.79ms
+step:1509/1575 train_time:91754ms step_avg:60.80ms
+step:1510/1575 train_time:91840ms step_avg:60.82ms
+step:1511/1575 train_time:91928ms step_avg:60.84ms
+step:1512/1575 train_time:92014ms step_avg:60.86ms
+step:1513/1575 train_time:92105ms step_avg:60.88ms
+step:1514/1575 train_time:92194ms step_avg:60.89ms
+step:1515/1575 train_time:92284ms step_avg:60.91ms
+step:1516/1575 train_time:92371ms step_avg:60.93ms
+step:1517/1575 train_time:92460ms step_avg:60.95ms
+step:1518/1575 train_time:92546ms step_avg:60.97ms
+step:1519/1575 train_time:92634ms step_avg:60.98ms
+step:1520/1575 train_time:92718ms step_avg:61.00ms
+step:1521/1575 train_time:92807ms step_avg:61.02ms
+step:1522/1575 train_time:92893ms step_avg:61.03ms
+step:1523/1575 train_time:92982ms step_avg:61.05ms
+step:1524/1575 train_time:93070ms step_avg:61.07ms
+step:1525/1575 train_time:93162ms step_avg:61.09ms
+step:1526/1575 train_time:93248ms step_avg:61.11ms
+step:1527/1575 train_time:93342ms step_avg:61.13ms
+step:1528/1575 train_time:93424ms step_avg:61.14ms
+step:1529/1575 train_time:93514ms step_avg:61.16ms
+step:1530/1575 train_time:93599ms step_avg:61.18ms
+step:1531/1575 train_time:93688ms step_avg:61.19ms
+step:1532/1575 train_time:93773ms step_avg:61.21ms
+step:1533/1575 train_time:93861ms step_avg:61.23ms
+step:1534/1575 train_time:93946ms step_avg:61.24ms
+step:1535/1575 train_time:94039ms step_avg:61.26ms
+step:1536/1575 train_time:94133ms step_avg:61.28ms
+step:1537/1575 train_time:94220ms step_avg:61.30ms
+step:1538/1575 train_time:94307ms step_avg:61.32ms
+step:1539/1575 train_time:94397ms step_avg:61.34ms
+step:1540/1575 train_time:94483ms step_avg:61.35ms
+step:1541/1575 train_time:94573ms step_avg:61.37ms
+step:1542/1575 train_time:94658ms step_avg:61.39ms
+step:1543/1575 train_time:94748ms step_avg:61.41ms
+step:1544/1575 train_time:94834ms step_avg:61.42ms
+step:1545/1575 train_time:94923ms step_avg:61.44ms
+step:1546/1575 train_time:95009ms step_avg:61.45ms
+step:1547/1575 train_time:95099ms step_avg:61.47ms
+step:1548/1575 train_time:95187ms step_avg:61.49ms
+step:1549/1575 train_time:95278ms step_avg:61.51ms
+step:1550/1575 train_time:95364ms step_avg:61.53ms
+step:1551/1575 train_time:95454ms step_avg:61.54ms
+step:1552/1575 train_time:95539ms step_avg:61.56ms
+step:1553/1575 train_time:95629ms step_avg:61.58ms
+step:1554/1575 train_time:95715ms step_avg:61.59ms
+step:1555/1575 train_time:95804ms step_avg:61.61ms
+step:1556/1575 train_time:95890ms step_avg:61.63ms
+step:1557/1575 train_time:95979ms step_avg:61.64ms
+step:1558/1575 train_time:96065ms step_avg:61.66ms
+step:1559/1575 train_time:96155ms step_avg:61.68ms
+step:1560/1575 train_time:96241ms step_avg:61.69ms
+step:1561/1575 train_time:96334ms step_avg:61.71ms
+step:1562/1575 train_time:96419ms step_avg:61.73ms
+step:1563/1575 train_time:96509ms step_avg:61.75ms
+step:1564/1575 train_time:96595ms step_avg:61.76ms
+step:1565/1575 train_time:96684ms step_avg:61.78ms
+step:1566/1575 train_time:96771ms step_avg:61.79ms
+step:1567/1575 train_time:96861ms step_avg:61.81ms
+step:1568/1575 train_time:96947ms step_avg:61.83ms
+step:1569/1575 train_time:97041ms step_avg:61.85ms
+step:1570/1575 train_time:97125ms step_avg:61.86ms
+step:1571/1575 train_time:97215ms step_avg:61.88ms
+step:1572/1575 train_time:97299ms step_avg:61.90ms
+step:1573/1575 train_time:97389ms step_avg:61.91ms
+step:1574/1575 train_time:97475ms step_avg:61.93ms
+step:1575/1575 train_time:97566ms step_avg:61.95ms
+step:1575/1575 val_loss:3.2782 train_time:97632ms step_avg:61.99ms
+peak memory allocated: 31016 MiB reserved: 46998 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/8fc286ac-58b8-4bb1-aa91-3804b48b2094.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/8fc286ac-58b8-4bb1-aa91-3804b48b2094.txt
@@ -1,0 +1,4096 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 01 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # shifting first layer updates this to 01 ... 01 @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:40:14 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   41C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            132W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          260848      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          260849      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          260850      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          260851      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          260852      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          260853      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          260854      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          260855      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 511, 512, 513, 1023, 1024, 1025, 1534, 1535, 1536] for warmup
+Resetting Model
+step:0/1575 val_loss:10.8318 train_time:0ms step_avg:0.03ms
+step:1/1575 train_time:83ms step_avg:83.46ms
+step:2/1575 train_time:104ms step_avg:51.93ms
+step:3/1575 train_time:122ms step_avg:40.65ms
+step:4/1575 train_time:162ms step_avg:40.39ms
+step:5/1575 train_time:192ms step_avg:38.45ms
+step:6/1575 train_time:292ms step_avg:48.68ms
+step:7/1575 train_time:309ms step_avg:44.16ms
+step:8/1575 train_time:333ms step_avg:41.65ms
+step:9/1575 train_time:364ms step_avg:40.45ms
+step:10/1575 train_time:402ms step_avg:40.21ms
+step:11/1575 train_time:434ms step_avg:39.44ms
+step:12/1575 train_time:472ms step_avg:39.37ms
+step:13/1575 train_time:503ms step_avg:38.72ms
+step:14/1575 train_time:542ms step_avg:38.71ms
+step:15/1575 train_time:573ms step_avg:38.20ms
+step:16/1575 train_time:612ms step_avg:38.22ms
+step:17/1575 train_time:643ms step_avg:37.80ms
+step:18/1575 train_time:681ms step_avg:37.85ms
+step:19/1575 train_time:713ms step_avg:37.51ms
+step:20/1575 train_time:751ms step_avg:37.57ms
+step:21/1575 train_time:782ms step_avg:37.25ms
+step:22/1575 train_time:821ms step_avg:37.32ms
+step:23/1575 train_time:852ms step_avg:37.05ms
+step:24/1575 train_time:891ms step_avg:37.12ms
+step:25/1575 train_time:922ms step_avg:36.88ms
+step:26/1575 train_time:960ms step_avg:36.94ms
+step:27/1575 train_time:992ms step_avg:36.73ms
+step:28/1575 train_time:1030ms step_avg:36.79ms
+step:29/1575 train_time:1061ms step_avg:36.60ms
+step:30/1575 train_time:1100ms step_avg:36.65ms
+step:31/1575 train_time:1131ms step_avg:36.48ms
+step:32/1575 train_time:1169ms step_avg:36.54ms
+step:33/1575 train_time:1201ms step_avg:36.38ms
+step:34/1575 train_time:1238ms step_avg:36.43ms
+step:35/1575 train_time:1270ms step_avg:36.29ms
+step:36/1575 train_time:1309ms step_avg:36.37ms
+step:37/1575 train_time:1340ms step_avg:36.22ms
+step:38/1575 train_time:1379ms step_avg:36.28ms
+step:39/1575 train_time:1410ms step_avg:36.15ms
+step:40/1575 train_time:1449ms step_avg:36.22ms
+step:41/1575 train_time:1479ms step_avg:36.08ms
+step:42/1575 train_time:1518ms step_avg:36.15ms
+step:43/1575 train_time:1550ms step_avg:36.04ms
+step:44/1575 train_time:1588ms step_avg:36.10ms
+step:45/1575 train_time:1620ms step_avg:35.99ms
+step:46/1575 train_time:1658ms step_avg:36.05ms
+step:47/1575 train_time:1690ms step_avg:35.95ms
+step:48/1575 train_time:1728ms step_avg:36.00ms
+step:49/1575 train_time:1759ms step_avg:35.90ms
+step:50/1575 train_time:1798ms step_avg:35.95ms
+step:51/1575 train_time:1829ms step_avg:35.87ms
+step:52/1575 train_time:1868ms step_avg:35.92ms
+step:53/1575 train_time:1899ms step_avg:35.82ms
+step:54/1575 train_time:1937ms step_avg:35.87ms
+step:55/1575 train_time:1968ms step_avg:35.79ms
+step:56/1575 train_time:2007ms step_avg:35.84ms
+step:57/1575 train_time:2038ms step_avg:35.75ms
+step:58/1575 train_time:2077ms step_avg:35.81ms
+step:59/1575 train_time:2108ms step_avg:35.73ms
+step:60/1575 train_time:2146ms step_avg:35.77ms
+step:61/1575 train_time:2178ms step_avg:35.70ms
+step:62/1575 train_time:2216ms step_avg:35.75ms
+step:63/1575 train_time:2248ms step_avg:35.67ms
+step:64/1575 train_time:2286ms step_avg:35.72ms
+step:65/1575 train_time:2317ms step_avg:35.65ms
+step:66/1575 train_time:2356ms step_avg:35.69ms
+step:67/1575 train_time:2386ms step_avg:35.62ms
+step:68/1575 train_time:2425ms step_avg:35.66ms
+step:69/1575 train_time:2456ms step_avg:35.60ms
+step:70/1575 train_time:2495ms step_avg:35.64ms
+step:71/1575 train_time:2526ms step_avg:35.57ms
+step:72/1575 train_time:2565ms step_avg:35.62ms
+step:73/1575 train_time:2596ms step_avg:35.56ms
+step:74/1575 train_time:2634ms step_avg:35.59ms
+step:75/1575 train_time:2665ms step_avg:35.53ms
+step:76/1575 train_time:2703ms step_avg:35.57ms
+step:77/1575 train_time:2734ms step_avg:35.51ms
+step:78/1575 train_time:2773ms step_avg:35.55ms
+step:79/1575 train_time:2804ms step_avg:35.50ms
+step:80/1575 train_time:2843ms step_avg:35.54ms
+step:81/1575 train_time:2874ms step_avg:35.48ms
+step:82/1575 train_time:2912ms step_avg:35.52ms
+step:83/1575 train_time:2944ms step_avg:35.46ms
+step:84/1575 train_time:2982ms step_avg:35.50ms
+step:85/1575 train_time:3013ms step_avg:35.45ms
+step:86/1575 train_time:3052ms step_avg:35.48ms
+step:87/1575 train_time:3083ms step_avg:35.43ms
+step:88/1575 train_time:3122ms step_avg:35.47ms
+step:89/1575 train_time:3153ms step_avg:35.42ms
+step:90/1575 train_time:3191ms step_avg:35.46ms
+step:91/1575 train_time:3222ms step_avg:35.41ms
+step:92/1575 train_time:3261ms step_avg:35.44ms
+step:93/1575 train_time:3292ms step_avg:35.39ms
+step:94/1575 train_time:3330ms step_avg:35.43ms
+step:95/1575 train_time:3362ms step_avg:35.38ms
+step:96/1575 train_time:3400ms step_avg:35.41ms
+step:97/1575 train_time:3431ms step_avg:35.37ms
+step:98/1575 train_time:3470ms step_avg:35.41ms
+step:99/1575 train_time:3501ms step_avg:35.36ms
+step:100/1575 train_time:3539ms step_avg:35.39ms
+step:101/1575 train_time:3570ms step_avg:35.35ms
+step:102/1575 train_time:3609ms step_avg:35.38ms
+step:103/1575 train_time:3640ms step_avg:35.34ms
+step:104/1575 train_time:3678ms step_avg:35.37ms
+step:105/1575 train_time:3709ms step_avg:35.33ms
+step:106/1575 train_time:3747ms step_avg:35.35ms
+step:107/1575 train_time:3779ms step_avg:35.31ms
+step:108/1575 train_time:3817ms step_avg:35.34ms
+step:109/1575 train_time:3849ms step_avg:35.31ms
+step:110/1575 train_time:3887ms step_avg:35.34ms
+step:111/1575 train_time:3918ms step_avg:35.30ms
+step:112/1575 train_time:3957ms step_avg:35.33ms
+step:113/1575 train_time:3988ms step_avg:35.29ms
+step:114/1575 train_time:4027ms step_avg:35.32ms
+step:115/1575 train_time:4058ms step_avg:35.29ms
+step:116/1575 train_time:4096ms step_avg:35.31ms
+step:117/1575 train_time:4127ms step_avg:35.28ms
+step:118/1575 train_time:4166ms step_avg:35.30ms
+step:119/1575 train_time:4197ms step_avg:35.27ms
+step:120/1575 train_time:4235ms step_avg:35.29ms
+step:121/1575 train_time:4267ms step_avg:35.26ms
+step:122/1575 train_time:4305ms step_avg:35.29ms
+step:123/1575 train_time:4336ms step_avg:35.25ms
+step:124/1575 train_time:4374ms step_avg:35.28ms
+step:125/1575 train_time:4405ms step_avg:35.24ms
+step:126/1575 train_time:4443ms step_avg:35.26ms
+step:127/1575 train_time:4475ms step_avg:35.23ms
+step:128/1575 train_time:4513ms step_avg:35.26ms
+step:129/1575 train_time:4544ms step_avg:35.23ms
+step:130/1575 train_time:4583ms step_avg:35.25ms
+step:131/1575 train_time:4614ms step_avg:35.22ms
+step:132/1575 train_time:4652ms step_avg:35.25ms
+step:133/1575 train_time:4684ms step_avg:35.22ms
+step:134/1575 train_time:4722ms step_avg:35.24ms
+step:135/1575 train_time:4753ms step_avg:35.21ms
+step:136/1575 train_time:4792ms step_avg:35.24ms
+step:137/1575 train_time:4823ms step_avg:35.20ms
+step:138/1575 train_time:4861ms step_avg:35.23ms
+step:139/1575 train_time:4892ms step_avg:35.20ms
+step:140/1575 train_time:4931ms step_avg:35.22ms
+step:141/1575 train_time:4962ms step_avg:35.19ms
+step:142/1575 train_time:5001ms step_avg:35.21ms
+step:143/1575 train_time:5032ms step_avg:35.19ms
+step:144/1575 train_time:5070ms step_avg:35.21ms
+step:145/1575 train_time:5101ms step_avg:35.18ms
+step:146/1575 train_time:5139ms step_avg:35.20ms
+step:147/1575 train_time:5171ms step_avg:35.17ms
+step:148/1575 train_time:5209ms step_avg:35.20ms
+step:149/1575 train_time:5240ms step_avg:35.17ms
+step:150/1575 train_time:5279ms step_avg:35.19ms
+step:151/1575 train_time:5310ms step_avg:35.17ms
+step:152/1575 train_time:5348ms step_avg:35.19ms
+step:153/1575 train_time:5379ms step_avg:35.16ms
+step:154/1575 train_time:5418ms step_avg:35.18ms
+step:155/1575 train_time:5449ms step_avg:35.15ms
+step:156/1575 train_time:5487ms step_avg:35.17ms
+step:157/1575 train_time:5518ms step_avg:35.15ms
+step:158/1575 train_time:5557ms step_avg:35.17ms
+step:159/1575 train_time:5588ms step_avg:35.14ms
+step:160/1575 train_time:5626ms step_avg:35.16ms
+step:161/1575 train_time:5657ms step_avg:35.14ms
+step:162/1575 train_time:5696ms step_avg:35.16ms
+step:163/1575 train_time:5727ms step_avg:35.13ms
+step:164/1575 train_time:5765ms step_avg:35.15ms
+step:165/1575 train_time:5796ms step_avg:35.13ms
+step:166/1575 train_time:5835ms step_avg:35.15ms
+step:167/1575 train_time:5866ms step_avg:35.13ms
+step:168/1575 train_time:5905ms step_avg:35.15ms
+step:169/1575 train_time:5935ms step_avg:35.12ms
+step:170/1575 train_time:5974ms step_avg:35.14ms
+step:171/1575 train_time:6005ms step_avg:35.12ms
+step:172/1575 train_time:6043ms step_avg:35.14ms
+step:173/1575 train_time:6074ms step_avg:35.11ms
+step:174/1575 train_time:6112ms step_avg:35.13ms
+step:175/1575 train_time:6143ms step_avg:35.10ms
+step:176/1575 train_time:6182ms step_avg:35.12ms
+step:177/1575 train_time:6212ms step_avg:35.10ms
+step:178/1575 train_time:6251ms step_avg:35.12ms
+step:179/1575 train_time:6282ms step_avg:35.09ms
+step:180/1575 train_time:6320ms step_avg:35.11ms
+step:181/1575 train_time:6352ms step_avg:35.09ms
+step:182/1575 train_time:6390ms step_avg:35.11ms
+step:183/1575 train_time:6422ms step_avg:35.09ms
+step:184/1575 train_time:6460ms step_avg:35.11ms
+step:185/1575 train_time:6491ms step_avg:35.09ms
+step:186/1575 train_time:6530ms step_avg:35.11ms
+step:187/1575 train_time:6561ms step_avg:35.09ms
+step:188/1575 train_time:6599ms step_avg:35.10ms
+step:189/1575 train_time:6630ms step_avg:35.08ms
+step:190/1575 train_time:6670ms step_avg:35.10ms
+step:191/1575 train_time:6700ms step_avg:35.08ms
+step:192/1575 train_time:6738ms step_avg:35.09ms
+step:193/1575 train_time:6769ms step_avg:35.07ms
+step:194/1575 train_time:6807ms step_avg:35.09ms
+step:195/1575 train_time:6838ms step_avg:35.07ms
+step:196/1575 train_time:6877ms step_avg:35.09ms
+step:197/1575 train_time:6908ms step_avg:35.06ms
+step:198/1575 train_time:6946ms step_avg:35.08ms
+step:199/1575 train_time:6977ms step_avg:35.06ms
+step:200/1575 train_time:7016ms step_avg:35.08ms
+step:201/1575 train_time:7047ms step_avg:35.06ms
+step:202/1575 train_time:7085ms step_avg:35.07ms
+step:203/1575 train_time:7116ms step_avg:35.06ms
+step:204/1575 train_time:7155ms step_avg:35.07ms
+step:205/1575 train_time:7186ms step_avg:35.05ms
+step:206/1575 train_time:7225ms step_avg:35.07ms
+step:207/1575 train_time:7255ms step_avg:35.05ms
+step:208/1575 train_time:7296ms step_avg:35.08ms
+step:209/1575 train_time:7325ms step_avg:35.05ms
+step:210/1575 train_time:7363ms step_avg:35.06ms
+step:211/1575 train_time:7394ms step_avg:35.04ms
+step:212/1575 train_time:7432ms step_avg:35.06ms
+step:213/1575 train_time:7463ms step_avg:35.04ms
+step:214/1575 train_time:7502ms step_avg:35.06ms
+step:215/1575 train_time:7533ms step_avg:35.04ms
+step:216/1575 train_time:7572ms step_avg:35.06ms
+step:217/1575 train_time:7602ms step_avg:35.03ms
+step:218/1575 train_time:7641ms step_avg:35.05ms
+step:219/1575 train_time:7672ms step_avg:35.03ms
+step:220/1575 train_time:7710ms step_avg:35.04ms
+step:221/1575 train_time:7741ms step_avg:35.03ms
+step:222/1575 train_time:7779ms step_avg:35.04ms
+step:223/1575 train_time:7811ms step_avg:35.02ms
+step:224/1575 train_time:7849ms step_avg:35.04ms
+step:225/1575 train_time:7880ms step_avg:35.02ms
+step:226/1575 train_time:7918ms step_avg:35.04ms
+step:227/1575 train_time:7950ms step_avg:35.02ms
+step:228/1575 train_time:7988ms step_avg:35.04ms
+step:229/1575 train_time:8019ms step_avg:35.02ms
+step:230/1575 train_time:8058ms step_avg:35.03ms
+step:231/1575 train_time:8089ms step_avg:35.02ms
+step:232/1575 train_time:8127ms step_avg:35.03ms
+step:233/1575 train_time:8158ms step_avg:35.01ms
+step:234/1575 train_time:8196ms step_avg:35.03ms
+step:235/1575 train_time:8227ms step_avg:35.01ms
+step:236/1575 train_time:8266ms step_avg:35.02ms
+step:237/1575 train_time:8297ms step_avg:35.01ms
+step:238/1575 train_time:8335ms step_avg:35.02ms
+step:239/1575 train_time:8366ms step_avg:35.00ms
+step:240/1575 train_time:8404ms step_avg:35.02ms
+step:241/1575 train_time:8436ms step_avg:35.00ms
+step:242/1575 train_time:8474ms step_avg:35.02ms
+step:243/1575 train_time:8505ms step_avg:35.00ms
+step:244/1575 train_time:8543ms step_avg:35.01ms
+step:245/1575 train_time:8575ms step_avg:35.00ms
+step:246/1575 train_time:8613ms step_avg:35.01ms
+step:247/1575 train_time:8644ms step_avg:35.00ms
+step:248/1575 train_time:8682ms step_avg:35.01ms
+step:249/1575 train_time:8714ms step_avg:34.99ms
+step:250/1575 train_time:8752ms step_avg:35.01ms
+step:250/1575 val_loss:4.5735 train_time:8801ms step_avg:35.20ms
+step:251/1575 train_time:8819ms step_avg:35.14ms
+step:252/1575 train_time:8838ms step_avg:35.07ms
+step:253/1575 train_time:8858ms step_avg:35.01ms
+step:254/1575 train_time:8897ms step_avg:35.03ms
+step:255/1575 train_time:8930ms step_avg:35.02ms
+step:256/1575 train_time:8970ms step_avg:35.04ms
+step:257/1575 train_time:9002ms step_avg:35.03ms
+step:258/1575 train_time:9040ms step_avg:35.04ms
+step:259/1575 train_time:9071ms step_avg:35.02ms
+step:260/1575 train_time:9110ms step_avg:35.04ms
+step:261/1575 train_time:9141ms step_avg:35.02ms
+step:262/1575 train_time:9179ms step_avg:35.03ms
+step:263/1575 train_time:9210ms step_avg:35.02ms
+step:264/1575 train_time:9249ms step_avg:35.03ms
+step:265/1575 train_time:9280ms step_avg:35.02ms
+step:266/1575 train_time:9318ms step_avg:35.03ms
+step:267/1575 train_time:9349ms step_avg:35.02ms
+step:268/1575 train_time:9387ms step_avg:35.03ms
+step:269/1575 train_time:9419ms step_avg:35.01ms
+step:270/1575 train_time:9457ms step_avg:35.03ms
+step:271/1575 train_time:9488ms step_avg:35.01ms
+step:272/1575 train_time:9527ms step_avg:35.03ms
+step:273/1575 train_time:9557ms step_avg:35.01ms
+step:274/1575 train_time:9596ms step_avg:35.02ms
+step:275/1575 train_time:9627ms step_avg:35.01ms
+step:276/1575 train_time:9665ms step_avg:35.02ms
+step:277/1575 train_time:9696ms step_avg:35.00ms
+step:278/1575 train_time:9734ms step_avg:35.02ms
+step:279/1575 train_time:9765ms step_avg:35.00ms
+step:280/1575 train_time:9803ms step_avg:35.01ms
+step:281/1575 train_time:9834ms step_avg:35.00ms
+step:282/1575 train_time:9873ms step_avg:35.01ms
+step:283/1575 train_time:9904ms step_avg:35.00ms
+step:284/1575 train_time:9943ms step_avg:35.01ms
+step:285/1575 train_time:9973ms step_avg:34.99ms
+step:286/1575 train_time:10012ms step_avg:35.01ms
+step:287/1575 train_time:10043ms step_avg:34.99ms
+step:288/1575 train_time:10082ms step_avg:35.01ms
+step:289/1575 train_time:10113ms step_avg:34.99ms
+step:290/1575 train_time:10152ms step_avg:35.01ms
+step:291/1575 train_time:10183ms step_avg:34.99ms
+step:292/1575 train_time:10221ms step_avg:35.00ms
+step:293/1575 train_time:10252ms step_avg:34.99ms
+step:294/1575 train_time:10290ms step_avg:35.00ms
+step:295/1575 train_time:10322ms step_avg:34.99ms
+step:296/1575 train_time:10360ms step_avg:35.00ms
+step:297/1575 train_time:10391ms step_avg:34.99ms
+step:298/1575 train_time:10429ms step_avg:35.00ms
+step:299/1575 train_time:10461ms step_avg:34.99ms
+step:300/1575 train_time:10499ms step_avg:35.00ms
+step:301/1575 train_time:10530ms step_avg:34.98ms
+step:302/1575 train_time:10568ms step_avg:34.99ms
+step:303/1575 train_time:10600ms step_avg:34.98ms
+step:304/1575 train_time:10638ms step_avg:34.99ms
+step:305/1575 train_time:10669ms step_avg:34.98ms
+step:306/1575 train_time:10707ms step_avg:34.99ms
+step:307/1575 train_time:10738ms step_avg:34.98ms
+step:308/1575 train_time:10777ms step_avg:34.99ms
+step:309/1575 train_time:10808ms step_avg:34.98ms
+step:310/1575 train_time:10846ms step_avg:34.99ms
+step:311/1575 train_time:10877ms step_avg:34.97ms
+step:312/1575 train_time:10916ms step_avg:34.99ms
+step:313/1575 train_time:10947ms step_avg:34.97ms
+step:314/1575 train_time:10985ms step_avg:34.99ms
+step:315/1575 train_time:11017ms step_avg:34.97ms
+step:316/1575 train_time:11055ms step_avg:34.98ms
+step:317/1575 train_time:11086ms step_avg:34.97ms
+step:318/1575 train_time:11124ms step_avg:34.98ms
+step:319/1575 train_time:11155ms step_avg:34.97ms
+step:320/1575 train_time:11194ms step_avg:34.98ms
+step:321/1575 train_time:11225ms step_avg:34.97ms
+step:322/1575 train_time:11264ms step_avg:34.98ms
+step:323/1575 train_time:11294ms step_avg:34.97ms
+step:324/1575 train_time:11333ms step_avg:34.98ms
+step:325/1575 train_time:11364ms step_avg:34.97ms
+step:326/1575 train_time:11402ms step_avg:34.98ms
+step:327/1575 train_time:11433ms step_avg:34.96ms
+step:328/1575 train_time:11471ms step_avg:34.97ms
+step:329/1575 train_time:11502ms step_avg:34.96ms
+step:330/1575 train_time:11541ms step_avg:34.97ms
+step:331/1575 train_time:11572ms step_avg:34.96ms
+step:332/1575 train_time:11610ms step_avg:34.97ms
+step:333/1575 train_time:11642ms step_avg:34.96ms
+step:334/1575 train_time:11680ms step_avg:34.97ms
+step:335/1575 train_time:11711ms step_avg:34.96ms
+step:336/1575 train_time:11750ms step_avg:34.97ms
+step:337/1575 train_time:11781ms step_avg:34.96ms
+step:338/1575 train_time:11819ms step_avg:34.97ms
+step:339/1575 train_time:11850ms step_avg:34.96ms
+step:340/1575 train_time:11889ms step_avg:34.97ms
+step:341/1575 train_time:11920ms step_avg:34.96ms
+step:342/1575 train_time:11959ms step_avg:34.97ms
+step:343/1575 train_time:11990ms step_avg:34.96ms
+step:344/1575 train_time:12029ms step_avg:34.97ms
+step:345/1575 train_time:12060ms step_avg:34.96ms
+step:346/1575 train_time:12098ms step_avg:34.97ms
+step:347/1575 train_time:12129ms step_avg:34.96ms
+step:348/1575 train_time:12168ms step_avg:34.96ms
+step:349/1575 train_time:12199ms step_avg:34.95ms
+step:350/1575 train_time:12237ms step_avg:34.96ms
+step:351/1575 train_time:12268ms step_avg:34.95ms
+step:352/1575 train_time:12306ms step_avg:34.96ms
+step:353/1575 train_time:12337ms step_avg:34.95ms
+step:354/1575 train_time:12376ms step_avg:34.96ms
+step:355/1575 train_time:12407ms step_avg:34.95ms
+step:356/1575 train_time:12445ms step_avg:34.96ms
+step:357/1575 train_time:12476ms step_avg:34.95ms
+step:358/1575 train_time:12515ms step_avg:34.96ms
+step:359/1575 train_time:12546ms step_avg:34.95ms
+step:360/1575 train_time:12584ms step_avg:34.95ms
+step:361/1575 train_time:12614ms step_avg:34.94ms
+step:362/1575 train_time:12653ms step_avg:34.95ms
+step:363/1575 train_time:12684ms step_avg:34.94ms
+step:364/1575 train_time:12722ms step_avg:34.95ms
+step:365/1575 train_time:12753ms step_avg:34.94ms
+step:366/1575 train_time:12791ms step_avg:34.95ms
+step:367/1575 train_time:12822ms step_avg:34.94ms
+step:368/1575 train_time:12860ms step_avg:34.95ms
+step:369/1575 train_time:12891ms step_avg:34.94ms
+step:370/1575 train_time:12930ms step_avg:34.94ms
+step:371/1575 train_time:12961ms step_avg:34.94ms
+step:372/1575 train_time:12999ms step_avg:34.94ms
+step:373/1575 train_time:13031ms step_avg:34.93ms
+step:374/1575 train_time:13069ms step_avg:34.94ms
+step:375/1575 train_time:13101ms step_avg:34.93ms
+step:376/1575 train_time:13140ms step_avg:34.95ms
+step:377/1575 train_time:13170ms step_avg:34.93ms
+step:378/1575 train_time:13209ms step_avg:34.94ms
+step:379/1575 train_time:13240ms step_avg:34.93ms
+step:380/1575 train_time:13278ms step_avg:34.94ms
+step:381/1575 train_time:13309ms step_avg:34.93ms
+step:382/1575 train_time:13348ms step_avg:34.94ms
+step:383/1575 train_time:13379ms step_avg:34.93ms
+step:384/1575 train_time:13418ms step_avg:34.94ms
+step:385/1575 train_time:13449ms step_avg:34.93ms
+step:386/1575 train_time:13487ms step_avg:34.94ms
+step:387/1575 train_time:13518ms step_avg:34.93ms
+step:388/1575 train_time:13557ms step_avg:34.94ms
+step:389/1575 train_time:13588ms step_avg:34.93ms
+step:390/1575 train_time:13626ms step_avg:34.94ms
+step:391/1575 train_time:13658ms step_avg:34.93ms
+step:392/1575 train_time:13696ms step_avg:34.94ms
+step:393/1575 train_time:13727ms step_avg:34.93ms
+step:394/1575 train_time:13766ms step_avg:34.94ms
+step:395/1575 train_time:13797ms step_avg:34.93ms
+step:396/1575 train_time:13835ms step_avg:34.94ms
+step:397/1575 train_time:13866ms step_avg:34.93ms
+step:398/1575 train_time:13905ms step_avg:34.94ms
+step:399/1575 train_time:13935ms step_avg:34.93ms
+step:400/1575 train_time:13974ms step_avg:34.94ms
+step:401/1575 train_time:14005ms step_avg:34.93ms
+step:402/1575 train_time:14043ms step_avg:34.93ms
+step:403/1575 train_time:14074ms step_avg:34.92ms
+step:404/1575 train_time:14112ms step_avg:34.93ms
+step:405/1575 train_time:14144ms step_avg:34.92ms
+step:406/1575 train_time:14182ms step_avg:34.93ms
+step:407/1575 train_time:14213ms step_avg:34.92ms
+step:408/1575 train_time:14251ms step_avg:34.93ms
+step:409/1575 train_time:14282ms step_avg:34.92ms
+step:410/1575 train_time:14321ms step_avg:34.93ms
+step:411/1575 train_time:14352ms step_avg:34.92ms
+step:412/1575 train_time:14390ms step_avg:34.93ms
+step:413/1575 train_time:14421ms step_avg:34.92ms
+step:414/1575 train_time:14461ms step_avg:34.93ms
+step:415/1575 train_time:14492ms step_avg:34.92ms
+step:416/1575 train_time:14530ms step_avg:34.93ms
+step:417/1575 train_time:14562ms step_avg:34.92ms
+step:418/1575 train_time:14600ms step_avg:34.93ms
+step:419/1575 train_time:14631ms step_avg:34.92ms
+step:420/1575 train_time:14670ms step_avg:34.93ms
+step:421/1575 train_time:14700ms step_avg:34.92ms
+step:422/1575 train_time:14740ms step_avg:34.93ms
+step:423/1575 train_time:14770ms step_avg:34.92ms
+step:424/1575 train_time:14808ms step_avg:34.92ms
+step:425/1575 train_time:14839ms step_avg:34.91ms
+step:426/1575 train_time:14878ms step_avg:34.92ms
+step:427/1575 train_time:14908ms step_avg:34.91ms
+step:428/1575 train_time:14947ms step_avg:34.92ms
+step:429/1575 train_time:14978ms step_avg:34.91ms
+step:430/1575 train_time:15016ms step_avg:34.92ms
+step:431/1575 train_time:15048ms step_avg:34.91ms
+step:432/1575 train_time:15086ms step_avg:34.92ms
+step:433/1575 train_time:15117ms step_avg:34.91ms
+step:434/1575 train_time:15155ms step_avg:34.92ms
+step:435/1575 train_time:15186ms step_avg:34.91ms
+step:436/1575 train_time:15225ms step_avg:34.92ms
+step:437/1575 train_time:15256ms step_avg:34.91ms
+step:438/1575 train_time:15294ms step_avg:34.92ms
+step:439/1575 train_time:15326ms step_avg:34.91ms
+step:440/1575 train_time:15365ms step_avg:34.92ms
+step:441/1575 train_time:15395ms step_avg:34.91ms
+step:442/1575 train_time:15434ms step_avg:34.92ms
+step:443/1575 train_time:15465ms step_avg:34.91ms
+step:444/1575 train_time:15503ms step_avg:34.92ms
+step:445/1575 train_time:15534ms step_avg:34.91ms
+step:446/1575 train_time:15573ms step_avg:34.92ms
+step:447/1575 train_time:15603ms step_avg:34.91ms
+step:448/1575 train_time:15642ms step_avg:34.91ms
+step:449/1575 train_time:15673ms step_avg:34.91ms
+step:450/1575 train_time:15711ms step_avg:34.91ms
+step:451/1575 train_time:15742ms step_avg:34.91ms
+step:452/1575 train_time:15781ms step_avg:34.91ms
+step:453/1575 train_time:15811ms step_avg:34.90ms
+step:454/1575 train_time:15850ms step_avg:34.91ms
+step:455/1575 train_time:15881ms step_avg:34.90ms
+step:456/1575 train_time:15919ms step_avg:34.91ms
+step:457/1575 train_time:15950ms step_avg:34.90ms
+step:458/1575 train_time:15989ms step_avg:34.91ms
+step:459/1575 train_time:16020ms step_avg:34.90ms
+step:460/1575 train_time:16058ms step_avg:34.91ms
+step:461/1575 train_time:16089ms step_avg:34.90ms
+step:462/1575 train_time:16128ms step_avg:34.91ms
+step:463/1575 train_time:16159ms step_avg:34.90ms
+step:464/1575 train_time:16197ms step_avg:34.91ms
+step:465/1575 train_time:16228ms step_avg:34.90ms
+step:466/1575 train_time:16267ms step_avg:34.91ms
+step:467/1575 train_time:16298ms step_avg:34.90ms
+step:468/1575 train_time:16336ms step_avg:34.91ms
+step:469/1575 train_time:16368ms step_avg:34.90ms
+step:470/1575 train_time:16407ms step_avg:34.91ms
+step:471/1575 train_time:16438ms step_avg:34.90ms
+step:472/1575 train_time:16477ms step_avg:34.91ms
+step:473/1575 train_time:16508ms step_avg:34.90ms
+step:474/1575 train_time:16546ms step_avg:34.91ms
+step:475/1575 train_time:16578ms step_avg:34.90ms
+step:476/1575 train_time:16616ms step_avg:34.91ms
+step:477/1575 train_time:16647ms step_avg:34.90ms
+step:478/1575 train_time:16685ms step_avg:34.91ms
+step:479/1575 train_time:16716ms step_avg:34.90ms
+step:480/1575 train_time:16755ms step_avg:34.91ms
+step:481/1575 train_time:16785ms step_avg:34.90ms
+step:482/1575 train_time:16824ms step_avg:34.90ms
+step:483/1575 train_time:16855ms step_avg:34.90ms
+step:484/1575 train_time:16893ms step_avg:34.90ms
+step:485/1575 train_time:16924ms step_avg:34.89ms
+step:486/1575 train_time:16962ms step_avg:34.90ms
+step:487/1575 train_time:16993ms step_avg:34.89ms
+step:488/1575 train_time:17032ms step_avg:34.90ms
+step:489/1575 train_time:17063ms step_avg:34.89ms
+step:490/1575 train_time:17101ms step_avg:34.90ms
+step:491/1575 train_time:17132ms step_avg:34.89ms
+step:492/1575 train_time:17171ms step_avg:34.90ms
+step:493/1575 train_time:17202ms step_avg:34.89ms
+step:494/1575 train_time:17240ms step_avg:34.90ms
+step:495/1575 train_time:17271ms step_avg:34.89ms
+step:496/1575 train_time:17309ms step_avg:34.90ms
+step:497/1575 train_time:17340ms step_avg:34.89ms
+step:498/1575 train_time:17379ms step_avg:34.90ms
+step:499/1575 train_time:17410ms step_avg:34.89ms
+step:500/1575 train_time:17448ms step_avg:34.90ms
+step:500/1575 val_loss:4.2405 train_time:17497ms step_avg:34.99ms
+step:501/1575 train_time:17515ms step_avg:34.96ms
+step:502/1575 train_time:17534ms step_avg:34.93ms
+step:503/1575 train_time:17553ms step_avg:34.90ms
+step:504/1575 train_time:17592ms step_avg:34.91ms
+step:505/1575 train_time:17625ms step_avg:34.90ms
+step:506/1575 train_time:17665ms step_avg:34.91ms
+step:507/1575 train_time:17696ms step_avg:34.90ms
+step:508/1575 train_time:17735ms step_avg:34.91ms
+step:509/1575 train_time:17766ms step_avg:34.90ms
+step:510/1575 train_time:17805ms step_avg:34.91ms
+step:511/1575 train_time:17836ms step_avg:34.90ms
+step:512/1575 train_time:17874ms step_avg:34.91ms
+step:513/1575 train_time:17945ms step_avg:34.98ms
+step:514/1575 train_time:18001ms step_avg:35.02ms
+step:515/1575 train_time:18064ms step_avg:35.08ms
+step:516/1575 train_time:18123ms step_avg:35.12ms
+step:517/1575 train_time:18185ms step_avg:35.17ms
+step:518/1575 train_time:18244ms step_avg:35.22ms
+step:519/1575 train_time:18306ms step_avg:35.27ms
+step:520/1575 train_time:18365ms step_avg:35.32ms
+step:521/1575 train_time:18428ms step_avg:35.37ms
+step:522/1575 train_time:18488ms step_avg:35.42ms
+step:523/1575 train_time:18553ms step_avg:35.47ms
+step:524/1575 train_time:18614ms step_avg:35.52ms
+step:525/1575 train_time:18678ms step_avg:35.58ms
+step:526/1575 train_time:18739ms step_avg:35.62ms
+step:527/1575 train_time:18804ms step_avg:35.68ms
+step:528/1575 train_time:18864ms step_avg:35.73ms
+step:529/1575 train_time:18928ms step_avg:35.78ms
+step:530/1575 train_time:18987ms step_avg:35.82ms
+step:531/1575 train_time:19051ms step_avg:35.88ms
+step:532/1575 train_time:19110ms step_avg:35.92ms
+step:533/1575 train_time:19172ms step_avg:35.97ms
+step:534/1575 train_time:19233ms step_avg:36.02ms
+step:535/1575 train_time:19295ms step_avg:36.07ms
+step:536/1575 train_time:19353ms step_avg:36.11ms
+step:537/1575 train_time:19416ms step_avg:36.16ms
+step:538/1575 train_time:19475ms step_avg:36.20ms
+step:539/1575 train_time:19538ms step_avg:36.25ms
+step:540/1575 train_time:19598ms step_avg:36.29ms
+step:541/1575 train_time:19661ms step_avg:36.34ms
+step:542/1575 train_time:19721ms step_avg:36.39ms
+step:543/1575 train_time:19786ms step_avg:36.44ms
+step:544/1575 train_time:19845ms step_avg:36.48ms
+step:545/1575 train_time:19910ms step_avg:36.53ms
+step:546/1575 train_time:19969ms step_avg:36.57ms
+step:547/1575 train_time:20032ms step_avg:36.62ms
+step:548/1575 train_time:20091ms step_avg:36.66ms
+step:549/1575 train_time:20154ms step_avg:36.71ms
+step:550/1575 train_time:20213ms step_avg:36.75ms
+step:551/1575 train_time:20276ms step_avg:36.80ms
+step:552/1575 train_time:20335ms step_avg:36.84ms
+step:553/1575 train_time:20398ms step_avg:36.89ms
+step:554/1575 train_time:20458ms step_avg:36.93ms
+step:555/1575 train_time:20521ms step_avg:36.98ms
+step:556/1575 train_time:20583ms step_avg:37.02ms
+step:557/1575 train_time:20644ms step_avg:37.06ms
+step:558/1575 train_time:20704ms step_avg:37.10ms
+step:559/1575 train_time:20768ms step_avg:37.15ms
+step:560/1575 train_time:20828ms step_avg:37.19ms
+step:561/1575 train_time:20891ms step_avg:37.24ms
+step:562/1575 train_time:20950ms step_avg:37.28ms
+step:563/1575 train_time:21014ms step_avg:37.32ms
+step:564/1575 train_time:21073ms step_avg:37.36ms
+step:565/1575 train_time:21136ms step_avg:37.41ms
+step:566/1575 train_time:21195ms step_avg:37.45ms
+step:567/1575 train_time:21258ms step_avg:37.49ms
+step:568/1575 train_time:21317ms step_avg:37.53ms
+step:569/1575 train_time:21385ms step_avg:37.58ms
+step:570/1575 train_time:21442ms step_avg:37.62ms
+step:571/1575 train_time:21504ms step_avg:37.66ms
+step:572/1575 train_time:21564ms step_avg:37.70ms
+step:573/1575 train_time:21626ms step_avg:37.74ms
+step:574/1575 train_time:21685ms step_avg:37.78ms
+step:575/1575 train_time:21751ms step_avg:37.83ms
+step:576/1575 train_time:21809ms step_avg:37.86ms
+step:577/1575 train_time:21872ms step_avg:37.91ms
+step:578/1575 train_time:21932ms step_avg:37.94ms
+step:579/1575 train_time:21995ms step_avg:37.99ms
+step:580/1575 train_time:22054ms step_avg:38.02ms
+step:581/1575 train_time:22118ms step_avg:38.07ms
+step:582/1575 train_time:22176ms step_avg:38.10ms
+step:583/1575 train_time:22240ms step_avg:38.15ms
+step:584/1575 train_time:22299ms step_avg:38.18ms
+step:585/1575 train_time:22363ms step_avg:38.23ms
+step:586/1575 train_time:22422ms step_avg:38.26ms
+step:587/1575 train_time:22484ms step_avg:38.30ms
+step:588/1575 train_time:22544ms step_avg:38.34ms
+step:589/1575 train_time:22607ms step_avg:38.38ms
+step:590/1575 train_time:22666ms step_avg:38.42ms
+step:591/1575 train_time:22730ms step_avg:38.46ms
+step:592/1575 train_time:22790ms step_avg:38.50ms
+step:593/1575 train_time:22853ms step_avg:38.54ms
+step:594/1575 train_time:22912ms step_avg:38.57ms
+step:595/1575 train_time:22978ms step_avg:38.62ms
+step:596/1575 train_time:23035ms step_avg:38.65ms
+step:597/1575 train_time:23097ms step_avg:38.69ms
+step:598/1575 train_time:23157ms step_avg:38.72ms
+step:599/1575 train_time:23220ms step_avg:38.77ms
+step:600/1575 train_time:23279ms step_avg:38.80ms
+step:601/1575 train_time:23343ms step_avg:38.84ms
+step:602/1575 train_time:23402ms step_avg:38.87ms
+step:603/1575 train_time:23466ms step_avg:38.92ms
+step:604/1575 train_time:23525ms step_avg:38.95ms
+step:605/1575 train_time:23588ms step_avg:38.99ms
+step:606/1575 train_time:23647ms step_avg:39.02ms
+step:607/1575 train_time:23711ms step_avg:39.06ms
+step:608/1575 train_time:23770ms step_avg:39.10ms
+step:609/1575 train_time:23833ms step_avg:39.13ms
+step:610/1575 train_time:23892ms step_avg:39.17ms
+step:611/1575 train_time:23956ms step_avg:39.21ms
+step:612/1575 train_time:24015ms step_avg:39.24ms
+step:613/1575 train_time:24079ms step_avg:39.28ms
+step:614/1575 train_time:24138ms step_avg:39.31ms
+step:615/1575 train_time:24202ms step_avg:39.35ms
+step:616/1575 train_time:24261ms step_avg:39.38ms
+step:617/1575 train_time:24324ms step_avg:39.42ms
+step:618/1575 train_time:24383ms step_avg:39.45ms
+step:619/1575 train_time:24446ms step_avg:39.49ms
+step:620/1575 train_time:24505ms step_avg:39.52ms
+step:621/1575 train_time:24569ms step_avg:39.56ms
+step:622/1575 train_time:24627ms step_avg:39.59ms
+step:623/1575 train_time:24691ms step_avg:39.63ms
+step:624/1575 train_time:24750ms step_avg:39.66ms
+step:625/1575 train_time:24814ms step_avg:39.70ms
+step:626/1575 train_time:24874ms step_avg:39.73ms
+step:627/1575 train_time:24937ms step_avg:39.77ms
+step:628/1575 train_time:24996ms step_avg:39.80ms
+step:629/1575 train_time:25060ms step_avg:39.84ms
+step:630/1575 train_time:25118ms step_avg:39.87ms
+step:631/1575 train_time:25182ms step_avg:39.91ms
+step:632/1575 train_time:25241ms step_avg:39.94ms
+step:633/1575 train_time:25304ms step_avg:39.97ms
+step:634/1575 train_time:25367ms step_avg:40.01ms
+step:635/1575 train_time:25429ms step_avg:40.05ms
+step:636/1575 train_time:25487ms step_avg:40.07ms
+step:637/1575 train_time:25550ms step_avg:40.11ms
+step:638/1575 train_time:25609ms step_avg:40.14ms
+step:639/1575 train_time:25672ms step_avg:40.17ms
+step:640/1575 train_time:25731ms step_avg:40.20ms
+step:641/1575 train_time:25795ms step_avg:40.24ms
+step:642/1575 train_time:25854ms step_avg:40.27ms
+step:643/1575 train_time:25918ms step_avg:40.31ms
+step:644/1575 train_time:25978ms step_avg:40.34ms
+step:645/1575 train_time:26041ms step_avg:40.37ms
+step:646/1575 train_time:26100ms step_avg:40.40ms
+step:647/1575 train_time:26163ms step_avg:40.44ms
+step:648/1575 train_time:26222ms step_avg:40.47ms
+step:649/1575 train_time:26285ms step_avg:40.50ms
+step:650/1575 train_time:26344ms step_avg:40.53ms
+step:651/1575 train_time:26408ms step_avg:40.56ms
+step:652/1575 train_time:26467ms step_avg:40.59ms
+step:653/1575 train_time:26531ms step_avg:40.63ms
+step:654/1575 train_time:26590ms step_avg:40.66ms
+step:655/1575 train_time:26656ms step_avg:40.70ms
+step:656/1575 train_time:26714ms step_avg:40.72ms
+step:657/1575 train_time:26777ms step_avg:40.76ms
+step:658/1575 train_time:26837ms step_avg:40.79ms
+step:659/1575 train_time:26900ms step_avg:40.82ms
+step:660/1575 train_time:26959ms step_avg:40.85ms
+step:661/1575 train_time:27022ms step_avg:40.88ms
+step:662/1575 train_time:27081ms step_avg:40.91ms
+step:663/1575 train_time:27145ms step_avg:40.94ms
+step:664/1575 train_time:27204ms step_avg:40.97ms
+step:665/1575 train_time:27268ms step_avg:41.00ms
+step:666/1575 train_time:27327ms step_avg:41.03ms
+step:667/1575 train_time:27391ms step_avg:41.07ms
+step:668/1575 train_time:27449ms step_avg:41.09ms
+step:669/1575 train_time:27513ms step_avg:41.13ms
+step:670/1575 train_time:27573ms step_avg:41.15ms
+step:671/1575 train_time:27636ms step_avg:41.19ms
+step:672/1575 train_time:27695ms step_avg:41.21ms
+step:673/1575 train_time:27758ms step_avg:41.25ms
+step:674/1575 train_time:27818ms step_avg:41.27ms
+step:675/1575 train_time:27881ms step_avg:41.31ms
+step:676/1575 train_time:27941ms step_avg:41.33ms
+step:677/1575 train_time:28004ms step_avg:41.36ms
+step:678/1575 train_time:28063ms step_avg:41.39ms
+step:679/1575 train_time:28126ms step_avg:41.42ms
+step:680/1575 train_time:28185ms step_avg:41.45ms
+step:681/1575 train_time:28249ms step_avg:41.48ms
+step:682/1575 train_time:28308ms step_avg:41.51ms
+step:683/1575 train_time:28371ms step_avg:41.54ms
+step:684/1575 train_time:28430ms step_avg:41.56ms
+step:685/1575 train_time:28494ms step_avg:41.60ms
+step:686/1575 train_time:28553ms step_avg:41.62ms
+step:687/1575 train_time:28616ms step_avg:41.65ms
+step:688/1575 train_time:28676ms step_avg:41.68ms
+step:689/1575 train_time:28738ms step_avg:41.71ms
+step:690/1575 train_time:28797ms step_avg:41.74ms
+step:691/1575 train_time:28861ms step_avg:41.77ms
+step:692/1575 train_time:28920ms step_avg:41.79ms
+step:693/1575 train_time:28984ms step_avg:41.82ms
+step:694/1575 train_time:29043ms step_avg:41.85ms
+step:695/1575 train_time:29107ms step_avg:41.88ms
+step:696/1575 train_time:29167ms step_avg:41.91ms
+step:697/1575 train_time:29230ms step_avg:41.94ms
+step:698/1575 train_time:29290ms step_avg:41.96ms
+step:699/1575 train_time:29353ms step_avg:41.99ms
+step:700/1575 train_time:29414ms step_avg:42.02ms
+step:701/1575 train_time:29476ms step_avg:42.05ms
+step:702/1575 train_time:29535ms step_avg:42.07ms
+step:703/1575 train_time:29599ms step_avg:42.10ms
+step:704/1575 train_time:29658ms step_avg:42.13ms
+step:705/1575 train_time:29721ms step_avg:42.16ms
+step:706/1575 train_time:29780ms step_avg:42.18ms
+step:707/1575 train_time:29843ms step_avg:42.21ms
+step:708/1575 train_time:29902ms step_avg:42.23ms
+step:709/1575 train_time:29966ms step_avg:42.26ms
+step:710/1575 train_time:30025ms step_avg:42.29ms
+step:711/1575 train_time:30088ms step_avg:42.32ms
+step:712/1575 train_time:30147ms step_avg:42.34ms
+step:713/1575 train_time:30211ms step_avg:42.37ms
+step:714/1575 train_time:30270ms step_avg:42.39ms
+step:715/1575 train_time:30335ms step_avg:42.43ms
+step:716/1575 train_time:30393ms step_avg:42.45ms
+step:717/1575 train_time:30456ms step_avg:42.48ms
+step:718/1575 train_time:30515ms step_avg:42.50ms
+step:719/1575 train_time:30578ms step_avg:42.53ms
+step:720/1575 train_time:30638ms step_avg:42.55ms
+step:721/1575 train_time:30701ms step_avg:42.58ms
+step:722/1575 train_time:30761ms step_avg:42.60ms
+step:723/1575 train_time:30823ms step_avg:42.63ms
+step:724/1575 train_time:30883ms step_avg:42.66ms
+step:725/1575 train_time:30947ms step_avg:42.69ms
+step:726/1575 train_time:31006ms step_avg:42.71ms
+step:727/1575 train_time:31069ms step_avg:42.74ms
+step:728/1575 train_time:31128ms step_avg:42.76ms
+step:729/1575 train_time:31192ms step_avg:42.79ms
+step:730/1575 train_time:31251ms step_avg:42.81ms
+step:731/1575 train_time:31315ms step_avg:42.84ms
+step:732/1575 train_time:31375ms step_avg:42.86ms
+step:733/1575 train_time:31437ms step_avg:42.89ms
+step:734/1575 train_time:31497ms step_avg:42.91ms
+step:735/1575 train_time:31560ms step_avg:42.94ms
+step:736/1575 train_time:31619ms step_avg:42.96ms
+step:737/1575 train_time:31682ms step_avg:42.99ms
+step:738/1575 train_time:31742ms step_avg:43.01ms
+step:739/1575 train_time:31804ms step_avg:43.04ms
+step:740/1575 train_time:31864ms step_avg:43.06ms
+step:741/1575 train_time:31928ms step_avg:43.09ms
+step:742/1575 train_time:31987ms step_avg:43.11ms
+step:743/1575 train_time:32051ms step_avg:43.14ms
+step:744/1575 train_time:32110ms step_avg:43.16ms
+step:745/1575 train_time:32174ms step_avg:43.19ms
+step:746/1575 train_time:32233ms step_avg:43.21ms
+step:747/1575 train_time:32297ms step_avg:43.24ms
+step:748/1575 train_time:32356ms step_avg:43.26ms
+step:749/1575 train_time:32419ms step_avg:43.28ms
+step:750/1575 train_time:32478ms step_avg:43.30ms
+step:750/1575 val_loss:3.8868 train_time:32526ms step_avg:43.37ms
+step:751/1575 train_time:32546ms step_avg:43.34ms
+step:752/1575 train_time:32606ms step_avg:43.36ms
+step:753/1575 train_time:32671ms step_avg:43.39ms
+step:754/1575 train_time:32732ms step_avg:43.41ms
+step:755/1575 train_time:32796ms step_avg:43.44ms
+step:756/1575 train_time:32855ms step_avg:43.46ms
+step:757/1575 train_time:32918ms step_avg:43.48ms
+step:758/1575 train_time:32977ms step_avg:43.51ms
+step:759/1575 train_time:33039ms step_avg:43.53ms
+step:760/1575 train_time:33098ms step_avg:43.55ms
+step:761/1575 train_time:33161ms step_avg:43.58ms
+step:762/1575 train_time:33220ms step_avg:43.60ms
+step:763/1575 train_time:33282ms step_avg:43.62ms
+step:764/1575 train_time:33341ms step_avg:43.64ms
+step:765/1575 train_time:33404ms step_avg:43.67ms
+step:766/1575 train_time:33465ms step_avg:43.69ms
+step:767/1575 train_time:33529ms step_avg:43.72ms
+step:768/1575 train_time:33589ms step_avg:43.74ms
+step:769/1575 train_time:33653ms step_avg:43.76ms
+step:770/1575 train_time:33713ms step_avg:43.78ms
+step:771/1575 train_time:33777ms step_avg:43.81ms
+step:772/1575 train_time:33837ms step_avg:43.83ms
+step:773/1575 train_time:33900ms step_avg:43.86ms
+step:774/1575 train_time:33960ms step_avg:43.88ms
+step:775/1575 train_time:34022ms step_avg:43.90ms
+step:776/1575 train_time:34081ms step_avg:43.92ms
+step:777/1575 train_time:34144ms step_avg:43.94ms
+step:778/1575 train_time:34203ms step_avg:43.96ms
+step:779/1575 train_time:34266ms step_avg:43.99ms
+step:780/1575 train_time:34324ms step_avg:44.01ms
+step:781/1575 train_time:34387ms step_avg:44.03ms
+step:782/1575 train_time:34446ms step_avg:44.05ms
+step:783/1575 train_time:34510ms step_avg:44.07ms
+step:784/1575 train_time:34569ms step_avg:44.09ms
+step:785/1575 train_time:34635ms step_avg:44.12ms
+step:786/1575 train_time:34697ms step_avg:44.14ms
+step:787/1575 train_time:34759ms step_avg:44.17ms
+step:788/1575 train_time:34819ms step_avg:44.19ms
+step:789/1575 train_time:34882ms step_avg:44.21ms
+step:790/1575 train_time:34941ms step_avg:44.23ms
+step:791/1575 train_time:35004ms step_avg:44.25ms
+step:792/1575 train_time:35063ms step_avg:44.27ms
+step:793/1575 train_time:35126ms step_avg:44.30ms
+step:794/1575 train_time:35185ms step_avg:44.31ms
+step:795/1575 train_time:35248ms step_avg:44.34ms
+step:796/1575 train_time:35307ms step_avg:44.36ms
+step:797/1575 train_time:35370ms step_avg:44.38ms
+step:798/1575 train_time:35430ms step_avg:44.40ms
+step:799/1575 train_time:35493ms step_avg:44.42ms
+step:800/1575 train_time:35552ms step_avg:44.44ms
+step:801/1575 train_time:35616ms step_avg:44.46ms
+step:802/1575 train_time:35675ms step_avg:44.48ms
+step:803/1575 train_time:35739ms step_avg:44.51ms
+step:804/1575 train_time:35798ms step_avg:44.53ms
+step:805/1575 train_time:35862ms step_avg:44.55ms
+step:806/1575 train_time:35922ms step_avg:44.57ms
+step:807/1575 train_time:35986ms step_avg:44.59ms
+step:808/1575 train_time:36044ms step_avg:44.61ms
+step:809/1575 train_time:36107ms step_avg:44.63ms
+step:810/1575 train_time:36167ms step_avg:44.65ms
+step:811/1575 train_time:36230ms step_avg:44.67ms
+step:812/1575 train_time:36289ms step_avg:44.69ms
+step:813/1575 train_time:36351ms step_avg:44.71ms
+step:814/1575 train_time:36411ms step_avg:44.73ms
+step:815/1575 train_time:36475ms step_avg:44.75ms
+step:816/1575 train_time:36534ms step_avg:44.77ms
+step:817/1575 train_time:36598ms step_avg:44.80ms
+step:818/1575 train_time:36656ms step_avg:44.81ms
+step:819/1575 train_time:36721ms step_avg:44.84ms
+step:820/1575 train_time:36780ms step_avg:44.85ms
+step:821/1575 train_time:36843ms step_avg:44.88ms
+step:822/1575 train_time:36902ms step_avg:44.89ms
+step:823/1575 train_time:36966ms step_avg:44.92ms
+step:824/1575 train_time:37024ms step_avg:44.93ms
+step:825/1575 train_time:37088ms step_avg:44.95ms
+step:826/1575 train_time:37147ms step_avg:44.97ms
+step:827/1575 train_time:37210ms step_avg:44.99ms
+step:828/1575 train_time:37269ms step_avg:45.01ms
+step:829/1575 train_time:37332ms step_avg:45.03ms
+step:830/1575 train_time:37392ms step_avg:45.05ms
+step:831/1575 train_time:37455ms step_avg:45.07ms
+step:832/1575 train_time:37515ms step_avg:45.09ms
+step:833/1575 train_time:37578ms step_avg:45.11ms
+step:834/1575 train_time:37638ms step_avg:45.13ms
+step:835/1575 train_time:37701ms step_avg:45.15ms
+step:836/1575 train_time:37760ms step_avg:45.17ms
+step:837/1575 train_time:37824ms step_avg:45.19ms
+step:838/1575 train_time:37883ms step_avg:45.21ms
+step:839/1575 train_time:37947ms step_avg:45.23ms
+step:840/1575 train_time:38006ms step_avg:45.24ms
+step:841/1575 train_time:38068ms step_avg:45.27ms
+step:842/1575 train_time:38128ms step_avg:45.28ms
+step:843/1575 train_time:38191ms step_avg:45.30ms
+step:844/1575 train_time:38250ms step_avg:45.32ms
+step:845/1575 train_time:38313ms step_avg:45.34ms
+step:846/1575 train_time:38372ms step_avg:45.36ms
+step:847/1575 train_time:38436ms step_avg:45.38ms
+step:848/1575 train_time:38495ms step_avg:45.40ms
+step:849/1575 train_time:38558ms step_avg:45.42ms
+step:850/1575 train_time:38618ms step_avg:45.43ms
+step:851/1575 train_time:38682ms step_avg:45.45ms
+step:852/1575 train_time:38742ms step_avg:45.47ms
+step:853/1575 train_time:38805ms step_avg:45.49ms
+step:854/1575 train_time:38865ms step_avg:45.51ms
+step:855/1575 train_time:38928ms step_avg:45.53ms
+step:856/1575 train_time:38987ms step_avg:45.55ms
+step:857/1575 train_time:39050ms step_avg:45.57ms
+step:858/1575 train_time:39110ms step_avg:45.58ms
+step:859/1575 train_time:39172ms step_avg:45.60ms
+step:860/1575 train_time:39232ms step_avg:45.62ms
+step:861/1575 train_time:39295ms step_avg:45.64ms
+step:862/1575 train_time:39354ms step_avg:45.65ms
+step:863/1575 train_time:39417ms step_avg:45.67ms
+step:864/1575 train_time:39477ms step_avg:45.69ms
+step:865/1575 train_time:39543ms step_avg:45.71ms
+step:866/1575 train_time:39600ms step_avg:45.73ms
+step:867/1575 train_time:39663ms step_avg:45.75ms
+step:868/1575 train_time:39723ms step_avg:45.76ms
+step:869/1575 train_time:39786ms step_avg:45.78ms
+step:870/1575 train_time:39845ms step_avg:45.80ms
+step:871/1575 train_time:39908ms step_avg:45.82ms
+step:872/1575 train_time:39967ms step_avg:45.83ms
+step:873/1575 train_time:40030ms step_avg:45.85ms
+step:874/1575 train_time:40090ms step_avg:45.87ms
+step:875/1575 train_time:40154ms step_avg:45.89ms
+step:876/1575 train_time:40212ms step_avg:45.90ms
+step:877/1575 train_time:40276ms step_avg:45.92ms
+step:878/1575 train_time:40335ms step_avg:45.94ms
+step:879/1575 train_time:40399ms step_avg:45.96ms
+step:880/1575 train_time:40458ms step_avg:45.98ms
+step:881/1575 train_time:40521ms step_avg:45.99ms
+step:882/1575 train_time:40581ms step_avg:46.01ms
+step:883/1575 train_time:40644ms step_avg:46.03ms
+step:884/1575 train_time:40704ms step_avg:46.04ms
+step:885/1575 train_time:40767ms step_avg:46.06ms
+step:886/1575 train_time:40832ms step_avg:46.09ms
+step:887/1575 train_time:40893ms step_avg:46.10ms
+step:888/1575 train_time:40952ms step_avg:46.12ms
+step:889/1575 train_time:41015ms step_avg:46.14ms
+step:890/1575 train_time:41075ms step_avg:46.15ms
+step:891/1575 train_time:41137ms step_avg:46.17ms
+step:892/1575 train_time:41196ms step_avg:46.18ms
+step:893/1575 train_time:41260ms step_avg:46.20ms
+step:894/1575 train_time:41320ms step_avg:46.22ms
+step:895/1575 train_time:41382ms step_avg:46.24ms
+step:896/1575 train_time:41442ms step_avg:46.25ms
+step:897/1575 train_time:41506ms step_avg:46.27ms
+step:898/1575 train_time:41564ms step_avg:46.28ms
+step:899/1575 train_time:41627ms step_avg:46.30ms
+step:900/1575 train_time:41686ms step_avg:46.32ms
+step:901/1575 train_time:41750ms step_avg:46.34ms
+step:902/1575 train_time:41809ms step_avg:46.35ms
+step:903/1575 train_time:41873ms step_avg:46.37ms
+step:904/1575 train_time:41932ms step_avg:46.38ms
+step:905/1575 train_time:41995ms step_avg:46.40ms
+step:906/1575 train_time:42055ms step_avg:46.42ms
+step:907/1575 train_time:42119ms step_avg:46.44ms
+step:908/1575 train_time:42178ms step_avg:46.45ms
+step:909/1575 train_time:42242ms step_avg:46.47ms
+step:910/1575 train_time:42302ms step_avg:46.49ms
+step:911/1575 train_time:42365ms step_avg:46.50ms
+step:912/1575 train_time:42424ms step_avg:46.52ms
+step:913/1575 train_time:42487ms step_avg:46.54ms
+step:914/1575 train_time:42546ms step_avg:46.55ms
+step:915/1575 train_time:42610ms step_avg:46.57ms
+step:916/1575 train_time:42670ms step_avg:46.58ms
+step:917/1575 train_time:42733ms step_avg:46.60ms
+step:918/1575 train_time:42793ms step_avg:46.62ms
+step:919/1575 train_time:42856ms step_avg:46.63ms
+step:920/1575 train_time:42915ms step_avg:46.65ms
+step:921/1575 train_time:42978ms step_avg:46.66ms
+step:922/1575 train_time:43037ms step_avg:46.68ms
+step:923/1575 train_time:43100ms step_avg:46.70ms
+step:924/1575 train_time:43161ms step_avg:46.71ms
+step:925/1575 train_time:43223ms step_avg:46.73ms
+step:926/1575 train_time:43282ms step_avg:46.74ms
+step:927/1575 train_time:43345ms step_avg:46.76ms
+step:928/1575 train_time:43404ms step_avg:46.77ms
+step:929/1575 train_time:43468ms step_avg:46.79ms
+step:930/1575 train_time:43527ms step_avg:46.80ms
+step:931/1575 train_time:43591ms step_avg:46.82ms
+step:932/1575 train_time:43650ms step_avg:46.83ms
+step:933/1575 train_time:43714ms step_avg:46.85ms
+step:934/1575 train_time:43774ms step_avg:46.87ms
+step:935/1575 train_time:43838ms step_avg:46.89ms
+step:936/1575 train_time:43897ms step_avg:46.90ms
+step:937/1575 train_time:43960ms step_avg:46.92ms
+step:938/1575 train_time:44019ms step_avg:46.93ms
+step:939/1575 train_time:44082ms step_avg:46.95ms
+step:940/1575 train_time:44141ms step_avg:46.96ms
+step:941/1575 train_time:44204ms step_avg:46.98ms
+step:942/1575 train_time:44263ms step_avg:46.99ms
+step:943/1575 train_time:44326ms step_avg:47.01ms
+step:944/1575 train_time:44385ms step_avg:47.02ms
+step:945/1575 train_time:44449ms step_avg:47.04ms
+step:946/1575 train_time:44508ms step_avg:47.05ms
+step:947/1575 train_time:44571ms step_avg:47.07ms
+step:948/1575 train_time:44631ms step_avg:47.08ms
+step:949/1575 train_time:44694ms step_avg:47.10ms
+step:950/1575 train_time:44753ms step_avg:47.11ms
+step:951/1575 train_time:44816ms step_avg:47.13ms
+step:952/1575 train_time:44875ms step_avg:47.14ms
+step:953/1575 train_time:44939ms step_avg:47.16ms
+step:954/1575 train_time:44998ms step_avg:47.17ms
+step:955/1575 train_time:45061ms step_avg:47.18ms
+step:956/1575 train_time:45121ms step_avg:47.20ms
+step:957/1575 train_time:45184ms step_avg:47.21ms
+step:958/1575 train_time:45243ms step_avg:47.23ms
+step:959/1575 train_time:45306ms step_avg:47.24ms
+step:960/1575 train_time:45365ms step_avg:47.26ms
+step:961/1575 train_time:45429ms step_avg:47.27ms
+step:962/1575 train_time:45488ms step_avg:47.28ms
+step:963/1575 train_time:45551ms step_avg:47.30ms
+step:964/1575 train_time:45610ms step_avg:47.31ms
+step:965/1575 train_time:45673ms step_avg:47.33ms
+step:966/1575 train_time:45733ms step_avg:47.34ms
+step:967/1575 train_time:45796ms step_avg:47.36ms
+step:968/1575 train_time:45856ms step_avg:47.37ms
+step:969/1575 train_time:45920ms step_avg:47.39ms
+step:970/1575 train_time:45980ms step_avg:47.40ms
+step:971/1575 train_time:46043ms step_avg:47.42ms
+step:972/1575 train_time:46102ms step_avg:47.43ms
+step:973/1575 train_time:46166ms step_avg:47.45ms
+step:974/1575 train_time:46225ms step_avg:47.46ms
+step:975/1575 train_time:46288ms step_avg:47.47ms
+step:976/1575 train_time:46347ms step_avg:47.49ms
+step:977/1575 train_time:46410ms step_avg:47.50ms
+step:978/1575 train_time:46470ms step_avg:47.51ms
+step:979/1575 train_time:46532ms step_avg:47.53ms
+step:980/1575 train_time:46592ms step_avg:47.54ms
+step:981/1575 train_time:46655ms step_avg:47.56ms
+step:982/1575 train_time:46715ms step_avg:47.57ms
+step:983/1575 train_time:46778ms step_avg:47.59ms
+step:984/1575 train_time:46838ms step_avg:47.60ms
+step:985/1575 train_time:46901ms step_avg:47.62ms
+step:986/1575 train_time:46961ms step_avg:47.63ms
+step:987/1575 train_time:47024ms step_avg:47.64ms
+step:988/1575 train_time:47083ms step_avg:47.65ms
+step:989/1575 train_time:47147ms step_avg:47.67ms
+step:990/1575 train_time:47206ms step_avg:47.68ms
+step:991/1575 train_time:47268ms step_avg:47.70ms
+step:992/1575 train_time:47328ms step_avg:47.71ms
+step:993/1575 train_time:47390ms step_avg:47.72ms
+step:994/1575 train_time:47449ms step_avg:47.74ms
+step:995/1575 train_time:47512ms step_avg:47.75ms
+step:996/1575 train_time:47572ms step_avg:47.76ms
+step:997/1575 train_time:47636ms step_avg:47.78ms
+step:998/1575 train_time:47696ms step_avg:47.79ms
+step:999/1575 train_time:47759ms step_avg:47.81ms
+step:1000/1575 train_time:47818ms step_avg:47.82ms
+step:1000/1575 val_loss:3.5833 train_time:47866ms step_avg:47.87ms
+step:1001/1575 train_time:47886ms step_avg:47.84ms
+step:1002/1575 train_time:47944ms step_avg:47.85ms
+step:1003/1575 train_time:48012ms step_avg:47.87ms
+step:1004/1575 train_time:48074ms step_avg:47.88ms
+step:1005/1575 train_time:48137ms step_avg:47.90ms
+step:1006/1575 train_time:48197ms step_avg:47.91ms
+step:1007/1575 train_time:48260ms step_avg:47.92ms
+step:1008/1575 train_time:48319ms step_avg:47.94ms
+step:1009/1575 train_time:48382ms step_avg:47.95ms
+step:1010/1575 train_time:48441ms step_avg:47.96ms
+step:1011/1575 train_time:48504ms step_avg:47.98ms
+step:1012/1575 train_time:48563ms step_avg:47.99ms
+step:1013/1575 train_time:48625ms step_avg:48.00ms
+step:1014/1575 train_time:48684ms step_avg:48.01ms
+step:1015/1575 train_time:48747ms step_avg:48.03ms
+step:1016/1575 train_time:48809ms step_avg:48.04ms
+step:1017/1575 train_time:48871ms step_avg:48.05ms
+step:1018/1575 train_time:48931ms step_avg:48.07ms
+step:1019/1575 train_time:48996ms step_avg:48.08ms
+step:1020/1575 train_time:49055ms step_avg:48.09ms
+step:1021/1575 train_time:49119ms step_avg:48.11ms
+step:1022/1575 train_time:49178ms step_avg:48.12ms
+step:1023/1575 train_time:49242ms step_avg:48.14ms
+step:1024/1575 train_time:49303ms step_avg:48.15ms
+step:1025/1575 train_time:49375ms step_avg:48.17ms
+step:1026/1575 train_time:49458ms step_avg:48.20ms
+step:1027/1575 train_time:49549ms step_avg:48.25ms
+step:1028/1575 train_time:49633ms step_avg:48.28ms
+step:1029/1575 train_time:49721ms step_avg:48.32ms
+step:1030/1575 train_time:49806ms step_avg:48.36ms
+step:1031/1575 train_time:49897ms step_avg:48.40ms
+step:1032/1575 train_time:49983ms step_avg:48.43ms
+step:1033/1575 train_time:50074ms step_avg:48.47ms
+step:1034/1575 train_time:50161ms step_avg:48.51ms
+step:1035/1575 train_time:50251ms step_avg:48.55ms
+step:1036/1575 train_time:50336ms step_avg:48.59ms
+step:1037/1575 train_time:50425ms step_avg:48.63ms
+step:1038/1575 train_time:50511ms step_avg:48.66ms
+step:1039/1575 train_time:50600ms step_avg:48.70ms
+step:1040/1575 train_time:50685ms step_avg:48.74ms
+step:1041/1575 train_time:50775ms step_avg:48.77ms
+step:1042/1575 train_time:50860ms step_avg:48.81ms
+step:1043/1575 train_time:50949ms step_avg:48.85ms
+step:1044/1575 train_time:51036ms step_avg:48.88ms
+step:1045/1575 train_time:51127ms step_avg:48.93ms
+step:1046/1575 train_time:51213ms step_avg:48.96ms
+step:1047/1575 train_time:51303ms step_avg:49.00ms
+step:1048/1575 train_time:51388ms step_avg:49.03ms
+step:1049/1575 train_time:51477ms step_avg:49.07ms
+step:1050/1575 train_time:51562ms step_avg:49.11ms
+step:1051/1575 train_time:51652ms step_avg:49.15ms
+step:1052/1575 train_time:51738ms step_avg:49.18ms
+step:1053/1575 train_time:51827ms step_avg:49.22ms
+step:1054/1575 train_time:51913ms step_avg:49.25ms
+step:1055/1575 train_time:52003ms step_avg:49.29ms
+step:1056/1575 train_time:52089ms step_avg:49.33ms
+step:1057/1575 train_time:52179ms step_avg:49.37ms
+step:1058/1575 train_time:52265ms step_avg:49.40ms
+step:1059/1575 train_time:52354ms step_avg:49.44ms
+step:1060/1575 train_time:52440ms step_avg:49.47ms
+step:1061/1575 train_time:52528ms step_avg:49.51ms
+step:1062/1575 train_time:52615ms step_avg:49.54ms
+step:1063/1575 train_time:52704ms step_avg:49.58ms
+step:1064/1575 train_time:52790ms step_avg:49.61ms
+step:1065/1575 train_time:52879ms step_avg:49.65ms
+step:1066/1575 train_time:52965ms step_avg:49.69ms
+step:1067/1575 train_time:53056ms step_avg:49.72ms
+step:1068/1575 train_time:53141ms step_avg:49.76ms
+step:1069/1575 train_time:53230ms step_avg:49.79ms
+step:1070/1575 train_time:53316ms step_avg:49.83ms
+step:1071/1575 train_time:53406ms step_avg:49.87ms
+step:1072/1575 train_time:53492ms step_avg:49.90ms
+step:1073/1575 train_time:53581ms step_avg:49.94ms
+step:1074/1575 train_time:53670ms step_avg:49.97ms
+step:1075/1575 train_time:53758ms step_avg:50.01ms
+step:1076/1575 train_time:53842ms step_avg:50.04ms
+step:1077/1575 train_time:53932ms step_avg:50.08ms
+step:1078/1575 train_time:54017ms step_avg:50.11ms
+step:1079/1575 train_time:54106ms step_avg:50.14ms
+step:1080/1575 train_time:54191ms step_avg:50.18ms
+step:1081/1575 train_time:54282ms step_avg:50.21ms
+step:1082/1575 train_time:54367ms step_avg:50.25ms
+step:1083/1575 train_time:54457ms step_avg:50.28ms
+step:1084/1575 train_time:54543ms step_avg:50.32ms
+step:1085/1575 train_time:54632ms step_avg:50.35ms
+step:1086/1575 train_time:54717ms step_avg:50.38ms
+step:1087/1575 train_time:54806ms step_avg:50.42ms
+step:1088/1575 train_time:54893ms step_avg:50.45ms
+step:1089/1575 train_time:54983ms step_avg:50.49ms
+step:1090/1575 train_time:55068ms step_avg:50.52ms
+step:1091/1575 train_time:55159ms step_avg:50.56ms
+step:1092/1575 train_time:55245ms step_avg:50.59ms
+step:1093/1575 train_time:55333ms step_avg:50.63ms
+step:1094/1575 train_time:55419ms step_avg:50.66ms
+step:1095/1575 train_time:55509ms step_avg:50.69ms
+step:1096/1575 train_time:55595ms step_avg:50.72ms
+step:1097/1575 train_time:55684ms step_avg:50.76ms
+step:1098/1575 train_time:55770ms step_avg:50.79ms
+step:1099/1575 train_time:55859ms step_avg:50.83ms
+step:1100/1575 train_time:55945ms step_avg:50.86ms
+step:1101/1575 train_time:56035ms step_avg:50.90ms
+step:1102/1575 train_time:56121ms step_avg:50.93ms
+step:1103/1575 train_time:56209ms step_avg:50.96ms
+step:1104/1575 train_time:56296ms step_avg:50.99ms
+step:1105/1575 train_time:56386ms step_avg:51.03ms
+step:1106/1575 train_time:56471ms step_avg:51.06ms
+step:1107/1575 train_time:56561ms step_avg:51.09ms
+step:1108/1575 train_time:56647ms step_avg:51.13ms
+step:1109/1575 train_time:56735ms step_avg:51.16ms
+step:1110/1575 train_time:56822ms step_avg:51.19ms
+step:1111/1575 train_time:56911ms step_avg:51.22ms
+step:1112/1575 train_time:56997ms step_avg:51.26ms
+step:1113/1575 train_time:57088ms step_avg:51.29ms
+step:1114/1575 train_time:57171ms step_avg:51.32ms
+step:1115/1575 train_time:57262ms step_avg:51.36ms
+step:1116/1575 train_time:57357ms step_avg:51.40ms
+step:1117/1575 train_time:57442ms step_avg:51.42ms
+step:1118/1575 train_time:57527ms step_avg:51.46ms
+step:1119/1575 train_time:57616ms step_avg:51.49ms
+step:1120/1575 train_time:57703ms step_avg:51.52ms
+step:1121/1575 train_time:57792ms step_avg:51.55ms
+step:1122/1575 train_time:57877ms step_avg:51.58ms
+step:1123/1575 train_time:57967ms step_avg:51.62ms
+step:1124/1575 train_time:58053ms step_avg:51.65ms
+step:1125/1575 train_time:58142ms step_avg:51.68ms
+step:1126/1575 train_time:58228ms step_avg:51.71ms
+step:1127/1575 train_time:58316ms step_avg:51.74ms
+step:1128/1575 train_time:58407ms step_avg:51.78ms
+step:1129/1575 train_time:58491ms step_avg:51.81ms
+step:1130/1575 train_time:58577ms step_avg:51.84ms
+step:1131/1575 train_time:58668ms step_avg:51.87ms
+step:1132/1575 train_time:58754ms step_avg:51.90ms
+step:1133/1575 train_time:58843ms step_avg:51.94ms
+step:1134/1575 train_time:58928ms step_avg:51.96ms
+step:1135/1575 train_time:59017ms step_avg:52.00ms
+step:1136/1575 train_time:59104ms step_avg:52.03ms
+step:1137/1575 train_time:59193ms step_avg:52.06ms
+step:1138/1575 train_time:59278ms step_avg:52.09ms
+step:1139/1575 train_time:59368ms step_avg:52.12ms
+step:1140/1575 train_time:59453ms step_avg:52.15ms
+step:1141/1575 train_time:59543ms step_avg:52.18ms
+step:1142/1575 train_time:59629ms step_avg:52.21ms
+step:1143/1575 train_time:59718ms step_avg:52.25ms
+step:1144/1575 train_time:59804ms step_avg:52.28ms
+step:1145/1575 train_time:59893ms step_avg:52.31ms
+step:1146/1575 train_time:59984ms step_avg:52.34ms
+step:1147/1575 train_time:60066ms step_avg:52.37ms
+step:1148/1575 train_time:60156ms step_avg:52.40ms
+step:1149/1575 train_time:60245ms step_avg:52.43ms
+step:1150/1575 train_time:60331ms step_avg:52.46ms
+step:1151/1575 train_time:60420ms step_avg:52.49ms
+step:1152/1575 train_time:60505ms step_avg:52.52ms
+step:1153/1575 train_time:60595ms step_avg:52.55ms
+step:1154/1575 train_time:60680ms step_avg:52.58ms
+step:1155/1575 train_time:60765ms step_avg:52.61ms
+step:1156/1575 train_time:60856ms step_avg:52.64ms
+step:1157/1575 train_time:60946ms step_avg:52.68ms
+step:1158/1575 train_time:61032ms step_avg:52.70ms
+step:1159/1575 train_time:61122ms step_avg:52.74ms
+step:1160/1575 train_time:61207ms step_avg:52.76ms
+step:1161/1575 train_time:61296ms step_avg:52.80ms
+step:1162/1575 train_time:61380ms step_avg:52.82ms
+step:1163/1575 train_time:61471ms step_avg:52.86ms
+step:1164/1575 train_time:61556ms step_avg:52.88ms
+step:1165/1575 train_time:61646ms step_avg:52.91ms
+step:1166/1575 train_time:61727ms step_avg:52.94ms
+step:1167/1575 train_time:61820ms step_avg:52.97ms
+step:1168/1575 train_time:61907ms step_avg:53.00ms
+step:1169/1575 train_time:61996ms step_avg:53.03ms
+step:1170/1575 train_time:62081ms step_avg:53.06ms
+step:1171/1575 train_time:62172ms step_avg:53.09ms
+step:1172/1575 train_time:62259ms step_avg:53.12ms
+step:1173/1575 train_time:62349ms step_avg:53.15ms
+step:1174/1575 train_time:62433ms step_avg:53.18ms
+step:1175/1575 train_time:62524ms step_avg:53.21ms
+step:1176/1575 train_time:62609ms step_avg:53.24ms
+step:1177/1575 train_time:62694ms step_avg:53.27ms
+step:1178/1575 train_time:62785ms step_avg:53.30ms
+step:1179/1575 train_time:62874ms step_avg:53.33ms
+step:1180/1575 train_time:62959ms step_avg:53.36ms
+step:1181/1575 train_time:63049ms step_avg:53.39ms
+step:1182/1575 train_time:63134ms step_avg:53.41ms
+step:1183/1575 train_time:63224ms step_avg:53.44ms
+step:1184/1575 train_time:63309ms step_avg:53.47ms
+step:1185/1575 train_time:63398ms step_avg:53.50ms
+step:1186/1575 train_time:63484ms step_avg:53.53ms
+step:1187/1575 train_time:63574ms step_avg:53.56ms
+step:1188/1575 train_time:63660ms step_avg:53.59ms
+step:1189/1575 train_time:63753ms step_avg:53.62ms
+step:1190/1575 train_time:63840ms step_avg:53.65ms
+step:1191/1575 train_time:63925ms step_avg:53.67ms
+step:1192/1575 train_time:64010ms step_avg:53.70ms
+step:1193/1575 train_time:64095ms step_avg:53.73ms
+step:1194/1575 train_time:64186ms step_avg:53.76ms
+step:1195/1575 train_time:64275ms step_avg:53.79ms
+step:1196/1575 train_time:64361ms step_avg:53.81ms
+step:1197/1575 train_time:64450ms step_avg:53.84ms
+step:1198/1575 train_time:64536ms step_avg:53.87ms
+step:1199/1575 train_time:64625ms step_avg:53.90ms
+step:1200/1575 train_time:64711ms step_avg:53.93ms
+step:1201/1575 train_time:64800ms step_avg:53.96ms
+step:1202/1575 train_time:64886ms step_avg:53.98ms
+step:1203/1575 train_time:64976ms step_avg:54.01ms
+step:1204/1575 train_time:65062ms step_avg:54.04ms
+step:1205/1575 train_time:65151ms step_avg:54.07ms
+step:1206/1575 train_time:65237ms step_avg:54.09ms
+step:1207/1575 train_time:65327ms step_avg:54.12ms
+step:1208/1575 train_time:65411ms step_avg:54.15ms
+step:1209/1575 train_time:65501ms step_avg:54.18ms
+step:1210/1575 train_time:65587ms step_avg:54.20ms
+step:1211/1575 train_time:65676ms step_avg:54.23ms
+step:1212/1575 train_time:65762ms step_avg:54.26ms
+step:1213/1575 train_time:65852ms step_avg:54.29ms
+step:1214/1575 train_time:65937ms step_avg:54.31ms
+step:1215/1575 train_time:66022ms step_avg:54.34ms
+step:1216/1575 train_time:66112ms step_avg:54.37ms
+step:1217/1575 train_time:66204ms step_avg:54.40ms
+step:1218/1575 train_time:66288ms step_avg:54.42ms
+step:1219/1575 train_time:66377ms step_avg:54.45ms
+step:1220/1575 train_time:66463ms step_avg:54.48ms
+step:1221/1575 train_time:66552ms step_avg:54.51ms
+step:1222/1575 train_time:66638ms step_avg:54.53ms
+step:1223/1575 train_time:66729ms step_avg:54.56ms
+step:1224/1575 train_time:66814ms step_avg:54.59ms
+step:1225/1575 train_time:66903ms step_avg:54.61ms
+step:1226/1575 train_time:66984ms step_avg:54.64ms
+step:1227/1575 train_time:67078ms step_avg:54.67ms
+step:1228/1575 train_time:67163ms step_avg:54.69ms
+step:1229/1575 train_time:67252ms step_avg:54.72ms
+step:1230/1575 train_time:67334ms step_avg:54.74ms
+step:1231/1575 train_time:67422ms step_avg:54.77ms
+step:1232/1575 train_time:67508ms step_avg:54.80ms
+step:1233/1575 train_time:67598ms step_avg:54.82ms
+step:1234/1575 train_time:67684ms step_avg:54.85ms
+step:1235/1575 train_time:67774ms step_avg:54.88ms
+step:1236/1575 train_time:67859ms step_avg:54.90ms
+step:1237/1575 train_time:67948ms step_avg:54.93ms
+step:1238/1575 train_time:68034ms step_avg:54.95ms
+step:1239/1575 train_time:68123ms step_avg:54.98ms
+step:1240/1575 train_time:68209ms step_avg:55.01ms
+step:1241/1575 train_time:68301ms step_avg:55.04ms
+step:1242/1575 train_time:68387ms step_avg:55.06ms
+step:1243/1575 train_time:68476ms step_avg:55.09ms
+step:1244/1575 train_time:68562ms step_avg:55.11ms
+step:1245/1575 train_time:68654ms step_avg:55.14ms
+step:1246/1575 train_time:68739ms step_avg:55.17ms
+step:1247/1575 train_time:68827ms step_avg:55.19ms
+step:1248/1575 train_time:68913ms step_avg:55.22ms
+step:1249/1575 train_time:69002ms step_avg:55.25ms
+step:1250/1575 train_time:69088ms step_avg:55.27ms
+step:1250/1575 val_loss:3.4071 train_time:69163ms step_avg:55.33ms
+step:1251/1575 train_time:69182ms step_avg:55.30ms
+step:1252/1575 train_time:69269ms step_avg:55.33ms
+step:1253/1575 train_time:69364ms step_avg:55.36ms
+step:1254/1575 train_time:69452ms step_avg:55.38ms
+step:1255/1575 train_time:69541ms step_avg:55.41ms
+step:1256/1575 train_time:69625ms step_avg:55.43ms
+step:1257/1575 train_time:69713ms step_avg:55.46ms
+step:1258/1575 train_time:69798ms step_avg:55.48ms
+step:1259/1575 train_time:69886ms step_avg:55.51ms
+step:1260/1575 train_time:69971ms step_avg:55.53ms
+step:1261/1575 train_time:70059ms step_avg:55.56ms
+step:1262/1575 train_time:70145ms step_avg:55.58ms
+step:1263/1575 train_time:70237ms step_avg:55.61ms
+step:1264/1575 train_time:70325ms step_avg:55.64ms
+step:1265/1575 train_time:70415ms step_avg:55.66ms
+step:1266/1575 train_time:70501ms step_avg:55.69ms
+step:1267/1575 train_time:70590ms step_avg:55.71ms
+step:1268/1575 train_time:70675ms step_avg:55.74ms
+step:1269/1575 train_time:70764ms step_avg:55.76ms
+step:1270/1575 train_time:70848ms step_avg:55.79ms
+step:1271/1575 train_time:70936ms step_avg:55.81ms
+step:1272/1575 train_time:71021ms step_avg:55.83ms
+step:1273/1575 train_time:71109ms step_avg:55.86ms
+step:1274/1575 train_time:71196ms step_avg:55.88ms
+step:1275/1575 train_time:71287ms step_avg:55.91ms
+step:1276/1575 train_time:71374ms step_avg:55.94ms
+step:1277/1575 train_time:71465ms step_avg:55.96ms
+step:1278/1575 train_time:71552ms step_avg:55.99ms
+step:1279/1575 train_time:71641ms step_avg:56.01ms
+step:1280/1575 train_time:71725ms step_avg:56.04ms
+step:1281/1575 train_time:71814ms step_avg:56.06ms
+step:1282/1575 train_time:71899ms step_avg:56.08ms
+step:1283/1575 train_time:71988ms step_avg:56.11ms
+step:1284/1575 train_time:72073ms step_avg:56.13ms
+step:1285/1575 train_time:72163ms step_avg:56.16ms
+step:1286/1575 train_time:72251ms step_avg:56.18ms
+step:1287/1575 train_time:72344ms step_avg:56.21ms
+step:1288/1575 train_time:72429ms step_avg:56.23ms
+step:1289/1575 train_time:72521ms step_avg:56.26ms
+step:1290/1575 train_time:72606ms step_avg:56.28ms
+step:1291/1575 train_time:72695ms step_avg:56.31ms
+step:1292/1575 train_time:72780ms step_avg:56.33ms
+step:1293/1575 train_time:72868ms step_avg:56.36ms
+step:1294/1575 train_time:72953ms step_avg:56.38ms
+step:1295/1575 train_time:73042ms step_avg:56.40ms
+step:1296/1575 train_time:73127ms step_avg:56.43ms
+step:1297/1575 train_time:73217ms step_avg:56.45ms
+step:1298/1575 train_time:73304ms step_avg:56.47ms
+step:1299/1575 train_time:73395ms step_avg:56.50ms
+step:1300/1575 train_time:73481ms step_avg:56.52ms
+step:1301/1575 train_time:73571ms step_avg:56.55ms
+step:1302/1575 train_time:73656ms step_avg:56.57ms
+step:1303/1575 train_time:73745ms step_avg:56.60ms
+step:1304/1575 train_time:73830ms step_avg:56.62ms
+step:1305/1575 train_time:73921ms step_avg:56.64ms
+step:1306/1575 train_time:74006ms step_avg:56.67ms
+step:1307/1575 train_time:74095ms step_avg:56.69ms
+step:1308/1575 train_time:74180ms step_avg:56.71ms
+step:1309/1575 train_time:74270ms step_avg:56.74ms
+step:1310/1575 train_time:74356ms step_avg:56.76ms
+step:1311/1575 train_time:74446ms step_avg:56.79ms
+step:1312/1575 train_time:74532ms step_avg:56.81ms
+step:1313/1575 train_time:74623ms step_avg:56.83ms
+step:1314/1575 train_time:74707ms step_avg:56.85ms
+step:1315/1575 train_time:74796ms step_avg:56.88ms
+step:1316/1575 train_time:74882ms step_avg:56.90ms
+step:1317/1575 train_time:74970ms step_avg:56.92ms
+step:1318/1575 train_time:75056ms step_avg:56.95ms
+step:1319/1575 train_time:75146ms step_avg:56.97ms
+step:1320/1575 train_time:75231ms step_avg:56.99ms
+step:1321/1575 train_time:75322ms step_avg:57.02ms
+step:1322/1575 train_time:75407ms step_avg:57.04ms
+step:1323/1575 train_time:75497ms step_avg:57.07ms
+step:1324/1575 train_time:75583ms step_avg:57.09ms
+step:1325/1575 train_time:75672ms step_avg:57.11ms
+step:1326/1575 train_time:75759ms step_avg:57.13ms
+step:1327/1575 train_time:75848ms step_avg:57.16ms
+step:1328/1575 train_time:75933ms step_avg:57.18ms
+step:1329/1575 train_time:76022ms step_avg:57.20ms
+step:1330/1575 train_time:76107ms step_avg:57.22ms
+step:1331/1575 train_time:76199ms step_avg:57.25ms
+step:1332/1575 train_time:76284ms step_avg:57.27ms
+step:1333/1575 train_time:76373ms step_avg:57.29ms
+step:1334/1575 train_time:76459ms step_avg:57.32ms
+step:1335/1575 train_time:76549ms step_avg:57.34ms
+step:1336/1575 train_time:76635ms step_avg:57.36ms
+step:1337/1575 train_time:76724ms step_avg:57.38ms
+step:1338/1575 train_time:76809ms step_avg:57.41ms
+step:1339/1575 train_time:76899ms step_avg:57.43ms
+step:1340/1575 train_time:76983ms step_avg:57.45ms
+step:1341/1575 train_time:77073ms step_avg:57.47ms
+step:1342/1575 train_time:77159ms step_avg:57.50ms
+step:1343/1575 train_time:77250ms step_avg:57.52ms
+step:1344/1575 train_time:77336ms step_avg:57.54ms
+step:1345/1575 train_time:77425ms step_avg:57.57ms
+step:1346/1575 train_time:77511ms step_avg:57.59ms
+step:1347/1575 train_time:77601ms step_avg:57.61ms
+step:1348/1575 train_time:77687ms step_avg:57.63ms
+step:1349/1575 train_time:77776ms step_avg:57.65ms
+step:1350/1575 train_time:77862ms step_avg:57.68ms
+step:1351/1575 train_time:77954ms step_avg:57.70ms
+step:1352/1575 train_time:78038ms step_avg:57.72ms
+step:1353/1575 train_time:78126ms step_avg:57.74ms
+step:1354/1575 train_time:78212ms step_avg:57.76ms
+step:1355/1575 train_time:78301ms step_avg:57.79ms
+step:1356/1575 train_time:78386ms step_avg:57.81ms
+step:1357/1575 train_time:78476ms step_avg:57.83ms
+step:1358/1575 train_time:78566ms step_avg:57.85ms
+step:1359/1575 train_time:78655ms step_avg:57.88ms
+step:1360/1575 train_time:78740ms step_avg:57.90ms
+step:1361/1575 train_time:78829ms step_avg:57.92ms
+step:1362/1575 train_time:78915ms step_avg:57.94ms
+step:1363/1575 train_time:79005ms step_avg:57.96ms
+step:1364/1575 train_time:79090ms step_avg:57.98ms
+step:1365/1575 train_time:79180ms step_avg:58.01ms
+step:1366/1575 train_time:79266ms step_avg:58.03ms
+step:1367/1575 train_time:79355ms step_avg:58.05ms
+step:1368/1575 train_time:79442ms step_avg:58.07ms
+step:1369/1575 train_time:79533ms step_avg:58.10ms
+step:1370/1575 train_time:79618ms step_avg:58.12ms
+step:1371/1575 train_time:79708ms step_avg:58.14ms
+step:1372/1575 train_time:79793ms step_avg:58.16ms
+step:1373/1575 train_time:79883ms step_avg:58.18ms
+step:1374/1575 train_time:79969ms step_avg:58.20ms
+step:1375/1575 train_time:80057ms step_avg:58.22ms
+step:1376/1575 train_time:80144ms step_avg:58.24ms
+step:1377/1575 train_time:80233ms step_avg:58.27ms
+step:1378/1575 train_time:80321ms step_avg:58.29ms
+step:1379/1575 train_time:80408ms step_avg:58.31ms
+step:1380/1575 train_time:80495ms step_avg:58.33ms
+step:1381/1575 train_time:80585ms step_avg:58.35ms
+step:1382/1575 train_time:80671ms step_avg:58.37ms
+step:1383/1575 train_time:80761ms step_avg:58.40ms
+step:1384/1575 train_time:80846ms step_avg:58.41ms
+step:1385/1575 train_time:80936ms step_avg:58.44ms
+step:1386/1575 train_time:81020ms step_avg:58.46ms
+step:1387/1575 train_time:81110ms step_avg:58.48ms
+step:1388/1575 train_time:81196ms step_avg:58.50ms
+step:1389/1575 train_time:81286ms step_avg:58.52ms
+step:1390/1575 train_time:81371ms step_avg:58.54ms
+step:1391/1575 train_time:81460ms step_avg:58.56ms
+step:1392/1575 train_time:81546ms step_avg:58.58ms
+step:1393/1575 train_time:81636ms step_avg:58.60ms
+step:1394/1575 train_time:81721ms step_avg:58.62ms
+step:1395/1575 train_time:81810ms step_avg:58.65ms
+step:1396/1575 train_time:81896ms step_avg:58.66ms
+step:1397/1575 train_time:81985ms step_avg:58.69ms
+step:1398/1575 train_time:82072ms step_avg:58.71ms
+step:1399/1575 train_time:82161ms step_avg:58.73ms
+step:1400/1575 train_time:82247ms step_avg:58.75ms
+step:1401/1575 train_time:82337ms step_avg:58.77ms
+step:1402/1575 train_time:82422ms step_avg:58.79ms
+step:1403/1575 train_time:82513ms step_avg:58.81ms
+step:1404/1575 train_time:82598ms step_avg:58.83ms
+step:1405/1575 train_time:82688ms step_avg:58.85ms
+step:1406/1575 train_time:82777ms step_avg:58.87ms
+step:1407/1575 train_time:82865ms step_avg:58.89ms
+step:1408/1575 train_time:82949ms step_avg:58.91ms
+step:1409/1575 train_time:83038ms step_avg:58.93ms
+step:1410/1575 train_time:83123ms step_avg:58.95ms
+step:1411/1575 train_time:83213ms step_avg:58.97ms
+step:1412/1575 train_time:83299ms step_avg:58.99ms
+step:1413/1575 train_time:83388ms step_avg:59.02ms
+step:1414/1575 train_time:83475ms step_avg:59.03ms
+step:1415/1575 train_time:83564ms step_avg:59.06ms
+step:1416/1575 train_time:83650ms step_avg:59.07ms
+step:1417/1575 train_time:83740ms step_avg:59.10ms
+step:1418/1575 train_time:83825ms step_avg:59.11ms
+step:1419/1575 train_time:83915ms step_avg:59.14ms
+step:1420/1575 train_time:84000ms step_avg:59.16ms
+step:1421/1575 train_time:84089ms step_avg:59.18ms
+step:1422/1575 train_time:84176ms step_avg:59.20ms
+step:1423/1575 train_time:84265ms step_avg:59.22ms
+step:1424/1575 train_time:84353ms step_avg:59.24ms
+step:1425/1575 train_time:84442ms step_avg:59.26ms
+step:1426/1575 train_time:84527ms step_avg:59.28ms
+step:1427/1575 train_time:84618ms step_avg:59.30ms
+step:1428/1575 train_time:84702ms step_avg:59.32ms
+step:1429/1575 train_time:84791ms step_avg:59.34ms
+step:1430/1575 train_time:84877ms step_avg:59.35ms
+step:1431/1575 train_time:84967ms step_avg:59.38ms
+step:1432/1575 train_time:85052ms step_avg:59.39ms
+step:1433/1575 train_time:85142ms step_avg:59.41ms
+step:1434/1575 train_time:85227ms step_avg:59.43ms
+step:1435/1575 train_time:85317ms step_avg:59.45ms
+step:1436/1575 train_time:85402ms step_avg:59.47ms
+step:1437/1575 train_time:85492ms step_avg:59.49ms
+step:1438/1575 train_time:85579ms step_avg:59.51ms
+step:1439/1575 train_time:85668ms step_avg:59.53ms
+step:1440/1575 train_time:85754ms step_avg:59.55ms
+step:1441/1575 train_time:85843ms step_avg:59.57ms
+step:1442/1575 train_time:85929ms step_avg:59.59ms
+step:1443/1575 train_time:86018ms step_avg:59.61ms
+step:1444/1575 train_time:86103ms step_avg:59.63ms
+step:1445/1575 train_time:86193ms step_avg:59.65ms
+step:1446/1575 train_time:86279ms step_avg:59.67ms
+step:1447/1575 train_time:86368ms step_avg:59.69ms
+step:1448/1575 train_time:86454ms step_avg:59.71ms
+step:1449/1575 train_time:86544ms step_avg:59.73ms
+step:1450/1575 train_time:86630ms step_avg:59.74ms
+step:1451/1575 train_time:86720ms step_avg:59.77ms
+step:1452/1575 train_time:86805ms step_avg:59.78ms
+step:1453/1575 train_time:86894ms step_avg:59.80ms
+step:1454/1575 train_time:86980ms step_avg:59.82ms
+step:1455/1575 train_time:87070ms step_avg:59.84ms
+step:1456/1575 train_time:87156ms step_avg:59.86ms
+step:1457/1575 train_time:87245ms step_avg:59.88ms
+step:1458/1575 train_time:87330ms step_avg:59.90ms
+step:1459/1575 train_time:87421ms step_avg:59.92ms
+step:1460/1575 train_time:87506ms step_avg:59.94ms
+step:1461/1575 train_time:87595ms step_avg:59.96ms
+step:1462/1575 train_time:87681ms step_avg:59.97ms
+step:1463/1575 train_time:87770ms step_avg:59.99ms
+step:1464/1575 train_time:87856ms step_avg:60.01ms
+step:1465/1575 train_time:87945ms step_avg:60.03ms
+step:1466/1575 train_time:88030ms step_avg:60.05ms
+step:1467/1575 train_time:88121ms step_avg:60.07ms
+step:1468/1575 train_time:88206ms step_avg:60.09ms
+step:1469/1575 train_time:88296ms step_avg:60.11ms
+step:1470/1575 train_time:88383ms step_avg:60.12ms
+step:1471/1575 train_time:88472ms step_avg:60.14ms
+step:1472/1575 train_time:88558ms step_avg:60.16ms
+step:1473/1575 train_time:88648ms step_avg:60.18ms
+step:1474/1575 train_time:88736ms step_avg:60.20ms
+step:1475/1575 train_time:88825ms step_avg:60.22ms
+step:1476/1575 train_time:88912ms step_avg:60.24ms
+step:1477/1575 train_time:89001ms step_avg:60.26ms
+step:1478/1575 train_time:89087ms step_avg:60.28ms
+step:1479/1575 train_time:89176ms step_avg:60.30ms
+step:1480/1575 train_time:89261ms step_avg:60.31ms
+step:1481/1575 train_time:89351ms step_avg:60.33ms
+step:1482/1575 train_time:89437ms step_avg:60.35ms
+step:1483/1575 train_time:89527ms step_avg:60.37ms
+step:1484/1575 train_time:89613ms step_avg:60.39ms
+step:1485/1575 train_time:89703ms step_avg:60.41ms
+step:1486/1575 train_time:89788ms step_avg:60.42ms
+step:1487/1575 train_time:89878ms step_avg:60.44ms
+step:1488/1575 train_time:89964ms step_avg:60.46ms
+step:1489/1575 train_time:90053ms step_avg:60.48ms
+step:1490/1575 train_time:90139ms step_avg:60.50ms
+step:1491/1575 train_time:90227ms step_avg:60.51ms
+step:1492/1575 train_time:90313ms step_avg:60.53ms
+step:1493/1575 train_time:90402ms step_avg:60.55ms
+step:1494/1575 train_time:90488ms step_avg:60.57ms
+step:1495/1575 train_time:90577ms step_avg:60.59ms
+step:1496/1575 train_time:90663ms step_avg:60.60ms
+step:1497/1575 train_time:90753ms step_avg:60.62ms
+step:1498/1575 train_time:90838ms step_avg:60.64ms
+step:1499/1575 train_time:90928ms step_avg:60.66ms
+step:1500/1575 train_time:91013ms step_avg:60.68ms
+step:1500/1575 val_loss:3.3010 train_time:91087ms step_avg:60.72ms
+step:1501/1575 train_time:91106ms step_avg:60.70ms
+step:1502/1575 train_time:91192ms step_avg:60.71ms
+step:1503/1575 train_time:91284ms step_avg:60.73ms
+step:1504/1575 train_time:91369ms step_avg:60.75ms
+step:1505/1575 train_time:91459ms step_avg:60.77ms
+step:1506/1575 train_time:91544ms step_avg:60.79ms
+step:1507/1575 train_time:91632ms step_avg:60.80ms
+step:1508/1575 train_time:91717ms step_avg:60.82ms
+step:1509/1575 train_time:91805ms step_avg:60.84ms
+step:1510/1575 train_time:91891ms step_avg:60.86ms
+step:1511/1575 train_time:91980ms step_avg:60.87ms
+step:1512/1575 train_time:92066ms step_avg:60.89ms
+step:1513/1575 train_time:92162ms step_avg:60.91ms
+step:1514/1575 train_time:92250ms step_avg:60.93ms
+step:1515/1575 train_time:92341ms step_avg:60.95ms
+step:1516/1575 train_time:92430ms step_avg:60.97ms
+step:1517/1575 train_time:92517ms step_avg:60.99ms
+step:1518/1575 train_time:92601ms step_avg:61.00ms
+step:1519/1575 train_time:92689ms step_avg:61.02ms
+step:1520/1575 train_time:92774ms step_avg:61.04ms
+step:1521/1575 train_time:92863ms step_avg:61.05ms
+step:1522/1575 train_time:92948ms step_avg:61.07ms
+step:1523/1575 train_time:93038ms step_avg:61.09ms
+step:1524/1575 train_time:93125ms step_avg:61.11ms
+step:1525/1575 train_time:93217ms step_avg:61.13ms
+step:1526/1575 train_time:93304ms step_avg:61.14ms
+step:1527/1575 train_time:93393ms step_avg:61.16ms
+step:1528/1575 train_time:93479ms step_avg:61.18ms
+step:1529/1575 train_time:93567ms step_avg:61.20ms
+step:1530/1575 train_time:93653ms step_avg:61.21ms
+step:1531/1575 train_time:93742ms step_avg:61.23ms
+step:1532/1575 train_time:93827ms step_avg:61.24ms
+step:1533/1575 train_time:93916ms step_avg:61.26ms
+step:1534/1575 train_time:94002ms step_avg:61.28ms
+step:1535/1575 train_time:94093ms step_avg:61.30ms
+step:1536/1575 train_time:94186ms step_avg:61.32ms
+step:1537/1575 train_time:94275ms step_avg:61.34ms
+step:1538/1575 train_time:94362ms step_avg:61.35ms
+step:1539/1575 train_time:94452ms step_avg:61.37ms
+step:1540/1575 train_time:94538ms step_avg:61.39ms
+step:1541/1575 train_time:94627ms step_avg:61.41ms
+step:1542/1575 train_time:94713ms step_avg:61.42ms
+step:1543/1575 train_time:94803ms step_avg:61.44ms
+step:1544/1575 train_time:94888ms step_avg:61.46ms
+step:1545/1575 train_time:94979ms step_avg:61.47ms
+step:1546/1575 train_time:95066ms step_avg:61.49ms
+step:1547/1575 train_time:95158ms step_avg:61.51ms
+step:1548/1575 train_time:95244ms step_avg:61.53ms
+step:1549/1575 train_time:95333ms step_avg:61.55ms
+step:1550/1575 train_time:95420ms step_avg:61.56ms
+step:1551/1575 train_time:95510ms step_avg:61.58ms
+step:1552/1575 train_time:95596ms step_avg:61.60ms
+step:1553/1575 train_time:95685ms step_avg:61.61ms
+step:1554/1575 train_time:95771ms step_avg:61.63ms
+step:1555/1575 train_time:95860ms step_avg:61.65ms
+step:1556/1575 train_time:95946ms step_avg:61.66ms
+step:1557/1575 train_time:96035ms step_avg:61.68ms
+step:1558/1575 train_time:96122ms step_avg:61.70ms
+step:1559/1575 train_time:96213ms step_avg:61.71ms
+step:1560/1575 train_time:96300ms step_avg:61.73ms
+step:1561/1575 train_time:96391ms step_avg:61.75ms
+step:1562/1575 train_time:96477ms step_avg:61.76ms
+step:1563/1575 train_time:96569ms step_avg:61.78ms
+step:1564/1575 train_time:96654ms step_avg:61.80ms
+step:1565/1575 train_time:96743ms step_avg:61.82ms
+step:1566/1575 train_time:96830ms step_avg:61.83ms
+step:1567/1575 train_time:96920ms step_avg:61.85ms
+step:1568/1575 train_time:97005ms step_avg:61.87ms
+step:1569/1575 train_time:97098ms step_avg:61.89ms
+step:1570/1575 train_time:97182ms step_avg:61.90ms
+step:1571/1575 train_time:97271ms step_avg:61.92ms
+step:1572/1575 train_time:97357ms step_avg:61.93ms
+step:1573/1575 train_time:97446ms step_avg:61.95ms
+step:1574/1575 train_time:97533ms step_avg:61.96ms
+step:1575/1575 train_time:97622ms step_avg:61.98ms
+step:1575/1575 val_loss:3.2794 train_time:97691ms step_avg:62.03ms
+peak memory allocated: 30933 MiB reserved: 46998 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/90fe80eb-6a98-4074-b907-0e6f60748177.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/90fe80eb-6a98-4074-b907-0e6f60748177.txt
@@ -1,0 +1,4119 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:56:39 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   32C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   32C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   33C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   31C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   34C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   33C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          274175      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          274176      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          274177      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          274178      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          274179      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          274180      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          274181      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          274182      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8263 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:86ms step_avg:85.52ms
+step:2/1600 train_time:109ms step_avg:54.30ms
+step:3/1600 train_time:129ms step_avg:43.05ms
+step:4/1600 train_time:153ms step_avg:38.27ms
+step:5/1600 train_time:183ms step_avg:36.63ms
+step:6/1600 train_time:291ms step_avg:48.53ms
+step:7/1600 train_time:309ms step_avg:44.11ms
+step:8/1600 train_time:328ms step_avg:41.04ms
+step:9/1600 train_time:359ms step_avg:39.85ms
+step:10/1600 train_time:396ms step_avg:39.60ms
+step:11/1600 train_time:427ms step_avg:38.78ms
+step:12/1600 train_time:464ms step_avg:38.68ms
+step:13/1600 train_time:494ms step_avg:38.03ms
+step:14/1600 train_time:532ms step_avg:37.98ms
+step:15/1600 train_time:563ms step_avg:37.53ms
+step:16/1600 train_time:600ms step_avg:37.53ms
+step:17/1600 train_time:631ms step_avg:37.13ms
+step:18/1600 train_time:669ms step_avg:37.16ms
+step:19/1600 train_time:700ms step_avg:36.83ms
+step:20/1600 train_time:737ms step_avg:36.84ms
+step:21/1600 train_time:767ms step_avg:36.55ms
+step:22/1600 train_time:805ms step_avg:36.58ms
+step:23/1600 train_time:835ms step_avg:36.32ms
+step:24/1600 train_time:873ms step_avg:36.36ms
+step:25/1600 train_time:903ms step_avg:36.14ms
+step:26/1600 train_time:941ms step_avg:36.20ms
+step:27/1600 train_time:972ms step_avg:36.00ms
+step:28/1600 train_time:1010ms step_avg:36.06ms
+step:29/1600 train_time:1040ms step_avg:35.88ms
+step:30/1600 train_time:1078ms step_avg:35.92ms
+step:31/1600 train_time:1108ms step_avg:35.75ms
+step:32/1600 train_time:1146ms step_avg:35.80ms
+step:33/1600 train_time:1176ms step_avg:35.64ms
+step:34/1600 train_time:1213ms step_avg:35.68ms
+step:35/1600 train_time:1244ms step_avg:35.55ms
+step:36/1600 train_time:1283ms step_avg:35.63ms
+step:37/1600 train_time:1314ms step_avg:35.51ms
+step:38/1600 train_time:1351ms step_avg:35.56ms
+step:39/1600 train_time:1382ms step_avg:35.44ms
+step:40/1600 train_time:1419ms step_avg:35.48ms
+step:41/1600 train_time:1450ms step_avg:35.36ms
+step:42/1600 train_time:1487ms step_avg:35.40ms
+step:43/1600 train_time:1518ms step_avg:35.29ms
+step:44/1600 train_time:1555ms step_avg:35.34ms
+step:45/1600 train_time:1585ms step_avg:35.23ms
+step:46/1600 train_time:1623ms step_avg:35.28ms
+step:47/1600 train_time:1654ms step_avg:35.18ms
+step:48/1600 train_time:1691ms step_avg:35.24ms
+step:49/1600 train_time:1722ms step_avg:35.14ms
+step:50/1600 train_time:1760ms step_avg:35.19ms
+step:51/1600 train_time:1790ms step_avg:35.10ms
+step:52/1600 train_time:1827ms step_avg:35.14ms
+step:53/1600 train_time:1858ms step_avg:35.05ms
+step:54/1600 train_time:1895ms step_avg:35.09ms
+step:55/1600 train_time:1925ms step_avg:35.01ms
+step:56/1600 train_time:1963ms step_avg:35.06ms
+step:57/1600 train_time:1994ms step_avg:34.98ms
+step:58/1600 train_time:2031ms step_avg:35.01ms
+step:59/1600 train_time:2061ms step_avg:34.93ms
+step:60/1600 train_time:2098ms step_avg:34.97ms
+step:61/1600 train_time:2129ms step_avg:34.90ms
+step:62/1600 train_time:2167ms step_avg:34.94ms
+step:63/1600 train_time:2197ms step_avg:34.87ms
+step:64/1600 train_time:2234ms step_avg:34.90ms
+step:65/1600 train_time:2264ms step_avg:34.83ms
+step:66/1600 train_time:2302ms step_avg:34.88ms
+step:67/1600 train_time:2333ms step_avg:34.82ms
+step:68/1600 train_time:2371ms step_avg:34.86ms
+step:69/1600 train_time:2401ms step_avg:34.80ms
+step:70/1600 train_time:2439ms step_avg:34.84ms
+step:71/1600 train_time:2469ms step_avg:34.78ms
+step:72/1600 train_time:2507ms step_avg:34.82ms
+step:73/1600 train_time:2538ms step_avg:34.76ms
+step:74/1600 train_time:2575ms step_avg:34.79ms
+step:75/1600 train_time:2605ms step_avg:34.74ms
+step:76/1600 train_time:2643ms step_avg:34.77ms
+step:77/1600 train_time:2673ms step_avg:34.72ms
+step:78/1600 train_time:2711ms step_avg:34.75ms
+step:79/1600 train_time:2742ms step_avg:34.70ms
+step:80/1600 train_time:2780ms step_avg:34.75ms
+step:81/1600 train_time:2810ms step_avg:34.70ms
+step:82/1600 train_time:2848ms step_avg:34.73ms
+step:83/1600 train_time:2878ms step_avg:34.68ms
+step:84/1600 train_time:2915ms step_avg:34.70ms
+step:85/1600 train_time:2946ms step_avg:34.66ms
+step:86/1600 train_time:2984ms step_avg:34.69ms
+step:87/1600 train_time:3014ms step_avg:34.64ms
+step:88/1600 train_time:3051ms step_avg:34.67ms
+step:89/1600 train_time:3082ms step_avg:34.63ms
+step:90/1600 train_time:3120ms step_avg:34.67ms
+step:91/1600 train_time:3151ms step_avg:34.63ms
+step:92/1600 train_time:3189ms step_avg:34.66ms
+step:93/1600 train_time:3219ms step_avg:34.61ms
+step:94/1600 train_time:3256ms step_avg:34.64ms
+step:95/1600 train_time:3287ms step_avg:34.59ms
+step:96/1600 train_time:3324ms step_avg:34.63ms
+step:97/1600 train_time:3355ms step_avg:34.59ms
+step:98/1600 train_time:3392ms step_avg:34.62ms
+step:99/1600 train_time:3423ms step_avg:34.57ms
+step:100/1600 train_time:3460ms step_avg:34.60ms
+step:101/1600 train_time:3491ms step_avg:34.56ms
+step:102/1600 train_time:3529ms step_avg:34.59ms
+step:103/1600 train_time:3559ms step_avg:34.55ms
+step:104/1600 train_time:3596ms step_avg:34.58ms
+step:105/1600 train_time:3627ms step_avg:34.54ms
+step:106/1600 train_time:3664ms step_avg:34.57ms
+step:107/1600 train_time:3695ms step_avg:34.53ms
+step:108/1600 train_time:3732ms step_avg:34.55ms
+step:109/1600 train_time:3763ms step_avg:34.52ms
+step:110/1600 train_time:3801ms step_avg:34.55ms
+step:111/1600 train_time:3832ms step_avg:34.52ms
+step:112/1600 train_time:3869ms step_avg:34.54ms
+step:113/1600 train_time:3900ms step_avg:34.51ms
+step:114/1600 train_time:3937ms step_avg:34.54ms
+step:115/1600 train_time:3968ms step_avg:34.51ms
+step:116/1600 train_time:4006ms step_avg:34.53ms
+step:117/1600 train_time:4036ms step_avg:34.50ms
+step:118/1600 train_time:4074ms step_avg:34.53ms
+step:119/1600 train_time:4104ms step_avg:34.49ms
+step:120/1600 train_time:4141ms step_avg:34.51ms
+step:121/1600 train_time:4172ms step_avg:34.48ms
+step:122/1600 train_time:4209ms step_avg:34.50ms
+step:123/1600 train_time:4240ms step_avg:34.47ms
+step:124/1600 train_time:4277ms step_avg:34.49ms
+step:125/1600 train_time:4308ms step_avg:34.46ms
+step:126/1600 train_time:4345ms step_avg:34.49ms
+step:127/1600 train_time:4376ms step_avg:34.46ms
+step:128/1600 train_time:4413ms step_avg:34.48ms
+step:129/1600 train_time:4444ms step_avg:34.45ms
+step:130/1600 train_time:4482ms step_avg:34.48ms
+step:131/1600 train_time:4512ms step_avg:34.44ms
+step:132/1600 train_time:4550ms step_avg:34.47ms
+step:133/1600 train_time:4580ms step_avg:34.44ms
+step:134/1600 train_time:4617ms step_avg:34.45ms
+step:135/1600 train_time:4647ms step_avg:34.43ms
+step:136/1600 train_time:4685ms step_avg:34.45ms
+step:137/1600 train_time:4716ms step_avg:34.42ms
+step:138/1600 train_time:4753ms step_avg:34.44ms
+step:139/1600 train_time:4784ms step_avg:34.42ms
+step:140/1600 train_time:4822ms step_avg:34.44ms
+step:141/1600 train_time:4852ms step_avg:34.41ms
+step:142/1600 train_time:4890ms step_avg:34.43ms
+step:143/1600 train_time:4920ms step_avg:34.41ms
+step:144/1600 train_time:4957ms step_avg:34.42ms
+step:145/1600 train_time:4988ms step_avg:34.40ms
+step:146/1600 train_time:5025ms step_avg:34.42ms
+step:147/1600 train_time:5056ms step_avg:34.39ms
+step:148/1600 train_time:5093ms step_avg:34.41ms
+step:149/1600 train_time:5124ms step_avg:34.39ms
+step:150/1600 train_time:5161ms step_avg:34.41ms
+step:151/1600 train_time:5191ms step_avg:34.38ms
+step:152/1600 train_time:5229ms step_avg:34.40ms
+step:153/1600 train_time:5260ms step_avg:34.38ms
+step:154/1600 train_time:5297ms step_avg:34.40ms
+step:155/1600 train_time:5328ms step_avg:34.37ms
+step:156/1600 train_time:5365ms step_avg:34.39ms
+step:157/1600 train_time:5395ms step_avg:34.36ms
+step:158/1600 train_time:5432ms step_avg:34.38ms
+step:159/1600 train_time:5463ms step_avg:34.36ms
+step:160/1600 train_time:5501ms step_avg:34.38ms
+step:161/1600 train_time:5531ms step_avg:34.36ms
+step:162/1600 train_time:5568ms step_avg:34.37ms
+step:163/1600 train_time:5600ms step_avg:34.35ms
+step:164/1600 train_time:5637ms step_avg:34.37ms
+step:165/1600 train_time:5668ms step_avg:34.35ms
+step:166/1600 train_time:5706ms step_avg:34.37ms
+step:167/1600 train_time:5736ms step_avg:34.35ms
+step:168/1600 train_time:5773ms step_avg:34.36ms
+step:169/1600 train_time:5804ms step_avg:34.34ms
+step:170/1600 train_time:5841ms step_avg:34.36ms
+step:171/1600 train_time:5872ms step_avg:34.34ms
+step:172/1600 train_time:5909ms step_avg:34.36ms
+step:173/1600 train_time:5940ms step_avg:34.33ms
+step:174/1600 train_time:5977ms step_avg:34.35ms
+step:175/1600 train_time:6008ms step_avg:34.33ms
+step:176/1600 train_time:6046ms step_avg:34.35ms
+step:177/1600 train_time:6076ms step_avg:34.33ms
+step:178/1600 train_time:6113ms step_avg:34.34ms
+step:179/1600 train_time:6144ms step_avg:34.32ms
+step:180/1600 train_time:6181ms step_avg:34.34ms
+step:181/1600 train_time:6211ms step_avg:34.32ms
+step:182/1600 train_time:6249ms step_avg:34.33ms
+step:183/1600 train_time:6279ms step_avg:34.31ms
+step:184/1600 train_time:6316ms step_avg:34.33ms
+step:185/1600 train_time:6347ms step_avg:34.31ms
+step:186/1600 train_time:6384ms step_avg:34.32ms
+step:187/1600 train_time:6415ms step_avg:34.30ms
+step:188/1600 train_time:6452ms step_avg:34.32ms
+step:189/1600 train_time:6482ms step_avg:34.30ms
+step:190/1600 train_time:6520ms step_avg:34.31ms
+step:191/1600 train_time:6550ms step_avg:34.29ms
+step:192/1600 train_time:6588ms step_avg:34.31ms
+step:193/1600 train_time:6618ms step_avg:34.29ms
+step:194/1600 train_time:6655ms step_avg:34.31ms
+step:195/1600 train_time:6686ms step_avg:34.29ms
+step:196/1600 train_time:6723ms step_avg:34.30ms
+step:197/1600 train_time:6754ms step_avg:34.28ms
+step:198/1600 train_time:6791ms step_avg:34.30ms
+step:199/1600 train_time:6821ms step_avg:34.28ms
+step:200/1600 train_time:6859ms step_avg:34.29ms
+step:201/1600 train_time:6890ms step_avg:34.28ms
+step:202/1600 train_time:6927ms step_avg:34.29ms
+step:203/1600 train_time:6957ms step_avg:34.27ms
+step:204/1600 train_time:6995ms step_avg:34.29ms
+step:205/1600 train_time:7025ms step_avg:34.27ms
+step:206/1600 train_time:7062ms step_avg:34.28ms
+step:207/1600 train_time:7093ms step_avg:34.27ms
+step:208/1600 train_time:7130ms step_avg:34.28ms
+step:209/1600 train_time:7161ms step_avg:34.26ms
+step:210/1600 train_time:7198ms step_avg:34.28ms
+step:211/1600 train_time:7229ms step_avg:34.26ms
+step:212/1600 train_time:7266ms step_avg:34.27ms
+step:213/1600 train_time:7297ms step_avg:34.26ms
+step:214/1600 train_time:7334ms step_avg:34.27ms
+step:215/1600 train_time:7364ms step_avg:34.25ms
+step:216/1600 train_time:7402ms step_avg:34.27ms
+step:217/1600 train_time:7432ms step_avg:34.25ms
+step:218/1600 train_time:7470ms step_avg:34.26ms
+step:219/1600 train_time:7500ms step_avg:34.25ms
+step:220/1600 train_time:7538ms step_avg:34.26ms
+step:221/1600 train_time:7568ms step_avg:34.25ms
+step:222/1600 train_time:7606ms step_avg:34.26ms
+step:223/1600 train_time:7636ms step_avg:34.24ms
+step:224/1600 train_time:7673ms step_avg:34.25ms
+step:225/1600 train_time:7704ms step_avg:34.24ms
+step:226/1600 train_time:7741ms step_avg:34.25ms
+step:227/1600 train_time:7772ms step_avg:34.24ms
+step:228/1600 train_time:7809ms step_avg:34.25ms
+step:229/1600 train_time:7840ms step_avg:34.24ms
+step:230/1600 train_time:7877ms step_avg:34.25ms
+step:231/1600 train_time:7908ms step_avg:34.23ms
+step:232/1600 train_time:7946ms step_avg:34.25ms
+step:233/1600 train_time:7976ms step_avg:34.23ms
+step:234/1600 train_time:8014ms step_avg:34.25ms
+step:235/1600 train_time:8045ms step_avg:34.23ms
+step:236/1600 train_time:8082ms step_avg:34.25ms
+step:237/1600 train_time:8113ms step_avg:34.23ms
+step:238/1600 train_time:8150ms step_avg:34.24ms
+step:239/1600 train_time:8180ms step_avg:34.23ms
+step:240/1600 train_time:8217ms step_avg:34.24ms
+step:241/1600 train_time:8248ms step_avg:34.22ms
+step:242/1600 train_time:8285ms step_avg:34.24ms
+step:243/1600 train_time:8316ms step_avg:34.22ms
+step:244/1600 train_time:8353ms step_avg:34.23ms
+step:245/1600 train_time:8383ms step_avg:34.22ms
+step:246/1600 train_time:8421ms step_avg:34.23ms
+step:247/1600 train_time:8451ms step_avg:34.21ms
+step:248/1600 train_time:8489ms step_avg:34.23ms
+step:249/1600 train_time:8519ms step_avg:34.21ms
+step:250/1600 train_time:8556ms step_avg:34.22ms
+step:250/1600 val_loss:4.5872 train_time:8604ms step_avg:34.41ms
+step:251/1600 train_time:8624ms step_avg:34.36ms
+step:252/1600 train_time:8644ms step_avg:34.30ms
+step:253/1600 train_time:8661ms step_avg:34.24ms
+step:254/1600 train_time:8696ms step_avg:34.24ms
+step:255/1600 train_time:8730ms step_avg:34.23ms
+step:256/1600 train_time:8768ms step_avg:34.25ms
+step:257/1600 train_time:8800ms step_avg:34.24ms
+step:258/1600 train_time:8838ms step_avg:34.26ms
+step:259/1600 train_time:8868ms step_avg:34.24ms
+step:260/1600 train_time:8906ms step_avg:34.25ms
+step:261/1600 train_time:8937ms step_avg:34.24ms
+step:262/1600 train_time:8974ms step_avg:34.25ms
+step:263/1600 train_time:9004ms step_avg:34.24ms
+step:264/1600 train_time:9041ms step_avg:34.25ms
+step:265/1600 train_time:9072ms step_avg:34.23ms
+step:266/1600 train_time:9109ms step_avg:34.25ms
+step:267/1600 train_time:9140ms step_avg:34.23ms
+step:268/1600 train_time:9177ms step_avg:34.24ms
+step:269/1600 train_time:9207ms step_avg:34.23ms
+step:270/1600 train_time:9245ms step_avg:34.24ms
+step:271/1600 train_time:9275ms step_avg:34.23ms
+step:272/1600 train_time:9312ms step_avg:34.24ms
+step:273/1600 train_time:9342ms step_avg:34.22ms
+step:274/1600 train_time:9379ms step_avg:34.23ms
+step:275/1600 train_time:9410ms step_avg:34.22ms
+step:276/1600 train_time:9447ms step_avg:34.23ms
+step:277/1600 train_time:9477ms step_avg:34.21ms
+step:278/1600 train_time:9514ms step_avg:34.22ms
+step:279/1600 train_time:9545ms step_avg:34.21ms
+step:280/1600 train_time:9582ms step_avg:34.22ms
+step:281/1600 train_time:9612ms step_avg:34.21ms
+step:282/1600 train_time:9650ms step_avg:34.22ms
+step:283/1600 train_time:9680ms step_avg:34.21ms
+step:284/1600 train_time:9717ms step_avg:34.22ms
+step:285/1600 train_time:9748ms step_avg:34.20ms
+step:286/1600 train_time:9786ms step_avg:34.22ms
+step:287/1600 train_time:9817ms step_avg:34.21ms
+step:288/1600 train_time:9855ms step_avg:34.22ms
+step:289/1600 train_time:9885ms step_avg:34.21ms
+step:290/1600 train_time:9923ms step_avg:34.22ms
+step:291/1600 train_time:9954ms step_avg:34.21ms
+step:292/1600 train_time:9991ms step_avg:34.22ms
+step:293/1600 train_time:10021ms step_avg:34.20ms
+step:294/1600 train_time:10059ms step_avg:34.21ms
+step:295/1600 train_time:10089ms step_avg:34.20ms
+step:296/1600 train_time:10127ms step_avg:34.21ms
+step:297/1600 train_time:10157ms step_avg:34.20ms
+step:298/1600 train_time:10195ms step_avg:34.21ms
+step:299/1600 train_time:10225ms step_avg:34.20ms
+step:300/1600 train_time:10262ms step_avg:34.21ms
+step:301/1600 train_time:10293ms step_avg:34.20ms
+step:302/1600 train_time:10330ms step_avg:34.21ms
+step:303/1600 train_time:10361ms step_avg:34.19ms
+step:304/1600 train_time:10398ms step_avg:34.20ms
+step:305/1600 train_time:10428ms step_avg:34.19ms
+step:306/1600 train_time:10465ms step_avg:34.20ms
+step:307/1600 train_time:10496ms step_avg:34.19ms
+step:308/1600 train_time:10533ms step_avg:34.20ms
+step:309/1600 train_time:10563ms step_avg:34.18ms
+step:310/1600 train_time:10600ms step_avg:34.19ms
+step:311/1600 train_time:10631ms step_avg:34.18ms
+step:312/1600 train_time:10669ms step_avg:34.19ms
+step:313/1600 train_time:10699ms step_avg:34.18ms
+step:314/1600 train_time:10736ms step_avg:34.19ms
+step:315/1600 train_time:10767ms step_avg:34.18ms
+step:316/1600 train_time:10804ms step_avg:34.19ms
+step:317/1600 train_time:10835ms step_avg:34.18ms
+step:318/1600 train_time:10873ms step_avg:34.19ms
+step:319/1600 train_time:10903ms step_avg:34.18ms
+step:320/1600 train_time:10941ms step_avg:34.19ms
+step:321/1600 train_time:10971ms step_avg:34.18ms
+step:322/1600 train_time:11008ms step_avg:34.19ms
+step:323/1600 train_time:11039ms step_avg:34.18ms
+step:324/1600 train_time:11076ms step_avg:34.19ms
+step:325/1600 train_time:11107ms step_avg:34.17ms
+step:326/1600 train_time:11144ms step_avg:34.18ms
+step:327/1600 train_time:11174ms step_avg:34.17ms
+step:328/1600 train_time:11212ms step_avg:34.18ms
+step:329/1600 train_time:11242ms step_avg:34.17ms
+step:330/1600 train_time:11279ms step_avg:34.18ms
+step:331/1600 train_time:11310ms step_avg:34.17ms
+step:332/1600 train_time:11347ms step_avg:34.18ms
+step:333/1600 train_time:11378ms step_avg:34.17ms
+step:334/1600 train_time:11415ms step_avg:34.18ms
+step:335/1600 train_time:11445ms step_avg:34.17ms
+step:336/1600 train_time:11482ms step_avg:34.17ms
+step:337/1600 train_time:11513ms step_avg:34.16ms
+step:338/1600 train_time:11550ms step_avg:34.17ms
+step:339/1600 train_time:11580ms step_avg:34.16ms
+step:340/1600 train_time:11617ms step_avg:34.17ms
+step:341/1600 train_time:11648ms step_avg:34.16ms
+step:342/1600 train_time:11686ms step_avg:34.17ms
+step:343/1600 train_time:11716ms step_avg:34.16ms
+step:344/1600 train_time:11754ms step_avg:34.17ms
+step:345/1600 train_time:11784ms step_avg:34.16ms
+step:346/1600 train_time:11821ms step_avg:34.16ms
+step:347/1600 train_time:11852ms step_avg:34.15ms
+step:348/1600 train_time:11889ms step_avg:34.16ms
+step:349/1600 train_time:11920ms step_avg:34.15ms
+step:350/1600 train_time:11957ms step_avg:34.16ms
+step:351/1600 train_time:11988ms step_avg:34.15ms
+step:352/1600 train_time:12025ms step_avg:34.16ms
+step:353/1600 train_time:12056ms step_avg:34.15ms
+step:354/1600 train_time:12093ms step_avg:34.16ms
+step:355/1600 train_time:12123ms step_avg:34.15ms
+step:356/1600 train_time:12160ms step_avg:34.16ms
+step:357/1600 train_time:12191ms step_avg:34.15ms
+step:358/1600 train_time:12228ms step_avg:34.16ms
+step:359/1600 train_time:12259ms step_avg:34.15ms
+step:360/1600 train_time:12296ms step_avg:34.16ms
+step:361/1600 train_time:12327ms step_avg:34.15ms
+step:362/1600 train_time:12364ms step_avg:34.16ms
+step:363/1600 train_time:12395ms step_avg:34.15ms
+step:364/1600 train_time:12432ms step_avg:34.15ms
+step:365/1600 train_time:12463ms step_avg:34.14ms
+step:366/1600 train_time:12500ms step_avg:34.15ms
+step:367/1600 train_time:12531ms step_avg:34.14ms
+step:368/1600 train_time:12568ms step_avg:34.15ms
+step:369/1600 train_time:12598ms step_avg:34.14ms
+step:370/1600 train_time:12636ms step_avg:34.15ms
+step:371/1600 train_time:12666ms step_avg:34.14ms
+step:372/1600 train_time:12704ms step_avg:34.15ms
+step:373/1600 train_time:12734ms step_avg:34.14ms
+step:374/1600 train_time:12772ms step_avg:34.15ms
+step:375/1600 train_time:12803ms step_avg:34.14ms
+step:376/1600 train_time:12840ms step_avg:34.15ms
+step:377/1600 train_time:12870ms step_avg:34.14ms
+step:378/1600 train_time:12908ms step_avg:34.15ms
+step:379/1600 train_time:12938ms step_avg:34.14ms
+step:380/1600 train_time:12975ms step_avg:34.15ms
+step:381/1600 train_time:13005ms step_avg:34.13ms
+step:382/1600 train_time:13043ms step_avg:34.14ms
+step:383/1600 train_time:13073ms step_avg:34.13ms
+step:384/1600 train_time:13111ms step_avg:34.14ms
+step:385/1600 train_time:13141ms step_avg:34.13ms
+step:386/1600 train_time:13178ms step_avg:34.14ms
+step:387/1600 train_time:13209ms step_avg:34.13ms
+step:388/1600 train_time:13246ms step_avg:34.14ms
+step:389/1600 train_time:13277ms step_avg:34.13ms
+step:390/1600 train_time:13314ms step_avg:34.14ms
+step:391/1600 train_time:13345ms step_avg:34.13ms
+step:392/1600 train_time:13382ms step_avg:34.14ms
+step:393/1600 train_time:13413ms step_avg:34.13ms
+step:394/1600 train_time:13451ms step_avg:34.14ms
+step:395/1600 train_time:13481ms step_avg:34.13ms
+step:396/1600 train_time:13518ms step_avg:34.14ms
+step:397/1600 train_time:13549ms step_avg:34.13ms
+step:398/1600 train_time:13586ms step_avg:34.14ms
+step:399/1600 train_time:13617ms step_avg:34.13ms
+step:400/1600 train_time:13654ms step_avg:34.14ms
+step:401/1600 train_time:13685ms step_avg:34.13ms
+step:402/1600 train_time:13722ms step_avg:34.13ms
+step:403/1600 train_time:13753ms step_avg:34.13ms
+step:404/1600 train_time:13790ms step_avg:34.13ms
+step:405/1600 train_time:13821ms step_avg:34.12ms
+step:406/1600 train_time:13858ms step_avg:34.13ms
+step:407/1600 train_time:13888ms step_avg:34.12ms
+step:408/1600 train_time:13926ms step_avg:34.13ms
+step:409/1600 train_time:13956ms step_avg:34.12ms
+step:410/1600 train_time:13993ms step_avg:34.13ms
+step:411/1600 train_time:14024ms step_avg:34.12ms
+step:412/1600 train_time:14062ms step_avg:34.13ms
+step:413/1600 train_time:14092ms step_avg:34.12ms
+step:414/1600 train_time:14129ms step_avg:34.13ms
+step:415/1600 train_time:14160ms step_avg:34.12ms
+step:416/1600 train_time:14197ms step_avg:34.13ms
+step:417/1600 train_time:14228ms step_avg:34.12ms
+step:418/1600 train_time:14266ms step_avg:34.13ms
+step:419/1600 train_time:14297ms step_avg:34.12ms
+step:420/1600 train_time:14334ms step_avg:34.13ms
+step:421/1600 train_time:14365ms step_avg:34.12ms
+step:422/1600 train_time:14403ms step_avg:34.13ms
+step:423/1600 train_time:14433ms step_avg:34.12ms
+step:424/1600 train_time:14471ms step_avg:34.13ms
+step:425/1600 train_time:14501ms step_avg:34.12ms
+step:426/1600 train_time:14538ms step_avg:34.13ms
+step:427/1600 train_time:14569ms step_avg:34.12ms
+step:428/1600 train_time:14606ms step_avg:34.13ms
+step:429/1600 train_time:14637ms step_avg:34.12ms
+step:430/1600 train_time:14674ms step_avg:34.13ms
+step:431/1600 train_time:14705ms step_avg:34.12ms
+step:432/1600 train_time:14742ms step_avg:34.13ms
+step:433/1600 train_time:14773ms step_avg:34.12ms
+step:434/1600 train_time:14810ms step_avg:34.13ms
+step:435/1600 train_time:14841ms step_avg:34.12ms
+step:436/1600 train_time:14878ms step_avg:34.12ms
+step:437/1600 train_time:14909ms step_avg:34.12ms
+step:438/1600 train_time:14946ms step_avg:34.12ms
+step:439/1600 train_time:14977ms step_avg:34.12ms
+step:440/1600 train_time:15014ms step_avg:34.12ms
+step:441/1600 train_time:15045ms step_avg:34.12ms
+step:442/1600 train_time:15082ms step_avg:34.12ms
+step:443/1600 train_time:15112ms step_avg:34.11ms
+step:444/1600 train_time:15150ms step_avg:34.12ms
+step:445/1600 train_time:15181ms step_avg:34.11ms
+step:446/1600 train_time:15218ms step_avg:34.12ms
+step:447/1600 train_time:15248ms step_avg:34.11ms
+step:448/1600 train_time:15286ms step_avg:34.12ms
+step:449/1600 train_time:15316ms step_avg:34.11ms
+step:450/1600 train_time:15353ms step_avg:34.12ms
+step:451/1600 train_time:15384ms step_avg:34.11ms
+step:452/1600 train_time:15421ms step_avg:34.12ms
+step:453/1600 train_time:15452ms step_avg:34.11ms
+step:454/1600 train_time:15489ms step_avg:34.12ms
+step:455/1600 train_time:15520ms step_avg:34.11ms
+step:456/1600 train_time:15557ms step_avg:34.12ms
+step:457/1600 train_time:15588ms step_avg:34.11ms
+step:458/1600 train_time:15625ms step_avg:34.12ms
+step:459/1600 train_time:15656ms step_avg:34.11ms
+step:460/1600 train_time:15693ms step_avg:34.11ms
+step:461/1600 train_time:15723ms step_avg:34.11ms
+step:462/1600 train_time:15761ms step_avg:34.12ms
+step:463/1600 train_time:15791ms step_avg:34.11ms
+step:464/1600 train_time:15829ms step_avg:34.11ms
+step:465/1600 train_time:15859ms step_avg:34.11ms
+step:466/1600 train_time:15896ms step_avg:34.11ms
+step:467/1600 train_time:15927ms step_avg:34.10ms
+step:468/1600 train_time:15964ms step_avg:34.11ms
+step:469/1600 train_time:15994ms step_avg:34.10ms
+step:470/1600 train_time:16031ms step_avg:34.11ms
+step:471/1600 train_time:16062ms step_avg:34.10ms
+step:472/1600 train_time:16099ms step_avg:34.11ms
+step:473/1600 train_time:16130ms step_avg:34.10ms
+step:474/1600 train_time:16168ms step_avg:34.11ms
+step:475/1600 train_time:16198ms step_avg:34.10ms
+step:476/1600 train_time:16235ms step_avg:34.11ms
+step:477/1600 train_time:16266ms step_avg:34.10ms
+step:478/1600 train_time:16303ms step_avg:34.11ms
+step:479/1600 train_time:16334ms step_avg:34.10ms
+step:480/1600 train_time:16371ms step_avg:34.11ms
+step:481/1600 train_time:16402ms step_avg:34.10ms
+step:482/1600 train_time:16439ms step_avg:34.11ms
+step:483/1600 train_time:16469ms step_avg:34.10ms
+step:484/1600 train_time:16507ms step_avg:34.10ms
+step:485/1600 train_time:16537ms step_avg:34.10ms
+step:486/1600 train_time:16574ms step_avg:34.10ms
+step:487/1600 train_time:16604ms step_avg:34.10ms
+step:488/1600 train_time:16642ms step_avg:34.10ms
+step:489/1600 train_time:16672ms step_avg:34.09ms
+step:490/1600 train_time:16709ms step_avg:34.10ms
+step:491/1600 train_time:16740ms step_avg:34.09ms
+step:492/1600 train_time:16777ms step_avg:34.10ms
+step:493/1600 train_time:16808ms step_avg:34.09ms
+step:494/1600 train_time:16845ms step_avg:34.10ms
+step:495/1600 train_time:16876ms step_avg:34.09ms
+step:496/1600 train_time:16914ms step_avg:34.10ms
+step:497/1600 train_time:16944ms step_avg:34.09ms
+step:498/1600 train_time:16981ms step_avg:34.10ms
+step:499/1600 train_time:17012ms step_avg:34.09ms
+step:500/1600 train_time:17049ms step_avg:34.10ms
+step:500/1600 val_loss:4.2438 train_time:17097ms step_avg:34.19ms
+step:501/1600 train_time:17119ms step_avg:34.17ms
+step:502/1600 train_time:17139ms step_avg:34.14ms
+step:503/1600 train_time:17157ms step_avg:34.11ms
+step:504/1600 train_time:17189ms step_avg:34.11ms
+step:505/1600 train_time:17221ms step_avg:34.10ms
+step:506/1600 train_time:17259ms step_avg:34.11ms
+step:507/1600 train_time:17290ms step_avg:34.10ms
+step:508/1600 train_time:17328ms step_avg:34.11ms
+step:509/1600 train_time:17358ms step_avg:34.10ms
+step:510/1600 train_time:17396ms step_avg:34.11ms
+step:511/1600 train_time:17427ms step_avg:34.10ms
+step:512/1600 train_time:17464ms step_avg:34.11ms
+step:513/1600 train_time:17494ms step_avg:34.10ms
+step:514/1600 train_time:17532ms step_avg:34.11ms
+step:515/1600 train_time:17562ms step_avg:34.10ms
+step:516/1600 train_time:17599ms step_avg:34.11ms
+step:517/1600 train_time:17630ms step_avg:34.10ms
+step:518/1600 train_time:17667ms step_avg:34.11ms
+step:519/1600 train_time:17697ms step_avg:34.10ms
+step:520/1600 train_time:17734ms step_avg:34.10ms
+step:521/1600 train_time:17806ms step_avg:34.18ms
+step:522/1600 train_time:17863ms step_avg:34.22ms
+step:523/1600 train_time:17924ms step_avg:34.27ms
+step:524/1600 train_time:17982ms step_avg:34.32ms
+step:525/1600 train_time:18043ms step_avg:34.37ms
+step:526/1600 train_time:18102ms step_avg:34.41ms
+step:527/1600 train_time:18165ms step_avg:34.47ms
+step:528/1600 train_time:18223ms step_avg:34.51ms
+step:529/1600 train_time:18287ms step_avg:34.57ms
+step:530/1600 train_time:18347ms step_avg:34.62ms
+step:531/1600 train_time:18409ms step_avg:34.67ms
+step:532/1600 train_time:18468ms step_avg:34.71ms
+step:533/1600 train_time:18531ms step_avg:34.77ms
+step:534/1600 train_time:18590ms step_avg:34.81ms
+step:535/1600 train_time:18654ms step_avg:34.87ms
+step:536/1600 train_time:18713ms step_avg:34.91ms
+step:537/1600 train_time:18775ms step_avg:34.96ms
+step:538/1600 train_time:18834ms step_avg:35.01ms
+step:539/1600 train_time:18896ms step_avg:35.06ms
+step:540/1600 train_time:18957ms step_avg:35.10ms
+step:541/1600 train_time:19018ms step_avg:35.15ms
+step:542/1600 train_time:19076ms step_avg:35.20ms
+step:543/1600 train_time:19139ms step_avg:35.25ms
+step:544/1600 train_time:19199ms step_avg:35.29ms
+step:545/1600 train_time:19262ms step_avg:35.34ms
+step:546/1600 train_time:19322ms step_avg:35.39ms
+step:547/1600 train_time:19384ms step_avg:35.44ms
+step:548/1600 train_time:19444ms step_avg:35.48ms
+step:549/1600 train_time:19506ms step_avg:35.53ms
+step:550/1600 train_time:19565ms step_avg:35.57ms
+step:551/1600 train_time:19627ms step_avg:35.62ms
+step:552/1600 train_time:19686ms step_avg:35.66ms
+step:553/1600 train_time:19748ms step_avg:35.71ms
+step:554/1600 train_time:19807ms step_avg:35.75ms
+step:555/1600 train_time:19870ms step_avg:35.80ms
+step:556/1600 train_time:19930ms step_avg:35.85ms
+step:557/1600 train_time:19992ms step_avg:35.89ms
+step:558/1600 train_time:20052ms step_avg:35.94ms
+step:559/1600 train_time:20115ms step_avg:35.98ms
+step:560/1600 train_time:20175ms step_avg:36.03ms
+step:561/1600 train_time:20239ms step_avg:36.08ms
+step:562/1600 train_time:20298ms step_avg:36.12ms
+step:563/1600 train_time:20360ms step_avg:36.16ms
+step:564/1600 train_time:20419ms step_avg:36.20ms
+step:565/1600 train_time:20482ms step_avg:36.25ms
+step:566/1600 train_time:20542ms step_avg:36.29ms
+step:567/1600 train_time:20604ms step_avg:36.34ms
+step:568/1600 train_time:20666ms step_avg:36.38ms
+step:569/1600 train_time:20729ms step_avg:36.43ms
+step:570/1600 train_time:20785ms step_avg:36.46ms
+step:571/1600 train_time:20847ms step_avg:36.51ms
+step:572/1600 train_time:20906ms step_avg:36.55ms
+step:573/1600 train_time:20973ms step_avg:36.60ms
+step:574/1600 train_time:21029ms step_avg:36.64ms
+step:575/1600 train_time:21091ms step_avg:36.68ms
+step:576/1600 train_time:21150ms step_avg:36.72ms
+step:577/1600 train_time:21211ms step_avg:36.76ms
+step:578/1600 train_time:21272ms step_avg:36.80ms
+step:579/1600 train_time:21334ms step_avg:36.85ms
+step:580/1600 train_time:21394ms step_avg:36.89ms
+step:581/1600 train_time:21458ms step_avg:36.93ms
+step:582/1600 train_time:21516ms step_avg:36.97ms
+step:583/1600 train_time:21579ms step_avg:37.01ms
+step:584/1600 train_time:21638ms step_avg:37.05ms
+step:585/1600 train_time:21701ms step_avg:37.10ms
+step:586/1600 train_time:21760ms step_avg:37.13ms
+step:587/1600 train_time:21822ms step_avg:37.18ms
+step:588/1600 train_time:21883ms step_avg:37.22ms
+step:589/1600 train_time:21944ms step_avg:37.26ms
+step:590/1600 train_time:22003ms step_avg:37.29ms
+step:591/1600 train_time:22066ms step_avg:37.34ms
+step:592/1600 train_time:22125ms step_avg:37.37ms
+step:593/1600 train_time:22187ms step_avg:37.41ms
+step:594/1600 train_time:22246ms step_avg:37.45ms
+step:595/1600 train_time:22307ms step_avg:37.49ms
+step:596/1600 train_time:22367ms step_avg:37.53ms
+step:597/1600 train_time:22429ms step_avg:37.57ms
+step:598/1600 train_time:22487ms step_avg:37.60ms
+step:599/1600 train_time:22550ms step_avg:37.65ms
+step:600/1600 train_time:22609ms step_avg:37.68ms
+step:601/1600 train_time:22673ms step_avg:37.73ms
+step:602/1600 train_time:22733ms step_avg:37.76ms
+step:603/1600 train_time:22796ms step_avg:37.80ms
+step:604/1600 train_time:22855ms step_avg:37.84ms
+step:605/1600 train_time:22917ms step_avg:37.88ms
+step:606/1600 train_time:22977ms step_avg:37.92ms
+step:607/1600 train_time:23039ms step_avg:37.96ms
+step:608/1600 train_time:23098ms step_avg:37.99ms
+step:609/1600 train_time:23161ms step_avg:38.03ms
+step:610/1600 train_time:23221ms step_avg:38.07ms
+step:611/1600 train_time:23283ms step_avg:38.11ms
+step:612/1600 train_time:23342ms step_avg:38.14ms
+step:613/1600 train_time:23404ms step_avg:38.18ms
+step:614/1600 train_time:23464ms step_avg:38.21ms
+step:615/1600 train_time:23525ms step_avg:38.25ms
+step:616/1600 train_time:23583ms step_avg:38.28ms
+step:617/1600 train_time:23646ms step_avg:38.32ms
+step:618/1600 train_time:23704ms step_avg:38.36ms
+step:619/1600 train_time:23767ms step_avg:38.40ms
+step:620/1600 train_time:23825ms step_avg:38.43ms
+step:621/1600 train_time:23887ms step_avg:38.47ms
+step:622/1600 train_time:23947ms step_avg:38.50ms
+step:623/1600 train_time:24009ms step_avg:38.54ms
+step:624/1600 train_time:24069ms step_avg:38.57ms
+step:625/1600 train_time:24131ms step_avg:38.61ms
+step:626/1600 train_time:24191ms step_avg:38.64ms
+step:627/1600 train_time:24254ms step_avg:38.68ms
+step:628/1600 train_time:24313ms step_avg:38.72ms
+step:629/1600 train_time:24376ms step_avg:38.75ms
+step:630/1600 train_time:24435ms step_avg:38.79ms
+step:631/1600 train_time:24497ms step_avg:38.82ms
+step:632/1600 train_time:24557ms step_avg:38.86ms
+step:633/1600 train_time:24620ms step_avg:38.89ms
+step:634/1600 train_time:24680ms step_avg:38.93ms
+step:635/1600 train_time:24742ms step_avg:38.96ms
+step:636/1600 train_time:24801ms step_avg:38.99ms
+step:637/1600 train_time:24863ms step_avg:39.03ms
+step:638/1600 train_time:24922ms step_avg:39.06ms
+step:639/1600 train_time:24987ms step_avg:39.10ms
+step:640/1600 train_time:25044ms step_avg:39.13ms
+step:641/1600 train_time:25107ms step_avg:39.17ms
+step:642/1600 train_time:25165ms step_avg:39.20ms
+step:643/1600 train_time:25228ms step_avg:39.23ms
+step:644/1600 train_time:25287ms step_avg:39.26ms
+step:645/1600 train_time:25348ms step_avg:39.30ms
+step:646/1600 train_time:25407ms step_avg:39.33ms
+step:647/1600 train_time:25470ms step_avg:39.37ms
+step:648/1600 train_time:25529ms step_avg:39.40ms
+step:649/1600 train_time:25593ms step_avg:39.43ms
+step:650/1600 train_time:25653ms step_avg:39.47ms
+step:651/1600 train_time:25714ms step_avg:39.50ms
+step:652/1600 train_time:25777ms step_avg:39.53ms
+step:653/1600 train_time:25838ms step_avg:39.57ms
+step:654/1600 train_time:25897ms step_avg:39.60ms
+step:655/1600 train_time:25961ms step_avg:39.63ms
+step:656/1600 train_time:26019ms step_avg:39.66ms
+step:657/1600 train_time:26081ms step_avg:39.70ms
+step:658/1600 train_time:26141ms step_avg:39.73ms
+step:659/1600 train_time:26204ms step_avg:39.76ms
+step:660/1600 train_time:26263ms step_avg:39.79ms
+step:661/1600 train_time:26325ms step_avg:39.83ms
+step:662/1600 train_time:26384ms step_avg:39.86ms
+step:663/1600 train_time:26446ms step_avg:39.89ms
+step:664/1600 train_time:26505ms step_avg:39.92ms
+step:665/1600 train_time:26568ms step_avg:39.95ms
+step:666/1600 train_time:26626ms step_avg:39.98ms
+step:667/1600 train_time:26688ms step_avg:40.01ms
+step:668/1600 train_time:26747ms step_avg:40.04ms
+step:669/1600 train_time:26809ms step_avg:40.07ms
+step:670/1600 train_time:26868ms step_avg:40.10ms
+step:671/1600 train_time:26932ms step_avg:40.14ms
+step:672/1600 train_time:26992ms step_avg:40.17ms
+step:673/1600 train_time:27054ms step_avg:40.20ms
+step:674/1600 train_time:27114ms step_avg:40.23ms
+step:675/1600 train_time:27177ms step_avg:40.26ms
+step:676/1600 train_time:27236ms step_avg:40.29ms
+step:677/1600 train_time:27298ms step_avg:40.32ms
+step:678/1600 train_time:27357ms step_avg:40.35ms
+step:679/1600 train_time:27420ms step_avg:40.38ms
+step:680/1600 train_time:27480ms step_avg:40.41ms
+step:681/1600 train_time:27543ms step_avg:40.44ms
+step:682/1600 train_time:27602ms step_avg:40.47ms
+step:683/1600 train_time:27664ms step_avg:40.50ms
+step:684/1600 train_time:27723ms step_avg:40.53ms
+step:685/1600 train_time:27786ms step_avg:40.56ms
+step:686/1600 train_time:27844ms step_avg:40.59ms
+step:687/1600 train_time:27906ms step_avg:40.62ms
+step:688/1600 train_time:27966ms step_avg:40.65ms
+step:689/1600 train_time:28028ms step_avg:40.68ms
+step:690/1600 train_time:28087ms step_avg:40.71ms
+step:691/1600 train_time:28150ms step_avg:40.74ms
+step:692/1600 train_time:28209ms step_avg:40.76ms
+step:693/1600 train_time:28272ms step_avg:40.80ms
+step:694/1600 train_time:28331ms step_avg:40.82ms
+step:695/1600 train_time:28395ms step_avg:40.86ms
+step:696/1600 train_time:28454ms step_avg:40.88ms
+step:697/1600 train_time:28518ms step_avg:40.91ms
+step:698/1600 train_time:28577ms step_avg:40.94ms
+step:699/1600 train_time:28639ms step_avg:40.97ms
+step:700/1600 train_time:28698ms step_avg:41.00ms
+step:701/1600 train_time:28760ms step_avg:41.03ms
+step:702/1600 train_time:28819ms step_avg:41.05ms
+step:703/1600 train_time:28882ms step_avg:41.08ms
+step:704/1600 train_time:28941ms step_avg:41.11ms
+step:705/1600 train_time:29003ms step_avg:41.14ms
+step:706/1600 train_time:29063ms step_avg:41.17ms
+step:707/1600 train_time:29125ms step_avg:41.20ms
+step:708/1600 train_time:29184ms step_avg:41.22ms
+step:709/1600 train_time:29247ms step_avg:41.25ms
+step:710/1600 train_time:29305ms step_avg:41.27ms
+step:711/1600 train_time:29368ms step_avg:41.30ms
+step:712/1600 train_time:29427ms step_avg:41.33ms
+step:713/1600 train_time:29490ms step_avg:41.36ms
+step:714/1600 train_time:29549ms step_avg:41.39ms
+step:715/1600 train_time:29611ms step_avg:41.41ms
+step:716/1600 train_time:29672ms step_avg:41.44ms
+step:717/1600 train_time:29735ms step_avg:41.47ms
+step:718/1600 train_time:29796ms step_avg:41.50ms
+step:719/1600 train_time:29857ms step_avg:41.53ms
+step:720/1600 train_time:29916ms step_avg:41.55ms
+step:721/1600 train_time:29978ms step_avg:41.58ms
+step:722/1600 train_time:30039ms step_avg:41.60ms
+step:723/1600 train_time:30101ms step_avg:41.63ms
+step:724/1600 train_time:30159ms step_avg:41.66ms
+step:725/1600 train_time:30222ms step_avg:41.68ms
+step:726/1600 train_time:30282ms step_avg:41.71ms
+step:727/1600 train_time:30345ms step_avg:41.74ms
+step:728/1600 train_time:30403ms step_avg:41.76ms
+step:729/1600 train_time:30466ms step_avg:41.79ms
+step:730/1600 train_time:30524ms step_avg:41.81ms
+step:731/1600 train_time:30587ms step_avg:41.84ms
+step:732/1600 train_time:30646ms step_avg:41.87ms
+step:733/1600 train_time:30708ms step_avg:41.89ms
+step:734/1600 train_time:30767ms step_avg:41.92ms
+step:735/1600 train_time:30828ms step_avg:41.94ms
+step:736/1600 train_time:30889ms step_avg:41.97ms
+step:737/1600 train_time:30951ms step_avg:42.00ms
+step:738/1600 train_time:31009ms step_avg:42.02ms
+step:739/1600 train_time:31072ms step_avg:42.05ms
+step:740/1600 train_time:31132ms step_avg:42.07ms
+step:741/1600 train_time:31195ms step_avg:42.10ms
+step:742/1600 train_time:31257ms step_avg:42.13ms
+step:743/1600 train_time:31318ms step_avg:42.15ms
+step:744/1600 train_time:31376ms step_avg:42.17ms
+step:745/1600 train_time:31439ms step_avg:42.20ms
+step:746/1600 train_time:31500ms step_avg:42.23ms
+step:747/1600 train_time:31562ms step_avg:42.25ms
+step:748/1600 train_time:31621ms step_avg:42.27ms
+step:749/1600 train_time:31684ms step_avg:42.30ms
+step:750/1600 train_time:31744ms step_avg:42.33ms
+step:750/1600 val_loss:3.8925 train_time:31789ms step_avg:42.39ms
+step:751/1600 train_time:31810ms step_avg:42.36ms
+step:752/1600 train_time:31870ms step_avg:42.38ms
+step:753/1600 train_time:31936ms step_avg:42.41ms
+step:754/1600 train_time:31999ms step_avg:42.44ms
+step:755/1600 train_time:32061ms step_avg:42.46ms
+step:756/1600 train_time:32120ms step_avg:42.49ms
+step:757/1600 train_time:32181ms step_avg:42.51ms
+step:758/1600 train_time:32240ms step_avg:42.53ms
+step:759/1600 train_time:32301ms step_avg:42.56ms
+step:760/1600 train_time:32359ms step_avg:42.58ms
+step:761/1600 train_time:32422ms step_avg:42.60ms
+step:762/1600 train_time:32480ms step_avg:42.62ms
+step:763/1600 train_time:32541ms step_avg:42.65ms
+step:764/1600 train_time:32602ms step_avg:42.67ms
+step:765/1600 train_time:32661ms step_avg:42.69ms
+step:766/1600 train_time:32720ms step_avg:42.72ms
+step:767/1600 train_time:32784ms step_avg:42.74ms
+step:768/1600 train_time:32845ms step_avg:42.77ms
+step:769/1600 train_time:32909ms step_avg:42.79ms
+step:770/1600 train_time:32969ms step_avg:42.82ms
+step:771/1600 train_time:33032ms step_avg:42.84ms
+step:772/1600 train_time:33092ms step_avg:42.87ms
+step:773/1600 train_time:33154ms step_avg:42.89ms
+step:774/1600 train_time:33212ms step_avg:42.91ms
+step:775/1600 train_time:33275ms step_avg:42.94ms
+step:776/1600 train_time:33334ms step_avg:42.96ms
+step:777/1600 train_time:33396ms step_avg:42.98ms
+step:778/1600 train_time:33455ms step_avg:43.00ms
+step:779/1600 train_time:33518ms step_avg:43.03ms
+step:780/1600 train_time:33576ms step_avg:43.05ms
+step:781/1600 train_time:33638ms step_avg:43.07ms
+step:782/1600 train_time:33697ms step_avg:43.09ms
+step:783/1600 train_time:33759ms step_avg:43.12ms
+step:784/1600 train_time:33819ms step_avg:43.14ms
+step:785/1600 train_time:33882ms step_avg:43.16ms
+step:786/1600 train_time:33941ms step_avg:43.18ms
+step:787/1600 train_time:34003ms step_avg:43.21ms
+step:788/1600 train_time:34063ms step_avg:43.23ms
+step:789/1600 train_time:34126ms step_avg:43.25ms
+step:790/1600 train_time:34185ms step_avg:43.27ms
+step:791/1600 train_time:34248ms step_avg:43.30ms
+step:792/1600 train_time:34307ms step_avg:43.32ms
+step:793/1600 train_time:34370ms step_avg:43.34ms
+step:794/1600 train_time:34429ms step_avg:43.36ms
+step:795/1600 train_time:34491ms step_avg:43.39ms
+step:796/1600 train_time:34550ms step_avg:43.40ms
+step:797/1600 train_time:34613ms step_avg:43.43ms
+step:798/1600 train_time:34673ms step_avg:43.45ms
+step:799/1600 train_time:34735ms step_avg:43.47ms
+step:800/1600 train_time:34795ms step_avg:43.49ms
+step:801/1600 train_time:34858ms step_avg:43.52ms
+step:802/1600 train_time:34916ms step_avg:43.54ms
+step:803/1600 train_time:34979ms step_avg:43.56ms
+step:804/1600 train_time:35037ms step_avg:43.58ms
+step:805/1600 train_time:35101ms step_avg:43.60ms
+step:806/1600 train_time:35161ms step_avg:43.62ms
+step:807/1600 train_time:35222ms step_avg:43.65ms
+step:808/1600 train_time:35279ms step_avg:43.66ms
+step:809/1600 train_time:35343ms step_avg:43.69ms
+step:810/1600 train_time:35403ms step_avg:43.71ms
+step:811/1600 train_time:35465ms step_avg:43.73ms
+step:812/1600 train_time:35524ms step_avg:43.75ms
+step:813/1600 train_time:35586ms step_avg:43.77ms
+step:814/1600 train_time:35645ms step_avg:43.79ms
+step:815/1600 train_time:35708ms step_avg:43.81ms
+step:816/1600 train_time:35767ms step_avg:43.83ms
+step:817/1600 train_time:35830ms step_avg:43.86ms
+step:818/1600 train_time:35890ms step_avg:43.88ms
+step:819/1600 train_time:35953ms step_avg:43.90ms
+step:820/1600 train_time:36014ms step_avg:43.92ms
+step:821/1600 train_time:36076ms step_avg:43.94ms
+step:822/1600 train_time:36134ms step_avg:43.96ms
+step:823/1600 train_time:36197ms step_avg:43.98ms
+step:824/1600 train_time:36256ms step_avg:44.00ms
+step:825/1600 train_time:36318ms step_avg:44.02ms
+step:826/1600 train_time:36378ms step_avg:44.04ms
+step:827/1600 train_time:36439ms step_avg:44.06ms
+step:828/1600 train_time:36498ms step_avg:44.08ms
+step:829/1600 train_time:36561ms step_avg:44.10ms
+step:830/1600 train_time:36620ms step_avg:44.12ms
+step:831/1600 train_time:36683ms step_avg:44.14ms
+step:832/1600 train_time:36742ms step_avg:44.16ms
+step:833/1600 train_time:36807ms step_avg:44.19ms
+step:834/1600 train_time:36865ms step_avg:44.20ms
+step:835/1600 train_time:36928ms step_avg:44.23ms
+step:836/1600 train_time:36988ms step_avg:44.24ms
+step:837/1600 train_time:37050ms step_avg:44.26ms
+step:838/1600 train_time:37110ms step_avg:44.28ms
+step:839/1600 train_time:37172ms step_avg:44.31ms
+step:840/1600 train_time:37231ms step_avg:44.32ms
+step:841/1600 train_time:37294ms step_avg:44.34ms
+step:842/1600 train_time:37352ms step_avg:44.36ms
+step:843/1600 train_time:37415ms step_avg:44.38ms
+step:844/1600 train_time:37474ms step_avg:44.40ms
+step:845/1600 train_time:37537ms step_avg:44.42ms
+step:846/1600 train_time:37596ms step_avg:44.44ms
+step:847/1600 train_time:37659ms step_avg:44.46ms
+step:848/1600 train_time:37718ms step_avg:44.48ms
+step:849/1600 train_time:37780ms step_avg:44.50ms
+step:850/1600 train_time:37839ms step_avg:44.52ms
+step:851/1600 train_time:37900ms step_avg:44.54ms
+step:852/1600 train_time:37959ms step_avg:44.55ms
+step:853/1600 train_time:38022ms step_avg:44.57ms
+step:854/1600 train_time:38081ms step_avg:44.59ms
+step:855/1600 train_time:38145ms step_avg:44.61ms
+step:856/1600 train_time:38204ms step_avg:44.63ms
+step:857/1600 train_time:38267ms step_avg:44.65ms
+step:858/1600 train_time:38327ms step_avg:44.67ms
+step:859/1600 train_time:38389ms step_avg:44.69ms
+step:860/1600 train_time:38449ms step_avg:44.71ms
+step:861/1600 train_time:38511ms step_avg:44.73ms
+step:862/1600 train_time:38570ms step_avg:44.75ms
+step:863/1600 train_time:38634ms step_avg:44.77ms
+step:864/1600 train_time:38694ms step_avg:44.78ms
+step:865/1600 train_time:38757ms step_avg:44.81ms
+step:866/1600 train_time:38815ms step_avg:44.82ms
+step:867/1600 train_time:38878ms step_avg:44.84ms
+step:868/1600 train_time:38937ms step_avg:44.86ms
+step:869/1600 train_time:38999ms step_avg:44.88ms
+step:870/1600 train_time:39058ms step_avg:44.89ms
+step:871/1600 train_time:39121ms step_avg:44.92ms
+step:872/1600 train_time:39179ms step_avg:44.93ms
+step:873/1600 train_time:39242ms step_avg:44.95ms
+step:874/1600 train_time:39301ms step_avg:44.97ms
+step:875/1600 train_time:39363ms step_avg:44.99ms
+step:876/1600 train_time:39423ms step_avg:45.00ms
+step:877/1600 train_time:39484ms step_avg:45.02ms
+step:878/1600 train_time:39545ms step_avg:45.04ms
+step:879/1600 train_time:39608ms step_avg:45.06ms
+step:880/1600 train_time:39667ms step_avg:45.08ms
+step:881/1600 train_time:39735ms step_avg:45.10ms
+step:882/1600 train_time:39789ms step_avg:45.11ms
+step:883/1600 train_time:39851ms step_avg:45.13ms
+step:884/1600 train_time:39911ms step_avg:45.15ms
+step:885/1600 train_time:39974ms step_avg:45.17ms
+step:886/1600 train_time:40033ms step_avg:45.18ms
+step:887/1600 train_time:40095ms step_avg:45.20ms
+step:888/1600 train_time:40154ms step_avg:45.22ms
+step:889/1600 train_time:40218ms step_avg:45.24ms
+step:890/1600 train_time:40284ms step_avg:45.26ms
+step:891/1600 train_time:40343ms step_avg:45.28ms
+step:892/1600 train_time:40401ms step_avg:45.29ms
+step:893/1600 train_time:40461ms step_avg:45.31ms
+step:894/1600 train_time:40519ms step_avg:45.32ms
+step:895/1600 train_time:40582ms step_avg:45.34ms
+step:896/1600 train_time:40640ms step_avg:45.36ms
+step:897/1600 train_time:40703ms step_avg:45.38ms
+step:898/1600 train_time:40762ms step_avg:45.39ms
+step:899/1600 train_time:40824ms step_avg:45.41ms
+step:900/1600 train_time:40884ms step_avg:45.43ms
+step:901/1600 train_time:40947ms step_avg:45.45ms
+step:902/1600 train_time:41006ms step_avg:45.46ms
+step:903/1600 train_time:41069ms step_avg:45.48ms
+step:904/1600 train_time:41129ms step_avg:45.50ms
+step:905/1600 train_time:41191ms step_avg:45.52ms
+step:906/1600 train_time:41251ms step_avg:45.53ms
+step:907/1600 train_time:41314ms step_avg:45.55ms
+step:908/1600 train_time:41373ms step_avg:45.57ms
+step:909/1600 train_time:41436ms step_avg:45.58ms
+step:910/1600 train_time:41494ms step_avg:45.60ms
+step:911/1600 train_time:41557ms step_avg:45.62ms
+step:912/1600 train_time:41617ms step_avg:45.63ms
+step:913/1600 train_time:41679ms step_avg:45.65ms
+step:914/1600 train_time:41738ms step_avg:45.66ms
+step:915/1600 train_time:41801ms step_avg:45.68ms
+step:916/1600 train_time:41860ms step_avg:45.70ms
+step:917/1600 train_time:41922ms step_avg:45.72ms
+step:918/1600 train_time:41980ms step_avg:45.73ms
+step:919/1600 train_time:42043ms step_avg:45.75ms
+step:920/1600 train_time:42105ms step_avg:45.77ms
+step:921/1600 train_time:42166ms step_avg:45.78ms
+step:922/1600 train_time:42226ms step_avg:45.80ms
+step:923/1600 train_time:42289ms step_avg:45.82ms
+step:924/1600 train_time:42349ms step_avg:45.83ms
+step:925/1600 train_time:42412ms step_avg:45.85ms
+step:926/1600 train_time:42471ms step_avg:45.86ms
+step:927/1600 train_time:42534ms step_avg:45.88ms
+step:928/1600 train_time:42593ms step_avg:45.90ms
+step:929/1600 train_time:42655ms step_avg:45.92ms
+step:930/1600 train_time:42714ms step_avg:45.93ms
+step:931/1600 train_time:42777ms step_avg:45.95ms
+step:932/1600 train_time:42836ms step_avg:45.96ms
+step:933/1600 train_time:42898ms step_avg:45.98ms
+step:934/1600 train_time:42957ms step_avg:45.99ms
+step:935/1600 train_time:43019ms step_avg:46.01ms
+step:936/1600 train_time:43078ms step_avg:46.02ms
+step:937/1600 train_time:43141ms step_avg:46.04ms
+step:938/1600 train_time:43200ms step_avg:46.05ms
+step:939/1600 train_time:43262ms step_avg:46.07ms
+step:940/1600 train_time:43321ms step_avg:46.09ms
+step:941/1600 train_time:43384ms step_avg:46.10ms
+step:942/1600 train_time:43444ms step_avg:46.12ms
+step:943/1600 train_time:43507ms step_avg:46.14ms
+step:944/1600 train_time:43566ms step_avg:46.15ms
+step:945/1600 train_time:43630ms step_avg:46.17ms
+step:946/1600 train_time:43689ms step_avg:46.18ms
+step:947/1600 train_time:43752ms step_avg:46.20ms
+step:948/1600 train_time:43810ms step_avg:46.21ms
+step:949/1600 train_time:43873ms step_avg:46.23ms
+step:950/1600 train_time:43933ms step_avg:46.25ms
+step:951/1600 train_time:43997ms step_avg:46.26ms
+step:952/1600 train_time:44055ms step_avg:46.28ms
+step:953/1600 train_time:44118ms step_avg:46.29ms
+step:954/1600 train_time:44176ms step_avg:46.31ms
+step:955/1600 train_time:44239ms step_avg:46.32ms
+step:956/1600 train_time:44298ms step_avg:46.34ms
+step:957/1600 train_time:44362ms step_avg:46.36ms
+step:958/1600 train_time:44419ms step_avg:46.37ms
+step:959/1600 train_time:44484ms step_avg:46.39ms
+step:960/1600 train_time:44541ms step_avg:46.40ms
+step:961/1600 train_time:44605ms step_avg:46.42ms
+step:962/1600 train_time:44664ms step_avg:46.43ms
+step:963/1600 train_time:44727ms step_avg:46.45ms
+step:964/1600 train_time:44787ms step_avg:46.46ms
+step:965/1600 train_time:44849ms step_avg:46.48ms
+step:966/1600 train_time:44908ms step_avg:46.49ms
+step:967/1600 train_time:44972ms step_avg:46.51ms
+step:968/1600 train_time:45031ms step_avg:46.52ms
+step:969/1600 train_time:45094ms step_avg:46.54ms
+step:970/1600 train_time:45153ms step_avg:46.55ms
+step:971/1600 train_time:45216ms step_avg:46.57ms
+step:972/1600 train_time:45275ms step_avg:46.58ms
+step:973/1600 train_time:45337ms step_avg:46.60ms
+step:974/1600 train_time:45398ms step_avg:46.61ms
+step:975/1600 train_time:45461ms step_avg:46.63ms
+step:976/1600 train_time:45518ms step_avg:46.64ms
+step:977/1600 train_time:45580ms step_avg:46.65ms
+step:978/1600 train_time:45639ms step_avg:46.67ms
+step:979/1600 train_time:45700ms step_avg:46.68ms
+step:980/1600 train_time:45759ms step_avg:46.69ms
+step:981/1600 train_time:45822ms step_avg:46.71ms
+step:982/1600 train_time:45882ms step_avg:46.72ms
+step:983/1600 train_time:45944ms step_avg:46.74ms
+step:984/1600 train_time:46004ms step_avg:46.75ms
+step:985/1600 train_time:46067ms step_avg:46.77ms
+step:986/1600 train_time:46126ms step_avg:46.78ms
+step:987/1600 train_time:46189ms step_avg:46.80ms
+step:988/1600 train_time:46249ms step_avg:46.81ms
+step:989/1600 train_time:46311ms step_avg:46.83ms
+step:990/1600 train_time:46371ms step_avg:46.84ms
+step:991/1600 train_time:46433ms step_avg:46.85ms
+step:992/1600 train_time:46492ms step_avg:46.87ms
+step:993/1600 train_time:46556ms step_avg:46.88ms
+step:994/1600 train_time:46616ms step_avg:46.90ms
+step:995/1600 train_time:46678ms step_avg:46.91ms
+step:996/1600 train_time:46736ms step_avg:46.92ms
+step:997/1600 train_time:46798ms step_avg:46.94ms
+step:998/1600 train_time:46857ms step_avg:46.95ms
+step:999/1600 train_time:46919ms step_avg:46.97ms
+step:1000/1600 train_time:46978ms step_avg:46.98ms
+step:1000/1600 val_loss:3.5970 train_time:47024ms step_avg:47.02ms
+step:1001/1600 train_time:47045ms step_avg:47.00ms
+step:1002/1600 train_time:47103ms step_avg:47.01ms
+step:1003/1600 train_time:47167ms step_avg:47.03ms
+step:1004/1600 train_time:47226ms step_avg:47.04ms
+step:1005/1600 train_time:47289ms step_avg:47.05ms
+step:1006/1600 train_time:47348ms step_avg:47.07ms
+step:1007/1600 train_time:47410ms step_avg:47.08ms
+step:1008/1600 train_time:47469ms step_avg:47.09ms
+step:1009/1600 train_time:47530ms step_avg:47.11ms
+step:1010/1600 train_time:47588ms step_avg:47.12ms
+step:1011/1600 train_time:47653ms step_avg:47.13ms
+step:1012/1600 train_time:47712ms step_avg:47.15ms
+step:1013/1600 train_time:47773ms step_avg:47.16ms
+step:1014/1600 train_time:47833ms step_avg:47.17ms
+step:1015/1600 train_time:47895ms step_avg:47.19ms
+step:1016/1600 train_time:47954ms step_avg:47.20ms
+step:1017/1600 train_time:48018ms step_avg:47.22ms
+step:1018/1600 train_time:48079ms step_avg:47.23ms
+step:1019/1600 train_time:48143ms step_avg:47.25ms
+step:1020/1600 train_time:48203ms step_avg:47.26ms
+step:1021/1600 train_time:48265ms step_avg:47.27ms
+step:1022/1600 train_time:48323ms step_avg:47.28ms
+step:1023/1600 train_time:48386ms step_avg:47.30ms
+step:1024/1600 train_time:48444ms step_avg:47.31ms
+step:1025/1600 train_time:48507ms step_avg:47.32ms
+step:1026/1600 train_time:48565ms step_avg:47.33ms
+step:1027/1600 train_time:48627ms step_avg:47.35ms
+step:1028/1600 train_time:48685ms step_avg:47.36ms
+step:1029/1600 train_time:48748ms step_avg:47.37ms
+step:1030/1600 train_time:48806ms step_avg:47.38ms
+step:1031/1600 train_time:48868ms step_avg:47.40ms
+step:1032/1600 train_time:48927ms step_avg:47.41ms
+step:1033/1600 train_time:48991ms step_avg:47.43ms
+step:1034/1600 train_time:49050ms step_avg:47.44ms
+step:1035/1600 train_time:49114ms step_avg:47.45ms
+step:1036/1600 train_time:49175ms step_avg:47.47ms
+step:1037/1600 train_time:49239ms step_avg:47.48ms
+step:1038/1600 train_time:49297ms step_avg:47.49ms
+step:1039/1600 train_time:49359ms step_avg:47.51ms
+step:1040/1600 train_time:49418ms step_avg:47.52ms
+step:1041/1600 train_time:49493ms step_avg:47.54ms
+step:1042/1600 train_time:49573ms step_avg:47.57ms
+step:1043/1600 train_time:49664ms step_avg:47.62ms
+step:1044/1600 train_time:49748ms step_avg:47.65ms
+step:1045/1600 train_time:49835ms step_avg:47.69ms
+step:1046/1600 train_time:49920ms step_avg:47.72ms
+step:1047/1600 train_time:50009ms step_avg:47.76ms
+step:1048/1600 train_time:50094ms step_avg:47.80ms
+step:1049/1600 train_time:50183ms step_avg:47.84ms
+step:1050/1600 train_time:50269ms step_avg:47.88ms
+step:1051/1600 train_time:50358ms step_avg:47.91ms
+step:1052/1600 train_time:50443ms step_avg:47.95ms
+step:1053/1600 train_time:50532ms step_avg:47.99ms
+step:1054/1600 train_time:50616ms step_avg:48.02ms
+step:1055/1600 train_time:50705ms step_avg:48.06ms
+step:1056/1600 train_time:50790ms step_avg:48.10ms
+step:1057/1600 train_time:50878ms step_avg:48.13ms
+step:1058/1600 train_time:50963ms step_avg:48.17ms
+step:1059/1600 train_time:51051ms step_avg:48.21ms
+step:1060/1600 train_time:51137ms step_avg:48.24ms
+step:1061/1600 train_time:51225ms step_avg:48.28ms
+step:1062/1600 train_time:51311ms step_avg:48.32ms
+step:1063/1600 train_time:51398ms step_avg:48.35ms
+step:1064/1600 train_time:51484ms step_avg:48.39ms
+step:1065/1600 train_time:51572ms step_avg:48.42ms
+step:1066/1600 train_time:51656ms step_avg:48.46ms
+step:1067/1600 train_time:51745ms step_avg:48.50ms
+step:1068/1600 train_time:51830ms step_avg:48.53ms
+step:1069/1600 train_time:51918ms step_avg:48.57ms
+step:1070/1600 train_time:52004ms step_avg:48.60ms
+step:1071/1600 train_time:52092ms step_avg:48.64ms
+step:1072/1600 train_time:52178ms step_avg:48.67ms
+step:1073/1600 train_time:52267ms step_avg:48.71ms
+step:1074/1600 train_time:52352ms step_avg:48.74ms
+step:1075/1600 train_time:52440ms step_avg:48.78ms
+step:1076/1600 train_time:52526ms step_avg:48.82ms
+step:1077/1600 train_time:52615ms step_avg:48.85ms
+step:1078/1600 train_time:52701ms step_avg:48.89ms
+step:1079/1600 train_time:52790ms step_avg:48.92ms
+step:1080/1600 train_time:52874ms step_avg:48.96ms
+step:1081/1600 train_time:52962ms step_avg:48.99ms
+step:1082/1600 train_time:53049ms step_avg:49.03ms
+step:1083/1600 train_time:53137ms step_avg:49.06ms
+step:1084/1600 train_time:53224ms step_avg:49.10ms
+step:1085/1600 train_time:53311ms step_avg:49.13ms
+step:1086/1600 train_time:53396ms step_avg:49.17ms
+step:1087/1600 train_time:53485ms step_avg:49.20ms
+step:1088/1600 train_time:53570ms step_avg:49.24ms
+step:1089/1600 train_time:53657ms step_avg:49.27ms
+step:1090/1600 train_time:53743ms step_avg:49.31ms
+step:1091/1600 train_time:53831ms step_avg:49.34ms
+step:1092/1600 train_time:53916ms step_avg:49.37ms
+step:1093/1600 train_time:54004ms step_avg:49.41ms
+step:1094/1600 train_time:54090ms step_avg:49.44ms
+step:1095/1600 train_time:54179ms step_avg:49.48ms
+step:1096/1600 train_time:54264ms step_avg:49.51ms
+step:1097/1600 train_time:54352ms step_avg:49.55ms
+step:1098/1600 train_time:54438ms step_avg:49.58ms
+step:1099/1600 train_time:54527ms step_avg:49.61ms
+step:1100/1600 train_time:54611ms step_avg:49.65ms
+step:1101/1600 train_time:54699ms step_avg:49.68ms
+step:1102/1600 train_time:54787ms step_avg:49.72ms
+step:1103/1600 train_time:54873ms step_avg:49.75ms
+step:1104/1600 train_time:54959ms step_avg:49.78ms
+step:1105/1600 train_time:55046ms step_avg:49.82ms
+step:1106/1600 train_time:55133ms step_avg:49.85ms
+step:1107/1600 train_time:55221ms step_avg:49.88ms
+step:1108/1600 train_time:55306ms step_avg:49.92ms
+step:1109/1600 train_time:55395ms step_avg:49.95ms
+step:1110/1600 train_time:55480ms step_avg:49.98ms
+step:1111/1600 train_time:55568ms step_avg:50.02ms
+step:1112/1600 train_time:55654ms step_avg:50.05ms
+step:1113/1600 train_time:55741ms step_avg:50.08ms
+step:1114/1600 train_time:55826ms step_avg:50.11ms
+step:1115/1600 train_time:55914ms step_avg:50.15ms
+step:1116/1600 train_time:55999ms step_avg:50.18ms
+step:1117/1600 train_time:56089ms step_avg:50.21ms
+step:1118/1600 train_time:56174ms step_avg:50.25ms
+step:1119/1600 train_time:56262ms step_avg:50.28ms
+step:1120/1600 train_time:56347ms step_avg:50.31ms
+step:1121/1600 train_time:56436ms step_avg:50.34ms
+step:1122/1600 train_time:56522ms step_avg:50.38ms
+step:1123/1600 train_time:56611ms step_avg:50.41ms
+step:1124/1600 train_time:56697ms step_avg:50.44ms
+step:1125/1600 train_time:56784ms step_avg:50.47ms
+step:1126/1600 train_time:56871ms step_avg:50.51ms
+step:1127/1600 train_time:56958ms step_avg:50.54ms
+step:1128/1600 train_time:57042ms step_avg:50.57ms
+step:1129/1600 train_time:57130ms step_avg:50.60ms
+step:1130/1600 train_time:57215ms step_avg:50.63ms
+step:1131/1600 train_time:57304ms step_avg:50.67ms
+step:1132/1600 train_time:57389ms step_avg:50.70ms
+step:1133/1600 train_time:57477ms step_avg:50.73ms
+step:1134/1600 train_time:57574ms step_avg:50.77ms
+step:1135/1600 train_time:57664ms step_avg:50.81ms
+step:1136/1600 train_time:57745ms step_avg:50.83ms
+step:1137/1600 train_time:57832ms step_avg:50.86ms
+step:1138/1600 train_time:57917ms step_avg:50.89ms
+step:1139/1600 train_time:58005ms step_avg:50.93ms
+step:1140/1600 train_time:58088ms step_avg:50.95ms
+step:1141/1600 train_time:58175ms step_avg:50.99ms
+step:1142/1600 train_time:58260ms step_avg:51.02ms
+step:1143/1600 train_time:58347ms step_avg:51.05ms
+step:1144/1600 train_time:58432ms step_avg:51.08ms
+step:1145/1600 train_time:58521ms step_avg:51.11ms
+step:1146/1600 train_time:58606ms step_avg:51.14ms
+step:1147/1600 train_time:58694ms step_avg:51.17ms
+step:1148/1600 train_time:58779ms step_avg:51.20ms
+step:1149/1600 train_time:58867ms step_avg:51.23ms
+step:1150/1600 train_time:58953ms step_avg:51.26ms
+step:1151/1600 train_time:59041ms step_avg:51.30ms
+step:1152/1600 train_time:59126ms step_avg:51.32ms
+step:1153/1600 train_time:59215ms step_avg:51.36ms
+step:1154/1600 train_time:59305ms step_avg:51.39ms
+step:1155/1600 train_time:59391ms step_avg:51.42ms
+step:1156/1600 train_time:59476ms step_avg:51.45ms
+step:1157/1600 train_time:59563ms step_avg:51.48ms
+step:1158/1600 train_time:59648ms step_avg:51.51ms
+step:1159/1600 train_time:59736ms step_avg:51.54ms
+step:1160/1600 train_time:59821ms step_avg:51.57ms
+step:1161/1600 train_time:59911ms step_avg:51.60ms
+step:1162/1600 train_time:59996ms step_avg:51.63ms
+step:1163/1600 train_time:60083ms step_avg:51.66ms
+step:1164/1600 train_time:60167ms step_avg:51.69ms
+step:1165/1600 train_time:60257ms step_avg:51.72ms
+step:1166/1600 train_time:60341ms step_avg:51.75ms
+step:1167/1600 train_time:60429ms step_avg:51.78ms
+step:1168/1600 train_time:60514ms step_avg:51.81ms
+step:1169/1600 train_time:60603ms step_avg:51.84ms
+step:1170/1600 train_time:60688ms step_avg:51.87ms
+step:1171/1600 train_time:60776ms step_avg:51.90ms
+step:1172/1600 train_time:60861ms step_avg:51.93ms
+step:1173/1600 train_time:60950ms step_avg:51.96ms
+step:1174/1600 train_time:61035ms step_avg:51.99ms
+step:1175/1600 train_time:61122ms step_avg:52.02ms
+step:1176/1600 train_time:61207ms step_avg:52.05ms
+step:1177/1600 train_time:61296ms step_avg:52.08ms
+step:1178/1600 train_time:61381ms step_avg:52.11ms
+step:1179/1600 train_time:61469ms step_avg:52.14ms
+step:1180/1600 train_time:61554ms step_avg:52.16ms
+step:1181/1600 train_time:61642ms step_avg:52.20ms
+step:1182/1600 train_time:61728ms step_avg:52.22ms
+step:1183/1600 train_time:61817ms step_avg:52.25ms
+step:1184/1600 train_time:61902ms step_avg:52.28ms
+step:1185/1600 train_time:61990ms step_avg:52.31ms
+step:1186/1600 train_time:62075ms step_avg:52.34ms
+step:1187/1600 train_time:62163ms step_avg:52.37ms
+step:1188/1600 train_time:62249ms step_avg:52.40ms
+step:1189/1600 train_time:62336ms step_avg:52.43ms
+step:1190/1600 train_time:62422ms step_avg:52.46ms
+step:1191/1600 train_time:62511ms step_avg:52.49ms
+step:1192/1600 train_time:62596ms step_avg:52.51ms
+step:1193/1600 train_time:62685ms step_avg:52.54ms
+step:1194/1600 train_time:62771ms step_avg:52.57ms
+step:1195/1600 train_time:62858ms step_avg:52.60ms
+step:1196/1600 train_time:62944ms step_avg:52.63ms
+step:1197/1600 train_time:63032ms step_avg:52.66ms
+step:1198/1600 train_time:63117ms step_avg:52.68ms
+step:1199/1600 train_time:63205ms step_avg:52.71ms
+step:1200/1600 train_time:63291ms step_avg:52.74ms
+step:1201/1600 train_time:63378ms step_avg:52.77ms
+step:1202/1600 train_time:63463ms step_avg:52.80ms
+step:1203/1600 train_time:63551ms step_avg:52.83ms
+step:1204/1600 train_time:63637ms step_avg:52.85ms
+step:1205/1600 train_time:63725ms step_avg:52.88ms
+step:1206/1600 train_time:63810ms step_avg:52.91ms
+step:1207/1600 train_time:63898ms step_avg:52.94ms
+step:1208/1600 train_time:63984ms step_avg:52.97ms
+step:1209/1600 train_time:64073ms step_avg:53.00ms
+step:1210/1600 train_time:64158ms step_avg:53.02ms
+step:1211/1600 train_time:64247ms step_avg:53.05ms
+step:1212/1600 train_time:64332ms step_avg:53.08ms
+step:1213/1600 train_time:64419ms step_avg:53.11ms
+step:1214/1600 train_time:64505ms step_avg:53.13ms
+step:1215/1600 train_time:64593ms step_avg:53.16ms
+step:1216/1600 train_time:64679ms step_avg:53.19ms
+step:1217/1600 train_time:64773ms step_avg:53.22ms
+step:1218/1600 train_time:64857ms step_avg:53.25ms
+step:1219/1600 train_time:64945ms step_avg:53.28ms
+step:1220/1600 train_time:65031ms step_avg:53.30ms
+step:1221/1600 train_time:65118ms step_avg:53.33ms
+step:1222/1600 train_time:65203ms step_avg:53.36ms
+step:1223/1600 train_time:65292ms step_avg:53.39ms
+step:1224/1600 train_time:65376ms step_avg:53.41ms
+step:1225/1600 train_time:65466ms step_avg:53.44ms
+step:1226/1600 train_time:65551ms step_avg:53.47ms
+step:1227/1600 train_time:65639ms step_avg:53.50ms
+step:1228/1600 train_time:65725ms step_avg:53.52ms
+step:1229/1600 train_time:65813ms step_avg:53.55ms
+step:1230/1600 train_time:65898ms step_avg:53.58ms
+step:1231/1600 train_time:65987ms step_avg:53.60ms
+step:1232/1600 train_time:66072ms step_avg:53.63ms
+step:1233/1600 train_time:66160ms step_avg:53.66ms
+step:1234/1600 train_time:66246ms step_avg:53.68ms
+step:1235/1600 train_time:66334ms step_avg:53.71ms
+step:1236/1600 train_time:66419ms step_avg:53.74ms
+step:1237/1600 train_time:66508ms step_avg:53.77ms
+step:1238/1600 train_time:66594ms step_avg:53.79ms
+step:1239/1600 train_time:66681ms step_avg:53.82ms
+step:1240/1600 train_time:66768ms step_avg:53.85ms
+step:1241/1600 train_time:66857ms step_avg:53.87ms
+step:1242/1600 train_time:66942ms step_avg:53.90ms
+step:1243/1600 train_time:67031ms step_avg:53.93ms
+step:1244/1600 train_time:67115ms step_avg:53.95ms
+step:1245/1600 train_time:67204ms step_avg:53.98ms
+step:1246/1600 train_time:67289ms step_avg:54.00ms
+step:1247/1600 train_time:67377ms step_avg:54.03ms
+step:1248/1600 train_time:67463ms step_avg:54.06ms
+step:1249/1600 train_time:67551ms step_avg:54.08ms
+step:1250/1600 train_time:67637ms step_avg:54.11ms
+step:1250/1600 val_loss:3.4166 train_time:67710ms step_avg:54.17ms
+step:1251/1600 train_time:67731ms step_avg:54.14ms
+step:1252/1600 train_time:67817ms step_avg:54.17ms
+step:1253/1600 train_time:67909ms step_avg:54.20ms
+step:1254/1600 train_time:67995ms step_avg:54.22ms
+step:1255/1600 train_time:68082ms step_avg:54.25ms
+step:1256/1600 train_time:68167ms step_avg:54.27ms
+step:1257/1600 train_time:68254ms step_avg:54.30ms
+step:1258/1600 train_time:68339ms step_avg:54.32ms
+step:1259/1600 train_time:68426ms step_avg:54.35ms
+step:1260/1600 train_time:68511ms step_avg:54.37ms
+step:1261/1600 train_time:68598ms step_avg:54.40ms
+step:1262/1600 train_time:68684ms step_avg:54.42ms
+step:1263/1600 train_time:68774ms step_avg:54.45ms
+step:1264/1600 train_time:68862ms step_avg:54.48ms
+step:1265/1600 train_time:68952ms step_avg:54.51ms
+step:1266/1600 train_time:69039ms step_avg:54.53ms
+step:1267/1600 train_time:69127ms step_avg:54.56ms
+step:1268/1600 train_time:69211ms step_avg:54.58ms
+step:1269/1600 train_time:69300ms step_avg:54.61ms
+step:1270/1600 train_time:69383ms step_avg:54.63ms
+step:1271/1600 train_time:69470ms step_avg:54.66ms
+step:1272/1600 train_time:69554ms step_avg:54.68ms
+step:1273/1600 train_time:69642ms step_avg:54.71ms
+step:1274/1600 train_time:69727ms step_avg:54.73ms
+step:1275/1600 train_time:69817ms step_avg:54.76ms
+step:1276/1600 train_time:69904ms step_avg:54.78ms
+step:1277/1600 train_time:69994ms step_avg:54.81ms
+step:1278/1600 train_time:70079ms step_avg:54.83ms
+step:1279/1600 train_time:70167ms step_avg:54.86ms
+step:1280/1600 train_time:70252ms step_avg:54.88ms
+step:1281/1600 train_time:70339ms step_avg:54.91ms
+step:1282/1600 train_time:70424ms step_avg:54.93ms
+step:1283/1600 train_time:70513ms step_avg:54.96ms
+step:1284/1600 train_time:70597ms step_avg:54.98ms
+step:1285/1600 train_time:70685ms step_avg:55.01ms
+step:1286/1600 train_time:70772ms step_avg:55.03ms
+step:1287/1600 train_time:70860ms step_avg:55.06ms
+step:1288/1600 train_time:70946ms step_avg:55.08ms
+step:1289/1600 train_time:71035ms step_avg:55.11ms
+step:1290/1600 train_time:71120ms step_avg:55.13ms
+step:1291/1600 train_time:71208ms step_avg:55.16ms
+step:1292/1600 train_time:71292ms step_avg:55.18ms
+step:1293/1600 train_time:71381ms step_avg:55.21ms
+step:1294/1600 train_time:71464ms step_avg:55.23ms
+step:1295/1600 train_time:71552ms step_avg:55.25ms
+step:1296/1600 train_time:71637ms step_avg:55.28ms
+step:1297/1600 train_time:71726ms step_avg:55.30ms
+step:1298/1600 train_time:71812ms step_avg:55.32ms
+step:1299/1600 train_time:71900ms step_avg:55.35ms
+step:1300/1600 train_time:71986ms step_avg:55.37ms
+step:1301/1600 train_time:72075ms step_avg:55.40ms
+step:1302/1600 train_time:72161ms step_avg:55.42ms
+step:1303/1600 train_time:72250ms step_avg:55.45ms
+step:1304/1600 train_time:72334ms step_avg:55.47ms
+step:1305/1600 train_time:72422ms step_avg:55.50ms
+step:1306/1600 train_time:72506ms step_avg:55.52ms
+step:1307/1600 train_time:72594ms step_avg:55.54ms
+step:1308/1600 train_time:72680ms step_avg:55.57ms
+step:1309/1600 train_time:72770ms step_avg:55.59ms
+step:1310/1600 train_time:72855ms step_avg:55.61ms
+step:1311/1600 train_time:72945ms step_avg:55.64ms
+step:1312/1600 train_time:73030ms step_avg:55.66ms
+step:1313/1600 train_time:73118ms step_avg:55.69ms
+step:1314/1600 train_time:73204ms step_avg:55.71ms
+step:1315/1600 train_time:73291ms step_avg:55.73ms
+step:1316/1600 train_time:73377ms step_avg:55.76ms
+step:1317/1600 train_time:73465ms step_avg:55.78ms
+step:1318/1600 train_time:73550ms step_avg:55.80ms
+step:1319/1600 train_time:73638ms step_avg:55.83ms
+step:1320/1600 train_time:73723ms step_avg:55.85ms
+step:1321/1600 train_time:73811ms step_avg:55.88ms
+step:1322/1600 train_time:73899ms step_avg:55.90ms
+step:1323/1600 train_time:73987ms step_avg:55.92ms
+step:1324/1600 train_time:74072ms step_avg:55.95ms
+step:1325/1600 train_time:74160ms step_avg:55.97ms
+step:1326/1600 train_time:74244ms step_avg:55.99ms
+step:1327/1600 train_time:74332ms step_avg:56.02ms
+step:1328/1600 train_time:74419ms step_avg:56.04ms
+step:1329/1600 train_time:74506ms step_avg:56.06ms
+step:1330/1600 train_time:74591ms step_avg:56.08ms
+step:1331/1600 train_time:74679ms step_avg:56.11ms
+step:1332/1600 train_time:74764ms step_avg:56.13ms
+step:1333/1600 train_time:74854ms step_avg:56.15ms
+step:1334/1600 train_time:74939ms step_avg:56.18ms
+step:1335/1600 train_time:75027ms step_avg:56.20ms
+step:1336/1600 train_time:75112ms step_avg:56.22ms
+step:1337/1600 train_time:75201ms step_avg:56.25ms
+step:1338/1600 train_time:75286ms step_avg:56.27ms
+step:1339/1600 train_time:75373ms step_avg:56.29ms
+step:1340/1600 train_time:75458ms step_avg:56.31ms
+step:1341/1600 train_time:75546ms step_avg:56.34ms
+step:1342/1600 train_time:75631ms step_avg:56.36ms
+step:1343/1600 train_time:75719ms step_avg:56.38ms
+step:1344/1600 train_time:75805ms step_avg:56.40ms
+step:1345/1600 train_time:75894ms step_avg:56.43ms
+step:1346/1600 train_time:75977ms step_avg:56.45ms
+step:1347/1600 train_time:76066ms step_avg:56.47ms
+step:1348/1600 train_time:76152ms step_avg:56.49ms
+step:1349/1600 train_time:76240ms step_avg:56.52ms
+step:1350/1600 train_time:76325ms step_avg:56.54ms
+step:1351/1600 train_time:76414ms step_avg:56.56ms
+step:1352/1600 train_time:76499ms step_avg:56.58ms
+step:1353/1600 train_time:76587ms step_avg:56.61ms
+step:1354/1600 train_time:76672ms step_avg:56.63ms
+step:1355/1600 train_time:76760ms step_avg:56.65ms
+step:1356/1600 train_time:76846ms step_avg:56.67ms
+step:1357/1600 train_time:76935ms step_avg:56.69ms
+step:1358/1600 train_time:77020ms step_avg:56.72ms
+step:1359/1600 train_time:77108ms step_avg:56.74ms
+step:1360/1600 train_time:77193ms step_avg:56.76ms
+step:1361/1600 train_time:77280ms step_avg:56.78ms
+step:1362/1600 train_time:77366ms step_avg:56.80ms
+step:1363/1600 train_time:77454ms step_avg:56.83ms
+step:1364/1600 train_time:77539ms step_avg:56.85ms
+step:1365/1600 train_time:77628ms step_avg:56.87ms
+step:1366/1600 train_time:77717ms step_avg:56.89ms
+step:1367/1600 train_time:77804ms step_avg:56.92ms
+step:1368/1600 train_time:77889ms step_avg:56.94ms
+step:1369/1600 train_time:77975ms step_avg:56.96ms
+step:1370/1600 train_time:78061ms step_avg:56.98ms
+step:1371/1600 train_time:78149ms step_avg:57.00ms
+step:1372/1600 train_time:78233ms step_avg:57.02ms
+step:1373/1600 train_time:78322ms step_avg:57.04ms
+step:1374/1600 train_time:78407ms step_avg:57.07ms
+step:1375/1600 train_time:78495ms step_avg:57.09ms
+step:1376/1600 train_time:78580ms step_avg:57.11ms
+step:1377/1600 train_time:78669ms step_avg:57.13ms
+step:1378/1600 train_time:78754ms step_avg:57.15ms
+step:1379/1600 train_time:78844ms step_avg:57.18ms
+step:1380/1600 train_time:78929ms step_avg:57.20ms
+step:1381/1600 train_time:79016ms step_avg:57.22ms
+step:1382/1600 train_time:79102ms step_avg:57.24ms
+step:1383/1600 train_time:79191ms step_avg:57.26ms
+step:1384/1600 train_time:79276ms step_avg:57.28ms
+step:1385/1600 train_time:79365ms step_avg:57.30ms
+step:1386/1600 train_time:79450ms step_avg:57.32ms
+step:1387/1600 train_time:79541ms step_avg:57.35ms
+step:1388/1600 train_time:79624ms step_avg:57.37ms
+step:1389/1600 train_time:79712ms step_avg:57.39ms
+step:1390/1600 train_time:79797ms step_avg:57.41ms
+step:1391/1600 train_time:79885ms step_avg:57.43ms
+step:1392/1600 train_time:79970ms step_avg:57.45ms
+step:1393/1600 train_time:80058ms step_avg:57.47ms
+step:1394/1600 train_time:80145ms step_avg:57.49ms
+step:1395/1600 train_time:80233ms step_avg:57.51ms
+step:1396/1600 train_time:80319ms step_avg:57.53ms
+step:1397/1600 train_time:80409ms step_avg:57.56ms
+step:1398/1600 train_time:80493ms step_avg:57.58ms
+step:1399/1600 train_time:80582ms step_avg:57.60ms
+step:1400/1600 train_time:80667ms step_avg:57.62ms
+step:1401/1600 train_time:80755ms step_avg:57.64ms
+step:1402/1600 train_time:80841ms step_avg:57.66ms
+step:1403/1600 train_time:80929ms step_avg:57.68ms
+step:1404/1600 train_time:81014ms step_avg:57.70ms
+step:1405/1600 train_time:81102ms step_avg:57.72ms
+step:1406/1600 train_time:81188ms step_avg:57.74ms
+step:1407/1600 train_time:81276ms step_avg:57.77ms
+step:1408/1600 train_time:81362ms step_avg:57.79ms
+step:1409/1600 train_time:81451ms step_avg:57.81ms
+step:1410/1600 train_time:81535ms step_avg:57.83ms
+step:1411/1600 train_time:81624ms step_avg:57.85ms
+step:1412/1600 train_time:81709ms step_avg:57.87ms
+step:1413/1600 train_time:81797ms step_avg:57.89ms
+step:1414/1600 train_time:81882ms step_avg:57.91ms
+step:1415/1600 train_time:81970ms step_avg:57.93ms
+step:1416/1600 train_time:82055ms step_avg:57.95ms
+step:1417/1600 train_time:82143ms step_avg:57.97ms
+step:1418/1600 train_time:82227ms step_avg:57.99ms
+step:1419/1600 train_time:82317ms step_avg:58.01ms
+step:1420/1600 train_time:82403ms step_avg:58.03ms
+step:1421/1600 train_time:82492ms step_avg:58.05ms
+step:1422/1600 train_time:82576ms step_avg:58.07ms
+step:1423/1600 train_time:82665ms step_avg:58.09ms
+step:1424/1600 train_time:82750ms step_avg:58.11ms
+step:1425/1600 train_time:82838ms step_avg:58.13ms
+step:1426/1600 train_time:82924ms step_avg:58.15ms
+step:1427/1600 train_time:83012ms step_avg:58.17ms
+step:1428/1600 train_time:83097ms step_avg:58.19ms
+step:1429/1600 train_time:83185ms step_avg:58.21ms
+step:1430/1600 train_time:83271ms step_avg:58.23ms
+step:1431/1600 train_time:83359ms step_avg:58.25ms
+step:1432/1600 train_time:83445ms step_avg:58.27ms
+step:1433/1600 train_time:83532ms step_avg:58.29ms
+step:1434/1600 train_time:83617ms step_avg:58.31ms
+step:1435/1600 train_time:83706ms step_avg:58.33ms
+step:1436/1600 train_time:83792ms step_avg:58.35ms
+step:1437/1600 train_time:83880ms step_avg:58.37ms
+step:1438/1600 train_time:83966ms step_avg:58.39ms
+step:1439/1600 train_time:84054ms step_avg:58.41ms
+step:1440/1600 train_time:84139ms step_avg:58.43ms
+step:1441/1600 train_time:84227ms step_avg:58.45ms
+step:1442/1600 train_time:84312ms step_avg:58.47ms
+step:1443/1600 train_time:84401ms step_avg:58.49ms
+step:1444/1600 train_time:84485ms step_avg:58.51ms
+step:1445/1600 train_time:84574ms step_avg:58.53ms
+step:1446/1600 train_time:84661ms step_avg:58.55ms
+step:1447/1600 train_time:84750ms step_avg:58.57ms
+step:1448/1600 train_time:84835ms step_avg:58.59ms
+step:1449/1600 train_time:84922ms step_avg:58.61ms
+step:1450/1600 train_time:85006ms step_avg:58.63ms
+step:1451/1600 train_time:85095ms step_avg:58.65ms
+step:1452/1600 train_time:85181ms step_avg:58.66ms
+step:1453/1600 train_time:85269ms step_avg:58.68ms
+step:1454/1600 train_time:85354ms step_avg:58.70ms
+step:1455/1600 train_time:85442ms step_avg:58.72ms
+step:1456/1600 train_time:85527ms step_avg:58.74ms
+step:1457/1600 train_time:85616ms step_avg:58.76ms
+step:1458/1600 train_time:85702ms step_avg:58.78ms
+step:1459/1600 train_time:85790ms step_avg:58.80ms
+step:1460/1600 train_time:85876ms step_avg:58.82ms
+step:1461/1600 train_time:85964ms step_avg:58.84ms
+step:1462/1600 train_time:86049ms step_avg:58.86ms
+step:1463/1600 train_time:86138ms step_avg:58.88ms
+step:1464/1600 train_time:86224ms step_avg:58.90ms
+step:1465/1600 train_time:86313ms step_avg:58.92ms
+step:1466/1600 train_time:86398ms step_avg:58.93ms
+step:1467/1600 train_time:86486ms step_avg:58.95ms
+step:1468/1600 train_time:86571ms step_avg:58.97ms
+step:1469/1600 train_time:86659ms step_avg:58.99ms
+step:1470/1600 train_time:86745ms step_avg:59.01ms
+step:1471/1600 train_time:86832ms step_avg:59.03ms
+step:1472/1600 train_time:86919ms step_avg:59.05ms
+step:1473/1600 train_time:87006ms step_avg:59.07ms
+step:1474/1600 train_time:87091ms step_avg:59.09ms
+step:1475/1600 train_time:87181ms step_avg:59.11ms
+step:1476/1600 train_time:87265ms step_avg:59.12ms
+step:1477/1600 train_time:87354ms step_avg:59.14ms
+step:1478/1600 train_time:87438ms step_avg:59.16ms
+step:1479/1600 train_time:87527ms step_avg:59.18ms
+step:1480/1600 train_time:87612ms step_avg:59.20ms
+step:1481/1600 train_time:87701ms step_avg:59.22ms
+step:1482/1600 train_time:87785ms step_avg:59.23ms
+step:1483/1600 train_time:87874ms step_avg:59.25ms
+step:1484/1600 train_time:87960ms step_avg:59.27ms
+step:1485/1600 train_time:88047ms step_avg:59.29ms
+step:1486/1600 train_time:88132ms step_avg:59.31ms
+step:1487/1600 train_time:88221ms step_avg:59.33ms
+step:1488/1600 train_time:88305ms step_avg:59.35ms
+step:1489/1600 train_time:88394ms step_avg:59.36ms
+step:1490/1600 train_time:88480ms step_avg:59.38ms
+step:1491/1600 train_time:88569ms step_avg:59.40ms
+step:1492/1600 train_time:88653ms step_avg:59.42ms
+step:1493/1600 train_time:88742ms step_avg:59.44ms
+step:1494/1600 train_time:88826ms step_avg:59.46ms
+step:1495/1600 train_time:88916ms step_avg:59.48ms
+step:1496/1600 train_time:89001ms step_avg:59.49ms
+step:1497/1600 train_time:89089ms step_avg:59.51ms
+step:1498/1600 train_time:89174ms step_avg:59.53ms
+step:1499/1600 train_time:89262ms step_avg:59.55ms
+step:1500/1600 train_time:89347ms step_avg:59.56ms
+step:1500/1600 val_loss:3.3079 train_time:89418ms step_avg:59.61ms
+step:1501/1600 train_time:89439ms step_avg:59.59ms
+step:1502/1600 train_time:89526ms step_avg:59.60ms
+step:1503/1600 train_time:89618ms step_avg:59.63ms
+step:1504/1600 train_time:89704ms step_avg:59.64ms
+step:1505/1600 train_time:89791ms step_avg:59.66ms
+step:1506/1600 train_time:89875ms step_avg:59.68ms
+step:1507/1600 train_time:89963ms step_avg:59.70ms
+step:1508/1600 train_time:90047ms step_avg:59.71ms
+step:1509/1600 train_time:90133ms step_avg:59.73ms
+step:1510/1600 train_time:90218ms step_avg:59.75ms
+step:1511/1600 train_time:90305ms step_avg:59.77ms
+step:1512/1600 train_time:90390ms step_avg:59.78ms
+step:1513/1600 train_time:90480ms step_avg:59.80ms
+step:1514/1600 train_time:90568ms step_avg:59.82ms
+step:1515/1600 train_time:90659ms step_avg:59.84ms
+step:1516/1600 train_time:90744ms step_avg:59.86ms
+step:1517/1600 train_time:90832ms step_avg:59.88ms
+step:1518/1600 train_time:90917ms step_avg:59.89ms
+step:1519/1600 train_time:91004ms step_avg:59.91ms
+step:1520/1600 train_time:91088ms step_avg:59.93ms
+step:1521/1600 train_time:91175ms step_avg:59.94ms
+step:1522/1600 train_time:91260ms step_avg:59.96ms
+step:1523/1600 train_time:91348ms step_avg:59.98ms
+step:1524/1600 train_time:91433ms step_avg:60.00ms
+step:1525/1600 train_time:91523ms step_avg:60.01ms
+step:1526/1600 train_time:91609ms step_avg:60.03ms
+step:1527/1600 train_time:91698ms step_avg:60.05ms
+step:1528/1600 train_time:91783ms step_avg:60.07ms
+step:1529/1600 train_time:91871ms step_avg:60.09ms
+step:1530/1600 train_time:91957ms step_avg:60.10ms
+step:1531/1600 train_time:92045ms step_avg:60.12ms
+step:1532/1600 train_time:92130ms step_avg:60.14ms
+step:1533/1600 train_time:92216ms step_avg:60.15ms
+step:1534/1600 train_time:92301ms step_avg:60.17ms
+step:1535/1600 train_time:92390ms step_avg:60.19ms
+step:1536/1600 train_time:92476ms step_avg:60.21ms
+step:1537/1600 train_time:92565ms step_avg:60.22ms
+step:1538/1600 train_time:92651ms step_avg:60.24ms
+step:1539/1600 train_time:92739ms step_avg:60.26ms
+step:1540/1600 train_time:92825ms step_avg:60.28ms
+step:1541/1600 train_time:92914ms step_avg:60.29ms
+step:1542/1600 train_time:93000ms step_avg:60.31ms
+step:1543/1600 train_time:93088ms step_avg:60.33ms
+step:1544/1600 train_time:93171ms step_avg:60.34ms
+step:1545/1600 train_time:93258ms step_avg:60.36ms
+step:1546/1600 train_time:93344ms step_avg:60.38ms
+step:1547/1600 train_time:93432ms step_avg:60.40ms
+step:1548/1600 train_time:93518ms step_avg:60.41ms
+step:1549/1600 train_time:93607ms step_avg:60.43ms
+step:1550/1600 train_time:93693ms step_avg:60.45ms
+step:1551/1600 train_time:93781ms step_avg:60.47ms
+step:1552/1600 train_time:93867ms step_avg:60.48ms
+step:1553/1600 train_time:93957ms step_avg:60.50ms
+step:1554/1600 train_time:94042ms step_avg:60.52ms
+step:1555/1600 train_time:94128ms step_avg:60.53ms
+step:1556/1600 train_time:94212ms step_avg:60.55ms
+step:1557/1600 train_time:94300ms step_avg:60.57ms
+step:1558/1600 train_time:94388ms step_avg:60.58ms
+step:1559/1600 train_time:94474ms step_avg:60.60ms
+step:1560/1600 train_time:94560ms step_avg:60.62ms
+step:1561/1600 train_time:94657ms step_avg:60.64ms
+step:1562/1600 train_time:94742ms step_avg:60.65ms
+step:1563/1600 train_time:94830ms step_avg:60.67ms
+step:1564/1600 train_time:94915ms step_avg:60.69ms
+step:1565/1600 train_time:95003ms step_avg:60.71ms
+step:1566/1600 train_time:95089ms step_avg:60.72ms
+step:1567/1600 train_time:95177ms step_avg:60.74ms
+step:1568/1600 train_time:95262ms step_avg:60.75ms
+step:1569/1600 train_time:95351ms step_avg:60.77ms
+step:1570/1600 train_time:95437ms step_avg:60.79ms
+step:1571/1600 train_time:95527ms step_avg:60.81ms
+step:1572/1600 train_time:95612ms step_avg:60.82ms
+step:1573/1600 train_time:95702ms step_avg:60.84ms
+step:1574/1600 train_time:95788ms step_avg:60.86ms
+step:1575/1600 train_time:95875ms step_avg:60.87ms
+step:1576/1600 train_time:95962ms step_avg:60.89ms
+step:1577/1600 train_time:96054ms step_avg:60.91ms
+step:1578/1600 train_time:96137ms step_avg:60.92ms
+step:1579/1600 train_time:96225ms step_avg:60.94ms
+step:1580/1600 train_time:96310ms step_avg:60.96ms
+step:1581/1600 train_time:96398ms step_avg:60.97ms
+step:1582/1600 train_time:96485ms step_avg:60.99ms
+step:1583/1600 train_time:96573ms step_avg:61.01ms
+step:1584/1600 train_time:96659ms step_avg:61.02ms
+step:1585/1600 train_time:96749ms step_avg:61.04ms
+step:1586/1600 train_time:96834ms step_avg:61.06ms
+step:1587/1600 train_time:96923ms step_avg:61.07ms
+step:1588/1600 train_time:97008ms step_avg:61.09ms
+step:1589/1600 train_time:97096ms step_avg:61.11ms
+step:1590/1600 train_time:97183ms step_avg:61.12ms
+step:1591/1600 train_time:97271ms step_avg:61.14ms
+step:1592/1600 train_time:97356ms step_avg:61.15ms
+step:1593/1600 train_time:97446ms step_avg:61.17ms
+step:1594/1600 train_time:97531ms step_avg:61.19ms
+step:1595/1600 train_time:97620ms step_avg:61.20ms
+step:1596/1600 train_time:97706ms step_avg:61.22ms
+step:1597/1600 train_time:97794ms step_avg:61.24ms
+step:1598/1600 train_time:97879ms step_avg:61.25ms
+step:1599/1600 train_time:97968ms step_avg:61.27ms
+step:1600/1600 train_time:98053ms step_avg:61.28ms
+step:1600/1600 val_loss:3.2784 train_time:98124ms step_avg:61.33ms
+peak memory allocated: 30264 MiB reserved: 46238 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/README.md
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/README.md
@@ -1,0 +1,39 @@
+Updates in PR, building off latest [PR#201](https://github.com/KellerJordan/modded-nanogpt/pull/201):
+- Untie value embeddings to replace pattern of `VE[.12...012]` with `VE[.01...345]`.
+
+## Ideas
+
+The latest idea is inspired by the principle of Bigram/Engram Hash embeddings to allow more uncontextualised information into the architecture. I believe there's further room in adding sparsity to be explored, i.e. Meta's STEM and optimizing the bwd to not communicate unaccessed indices in sparse embeddings.
+
+I tried these ablations:
+- Same weights but more tied layers: `ve[012...012]` (1) 
+- Fewer VE tied layers: `ve[01…01]`
+- Different layers: `ve[.01…01.]`
+- Apply VE to all layers
+Surprisingly, the [old finding](https://github.com/KellerJordan/modded-nanogpt/pull/194) (1) that adding VE to the first layer no longer held up. I hypothesize that improvements in between (Partial Key Offset, Bigram Hash) removed the need for this somehow, but I'm not quite sure why.
+
+Unrelated to this VE idea, I tried to optimize the bwd with `torch.Embedding(..., sparse=True)`, but I'm running into 2 issues: 1) the metadata overhead of keeping count of the accessed indices complicates the Adam step, especially when distributed, and 2) Full CUDA graphs aren't preserved under sparse embeddings in [2.10](https://github.com/pytorch/pytorch/issues/150656).
+
+## Timing
+
+The timings (-25 steps) hold up to the latest PR, and are significant (p<0.001).
+- H0: Control is latest WR at 1600 steps.
+- H1: Untie VE at 1575 steps.
+
+```
+                   Runs   Time μ  Time σ  Time +/-  Time p  Loss μ  Loss σ  Loss +/-      p
+H0                   10  98.1066  0.0904    0.0000     NaN  3.2778  0.0010    0.0000 0.0000
+H1                   10  97.7141  0.0533   -0.3925  0.0000  3.2784  0.0009    0.0006 0.0002
+
+H0:
+  losses = [3.2776, 3.2785, 3.277, 3.2772, 3.2788, 3.2764, 3.2763, 3.2784, 3.2788, 3.2791]
+  times  = [98.081, 98.053, 97.895, 98.193, 98.136, 98.093, 98.11, 98.124, 98.156, 98.225]
+  (n = 10)
+
+H1:
+  losses = [3.2784, 3.2778, 3.2792, 3.2799, 3.2776, 3.2782, 3.2771, 3.2786, 3.2775, 3.2794]
+  times  = [97.715, 97.704, 97.725, 97.666, 97.725, 97.632, 97.755, 97.831, 97.697, 97.691]
+  (n = 10)
+```
+
+The 3 extra embedding weights in H1 added to the average step time, compared to H0. I suggest we time this improvement `time delta = 98.1-97.7 = 0.4s`.

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/a1243426-0fde-41ae-8a86-85c996f2b191.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/a1243426-0fde-41ae-8a86-85c996f2b191.txt
@@ -1,0 +1,4119 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 03:10:00 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   34C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   40C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   41C    P0            130W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   39C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          288633      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          288634      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          288635      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          288636      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          288637      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          288638      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          288639      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          288640      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8301 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:89ms step_avg:88.63ms
+step:2/1600 train_time:112ms step_avg:56.05ms
+step:3/1600 train_time:133ms step_avg:44.33ms
+step:4/1600 train_time:165ms step_avg:41.25ms
+step:5/1600 train_time:195ms step_avg:38.91ms
+step:6/1600 train_time:298ms step_avg:49.66ms
+step:7/1600 train_time:317ms step_avg:45.28ms
+step:8/1600 train_time:438ms step_avg:54.72ms
+step:9/1600 train_time:468ms step_avg:51.99ms
+step:10/1600 train_time:505ms step_avg:50.49ms
+step:11/1600 train_time:535ms step_avg:48.66ms
+step:12/1600 train_time:573ms step_avg:47.72ms
+step:13/1600 train_time:603ms step_avg:46.39ms
+step:14/1600 train_time:640ms step_avg:45.73ms
+step:15/1600 train_time:671ms step_avg:44.71ms
+step:16/1600 train_time:708ms step_avg:44.26ms
+step:17/1600 train_time:739ms step_avg:43.48ms
+step:18/1600 train_time:777ms step_avg:43.15ms
+step:19/1600 train_time:807ms step_avg:42.48ms
+step:20/1600 train_time:844ms step_avg:42.21ms
+step:21/1600 train_time:875ms step_avg:41.66ms
+step:22/1600 train_time:913ms step_avg:41.48ms
+step:23/1600 train_time:943ms step_avg:40.99ms
+step:24/1600 train_time:980ms step_avg:40.85ms
+step:25/1600 train_time:1011ms step_avg:40.44ms
+step:26/1600 train_time:1048ms step_avg:40.32ms
+step:27/1600 train_time:1079ms step_avg:39.95ms
+step:28/1600 train_time:1116ms step_avg:39.85ms
+step:29/1600 train_time:1146ms step_avg:39.53ms
+step:30/1600 train_time:1184ms step_avg:39.45ms
+step:31/1600 train_time:1214ms step_avg:39.16ms
+step:32/1600 train_time:1252ms step_avg:39.12ms
+step:33/1600 train_time:1282ms step_avg:38.85ms
+step:34/1600 train_time:1320ms step_avg:38.82ms
+step:35/1600 train_time:1351ms step_avg:38.59ms
+step:36/1600 train_time:1389ms step_avg:38.57ms
+step:37/1600 train_time:1419ms step_avg:38.36ms
+step:38/1600 train_time:1456ms step_avg:38.32ms
+step:39/1600 train_time:1487ms step_avg:38.13ms
+step:40/1600 train_time:1524ms step_avg:38.10ms
+step:41/1600 train_time:1555ms step_avg:37.92ms
+step:42/1600 train_time:1593ms step_avg:37.92ms
+step:43/1600 train_time:1623ms step_avg:37.76ms
+step:44/1600 train_time:1661ms step_avg:37.76ms
+step:45/1600 train_time:1692ms step_avg:37.60ms
+step:46/1600 train_time:1729ms step_avg:37.60ms
+step:47/1600 train_time:1760ms step_avg:37.45ms
+step:48/1600 train_time:1798ms step_avg:37.45ms
+step:49/1600 train_time:1828ms step_avg:37.31ms
+step:50/1600 train_time:1865ms step_avg:37.31ms
+step:51/1600 train_time:1896ms step_avg:37.18ms
+step:52/1600 train_time:1934ms step_avg:37.19ms
+step:53/1600 train_time:1964ms step_avg:37.06ms
+step:54/1600 train_time:2001ms step_avg:37.06ms
+step:55/1600 train_time:2032ms step_avg:36.94ms
+step:56/1600 train_time:2069ms step_avg:36.95ms
+step:57/1600 train_time:2100ms step_avg:36.84ms
+step:58/1600 train_time:2137ms step_avg:36.84ms
+step:59/1600 train_time:2168ms step_avg:36.74ms
+step:60/1600 train_time:2205ms step_avg:36.75ms
+step:61/1600 train_time:2236ms step_avg:36.65ms
+step:62/1600 train_time:2273ms step_avg:36.66ms
+step:63/1600 train_time:2303ms step_avg:36.56ms
+step:64/1600 train_time:2340ms step_avg:36.57ms
+step:65/1600 train_time:2371ms step_avg:36.48ms
+step:66/1600 train_time:2408ms step_avg:36.49ms
+step:67/1600 train_time:2439ms step_avg:36.40ms
+step:68/1600 train_time:2477ms step_avg:36.42ms
+step:69/1600 train_time:2507ms step_avg:36.33ms
+step:70/1600 train_time:2544ms step_avg:36.35ms
+step:71/1600 train_time:2575ms step_avg:36.27ms
+step:72/1600 train_time:2613ms step_avg:36.29ms
+step:73/1600 train_time:2643ms step_avg:36.21ms
+step:74/1600 train_time:2681ms step_avg:36.22ms
+step:75/1600 train_time:2711ms step_avg:36.15ms
+step:76/1600 train_time:2749ms step_avg:36.17ms
+step:77/1600 train_time:2779ms step_avg:36.10ms
+step:78/1600 train_time:2817ms step_avg:36.11ms
+step:79/1600 train_time:2848ms step_avg:36.05ms
+step:80/1600 train_time:2885ms step_avg:36.07ms
+step:81/1600 train_time:2916ms step_avg:36.00ms
+step:82/1600 train_time:2953ms step_avg:36.02ms
+step:83/1600 train_time:2984ms step_avg:35.95ms
+step:84/1600 train_time:3021ms step_avg:35.96ms
+step:85/1600 train_time:3052ms step_avg:35.90ms
+step:86/1600 train_time:3089ms step_avg:35.92ms
+step:87/1600 train_time:3119ms step_avg:35.85ms
+step:88/1600 train_time:3157ms step_avg:35.87ms
+step:89/1600 train_time:3187ms step_avg:35.81ms
+step:90/1600 train_time:3225ms step_avg:35.83ms
+step:91/1600 train_time:3256ms step_avg:35.78ms
+step:92/1600 train_time:3293ms step_avg:35.80ms
+step:93/1600 train_time:3324ms step_avg:35.74ms
+step:94/1600 train_time:3361ms step_avg:35.76ms
+step:95/1600 train_time:3391ms step_avg:35.70ms
+step:96/1600 train_time:3429ms step_avg:35.72ms
+step:97/1600 train_time:3460ms step_avg:35.67ms
+step:98/1600 train_time:3497ms step_avg:35.68ms
+step:99/1600 train_time:3528ms step_avg:35.63ms
+step:100/1600 train_time:3565ms step_avg:35.65ms
+step:101/1600 train_time:3596ms step_avg:35.60ms
+step:102/1600 train_time:3633ms step_avg:35.62ms
+step:103/1600 train_time:3664ms step_avg:35.57ms
+step:104/1600 train_time:3701ms step_avg:35.59ms
+step:105/1600 train_time:3731ms step_avg:35.54ms
+step:106/1600 train_time:3769ms step_avg:35.56ms
+step:107/1600 train_time:3800ms step_avg:35.51ms
+step:108/1600 train_time:3837ms step_avg:35.53ms
+step:109/1600 train_time:3868ms step_avg:35.49ms
+step:110/1600 train_time:3906ms step_avg:35.51ms
+step:111/1600 train_time:3937ms step_avg:35.47ms
+step:112/1600 train_time:3974ms step_avg:35.48ms
+step:113/1600 train_time:4004ms step_avg:35.43ms
+step:114/1600 train_time:4041ms step_avg:35.45ms
+step:115/1600 train_time:4072ms step_avg:35.41ms
+step:116/1600 train_time:4109ms step_avg:35.43ms
+step:117/1600 train_time:4140ms step_avg:35.38ms
+step:118/1600 train_time:4177ms step_avg:35.40ms
+step:119/1600 train_time:4208ms step_avg:35.36ms
+step:120/1600 train_time:4245ms step_avg:35.38ms
+step:121/1600 train_time:4276ms step_avg:35.34ms
+step:122/1600 train_time:4313ms step_avg:35.36ms
+step:123/1600 train_time:4344ms step_avg:35.32ms
+step:124/1600 train_time:4381ms step_avg:35.33ms
+step:125/1600 train_time:4412ms step_avg:35.29ms
+step:126/1600 train_time:4449ms step_avg:35.31ms
+step:127/1600 train_time:4480ms step_avg:35.28ms
+step:128/1600 train_time:4517ms step_avg:35.29ms
+step:129/1600 train_time:4548ms step_avg:35.25ms
+step:130/1600 train_time:4585ms step_avg:35.27ms
+step:131/1600 train_time:4616ms step_avg:35.24ms
+step:132/1600 train_time:4654ms step_avg:35.26ms
+step:133/1600 train_time:4684ms step_avg:35.22ms
+step:134/1600 train_time:4721ms step_avg:35.23ms
+step:135/1600 train_time:4752ms step_avg:35.20ms
+step:136/1600 train_time:4791ms step_avg:35.23ms
+step:137/1600 train_time:4821ms step_avg:35.19ms
+step:138/1600 train_time:4859ms step_avg:35.21ms
+step:139/1600 train_time:4890ms step_avg:35.18ms
+step:140/1600 train_time:4927ms step_avg:35.19ms
+step:141/1600 train_time:4957ms step_avg:35.16ms
+step:142/1600 train_time:4995ms step_avg:35.18ms
+step:143/1600 train_time:5026ms step_avg:35.14ms
+step:144/1600 train_time:5063ms step_avg:35.16ms
+step:145/1600 train_time:5093ms step_avg:35.13ms
+step:146/1600 train_time:5131ms step_avg:35.15ms
+step:147/1600 train_time:5162ms step_avg:35.11ms
+step:148/1600 train_time:5199ms step_avg:35.13ms
+step:149/1600 train_time:5230ms step_avg:35.10ms
+step:150/1600 train_time:5267ms step_avg:35.12ms
+step:151/1600 train_time:5298ms step_avg:35.09ms
+step:152/1600 train_time:5335ms step_avg:35.10ms
+step:153/1600 train_time:5366ms step_avg:35.07ms
+step:154/1600 train_time:5403ms step_avg:35.08ms
+step:155/1600 train_time:5433ms step_avg:35.05ms
+step:156/1600 train_time:5471ms step_avg:35.07ms
+step:157/1600 train_time:5501ms step_avg:35.04ms
+step:158/1600 train_time:5538ms step_avg:35.05ms
+step:159/1600 train_time:5569ms step_avg:35.02ms
+step:160/1600 train_time:5606ms step_avg:35.04ms
+step:161/1600 train_time:5637ms step_avg:35.01ms
+step:162/1600 train_time:5674ms step_avg:35.03ms
+step:163/1600 train_time:5704ms step_avg:35.00ms
+step:164/1600 train_time:5742ms step_avg:35.01ms
+step:165/1600 train_time:5772ms step_avg:34.98ms
+step:166/1600 train_time:5810ms step_avg:35.00ms
+step:167/1600 train_time:5840ms step_avg:34.97ms
+step:168/1600 train_time:5877ms step_avg:34.98ms
+step:169/1600 train_time:5908ms step_avg:34.96ms
+step:170/1600 train_time:5946ms step_avg:34.97ms
+step:171/1600 train_time:5976ms step_avg:34.95ms
+step:172/1600 train_time:6014ms step_avg:34.97ms
+step:173/1600 train_time:6044ms step_avg:34.94ms
+step:174/1600 train_time:6082ms step_avg:34.95ms
+step:175/1600 train_time:6112ms step_avg:34.92ms
+step:176/1600 train_time:6150ms step_avg:34.94ms
+step:177/1600 train_time:6180ms step_avg:34.92ms
+step:178/1600 train_time:6217ms step_avg:34.93ms
+step:179/1600 train_time:6248ms step_avg:34.91ms
+step:180/1600 train_time:6286ms step_avg:34.92ms
+step:181/1600 train_time:6316ms step_avg:34.90ms
+step:182/1600 train_time:6354ms step_avg:34.91ms
+step:183/1600 train_time:6384ms step_avg:34.89ms
+step:184/1600 train_time:6421ms step_avg:34.90ms
+step:185/1600 train_time:6452ms step_avg:34.88ms
+step:186/1600 train_time:6490ms step_avg:34.89ms
+step:187/1600 train_time:6520ms step_avg:34.87ms
+step:188/1600 train_time:6557ms step_avg:34.88ms
+step:189/1600 train_time:6588ms step_avg:34.86ms
+step:190/1600 train_time:6625ms step_avg:34.87ms
+step:191/1600 train_time:6656ms step_avg:34.85ms
+step:192/1600 train_time:6693ms step_avg:34.86ms
+step:193/1600 train_time:6724ms step_avg:34.84ms
+step:194/1600 train_time:6761ms step_avg:34.85ms
+step:195/1600 train_time:6791ms step_avg:34.83ms
+step:196/1600 train_time:6829ms step_avg:34.84ms
+step:197/1600 train_time:6860ms step_avg:34.82ms
+step:198/1600 train_time:6897ms step_avg:34.83ms
+step:199/1600 train_time:6927ms step_avg:34.81ms
+step:200/1600 train_time:6965ms step_avg:34.83ms
+step:201/1600 train_time:6996ms step_avg:34.80ms
+step:202/1600 train_time:7033ms step_avg:34.82ms
+step:203/1600 train_time:7063ms step_avg:34.80ms
+step:204/1600 train_time:7101ms step_avg:34.81ms
+step:205/1600 train_time:7131ms step_avg:34.79ms
+step:206/1600 train_time:7169ms step_avg:34.80ms
+step:207/1600 train_time:7199ms step_avg:34.78ms
+step:208/1600 train_time:7236ms step_avg:34.79ms
+step:209/1600 train_time:7267ms step_avg:34.77ms
+step:210/1600 train_time:7305ms step_avg:34.79ms
+step:211/1600 train_time:7335ms step_avg:34.76ms
+step:212/1600 train_time:7372ms step_avg:34.77ms
+step:213/1600 train_time:7402ms step_avg:34.75ms
+step:214/1600 train_time:7439ms step_avg:34.76ms
+step:215/1600 train_time:7470ms step_avg:34.74ms
+step:216/1600 train_time:7507ms step_avg:34.76ms
+step:217/1600 train_time:7538ms step_avg:34.74ms
+step:218/1600 train_time:7576ms step_avg:34.75ms
+step:219/1600 train_time:7606ms step_avg:34.73ms
+step:220/1600 train_time:7643ms step_avg:34.74ms
+step:221/1600 train_time:7674ms step_avg:34.72ms
+step:222/1600 train_time:7712ms step_avg:34.74ms
+step:223/1600 train_time:7742ms step_avg:34.72ms
+step:224/1600 train_time:7779ms step_avg:34.73ms
+step:225/1600 train_time:7810ms step_avg:34.71ms
+step:226/1600 train_time:7847ms step_avg:34.72ms
+step:227/1600 train_time:7877ms step_avg:34.70ms
+step:228/1600 train_time:7915ms step_avg:34.71ms
+step:229/1600 train_time:7945ms step_avg:34.69ms
+step:230/1600 train_time:7982ms step_avg:34.70ms
+step:231/1600 train_time:8012ms step_avg:34.68ms
+step:232/1600 train_time:8050ms step_avg:34.70ms
+step:233/1600 train_time:8080ms step_avg:34.68ms
+step:234/1600 train_time:8117ms step_avg:34.69ms
+step:235/1600 train_time:8148ms step_avg:34.67ms
+step:236/1600 train_time:8186ms step_avg:34.69ms
+step:237/1600 train_time:8216ms step_avg:34.67ms
+step:238/1600 train_time:8254ms step_avg:34.68ms
+step:239/1600 train_time:8284ms step_avg:34.66ms
+step:240/1600 train_time:8321ms step_avg:34.67ms
+step:241/1600 train_time:8352ms step_avg:34.66ms
+step:242/1600 train_time:8390ms step_avg:34.67ms
+step:243/1600 train_time:8420ms step_avg:34.65ms
+step:244/1600 train_time:8458ms step_avg:34.66ms
+step:245/1600 train_time:8488ms step_avg:34.64ms
+step:246/1600 train_time:8525ms step_avg:34.66ms
+step:247/1600 train_time:8556ms step_avg:34.64ms
+step:248/1600 train_time:8593ms step_avg:34.65ms
+step:249/1600 train_time:8624ms step_avg:34.63ms
+step:250/1600 train_time:8661ms step_avg:34.64ms
+step:250/1600 val_loss:4.5943 train_time:8708ms step_avg:34.83ms
+step:251/1600 train_time:8729ms step_avg:34.78ms
+step:252/1600 train_time:8749ms step_avg:34.72ms
+step:253/1600 train_time:8766ms step_avg:34.65ms
+step:254/1600 train_time:8801ms step_avg:34.65ms
+step:255/1600 train_time:8833ms step_avg:34.64ms
+step:256/1600 train_time:8872ms step_avg:34.66ms
+step:257/1600 train_time:8903ms step_avg:34.64ms
+step:258/1600 train_time:8941ms step_avg:34.65ms
+step:259/1600 train_time:8971ms step_avg:34.64ms
+step:260/1600 train_time:9009ms step_avg:34.65ms
+step:261/1600 train_time:9040ms step_avg:34.63ms
+step:262/1600 train_time:9077ms step_avg:34.65ms
+step:263/1600 train_time:9108ms step_avg:34.63ms
+step:264/1600 train_time:9145ms step_avg:34.64ms
+step:265/1600 train_time:9175ms step_avg:34.62ms
+step:266/1600 train_time:9212ms step_avg:34.63ms
+step:267/1600 train_time:9243ms step_avg:34.62ms
+step:268/1600 train_time:9280ms step_avg:34.63ms
+step:269/1600 train_time:9310ms step_avg:34.61ms
+step:270/1600 train_time:9347ms step_avg:34.62ms
+step:271/1600 train_time:9377ms step_avg:34.60ms
+step:272/1600 train_time:9415ms step_avg:34.61ms
+step:273/1600 train_time:9445ms step_avg:34.60ms
+step:274/1600 train_time:9482ms step_avg:34.61ms
+step:275/1600 train_time:9512ms step_avg:34.59ms
+step:276/1600 train_time:9549ms step_avg:34.60ms
+step:277/1600 train_time:9579ms step_avg:34.58ms
+step:278/1600 train_time:9617ms step_avg:34.59ms
+step:279/1600 train_time:9647ms step_avg:34.58ms
+step:280/1600 train_time:9684ms step_avg:34.59ms
+step:281/1600 train_time:9715ms step_avg:34.57ms
+step:282/1600 train_time:9752ms step_avg:34.58ms
+step:283/1600 train_time:9783ms step_avg:34.57ms
+step:284/1600 train_time:9820ms step_avg:34.58ms
+step:285/1600 train_time:9850ms step_avg:34.56ms
+step:286/1600 train_time:9888ms step_avg:34.57ms
+step:287/1600 train_time:9918ms step_avg:34.56ms
+step:288/1600 train_time:9956ms step_avg:34.57ms
+step:289/1600 train_time:9986ms step_avg:34.55ms
+step:290/1600 train_time:10024ms step_avg:34.56ms
+step:291/1600 train_time:10055ms step_avg:34.55ms
+step:292/1600 train_time:10092ms step_avg:34.56ms
+step:293/1600 train_time:10123ms step_avg:34.55ms
+step:294/1600 train_time:10160ms step_avg:34.56ms
+step:295/1600 train_time:10190ms step_avg:34.54ms
+step:296/1600 train_time:10227ms step_avg:34.55ms
+step:297/1600 train_time:10258ms step_avg:34.54ms
+step:298/1600 train_time:10295ms step_avg:34.55ms
+step:299/1600 train_time:10326ms step_avg:34.53ms
+step:300/1600 train_time:10363ms step_avg:34.54ms
+step:301/1600 train_time:10393ms step_avg:34.53ms
+step:302/1600 train_time:10430ms step_avg:34.54ms
+step:303/1600 train_time:10461ms step_avg:34.52ms
+step:304/1600 train_time:10498ms step_avg:34.53ms
+step:305/1600 train_time:10529ms step_avg:34.52ms
+step:306/1600 train_time:10566ms step_avg:34.53ms
+step:307/1600 train_time:10597ms step_avg:34.52ms
+step:308/1600 train_time:10634ms step_avg:34.53ms
+step:309/1600 train_time:10665ms step_avg:34.51ms
+step:310/1600 train_time:10702ms step_avg:34.52ms
+step:311/1600 train_time:10732ms step_avg:34.51ms
+step:312/1600 train_time:10770ms step_avg:34.52ms
+step:313/1600 train_time:10800ms step_avg:34.50ms
+step:314/1600 train_time:10837ms step_avg:34.51ms
+step:315/1600 train_time:10868ms step_avg:34.50ms
+step:316/1600 train_time:10905ms step_avg:34.51ms
+step:317/1600 train_time:10935ms step_avg:34.50ms
+step:318/1600 train_time:10973ms step_avg:34.51ms
+step:319/1600 train_time:11004ms step_avg:34.50ms
+step:320/1600 train_time:11042ms step_avg:34.51ms
+step:321/1600 train_time:11072ms step_avg:34.49ms
+step:322/1600 train_time:11110ms step_avg:34.50ms
+step:323/1600 train_time:11140ms step_avg:34.49ms
+step:324/1600 train_time:11177ms step_avg:34.50ms
+step:325/1600 train_time:11208ms step_avg:34.49ms
+step:326/1600 train_time:11245ms step_avg:34.49ms
+step:327/1600 train_time:11275ms step_avg:34.48ms
+step:328/1600 train_time:11313ms step_avg:34.49ms
+step:329/1600 train_time:11343ms step_avg:34.48ms
+step:330/1600 train_time:11380ms step_avg:34.49ms
+step:331/1600 train_time:11411ms step_avg:34.47ms
+step:332/1600 train_time:11448ms step_avg:34.48ms
+step:333/1600 train_time:11479ms step_avg:34.47ms
+step:334/1600 train_time:11516ms step_avg:34.48ms
+step:335/1600 train_time:11547ms step_avg:34.47ms
+step:336/1600 train_time:11584ms step_avg:34.48ms
+step:337/1600 train_time:11614ms step_avg:34.46ms
+step:338/1600 train_time:11652ms step_avg:34.47ms
+step:339/1600 train_time:11682ms step_avg:34.46ms
+step:340/1600 train_time:11719ms step_avg:34.47ms
+step:341/1600 train_time:11749ms step_avg:34.46ms
+step:342/1600 train_time:11786ms step_avg:34.46ms
+step:343/1600 train_time:11817ms step_avg:34.45ms
+step:344/1600 train_time:11855ms step_avg:34.46ms
+step:345/1600 train_time:11885ms step_avg:34.45ms
+step:346/1600 train_time:11922ms step_avg:34.46ms
+step:347/1600 train_time:11952ms step_avg:34.44ms
+step:348/1600 train_time:11990ms step_avg:34.45ms
+step:349/1600 train_time:12020ms step_avg:34.44ms
+step:350/1600 train_time:12057ms step_avg:34.45ms
+step:351/1600 train_time:12088ms step_avg:34.44ms
+step:352/1600 train_time:12125ms step_avg:34.44ms
+step:353/1600 train_time:12155ms step_avg:34.43ms
+step:354/1600 train_time:12192ms step_avg:34.44ms
+step:355/1600 train_time:12224ms step_avg:34.43ms
+step:356/1600 train_time:12261ms step_avg:34.44ms
+step:357/1600 train_time:12292ms step_avg:34.43ms
+step:358/1600 train_time:12329ms step_avg:34.44ms
+step:359/1600 train_time:12359ms step_avg:34.43ms
+step:360/1600 train_time:12397ms step_avg:34.44ms
+step:361/1600 train_time:12427ms step_avg:34.42ms
+step:362/1600 train_time:12464ms step_avg:34.43ms
+step:363/1600 train_time:12494ms step_avg:34.42ms
+step:364/1600 train_time:12532ms step_avg:34.43ms
+step:365/1600 train_time:12562ms step_avg:34.42ms
+step:366/1600 train_time:12599ms step_avg:34.42ms
+step:367/1600 train_time:12630ms step_avg:34.41ms
+step:368/1600 train_time:12668ms step_avg:34.42ms
+step:369/1600 train_time:12698ms step_avg:34.41ms
+step:370/1600 train_time:12735ms step_avg:34.42ms
+step:371/1600 train_time:12765ms step_avg:34.41ms
+step:372/1600 train_time:12802ms step_avg:34.41ms
+step:373/1600 train_time:12833ms step_avg:34.40ms
+step:374/1600 train_time:12870ms step_avg:34.41ms
+step:375/1600 train_time:12900ms step_avg:34.40ms
+step:376/1600 train_time:12937ms step_avg:34.41ms
+step:377/1600 train_time:12968ms step_avg:34.40ms
+step:378/1600 train_time:13005ms step_avg:34.40ms
+step:379/1600 train_time:13035ms step_avg:34.39ms
+step:380/1600 train_time:13073ms step_avg:34.40ms
+step:381/1600 train_time:13103ms step_avg:34.39ms
+step:382/1600 train_time:13140ms step_avg:34.40ms
+step:383/1600 train_time:13171ms step_avg:34.39ms
+step:384/1600 train_time:13208ms step_avg:34.40ms
+step:385/1600 train_time:13238ms step_avg:34.39ms
+step:386/1600 train_time:13276ms step_avg:34.39ms
+step:387/1600 train_time:13306ms step_avg:34.38ms
+step:388/1600 train_time:13343ms step_avg:34.39ms
+step:389/1600 train_time:13374ms step_avg:34.38ms
+step:390/1600 train_time:13411ms step_avg:34.39ms
+step:391/1600 train_time:13442ms step_avg:34.38ms
+step:392/1600 train_time:13479ms step_avg:34.38ms
+step:393/1600 train_time:13509ms step_avg:34.37ms
+step:394/1600 train_time:13547ms step_avg:34.38ms
+step:395/1600 train_time:13577ms step_avg:34.37ms
+step:396/1600 train_time:13615ms step_avg:34.38ms
+step:397/1600 train_time:13645ms step_avg:34.37ms
+step:398/1600 train_time:13682ms step_avg:34.38ms
+step:399/1600 train_time:13713ms step_avg:34.37ms
+step:400/1600 train_time:13750ms step_avg:34.38ms
+step:401/1600 train_time:13781ms step_avg:34.37ms
+step:402/1600 train_time:13818ms step_avg:34.37ms
+step:403/1600 train_time:13848ms step_avg:34.36ms
+step:404/1600 train_time:13885ms step_avg:34.37ms
+step:405/1600 train_time:13916ms step_avg:34.36ms
+step:406/1600 train_time:13954ms step_avg:34.37ms
+step:407/1600 train_time:13985ms step_avg:34.36ms
+step:408/1600 train_time:14022ms step_avg:34.37ms
+step:409/1600 train_time:14052ms step_avg:34.36ms
+step:410/1600 train_time:14089ms step_avg:34.36ms
+step:411/1600 train_time:14120ms step_avg:34.35ms
+step:412/1600 train_time:14157ms step_avg:34.36ms
+step:413/1600 train_time:14187ms step_avg:34.35ms
+step:414/1600 train_time:14224ms step_avg:34.36ms
+step:415/1600 train_time:14255ms step_avg:34.35ms
+step:416/1600 train_time:14293ms step_avg:34.36ms
+step:417/1600 train_time:14323ms step_avg:34.35ms
+step:418/1600 train_time:14360ms step_avg:34.36ms
+step:419/1600 train_time:14391ms step_avg:34.35ms
+step:420/1600 train_time:14428ms step_avg:34.35ms
+step:421/1600 train_time:14458ms step_avg:34.34ms
+step:422/1600 train_time:14495ms step_avg:34.35ms
+step:423/1600 train_time:14525ms step_avg:34.34ms
+step:424/1600 train_time:14562ms step_avg:34.35ms
+step:425/1600 train_time:14593ms step_avg:34.34ms
+step:426/1600 train_time:14630ms step_avg:34.34ms
+step:427/1600 train_time:14661ms step_avg:34.33ms
+step:428/1600 train_time:14698ms step_avg:34.34ms
+step:429/1600 train_time:14728ms step_avg:34.33ms
+step:430/1600 train_time:14765ms step_avg:34.34ms
+step:431/1600 train_time:14796ms step_avg:34.33ms
+step:432/1600 train_time:14834ms step_avg:34.34ms
+step:433/1600 train_time:14864ms step_avg:34.33ms
+step:434/1600 train_time:14902ms step_avg:34.34ms
+step:435/1600 train_time:14932ms step_avg:34.33ms
+step:436/1600 train_time:15000ms step_avg:34.40ms
+step:437/1600 train_time:15030ms step_avg:34.39ms
+step:438/1600 train_time:15067ms step_avg:34.40ms
+step:439/1600 train_time:15098ms step_avg:34.39ms
+step:440/1600 train_time:15135ms step_avg:34.40ms
+step:441/1600 train_time:15166ms step_avg:34.39ms
+step:442/1600 train_time:15203ms step_avg:34.40ms
+step:443/1600 train_time:15233ms step_avg:34.39ms
+step:444/1600 train_time:15271ms step_avg:34.39ms
+step:445/1600 train_time:15301ms step_avg:34.38ms
+step:446/1600 train_time:15338ms step_avg:34.39ms
+step:447/1600 train_time:15369ms step_avg:34.38ms
+step:448/1600 train_time:15406ms step_avg:34.39ms
+step:449/1600 train_time:15436ms step_avg:34.38ms
+step:450/1600 train_time:15473ms step_avg:34.38ms
+step:451/1600 train_time:15504ms step_avg:34.38ms
+step:452/1600 train_time:15541ms step_avg:34.38ms
+step:453/1600 train_time:15571ms step_avg:34.37ms
+step:454/1600 train_time:15608ms step_avg:34.38ms
+step:455/1600 train_time:15639ms step_avg:34.37ms
+step:456/1600 train_time:15676ms step_avg:34.38ms
+step:457/1600 train_time:15707ms step_avg:34.37ms
+step:458/1600 train_time:15744ms step_avg:34.37ms
+step:459/1600 train_time:15774ms step_avg:34.37ms
+step:460/1600 train_time:15811ms step_avg:34.37ms
+step:461/1600 train_time:15841ms step_avg:34.36ms
+step:462/1600 train_time:15879ms step_avg:34.37ms
+step:463/1600 train_time:15909ms step_avg:34.36ms
+step:464/1600 train_time:15947ms step_avg:34.37ms
+step:465/1600 train_time:15977ms step_avg:34.36ms
+step:466/1600 train_time:16015ms step_avg:34.37ms
+step:467/1600 train_time:16046ms step_avg:34.36ms
+step:468/1600 train_time:16083ms step_avg:34.37ms
+step:469/1600 train_time:16114ms step_avg:34.36ms
+step:470/1600 train_time:16151ms step_avg:34.36ms
+step:471/1600 train_time:16181ms step_avg:34.36ms
+step:472/1600 train_time:16218ms step_avg:34.36ms
+step:473/1600 train_time:16249ms step_avg:34.35ms
+step:474/1600 train_time:16286ms step_avg:34.36ms
+step:475/1600 train_time:16317ms step_avg:34.35ms
+step:476/1600 train_time:16355ms step_avg:34.36ms
+step:477/1600 train_time:16385ms step_avg:34.35ms
+step:478/1600 train_time:16422ms step_avg:34.36ms
+step:479/1600 train_time:16453ms step_avg:34.35ms
+step:480/1600 train_time:16490ms step_avg:34.35ms
+step:481/1600 train_time:16520ms step_avg:34.35ms
+step:482/1600 train_time:16558ms step_avg:34.35ms
+step:483/1600 train_time:16588ms step_avg:34.34ms
+step:484/1600 train_time:16625ms step_avg:34.35ms
+step:485/1600 train_time:16655ms step_avg:34.34ms
+step:486/1600 train_time:16693ms step_avg:34.35ms
+step:487/1600 train_time:16723ms step_avg:34.34ms
+step:488/1600 train_time:16761ms step_avg:34.35ms
+step:489/1600 train_time:16791ms step_avg:34.34ms
+step:490/1600 train_time:16828ms step_avg:34.34ms
+step:491/1600 train_time:16858ms step_avg:34.33ms
+step:492/1600 train_time:16896ms step_avg:34.34ms
+step:493/1600 train_time:16926ms step_avg:34.33ms
+step:494/1600 train_time:16963ms step_avg:34.34ms
+step:495/1600 train_time:16994ms step_avg:34.33ms
+step:496/1600 train_time:17031ms step_avg:34.34ms
+step:497/1600 train_time:17061ms step_avg:34.33ms
+step:498/1600 train_time:17099ms step_avg:34.33ms
+step:499/1600 train_time:17129ms step_avg:34.33ms
+step:500/1600 train_time:17166ms step_avg:34.33ms
+step:500/1600 val_loss:4.2349 train_time:17214ms step_avg:34.43ms
+step:501/1600 train_time:17235ms step_avg:34.40ms
+step:502/1600 train_time:17255ms step_avg:34.37ms
+step:503/1600 train_time:17272ms step_avg:34.34ms
+step:504/1600 train_time:17306ms step_avg:34.34ms
+step:505/1600 train_time:17339ms step_avg:34.33ms
+step:506/1600 train_time:17377ms step_avg:34.34ms
+step:507/1600 train_time:17408ms step_avg:34.34ms
+step:508/1600 train_time:17446ms step_avg:34.34ms
+step:509/1600 train_time:17476ms step_avg:34.33ms
+step:510/1600 train_time:17514ms step_avg:34.34ms
+step:511/1600 train_time:17544ms step_avg:34.33ms
+step:512/1600 train_time:17581ms step_avg:34.34ms
+step:513/1600 train_time:17612ms step_avg:34.33ms
+step:514/1600 train_time:17648ms step_avg:34.34ms
+step:515/1600 train_time:17679ms step_avg:34.33ms
+step:516/1600 train_time:17717ms step_avg:34.33ms
+step:517/1600 train_time:17747ms step_avg:34.33ms
+step:518/1600 train_time:17784ms step_avg:34.33ms
+step:519/1600 train_time:17814ms step_avg:34.32ms
+step:520/1600 train_time:17851ms step_avg:34.33ms
+step:521/1600 train_time:17922ms step_avg:34.40ms
+step:522/1600 train_time:17979ms step_avg:34.44ms
+step:523/1600 train_time:18040ms step_avg:34.49ms
+step:524/1600 train_time:18098ms step_avg:34.54ms
+step:525/1600 train_time:18159ms step_avg:34.59ms
+step:526/1600 train_time:18218ms step_avg:34.64ms
+step:527/1600 train_time:18281ms step_avg:34.69ms
+step:528/1600 train_time:18342ms step_avg:34.74ms
+step:529/1600 train_time:18406ms step_avg:34.79ms
+step:530/1600 train_time:18469ms step_avg:34.85ms
+step:531/1600 train_time:18529ms step_avg:34.90ms
+step:532/1600 train_time:18588ms step_avg:34.94ms
+step:533/1600 train_time:18651ms step_avg:34.99ms
+step:534/1600 train_time:18710ms step_avg:35.04ms
+step:535/1600 train_time:18773ms step_avg:35.09ms
+step:536/1600 train_time:18832ms step_avg:35.13ms
+step:537/1600 train_time:18895ms step_avg:35.19ms
+step:538/1600 train_time:18954ms step_avg:35.23ms
+step:539/1600 train_time:19016ms step_avg:35.28ms
+step:540/1600 train_time:19075ms step_avg:35.32ms
+step:541/1600 train_time:19137ms step_avg:35.37ms
+step:542/1600 train_time:19195ms step_avg:35.42ms
+step:543/1600 train_time:19257ms step_avg:35.46ms
+step:544/1600 train_time:19316ms step_avg:35.51ms
+step:545/1600 train_time:19379ms step_avg:35.56ms
+step:546/1600 train_time:19438ms step_avg:35.60ms
+step:547/1600 train_time:19500ms step_avg:35.65ms
+step:548/1600 train_time:19559ms step_avg:35.69ms
+step:549/1600 train_time:19623ms step_avg:35.74ms
+step:550/1600 train_time:19681ms step_avg:35.78ms
+step:551/1600 train_time:19743ms step_avg:35.83ms
+step:552/1600 train_time:19803ms step_avg:35.87ms
+step:553/1600 train_time:19866ms step_avg:35.92ms
+step:554/1600 train_time:19925ms step_avg:35.97ms
+step:555/1600 train_time:19989ms step_avg:36.02ms
+step:556/1600 train_time:20048ms step_avg:36.06ms
+step:557/1600 train_time:20110ms step_avg:36.10ms
+step:558/1600 train_time:20170ms step_avg:36.15ms
+step:559/1600 train_time:20233ms step_avg:36.19ms
+step:560/1600 train_time:20291ms step_avg:36.23ms
+step:561/1600 train_time:20353ms step_avg:36.28ms
+step:562/1600 train_time:20413ms step_avg:36.32ms
+step:563/1600 train_time:20476ms step_avg:36.37ms
+step:564/1600 train_time:20535ms step_avg:36.41ms
+step:565/1600 train_time:20597ms step_avg:36.46ms
+step:566/1600 train_time:20656ms step_avg:36.49ms
+step:567/1600 train_time:20718ms step_avg:36.54ms
+step:568/1600 train_time:20776ms step_avg:36.58ms
+step:569/1600 train_time:20840ms step_avg:36.62ms
+step:570/1600 train_time:20898ms step_avg:36.66ms
+step:571/1600 train_time:20963ms step_avg:36.71ms
+step:572/1600 train_time:21022ms step_avg:36.75ms
+step:573/1600 train_time:21089ms step_avg:36.80ms
+step:574/1600 train_time:21145ms step_avg:36.84ms
+step:575/1600 train_time:21206ms step_avg:36.88ms
+step:576/1600 train_time:21266ms step_avg:36.92ms
+step:577/1600 train_time:21328ms step_avg:36.96ms
+step:578/1600 train_time:21387ms step_avg:37.00ms
+step:579/1600 train_time:21449ms step_avg:37.04ms
+step:580/1600 train_time:21510ms step_avg:37.09ms
+step:581/1600 train_time:21572ms step_avg:37.13ms
+step:582/1600 train_time:21634ms step_avg:37.17ms
+step:583/1600 train_time:21694ms step_avg:37.21ms
+step:584/1600 train_time:21754ms step_avg:37.25ms
+step:585/1600 train_time:21816ms step_avg:37.29ms
+step:586/1600 train_time:21875ms step_avg:37.33ms
+step:587/1600 train_time:21937ms step_avg:37.37ms
+step:588/1600 train_time:21996ms step_avg:37.41ms
+step:589/1600 train_time:22058ms step_avg:37.45ms
+step:590/1600 train_time:22117ms step_avg:37.49ms
+step:591/1600 train_time:22179ms step_avg:37.53ms
+step:592/1600 train_time:22239ms step_avg:37.57ms
+step:593/1600 train_time:22301ms step_avg:37.61ms
+step:594/1600 train_time:22359ms step_avg:37.64ms
+step:595/1600 train_time:22422ms step_avg:37.68ms
+step:596/1600 train_time:22482ms step_avg:37.72ms
+step:597/1600 train_time:22545ms step_avg:37.76ms
+step:598/1600 train_time:22604ms step_avg:37.80ms
+step:599/1600 train_time:22667ms step_avg:37.84ms
+step:600/1600 train_time:22726ms step_avg:37.88ms
+step:601/1600 train_time:22788ms step_avg:37.92ms
+step:602/1600 train_time:22847ms step_avg:37.95ms
+step:603/1600 train_time:22910ms step_avg:37.99ms
+step:604/1600 train_time:22969ms step_avg:38.03ms
+step:605/1600 train_time:23032ms step_avg:38.07ms
+step:606/1600 train_time:23092ms step_avg:38.10ms
+step:607/1600 train_time:23154ms step_avg:38.14ms
+step:608/1600 train_time:23213ms step_avg:38.18ms
+step:609/1600 train_time:23276ms step_avg:38.22ms
+step:610/1600 train_time:23334ms step_avg:38.25ms
+step:611/1600 train_time:23396ms step_avg:38.29ms
+step:612/1600 train_time:23456ms step_avg:38.33ms
+step:613/1600 train_time:23518ms step_avg:38.36ms
+step:614/1600 train_time:23577ms step_avg:38.40ms
+step:615/1600 train_time:23640ms step_avg:38.44ms
+step:616/1600 train_time:23698ms step_avg:38.47ms
+step:617/1600 train_time:23762ms step_avg:38.51ms
+step:618/1600 train_time:23821ms step_avg:38.54ms
+step:619/1600 train_time:23883ms step_avg:38.58ms
+step:620/1600 train_time:23943ms step_avg:38.62ms
+step:621/1600 train_time:24005ms step_avg:38.65ms
+step:622/1600 train_time:24064ms step_avg:38.69ms
+step:623/1600 train_time:24128ms step_avg:38.73ms
+step:624/1600 train_time:24186ms step_avg:38.76ms
+step:625/1600 train_time:24248ms step_avg:38.80ms
+step:626/1600 train_time:24308ms step_avg:38.83ms
+step:627/1600 train_time:24371ms step_avg:38.87ms
+step:628/1600 train_time:24430ms step_avg:38.90ms
+step:629/1600 train_time:24493ms step_avg:38.94ms
+step:630/1600 train_time:24552ms step_avg:38.97ms
+step:631/1600 train_time:24614ms step_avg:39.01ms
+step:632/1600 train_time:24675ms step_avg:39.04ms
+step:633/1600 train_time:24738ms step_avg:39.08ms
+step:634/1600 train_time:24796ms step_avg:39.11ms
+step:635/1600 train_time:24859ms step_avg:39.15ms
+step:636/1600 train_time:24917ms step_avg:39.18ms
+step:637/1600 train_time:24980ms step_avg:39.21ms
+step:638/1600 train_time:25039ms step_avg:39.25ms
+step:639/1600 train_time:25100ms step_avg:39.28ms
+step:640/1600 train_time:25160ms step_avg:39.31ms
+step:641/1600 train_time:25222ms step_avg:39.35ms
+step:642/1600 train_time:25281ms step_avg:39.38ms
+step:643/1600 train_time:25344ms step_avg:39.42ms
+step:644/1600 train_time:25403ms step_avg:39.45ms
+step:645/1600 train_time:25467ms step_avg:39.48ms
+step:646/1600 train_time:25526ms step_avg:39.51ms
+step:647/1600 train_time:25590ms step_avg:39.55ms
+step:648/1600 train_time:25649ms step_avg:39.58ms
+step:649/1600 train_time:25712ms step_avg:39.62ms
+step:650/1600 train_time:25771ms step_avg:39.65ms
+step:651/1600 train_time:25833ms step_avg:39.68ms
+step:652/1600 train_time:25892ms step_avg:39.71ms
+step:653/1600 train_time:25954ms step_avg:39.75ms
+step:654/1600 train_time:26013ms step_avg:39.78ms
+step:655/1600 train_time:26076ms step_avg:39.81ms
+step:656/1600 train_time:26136ms step_avg:39.84ms
+step:657/1600 train_time:26197ms step_avg:39.87ms
+step:658/1600 train_time:26256ms step_avg:39.90ms
+step:659/1600 train_time:26318ms step_avg:39.94ms
+step:660/1600 train_time:26377ms step_avg:39.96ms
+step:661/1600 train_time:26439ms step_avg:40.00ms
+step:662/1600 train_time:26498ms step_avg:40.03ms
+step:663/1600 train_time:26561ms step_avg:40.06ms
+step:664/1600 train_time:26620ms step_avg:40.09ms
+step:665/1600 train_time:26681ms step_avg:40.12ms
+step:666/1600 train_time:26740ms step_avg:40.15ms
+step:667/1600 train_time:26803ms step_avg:40.18ms
+step:668/1600 train_time:26863ms step_avg:40.21ms
+step:669/1600 train_time:26925ms step_avg:40.25ms
+step:670/1600 train_time:26984ms step_avg:40.27ms
+step:671/1600 train_time:27047ms step_avg:40.31ms
+step:672/1600 train_time:27106ms step_avg:40.34ms
+step:673/1600 train_time:27170ms step_avg:40.37ms
+step:674/1600 train_time:27230ms step_avg:40.40ms
+step:675/1600 train_time:27293ms step_avg:40.43ms
+step:676/1600 train_time:27352ms step_avg:40.46ms
+step:677/1600 train_time:27415ms step_avg:40.50ms
+step:678/1600 train_time:27474ms step_avg:40.52ms
+step:679/1600 train_time:27536ms step_avg:40.55ms
+step:680/1600 train_time:27595ms step_avg:40.58ms
+step:681/1600 train_time:27657ms step_avg:40.61ms
+step:682/1600 train_time:27716ms step_avg:40.64ms
+step:683/1600 train_time:27777ms step_avg:40.67ms
+step:684/1600 train_time:27836ms step_avg:40.70ms
+step:685/1600 train_time:27898ms step_avg:40.73ms
+step:686/1600 train_time:27956ms step_avg:40.75ms
+step:687/1600 train_time:28018ms step_avg:40.78ms
+step:688/1600 train_time:28078ms step_avg:40.81ms
+step:689/1600 train_time:28141ms step_avg:40.84ms
+step:690/1600 train_time:28200ms step_avg:40.87ms
+step:691/1600 train_time:28262ms step_avg:40.90ms
+step:692/1600 train_time:28322ms step_avg:40.93ms
+step:693/1600 train_time:28383ms step_avg:40.96ms
+step:694/1600 train_time:28443ms step_avg:40.98ms
+step:695/1600 train_time:28505ms step_avg:41.01ms
+step:696/1600 train_time:28565ms step_avg:41.04ms
+step:697/1600 train_time:28628ms step_avg:41.07ms
+step:698/1600 train_time:28686ms step_avg:41.10ms
+step:699/1600 train_time:28749ms step_avg:41.13ms
+step:700/1600 train_time:28807ms step_avg:41.15ms
+step:701/1600 train_time:28870ms step_avg:41.18ms
+step:702/1600 train_time:28930ms step_avg:41.21ms
+step:703/1600 train_time:28993ms step_avg:41.24ms
+step:704/1600 train_time:29051ms step_avg:41.27ms
+step:705/1600 train_time:29113ms step_avg:41.30ms
+step:706/1600 train_time:29172ms step_avg:41.32ms
+step:707/1600 train_time:29235ms step_avg:41.35ms
+step:708/1600 train_time:29294ms step_avg:41.38ms
+step:709/1600 train_time:29356ms step_avg:41.41ms
+step:710/1600 train_time:29415ms step_avg:41.43ms
+step:711/1600 train_time:29477ms step_avg:41.46ms
+step:712/1600 train_time:29536ms step_avg:41.48ms
+step:713/1600 train_time:29599ms step_avg:41.51ms
+step:714/1600 train_time:29657ms step_avg:41.54ms
+step:715/1600 train_time:29718ms step_avg:41.56ms
+step:716/1600 train_time:29776ms step_avg:41.59ms
+step:717/1600 train_time:29838ms step_avg:41.62ms
+step:718/1600 train_time:29897ms step_avg:41.64ms
+step:719/1600 train_time:29959ms step_avg:41.67ms
+step:720/1600 train_time:30018ms step_avg:41.69ms
+step:721/1600 train_time:30081ms step_avg:41.72ms
+step:722/1600 train_time:30141ms step_avg:41.75ms
+step:723/1600 train_time:30203ms step_avg:41.77ms
+step:724/1600 train_time:30262ms step_avg:41.80ms
+step:725/1600 train_time:30324ms step_avg:41.83ms
+step:726/1600 train_time:30384ms step_avg:41.85ms
+step:727/1600 train_time:30447ms step_avg:41.88ms
+step:728/1600 train_time:30506ms step_avg:41.90ms
+step:729/1600 train_time:30569ms step_avg:41.93ms
+step:730/1600 train_time:30628ms step_avg:41.96ms
+step:731/1600 train_time:30689ms step_avg:41.98ms
+step:732/1600 train_time:30748ms step_avg:42.01ms
+step:733/1600 train_time:30810ms step_avg:42.03ms
+step:734/1600 train_time:30870ms step_avg:42.06ms
+step:735/1600 train_time:30931ms step_avg:42.08ms
+step:736/1600 train_time:30990ms step_avg:42.11ms
+step:737/1600 train_time:31053ms step_avg:42.13ms
+step:738/1600 train_time:31111ms step_avg:42.16ms
+step:739/1600 train_time:31174ms step_avg:42.18ms
+step:740/1600 train_time:31236ms step_avg:42.21ms
+step:741/1600 train_time:31297ms step_avg:42.24ms
+step:742/1600 train_time:31355ms step_avg:42.26ms
+step:743/1600 train_time:31417ms step_avg:42.28ms
+step:744/1600 train_time:31476ms step_avg:42.31ms
+step:745/1600 train_time:31538ms step_avg:42.33ms
+step:746/1600 train_time:31596ms step_avg:42.35ms
+step:747/1600 train_time:31657ms step_avg:42.38ms
+step:748/1600 train_time:31716ms step_avg:42.40ms
+step:749/1600 train_time:31777ms step_avg:42.43ms
+step:750/1600 train_time:31836ms step_avg:42.45ms
+step:750/1600 val_loss:3.9014 train_time:31881ms step_avg:42.51ms
+step:751/1600 train_time:31902ms step_avg:42.48ms
+step:752/1600 train_time:31961ms step_avg:42.50ms
+step:753/1600 train_time:32024ms step_avg:42.53ms
+step:754/1600 train_time:32083ms step_avg:42.55ms
+step:755/1600 train_time:32145ms step_avg:42.58ms
+step:756/1600 train_time:32205ms step_avg:42.60ms
+step:757/1600 train_time:32268ms step_avg:42.63ms
+step:758/1600 train_time:32325ms step_avg:42.64ms
+step:759/1600 train_time:32387ms step_avg:42.67ms
+step:760/1600 train_time:32445ms step_avg:42.69ms
+step:761/1600 train_time:32508ms step_avg:42.72ms
+step:762/1600 train_time:32566ms step_avg:42.74ms
+step:763/1600 train_time:32628ms step_avg:42.76ms
+step:764/1600 train_time:32688ms step_avg:42.78ms
+step:765/1600 train_time:32749ms step_avg:42.81ms
+step:766/1600 train_time:32809ms step_avg:42.83ms
+step:767/1600 train_time:32873ms step_avg:42.86ms
+step:768/1600 train_time:32934ms step_avg:42.88ms
+step:769/1600 train_time:32996ms step_avg:42.91ms
+step:770/1600 train_time:33056ms step_avg:42.93ms
+step:771/1600 train_time:33118ms step_avg:42.95ms
+step:772/1600 train_time:33178ms step_avg:42.98ms
+step:773/1600 train_time:33241ms step_avg:43.00ms
+step:774/1600 train_time:33300ms step_avg:43.02ms
+step:775/1600 train_time:33362ms step_avg:43.05ms
+step:776/1600 train_time:33421ms step_avg:43.07ms
+step:777/1600 train_time:33483ms step_avg:43.09ms
+step:778/1600 train_time:33541ms step_avg:43.11ms
+step:779/1600 train_time:33603ms step_avg:43.14ms
+step:780/1600 train_time:33662ms step_avg:43.16ms
+step:781/1600 train_time:33725ms step_avg:43.18ms
+step:782/1600 train_time:33783ms step_avg:43.20ms
+step:783/1600 train_time:33846ms step_avg:43.23ms
+step:784/1600 train_time:33905ms step_avg:43.25ms
+step:785/1600 train_time:33969ms step_avg:43.27ms
+step:786/1600 train_time:34029ms step_avg:43.29ms
+step:787/1600 train_time:34092ms step_avg:43.32ms
+step:788/1600 train_time:34151ms step_avg:43.34ms
+step:789/1600 train_time:34214ms step_avg:43.36ms
+step:790/1600 train_time:34274ms step_avg:43.39ms
+step:791/1600 train_time:34336ms step_avg:43.41ms
+step:792/1600 train_time:34395ms step_avg:43.43ms
+step:793/1600 train_time:34458ms step_avg:43.45ms
+step:794/1600 train_time:34518ms step_avg:43.47ms
+step:795/1600 train_time:34580ms step_avg:43.50ms
+step:796/1600 train_time:34638ms step_avg:43.52ms
+step:797/1600 train_time:34701ms step_avg:43.54ms
+step:798/1600 train_time:34760ms step_avg:43.56ms
+step:799/1600 train_time:34823ms step_avg:43.58ms
+step:800/1600 train_time:34881ms step_avg:43.60ms
+step:801/1600 train_time:34943ms step_avg:43.62ms
+step:802/1600 train_time:35003ms step_avg:43.64ms
+step:803/1600 train_time:35066ms step_avg:43.67ms
+step:804/1600 train_time:35124ms step_avg:43.69ms
+step:805/1600 train_time:35187ms step_avg:43.71ms
+step:806/1600 train_time:35246ms step_avg:43.73ms
+step:807/1600 train_time:35310ms step_avg:43.75ms
+step:808/1600 train_time:35369ms step_avg:43.77ms
+step:809/1600 train_time:35432ms step_avg:43.80ms
+step:810/1600 train_time:35493ms step_avg:43.82ms
+step:811/1600 train_time:35555ms step_avg:43.84ms
+step:812/1600 train_time:35613ms step_avg:43.86ms
+step:813/1600 train_time:35676ms step_avg:43.88ms
+step:814/1600 train_time:35737ms step_avg:43.90ms
+step:815/1600 train_time:35799ms step_avg:43.92ms
+step:816/1600 train_time:35858ms step_avg:43.94ms
+step:817/1600 train_time:35919ms step_avg:43.96ms
+step:818/1600 train_time:35978ms step_avg:43.98ms
+step:819/1600 train_time:36040ms step_avg:44.01ms
+step:820/1600 train_time:36099ms step_avg:44.02ms
+step:821/1600 train_time:36162ms step_avg:44.05ms
+step:822/1600 train_time:36221ms step_avg:44.06ms
+step:823/1600 train_time:36284ms step_avg:44.09ms
+step:824/1600 train_time:36343ms step_avg:44.11ms
+step:825/1600 train_time:36406ms step_avg:44.13ms
+step:826/1600 train_time:36464ms step_avg:44.15ms
+step:827/1600 train_time:36527ms step_avg:44.17ms
+step:828/1600 train_time:36586ms step_avg:44.19ms
+step:829/1600 train_time:36649ms step_avg:44.21ms
+step:830/1600 train_time:36708ms step_avg:44.23ms
+step:831/1600 train_time:36772ms step_avg:44.25ms
+step:832/1600 train_time:36830ms step_avg:44.27ms
+step:833/1600 train_time:36893ms step_avg:44.29ms
+step:834/1600 train_time:36952ms step_avg:44.31ms
+step:835/1600 train_time:37016ms step_avg:44.33ms
+step:836/1600 train_time:37075ms step_avg:44.35ms
+step:837/1600 train_time:37137ms step_avg:44.37ms
+step:838/1600 train_time:37196ms step_avg:44.39ms
+step:839/1600 train_time:37259ms step_avg:44.41ms
+step:840/1600 train_time:37318ms step_avg:44.43ms
+step:841/1600 train_time:37380ms step_avg:44.45ms
+step:842/1600 train_time:37438ms step_avg:44.46ms
+step:843/1600 train_time:37501ms step_avg:44.49ms
+step:844/1600 train_time:37560ms step_avg:44.50ms
+step:845/1600 train_time:37622ms step_avg:44.52ms
+step:846/1600 train_time:37681ms step_avg:44.54ms
+step:847/1600 train_time:37744ms step_avg:44.56ms
+step:848/1600 train_time:37803ms step_avg:44.58ms
+step:849/1600 train_time:37865ms step_avg:44.60ms
+step:850/1600 train_time:37924ms step_avg:44.62ms
+step:851/1600 train_time:37986ms step_avg:44.64ms
+step:852/1600 train_time:38045ms step_avg:44.65ms
+step:853/1600 train_time:38109ms step_avg:44.68ms
+step:854/1600 train_time:38167ms step_avg:44.69ms
+step:855/1600 train_time:38231ms step_avg:44.71ms
+step:856/1600 train_time:38289ms step_avg:44.73ms
+step:857/1600 train_time:38352ms step_avg:44.75ms
+step:858/1600 train_time:38411ms step_avg:44.77ms
+step:859/1600 train_time:38473ms step_avg:44.79ms
+step:860/1600 train_time:38532ms step_avg:44.80ms
+step:861/1600 train_time:38595ms step_avg:44.83ms
+step:862/1600 train_time:38654ms step_avg:44.84ms
+step:863/1600 train_time:38717ms step_avg:44.86ms
+step:864/1600 train_time:38777ms step_avg:44.88ms
+step:865/1600 train_time:38838ms step_avg:44.90ms
+step:866/1600 train_time:38897ms step_avg:44.92ms
+step:867/1600 train_time:38961ms step_avg:44.94ms
+step:868/1600 train_time:39019ms step_avg:44.95ms
+step:869/1600 train_time:39081ms step_avg:44.97ms
+step:870/1600 train_time:39141ms step_avg:44.99ms
+step:871/1600 train_time:39203ms step_avg:45.01ms
+step:872/1600 train_time:39262ms step_avg:45.03ms
+step:873/1600 train_time:39325ms step_avg:45.05ms
+step:874/1600 train_time:39384ms step_avg:45.06ms
+step:875/1600 train_time:39445ms step_avg:45.08ms
+step:876/1600 train_time:39504ms step_avg:45.10ms
+step:877/1600 train_time:39566ms step_avg:45.11ms
+step:878/1600 train_time:39624ms step_avg:45.13ms
+step:879/1600 train_time:39686ms step_avg:45.15ms
+step:880/1600 train_time:39746ms step_avg:45.17ms
+step:881/1600 train_time:39808ms step_avg:45.19ms
+step:882/1600 train_time:39867ms step_avg:45.20ms
+step:883/1600 train_time:39930ms step_avg:45.22ms
+step:884/1600 train_time:39990ms step_avg:45.24ms
+step:885/1600 train_time:40053ms step_avg:45.26ms
+step:886/1600 train_time:40113ms step_avg:45.27ms
+step:887/1600 train_time:40175ms step_avg:45.29ms
+step:888/1600 train_time:40233ms step_avg:45.31ms
+step:889/1600 train_time:40297ms step_avg:45.33ms
+step:890/1600 train_time:40362ms step_avg:45.35ms
+step:891/1600 train_time:40421ms step_avg:45.37ms
+step:892/1600 train_time:40480ms step_avg:45.38ms
+step:893/1600 train_time:40543ms step_avg:45.40ms
+step:894/1600 train_time:40601ms step_avg:45.42ms
+step:895/1600 train_time:40663ms step_avg:45.43ms
+step:896/1600 train_time:40721ms step_avg:45.45ms
+step:897/1600 train_time:40783ms step_avg:45.47ms
+step:898/1600 train_time:40842ms step_avg:45.48ms
+step:899/1600 train_time:40904ms step_avg:45.50ms
+step:900/1600 train_time:40963ms step_avg:45.51ms
+step:901/1600 train_time:41026ms step_avg:45.53ms
+step:902/1600 train_time:41084ms step_avg:45.55ms
+step:903/1600 train_time:41146ms step_avg:45.57ms
+step:904/1600 train_time:41205ms step_avg:45.58ms
+step:905/1600 train_time:41268ms step_avg:45.60ms
+step:906/1600 train_time:41329ms step_avg:45.62ms
+step:907/1600 train_time:41391ms step_avg:45.64ms
+step:908/1600 train_time:41450ms step_avg:45.65ms
+step:909/1600 train_time:41513ms step_avg:45.67ms
+step:910/1600 train_time:41572ms step_avg:45.68ms
+step:911/1600 train_time:41635ms step_avg:45.70ms
+step:912/1600 train_time:41694ms step_avg:45.72ms
+step:913/1600 train_time:41758ms step_avg:45.74ms
+step:914/1600 train_time:41817ms step_avg:45.75ms
+step:915/1600 train_time:41879ms step_avg:45.77ms
+step:916/1600 train_time:41938ms step_avg:45.78ms
+step:917/1600 train_time:42001ms step_avg:45.80ms
+step:918/1600 train_time:42060ms step_avg:45.82ms
+step:919/1600 train_time:42122ms step_avg:45.83ms
+step:920/1600 train_time:42181ms step_avg:45.85ms
+step:921/1600 train_time:42243ms step_avg:45.87ms
+step:922/1600 train_time:42301ms step_avg:45.88ms
+step:923/1600 train_time:42364ms step_avg:45.90ms
+step:924/1600 train_time:42424ms step_avg:45.91ms
+step:925/1600 train_time:42485ms step_avg:45.93ms
+step:926/1600 train_time:42543ms step_avg:45.94ms
+step:927/1600 train_time:42606ms step_avg:45.96ms
+step:928/1600 train_time:42664ms step_avg:45.97ms
+step:929/1600 train_time:42727ms step_avg:45.99ms
+step:930/1600 train_time:42787ms step_avg:46.01ms
+step:931/1600 train_time:42849ms step_avg:46.02ms
+step:932/1600 train_time:42908ms step_avg:46.04ms
+step:933/1600 train_time:42971ms step_avg:46.06ms
+step:934/1600 train_time:43030ms step_avg:46.07ms
+step:935/1600 train_time:43093ms step_avg:46.09ms
+step:936/1600 train_time:43152ms step_avg:46.10ms
+step:937/1600 train_time:43214ms step_avg:46.12ms
+step:938/1600 train_time:43273ms step_avg:46.13ms
+step:939/1600 train_time:43379ms step_avg:46.20ms
+step:940/1600 train_time:43437ms step_avg:46.21ms
+step:941/1600 train_time:43498ms step_avg:46.23ms
+step:942/1600 train_time:43556ms step_avg:46.24ms
+step:943/1600 train_time:43618ms step_avg:46.25ms
+step:944/1600 train_time:43676ms step_avg:46.27ms
+step:945/1600 train_time:43737ms step_avg:46.28ms
+step:946/1600 train_time:43795ms step_avg:46.30ms
+step:947/1600 train_time:43857ms step_avg:46.31ms
+step:948/1600 train_time:43916ms step_avg:46.32ms
+step:949/1600 train_time:43978ms step_avg:46.34ms
+step:950/1600 train_time:44036ms step_avg:46.35ms
+step:951/1600 train_time:44099ms step_avg:46.37ms
+step:952/1600 train_time:44158ms step_avg:46.38ms
+step:953/1600 train_time:44220ms step_avg:46.40ms
+step:954/1600 train_time:44282ms step_avg:46.42ms
+step:955/1600 train_time:44348ms step_avg:46.44ms
+step:956/1600 train_time:44407ms step_avg:46.45ms
+step:957/1600 train_time:44469ms step_avg:46.47ms
+step:958/1600 train_time:44529ms step_avg:46.48ms
+step:959/1600 train_time:44591ms step_avg:46.50ms
+step:960/1600 train_time:44650ms step_avg:46.51ms
+step:961/1600 train_time:44712ms step_avg:46.53ms
+step:962/1600 train_time:44770ms step_avg:46.54ms
+step:963/1600 train_time:44832ms step_avg:46.55ms
+step:964/1600 train_time:44891ms step_avg:46.57ms
+step:965/1600 train_time:44953ms step_avg:46.58ms
+step:966/1600 train_time:45012ms step_avg:46.60ms
+step:967/1600 train_time:45074ms step_avg:46.61ms
+step:968/1600 train_time:45133ms step_avg:46.63ms
+step:969/1600 train_time:45196ms step_avg:46.64ms
+step:970/1600 train_time:45256ms step_avg:46.66ms
+step:971/1600 train_time:45320ms step_avg:46.67ms
+step:972/1600 train_time:45379ms step_avg:46.69ms
+step:973/1600 train_time:45442ms step_avg:46.70ms
+step:974/1600 train_time:45502ms step_avg:46.72ms
+step:975/1600 train_time:45564ms step_avg:46.73ms
+step:976/1600 train_time:45623ms step_avg:46.74ms
+step:977/1600 train_time:45687ms step_avg:46.76ms
+step:978/1600 train_time:45745ms step_avg:46.77ms
+step:979/1600 train_time:45806ms step_avg:46.79ms
+step:980/1600 train_time:45864ms step_avg:46.80ms
+step:981/1600 train_time:45926ms step_avg:46.82ms
+step:982/1600 train_time:45985ms step_avg:46.83ms
+step:983/1600 train_time:46046ms step_avg:46.84ms
+step:984/1600 train_time:46105ms step_avg:46.85ms
+step:985/1600 train_time:46168ms step_avg:46.87ms
+step:986/1600 train_time:46229ms step_avg:46.88ms
+step:987/1600 train_time:46292ms step_avg:46.90ms
+step:988/1600 train_time:46351ms step_avg:46.91ms
+step:989/1600 train_time:46414ms step_avg:46.93ms
+step:990/1600 train_time:46473ms step_avg:46.94ms
+step:991/1600 train_time:46538ms step_avg:46.96ms
+step:992/1600 train_time:46596ms step_avg:46.97ms
+step:993/1600 train_time:46659ms step_avg:46.99ms
+step:994/1600 train_time:46718ms step_avg:47.00ms
+step:995/1600 train_time:46780ms step_avg:47.02ms
+step:996/1600 train_time:46838ms step_avg:47.03ms
+step:997/1600 train_time:46902ms step_avg:47.04ms
+step:998/1600 train_time:46960ms step_avg:47.05ms
+step:999/1600 train_time:47022ms step_avg:47.07ms
+step:1000/1600 train_time:47081ms step_avg:47.08ms
+step:1000/1600 val_loss:3.6001 train_time:47126ms step_avg:47.13ms
+step:1001/1600 train_time:47146ms step_avg:47.10ms
+step:1002/1600 train_time:47204ms step_avg:47.11ms
+step:1003/1600 train_time:47269ms step_avg:47.13ms
+step:1004/1600 train_time:47329ms step_avg:47.14ms
+step:1005/1600 train_time:47391ms step_avg:47.16ms
+step:1006/1600 train_time:47451ms step_avg:47.17ms
+step:1007/1600 train_time:47513ms step_avg:47.18ms
+step:1008/1600 train_time:47571ms step_avg:47.19ms
+step:1009/1600 train_time:47633ms step_avg:47.21ms
+step:1010/1600 train_time:47691ms step_avg:47.22ms
+step:1011/1600 train_time:47752ms step_avg:47.23ms
+step:1012/1600 train_time:47810ms step_avg:47.24ms
+step:1013/1600 train_time:47872ms step_avg:47.26ms
+step:1014/1600 train_time:47931ms step_avg:47.27ms
+step:1015/1600 train_time:47993ms step_avg:47.28ms
+step:1016/1600 train_time:48052ms step_avg:47.30ms
+step:1017/1600 train_time:48117ms step_avg:47.31ms
+step:1018/1600 train_time:48177ms step_avg:47.32ms
+step:1019/1600 train_time:48240ms step_avg:47.34ms
+step:1020/1600 train_time:48299ms step_avg:47.35ms
+step:1021/1600 train_time:48363ms step_avg:47.37ms
+step:1022/1600 train_time:48422ms step_avg:47.38ms
+step:1023/1600 train_time:48483ms step_avg:47.39ms
+step:1024/1600 train_time:48542ms step_avg:47.40ms
+step:1025/1600 train_time:48604ms step_avg:47.42ms
+step:1026/1600 train_time:48663ms step_avg:47.43ms
+step:1027/1600 train_time:48725ms step_avg:47.44ms
+step:1028/1600 train_time:48784ms step_avg:47.46ms
+step:1029/1600 train_time:48847ms step_avg:47.47ms
+step:1030/1600 train_time:48906ms step_avg:47.48ms
+step:1031/1600 train_time:48969ms step_avg:47.50ms
+step:1032/1600 train_time:49027ms step_avg:47.51ms
+step:1033/1600 train_time:49089ms step_avg:47.52ms
+step:1034/1600 train_time:49149ms step_avg:47.53ms
+step:1035/1600 train_time:49211ms step_avg:47.55ms
+step:1036/1600 train_time:49270ms step_avg:47.56ms
+step:1037/1600 train_time:49332ms step_avg:47.57ms
+step:1038/1600 train_time:49391ms step_avg:47.58ms
+step:1039/1600 train_time:49455ms step_avg:47.60ms
+step:1040/1600 train_time:49513ms step_avg:47.61ms
+step:1041/1600 train_time:49582ms step_avg:47.63ms
+step:1042/1600 train_time:49668ms step_avg:47.67ms
+step:1043/1600 train_time:49758ms step_avg:47.71ms
+step:1044/1600 train_time:49844ms step_avg:47.74ms
+step:1045/1600 train_time:49932ms step_avg:47.78ms
+step:1046/1600 train_time:50017ms step_avg:47.82ms
+step:1047/1600 train_time:50103ms step_avg:47.85ms
+step:1048/1600 train_time:50189ms step_avg:47.89ms
+step:1049/1600 train_time:50278ms step_avg:47.93ms
+step:1050/1600 train_time:50363ms step_avg:47.96ms
+step:1051/1600 train_time:50451ms step_avg:48.00ms
+step:1052/1600 train_time:50536ms step_avg:48.04ms
+step:1053/1600 train_time:50625ms step_avg:48.08ms
+step:1054/1600 train_time:50710ms step_avg:48.11ms
+step:1055/1600 train_time:50797ms step_avg:48.15ms
+step:1056/1600 train_time:50882ms step_avg:48.18ms
+step:1057/1600 train_time:50971ms step_avg:48.22ms
+step:1058/1600 train_time:51055ms step_avg:48.26ms
+step:1059/1600 train_time:51143ms step_avg:48.29ms
+step:1060/1600 train_time:51230ms step_avg:48.33ms
+step:1061/1600 train_time:51318ms step_avg:48.37ms
+step:1062/1600 train_time:51404ms step_avg:48.40ms
+step:1063/1600 train_time:51492ms step_avg:48.44ms
+step:1064/1600 train_time:51577ms step_avg:48.47ms
+step:1065/1600 train_time:51666ms step_avg:48.51ms
+step:1066/1600 train_time:51751ms step_avg:48.55ms
+step:1067/1600 train_time:51838ms step_avg:48.58ms
+step:1068/1600 train_time:51924ms step_avg:48.62ms
+step:1069/1600 train_time:52011ms step_avg:48.65ms
+step:1070/1600 train_time:52096ms step_avg:48.69ms
+step:1071/1600 train_time:52185ms step_avg:48.73ms
+step:1072/1600 train_time:52270ms step_avg:48.76ms
+step:1073/1600 train_time:52359ms step_avg:48.80ms
+step:1074/1600 train_time:52444ms step_avg:48.83ms
+step:1075/1600 train_time:52532ms step_avg:48.87ms
+step:1076/1600 train_time:52617ms step_avg:48.90ms
+step:1077/1600 train_time:52705ms step_avg:48.94ms
+step:1078/1600 train_time:52791ms step_avg:48.97ms
+step:1079/1600 train_time:52878ms step_avg:49.01ms
+step:1080/1600 train_time:52964ms step_avg:49.04ms
+step:1081/1600 train_time:53052ms step_avg:49.08ms
+step:1082/1600 train_time:53137ms step_avg:49.11ms
+step:1083/1600 train_time:53225ms step_avg:49.15ms
+step:1084/1600 train_time:53311ms step_avg:49.18ms
+step:1085/1600 train_time:53398ms step_avg:49.21ms
+step:1086/1600 train_time:53484ms step_avg:49.25ms
+step:1087/1600 train_time:53571ms step_avg:49.28ms
+step:1088/1600 train_time:53656ms step_avg:49.32ms
+step:1089/1600 train_time:53744ms step_avg:49.35ms
+step:1090/1600 train_time:53830ms step_avg:49.39ms
+step:1091/1600 train_time:53919ms step_avg:49.42ms
+step:1092/1600 train_time:54004ms step_avg:49.45ms
+step:1093/1600 train_time:54092ms step_avg:49.49ms
+step:1094/1600 train_time:54177ms step_avg:49.52ms
+step:1095/1600 train_time:54265ms step_avg:49.56ms
+step:1096/1600 train_time:54351ms step_avg:49.59ms
+step:1097/1600 train_time:54439ms step_avg:49.63ms
+step:1098/1600 train_time:54524ms step_avg:49.66ms
+step:1099/1600 train_time:54612ms step_avg:49.69ms
+step:1100/1600 train_time:54698ms step_avg:49.73ms
+step:1101/1600 train_time:54788ms step_avg:49.76ms
+step:1102/1600 train_time:54872ms step_avg:49.79ms
+step:1103/1600 train_time:54959ms step_avg:49.83ms
+step:1104/1600 train_time:55045ms step_avg:49.86ms
+step:1105/1600 train_time:55135ms step_avg:49.90ms
+step:1106/1600 train_time:55218ms step_avg:49.93ms
+step:1107/1600 train_time:55306ms step_avg:49.96ms
+step:1108/1600 train_time:55391ms step_avg:49.99ms
+step:1109/1600 train_time:55479ms step_avg:50.03ms
+step:1110/1600 train_time:55565ms step_avg:50.06ms
+step:1111/1600 train_time:55654ms step_avg:50.09ms
+step:1112/1600 train_time:55738ms step_avg:50.12ms
+step:1113/1600 train_time:55827ms step_avg:50.16ms
+step:1114/1600 train_time:55913ms step_avg:50.19ms
+step:1115/1600 train_time:56000ms step_avg:50.22ms
+step:1116/1600 train_time:56085ms step_avg:50.26ms
+step:1117/1600 train_time:56174ms step_avg:50.29ms
+step:1118/1600 train_time:56258ms step_avg:50.32ms
+step:1119/1600 train_time:56347ms step_avg:50.35ms
+step:1120/1600 train_time:56432ms step_avg:50.39ms
+step:1121/1600 train_time:56519ms step_avg:50.42ms
+step:1122/1600 train_time:56604ms step_avg:50.45ms
+step:1123/1600 train_time:56693ms step_avg:50.48ms
+step:1124/1600 train_time:56778ms step_avg:50.51ms
+step:1125/1600 train_time:56865ms step_avg:50.55ms
+step:1126/1600 train_time:56951ms step_avg:50.58ms
+step:1127/1600 train_time:57038ms step_avg:50.61ms
+step:1128/1600 train_time:57123ms step_avg:50.64ms
+step:1129/1600 train_time:57211ms step_avg:50.67ms
+step:1130/1600 train_time:57297ms step_avg:50.70ms
+step:1131/1600 train_time:57384ms step_avg:50.74ms
+step:1132/1600 train_time:57469ms step_avg:50.77ms
+step:1133/1600 train_time:57557ms step_avg:50.80ms
+step:1134/1600 train_time:57643ms step_avg:50.83ms
+step:1135/1600 train_time:57731ms step_avg:50.86ms
+step:1136/1600 train_time:57817ms step_avg:50.89ms
+step:1137/1600 train_time:57906ms step_avg:50.93ms
+step:1138/1600 train_time:57989ms step_avg:50.96ms
+step:1139/1600 train_time:58077ms step_avg:50.99ms
+step:1140/1600 train_time:58162ms step_avg:51.02ms
+step:1141/1600 train_time:58251ms step_avg:51.05ms
+step:1142/1600 train_time:58335ms step_avg:51.08ms
+step:1143/1600 train_time:58424ms step_avg:51.11ms
+step:1144/1600 train_time:58509ms step_avg:51.14ms
+step:1145/1600 train_time:58602ms step_avg:51.18ms
+step:1146/1600 train_time:58691ms step_avg:51.21ms
+step:1147/1600 train_time:58778ms step_avg:51.24ms
+step:1148/1600 train_time:58861ms step_avg:51.27ms
+step:1149/1600 train_time:58947ms step_avg:51.30ms
+step:1150/1600 train_time:59032ms step_avg:51.33ms
+step:1151/1600 train_time:59119ms step_avg:51.36ms
+step:1152/1600 train_time:59204ms step_avg:51.39ms
+step:1153/1600 train_time:59292ms step_avg:51.42ms
+step:1154/1600 train_time:59382ms step_avg:51.46ms
+step:1155/1600 train_time:59468ms step_avg:51.49ms
+step:1156/1600 train_time:59553ms step_avg:51.52ms
+step:1157/1600 train_time:59640ms step_avg:51.55ms
+step:1158/1600 train_time:59725ms step_avg:51.58ms
+step:1159/1600 train_time:59814ms step_avg:51.61ms
+step:1160/1600 train_time:59899ms step_avg:51.64ms
+step:1161/1600 train_time:59987ms step_avg:51.67ms
+step:1162/1600 train_time:60071ms step_avg:51.70ms
+step:1163/1600 train_time:60160ms step_avg:51.73ms
+step:1164/1600 train_time:60246ms step_avg:51.76ms
+step:1165/1600 train_time:60332ms step_avg:51.79ms
+step:1166/1600 train_time:60417ms step_avg:51.82ms
+step:1167/1600 train_time:60506ms step_avg:51.85ms
+step:1168/1600 train_time:60591ms step_avg:51.88ms
+step:1169/1600 train_time:60679ms step_avg:51.91ms
+step:1170/1600 train_time:60766ms step_avg:51.94ms
+step:1171/1600 train_time:60854ms step_avg:51.97ms
+step:1172/1600 train_time:60939ms step_avg:52.00ms
+step:1173/1600 train_time:61027ms step_avg:52.03ms
+step:1174/1600 train_time:61113ms step_avg:52.06ms
+step:1175/1600 train_time:61200ms step_avg:52.09ms
+step:1176/1600 train_time:61285ms step_avg:52.11ms
+step:1177/1600 train_time:61374ms step_avg:52.14ms
+step:1178/1600 train_time:61459ms step_avg:52.17ms
+step:1179/1600 train_time:61547ms step_avg:52.20ms
+step:1180/1600 train_time:61630ms step_avg:52.23ms
+step:1181/1600 train_time:61720ms step_avg:52.26ms
+step:1182/1600 train_time:61805ms step_avg:52.29ms
+step:1183/1600 train_time:61894ms step_avg:52.32ms
+step:1184/1600 train_time:61979ms step_avg:52.35ms
+step:1185/1600 train_time:62068ms step_avg:52.38ms
+step:1186/1600 train_time:62152ms step_avg:52.40ms
+step:1187/1600 train_time:62240ms step_avg:52.43ms
+step:1188/1600 train_time:62326ms step_avg:52.46ms
+step:1189/1600 train_time:62414ms step_avg:52.49ms
+step:1190/1600 train_time:62498ms step_avg:52.52ms
+step:1191/1600 train_time:62587ms step_avg:52.55ms
+step:1192/1600 train_time:62672ms step_avg:52.58ms
+step:1193/1600 train_time:62761ms step_avg:52.61ms
+step:1194/1600 train_time:62845ms step_avg:52.63ms
+step:1195/1600 train_time:62934ms step_avg:52.66ms
+step:1196/1600 train_time:63018ms step_avg:52.69ms
+step:1197/1600 train_time:63106ms step_avg:52.72ms
+step:1198/1600 train_time:63191ms step_avg:52.75ms
+step:1199/1600 train_time:63279ms step_avg:52.78ms
+step:1200/1600 train_time:63365ms step_avg:52.80ms
+step:1201/1600 train_time:63453ms step_avg:52.83ms
+step:1202/1600 train_time:63538ms step_avg:52.86ms
+step:1203/1600 train_time:63626ms step_avg:52.89ms
+step:1204/1600 train_time:63711ms step_avg:52.92ms
+step:1205/1600 train_time:63799ms step_avg:52.95ms
+step:1206/1600 train_time:63884ms step_avg:52.97ms
+step:1207/1600 train_time:63974ms step_avg:53.00ms
+step:1208/1600 train_time:64059ms step_avg:53.03ms
+step:1209/1600 train_time:64147ms step_avg:53.06ms
+step:1210/1600 train_time:64232ms step_avg:53.08ms
+step:1211/1600 train_time:64320ms step_avg:53.11ms
+step:1212/1600 train_time:64405ms step_avg:53.14ms
+step:1213/1600 train_time:64494ms step_avg:53.17ms
+step:1214/1600 train_time:64579ms step_avg:53.19ms
+step:1215/1600 train_time:64667ms step_avg:53.22ms
+step:1216/1600 train_time:64752ms step_avg:53.25ms
+step:1217/1600 train_time:64841ms step_avg:53.28ms
+step:1218/1600 train_time:64926ms step_avg:53.31ms
+step:1219/1600 train_time:65014ms step_avg:53.33ms
+step:1220/1600 train_time:65099ms step_avg:53.36ms
+step:1221/1600 train_time:65187ms step_avg:53.39ms
+step:1222/1600 train_time:65272ms step_avg:53.41ms
+step:1223/1600 train_time:65360ms step_avg:53.44ms
+step:1224/1600 train_time:65445ms step_avg:53.47ms
+step:1225/1600 train_time:65533ms step_avg:53.50ms
+step:1226/1600 train_time:65617ms step_avg:53.52ms
+step:1227/1600 train_time:65705ms step_avg:53.55ms
+step:1228/1600 train_time:65790ms step_avg:53.58ms
+step:1229/1600 train_time:65878ms step_avg:53.60ms
+step:1230/1600 train_time:65965ms step_avg:53.63ms
+step:1231/1600 train_time:66054ms step_avg:53.66ms
+step:1232/1600 train_time:66139ms step_avg:53.68ms
+step:1233/1600 train_time:66226ms step_avg:53.71ms
+step:1234/1600 train_time:66312ms step_avg:53.74ms
+step:1235/1600 train_time:66400ms step_avg:53.76ms
+step:1236/1600 train_time:66486ms step_avg:53.79ms
+step:1237/1600 train_time:66574ms step_avg:53.82ms
+step:1238/1600 train_time:66659ms step_avg:53.84ms
+step:1239/1600 train_time:66747ms step_avg:53.87ms
+step:1240/1600 train_time:66831ms step_avg:53.90ms
+step:1241/1600 train_time:66920ms step_avg:53.92ms
+step:1242/1600 train_time:67006ms step_avg:53.95ms
+step:1243/1600 train_time:67095ms step_avg:53.98ms
+step:1244/1600 train_time:67181ms step_avg:54.00ms
+step:1245/1600 train_time:67270ms step_avg:54.03ms
+step:1246/1600 train_time:67354ms step_avg:54.06ms
+step:1247/1600 train_time:67443ms step_avg:54.08ms
+step:1248/1600 train_time:67529ms step_avg:54.11ms
+step:1249/1600 train_time:67617ms step_avg:54.14ms
+step:1250/1600 train_time:67701ms step_avg:54.16ms
+step:1250/1600 val_loss:3.4180 train_time:67773ms step_avg:54.22ms
+step:1251/1600 train_time:67794ms step_avg:54.19ms
+step:1252/1600 train_time:67877ms step_avg:54.22ms
+step:1253/1600 train_time:67971ms step_avg:54.25ms
+step:1254/1600 train_time:68059ms step_avg:54.27ms
+step:1255/1600 train_time:68145ms step_avg:54.30ms
+step:1256/1600 train_time:68229ms step_avg:54.32ms
+step:1257/1600 train_time:68316ms step_avg:54.35ms
+step:1258/1600 train_time:68400ms step_avg:54.37ms
+step:1259/1600 train_time:68487ms step_avg:54.40ms
+step:1260/1600 train_time:68572ms step_avg:54.42ms
+step:1261/1600 train_time:68659ms step_avg:54.45ms
+step:1262/1600 train_time:68746ms step_avg:54.47ms
+step:1263/1600 train_time:68835ms step_avg:54.50ms
+step:1264/1600 train_time:68923ms step_avg:54.53ms
+step:1265/1600 train_time:69013ms step_avg:54.56ms
+step:1266/1600 train_time:69099ms step_avg:54.58ms
+step:1267/1600 train_time:69187ms step_avg:54.61ms
+step:1268/1600 train_time:69271ms step_avg:54.63ms
+step:1269/1600 train_time:69358ms step_avg:54.66ms
+step:1270/1600 train_time:69442ms step_avg:54.68ms
+step:1271/1600 train_time:69531ms step_avg:54.71ms
+step:1272/1600 train_time:69615ms step_avg:54.73ms
+step:1273/1600 train_time:69701ms step_avg:54.75ms
+step:1274/1600 train_time:69787ms step_avg:54.78ms
+step:1275/1600 train_time:69877ms step_avg:54.81ms
+step:1276/1600 train_time:69963ms step_avg:54.83ms
+step:1277/1600 train_time:70052ms step_avg:54.86ms
+step:1278/1600 train_time:70136ms step_avg:54.88ms
+step:1279/1600 train_time:70224ms step_avg:54.91ms
+step:1280/1600 train_time:70308ms step_avg:54.93ms
+step:1281/1600 train_time:70396ms step_avg:54.95ms
+step:1282/1600 train_time:70480ms step_avg:54.98ms
+step:1283/1600 train_time:70568ms step_avg:55.00ms
+step:1284/1600 train_time:70652ms step_avg:55.02ms
+step:1285/1600 train_time:70741ms step_avg:55.05ms
+step:1286/1600 train_time:70826ms step_avg:55.07ms
+step:1287/1600 train_time:70915ms step_avg:55.10ms
+step:1288/1600 train_time:71001ms step_avg:55.12ms
+step:1289/1600 train_time:71091ms step_avg:55.15ms
+step:1290/1600 train_time:71176ms step_avg:55.18ms
+step:1291/1600 train_time:71264ms step_avg:55.20ms
+step:1292/1600 train_time:71348ms step_avg:55.22ms
+step:1293/1600 train_time:71436ms step_avg:55.25ms
+step:1294/1600 train_time:71522ms step_avg:55.27ms
+step:1295/1600 train_time:71610ms step_avg:55.30ms
+step:1296/1600 train_time:71695ms step_avg:55.32ms
+step:1297/1600 train_time:71783ms step_avg:55.35ms
+step:1298/1600 train_time:71869ms step_avg:55.37ms
+step:1299/1600 train_time:71957ms step_avg:55.39ms
+step:1300/1600 train_time:72044ms step_avg:55.42ms
+step:1301/1600 train_time:72132ms step_avg:55.44ms
+step:1302/1600 train_time:72218ms step_avg:55.47ms
+step:1303/1600 train_time:72306ms step_avg:55.49ms
+step:1304/1600 train_time:72391ms step_avg:55.51ms
+step:1305/1600 train_time:72478ms step_avg:55.54ms
+step:1306/1600 train_time:72564ms step_avg:55.56ms
+step:1307/1600 train_time:72651ms step_avg:55.59ms
+step:1308/1600 train_time:72737ms step_avg:55.61ms
+step:1309/1600 train_time:72825ms step_avg:55.63ms
+step:1310/1600 train_time:72910ms step_avg:55.66ms
+step:1311/1600 train_time:72998ms step_avg:55.68ms
+step:1312/1600 train_time:73085ms step_avg:55.71ms
+step:1313/1600 train_time:73173ms step_avg:55.73ms
+step:1314/1600 train_time:73258ms step_avg:55.75ms
+step:1315/1600 train_time:73347ms step_avg:55.78ms
+step:1316/1600 train_time:73431ms step_avg:55.80ms
+step:1317/1600 train_time:73519ms step_avg:55.82ms
+step:1318/1600 train_time:73604ms step_avg:55.84ms
+step:1319/1600 train_time:73691ms step_avg:55.87ms
+step:1320/1600 train_time:73776ms step_avg:55.89ms
+step:1321/1600 train_time:73864ms step_avg:55.92ms
+step:1322/1600 train_time:73950ms step_avg:55.94ms
+step:1323/1600 train_time:74038ms step_avg:55.96ms
+step:1324/1600 train_time:74125ms step_avg:55.99ms
+step:1325/1600 train_time:74213ms step_avg:56.01ms
+step:1326/1600 train_time:74298ms step_avg:56.03ms
+step:1327/1600 train_time:74387ms step_avg:56.06ms
+step:1328/1600 train_time:74471ms step_avg:56.08ms
+step:1329/1600 train_time:74560ms step_avg:56.10ms
+step:1330/1600 train_time:74644ms step_avg:56.12ms
+step:1331/1600 train_time:74733ms step_avg:56.15ms
+step:1332/1600 train_time:74817ms step_avg:56.17ms
+step:1333/1600 train_time:74905ms step_avg:56.19ms
+step:1334/1600 train_time:74991ms step_avg:56.21ms
+step:1335/1600 train_time:75080ms step_avg:56.24ms
+step:1336/1600 train_time:75166ms step_avg:56.26ms
+step:1337/1600 train_time:75254ms step_avg:56.29ms
+step:1338/1600 train_time:75339ms step_avg:56.31ms
+step:1339/1600 train_time:75428ms step_avg:56.33ms
+step:1340/1600 train_time:75512ms step_avg:56.35ms
+step:1341/1600 train_time:75600ms step_avg:56.38ms
+step:1342/1600 train_time:75685ms step_avg:56.40ms
+step:1343/1600 train_time:75773ms step_avg:56.42ms
+step:1344/1600 train_time:75858ms step_avg:56.44ms
+step:1345/1600 train_time:75946ms step_avg:56.47ms
+step:1346/1600 train_time:76031ms step_avg:56.49ms
+step:1347/1600 train_time:76119ms step_avg:56.51ms
+step:1348/1600 train_time:76204ms step_avg:56.53ms
+step:1349/1600 train_time:76294ms step_avg:56.56ms
+step:1350/1600 train_time:76380ms step_avg:56.58ms
+step:1351/1600 train_time:76467ms step_avg:56.60ms
+step:1352/1600 train_time:76551ms step_avg:56.62ms
+step:1353/1600 train_time:76639ms step_avg:56.64ms
+step:1354/1600 train_time:76725ms step_avg:56.67ms
+step:1355/1600 train_time:76813ms step_avg:56.69ms
+step:1356/1600 train_time:76898ms step_avg:56.71ms
+step:1357/1600 train_time:76987ms step_avg:56.73ms
+step:1358/1600 train_time:77073ms step_avg:56.75ms
+step:1359/1600 train_time:77161ms step_avg:56.78ms
+step:1360/1600 train_time:77246ms step_avg:56.80ms
+step:1361/1600 train_time:77334ms step_avg:56.82ms
+step:1362/1600 train_time:77418ms step_avg:56.84ms
+step:1363/1600 train_time:77506ms step_avg:56.86ms
+step:1364/1600 train_time:77591ms step_avg:56.88ms
+step:1365/1600 train_time:77678ms step_avg:56.91ms
+step:1366/1600 train_time:77767ms step_avg:56.93ms
+step:1367/1600 train_time:77853ms step_avg:56.95ms
+step:1368/1600 train_time:77938ms step_avg:56.97ms
+step:1369/1600 train_time:78026ms step_avg:56.99ms
+step:1370/1600 train_time:78111ms step_avg:57.02ms
+step:1371/1600 train_time:78199ms step_avg:57.04ms
+step:1372/1600 train_time:78284ms step_avg:57.06ms
+step:1373/1600 train_time:78372ms step_avg:57.08ms
+step:1374/1600 train_time:78457ms step_avg:57.10ms
+step:1375/1600 train_time:78546ms step_avg:57.12ms
+step:1376/1600 train_time:78631ms step_avg:57.14ms
+step:1377/1600 train_time:78719ms step_avg:57.17ms
+step:1378/1600 train_time:78806ms step_avg:57.19ms
+step:1379/1600 train_time:78895ms step_avg:57.21ms
+step:1380/1600 train_time:78980ms step_avg:57.23ms
+step:1381/1600 train_time:79068ms step_avg:57.25ms
+step:1382/1600 train_time:79152ms step_avg:57.27ms
+step:1383/1600 train_time:79239ms step_avg:57.30ms
+step:1384/1600 train_time:79326ms step_avg:57.32ms
+step:1385/1600 train_time:79413ms step_avg:57.34ms
+step:1386/1600 train_time:79498ms step_avg:57.36ms
+step:1387/1600 train_time:79587ms step_avg:57.38ms
+step:1388/1600 train_time:79672ms step_avg:57.40ms
+step:1389/1600 train_time:79759ms step_avg:57.42ms
+step:1390/1600 train_time:79846ms step_avg:57.44ms
+step:1391/1600 train_time:79934ms step_avg:57.47ms
+step:1392/1600 train_time:80019ms step_avg:57.49ms
+step:1393/1600 train_time:80108ms step_avg:57.51ms
+step:1394/1600 train_time:80193ms step_avg:57.53ms
+step:1395/1600 train_time:80282ms step_avg:57.55ms
+step:1396/1600 train_time:80367ms step_avg:57.57ms
+step:1397/1600 train_time:80455ms step_avg:57.59ms
+step:1398/1600 train_time:80541ms step_avg:57.61ms
+step:1399/1600 train_time:80630ms step_avg:57.63ms
+step:1400/1600 train_time:80714ms step_avg:57.65ms
+step:1401/1600 train_time:80803ms step_avg:57.67ms
+step:1402/1600 train_time:80888ms step_avg:57.69ms
+step:1403/1600 train_time:80975ms step_avg:57.72ms
+step:1404/1600 train_time:81061ms step_avg:57.74ms
+step:1405/1600 train_time:81149ms step_avg:57.76ms
+step:1406/1600 train_time:81234ms step_avg:57.78ms
+step:1407/1600 train_time:81322ms step_avg:57.80ms
+step:1408/1600 train_time:81407ms step_avg:57.82ms
+step:1409/1600 train_time:81495ms step_avg:57.84ms
+step:1410/1600 train_time:81581ms step_avg:57.86ms
+step:1411/1600 train_time:81670ms step_avg:57.88ms
+step:1412/1600 train_time:81755ms step_avg:57.90ms
+step:1413/1600 train_time:81843ms step_avg:57.92ms
+step:1414/1600 train_time:81928ms step_avg:57.94ms
+step:1415/1600 train_time:82016ms step_avg:57.96ms
+step:1416/1600 train_time:82101ms step_avg:57.98ms
+step:1417/1600 train_time:82189ms step_avg:58.00ms
+step:1418/1600 train_time:82273ms step_avg:58.02ms
+step:1419/1600 train_time:82362ms step_avg:58.04ms
+step:1420/1600 train_time:82447ms step_avg:58.06ms
+step:1421/1600 train_time:82535ms step_avg:58.08ms
+step:1422/1600 train_time:82621ms step_avg:58.10ms
+step:1423/1600 train_time:82710ms step_avg:58.12ms
+step:1424/1600 train_time:82795ms step_avg:58.14ms
+step:1425/1600 train_time:82883ms step_avg:58.16ms
+step:1426/1600 train_time:82967ms step_avg:58.18ms
+step:1427/1600 train_time:83056ms step_avg:58.20ms
+step:1428/1600 train_time:83140ms step_avg:58.22ms
+step:1429/1600 train_time:83229ms step_avg:58.24ms
+step:1430/1600 train_time:83314ms step_avg:58.26ms
+step:1431/1600 train_time:83402ms step_avg:58.28ms
+step:1432/1600 train_time:83487ms step_avg:58.30ms
+step:1433/1600 train_time:83576ms step_avg:58.32ms
+step:1434/1600 train_time:83661ms step_avg:58.34ms
+step:1435/1600 train_time:83750ms step_avg:58.36ms
+step:1436/1600 train_time:83835ms step_avg:58.38ms
+step:1437/1600 train_time:83923ms step_avg:58.40ms
+step:1438/1600 train_time:84008ms step_avg:58.42ms
+step:1439/1600 train_time:84095ms step_avg:58.44ms
+step:1440/1600 train_time:84181ms step_avg:58.46ms
+step:1441/1600 train_time:84269ms step_avg:58.48ms
+step:1442/1600 train_time:84354ms step_avg:58.50ms
+step:1443/1600 train_time:84442ms step_avg:58.52ms
+step:1444/1600 train_time:84528ms step_avg:58.54ms
+step:1445/1600 train_time:84616ms step_avg:58.56ms
+step:1446/1600 train_time:84701ms step_avg:58.58ms
+step:1447/1600 train_time:84790ms step_avg:58.60ms
+step:1448/1600 train_time:84875ms step_avg:58.62ms
+step:1449/1600 train_time:84966ms step_avg:58.64ms
+step:1450/1600 train_time:85049ms step_avg:58.65ms
+step:1451/1600 train_time:85137ms step_avg:58.67ms
+step:1452/1600 train_time:85222ms step_avg:58.69ms
+step:1453/1600 train_time:85311ms step_avg:58.71ms
+step:1454/1600 train_time:85396ms step_avg:58.73ms
+step:1455/1600 train_time:85484ms step_avg:58.75ms
+step:1456/1600 train_time:85570ms step_avg:58.77ms
+step:1457/1600 train_time:85658ms step_avg:58.79ms
+step:1458/1600 train_time:85743ms step_avg:58.81ms
+step:1459/1600 train_time:85832ms step_avg:58.83ms
+step:1460/1600 train_time:85917ms step_avg:58.85ms
+step:1461/1600 train_time:86006ms step_avg:58.87ms
+step:1462/1600 train_time:86090ms step_avg:58.89ms
+step:1463/1600 train_time:86178ms step_avg:58.91ms
+step:1464/1600 train_time:86265ms step_avg:58.92ms
+step:1465/1600 train_time:86353ms step_avg:58.94ms
+step:1466/1600 train_time:86438ms step_avg:58.96ms
+step:1467/1600 train_time:86527ms step_avg:58.98ms
+step:1468/1600 train_time:86611ms step_avg:59.00ms
+step:1469/1600 train_time:86699ms step_avg:59.02ms
+step:1470/1600 train_time:86784ms step_avg:59.04ms
+step:1471/1600 train_time:86872ms step_avg:59.06ms
+step:1472/1600 train_time:86958ms step_avg:59.07ms
+step:1473/1600 train_time:87047ms step_avg:59.10ms
+step:1474/1600 train_time:87132ms step_avg:59.11ms
+step:1475/1600 train_time:87221ms step_avg:59.13ms
+step:1476/1600 train_time:87305ms step_avg:59.15ms
+step:1477/1600 train_time:87393ms step_avg:59.17ms
+step:1478/1600 train_time:87479ms step_avg:59.19ms
+step:1479/1600 train_time:87568ms step_avg:59.21ms
+step:1480/1600 train_time:87654ms step_avg:59.23ms
+step:1481/1600 train_time:87741ms step_avg:59.24ms
+step:1482/1600 train_time:87826ms step_avg:59.26ms
+step:1483/1600 train_time:87913ms step_avg:59.28ms
+step:1484/1600 train_time:87999ms step_avg:59.30ms
+step:1485/1600 train_time:88087ms step_avg:59.32ms
+step:1486/1600 train_time:88172ms step_avg:59.33ms
+step:1487/1600 train_time:88260ms step_avg:59.35ms
+step:1488/1600 train_time:88345ms step_avg:59.37ms
+step:1489/1600 train_time:88434ms step_avg:59.39ms
+step:1490/1600 train_time:88518ms step_avg:59.41ms
+step:1491/1600 train_time:88606ms step_avg:59.43ms
+step:1492/1600 train_time:88691ms step_avg:59.44ms
+step:1493/1600 train_time:88779ms step_avg:59.46ms
+step:1494/1600 train_time:88864ms step_avg:59.48ms
+step:1495/1600 train_time:88953ms step_avg:59.50ms
+step:1496/1600 train_time:89038ms step_avg:59.52ms
+step:1497/1600 train_time:89128ms step_avg:59.54ms
+step:1498/1600 train_time:89212ms step_avg:59.55ms
+step:1499/1600 train_time:89299ms step_avg:59.57ms
+step:1500/1600 train_time:89385ms step_avg:59.59ms
+step:1500/1600 val_loss:3.3080 train_time:89456ms step_avg:59.64ms
+step:1501/1600 train_time:89478ms step_avg:59.61ms
+step:1502/1600 train_time:89562ms step_avg:59.63ms
+step:1503/1600 train_time:89654ms step_avg:59.65ms
+step:1504/1600 train_time:89739ms step_avg:59.67ms
+step:1505/1600 train_time:89826ms step_avg:59.68ms
+step:1506/1600 train_time:89910ms step_avg:59.70ms
+step:1507/1600 train_time:89997ms step_avg:59.72ms
+step:1508/1600 train_time:90082ms step_avg:59.74ms
+step:1509/1600 train_time:90168ms step_avg:59.75ms
+step:1510/1600 train_time:90254ms step_avg:59.77ms
+step:1511/1600 train_time:90343ms step_avg:59.79ms
+step:1512/1600 train_time:90429ms step_avg:59.81ms
+step:1513/1600 train_time:90519ms step_avg:59.83ms
+step:1514/1600 train_time:90606ms step_avg:59.85ms
+step:1515/1600 train_time:90696ms step_avg:59.87ms
+step:1516/1600 train_time:90780ms step_avg:59.88ms
+step:1517/1600 train_time:90868ms step_avg:59.90ms
+step:1518/1600 train_time:90952ms step_avg:59.92ms
+step:1519/1600 train_time:91040ms step_avg:59.93ms
+step:1520/1600 train_time:91125ms step_avg:59.95ms
+step:1521/1600 train_time:91213ms step_avg:59.97ms
+step:1522/1600 train_time:91297ms step_avg:59.99ms
+step:1523/1600 train_time:91386ms step_avg:60.00ms
+step:1524/1600 train_time:91472ms step_avg:60.02ms
+step:1525/1600 train_time:91561ms step_avg:60.04ms
+step:1526/1600 train_time:91647ms step_avg:60.06ms
+step:1527/1600 train_time:91735ms step_avg:60.08ms
+step:1528/1600 train_time:91820ms step_avg:60.09ms
+step:1529/1600 train_time:91908ms step_avg:60.11ms
+step:1530/1600 train_time:91993ms step_avg:60.13ms
+step:1531/1600 train_time:92081ms step_avg:60.14ms
+step:1532/1600 train_time:92165ms step_avg:60.16ms
+step:1533/1600 train_time:92253ms step_avg:60.18ms
+step:1534/1600 train_time:92337ms step_avg:60.19ms
+step:1535/1600 train_time:92426ms step_avg:60.21ms
+step:1536/1600 train_time:92512ms step_avg:60.23ms
+step:1537/1600 train_time:92602ms step_avg:60.25ms
+step:1538/1600 train_time:92687ms step_avg:60.26ms
+step:1539/1600 train_time:92776ms step_avg:60.28ms
+step:1540/1600 train_time:92860ms step_avg:60.30ms
+step:1541/1600 train_time:92948ms step_avg:60.32ms
+step:1542/1600 train_time:93035ms step_avg:60.33ms
+step:1543/1600 train_time:93122ms step_avg:60.35ms
+step:1544/1600 train_time:93207ms step_avg:60.37ms
+step:1545/1600 train_time:93296ms step_avg:60.39ms
+step:1546/1600 train_time:93379ms step_avg:60.40ms
+step:1547/1600 train_time:93468ms step_avg:60.42ms
+step:1548/1600 train_time:93554ms step_avg:60.44ms
+step:1549/1600 train_time:93644ms step_avg:60.45ms
+step:1550/1600 train_time:93729ms step_avg:60.47ms
+step:1551/1600 train_time:93817ms step_avg:60.49ms
+step:1552/1600 train_time:93902ms step_avg:60.50ms
+step:1553/1600 train_time:93990ms step_avg:60.52ms
+step:1554/1600 train_time:94076ms step_avg:60.54ms
+step:1555/1600 train_time:94163ms step_avg:60.55ms
+step:1556/1600 train_time:94249ms step_avg:60.57ms
+step:1557/1600 train_time:94337ms step_avg:60.59ms
+step:1558/1600 train_time:94421ms step_avg:60.60ms
+step:1559/1600 train_time:94509ms step_avg:60.62ms
+step:1560/1600 train_time:94594ms step_avg:60.64ms
+step:1561/1600 train_time:94690ms step_avg:60.66ms
+step:1562/1600 train_time:94775ms step_avg:60.68ms
+step:1563/1600 train_time:94864ms step_avg:60.69ms
+step:1564/1600 train_time:94949ms step_avg:60.71ms
+step:1565/1600 train_time:95037ms step_avg:60.73ms
+step:1566/1600 train_time:95122ms step_avg:60.74ms
+step:1567/1600 train_time:95210ms step_avg:60.76ms
+step:1568/1600 train_time:95296ms step_avg:60.78ms
+step:1569/1600 train_time:95385ms step_avg:60.79ms
+step:1570/1600 train_time:95470ms step_avg:60.81ms
+step:1571/1600 train_time:95560ms step_avg:60.83ms
+step:1572/1600 train_time:95646ms step_avg:60.84ms
+step:1573/1600 train_time:95735ms step_avg:60.86ms
+step:1574/1600 train_time:95820ms step_avg:60.88ms
+step:1575/1600 train_time:95909ms step_avg:60.89ms
+step:1576/1600 train_time:95995ms step_avg:60.91ms
+step:1577/1600 train_time:96087ms step_avg:60.93ms
+step:1578/1600 train_time:96171ms step_avg:60.94ms
+step:1579/1600 train_time:96259ms step_avg:60.96ms
+step:1580/1600 train_time:96345ms step_avg:60.98ms
+step:1581/1600 train_time:96434ms step_avg:61.00ms
+step:1582/1600 train_time:96519ms step_avg:61.01ms
+step:1583/1600 train_time:96607ms step_avg:61.03ms
+step:1584/1600 train_time:96694ms step_avg:61.04ms
+step:1585/1600 train_time:96782ms step_avg:61.06ms
+step:1586/1600 train_time:96867ms step_avg:61.08ms
+step:1587/1600 train_time:96956ms step_avg:61.09ms
+step:1588/1600 train_time:97042ms step_avg:61.11ms
+step:1589/1600 train_time:97129ms step_avg:61.13ms
+step:1590/1600 train_time:97216ms step_avg:61.14ms
+step:1591/1600 train_time:97303ms step_avg:61.16ms
+step:1592/1600 train_time:97389ms step_avg:61.17ms
+step:1593/1600 train_time:97477ms step_avg:61.19ms
+step:1594/1600 train_time:97562ms step_avg:61.21ms
+step:1595/1600 train_time:97651ms step_avg:61.22ms
+step:1596/1600 train_time:97736ms step_avg:61.24ms
+step:1597/1600 train_time:97825ms step_avg:61.26ms
+step:1598/1600 train_time:97912ms step_avg:61.27ms
+step:1599/1600 train_time:97999ms step_avg:61.29ms
+step:1600/1600 train_time:98085ms step_avg:61.30ms
+step:1600/1600 val_loss:3.2788 train_time:98156ms step_avg:61.35ms
+peak memory allocated: 30264 MiB reserved: 46238 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/a88564a2-7783-4a1e-9cdc-1dd16244525b.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/a88564a2-7783-4a1e-9cdc-1dd16244525b.txt
@@ -1,0 +1,4096 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 01 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # shifting first layer updates this to 01 ... 01 @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:33:33 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            131W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          254119      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          254120      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          254121      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          254122      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          254123      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          254124      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          254125      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          254126      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 511, 512, 513, 1023, 1024, 1025, 1534, 1535, 1536] for warmup
+Resetting Model
+step:0/1575 val_loss:10.8295 train_time:0ms step_avg:0.03ms
+step:1/1575 train_time:91ms step_avg:90.81ms
+step:2/1575 train_time:115ms step_avg:57.59ms
+step:3/1575 train_time:136ms step_avg:45.35ms
+step:4/1575 train_time:167ms step_avg:41.70ms
+step:5/1575 train_time:197ms step_avg:39.40ms
+step:6/1575 train_time:270ms step_avg:45.08ms
+step:7/1575 train_time:289ms step_avg:41.27ms
+step:8/1575 train_time:440ms step_avg:55.05ms
+step:9/1575 train_time:471ms step_avg:52.30ms
+step:10/1575 train_time:510ms step_avg:50.98ms
+step:11/1575 train_time:540ms step_avg:49.10ms
+step:12/1575 train_time:579ms step_avg:48.23ms
+step:13/1575 train_time:610ms step_avg:46.91ms
+step:14/1575 train_time:649ms step_avg:46.33ms
+step:15/1575 train_time:680ms step_avg:45.31ms
+step:16/1575 train_time:719ms step_avg:44.93ms
+step:17/1575 train_time:749ms step_avg:44.09ms
+step:18/1575 train_time:788ms step_avg:43.79ms
+step:19/1575 train_time:819ms step_avg:43.11ms
+step:20/1575 train_time:858ms step_avg:42.90ms
+step:21/1575 train_time:889ms step_avg:42.32ms
+step:22/1575 train_time:928ms step_avg:42.16ms
+step:23/1575 train_time:959ms step_avg:41.68ms
+step:24/1575 train_time:998ms step_avg:41.57ms
+step:25/1575 train_time:1029ms step_avg:41.14ms
+step:26/1575 train_time:1067ms step_avg:41.05ms
+step:27/1575 train_time:1098ms step_avg:40.68ms
+step:28/1575 train_time:1137ms step_avg:40.61ms
+step:29/1575 train_time:1168ms step_avg:40.26ms
+step:30/1575 train_time:1207ms step_avg:40.24ms
+step:31/1575 train_time:1238ms step_avg:39.92ms
+step:32/1575 train_time:1276ms step_avg:39.89ms
+step:33/1575 train_time:1307ms step_avg:39.61ms
+step:34/1575 train_time:1346ms step_avg:39.58ms
+step:35/1575 train_time:1377ms step_avg:39.34ms
+step:36/1575 train_time:1416ms step_avg:39.33ms
+step:37/1575 train_time:1447ms step_avg:39.10ms
+step:38/1575 train_time:1485ms step_avg:39.09ms
+step:39/1575 train_time:1516ms step_avg:38.88ms
+step:40/1575 train_time:1555ms step_avg:38.88ms
+step:41/1575 train_time:1586ms step_avg:38.69ms
+step:42/1575 train_time:1625ms step_avg:38.70ms
+step:43/1575 train_time:1656ms step_avg:38.52ms
+step:44/1575 train_time:1695ms step_avg:38.52ms
+step:45/1575 train_time:1726ms step_avg:38.35ms
+step:46/1575 train_time:1765ms step_avg:38.36ms
+step:47/1575 train_time:1796ms step_avg:38.22ms
+step:48/1575 train_time:1835ms step_avg:38.23ms
+step:49/1575 train_time:1866ms step_avg:38.08ms
+step:50/1575 train_time:1905ms step_avg:38.10ms
+step:51/1575 train_time:1936ms step_avg:37.96ms
+step:52/1575 train_time:1974ms step_avg:37.97ms
+step:53/1575 train_time:2006ms step_avg:37.84ms
+step:54/1575 train_time:2045ms step_avg:37.87ms
+step:55/1575 train_time:2076ms step_avg:37.75ms
+step:56/1575 train_time:2115ms step_avg:37.77ms
+step:57/1575 train_time:2146ms step_avg:37.64ms
+step:58/1575 train_time:2185ms step_avg:37.67ms
+step:59/1575 train_time:2216ms step_avg:37.56ms
+step:60/1575 train_time:2255ms step_avg:37.59ms
+step:61/1575 train_time:2286ms step_avg:37.48ms
+step:62/1575 train_time:2326ms step_avg:37.51ms
+step:63/1575 train_time:2356ms step_avg:37.40ms
+step:64/1575 train_time:2395ms step_avg:37.42ms
+step:65/1575 train_time:2426ms step_avg:37.32ms
+step:66/1575 train_time:2465ms step_avg:37.35ms
+step:67/1575 train_time:2496ms step_avg:37.25ms
+step:68/1575 train_time:2535ms step_avg:37.27ms
+step:69/1575 train_time:2566ms step_avg:37.18ms
+step:70/1575 train_time:2605ms step_avg:37.21ms
+step:71/1575 train_time:2636ms step_avg:37.12ms
+step:72/1575 train_time:2674ms step_avg:37.14ms
+step:73/1575 train_time:2705ms step_avg:37.06ms
+step:74/1575 train_time:2744ms step_avg:37.08ms
+step:75/1575 train_time:2775ms step_avg:36.99ms
+step:76/1575 train_time:2814ms step_avg:37.02ms
+step:77/1575 train_time:2845ms step_avg:36.94ms
+step:78/1575 train_time:2883ms step_avg:36.96ms
+step:79/1575 train_time:2914ms step_avg:36.89ms
+step:80/1575 train_time:2953ms step_avg:36.91ms
+step:81/1575 train_time:2984ms step_avg:36.84ms
+step:82/1575 train_time:3023ms step_avg:36.87ms
+step:83/1575 train_time:3054ms step_avg:36.80ms
+step:84/1575 train_time:3093ms step_avg:36.82ms
+step:85/1575 train_time:3124ms step_avg:36.75ms
+step:86/1575 train_time:3163ms step_avg:36.78ms
+step:87/1575 train_time:3194ms step_avg:36.71ms
+step:88/1575 train_time:3233ms step_avg:36.74ms
+step:89/1575 train_time:3264ms step_avg:36.67ms
+step:90/1575 train_time:3303ms step_avg:36.70ms
+step:91/1575 train_time:3334ms step_avg:36.64ms
+step:92/1575 train_time:3372ms step_avg:36.66ms
+step:93/1575 train_time:3404ms step_avg:36.60ms
+step:94/1575 train_time:3442ms step_avg:36.62ms
+step:95/1575 train_time:3473ms step_avg:36.56ms
+step:96/1575 train_time:3513ms step_avg:36.59ms
+step:97/1575 train_time:3543ms step_avg:36.53ms
+step:98/1575 train_time:3582ms step_avg:36.55ms
+step:99/1575 train_time:3613ms step_avg:36.50ms
+step:100/1575 train_time:3652ms step_avg:36.52ms
+step:101/1575 train_time:3683ms step_avg:36.46ms
+step:102/1575 train_time:3722ms step_avg:36.49ms
+step:103/1575 train_time:3752ms step_avg:36.43ms
+step:104/1575 train_time:3792ms step_avg:36.46ms
+step:105/1575 train_time:3823ms step_avg:36.41ms
+step:106/1575 train_time:3861ms step_avg:36.43ms
+step:107/1575 train_time:3892ms step_avg:36.38ms
+step:108/1575 train_time:3932ms step_avg:36.40ms
+step:109/1575 train_time:3963ms step_avg:36.35ms
+step:110/1575 train_time:4001ms step_avg:36.37ms
+step:111/1575 train_time:4032ms step_avg:36.32ms
+step:112/1575 train_time:4070ms step_avg:36.34ms
+step:113/1575 train_time:4101ms step_avg:36.30ms
+step:114/1575 train_time:4140ms step_avg:36.32ms
+step:115/1575 train_time:4171ms step_avg:36.27ms
+step:116/1575 train_time:4210ms step_avg:36.29ms
+step:117/1575 train_time:4241ms step_avg:36.24ms
+step:118/1575 train_time:4279ms step_avg:36.26ms
+step:119/1575 train_time:4310ms step_avg:36.22ms
+step:120/1575 train_time:4349ms step_avg:36.24ms
+step:121/1575 train_time:4380ms step_avg:36.20ms
+step:122/1575 train_time:4419ms step_avg:36.22ms
+step:123/1575 train_time:4449ms step_avg:36.17ms
+step:124/1575 train_time:4488ms step_avg:36.19ms
+step:125/1575 train_time:4519ms step_avg:36.15ms
+step:126/1575 train_time:4558ms step_avg:36.17ms
+step:127/1575 train_time:4589ms step_avg:36.13ms
+step:128/1575 train_time:4628ms step_avg:36.15ms
+step:129/1575 train_time:4658ms step_avg:36.11ms
+step:130/1575 train_time:4697ms step_avg:36.13ms
+step:131/1575 train_time:4728ms step_avg:36.09ms
+step:132/1575 train_time:4767ms step_avg:36.11ms
+step:133/1575 train_time:4798ms step_avg:36.07ms
+step:134/1575 train_time:4836ms step_avg:36.09ms
+step:135/1575 train_time:4867ms step_avg:36.05ms
+step:136/1575 train_time:4906ms step_avg:36.07ms
+step:137/1575 train_time:4937ms step_avg:36.04ms
+step:138/1575 train_time:4975ms step_avg:36.05ms
+step:139/1575 train_time:5006ms step_avg:36.01ms
+step:140/1575 train_time:5045ms step_avg:36.04ms
+step:141/1575 train_time:5076ms step_avg:36.00ms
+step:142/1575 train_time:5115ms step_avg:36.02ms
+step:143/1575 train_time:5145ms step_avg:35.98ms
+step:144/1575 train_time:5184ms step_avg:36.00ms
+step:145/1575 train_time:5215ms step_avg:35.96ms
+step:146/1575 train_time:5253ms step_avg:35.98ms
+step:147/1575 train_time:5284ms step_avg:35.95ms
+step:148/1575 train_time:5323ms step_avg:35.97ms
+step:149/1575 train_time:5354ms step_avg:35.94ms
+step:150/1575 train_time:5393ms step_avg:35.95ms
+step:151/1575 train_time:5424ms step_avg:35.92ms
+step:152/1575 train_time:5463ms step_avg:35.94ms
+step:153/1575 train_time:5494ms step_avg:35.91ms
+step:154/1575 train_time:5533ms step_avg:35.93ms
+step:155/1575 train_time:5563ms step_avg:35.89ms
+step:156/1575 train_time:5602ms step_avg:35.91ms
+step:157/1575 train_time:5633ms step_avg:35.88ms
+step:158/1575 train_time:5672ms step_avg:35.90ms
+step:159/1575 train_time:5703ms step_avg:35.87ms
+step:160/1575 train_time:5742ms step_avg:35.89ms
+step:161/1575 train_time:5772ms step_avg:35.85ms
+step:162/1575 train_time:5811ms step_avg:35.87ms
+step:163/1575 train_time:5842ms step_avg:35.84ms
+step:164/1575 train_time:5881ms step_avg:35.86ms
+step:165/1575 train_time:5911ms step_avg:35.83ms
+step:166/1575 train_time:5950ms step_avg:35.84ms
+step:167/1575 train_time:5981ms step_avg:35.81ms
+step:168/1575 train_time:6019ms step_avg:35.83ms
+step:169/1575 train_time:6050ms step_avg:35.80ms
+step:170/1575 train_time:6089ms step_avg:35.82ms
+step:171/1575 train_time:6120ms step_avg:35.79ms
+step:172/1575 train_time:6159ms step_avg:35.81ms
+step:173/1575 train_time:6190ms step_avg:35.78ms
+step:174/1575 train_time:6229ms step_avg:35.80ms
+step:175/1575 train_time:6259ms step_avg:35.77ms
+step:176/1575 train_time:6298ms step_avg:35.78ms
+step:177/1575 train_time:6328ms step_avg:35.75ms
+step:178/1575 train_time:6367ms step_avg:35.77ms
+step:179/1575 train_time:6398ms step_avg:35.74ms
+step:180/1575 train_time:6437ms step_avg:35.76ms
+step:181/1575 train_time:6467ms step_avg:35.73ms
+step:182/1575 train_time:6506ms step_avg:35.75ms
+step:183/1575 train_time:6537ms step_avg:35.72ms
+step:184/1575 train_time:6575ms step_avg:35.74ms
+step:185/1575 train_time:6606ms step_avg:35.71ms
+step:186/1575 train_time:6645ms step_avg:35.73ms
+step:187/1575 train_time:6675ms step_avg:35.70ms
+step:188/1575 train_time:6714ms step_avg:35.71ms
+step:189/1575 train_time:6745ms step_avg:35.69ms
+step:190/1575 train_time:6784ms step_avg:35.71ms
+step:191/1575 train_time:6815ms step_avg:35.68ms
+step:192/1575 train_time:6854ms step_avg:35.70ms
+step:193/1575 train_time:6885ms step_avg:35.67ms
+step:194/1575 train_time:6923ms step_avg:35.69ms
+step:195/1575 train_time:6954ms step_avg:35.66ms
+step:196/1575 train_time:6993ms step_avg:35.68ms
+step:197/1575 train_time:7023ms step_avg:35.65ms
+step:198/1575 train_time:7062ms step_avg:35.67ms
+step:199/1575 train_time:7093ms step_avg:35.64ms
+step:200/1575 train_time:7132ms step_avg:35.66ms
+step:201/1575 train_time:7162ms step_avg:35.63ms
+step:202/1575 train_time:7202ms step_avg:35.65ms
+step:203/1575 train_time:7232ms step_avg:35.63ms
+step:204/1575 train_time:7270ms step_avg:35.64ms
+step:205/1575 train_time:7301ms step_avg:35.62ms
+step:206/1575 train_time:7340ms step_avg:35.63ms
+step:207/1575 train_time:7371ms step_avg:35.61ms
+step:208/1575 train_time:7410ms step_avg:35.62ms
+step:209/1575 train_time:7440ms step_avg:35.60ms
+step:210/1575 train_time:7479ms step_avg:35.61ms
+step:211/1575 train_time:7510ms step_avg:35.59ms
+step:212/1575 train_time:7548ms step_avg:35.61ms
+step:213/1575 train_time:7579ms step_avg:35.58ms
+step:214/1575 train_time:7618ms step_avg:35.60ms
+step:215/1575 train_time:7649ms step_avg:35.58ms
+step:216/1575 train_time:7688ms step_avg:35.59ms
+step:217/1575 train_time:7719ms step_avg:35.57ms
+step:218/1575 train_time:7757ms step_avg:35.58ms
+step:219/1575 train_time:7788ms step_avg:35.56ms
+step:220/1575 train_time:7827ms step_avg:35.58ms
+step:221/1575 train_time:7858ms step_avg:35.56ms
+step:222/1575 train_time:7896ms step_avg:35.57ms
+step:223/1575 train_time:7927ms step_avg:35.55ms
+step:224/1575 train_time:7966ms step_avg:35.56ms
+step:225/1575 train_time:7997ms step_avg:35.54ms
+step:226/1575 train_time:8036ms step_avg:35.56ms
+step:227/1575 train_time:8066ms step_avg:35.53ms
+step:228/1575 train_time:8105ms step_avg:35.55ms
+step:229/1575 train_time:8136ms step_avg:35.53ms
+step:230/1575 train_time:8175ms step_avg:35.54ms
+step:231/1575 train_time:8206ms step_avg:35.52ms
+step:232/1575 train_time:8244ms step_avg:35.54ms
+step:233/1575 train_time:8275ms step_avg:35.51ms
+step:234/1575 train_time:8314ms step_avg:35.53ms
+step:235/1575 train_time:8344ms step_avg:35.51ms
+step:236/1575 train_time:8383ms step_avg:35.52ms
+step:237/1575 train_time:8414ms step_avg:35.50ms
+step:238/1575 train_time:8453ms step_avg:35.52ms
+step:239/1575 train_time:8484ms step_avg:35.50ms
+step:240/1575 train_time:8523ms step_avg:35.51ms
+step:241/1575 train_time:8554ms step_avg:35.49ms
+step:242/1575 train_time:8592ms step_avg:35.51ms
+step:243/1575 train_time:8623ms step_avg:35.48ms
+step:244/1575 train_time:8662ms step_avg:35.50ms
+step:245/1575 train_time:8693ms step_avg:35.48ms
+step:246/1575 train_time:8731ms step_avg:35.49ms
+step:247/1575 train_time:8762ms step_avg:35.47ms
+step:248/1575 train_time:8801ms step_avg:35.49ms
+step:249/1575 train_time:8832ms step_avg:35.47ms
+step:250/1575 train_time:8871ms step_avg:35.48ms
+step:250/1575 val_loss:4.5825 train_time:8920ms step_avg:35.68ms
+step:251/1575 train_time:8940ms step_avg:35.62ms
+step:252/1575 train_time:8960ms step_avg:35.56ms
+step:253/1575 train_time:8978ms step_avg:35.49ms
+step:254/1575 train_time:9016ms step_avg:35.50ms
+step:255/1575 train_time:9049ms step_avg:35.49ms
+step:256/1575 train_time:9089ms step_avg:35.50ms
+step:257/1575 train_time:9120ms step_avg:35.49ms
+step:258/1575 train_time:9159ms step_avg:35.50ms
+step:259/1575 train_time:9189ms step_avg:35.48ms
+step:260/1575 train_time:9228ms step_avg:35.49ms
+step:261/1575 train_time:9259ms step_avg:35.48ms
+step:262/1575 train_time:9298ms step_avg:35.49ms
+step:263/1575 train_time:9329ms step_avg:35.47ms
+step:264/1575 train_time:9367ms step_avg:35.48ms
+step:265/1575 train_time:9398ms step_avg:35.46ms
+step:266/1575 train_time:9437ms step_avg:35.48ms
+step:267/1575 train_time:9467ms step_avg:35.46ms
+step:268/1575 train_time:9506ms step_avg:35.47ms
+step:269/1575 train_time:9536ms step_avg:35.45ms
+step:270/1575 train_time:9575ms step_avg:35.46ms
+step:271/1575 train_time:9605ms step_avg:35.44ms
+step:272/1575 train_time:9644ms step_avg:35.46ms
+step:273/1575 train_time:9675ms step_avg:35.44ms
+step:274/1575 train_time:9713ms step_avg:35.45ms
+step:275/1575 train_time:9744ms step_avg:35.43ms
+step:276/1575 train_time:9782ms step_avg:35.44ms
+step:277/1575 train_time:9813ms step_avg:35.43ms
+step:278/1575 train_time:9852ms step_avg:35.44ms
+step:279/1575 train_time:9882ms step_avg:35.42ms
+step:280/1575 train_time:9921ms step_avg:35.43ms
+step:281/1575 train_time:9951ms step_avg:35.41ms
+step:282/1575 train_time:9991ms step_avg:35.43ms
+step:283/1575 train_time:10021ms step_avg:35.41ms
+step:284/1575 train_time:10060ms step_avg:35.42ms
+step:285/1575 train_time:10090ms step_avg:35.40ms
+step:286/1575 train_time:10129ms step_avg:35.42ms
+step:287/1575 train_time:10160ms step_avg:35.40ms
+step:288/1575 train_time:10199ms step_avg:35.41ms
+step:289/1575 train_time:10230ms step_avg:35.40ms
+step:290/1575 train_time:10269ms step_avg:35.41ms
+step:291/1575 train_time:10299ms step_avg:35.39ms
+step:292/1575 train_time:10338ms step_avg:35.40ms
+step:293/1575 train_time:10369ms step_avg:35.39ms
+step:294/1575 train_time:10408ms step_avg:35.40ms
+step:295/1575 train_time:10438ms step_avg:35.38ms
+step:296/1575 train_time:10477ms step_avg:35.40ms
+step:297/1575 train_time:10508ms step_avg:35.38ms
+step:298/1575 train_time:10546ms step_avg:35.39ms
+step:299/1575 train_time:10578ms step_avg:35.38ms
+step:300/1575 train_time:10617ms step_avg:35.39ms
+step:301/1575 train_time:10647ms step_avg:35.37ms
+step:302/1575 train_time:10686ms step_avg:35.38ms
+step:303/1575 train_time:10717ms step_avg:35.37ms
+step:304/1575 train_time:10755ms step_avg:35.38ms
+step:305/1575 train_time:10786ms step_avg:35.36ms
+step:306/1575 train_time:10825ms step_avg:35.38ms
+step:307/1575 train_time:10856ms step_avg:35.36ms
+step:308/1575 train_time:10895ms step_avg:35.37ms
+step:309/1575 train_time:10926ms step_avg:35.36ms
+step:310/1575 train_time:10965ms step_avg:35.37ms
+step:311/1575 train_time:10996ms step_avg:35.36ms
+step:312/1575 train_time:11035ms step_avg:35.37ms
+step:313/1575 train_time:11066ms step_avg:35.35ms
+step:314/1575 train_time:11104ms step_avg:35.36ms
+step:315/1575 train_time:11135ms step_avg:35.35ms
+step:316/1575 train_time:11173ms step_avg:35.36ms
+step:317/1575 train_time:11204ms step_avg:35.34ms
+step:318/1575 train_time:11243ms step_avg:35.36ms
+step:319/1575 train_time:11274ms step_avg:35.34ms
+step:320/1575 train_time:11313ms step_avg:35.35ms
+step:321/1575 train_time:11343ms step_avg:35.34ms
+step:322/1575 train_time:11382ms step_avg:35.35ms
+step:323/1575 train_time:11412ms step_avg:35.33ms
+step:324/1575 train_time:11451ms step_avg:35.34ms
+step:325/1575 train_time:11482ms step_avg:35.33ms
+step:326/1575 train_time:11521ms step_avg:35.34ms
+step:327/1575 train_time:11552ms step_avg:35.33ms
+step:328/1575 train_time:11590ms step_avg:35.34ms
+step:329/1575 train_time:11621ms step_avg:35.32ms
+step:330/1575 train_time:11660ms step_avg:35.33ms
+step:331/1575 train_time:11690ms step_avg:35.32ms
+step:332/1575 train_time:11729ms step_avg:35.33ms
+step:333/1575 train_time:11760ms step_avg:35.31ms
+step:334/1575 train_time:11798ms step_avg:35.32ms
+step:335/1575 train_time:11829ms step_avg:35.31ms
+step:336/1575 train_time:11868ms step_avg:35.32ms
+step:337/1575 train_time:11899ms step_avg:35.31ms
+step:338/1575 train_time:11937ms step_avg:35.32ms
+step:339/1575 train_time:11968ms step_avg:35.30ms
+step:340/1575 train_time:12007ms step_avg:35.31ms
+step:341/1575 train_time:12038ms step_avg:35.30ms
+step:342/1575 train_time:12077ms step_avg:35.31ms
+step:343/1575 train_time:12108ms step_avg:35.30ms
+step:344/1575 train_time:12146ms step_avg:35.31ms
+step:345/1575 train_time:12177ms step_avg:35.30ms
+step:346/1575 train_time:12215ms step_avg:35.30ms
+step:347/1575 train_time:12246ms step_avg:35.29ms
+step:348/1575 train_time:12284ms step_avg:35.30ms
+step:349/1575 train_time:12315ms step_avg:35.29ms
+step:350/1575 train_time:12354ms step_avg:35.30ms
+step:351/1575 train_time:12385ms step_avg:35.28ms
+step:352/1575 train_time:12423ms step_avg:35.29ms
+step:353/1575 train_time:12454ms step_avg:35.28ms
+step:354/1575 train_time:12492ms step_avg:35.29ms
+step:355/1575 train_time:12523ms step_avg:35.28ms
+step:356/1575 train_time:12562ms step_avg:35.29ms
+step:357/1575 train_time:12592ms step_avg:35.27ms
+step:358/1575 train_time:12631ms step_avg:35.28ms
+step:359/1575 train_time:12662ms step_avg:35.27ms
+step:360/1575 train_time:12700ms step_avg:35.28ms
+step:361/1575 train_time:12731ms step_avg:35.27ms
+step:362/1575 train_time:12769ms step_avg:35.27ms
+step:363/1575 train_time:12800ms step_avg:35.26ms
+step:364/1575 train_time:12838ms step_avg:35.27ms
+step:365/1575 train_time:12869ms step_avg:35.26ms
+step:366/1575 train_time:12908ms step_avg:35.27ms
+step:367/1575 train_time:12938ms step_avg:35.25ms
+step:368/1575 train_time:12977ms step_avg:35.26ms
+step:369/1575 train_time:13008ms step_avg:35.25ms
+step:370/1575 train_time:13046ms step_avg:35.26ms
+step:371/1575 train_time:13077ms step_avg:35.25ms
+step:372/1575 train_time:13116ms step_avg:35.26ms
+step:373/1575 train_time:13146ms step_avg:35.24ms
+step:374/1575 train_time:13185ms step_avg:35.25ms
+step:375/1575 train_time:13215ms step_avg:35.24ms
+step:376/1575 train_time:13254ms step_avg:35.25ms
+step:377/1575 train_time:13285ms step_avg:35.24ms
+step:378/1575 train_time:13324ms step_avg:35.25ms
+step:379/1575 train_time:13355ms step_avg:35.24ms
+step:380/1575 train_time:13394ms step_avg:35.25ms
+step:381/1575 train_time:13424ms step_avg:35.23ms
+step:382/1575 train_time:13462ms step_avg:35.24ms
+step:383/1575 train_time:13493ms step_avg:35.23ms
+step:384/1575 train_time:13532ms step_avg:35.24ms
+step:385/1575 train_time:13563ms step_avg:35.23ms
+step:386/1575 train_time:13601ms step_avg:35.24ms
+step:387/1575 train_time:13632ms step_avg:35.22ms
+step:388/1575 train_time:13670ms step_avg:35.23ms
+step:389/1575 train_time:13701ms step_avg:35.22ms
+step:390/1575 train_time:13740ms step_avg:35.23ms
+step:391/1575 train_time:13770ms step_avg:35.22ms
+step:392/1575 train_time:13809ms step_avg:35.23ms
+step:393/1575 train_time:13840ms step_avg:35.22ms
+step:394/1575 train_time:13878ms step_avg:35.22ms
+step:395/1575 train_time:13909ms step_avg:35.21ms
+step:396/1575 train_time:13947ms step_avg:35.22ms
+step:397/1575 train_time:13978ms step_avg:35.21ms
+step:398/1575 train_time:14017ms step_avg:35.22ms
+step:399/1575 train_time:14048ms step_avg:35.21ms
+step:400/1575 train_time:14086ms step_avg:35.22ms
+step:401/1575 train_time:14117ms step_avg:35.20ms
+step:402/1575 train_time:14155ms step_avg:35.21ms
+step:403/1575 train_time:14186ms step_avg:35.20ms
+step:404/1575 train_time:14225ms step_avg:35.21ms
+step:405/1575 train_time:14256ms step_avg:35.20ms
+step:406/1575 train_time:14295ms step_avg:35.21ms
+step:407/1575 train_time:14325ms step_avg:35.20ms
+step:408/1575 train_time:14363ms step_avg:35.20ms
+step:409/1575 train_time:14394ms step_avg:35.19ms
+step:410/1575 train_time:14433ms step_avg:35.20ms
+step:411/1575 train_time:14463ms step_avg:35.19ms
+step:412/1575 train_time:14502ms step_avg:35.20ms
+step:413/1575 train_time:14533ms step_avg:35.19ms
+step:414/1575 train_time:14572ms step_avg:35.20ms
+step:415/1575 train_time:14603ms step_avg:35.19ms
+step:416/1575 train_time:14641ms step_avg:35.19ms
+step:417/1575 train_time:14672ms step_avg:35.18ms
+step:418/1575 train_time:14710ms step_avg:35.19ms
+step:419/1575 train_time:14741ms step_avg:35.18ms
+step:420/1575 train_time:14780ms step_avg:35.19ms
+step:421/1575 train_time:14810ms step_avg:35.18ms
+step:422/1575 train_time:14849ms step_avg:35.19ms
+step:423/1575 train_time:14880ms step_avg:35.18ms
+step:424/1575 train_time:14919ms step_avg:35.19ms
+step:425/1575 train_time:14949ms step_avg:35.17ms
+step:426/1575 train_time:14988ms step_avg:35.18ms
+step:427/1575 train_time:15019ms step_avg:35.17ms
+step:428/1575 train_time:15057ms step_avg:35.18ms
+step:429/1575 train_time:15088ms step_avg:35.17ms
+step:430/1575 train_time:15127ms step_avg:35.18ms
+step:431/1575 train_time:15157ms step_avg:35.17ms
+step:432/1575 train_time:15196ms step_avg:35.18ms
+step:433/1575 train_time:15227ms step_avg:35.17ms
+step:434/1575 train_time:15266ms step_avg:35.17ms
+step:435/1575 train_time:15296ms step_avg:35.16ms
+step:436/1575 train_time:15335ms step_avg:35.17ms
+step:437/1575 train_time:15366ms step_avg:35.16ms
+step:438/1575 train_time:15404ms step_avg:35.17ms
+step:439/1575 train_time:15435ms step_avg:35.16ms
+step:440/1575 train_time:15473ms step_avg:35.17ms
+step:441/1575 train_time:15504ms step_avg:35.16ms
+step:442/1575 train_time:15543ms step_avg:35.16ms
+step:443/1575 train_time:15573ms step_avg:35.15ms
+step:444/1575 train_time:15612ms step_avg:35.16ms
+step:445/1575 train_time:15643ms step_avg:35.15ms
+step:446/1575 train_time:15682ms step_avg:35.16ms
+step:447/1575 train_time:15713ms step_avg:35.15ms
+step:448/1575 train_time:15751ms step_avg:35.16ms
+step:449/1575 train_time:15782ms step_avg:35.15ms
+step:450/1575 train_time:15820ms step_avg:35.16ms
+step:451/1575 train_time:15851ms step_avg:35.15ms
+step:452/1575 train_time:15890ms step_avg:35.15ms
+step:453/1575 train_time:15921ms step_avg:35.15ms
+step:454/1575 train_time:15959ms step_avg:35.15ms
+step:455/1575 train_time:15990ms step_avg:35.14ms
+step:456/1575 train_time:16029ms step_avg:35.15ms
+step:457/1575 train_time:16060ms step_avg:35.14ms
+step:458/1575 train_time:16099ms step_avg:35.15ms
+step:459/1575 train_time:16129ms step_avg:35.14ms
+step:460/1575 train_time:16167ms step_avg:35.15ms
+step:461/1575 train_time:16198ms step_avg:35.14ms
+step:462/1575 train_time:16237ms step_avg:35.14ms
+step:463/1575 train_time:16267ms step_avg:35.13ms
+step:464/1575 train_time:16307ms step_avg:35.14ms
+step:465/1575 train_time:16338ms step_avg:35.14ms
+step:466/1575 train_time:16377ms step_avg:35.14ms
+step:467/1575 train_time:16408ms step_avg:35.13ms
+step:468/1575 train_time:16447ms step_avg:35.14ms
+step:469/1575 train_time:16478ms step_avg:35.13ms
+step:470/1575 train_time:16517ms step_avg:35.14ms
+step:471/1575 train_time:16547ms step_avg:35.13ms
+step:472/1575 train_time:16586ms step_avg:35.14ms
+step:473/1575 train_time:16617ms step_avg:35.13ms
+step:474/1575 train_time:16656ms step_avg:35.14ms
+step:475/1575 train_time:16687ms step_avg:35.13ms
+step:476/1575 train_time:16725ms step_avg:35.14ms
+step:477/1575 train_time:16756ms step_avg:35.13ms
+step:478/1575 train_time:16795ms step_avg:35.14ms
+step:479/1575 train_time:16826ms step_avg:35.13ms
+step:480/1575 train_time:16864ms step_avg:35.13ms
+step:481/1575 train_time:16895ms step_avg:35.12ms
+step:482/1575 train_time:16934ms step_avg:35.13ms
+step:483/1575 train_time:16964ms step_avg:35.12ms
+step:484/1575 train_time:17003ms step_avg:35.13ms
+step:485/1575 train_time:17034ms step_avg:35.12ms
+step:486/1575 train_time:17073ms step_avg:35.13ms
+step:487/1575 train_time:17104ms step_avg:35.12ms
+step:488/1575 train_time:17142ms step_avg:35.13ms
+step:489/1575 train_time:17173ms step_avg:35.12ms
+step:490/1575 train_time:17211ms step_avg:35.13ms
+step:491/1575 train_time:17242ms step_avg:35.12ms
+step:492/1575 train_time:17280ms step_avg:35.12ms
+step:493/1575 train_time:17311ms step_avg:35.11ms
+step:494/1575 train_time:17350ms step_avg:35.12ms
+step:495/1575 train_time:17381ms step_avg:35.11ms
+step:496/1575 train_time:17419ms step_avg:35.12ms
+step:497/1575 train_time:17450ms step_avg:35.11ms
+step:498/1575 train_time:17489ms step_avg:35.12ms
+step:499/1575 train_time:17520ms step_avg:35.11ms
+step:500/1575 train_time:17559ms step_avg:35.12ms
+step:500/1575 val_loss:4.2456 train_time:17607ms step_avg:35.21ms
+step:501/1575 train_time:17627ms step_avg:35.18ms
+step:502/1575 train_time:17647ms step_avg:35.15ms
+step:503/1575 train_time:17665ms step_avg:35.12ms
+step:504/1575 train_time:17701ms step_avg:35.12ms
+step:505/1575 train_time:17733ms step_avg:35.11ms
+step:506/1575 train_time:17772ms step_avg:35.12ms
+step:507/1575 train_time:17803ms step_avg:35.12ms
+step:508/1575 train_time:17842ms step_avg:35.12ms
+step:509/1575 train_time:17873ms step_avg:35.11ms
+step:510/1575 train_time:17912ms step_avg:35.12ms
+step:511/1575 train_time:17943ms step_avg:35.11ms
+step:512/1575 train_time:17982ms step_avg:35.12ms
+step:513/1575 train_time:18056ms step_avg:35.20ms
+step:514/1575 train_time:18112ms step_avg:35.24ms
+step:515/1575 train_time:18174ms step_avg:35.29ms
+step:516/1575 train_time:18232ms step_avg:35.33ms
+step:517/1575 train_time:18295ms step_avg:35.39ms
+step:518/1575 train_time:18354ms step_avg:35.43ms
+step:519/1575 train_time:18415ms step_avg:35.48ms
+step:520/1575 train_time:18474ms step_avg:35.53ms
+step:521/1575 train_time:18537ms step_avg:35.58ms
+step:522/1575 train_time:18596ms step_avg:35.62ms
+step:523/1575 train_time:18661ms step_avg:35.68ms
+step:524/1575 train_time:18722ms step_avg:35.73ms
+step:525/1575 train_time:18788ms step_avg:35.79ms
+step:526/1575 train_time:18846ms step_avg:35.83ms
+step:527/1575 train_time:18910ms step_avg:35.88ms
+step:528/1575 train_time:18970ms step_avg:35.93ms
+step:529/1575 train_time:19033ms step_avg:35.98ms
+step:530/1575 train_time:19093ms step_avg:36.02ms
+step:531/1575 train_time:19156ms step_avg:36.08ms
+step:532/1575 train_time:19214ms step_avg:36.12ms
+step:533/1575 train_time:19277ms step_avg:36.17ms
+step:534/1575 train_time:19336ms step_avg:36.21ms
+step:535/1575 train_time:19399ms step_avg:36.26ms
+step:536/1575 train_time:19458ms step_avg:36.30ms
+step:537/1575 train_time:19521ms step_avg:36.35ms
+step:538/1575 train_time:19580ms step_avg:36.39ms
+step:539/1575 train_time:19644ms step_avg:36.45ms
+step:540/1575 train_time:19704ms step_avg:36.49ms
+step:541/1575 train_time:19769ms step_avg:36.54ms
+step:542/1575 train_time:19828ms step_avg:36.58ms
+step:543/1575 train_time:19892ms step_avg:36.63ms
+step:544/1575 train_time:19952ms step_avg:36.68ms
+step:545/1575 train_time:20015ms step_avg:36.72ms
+step:546/1575 train_time:20075ms step_avg:36.77ms
+step:547/1575 train_time:20138ms step_avg:36.82ms
+step:548/1575 train_time:20198ms step_avg:36.86ms
+step:549/1575 train_time:20261ms step_avg:36.91ms
+step:550/1575 train_time:20321ms step_avg:36.95ms
+step:551/1575 train_time:20384ms step_avg:36.99ms
+step:552/1575 train_time:20445ms step_avg:37.04ms
+step:553/1575 train_time:20507ms step_avg:37.08ms
+step:554/1575 train_time:20566ms step_avg:37.12ms
+step:555/1575 train_time:20628ms step_avg:37.17ms
+step:556/1575 train_time:20687ms step_avg:37.21ms
+step:557/1575 train_time:20750ms step_avg:37.25ms
+step:558/1575 train_time:20810ms step_avg:37.29ms
+step:559/1575 train_time:20874ms step_avg:37.34ms
+step:560/1575 train_time:20932ms step_avg:37.38ms
+step:561/1575 train_time:20995ms step_avg:37.42ms
+step:562/1575 train_time:21055ms step_avg:37.46ms
+step:563/1575 train_time:21118ms step_avg:37.51ms
+step:564/1575 train_time:21178ms step_avg:37.55ms
+step:565/1575 train_time:21240ms step_avg:37.59ms
+step:566/1575 train_time:21300ms step_avg:37.63ms
+step:567/1575 train_time:21364ms step_avg:37.68ms
+step:568/1575 train_time:21423ms step_avg:37.72ms
+step:569/1575 train_time:21491ms step_avg:37.77ms
+step:570/1575 train_time:21547ms step_avg:37.80ms
+step:571/1575 train_time:21610ms step_avg:37.85ms
+step:572/1575 train_time:21670ms step_avg:37.88ms
+step:573/1575 train_time:21732ms step_avg:37.93ms
+step:574/1575 train_time:21791ms step_avg:37.96ms
+step:575/1575 train_time:21854ms step_avg:38.01ms
+step:576/1575 train_time:21913ms step_avg:38.04ms
+step:577/1575 train_time:21977ms step_avg:38.09ms
+step:578/1575 train_time:22037ms step_avg:38.13ms
+step:579/1575 train_time:22100ms step_avg:38.17ms
+step:580/1575 train_time:22160ms step_avg:38.21ms
+step:581/1575 train_time:22223ms step_avg:38.25ms
+step:582/1575 train_time:22282ms step_avg:38.29ms
+step:583/1575 train_time:22346ms step_avg:38.33ms
+step:584/1575 train_time:22406ms step_avg:38.37ms
+step:585/1575 train_time:22468ms step_avg:38.41ms
+step:586/1575 train_time:22527ms step_avg:38.44ms
+step:587/1575 train_time:22590ms step_avg:38.48ms
+step:588/1575 train_time:22650ms step_avg:38.52ms
+step:589/1575 train_time:22714ms step_avg:38.56ms
+step:590/1575 train_time:22772ms step_avg:38.60ms
+step:591/1575 train_time:22835ms step_avg:38.64ms
+step:592/1575 train_time:22895ms step_avg:38.67ms
+step:593/1575 train_time:22958ms step_avg:38.71ms
+step:594/1575 train_time:23017ms step_avg:38.75ms
+step:595/1575 train_time:23080ms step_avg:38.79ms
+step:596/1575 train_time:23139ms step_avg:38.82ms
+step:597/1575 train_time:23203ms step_avg:38.87ms
+step:598/1575 train_time:23263ms step_avg:38.90ms
+step:599/1575 train_time:23326ms step_avg:38.94ms
+step:600/1575 train_time:23385ms step_avg:38.98ms
+step:601/1575 train_time:23448ms step_avg:39.02ms
+step:602/1575 train_time:23508ms step_avg:39.05ms
+step:603/1575 train_time:23571ms step_avg:39.09ms
+step:604/1575 train_time:23630ms step_avg:39.12ms
+step:605/1575 train_time:23693ms step_avg:39.16ms
+step:606/1575 train_time:23752ms step_avg:39.19ms
+step:607/1575 train_time:23815ms step_avg:39.23ms
+step:608/1575 train_time:23876ms step_avg:39.27ms
+step:609/1575 train_time:23939ms step_avg:39.31ms
+step:610/1575 train_time:23997ms step_avg:39.34ms
+step:611/1575 train_time:24060ms step_avg:39.38ms
+step:612/1575 train_time:24120ms step_avg:39.41ms
+step:613/1575 train_time:24183ms step_avg:39.45ms
+step:614/1575 train_time:24243ms step_avg:39.48ms
+step:615/1575 train_time:24307ms step_avg:39.52ms
+step:616/1575 train_time:24365ms step_avg:39.55ms
+step:617/1575 train_time:24428ms step_avg:39.59ms
+step:618/1575 train_time:24488ms step_avg:39.62ms
+step:619/1575 train_time:24552ms step_avg:39.66ms
+step:620/1575 train_time:24612ms step_avg:39.70ms
+step:621/1575 train_time:24675ms step_avg:39.73ms
+step:622/1575 train_time:24734ms step_avg:39.77ms
+step:623/1575 train_time:24797ms step_avg:39.80ms
+step:624/1575 train_time:24857ms step_avg:39.84ms
+step:625/1575 train_time:24920ms step_avg:39.87ms
+step:626/1575 train_time:24979ms step_avg:39.90ms
+step:627/1575 train_time:25043ms step_avg:39.94ms
+step:628/1575 train_time:25102ms step_avg:39.97ms
+step:629/1575 train_time:25165ms step_avg:40.01ms
+step:630/1575 train_time:25224ms step_avg:40.04ms
+step:631/1575 train_time:25288ms step_avg:40.08ms
+step:632/1575 train_time:25347ms step_avg:40.11ms
+step:633/1575 train_time:25411ms step_avg:40.14ms
+step:634/1575 train_time:25471ms step_avg:40.17ms
+step:635/1575 train_time:25533ms step_avg:40.21ms
+step:636/1575 train_time:25593ms step_avg:40.24ms
+step:637/1575 train_time:25656ms step_avg:40.28ms
+step:638/1575 train_time:25715ms step_avg:40.31ms
+step:639/1575 train_time:25778ms step_avg:40.34ms
+step:640/1575 train_time:25837ms step_avg:40.37ms
+step:641/1575 train_time:25900ms step_avg:40.41ms
+step:642/1575 train_time:25959ms step_avg:40.44ms
+step:643/1575 train_time:26023ms step_avg:40.47ms
+step:644/1575 train_time:26083ms step_avg:40.50ms
+step:645/1575 train_time:26146ms step_avg:40.54ms
+step:646/1575 train_time:26205ms step_avg:40.57ms
+step:647/1575 train_time:26269ms step_avg:40.60ms
+step:648/1575 train_time:26328ms step_avg:40.63ms
+step:649/1575 train_time:26391ms step_avg:40.66ms
+step:650/1575 train_time:26451ms step_avg:40.69ms
+step:651/1575 train_time:26514ms step_avg:40.73ms
+step:652/1575 train_time:26573ms step_avg:40.76ms
+step:653/1575 train_time:26636ms step_avg:40.79ms
+step:654/1575 train_time:26696ms step_avg:40.82ms
+step:655/1575 train_time:26759ms step_avg:40.85ms
+step:656/1575 train_time:26818ms step_avg:40.88ms
+step:657/1575 train_time:26882ms step_avg:40.92ms
+step:658/1575 train_time:26940ms step_avg:40.94ms
+step:659/1575 train_time:27003ms step_avg:40.98ms
+step:660/1575 train_time:27062ms step_avg:41.00ms
+step:661/1575 train_time:27126ms step_avg:41.04ms
+step:662/1575 train_time:27185ms step_avg:41.06ms
+step:663/1575 train_time:27248ms step_avg:41.10ms
+step:664/1575 train_time:27308ms step_avg:41.13ms
+step:665/1575 train_time:27374ms step_avg:41.16ms
+step:666/1575 train_time:27431ms step_avg:41.19ms
+step:667/1575 train_time:27494ms step_avg:41.22ms
+step:668/1575 train_time:27552ms step_avg:41.25ms
+step:669/1575 train_time:27616ms step_avg:41.28ms
+step:670/1575 train_time:27675ms step_avg:41.31ms
+step:671/1575 train_time:27738ms step_avg:41.34ms
+step:672/1575 train_time:27797ms step_avg:41.36ms
+step:673/1575 train_time:27859ms step_avg:41.40ms
+step:674/1575 train_time:27919ms step_avg:41.42ms
+step:675/1575 train_time:27983ms step_avg:41.46ms
+step:676/1575 train_time:28042ms step_avg:41.48ms
+step:677/1575 train_time:28105ms step_avg:41.51ms
+step:678/1575 train_time:28165ms step_avg:41.54ms
+step:679/1575 train_time:28228ms step_avg:41.57ms
+step:680/1575 train_time:28288ms step_avg:41.60ms
+step:681/1575 train_time:28352ms step_avg:41.63ms
+step:682/1575 train_time:28411ms step_avg:41.66ms
+step:683/1575 train_time:28474ms step_avg:41.69ms
+step:684/1575 train_time:28534ms step_avg:41.72ms
+step:685/1575 train_time:28597ms step_avg:41.75ms
+step:686/1575 train_time:28655ms step_avg:41.77ms
+step:687/1575 train_time:28719ms step_avg:41.80ms
+step:688/1575 train_time:28778ms step_avg:41.83ms
+step:689/1575 train_time:28841ms step_avg:41.86ms
+step:690/1575 train_time:28902ms step_avg:41.89ms
+step:691/1575 train_time:28965ms step_avg:41.92ms
+step:692/1575 train_time:29025ms step_avg:41.94ms
+step:693/1575 train_time:29088ms step_avg:41.97ms
+step:694/1575 train_time:29146ms step_avg:42.00ms
+step:695/1575 train_time:29210ms step_avg:42.03ms
+step:696/1575 train_time:29269ms step_avg:42.05ms
+step:697/1575 train_time:29332ms step_avg:42.08ms
+step:698/1575 train_time:29391ms step_avg:42.11ms
+step:699/1575 train_time:29454ms step_avg:42.14ms
+step:700/1575 train_time:29514ms step_avg:42.16ms
+step:701/1575 train_time:29577ms step_avg:42.19ms
+step:702/1575 train_time:29636ms step_avg:42.22ms
+step:703/1575 train_time:29699ms step_avg:42.25ms
+step:704/1575 train_time:29758ms step_avg:42.27ms
+step:705/1575 train_time:29822ms step_avg:42.30ms
+step:706/1575 train_time:29882ms step_avg:42.33ms
+step:707/1575 train_time:29945ms step_avg:42.35ms
+step:708/1575 train_time:30004ms step_avg:42.38ms
+step:709/1575 train_time:30068ms step_avg:42.41ms
+step:710/1575 train_time:30128ms step_avg:42.43ms
+step:711/1575 train_time:30191ms step_avg:42.46ms
+step:712/1575 train_time:30250ms step_avg:42.49ms
+step:713/1575 train_time:30313ms step_avg:42.51ms
+step:714/1575 train_time:30374ms step_avg:42.54ms
+step:715/1575 train_time:30436ms step_avg:42.57ms
+step:716/1575 train_time:30495ms step_avg:42.59ms
+step:717/1575 train_time:30559ms step_avg:42.62ms
+step:718/1575 train_time:30617ms step_avg:42.64ms
+step:719/1575 train_time:30681ms step_avg:42.67ms
+step:720/1575 train_time:30739ms step_avg:42.69ms
+step:721/1575 train_time:30802ms step_avg:42.72ms
+step:722/1575 train_time:30862ms step_avg:42.74ms
+step:723/1575 train_time:30925ms step_avg:42.77ms
+step:724/1575 train_time:30984ms step_avg:42.80ms
+step:725/1575 train_time:31047ms step_avg:42.82ms
+step:726/1575 train_time:31106ms step_avg:42.85ms
+step:727/1575 train_time:31170ms step_avg:42.87ms
+step:728/1575 train_time:31230ms step_avg:42.90ms
+step:729/1575 train_time:31292ms step_avg:42.93ms
+step:730/1575 train_time:31352ms step_avg:42.95ms
+step:731/1575 train_time:31415ms step_avg:42.98ms
+step:732/1575 train_time:31475ms step_avg:43.00ms
+step:733/1575 train_time:31538ms step_avg:43.03ms
+step:734/1575 train_time:31597ms step_avg:43.05ms
+step:735/1575 train_time:31660ms step_avg:43.07ms
+step:736/1575 train_time:31719ms step_avg:43.10ms
+step:737/1575 train_time:31784ms step_avg:43.13ms
+step:738/1575 train_time:31843ms step_avg:43.15ms
+step:739/1575 train_time:31906ms step_avg:43.17ms
+step:740/1575 train_time:31965ms step_avg:43.20ms
+step:741/1575 train_time:32029ms step_avg:43.22ms
+step:742/1575 train_time:32092ms step_avg:43.25ms
+step:743/1575 train_time:32151ms step_avg:43.27ms
+step:744/1575 train_time:32211ms step_avg:43.29ms
+step:745/1575 train_time:32274ms step_avg:43.32ms
+step:746/1575 train_time:32333ms step_avg:43.34ms
+step:747/1575 train_time:32396ms step_avg:43.37ms
+step:748/1575 train_time:32455ms step_avg:43.39ms
+step:749/1575 train_time:32518ms step_avg:43.42ms
+step:750/1575 train_time:32578ms step_avg:43.44ms
+step:750/1575 val_loss:3.8849 train_time:32624ms step_avg:43.50ms
+step:751/1575 train_time:32644ms step_avg:43.47ms
+step:752/1575 train_time:32704ms step_avg:43.49ms
+step:753/1575 train_time:32771ms step_avg:43.52ms
+step:754/1575 train_time:32834ms step_avg:43.55ms
+step:755/1575 train_time:32897ms step_avg:43.57ms
+step:756/1575 train_time:32957ms step_avg:43.59ms
+step:757/1575 train_time:33021ms step_avg:43.62ms
+step:758/1575 train_time:33079ms step_avg:43.64ms
+step:759/1575 train_time:33141ms step_avg:43.66ms
+step:760/1575 train_time:33200ms step_avg:43.68ms
+step:761/1575 train_time:33264ms step_avg:43.71ms
+step:762/1575 train_time:33323ms step_avg:43.73ms
+step:763/1575 train_time:33384ms step_avg:43.75ms
+step:764/1575 train_time:33443ms step_avg:43.77ms
+step:765/1575 train_time:33505ms step_avg:43.80ms
+step:766/1575 train_time:33564ms step_avg:43.82ms
+step:767/1575 train_time:33628ms step_avg:43.84ms
+step:768/1575 train_time:33689ms step_avg:43.87ms
+step:769/1575 train_time:33755ms step_avg:43.89ms
+step:770/1575 train_time:33815ms step_avg:43.92ms
+step:771/1575 train_time:33878ms step_avg:43.94ms
+step:772/1575 train_time:33938ms step_avg:43.96ms
+step:773/1575 train_time:34001ms step_avg:43.99ms
+step:774/1575 train_time:34060ms step_avg:44.01ms
+step:775/1575 train_time:34123ms step_avg:44.03ms
+step:776/1575 train_time:34182ms step_avg:44.05ms
+step:777/1575 train_time:34245ms step_avg:44.07ms
+step:778/1575 train_time:34303ms step_avg:44.09ms
+step:779/1575 train_time:34366ms step_avg:44.12ms
+step:780/1575 train_time:34425ms step_avg:44.13ms
+step:781/1575 train_time:34487ms step_avg:44.16ms
+step:782/1575 train_time:34549ms step_avg:44.18ms
+step:783/1575 train_time:34612ms step_avg:44.20ms
+step:784/1575 train_time:34672ms step_avg:44.22ms
+step:785/1575 train_time:34735ms step_avg:44.25ms
+step:786/1575 train_time:34795ms step_avg:44.27ms
+step:787/1575 train_time:34858ms step_avg:44.29ms
+step:788/1575 train_time:34918ms step_avg:44.31ms
+step:789/1575 train_time:34981ms step_avg:44.34ms
+step:790/1575 train_time:35041ms step_avg:44.36ms
+step:791/1575 train_time:35104ms step_avg:44.38ms
+step:792/1575 train_time:35163ms step_avg:44.40ms
+step:793/1575 train_time:35226ms step_avg:44.42ms
+step:794/1575 train_time:35285ms step_avg:44.44ms
+step:795/1575 train_time:35348ms step_avg:44.46ms
+step:796/1575 train_time:35407ms step_avg:44.48ms
+step:797/1575 train_time:35470ms step_avg:44.50ms
+step:798/1575 train_time:35530ms step_avg:44.52ms
+step:799/1575 train_time:35592ms step_avg:44.55ms
+step:800/1575 train_time:35652ms step_avg:44.57ms
+step:801/1575 train_time:35716ms step_avg:44.59ms
+step:802/1575 train_time:35781ms step_avg:44.62ms
+step:803/1575 train_time:35840ms step_avg:44.63ms
+step:804/1575 train_time:35901ms step_avg:44.65ms
+step:805/1575 train_time:35964ms step_avg:44.68ms
+step:806/1575 train_time:36024ms step_avg:44.69ms
+step:807/1575 train_time:36087ms step_avg:44.72ms
+step:808/1575 train_time:36146ms step_avg:44.73ms
+step:809/1575 train_time:36209ms step_avg:44.76ms
+step:810/1575 train_time:36268ms step_avg:44.78ms
+step:811/1575 train_time:36332ms step_avg:44.80ms
+step:812/1575 train_time:36391ms step_avg:44.82ms
+step:813/1575 train_time:36454ms step_avg:44.84ms
+step:814/1575 train_time:36514ms step_avg:44.86ms
+step:815/1575 train_time:36577ms step_avg:44.88ms
+step:816/1575 train_time:36636ms step_avg:44.90ms
+step:817/1575 train_time:36699ms step_avg:44.92ms
+step:818/1575 train_time:36759ms step_avg:44.94ms
+step:819/1575 train_time:36822ms step_avg:44.96ms
+step:820/1575 train_time:36881ms step_avg:44.98ms
+step:821/1575 train_time:36945ms step_avg:45.00ms
+step:822/1575 train_time:37004ms step_avg:45.02ms
+step:823/1575 train_time:37068ms step_avg:45.04ms
+step:824/1575 train_time:37127ms step_avg:45.06ms
+step:825/1575 train_time:37190ms step_avg:45.08ms
+step:826/1575 train_time:37250ms step_avg:45.10ms
+step:827/1575 train_time:37313ms step_avg:45.12ms
+step:828/1575 train_time:37372ms step_avg:45.14ms
+step:829/1575 train_time:37436ms step_avg:45.16ms
+step:830/1575 train_time:37495ms step_avg:45.17ms
+step:831/1575 train_time:37558ms step_avg:45.20ms
+step:832/1575 train_time:37617ms step_avg:45.21ms
+step:833/1575 train_time:37680ms step_avg:45.23ms
+step:834/1575 train_time:37739ms step_avg:45.25ms
+step:835/1575 train_time:37802ms step_avg:45.27ms
+step:836/1575 train_time:37863ms step_avg:45.29ms
+step:837/1575 train_time:37925ms step_avg:45.31ms
+step:838/1575 train_time:37984ms step_avg:45.33ms
+step:839/1575 train_time:38047ms step_avg:45.35ms
+step:840/1575 train_time:38107ms step_avg:45.37ms
+step:841/1575 train_time:38171ms step_avg:45.39ms
+step:842/1575 train_time:38229ms step_avg:45.40ms
+step:843/1575 train_time:38292ms step_avg:45.42ms
+step:844/1575 train_time:38354ms step_avg:45.44ms
+step:845/1575 train_time:38417ms step_avg:45.46ms
+step:846/1575 train_time:38475ms step_avg:45.48ms
+step:847/1575 train_time:38538ms step_avg:45.50ms
+step:848/1575 train_time:38597ms step_avg:45.52ms
+step:849/1575 train_time:38660ms step_avg:45.54ms
+step:850/1575 train_time:38720ms step_avg:45.55ms
+step:851/1575 train_time:38783ms step_avg:45.57ms
+step:852/1575 train_time:38843ms step_avg:45.59ms
+step:853/1575 train_time:38907ms step_avg:45.61ms
+step:854/1575 train_time:38965ms step_avg:45.63ms
+step:855/1575 train_time:39030ms step_avg:45.65ms
+step:856/1575 train_time:39089ms step_avg:45.66ms
+step:857/1575 train_time:39152ms step_avg:45.68ms
+step:858/1575 train_time:39211ms step_avg:45.70ms
+step:859/1575 train_time:39274ms step_avg:45.72ms
+step:860/1575 train_time:39334ms step_avg:45.74ms
+step:861/1575 train_time:39397ms step_avg:45.76ms
+step:862/1575 train_time:39457ms step_avg:45.77ms
+step:863/1575 train_time:39519ms step_avg:45.79ms
+step:864/1575 train_time:39579ms step_avg:45.81ms
+step:865/1575 train_time:39642ms step_avg:45.83ms
+step:866/1575 train_time:39701ms step_avg:45.84ms
+step:867/1575 train_time:39764ms step_avg:45.86ms
+step:868/1575 train_time:39824ms step_avg:45.88ms
+step:869/1575 train_time:39887ms step_avg:45.90ms
+step:870/1575 train_time:39946ms step_avg:45.91ms
+step:871/1575 train_time:40009ms step_avg:45.93ms
+step:872/1575 train_time:40068ms step_avg:45.95ms
+step:873/1575 train_time:40131ms step_avg:45.97ms
+step:874/1575 train_time:40191ms step_avg:45.98ms
+step:875/1575 train_time:40254ms step_avg:46.00ms
+step:876/1575 train_time:40313ms step_avg:46.02ms
+step:877/1575 train_time:40377ms step_avg:46.04ms
+step:878/1575 train_time:40436ms step_avg:46.06ms
+step:879/1575 train_time:40504ms step_avg:46.08ms
+step:880/1575 train_time:40559ms step_avg:46.09ms
+step:881/1575 train_time:40621ms step_avg:46.11ms
+step:882/1575 train_time:40680ms step_avg:46.12ms
+step:883/1575 train_time:40744ms step_avg:46.14ms
+step:884/1575 train_time:40803ms step_avg:46.16ms
+step:885/1575 train_time:40866ms step_avg:46.18ms
+step:886/1575 train_time:40931ms step_avg:46.20ms
+step:887/1575 train_time:40991ms step_avg:46.21ms
+step:888/1575 train_time:41050ms step_avg:46.23ms
+step:889/1575 train_time:41112ms step_avg:46.25ms
+step:890/1575 train_time:41171ms step_avg:46.26ms
+step:891/1575 train_time:41234ms step_avg:46.28ms
+step:892/1575 train_time:41294ms step_avg:46.29ms
+step:893/1575 train_time:41357ms step_avg:46.31ms
+step:894/1575 train_time:41416ms step_avg:46.33ms
+step:895/1575 train_time:41480ms step_avg:46.35ms
+step:896/1575 train_time:41540ms step_avg:46.36ms
+step:897/1575 train_time:41602ms step_avg:46.38ms
+step:898/1575 train_time:41661ms step_avg:46.39ms
+step:899/1575 train_time:41724ms step_avg:46.41ms
+step:900/1575 train_time:41783ms step_avg:46.43ms
+step:901/1575 train_time:41846ms step_avg:46.44ms
+step:902/1575 train_time:41906ms step_avg:46.46ms
+step:903/1575 train_time:41969ms step_avg:46.48ms
+step:904/1575 train_time:42029ms step_avg:46.49ms
+step:905/1575 train_time:42092ms step_avg:46.51ms
+step:906/1575 train_time:42151ms step_avg:46.52ms
+step:907/1575 train_time:42215ms step_avg:46.54ms
+step:908/1575 train_time:42275ms step_avg:46.56ms
+step:909/1575 train_time:42338ms step_avg:46.58ms
+step:910/1575 train_time:42399ms step_avg:46.59ms
+step:911/1575 train_time:42461ms step_avg:46.61ms
+step:912/1575 train_time:42520ms step_avg:46.62ms
+step:913/1575 train_time:42584ms step_avg:46.64ms
+step:914/1575 train_time:42643ms step_avg:46.66ms
+step:915/1575 train_time:42706ms step_avg:46.67ms
+step:916/1575 train_time:42765ms step_avg:46.69ms
+step:917/1575 train_time:42828ms step_avg:46.70ms
+step:918/1575 train_time:42887ms step_avg:46.72ms
+step:919/1575 train_time:42950ms step_avg:46.74ms
+step:920/1575 train_time:43010ms step_avg:46.75ms
+step:921/1575 train_time:43073ms step_avg:46.77ms
+step:922/1575 train_time:43132ms step_avg:46.78ms
+step:923/1575 train_time:43195ms step_avg:46.80ms
+step:924/1575 train_time:43255ms step_avg:46.81ms
+step:925/1575 train_time:43319ms step_avg:46.83ms
+step:926/1575 train_time:43378ms step_avg:46.84ms
+step:927/1575 train_time:43442ms step_avg:46.86ms
+step:928/1575 train_time:43502ms step_avg:46.88ms
+step:929/1575 train_time:43564ms step_avg:46.89ms
+step:930/1575 train_time:43624ms step_avg:46.91ms
+step:931/1575 train_time:43687ms step_avg:46.92ms
+step:932/1575 train_time:43746ms step_avg:46.94ms
+step:933/1575 train_time:43809ms step_avg:46.96ms
+step:934/1575 train_time:43869ms step_avg:46.97ms
+step:935/1575 train_time:43932ms step_avg:46.99ms
+step:936/1575 train_time:43991ms step_avg:47.00ms
+step:937/1575 train_time:44054ms step_avg:47.02ms
+step:938/1575 train_time:44114ms step_avg:47.03ms
+step:939/1575 train_time:44177ms step_avg:47.05ms
+step:940/1575 train_time:44236ms step_avg:47.06ms
+step:941/1575 train_time:44299ms step_avg:47.08ms
+step:942/1575 train_time:44359ms step_avg:47.09ms
+step:943/1575 train_time:44422ms step_avg:47.11ms
+step:944/1575 train_time:44481ms step_avg:47.12ms
+step:945/1575 train_time:44545ms step_avg:47.14ms
+step:946/1575 train_time:44604ms step_avg:47.15ms
+step:947/1575 train_time:44667ms step_avg:47.17ms
+step:948/1575 train_time:44728ms step_avg:47.18ms
+step:949/1575 train_time:44791ms step_avg:47.20ms
+step:950/1575 train_time:44849ms step_avg:47.21ms
+step:951/1575 train_time:44912ms step_avg:47.23ms
+step:952/1575 train_time:44971ms step_avg:47.24ms
+step:953/1575 train_time:45037ms step_avg:47.26ms
+step:954/1575 train_time:45094ms step_avg:47.27ms
+step:955/1575 train_time:45158ms step_avg:47.29ms
+step:956/1575 train_time:45217ms step_avg:47.30ms
+step:957/1575 train_time:45280ms step_avg:47.32ms
+step:958/1575 train_time:45339ms step_avg:47.33ms
+step:959/1575 train_time:45403ms step_avg:47.34ms
+step:960/1575 train_time:45462ms step_avg:47.36ms
+step:961/1575 train_time:45525ms step_avg:47.37ms
+step:962/1575 train_time:45584ms step_avg:47.38ms
+step:963/1575 train_time:45647ms step_avg:47.40ms
+step:964/1575 train_time:45706ms step_avg:47.41ms
+step:965/1575 train_time:45769ms step_avg:47.43ms
+step:966/1575 train_time:45829ms step_avg:47.44ms
+step:967/1575 train_time:45893ms step_avg:47.46ms
+step:968/1575 train_time:45952ms step_avg:47.47ms
+step:969/1575 train_time:46015ms step_avg:47.49ms
+step:970/1575 train_time:46074ms step_avg:47.50ms
+step:971/1575 train_time:46138ms step_avg:47.52ms
+step:972/1575 train_time:46197ms step_avg:47.53ms
+step:973/1575 train_time:46261ms step_avg:47.54ms
+step:974/1575 train_time:46320ms step_avg:47.56ms
+step:975/1575 train_time:46383ms step_avg:47.57ms
+step:976/1575 train_time:46443ms step_avg:47.58ms
+step:977/1575 train_time:46505ms step_avg:47.60ms
+step:978/1575 train_time:46564ms step_avg:47.61ms
+step:979/1575 train_time:46627ms step_avg:47.63ms
+step:980/1575 train_time:46687ms step_avg:47.64ms
+step:981/1575 train_time:46750ms step_avg:47.66ms
+step:982/1575 train_time:46810ms step_avg:47.67ms
+step:983/1575 train_time:46873ms step_avg:47.68ms
+step:984/1575 train_time:46932ms step_avg:47.70ms
+step:985/1575 train_time:46997ms step_avg:47.71ms
+step:986/1575 train_time:47056ms step_avg:47.72ms
+step:987/1575 train_time:47120ms step_avg:47.74ms
+step:988/1575 train_time:47179ms step_avg:47.75ms
+step:989/1575 train_time:47242ms step_avg:47.77ms
+step:990/1575 train_time:47302ms step_avg:47.78ms
+step:991/1575 train_time:47364ms step_avg:47.79ms
+step:992/1575 train_time:47424ms step_avg:47.81ms
+step:993/1575 train_time:47488ms step_avg:47.82ms
+step:994/1575 train_time:47548ms step_avg:47.83ms
+step:995/1575 train_time:47610ms step_avg:47.85ms
+step:996/1575 train_time:47670ms step_avg:47.86ms
+step:997/1575 train_time:47733ms step_avg:47.88ms
+step:998/1575 train_time:47792ms step_avg:47.89ms
+step:999/1575 train_time:47855ms step_avg:47.90ms
+step:1000/1575 train_time:47914ms step_avg:47.91ms
+step:1000/1575 val_loss:3.5839 train_time:47961ms step_avg:47.96ms
+step:1001/1575 train_time:47982ms step_avg:47.93ms
+step:1002/1575 train_time:48043ms step_avg:47.95ms
+step:1003/1575 train_time:48108ms step_avg:47.96ms
+step:1004/1575 train_time:48174ms step_avg:47.98ms
+step:1005/1575 train_time:48236ms step_avg:48.00ms
+step:1006/1575 train_time:48295ms step_avg:48.01ms
+step:1007/1575 train_time:48358ms step_avg:48.02ms
+step:1008/1575 train_time:48417ms step_avg:48.03ms
+step:1009/1575 train_time:48480ms step_avg:48.05ms
+step:1010/1575 train_time:48539ms step_avg:48.06ms
+step:1011/1575 train_time:48602ms step_avg:48.07ms
+step:1012/1575 train_time:48662ms step_avg:48.08ms
+step:1013/1575 train_time:48726ms step_avg:48.10ms
+step:1014/1575 train_time:48784ms step_avg:48.11ms
+step:1015/1575 train_time:48847ms step_avg:48.13ms
+step:1016/1575 train_time:48906ms step_avg:48.14ms
+step:1017/1575 train_time:48969ms step_avg:48.15ms
+step:1018/1575 train_time:49029ms step_avg:48.16ms
+step:1019/1575 train_time:49093ms step_avg:48.18ms
+step:1020/1575 train_time:49153ms step_avg:48.19ms
+step:1021/1575 train_time:49217ms step_avg:48.21ms
+step:1022/1575 train_time:49277ms step_avg:48.22ms
+step:1023/1575 train_time:49341ms step_avg:48.23ms
+step:1024/1575 train_time:49400ms step_avg:48.24ms
+step:1025/1575 train_time:49475ms step_avg:48.27ms
+step:1026/1575 train_time:49556ms step_avg:48.30ms
+step:1027/1575 train_time:49645ms step_avg:48.34ms
+step:1028/1575 train_time:49730ms step_avg:48.38ms
+step:1029/1575 train_time:49819ms step_avg:48.41ms
+step:1030/1575 train_time:49904ms step_avg:48.45ms
+step:1031/1575 train_time:49994ms step_avg:48.49ms
+step:1032/1575 train_time:50080ms step_avg:48.53ms
+step:1033/1575 train_time:50170ms step_avg:48.57ms
+step:1034/1575 train_time:50256ms step_avg:48.60ms
+step:1035/1575 train_time:50346ms step_avg:48.64ms
+step:1036/1575 train_time:50431ms step_avg:48.68ms
+step:1037/1575 train_time:50520ms step_avg:48.72ms
+step:1038/1575 train_time:50606ms step_avg:48.75ms
+step:1039/1575 train_time:50694ms step_avg:48.79ms
+step:1040/1575 train_time:50780ms step_avg:48.83ms
+step:1041/1575 train_time:50869ms step_avg:48.87ms
+step:1042/1575 train_time:50955ms step_avg:48.90ms
+step:1043/1575 train_time:51046ms step_avg:48.94ms
+step:1044/1575 train_time:51132ms step_avg:48.98ms
+step:1045/1575 train_time:51223ms step_avg:49.02ms
+step:1046/1575 train_time:51308ms step_avg:49.05ms
+step:1047/1575 train_time:51397ms step_avg:49.09ms
+step:1048/1575 train_time:51483ms step_avg:49.13ms
+step:1049/1575 train_time:51572ms step_avg:49.16ms
+step:1050/1575 train_time:51657ms step_avg:49.20ms
+step:1051/1575 train_time:51746ms step_avg:49.24ms
+step:1052/1575 train_time:51833ms step_avg:49.27ms
+step:1053/1575 train_time:51923ms step_avg:49.31ms
+step:1054/1575 train_time:52009ms step_avg:49.34ms
+step:1055/1575 train_time:52098ms step_avg:49.38ms
+step:1056/1575 train_time:52185ms step_avg:49.42ms
+step:1057/1575 train_time:52273ms step_avg:49.45ms
+step:1058/1575 train_time:52360ms step_avg:49.49ms
+step:1059/1575 train_time:52449ms step_avg:49.53ms
+step:1060/1575 train_time:52535ms step_avg:49.56ms
+step:1061/1575 train_time:52624ms step_avg:49.60ms
+step:1062/1575 train_time:52710ms step_avg:49.63ms
+step:1063/1575 train_time:52799ms step_avg:49.67ms
+step:1064/1575 train_time:52885ms step_avg:49.70ms
+step:1065/1575 train_time:52973ms step_avg:49.74ms
+step:1066/1575 train_time:53058ms step_avg:49.77ms
+step:1067/1575 train_time:53148ms step_avg:49.81ms
+step:1068/1575 train_time:53234ms step_avg:49.84ms
+step:1069/1575 train_time:53325ms step_avg:49.88ms
+step:1070/1575 train_time:53411ms step_avg:49.92ms
+step:1071/1575 train_time:53500ms step_avg:49.95ms
+step:1072/1575 train_time:53586ms step_avg:49.99ms
+step:1073/1575 train_time:53675ms step_avg:50.02ms
+step:1074/1575 train_time:53760ms step_avg:50.06ms
+step:1075/1575 train_time:53850ms step_avg:50.09ms
+step:1076/1575 train_time:53936ms step_avg:50.13ms
+step:1077/1575 train_time:54025ms step_avg:50.16ms
+step:1078/1575 train_time:54112ms step_avg:50.20ms
+step:1079/1575 train_time:54201ms step_avg:50.23ms
+step:1080/1575 train_time:54287ms step_avg:50.27ms
+step:1081/1575 train_time:54378ms step_avg:50.30ms
+step:1082/1575 train_time:54463ms step_avg:50.34ms
+step:1083/1575 train_time:54552ms step_avg:50.37ms
+step:1084/1575 train_time:54638ms step_avg:50.40ms
+step:1085/1575 train_time:54727ms step_avg:50.44ms
+step:1086/1575 train_time:54813ms step_avg:50.47ms
+step:1087/1575 train_time:54902ms step_avg:50.51ms
+step:1088/1575 train_time:54988ms step_avg:50.54ms
+step:1089/1575 train_time:55078ms step_avg:50.58ms
+step:1090/1575 train_time:55165ms step_avg:50.61ms
+step:1091/1575 train_time:55255ms step_avg:50.65ms
+step:1092/1575 train_time:55340ms step_avg:50.68ms
+step:1093/1575 train_time:55430ms step_avg:50.71ms
+step:1094/1575 train_time:55517ms step_avg:50.75ms
+step:1095/1575 train_time:55605ms step_avg:50.78ms
+step:1096/1575 train_time:55690ms step_avg:50.81ms
+step:1097/1575 train_time:55778ms step_avg:50.85ms
+step:1098/1575 train_time:55864ms step_avg:50.88ms
+step:1099/1575 train_time:55953ms step_avg:50.91ms
+step:1100/1575 train_time:56038ms step_avg:50.94ms
+step:1101/1575 train_time:56128ms step_avg:50.98ms
+step:1102/1575 train_time:56214ms step_avg:51.01ms
+step:1103/1575 train_time:56304ms step_avg:51.05ms
+step:1104/1575 train_time:56389ms step_avg:51.08ms
+step:1105/1575 train_time:56480ms step_avg:51.11ms
+step:1106/1575 train_time:56566ms step_avg:51.14ms
+step:1107/1575 train_time:56656ms step_avg:51.18ms
+step:1108/1575 train_time:56741ms step_avg:51.21ms
+step:1109/1575 train_time:56833ms step_avg:51.25ms
+step:1110/1575 train_time:56920ms step_avg:51.28ms
+step:1111/1575 train_time:57006ms step_avg:51.31ms
+step:1112/1575 train_time:57091ms step_avg:51.34ms
+step:1113/1575 train_time:57182ms step_avg:51.38ms
+step:1114/1575 train_time:57266ms step_avg:51.41ms
+step:1115/1575 train_time:57355ms step_avg:51.44ms
+step:1116/1575 train_time:57441ms step_avg:51.47ms
+step:1117/1575 train_time:57530ms step_avg:51.50ms
+step:1118/1575 train_time:57617ms step_avg:51.54ms
+step:1119/1575 train_time:57707ms step_avg:51.57ms
+step:1120/1575 train_time:57792ms step_avg:51.60ms
+step:1121/1575 train_time:57881ms step_avg:51.63ms
+step:1122/1575 train_time:57967ms step_avg:51.66ms
+step:1123/1575 train_time:58056ms step_avg:51.70ms
+step:1124/1575 train_time:58142ms step_avg:51.73ms
+step:1125/1575 train_time:58231ms step_avg:51.76ms
+step:1126/1575 train_time:58318ms step_avg:51.79ms
+step:1127/1575 train_time:58406ms step_avg:51.82ms
+step:1128/1575 train_time:58493ms step_avg:51.86ms
+step:1129/1575 train_time:58582ms step_avg:51.89ms
+step:1130/1575 train_time:58667ms step_avg:51.92ms
+step:1131/1575 train_time:58758ms step_avg:51.95ms
+step:1132/1575 train_time:58845ms step_avg:51.98ms
+step:1133/1575 train_time:58934ms step_avg:52.02ms
+step:1134/1575 train_time:59020ms step_avg:52.05ms
+step:1135/1575 train_time:59109ms step_avg:52.08ms
+step:1136/1575 train_time:59195ms step_avg:52.11ms
+step:1137/1575 train_time:59284ms step_avg:52.14ms
+step:1138/1575 train_time:59369ms step_avg:52.17ms
+step:1139/1575 train_time:59458ms step_avg:52.20ms
+step:1140/1575 train_time:59545ms step_avg:52.23ms
+step:1141/1575 train_time:59633ms step_avg:52.26ms
+step:1142/1575 train_time:59719ms step_avg:52.29ms
+step:1143/1575 train_time:59809ms step_avg:52.33ms
+step:1144/1575 train_time:59895ms step_avg:52.36ms
+step:1145/1575 train_time:59985ms step_avg:52.39ms
+step:1146/1575 train_time:60075ms step_avg:52.42ms
+step:1147/1575 train_time:60162ms step_avg:52.45ms
+step:1148/1575 train_time:60248ms step_avg:52.48ms
+step:1149/1575 train_time:60338ms step_avg:52.51ms
+step:1150/1575 train_time:60423ms step_avg:52.54ms
+step:1151/1575 train_time:60513ms step_avg:52.57ms
+step:1152/1575 train_time:60598ms step_avg:52.60ms
+step:1153/1575 train_time:60688ms step_avg:52.63ms
+step:1154/1575 train_time:60773ms step_avg:52.66ms
+step:1155/1575 train_time:60863ms step_avg:52.70ms
+step:1156/1575 train_time:60949ms step_avg:52.72ms
+step:1157/1575 train_time:61039ms step_avg:52.76ms
+step:1158/1575 train_time:61125ms step_avg:52.78ms
+step:1159/1575 train_time:61214ms step_avg:52.82ms
+step:1160/1575 train_time:61299ms step_avg:52.84ms
+step:1161/1575 train_time:61389ms step_avg:52.88ms
+step:1162/1575 train_time:61476ms step_avg:52.91ms
+step:1163/1575 train_time:61565ms step_avg:52.94ms
+step:1164/1575 train_time:61650ms step_avg:52.96ms
+step:1165/1575 train_time:61740ms step_avg:53.00ms
+step:1166/1575 train_time:61825ms step_avg:53.02ms
+step:1167/1575 train_time:61915ms step_avg:53.06ms
+step:1168/1575 train_time:62001ms step_avg:53.08ms
+step:1169/1575 train_time:62091ms step_avg:53.11ms
+step:1170/1575 train_time:62176ms step_avg:53.14ms
+step:1171/1575 train_time:62265ms step_avg:53.17ms
+step:1172/1575 train_time:62353ms step_avg:53.20ms
+step:1173/1575 train_time:62442ms step_avg:53.23ms
+step:1174/1575 train_time:62528ms step_avg:53.26ms
+step:1175/1575 train_time:62618ms step_avg:53.29ms
+step:1176/1575 train_time:62704ms step_avg:53.32ms
+step:1177/1575 train_time:62793ms step_avg:53.35ms
+step:1178/1575 train_time:62878ms step_avg:53.38ms
+step:1179/1575 train_time:62968ms step_avg:53.41ms
+step:1180/1575 train_time:63054ms step_avg:53.44ms
+step:1181/1575 train_time:63145ms step_avg:53.47ms
+step:1182/1575 train_time:63229ms step_avg:53.49ms
+step:1183/1575 train_time:63319ms step_avg:53.52ms
+step:1184/1575 train_time:63406ms step_avg:53.55ms
+step:1185/1575 train_time:63495ms step_avg:53.58ms
+step:1186/1575 train_time:63581ms step_avg:53.61ms
+step:1187/1575 train_time:63671ms step_avg:53.64ms
+step:1188/1575 train_time:63756ms step_avg:53.67ms
+step:1189/1575 train_time:63845ms step_avg:53.70ms
+step:1190/1575 train_time:63931ms step_avg:53.72ms
+step:1191/1575 train_time:64022ms step_avg:53.75ms
+step:1192/1575 train_time:64107ms step_avg:53.78ms
+step:1193/1575 train_time:64197ms step_avg:53.81ms
+step:1194/1575 train_time:64282ms step_avg:53.84ms
+step:1195/1575 train_time:64371ms step_avg:53.87ms
+step:1196/1575 train_time:64456ms step_avg:53.89ms
+step:1197/1575 train_time:64545ms step_avg:53.92ms
+step:1198/1575 train_time:64632ms step_avg:53.95ms
+step:1199/1575 train_time:64721ms step_avg:53.98ms
+step:1200/1575 train_time:64807ms step_avg:54.01ms
+step:1201/1575 train_time:64897ms step_avg:54.04ms
+step:1202/1575 train_time:64982ms step_avg:54.06ms
+step:1203/1575 train_time:65072ms step_avg:54.09ms
+step:1204/1575 train_time:65158ms step_avg:54.12ms
+step:1205/1575 train_time:65248ms step_avg:54.15ms
+step:1206/1575 train_time:65334ms step_avg:54.17ms
+step:1207/1575 train_time:65424ms step_avg:54.20ms
+step:1208/1575 train_time:65510ms step_avg:54.23ms
+step:1209/1575 train_time:65601ms step_avg:54.26ms
+step:1210/1575 train_time:65687ms step_avg:54.29ms
+step:1211/1575 train_time:65776ms step_avg:54.32ms
+step:1212/1575 train_time:65861ms step_avg:54.34ms
+step:1213/1575 train_time:65950ms step_avg:54.37ms
+step:1214/1575 train_time:66037ms step_avg:54.40ms
+step:1215/1575 train_time:66126ms step_avg:54.42ms
+step:1216/1575 train_time:66211ms step_avg:54.45ms
+step:1217/1575 train_time:66302ms step_avg:54.48ms
+step:1218/1575 train_time:66388ms step_avg:54.51ms
+step:1219/1575 train_time:66478ms step_avg:54.53ms
+step:1220/1575 train_time:66564ms step_avg:54.56ms
+step:1221/1575 train_time:66654ms step_avg:54.59ms
+step:1222/1575 train_time:66740ms step_avg:54.62ms
+step:1223/1575 train_time:66828ms step_avg:54.64ms
+step:1224/1575 train_time:66914ms step_avg:54.67ms
+step:1225/1575 train_time:67004ms step_avg:54.70ms
+step:1226/1575 train_time:67089ms step_avg:54.72ms
+step:1227/1575 train_time:67179ms step_avg:54.75ms
+step:1228/1575 train_time:67265ms step_avg:54.78ms
+step:1229/1575 train_time:67354ms step_avg:54.80ms
+step:1230/1575 train_time:67439ms step_avg:54.83ms
+step:1231/1575 train_time:67529ms step_avg:54.86ms
+step:1232/1575 train_time:67615ms step_avg:54.88ms
+step:1233/1575 train_time:67705ms step_avg:54.91ms
+step:1234/1575 train_time:67791ms step_avg:54.94ms
+step:1235/1575 train_time:67881ms step_avg:54.96ms
+step:1236/1575 train_time:67966ms step_avg:54.99ms
+step:1237/1575 train_time:68055ms step_avg:55.02ms
+step:1238/1575 train_time:68141ms step_avg:55.04ms
+step:1239/1575 train_time:68232ms step_avg:55.07ms
+step:1240/1575 train_time:68317ms step_avg:55.09ms
+step:1241/1575 train_time:68406ms step_avg:55.12ms
+step:1242/1575 train_time:68492ms step_avg:55.15ms
+step:1243/1575 train_time:68582ms step_avg:55.17ms
+step:1244/1575 train_time:68667ms step_avg:55.20ms
+step:1245/1575 train_time:68758ms step_avg:55.23ms
+step:1246/1575 train_time:68843ms step_avg:55.25ms
+step:1247/1575 train_time:68932ms step_avg:55.28ms
+step:1248/1575 train_time:69019ms step_avg:55.30ms
+step:1249/1575 train_time:69108ms step_avg:55.33ms
+step:1250/1575 train_time:69194ms step_avg:55.36ms
+step:1250/1575 val_loss:3.4077 train_time:69266ms step_avg:55.41ms
+step:1251/1575 train_time:69287ms step_avg:55.39ms
+step:1252/1575 train_time:69376ms step_avg:55.41ms
+step:1253/1575 train_time:69470ms step_avg:55.44ms
+step:1254/1575 train_time:69556ms step_avg:55.47ms
+step:1255/1575 train_time:69645ms step_avg:55.49ms
+step:1256/1575 train_time:69731ms step_avg:55.52ms
+step:1257/1575 train_time:69821ms step_avg:55.55ms
+step:1258/1575 train_time:69905ms step_avg:55.57ms
+step:1259/1575 train_time:69994ms step_avg:55.60ms
+step:1260/1575 train_time:70080ms step_avg:55.62ms
+step:1261/1575 train_time:70168ms step_avg:55.64ms
+step:1262/1575 train_time:70255ms step_avg:55.67ms
+step:1263/1575 train_time:70349ms step_avg:55.70ms
+step:1264/1575 train_time:70438ms step_avg:55.73ms
+step:1265/1575 train_time:70528ms step_avg:55.75ms
+step:1266/1575 train_time:70614ms step_avg:55.78ms
+step:1267/1575 train_time:70704ms step_avg:55.80ms
+step:1268/1575 train_time:70789ms step_avg:55.83ms
+step:1269/1575 train_time:70878ms step_avg:55.85ms
+step:1270/1575 train_time:70963ms step_avg:55.88ms
+step:1271/1575 train_time:71052ms step_avg:55.90ms
+step:1272/1575 train_time:71138ms step_avg:55.93ms
+step:1273/1575 train_time:71227ms step_avg:55.95ms
+step:1274/1575 train_time:71314ms step_avg:55.98ms
+step:1275/1575 train_time:71405ms step_avg:56.00ms
+step:1276/1575 train_time:71492ms step_avg:56.03ms
+step:1277/1575 train_time:71583ms step_avg:56.06ms
+step:1278/1575 train_time:71670ms step_avg:56.08ms
+step:1279/1575 train_time:71759ms step_avg:56.11ms
+step:1280/1575 train_time:71844ms step_avg:56.13ms
+step:1281/1575 train_time:71933ms step_avg:56.15ms
+step:1282/1575 train_time:72019ms step_avg:56.18ms
+step:1283/1575 train_time:72107ms step_avg:56.20ms
+step:1284/1575 train_time:72193ms step_avg:56.22ms
+step:1285/1575 train_time:72283ms step_avg:56.25ms
+step:1286/1575 train_time:72370ms step_avg:56.28ms
+step:1287/1575 train_time:72462ms step_avg:56.30ms
+step:1288/1575 train_time:72548ms step_avg:56.33ms
+step:1289/1575 train_time:72637ms step_avg:56.35ms
+step:1290/1575 train_time:72723ms step_avg:56.37ms
+step:1291/1575 train_time:72813ms step_avg:56.40ms
+step:1292/1575 train_time:72899ms step_avg:56.42ms
+step:1293/1575 train_time:72989ms step_avg:56.45ms
+step:1294/1575 train_time:73073ms step_avg:56.47ms
+step:1295/1575 train_time:73162ms step_avg:56.50ms
+step:1296/1575 train_time:73249ms step_avg:56.52ms
+step:1297/1575 train_time:73339ms step_avg:56.55ms
+step:1298/1575 train_time:73425ms step_avg:56.57ms
+step:1299/1575 train_time:73515ms step_avg:56.59ms
+step:1300/1575 train_time:73601ms step_avg:56.62ms
+step:1301/1575 train_time:73690ms step_avg:56.64ms
+step:1302/1575 train_time:73778ms step_avg:56.66ms
+step:1303/1575 train_time:73867ms step_avg:56.69ms
+step:1304/1575 train_time:73952ms step_avg:56.71ms
+step:1305/1575 train_time:74041ms step_avg:56.74ms
+step:1306/1575 train_time:74127ms step_avg:56.76ms
+step:1307/1575 train_time:74216ms step_avg:56.78ms
+step:1308/1575 train_time:74302ms step_avg:56.81ms
+step:1309/1575 train_time:74391ms step_avg:56.83ms
+step:1310/1575 train_time:74477ms step_avg:56.85ms
+step:1311/1575 train_time:74567ms step_avg:56.88ms
+step:1312/1575 train_time:74653ms step_avg:56.90ms
+step:1313/1575 train_time:74744ms step_avg:56.93ms
+step:1314/1575 train_time:74831ms step_avg:56.95ms
+step:1315/1575 train_time:74919ms step_avg:56.97ms
+step:1316/1575 train_time:75004ms step_avg:56.99ms
+step:1317/1575 train_time:75094ms step_avg:57.02ms
+step:1318/1575 train_time:75180ms step_avg:57.04ms
+step:1319/1575 train_time:75269ms step_avg:57.07ms
+step:1320/1575 train_time:75355ms step_avg:57.09ms
+step:1321/1575 train_time:75445ms step_avg:57.11ms
+step:1322/1575 train_time:75532ms step_avg:57.13ms
+step:1323/1575 train_time:75622ms step_avg:57.16ms
+step:1324/1575 train_time:75708ms step_avg:57.18ms
+step:1325/1575 train_time:75798ms step_avg:57.21ms
+step:1326/1575 train_time:75883ms step_avg:57.23ms
+step:1327/1575 train_time:75972ms step_avg:57.25ms
+step:1328/1575 train_time:76058ms step_avg:57.27ms
+step:1329/1575 train_time:76147ms step_avg:57.30ms
+step:1330/1575 train_time:76233ms step_avg:57.32ms
+step:1331/1575 train_time:76324ms step_avg:57.34ms
+step:1332/1575 train_time:76410ms step_avg:57.36ms
+step:1333/1575 train_time:76499ms step_avg:57.39ms
+step:1334/1575 train_time:76585ms step_avg:57.41ms
+step:1335/1575 train_time:76675ms step_avg:57.43ms
+step:1336/1575 train_time:76760ms step_avg:57.46ms
+step:1337/1575 train_time:76849ms step_avg:57.48ms
+step:1338/1575 train_time:76936ms step_avg:57.50ms
+step:1339/1575 train_time:77025ms step_avg:57.52ms
+step:1340/1575 train_time:77110ms step_avg:57.54ms
+step:1341/1575 train_time:77200ms step_avg:57.57ms
+step:1342/1575 train_time:77286ms step_avg:57.59ms
+step:1343/1575 train_time:77376ms step_avg:57.61ms
+step:1344/1575 train_time:77461ms step_avg:57.63ms
+step:1345/1575 train_time:77552ms step_avg:57.66ms
+step:1346/1575 train_time:77639ms step_avg:57.68ms
+step:1347/1575 train_time:77727ms step_avg:57.70ms
+step:1348/1575 train_time:77816ms step_avg:57.73ms
+step:1349/1575 train_time:77906ms step_avg:57.75ms
+step:1350/1575 train_time:77989ms step_avg:57.77ms
+step:1351/1575 train_time:78078ms step_avg:57.79ms
+step:1352/1575 train_time:78163ms step_avg:57.81ms
+step:1353/1575 train_time:78254ms step_avg:57.84ms
+step:1354/1575 train_time:78341ms step_avg:57.86ms
+step:1355/1575 train_time:78430ms step_avg:57.88ms
+step:1356/1575 train_time:78516ms step_avg:57.90ms
+step:1357/1575 train_time:78606ms step_avg:57.93ms
+step:1358/1575 train_time:78696ms step_avg:57.95ms
+step:1359/1575 train_time:78784ms step_avg:57.97ms
+step:1360/1575 train_time:78869ms step_avg:57.99ms
+step:1361/1575 train_time:78958ms step_avg:58.01ms
+step:1362/1575 train_time:79043ms step_avg:58.03ms
+step:1363/1575 train_time:79133ms step_avg:58.06ms
+step:1364/1575 train_time:79218ms step_avg:58.08ms
+step:1365/1575 train_time:79308ms step_avg:58.10ms
+step:1366/1575 train_time:79395ms step_avg:58.12ms
+step:1367/1575 train_time:79484ms step_avg:58.14ms
+step:1368/1575 train_time:79570ms step_avg:58.17ms
+step:1369/1575 train_time:79659ms step_avg:58.19ms
+step:1370/1575 train_time:79745ms step_avg:58.21ms
+step:1371/1575 train_time:79836ms step_avg:58.23ms
+step:1372/1575 train_time:79920ms step_avg:58.25ms
+step:1373/1575 train_time:80009ms step_avg:58.27ms
+step:1374/1575 train_time:80094ms step_avg:58.29ms
+step:1375/1575 train_time:80184ms step_avg:58.32ms
+step:1376/1575 train_time:80269ms step_avg:58.34ms
+step:1377/1575 train_time:80360ms step_avg:58.36ms
+step:1378/1575 train_time:80446ms step_avg:58.38ms
+step:1379/1575 train_time:80536ms step_avg:58.40ms
+step:1380/1575 train_time:80621ms step_avg:58.42ms
+step:1381/1575 train_time:80711ms step_avg:58.44ms
+step:1382/1575 train_time:80798ms step_avg:58.46ms
+step:1383/1575 train_time:80887ms step_avg:58.49ms
+step:1384/1575 train_time:80973ms step_avg:58.51ms
+step:1385/1575 train_time:81063ms step_avg:58.53ms
+step:1386/1575 train_time:81149ms step_avg:58.55ms
+step:1387/1575 train_time:81239ms step_avg:58.57ms
+step:1388/1575 train_time:81324ms step_avg:58.59ms
+step:1389/1575 train_time:81415ms step_avg:58.61ms
+step:1390/1575 train_time:81500ms step_avg:58.63ms
+step:1391/1575 train_time:81589ms step_avg:58.65ms
+step:1392/1575 train_time:81675ms step_avg:58.67ms
+step:1393/1575 train_time:81765ms step_avg:58.70ms
+step:1394/1575 train_time:81851ms step_avg:58.72ms
+step:1395/1575 train_time:81940ms step_avg:58.74ms
+step:1396/1575 train_time:82026ms step_avg:58.76ms
+step:1397/1575 train_time:82115ms step_avg:58.78ms
+step:1398/1575 train_time:82202ms step_avg:58.80ms
+step:1399/1575 train_time:82290ms step_avg:58.82ms
+step:1400/1575 train_time:82377ms step_avg:58.84ms
+step:1401/1575 train_time:82466ms step_avg:58.86ms
+step:1402/1575 train_time:82552ms step_avg:58.88ms
+step:1403/1575 train_time:82643ms step_avg:58.90ms
+step:1404/1575 train_time:82729ms step_avg:58.92ms
+step:1405/1575 train_time:82818ms step_avg:58.95ms
+step:1406/1575 train_time:82903ms step_avg:58.96ms
+step:1407/1575 train_time:82992ms step_avg:58.99ms
+step:1408/1575 train_time:83078ms step_avg:59.00ms
+step:1409/1575 train_time:83167ms step_avg:59.03ms
+step:1410/1575 train_time:83254ms step_avg:59.05ms
+step:1411/1575 train_time:83344ms step_avg:59.07ms
+step:1412/1575 train_time:83429ms step_avg:59.09ms
+step:1413/1575 train_time:83518ms step_avg:59.11ms
+step:1414/1575 train_time:83604ms step_avg:59.13ms
+step:1415/1575 train_time:83694ms step_avg:59.15ms
+step:1416/1575 train_time:83780ms step_avg:59.17ms
+step:1417/1575 train_time:83869ms step_avg:59.19ms
+step:1418/1575 train_time:83956ms step_avg:59.21ms
+step:1419/1575 train_time:84046ms step_avg:59.23ms
+step:1420/1575 train_time:84131ms step_avg:59.25ms
+step:1421/1575 train_time:84222ms step_avg:59.27ms
+step:1422/1575 train_time:84307ms step_avg:59.29ms
+step:1423/1575 train_time:84397ms step_avg:59.31ms
+step:1424/1575 train_time:84483ms step_avg:59.33ms
+step:1425/1575 train_time:84572ms step_avg:59.35ms
+step:1426/1575 train_time:84658ms step_avg:59.37ms
+step:1427/1575 train_time:84747ms step_avg:59.39ms
+step:1428/1575 train_time:84832ms step_avg:59.41ms
+step:1429/1575 train_time:84923ms step_avg:59.43ms
+step:1430/1575 train_time:85010ms step_avg:59.45ms
+step:1431/1575 train_time:85099ms step_avg:59.47ms
+step:1432/1575 train_time:85184ms step_avg:59.49ms
+step:1433/1575 train_time:85274ms step_avg:59.51ms
+step:1434/1575 train_time:85360ms step_avg:59.53ms
+step:1435/1575 train_time:85450ms step_avg:59.55ms
+step:1436/1575 train_time:85536ms step_avg:59.57ms
+step:1437/1575 train_time:85626ms step_avg:59.59ms
+step:1438/1575 train_time:85712ms step_avg:59.61ms
+step:1439/1575 train_time:85802ms step_avg:59.63ms
+step:1440/1575 train_time:85888ms step_avg:59.64ms
+step:1441/1575 train_time:85978ms step_avg:59.67ms
+step:1442/1575 train_time:86064ms step_avg:59.68ms
+step:1443/1575 train_time:86153ms step_avg:59.70ms
+step:1444/1575 train_time:86239ms step_avg:59.72ms
+step:1445/1575 train_time:86328ms step_avg:59.74ms
+step:1446/1575 train_time:86414ms step_avg:59.76ms
+step:1447/1575 train_time:86503ms step_avg:59.78ms
+step:1448/1575 train_time:86590ms step_avg:59.80ms
+step:1449/1575 train_time:86680ms step_avg:59.82ms
+step:1450/1575 train_time:86765ms step_avg:59.84ms
+step:1451/1575 train_time:86855ms step_avg:59.86ms
+step:1452/1575 train_time:86940ms step_avg:59.88ms
+step:1453/1575 train_time:87029ms step_avg:59.90ms
+step:1454/1575 train_time:87116ms step_avg:59.91ms
+step:1455/1575 train_time:87206ms step_avg:59.94ms
+step:1456/1575 train_time:87293ms step_avg:59.95ms
+step:1457/1575 train_time:87384ms step_avg:59.97ms
+step:1458/1575 train_time:87469ms step_avg:59.99ms
+step:1459/1575 train_time:87558ms step_avg:60.01ms
+step:1460/1575 train_time:87644ms step_avg:60.03ms
+step:1461/1575 train_time:87733ms step_avg:60.05ms
+step:1462/1575 train_time:87820ms step_avg:60.07ms
+step:1463/1575 train_time:87909ms step_avg:60.09ms
+step:1464/1575 train_time:87995ms step_avg:60.11ms
+step:1465/1575 train_time:88084ms step_avg:60.13ms
+step:1466/1575 train_time:88169ms step_avg:60.14ms
+step:1467/1575 train_time:88259ms step_avg:60.16ms
+step:1468/1575 train_time:88345ms step_avg:60.18ms
+step:1469/1575 train_time:88434ms step_avg:60.20ms
+step:1470/1575 train_time:88520ms step_avg:60.22ms
+step:1471/1575 train_time:88609ms step_avg:60.24ms
+step:1472/1575 train_time:88695ms step_avg:60.25ms
+step:1473/1575 train_time:88785ms step_avg:60.27ms
+step:1474/1575 train_time:88870ms step_avg:60.29ms
+step:1475/1575 train_time:88960ms step_avg:60.31ms
+step:1476/1575 train_time:89046ms step_avg:60.33ms
+step:1477/1575 train_time:89136ms step_avg:60.35ms
+step:1478/1575 train_time:89222ms step_avg:60.37ms
+step:1479/1575 train_time:89311ms step_avg:60.39ms
+step:1480/1575 train_time:89398ms step_avg:60.40ms
+step:1481/1575 train_time:89486ms step_avg:60.42ms
+step:1482/1575 train_time:89572ms step_avg:60.44ms
+step:1483/1575 train_time:89661ms step_avg:60.46ms
+step:1484/1575 train_time:89747ms step_avg:60.48ms
+step:1485/1575 train_time:89836ms step_avg:60.50ms
+step:1486/1575 train_time:89922ms step_avg:60.51ms
+step:1487/1575 train_time:90012ms step_avg:60.53ms
+step:1488/1575 train_time:90098ms step_avg:60.55ms
+step:1489/1575 train_time:90188ms step_avg:60.57ms
+step:1490/1575 train_time:90274ms step_avg:60.59ms
+step:1491/1575 train_time:90363ms step_avg:60.61ms
+step:1492/1575 train_time:90449ms step_avg:60.62ms
+step:1493/1575 train_time:90540ms step_avg:60.64ms
+step:1494/1575 train_time:90626ms step_avg:60.66ms
+step:1495/1575 train_time:90715ms step_avg:60.68ms
+step:1496/1575 train_time:90802ms step_avg:60.70ms
+step:1497/1575 train_time:90891ms step_avg:60.72ms
+step:1498/1575 train_time:90977ms step_avg:60.73ms
+step:1499/1575 train_time:91067ms step_avg:60.75ms
+step:1500/1575 train_time:91153ms step_avg:60.77ms
+step:1500/1575 val_loss:3.3007 train_time:91226ms step_avg:60.82ms
+step:1501/1575 train_time:91247ms step_avg:60.79ms
+step:1502/1575 train_time:91334ms step_avg:60.81ms
+step:1503/1575 train_time:91427ms step_avg:60.83ms
+step:1504/1575 train_time:91513ms step_avg:60.85ms
+step:1505/1575 train_time:91603ms step_avg:60.87ms
+step:1506/1575 train_time:91688ms step_avg:60.88ms
+step:1507/1575 train_time:91776ms step_avg:60.90ms
+step:1508/1575 train_time:91860ms step_avg:60.92ms
+step:1509/1575 train_time:91950ms step_avg:60.93ms
+step:1510/1575 train_time:92037ms step_avg:60.95ms
+step:1511/1575 train_time:92125ms step_avg:60.97ms
+step:1512/1575 train_time:92210ms step_avg:60.99ms
+step:1513/1575 train_time:92302ms step_avg:61.01ms
+step:1514/1575 train_time:92389ms step_avg:61.02ms
+step:1515/1575 train_time:92481ms step_avg:61.04ms
+step:1516/1575 train_time:92567ms step_avg:61.06ms
+step:1517/1575 train_time:92656ms step_avg:61.08ms
+step:1518/1575 train_time:92742ms step_avg:61.09ms
+step:1519/1575 train_time:92829ms step_avg:61.11ms
+step:1520/1575 train_time:92916ms step_avg:61.13ms
+step:1521/1575 train_time:93004ms step_avg:61.15ms
+step:1522/1575 train_time:93090ms step_avg:61.16ms
+step:1523/1575 train_time:93180ms step_avg:61.18ms
+step:1524/1575 train_time:93267ms step_avg:61.20ms
+step:1525/1575 train_time:93359ms step_avg:61.22ms
+step:1526/1575 train_time:93445ms step_avg:61.24ms
+step:1527/1575 train_time:93535ms step_avg:61.25ms
+step:1528/1575 train_time:93621ms step_avg:61.27ms
+step:1529/1575 train_time:93710ms step_avg:61.29ms
+step:1530/1575 train_time:93795ms step_avg:61.30ms
+step:1531/1575 train_time:93884ms step_avg:61.32ms
+step:1532/1575 train_time:93970ms step_avg:61.34ms
+step:1533/1575 train_time:94059ms step_avg:61.36ms
+step:1534/1575 train_time:94144ms step_avg:61.37ms
+step:1535/1575 train_time:94235ms step_avg:61.39ms
+step:1536/1575 train_time:94330ms step_avg:61.41ms
+step:1537/1575 train_time:94418ms step_avg:61.43ms
+step:1538/1575 train_time:94505ms step_avg:61.45ms
+step:1539/1575 train_time:94595ms step_avg:61.47ms
+step:1540/1575 train_time:94681ms step_avg:61.48ms
+step:1541/1575 train_time:94770ms step_avg:61.50ms
+step:1542/1575 train_time:94855ms step_avg:61.51ms
+step:1543/1575 train_time:94944ms step_avg:61.53ms
+step:1544/1575 train_time:95030ms step_avg:61.55ms
+step:1545/1575 train_time:95119ms step_avg:61.57ms
+step:1546/1575 train_time:95205ms step_avg:61.58ms
+step:1547/1575 train_time:95296ms step_avg:61.60ms
+step:1548/1575 train_time:95383ms step_avg:61.62ms
+step:1549/1575 train_time:95474ms step_avg:61.64ms
+step:1550/1575 train_time:95559ms step_avg:61.65ms
+step:1551/1575 train_time:95649ms step_avg:61.67ms
+step:1552/1575 train_time:95735ms step_avg:61.69ms
+step:1553/1575 train_time:95825ms step_avg:61.70ms
+step:1554/1575 train_time:95911ms step_avg:61.72ms
+step:1555/1575 train_time:96001ms step_avg:61.74ms
+step:1556/1575 train_time:96087ms step_avg:61.75ms
+step:1557/1575 train_time:96176ms step_avg:61.77ms
+step:1558/1575 train_time:96262ms step_avg:61.79ms
+step:1559/1575 train_time:96352ms step_avg:61.80ms
+step:1560/1575 train_time:96438ms step_avg:61.82ms
+step:1561/1575 train_time:96528ms step_avg:61.84ms
+step:1562/1575 train_time:96615ms step_avg:61.85ms
+step:1563/1575 train_time:96705ms step_avg:61.87ms
+step:1564/1575 train_time:96791ms step_avg:61.89ms
+step:1565/1575 train_time:96881ms step_avg:61.90ms
+step:1566/1575 train_time:96969ms step_avg:61.92ms
+step:1567/1575 train_time:97060ms step_avg:61.94ms
+step:1568/1575 train_time:97145ms step_avg:61.95ms
+step:1569/1575 train_time:97241ms step_avg:61.98ms
+step:1570/1575 train_time:97325ms step_avg:61.99ms
+step:1571/1575 train_time:97413ms step_avg:62.01ms
+step:1572/1575 train_time:97499ms step_avg:62.02ms
+step:1573/1575 train_time:97588ms step_avg:62.04ms
+step:1574/1575 train_time:97675ms step_avg:62.05ms
+step:1575/1575 train_time:97763ms step_avg:62.07ms
+step:1575/1575 val_loss:3.2786 train_time:97831ms step_avg:62.11ms
+peak memory allocated: 30933 MiB reserved: 46918 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/bac9cc79-57df-4948-b800-ff33a04a4bc8.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/bac9cc79-57df-4948-b800-ff33a04a4bc8.txt
@@ -1,0 +1,4119 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 03:23:19 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   34C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   40C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   34C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   41C    P0            129W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   39C    P0            125W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   35C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          303355      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          303356      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          303357      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          303358      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          303359      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          303360      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          303361      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          303362      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8285 train_time:0ms step_avg:0.06ms
+step:1/1600 train_time:79ms step_avg:78.68ms
+step:2/1600 train_time:104ms step_avg:52.04ms
+step:3/1600 train_time:123ms step_avg:40.87ms
+step:4/1600 train_time:145ms step_avg:36.33ms
+step:5/1600 train_time:176ms step_avg:35.15ms
+step:6/1600 train_time:286ms step_avg:47.73ms
+step:7/1600 train_time:307ms step_avg:43.88ms
+step:8/1600 train_time:326ms step_avg:40.77ms
+step:9/1600 train_time:352ms step_avg:39.06ms
+step:10/1600 train_time:389ms step_avg:38.86ms
+step:11/1600 train_time:419ms step_avg:38.08ms
+step:12/1600 train_time:456ms step_avg:38.01ms
+step:13/1600 train_time:487ms step_avg:37.44ms
+step:14/1600 train_time:524ms step_avg:37.42ms
+step:15/1600 train_time:554ms step_avg:36.97ms
+step:16/1600 train_time:592ms step_avg:37.01ms
+step:17/1600 train_time:624ms step_avg:36.68ms
+step:18/1600 train_time:661ms step_avg:36.73ms
+step:19/1600 train_time:692ms step_avg:36.40ms
+step:20/1600 train_time:729ms step_avg:36.44ms
+step:21/1600 train_time:759ms step_avg:36.16ms
+step:22/1600 train_time:796ms step_avg:36.20ms
+step:23/1600 train_time:827ms step_avg:35.96ms
+step:24/1600 train_time:864ms step_avg:36.02ms
+step:25/1600 train_time:895ms step_avg:35.80ms
+step:26/1600 train_time:933ms step_avg:35.87ms
+step:27/1600 train_time:963ms step_avg:35.68ms
+step:28/1600 train_time:1001ms step_avg:35.74ms
+step:29/1600 train_time:1031ms step_avg:35.56ms
+step:30/1600 train_time:1068ms step_avg:35.61ms
+step:31/1600 train_time:1099ms step_avg:35.46ms
+step:32/1600 train_time:1136ms step_avg:35.51ms
+step:33/1600 train_time:1167ms step_avg:35.37ms
+step:34/1600 train_time:1204ms step_avg:35.42ms
+step:35/1600 train_time:1235ms step_avg:35.30ms
+step:36/1600 train_time:1274ms step_avg:35.38ms
+step:37/1600 train_time:1305ms step_avg:35.26ms
+step:38/1600 train_time:1342ms step_avg:35.31ms
+step:39/1600 train_time:1373ms step_avg:35.20ms
+step:40/1600 train_time:1410ms step_avg:35.26ms
+step:41/1600 train_time:1441ms step_avg:35.15ms
+step:42/1600 train_time:1478ms step_avg:35.20ms
+step:43/1600 train_time:1509ms step_avg:35.09ms
+step:44/1600 train_time:1546ms step_avg:35.14ms
+step:45/1600 train_time:1577ms step_avg:35.05ms
+step:46/1600 train_time:1614ms step_avg:35.09ms
+step:47/1600 train_time:1645ms step_avg:35.01ms
+step:48/1600 train_time:1682ms step_avg:35.05ms
+step:49/1600 train_time:1713ms step_avg:34.96ms
+step:50/1600 train_time:1750ms step_avg:35.01ms
+step:51/1600 train_time:1781ms step_avg:34.93ms
+step:52/1600 train_time:1818ms step_avg:34.97ms
+step:53/1600 train_time:1849ms step_avg:34.89ms
+step:54/1600 train_time:1887ms step_avg:34.94ms
+step:55/1600 train_time:1917ms step_avg:34.86ms
+step:56/1600 train_time:1954ms step_avg:34.90ms
+step:57/1600 train_time:1986ms step_avg:34.84ms
+step:58/1600 train_time:2022ms step_avg:34.87ms
+step:59/1600 train_time:2053ms step_avg:34.80ms
+step:60/1600 train_time:2091ms step_avg:34.85ms
+step:61/1600 train_time:2122ms step_avg:34.78ms
+step:62/1600 train_time:2159ms step_avg:34.82ms
+step:63/1600 train_time:2190ms step_avg:34.76ms
+step:64/1600 train_time:2227ms step_avg:34.79ms
+step:65/1600 train_time:2258ms step_avg:34.73ms
+step:66/1600 train_time:2295ms step_avg:34.77ms
+step:67/1600 train_time:2326ms step_avg:34.71ms
+step:68/1600 train_time:2363ms step_avg:34.75ms
+step:69/1600 train_time:2394ms step_avg:34.69ms
+step:70/1600 train_time:2431ms step_avg:34.73ms
+step:71/1600 train_time:2462ms step_avg:34.68ms
+step:72/1600 train_time:2500ms step_avg:34.72ms
+step:73/1600 train_time:2531ms step_avg:34.67ms
+step:74/1600 train_time:2568ms step_avg:34.70ms
+step:75/1600 train_time:2599ms step_avg:34.65ms
+step:76/1600 train_time:2636ms step_avg:34.69ms
+step:77/1600 train_time:2667ms step_avg:34.64ms
+step:78/1600 train_time:2704ms step_avg:34.66ms
+step:79/1600 train_time:2734ms step_avg:34.61ms
+step:80/1600 train_time:2772ms step_avg:34.65ms
+step:81/1600 train_time:2802ms step_avg:34.60ms
+step:82/1600 train_time:2839ms step_avg:34.62ms
+step:83/1600 train_time:2870ms step_avg:34.58ms
+step:84/1600 train_time:2907ms step_avg:34.61ms
+step:85/1600 train_time:2938ms step_avg:34.56ms
+step:86/1600 train_time:2975ms step_avg:34.59ms
+step:87/1600 train_time:3005ms step_avg:34.55ms
+step:88/1600 train_time:3043ms step_avg:34.58ms
+step:89/1600 train_time:3074ms step_avg:34.54ms
+step:90/1600 train_time:3111ms step_avg:34.57ms
+step:91/1600 train_time:3142ms step_avg:34.53ms
+step:92/1600 train_time:3180ms step_avg:34.56ms
+step:93/1600 train_time:3210ms step_avg:34.52ms
+step:94/1600 train_time:3248ms step_avg:34.55ms
+step:95/1600 train_time:3279ms step_avg:34.51ms
+step:96/1600 train_time:3316ms step_avg:34.54ms
+step:97/1600 train_time:3346ms step_avg:34.50ms
+step:98/1600 train_time:3384ms step_avg:34.53ms
+step:99/1600 train_time:3414ms step_avg:34.49ms
+step:100/1600 train_time:3452ms step_avg:34.52ms
+step:101/1600 train_time:3483ms step_avg:34.48ms
+step:102/1600 train_time:3520ms step_avg:34.51ms
+step:103/1600 train_time:3551ms step_avg:34.47ms
+step:104/1600 train_time:3588ms step_avg:34.50ms
+step:105/1600 train_time:3618ms step_avg:34.46ms
+step:106/1600 train_time:3655ms step_avg:34.48ms
+step:107/1600 train_time:3686ms step_avg:34.45ms
+step:108/1600 train_time:3723ms step_avg:34.47ms
+step:109/1600 train_time:3753ms step_avg:34.44ms
+step:110/1600 train_time:3791ms step_avg:34.47ms
+step:111/1600 train_time:3822ms step_avg:34.43ms
+step:112/1600 train_time:3859ms step_avg:34.46ms
+step:113/1600 train_time:3890ms step_avg:34.42ms
+step:114/1600 train_time:3927ms step_avg:34.45ms
+step:115/1600 train_time:3958ms step_avg:34.41ms
+step:116/1600 train_time:3995ms step_avg:34.44ms
+step:117/1600 train_time:4026ms step_avg:34.41ms
+step:118/1600 train_time:4063ms step_avg:34.43ms
+step:119/1600 train_time:4094ms step_avg:34.40ms
+step:120/1600 train_time:4131ms step_avg:34.43ms
+step:121/1600 train_time:4162ms step_avg:34.40ms
+step:122/1600 train_time:4199ms step_avg:34.42ms
+step:123/1600 train_time:4230ms step_avg:34.39ms
+step:124/1600 train_time:4267ms step_avg:34.41ms
+step:125/1600 train_time:4298ms step_avg:34.38ms
+step:126/1600 train_time:4335ms step_avg:34.41ms
+step:127/1600 train_time:4366ms step_avg:34.37ms
+step:128/1600 train_time:4403ms step_avg:34.40ms
+step:129/1600 train_time:4434ms step_avg:34.37ms
+step:130/1600 train_time:4471ms step_avg:34.39ms
+step:131/1600 train_time:4502ms step_avg:34.37ms
+step:132/1600 train_time:4540ms step_avg:34.39ms
+step:133/1600 train_time:4570ms step_avg:34.36ms
+step:134/1600 train_time:4607ms step_avg:34.38ms
+step:135/1600 train_time:4638ms step_avg:34.35ms
+step:136/1600 train_time:4676ms step_avg:34.38ms
+step:137/1600 train_time:4706ms step_avg:34.35ms
+step:138/1600 train_time:4743ms step_avg:34.37ms
+step:139/1600 train_time:4774ms step_avg:34.34ms
+step:140/1600 train_time:4811ms step_avg:34.36ms
+step:141/1600 train_time:4842ms step_avg:34.34ms
+step:142/1600 train_time:4880ms step_avg:34.36ms
+step:143/1600 train_time:4910ms step_avg:34.34ms
+step:144/1600 train_time:4947ms step_avg:34.35ms
+step:145/1600 train_time:4978ms step_avg:34.33ms
+step:146/1600 train_time:5015ms step_avg:34.35ms
+step:147/1600 train_time:5046ms step_avg:34.32ms
+step:148/1600 train_time:5083ms step_avg:34.35ms
+step:149/1600 train_time:5114ms step_avg:34.32ms
+step:150/1600 train_time:5151ms step_avg:34.34ms
+step:151/1600 train_time:5183ms step_avg:34.32ms
+step:152/1600 train_time:5220ms step_avg:34.34ms
+step:153/1600 train_time:5251ms step_avg:34.32ms
+step:154/1600 train_time:5289ms step_avg:34.34ms
+step:155/1600 train_time:5319ms step_avg:34.32ms
+step:156/1600 train_time:5356ms step_avg:34.33ms
+step:157/1600 train_time:5387ms step_avg:34.31ms
+step:158/1600 train_time:5423ms step_avg:34.32ms
+step:159/1600 train_time:5455ms step_avg:34.31ms
+step:160/1600 train_time:5492ms step_avg:34.33ms
+step:161/1600 train_time:5523ms step_avg:34.31ms
+step:162/1600 train_time:5560ms step_avg:34.32ms
+step:163/1600 train_time:5591ms step_avg:34.30ms
+step:164/1600 train_time:5628ms step_avg:34.32ms
+step:165/1600 train_time:5659ms step_avg:34.30ms
+step:166/1600 train_time:5697ms step_avg:34.32ms
+step:167/1600 train_time:5727ms step_avg:34.29ms
+step:168/1600 train_time:5764ms step_avg:34.31ms
+step:169/1600 train_time:5795ms step_avg:34.29ms
+step:170/1600 train_time:5832ms step_avg:34.31ms
+step:171/1600 train_time:5863ms step_avg:34.29ms
+step:172/1600 train_time:5900ms step_avg:34.30ms
+step:173/1600 train_time:5931ms step_avg:34.28ms
+step:174/1600 train_time:5968ms step_avg:34.30ms
+step:175/1600 train_time:5999ms step_avg:34.28ms
+step:176/1600 train_time:6036ms step_avg:34.29ms
+step:177/1600 train_time:6066ms step_avg:34.27ms
+step:178/1600 train_time:6103ms step_avg:34.29ms
+step:179/1600 train_time:6134ms step_avg:34.27ms
+step:180/1600 train_time:6171ms step_avg:34.29ms
+step:181/1600 train_time:6202ms step_avg:34.27ms
+step:182/1600 train_time:6239ms step_avg:34.28ms
+step:183/1600 train_time:6270ms step_avg:34.26ms
+step:184/1600 train_time:6307ms step_avg:34.28ms
+step:185/1600 train_time:6337ms step_avg:34.26ms
+step:186/1600 train_time:6375ms step_avg:34.27ms
+step:187/1600 train_time:6405ms step_avg:34.25ms
+step:188/1600 train_time:6442ms step_avg:34.27ms
+step:189/1600 train_time:6473ms step_avg:34.25ms
+step:190/1600 train_time:6510ms step_avg:34.26ms
+step:191/1600 train_time:6541ms step_avg:34.25ms
+step:192/1600 train_time:6579ms step_avg:34.26ms
+step:193/1600 train_time:6609ms step_avg:34.24ms
+step:194/1600 train_time:6646ms step_avg:34.26ms
+step:195/1600 train_time:6677ms step_avg:34.24ms
+step:196/1600 train_time:6714ms step_avg:34.26ms
+step:197/1600 train_time:6745ms step_avg:34.24ms
+step:198/1600 train_time:6782ms step_avg:34.25ms
+step:199/1600 train_time:6813ms step_avg:34.24ms
+step:200/1600 train_time:6850ms step_avg:34.25ms
+step:201/1600 train_time:6882ms step_avg:34.24ms
+step:202/1600 train_time:6919ms step_avg:34.25ms
+step:203/1600 train_time:6950ms step_avg:34.24ms
+step:204/1600 train_time:6987ms step_avg:34.25ms
+step:205/1600 train_time:7017ms step_avg:34.23ms
+step:206/1600 train_time:7054ms step_avg:34.24ms
+step:207/1600 train_time:7085ms step_avg:34.23ms
+step:208/1600 train_time:7122ms step_avg:34.24ms
+step:209/1600 train_time:7153ms step_avg:34.23ms
+step:210/1600 train_time:7190ms step_avg:34.24ms
+step:211/1600 train_time:7222ms step_avg:34.23ms
+step:212/1600 train_time:7258ms step_avg:34.24ms
+step:213/1600 train_time:7289ms step_avg:34.22ms
+step:214/1600 train_time:7327ms step_avg:34.24ms
+step:215/1600 train_time:7357ms step_avg:34.22ms
+step:216/1600 train_time:7394ms step_avg:34.23ms
+step:217/1600 train_time:7424ms step_avg:34.21ms
+step:218/1600 train_time:7462ms step_avg:34.23ms
+step:219/1600 train_time:7492ms step_avg:34.21ms
+step:220/1600 train_time:7529ms step_avg:34.22ms
+step:221/1600 train_time:7560ms step_avg:34.21ms
+step:222/1600 train_time:7598ms step_avg:34.22ms
+step:223/1600 train_time:7629ms step_avg:34.21ms
+step:224/1600 train_time:7665ms step_avg:34.22ms
+step:225/1600 train_time:7696ms step_avg:34.21ms
+step:226/1600 train_time:7734ms step_avg:34.22ms
+step:227/1600 train_time:7764ms step_avg:34.20ms
+step:228/1600 train_time:7801ms step_avg:34.22ms
+step:229/1600 train_time:7832ms step_avg:34.20ms
+step:230/1600 train_time:7870ms step_avg:34.22ms
+step:231/1600 train_time:7901ms step_avg:34.20ms
+step:232/1600 train_time:7938ms step_avg:34.21ms
+step:233/1600 train_time:7968ms step_avg:34.20ms
+step:234/1600 train_time:8006ms step_avg:34.21ms
+step:235/1600 train_time:8036ms step_avg:34.20ms
+step:236/1600 train_time:8073ms step_avg:34.21ms
+step:237/1600 train_time:8104ms step_avg:34.19ms
+step:238/1600 train_time:8141ms step_avg:34.21ms
+step:239/1600 train_time:8172ms step_avg:34.19ms
+step:240/1600 train_time:8209ms step_avg:34.20ms
+step:241/1600 train_time:8240ms step_avg:34.19ms
+step:242/1600 train_time:8277ms step_avg:34.20ms
+step:243/1600 train_time:8308ms step_avg:34.19ms
+step:244/1600 train_time:8345ms step_avg:34.20ms
+step:245/1600 train_time:8375ms step_avg:34.19ms
+step:246/1600 train_time:8412ms step_avg:34.20ms
+step:247/1600 train_time:8444ms step_avg:34.18ms
+step:248/1600 train_time:8480ms step_avg:34.20ms
+step:249/1600 train_time:8511ms step_avg:34.18ms
+step:250/1600 train_time:8548ms step_avg:34.19ms
+step:250/1600 val_loss:4.5834 train_time:8596ms step_avg:34.38ms
+step:251/1600 train_time:8615ms step_avg:34.32ms
+step:252/1600 train_time:8633ms step_avg:34.26ms
+step:253/1600 train_time:8650ms step_avg:34.19ms
+step:254/1600 train_time:8688ms step_avg:34.20ms
+step:255/1600 train_time:8721ms step_avg:34.20ms
+step:256/1600 train_time:8760ms step_avg:34.22ms
+step:257/1600 train_time:8791ms step_avg:34.21ms
+step:258/1600 train_time:8828ms step_avg:34.22ms
+step:259/1600 train_time:8859ms step_avg:34.20ms
+step:260/1600 train_time:8897ms step_avg:34.22ms
+step:261/1600 train_time:8928ms step_avg:34.21ms
+step:262/1600 train_time:8966ms step_avg:34.22ms
+step:263/1600 train_time:8996ms step_avg:34.21ms
+step:264/1600 train_time:9034ms step_avg:34.22ms
+step:265/1600 train_time:9064ms step_avg:34.20ms
+step:266/1600 train_time:9101ms step_avg:34.21ms
+step:267/1600 train_time:9132ms step_avg:34.20ms
+step:268/1600 train_time:9168ms step_avg:34.21ms
+step:269/1600 train_time:9199ms step_avg:34.20ms
+step:270/1600 train_time:9237ms step_avg:34.21ms
+step:271/1600 train_time:9267ms step_avg:34.19ms
+step:272/1600 train_time:9304ms step_avg:34.20ms
+step:273/1600 train_time:9334ms step_avg:34.19ms
+step:274/1600 train_time:9371ms step_avg:34.20ms
+step:275/1600 train_time:9401ms step_avg:34.19ms
+step:276/1600 train_time:9438ms step_avg:34.20ms
+step:277/1600 train_time:9469ms step_avg:34.18ms
+step:278/1600 train_time:9506ms step_avg:34.19ms
+step:279/1600 train_time:9536ms step_avg:34.18ms
+step:280/1600 train_time:9573ms step_avg:34.19ms
+step:281/1600 train_time:9604ms step_avg:34.18ms
+step:282/1600 train_time:9641ms step_avg:34.19ms
+step:283/1600 train_time:9672ms step_avg:34.18ms
+step:284/1600 train_time:9709ms step_avg:34.19ms
+step:285/1600 train_time:9740ms step_avg:34.18ms
+step:286/1600 train_time:9777ms step_avg:34.19ms
+step:287/1600 train_time:9808ms step_avg:34.17ms
+step:288/1600 train_time:9845ms step_avg:34.18ms
+step:289/1600 train_time:9876ms step_avg:34.17ms
+step:290/1600 train_time:9913ms step_avg:34.18ms
+step:291/1600 train_time:9944ms step_avg:34.17ms
+step:292/1600 train_time:9981ms step_avg:34.18ms
+step:293/1600 train_time:10012ms step_avg:34.17ms
+step:294/1600 train_time:10049ms step_avg:34.18ms
+step:295/1600 train_time:10080ms step_avg:34.17ms
+step:296/1600 train_time:10117ms step_avg:34.18ms
+step:297/1600 train_time:10148ms step_avg:34.17ms
+step:298/1600 train_time:10185ms step_avg:34.18ms
+step:299/1600 train_time:10215ms step_avg:34.16ms
+step:300/1600 train_time:10252ms step_avg:34.17ms
+step:301/1600 train_time:10282ms step_avg:34.16ms
+step:302/1600 train_time:10320ms step_avg:34.17ms
+step:303/1600 train_time:10350ms step_avg:34.16ms
+step:304/1600 train_time:10387ms step_avg:34.17ms
+step:305/1600 train_time:10418ms step_avg:34.16ms
+step:306/1600 train_time:10455ms step_avg:34.17ms
+step:307/1600 train_time:10486ms step_avg:34.16ms
+step:308/1600 train_time:10523ms step_avg:34.16ms
+step:309/1600 train_time:10553ms step_avg:34.15ms
+step:310/1600 train_time:10590ms step_avg:34.16ms
+step:311/1600 train_time:10621ms step_avg:34.15ms
+step:312/1600 train_time:10658ms step_avg:34.16ms
+step:313/1600 train_time:10689ms step_avg:34.15ms
+step:314/1600 train_time:10726ms step_avg:34.16ms
+step:315/1600 train_time:10756ms step_avg:34.15ms
+step:316/1600 train_time:10793ms step_avg:34.15ms
+step:317/1600 train_time:10824ms step_avg:34.14ms
+step:318/1600 train_time:10861ms step_avg:34.15ms
+step:319/1600 train_time:10892ms step_avg:34.14ms
+step:320/1600 train_time:10929ms step_avg:34.15ms
+step:321/1600 train_time:10960ms step_avg:34.14ms
+step:322/1600 train_time:10997ms step_avg:34.15ms
+step:323/1600 train_time:11028ms step_avg:34.14ms
+step:324/1600 train_time:11065ms step_avg:34.15ms
+step:325/1600 train_time:11096ms step_avg:34.14ms
+step:326/1600 train_time:11133ms step_avg:34.15ms
+step:327/1600 train_time:11164ms step_avg:34.14ms
+step:328/1600 train_time:11201ms step_avg:34.15ms
+step:329/1600 train_time:11232ms step_avg:34.14ms
+step:330/1600 train_time:11269ms step_avg:34.15ms
+step:331/1600 train_time:11300ms step_avg:34.14ms
+step:332/1600 train_time:11337ms step_avg:34.15ms
+step:333/1600 train_time:11368ms step_avg:34.14ms
+step:334/1600 train_time:11405ms step_avg:34.15ms
+step:335/1600 train_time:11436ms step_avg:34.14ms
+step:336/1600 train_time:11473ms step_avg:34.15ms
+step:337/1600 train_time:11503ms step_avg:34.13ms
+step:338/1600 train_time:11540ms step_avg:34.14ms
+step:339/1600 train_time:11571ms step_avg:34.13ms
+step:340/1600 train_time:11608ms step_avg:34.14ms
+step:341/1600 train_time:11639ms step_avg:34.13ms
+step:342/1600 train_time:11676ms step_avg:34.14ms
+step:343/1600 train_time:11707ms step_avg:34.13ms
+step:344/1600 train_time:11744ms step_avg:34.14ms
+step:345/1600 train_time:11775ms step_avg:34.13ms
+step:346/1600 train_time:11812ms step_avg:34.14ms
+step:347/1600 train_time:11842ms step_avg:34.13ms
+step:348/1600 train_time:11879ms step_avg:34.14ms
+step:349/1600 train_time:11910ms step_avg:34.13ms
+step:350/1600 train_time:11947ms step_avg:34.13ms
+step:351/1600 train_time:11978ms step_avg:34.12ms
+step:352/1600 train_time:12015ms step_avg:34.13ms
+step:353/1600 train_time:12046ms step_avg:34.12ms
+step:354/1600 train_time:12083ms step_avg:34.13ms
+step:355/1600 train_time:12114ms step_avg:34.12ms
+step:356/1600 train_time:12151ms step_avg:34.13ms
+step:357/1600 train_time:12181ms step_avg:34.12ms
+step:358/1600 train_time:12219ms step_avg:34.13ms
+step:359/1600 train_time:12249ms step_avg:34.12ms
+step:360/1600 train_time:12286ms step_avg:34.13ms
+step:361/1600 train_time:12317ms step_avg:34.12ms
+step:362/1600 train_time:12355ms step_avg:34.13ms
+step:363/1600 train_time:12385ms step_avg:34.12ms
+step:364/1600 train_time:12423ms step_avg:34.13ms
+step:365/1600 train_time:12453ms step_avg:34.12ms
+step:366/1600 train_time:12490ms step_avg:34.13ms
+step:367/1600 train_time:12521ms step_avg:34.12ms
+step:368/1600 train_time:12558ms step_avg:34.12ms
+step:369/1600 train_time:12588ms step_avg:34.11ms
+step:370/1600 train_time:12625ms step_avg:34.12ms
+step:371/1600 train_time:12656ms step_avg:34.11ms
+step:372/1600 train_time:12693ms step_avg:34.12ms
+step:373/1600 train_time:12724ms step_avg:34.11ms
+step:374/1600 train_time:12761ms step_avg:34.12ms
+step:375/1600 train_time:12791ms step_avg:34.11ms
+step:376/1600 train_time:12828ms step_avg:34.12ms
+step:377/1600 train_time:12859ms step_avg:34.11ms
+step:378/1600 train_time:12896ms step_avg:34.12ms
+step:379/1600 train_time:12927ms step_avg:34.11ms
+step:380/1600 train_time:12964ms step_avg:34.11ms
+step:381/1600 train_time:12994ms step_avg:34.10ms
+step:382/1600 train_time:13031ms step_avg:34.11ms
+step:383/1600 train_time:13061ms step_avg:34.10ms
+step:384/1600 train_time:13098ms step_avg:34.11ms
+step:385/1600 train_time:13129ms step_avg:34.10ms
+step:386/1600 train_time:13166ms step_avg:34.11ms
+step:387/1600 train_time:13197ms step_avg:34.10ms
+step:388/1600 train_time:13233ms step_avg:34.11ms
+step:389/1600 train_time:13264ms step_avg:34.10ms
+step:390/1600 train_time:13301ms step_avg:34.11ms
+step:391/1600 train_time:13332ms step_avg:34.10ms
+step:392/1600 train_time:13368ms step_avg:34.10ms
+step:393/1600 train_time:13399ms step_avg:34.09ms
+step:394/1600 train_time:13437ms step_avg:34.10ms
+step:395/1600 train_time:13468ms step_avg:34.10ms
+step:396/1600 train_time:13505ms step_avg:34.10ms
+step:397/1600 train_time:13535ms step_avg:34.09ms
+step:398/1600 train_time:13572ms step_avg:34.10ms
+step:399/1600 train_time:13602ms step_avg:34.09ms
+step:400/1600 train_time:13639ms step_avg:34.10ms
+step:401/1600 train_time:13670ms step_avg:34.09ms
+step:402/1600 train_time:13707ms step_avg:34.10ms
+step:403/1600 train_time:13738ms step_avg:34.09ms
+step:404/1600 train_time:13776ms step_avg:34.10ms
+step:405/1600 train_time:13806ms step_avg:34.09ms
+step:406/1600 train_time:13844ms step_avg:34.10ms
+step:407/1600 train_time:13875ms step_avg:34.09ms
+step:408/1600 train_time:13912ms step_avg:34.10ms
+step:409/1600 train_time:13942ms step_avg:34.09ms
+step:410/1600 train_time:13979ms step_avg:34.10ms
+step:411/1600 train_time:14010ms step_avg:34.09ms
+step:412/1600 train_time:14047ms step_avg:34.09ms
+step:413/1600 train_time:14078ms step_avg:34.09ms
+step:414/1600 train_time:14115ms step_avg:34.09ms
+step:415/1600 train_time:14146ms step_avg:34.09ms
+step:416/1600 train_time:14183ms step_avg:34.09ms
+step:417/1600 train_time:14214ms step_avg:34.09ms
+step:418/1600 train_time:14250ms step_avg:34.09ms
+step:419/1600 train_time:14281ms step_avg:34.08ms
+step:420/1600 train_time:14318ms step_avg:34.09ms
+step:421/1600 train_time:14349ms step_avg:34.08ms
+step:422/1600 train_time:14386ms step_avg:34.09ms
+step:423/1600 train_time:14416ms step_avg:34.08ms
+step:424/1600 train_time:14455ms step_avg:34.09ms
+step:425/1600 train_time:14485ms step_avg:34.08ms
+step:426/1600 train_time:14522ms step_avg:34.09ms
+step:427/1600 train_time:14552ms step_avg:34.08ms
+step:428/1600 train_time:14590ms step_avg:34.09ms
+step:429/1600 train_time:14620ms step_avg:34.08ms
+step:430/1600 train_time:14658ms step_avg:34.09ms
+step:431/1600 train_time:14688ms step_avg:34.08ms
+step:432/1600 train_time:14726ms step_avg:34.09ms
+step:433/1600 train_time:14756ms step_avg:34.08ms
+step:434/1600 train_time:14794ms step_avg:34.09ms
+step:435/1600 train_time:14825ms step_avg:34.08ms
+step:436/1600 train_time:14862ms step_avg:34.09ms
+step:437/1600 train_time:14893ms step_avg:34.08ms
+step:438/1600 train_time:14930ms step_avg:34.09ms
+step:439/1600 train_time:14960ms step_avg:34.08ms
+step:440/1600 train_time:14997ms step_avg:34.08ms
+step:441/1600 train_time:15029ms step_avg:34.08ms
+step:442/1600 train_time:15066ms step_avg:34.09ms
+step:443/1600 train_time:15096ms step_avg:34.08ms
+step:444/1600 train_time:15133ms step_avg:34.08ms
+step:445/1600 train_time:15164ms step_avg:34.08ms
+step:446/1600 train_time:15201ms step_avg:34.08ms
+step:447/1600 train_time:15232ms step_avg:34.08ms
+step:448/1600 train_time:15269ms step_avg:34.08ms
+step:449/1600 train_time:15300ms step_avg:34.07ms
+step:450/1600 train_time:15337ms step_avg:34.08ms
+step:451/1600 train_time:15367ms step_avg:34.07ms
+step:452/1600 train_time:15404ms step_avg:34.08ms
+step:453/1600 train_time:15435ms step_avg:34.07ms
+step:454/1600 train_time:15472ms step_avg:34.08ms
+step:455/1600 train_time:15503ms step_avg:34.07ms
+step:456/1600 train_time:15540ms step_avg:34.08ms
+step:457/1600 train_time:15571ms step_avg:34.07ms
+step:458/1600 train_time:15608ms step_avg:34.08ms
+step:459/1600 train_time:15638ms step_avg:34.07ms
+step:460/1600 train_time:15676ms step_avg:34.08ms
+step:461/1600 train_time:15706ms step_avg:34.07ms
+step:462/1600 train_time:15743ms step_avg:34.08ms
+step:463/1600 train_time:15774ms step_avg:34.07ms
+step:464/1600 train_time:15811ms step_avg:34.07ms
+step:465/1600 train_time:15841ms step_avg:34.07ms
+step:466/1600 train_time:15878ms step_avg:34.07ms
+step:467/1600 train_time:15909ms step_avg:34.07ms
+step:468/1600 train_time:15946ms step_avg:34.07ms
+step:469/1600 train_time:15977ms step_avg:34.07ms
+step:470/1600 train_time:16014ms step_avg:34.07ms
+step:471/1600 train_time:16044ms step_avg:34.06ms
+step:472/1600 train_time:16082ms step_avg:34.07ms
+step:473/1600 train_time:16112ms step_avg:34.06ms
+step:474/1600 train_time:16149ms step_avg:34.07ms
+step:475/1600 train_time:16180ms step_avg:34.06ms
+step:476/1600 train_time:16217ms step_avg:34.07ms
+step:477/1600 train_time:16248ms step_avg:34.06ms
+step:478/1600 train_time:16285ms step_avg:34.07ms
+step:479/1600 train_time:16316ms step_avg:34.06ms
+step:480/1600 train_time:16353ms step_avg:34.07ms
+step:481/1600 train_time:16384ms step_avg:34.06ms
+step:482/1600 train_time:16421ms step_avg:34.07ms
+step:483/1600 train_time:16452ms step_avg:34.06ms
+step:484/1600 train_time:16488ms step_avg:34.07ms
+step:485/1600 train_time:16519ms step_avg:34.06ms
+step:486/1600 train_time:16556ms step_avg:34.07ms
+step:487/1600 train_time:16587ms step_avg:34.06ms
+step:488/1600 train_time:16623ms step_avg:34.06ms
+step:489/1600 train_time:16654ms step_avg:34.06ms
+step:490/1600 train_time:16691ms step_avg:34.06ms
+step:491/1600 train_time:16721ms step_avg:34.06ms
+step:492/1600 train_time:16759ms step_avg:34.06ms
+step:493/1600 train_time:16790ms step_avg:34.06ms
+step:494/1600 train_time:16827ms step_avg:34.06ms
+step:495/1600 train_time:16857ms step_avg:34.06ms
+step:496/1600 train_time:16895ms step_avg:34.06ms
+step:497/1600 train_time:16926ms step_avg:34.06ms
+step:498/1600 train_time:16964ms step_avg:34.06ms
+step:499/1600 train_time:16994ms step_avg:34.06ms
+step:500/1600 train_time:17031ms step_avg:34.06ms
+step:500/1600 val_loss:4.2447 train_time:17078ms step_avg:34.16ms
+step:501/1600 train_time:17097ms step_avg:34.13ms
+step:502/1600 train_time:17115ms step_avg:34.09ms
+step:503/1600 train_time:17132ms step_avg:34.06ms
+step:504/1600 train_time:17169ms step_avg:34.07ms
+step:505/1600 train_time:17202ms step_avg:34.06ms
+step:506/1600 train_time:17240ms step_avg:34.07ms
+step:507/1600 train_time:17272ms step_avg:34.07ms
+step:508/1600 train_time:17310ms step_avg:34.07ms
+step:509/1600 train_time:17341ms step_avg:34.07ms
+step:510/1600 train_time:17378ms step_avg:34.07ms
+step:511/1600 train_time:17409ms step_avg:34.07ms
+step:512/1600 train_time:17446ms step_avg:34.07ms
+step:513/1600 train_time:17476ms step_avg:34.07ms
+step:514/1600 train_time:17513ms step_avg:34.07ms
+step:515/1600 train_time:17544ms step_avg:34.07ms
+step:516/1600 train_time:17581ms step_avg:34.07ms
+step:517/1600 train_time:17611ms step_avg:34.06ms
+step:518/1600 train_time:17648ms step_avg:34.07ms
+step:519/1600 train_time:17678ms step_avg:34.06ms
+step:520/1600 train_time:17715ms step_avg:34.07ms
+step:521/1600 train_time:17787ms step_avg:34.14ms
+step:522/1600 train_time:17842ms step_avg:34.18ms
+step:523/1600 train_time:17903ms step_avg:34.23ms
+step:524/1600 train_time:17961ms step_avg:34.28ms
+step:525/1600 train_time:18022ms step_avg:34.33ms
+step:526/1600 train_time:18081ms step_avg:34.37ms
+step:527/1600 train_time:18145ms step_avg:34.43ms
+step:528/1600 train_time:18206ms step_avg:34.48ms
+step:529/1600 train_time:18270ms step_avg:34.54ms
+step:530/1600 train_time:18329ms step_avg:34.58ms
+step:531/1600 train_time:18391ms step_avg:34.64ms
+step:532/1600 train_time:18450ms step_avg:34.68ms
+step:533/1600 train_time:18512ms step_avg:34.73ms
+step:534/1600 train_time:18572ms step_avg:34.78ms
+step:535/1600 train_time:18635ms step_avg:34.83ms
+step:536/1600 train_time:18694ms step_avg:34.88ms
+step:537/1600 train_time:18757ms step_avg:34.93ms
+step:538/1600 train_time:18816ms step_avg:34.97ms
+step:539/1600 train_time:18878ms step_avg:35.02ms
+step:540/1600 train_time:18937ms step_avg:35.07ms
+step:541/1600 train_time:18999ms step_avg:35.12ms
+step:542/1600 train_time:19057ms step_avg:35.16ms
+step:543/1600 train_time:19120ms step_avg:35.21ms
+step:544/1600 train_time:19178ms step_avg:35.25ms
+step:545/1600 train_time:19241ms step_avg:35.30ms
+step:546/1600 train_time:19300ms step_avg:35.35ms
+step:547/1600 train_time:19362ms step_avg:35.40ms
+step:548/1600 train_time:19422ms step_avg:35.44ms
+step:549/1600 train_time:19485ms step_avg:35.49ms
+step:550/1600 train_time:19545ms step_avg:35.54ms
+step:551/1600 train_time:19607ms step_avg:35.58ms
+step:552/1600 train_time:19667ms step_avg:35.63ms
+step:553/1600 train_time:19730ms step_avg:35.68ms
+step:554/1600 train_time:19788ms step_avg:35.72ms
+step:555/1600 train_time:19850ms step_avg:35.77ms
+step:556/1600 train_time:19909ms step_avg:35.81ms
+step:557/1600 train_time:19971ms step_avg:35.85ms
+step:558/1600 train_time:20031ms step_avg:35.90ms
+step:559/1600 train_time:20093ms step_avg:35.94ms
+step:560/1600 train_time:20153ms step_avg:35.99ms
+step:561/1600 train_time:20216ms step_avg:36.04ms
+step:562/1600 train_time:20275ms step_avg:36.08ms
+step:563/1600 train_time:20338ms step_avg:36.12ms
+step:564/1600 train_time:20397ms step_avg:36.16ms
+step:565/1600 train_time:20460ms step_avg:36.21ms
+step:566/1600 train_time:20519ms step_avg:36.25ms
+step:567/1600 train_time:20581ms step_avg:36.30ms
+step:568/1600 train_time:20640ms step_avg:36.34ms
+step:569/1600 train_time:20702ms step_avg:36.38ms
+step:570/1600 train_time:20762ms step_avg:36.42ms
+step:571/1600 train_time:20823ms step_avg:36.47ms
+step:572/1600 train_time:20882ms step_avg:36.51ms
+step:573/1600 train_time:20949ms step_avg:36.56ms
+step:574/1600 train_time:21006ms step_avg:36.60ms
+step:575/1600 train_time:21072ms step_avg:36.65ms
+step:576/1600 train_time:21127ms step_avg:36.68ms
+step:577/1600 train_time:21189ms step_avg:36.72ms
+step:578/1600 train_time:21248ms step_avg:36.76ms
+step:579/1600 train_time:21310ms step_avg:36.81ms
+step:580/1600 train_time:21369ms step_avg:36.84ms
+step:581/1600 train_time:21432ms step_avg:36.89ms
+step:582/1600 train_time:21492ms step_avg:36.93ms
+step:583/1600 train_time:21554ms step_avg:36.97ms
+step:584/1600 train_time:21613ms step_avg:37.01ms
+step:585/1600 train_time:21676ms step_avg:37.05ms
+step:586/1600 train_time:21736ms step_avg:37.09ms
+step:587/1600 train_time:21798ms step_avg:37.14ms
+step:588/1600 train_time:21857ms step_avg:37.17ms
+step:589/1600 train_time:21920ms step_avg:37.22ms
+step:590/1600 train_time:21978ms step_avg:37.25ms
+step:591/1600 train_time:22041ms step_avg:37.29ms
+step:592/1600 train_time:22099ms step_avg:37.33ms
+step:593/1600 train_time:22161ms step_avg:37.37ms
+step:594/1600 train_time:22220ms step_avg:37.41ms
+step:595/1600 train_time:22283ms step_avg:37.45ms
+step:596/1600 train_time:22342ms step_avg:37.49ms
+step:597/1600 train_time:22404ms step_avg:37.53ms
+step:598/1600 train_time:22465ms step_avg:37.57ms
+step:599/1600 train_time:22529ms step_avg:37.61ms
+step:600/1600 train_time:22586ms step_avg:37.64ms
+step:601/1600 train_time:22649ms step_avg:37.69ms
+step:602/1600 train_time:22707ms step_avg:37.72ms
+step:603/1600 train_time:22769ms step_avg:37.76ms
+step:604/1600 train_time:22828ms step_avg:37.79ms
+step:605/1600 train_time:22890ms step_avg:37.84ms
+step:606/1600 train_time:22949ms step_avg:37.87ms
+step:607/1600 train_time:23012ms step_avg:37.91ms
+step:608/1600 train_time:23071ms step_avg:37.95ms
+step:609/1600 train_time:23134ms step_avg:37.99ms
+step:610/1600 train_time:23194ms step_avg:38.02ms
+step:611/1600 train_time:23257ms step_avg:38.06ms
+step:612/1600 train_time:23316ms step_avg:38.10ms
+step:613/1600 train_time:23378ms step_avg:38.14ms
+step:614/1600 train_time:23437ms step_avg:38.17ms
+step:615/1600 train_time:23500ms step_avg:38.21ms
+step:616/1600 train_time:23558ms step_avg:38.24ms
+step:617/1600 train_time:23620ms step_avg:38.28ms
+step:618/1600 train_time:23679ms step_avg:38.32ms
+step:619/1600 train_time:23742ms step_avg:38.35ms
+step:620/1600 train_time:23800ms step_avg:38.39ms
+step:621/1600 train_time:23862ms step_avg:38.43ms
+step:622/1600 train_time:23921ms step_avg:38.46ms
+step:623/1600 train_time:23984ms step_avg:38.50ms
+step:624/1600 train_time:24043ms step_avg:38.53ms
+step:625/1600 train_time:24105ms step_avg:38.57ms
+step:626/1600 train_time:24166ms step_avg:38.60ms
+step:627/1600 train_time:24229ms step_avg:38.64ms
+step:628/1600 train_time:24288ms step_avg:38.67ms
+step:629/1600 train_time:24350ms step_avg:38.71ms
+step:630/1600 train_time:24409ms step_avg:38.74ms
+step:631/1600 train_time:24471ms step_avg:38.78ms
+step:632/1600 train_time:24530ms step_avg:38.81ms
+step:633/1600 train_time:24592ms step_avg:38.85ms
+step:634/1600 train_time:24652ms step_avg:38.88ms
+step:635/1600 train_time:24715ms step_avg:38.92ms
+step:636/1600 train_time:24774ms step_avg:38.95ms
+step:637/1600 train_time:24836ms step_avg:38.99ms
+step:638/1600 train_time:24895ms step_avg:39.02ms
+step:639/1600 train_time:24958ms step_avg:39.06ms
+step:640/1600 train_time:25018ms step_avg:39.09ms
+step:641/1600 train_time:25080ms step_avg:39.13ms
+step:642/1600 train_time:25138ms step_avg:39.16ms
+step:643/1600 train_time:25201ms step_avg:39.19ms
+step:644/1600 train_time:25260ms step_avg:39.22ms
+step:645/1600 train_time:25322ms step_avg:39.26ms
+step:646/1600 train_time:25381ms step_avg:39.29ms
+step:647/1600 train_time:25443ms step_avg:39.32ms
+step:648/1600 train_time:25502ms step_avg:39.35ms
+step:649/1600 train_time:25564ms step_avg:39.39ms
+step:650/1600 train_time:25623ms step_avg:39.42ms
+step:651/1600 train_time:25685ms step_avg:39.46ms
+step:652/1600 train_time:25744ms step_avg:39.48ms
+step:653/1600 train_time:25809ms step_avg:39.52ms
+step:654/1600 train_time:25866ms step_avg:39.55ms
+step:655/1600 train_time:25928ms step_avg:39.58ms
+step:656/1600 train_time:25987ms step_avg:39.61ms
+step:657/1600 train_time:26049ms step_avg:39.65ms
+step:658/1600 train_time:26108ms step_avg:39.68ms
+step:659/1600 train_time:26173ms step_avg:39.72ms
+step:660/1600 train_time:26231ms step_avg:39.74ms
+step:661/1600 train_time:26293ms step_avg:39.78ms
+step:662/1600 train_time:26353ms step_avg:39.81ms
+step:663/1600 train_time:26416ms step_avg:39.84ms
+step:664/1600 train_time:26475ms step_avg:39.87ms
+step:665/1600 train_time:26538ms step_avg:39.91ms
+step:666/1600 train_time:26597ms step_avg:39.93ms
+step:667/1600 train_time:26659ms step_avg:39.97ms
+step:668/1600 train_time:26717ms step_avg:40.00ms
+step:669/1600 train_time:26780ms step_avg:40.03ms
+step:670/1600 train_time:26839ms step_avg:40.06ms
+step:671/1600 train_time:26900ms step_avg:40.09ms
+step:672/1600 train_time:26959ms step_avg:40.12ms
+step:673/1600 train_time:27021ms step_avg:40.15ms
+step:674/1600 train_time:27080ms step_avg:40.18ms
+step:675/1600 train_time:27142ms step_avg:40.21ms
+step:676/1600 train_time:27202ms step_avg:40.24ms
+step:677/1600 train_time:27265ms step_avg:40.27ms
+step:678/1600 train_time:27325ms step_avg:40.30ms
+step:679/1600 train_time:27388ms step_avg:40.34ms
+step:680/1600 train_time:27448ms step_avg:40.36ms
+step:681/1600 train_time:27511ms step_avg:40.40ms
+step:682/1600 train_time:27569ms step_avg:40.42ms
+step:683/1600 train_time:27632ms step_avg:40.46ms
+step:684/1600 train_time:27692ms step_avg:40.48ms
+step:685/1600 train_time:27754ms step_avg:40.52ms
+step:686/1600 train_time:27813ms step_avg:40.54ms
+step:687/1600 train_time:27875ms step_avg:40.58ms
+step:688/1600 train_time:27935ms step_avg:40.60ms
+step:689/1600 train_time:27997ms step_avg:40.63ms
+step:690/1600 train_time:28056ms step_avg:40.66ms
+step:691/1600 train_time:28118ms step_avg:40.69ms
+step:692/1600 train_time:28178ms step_avg:40.72ms
+step:693/1600 train_time:28240ms step_avg:40.75ms
+step:694/1600 train_time:28299ms step_avg:40.78ms
+step:695/1600 train_time:28362ms step_avg:40.81ms
+step:696/1600 train_time:28420ms step_avg:40.83ms
+step:697/1600 train_time:28482ms step_avg:40.86ms
+step:698/1600 train_time:28541ms step_avg:40.89ms
+step:699/1600 train_time:28604ms step_avg:40.92ms
+step:700/1600 train_time:28663ms step_avg:40.95ms
+step:701/1600 train_time:28726ms step_avg:40.98ms
+step:702/1600 train_time:28786ms step_avg:41.01ms
+step:703/1600 train_time:28848ms step_avg:41.04ms
+step:704/1600 train_time:28907ms step_avg:41.06ms
+step:705/1600 train_time:28969ms step_avg:41.09ms
+step:706/1600 train_time:29029ms step_avg:41.12ms
+step:707/1600 train_time:29092ms step_avg:41.15ms
+step:708/1600 train_time:29151ms step_avg:41.17ms
+step:709/1600 train_time:29213ms step_avg:41.20ms
+step:710/1600 train_time:29272ms step_avg:41.23ms
+step:711/1600 train_time:29335ms step_avg:41.26ms
+step:712/1600 train_time:29394ms step_avg:41.28ms
+step:713/1600 train_time:29457ms step_avg:41.31ms
+step:714/1600 train_time:29516ms step_avg:41.34ms
+step:715/1600 train_time:29578ms step_avg:41.37ms
+step:716/1600 train_time:29638ms step_avg:41.39ms
+step:717/1600 train_time:29700ms step_avg:41.42ms
+step:718/1600 train_time:29759ms step_avg:41.45ms
+step:719/1600 train_time:29821ms step_avg:41.48ms
+step:720/1600 train_time:29880ms step_avg:41.50ms
+step:721/1600 train_time:29942ms step_avg:41.53ms
+step:722/1600 train_time:30001ms step_avg:41.55ms
+step:723/1600 train_time:30065ms step_avg:41.58ms
+step:724/1600 train_time:30124ms step_avg:41.61ms
+step:725/1600 train_time:30186ms step_avg:41.64ms
+step:726/1600 train_time:30246ms step_avg:41.66ms
+step:727/1600 train_time:30308ms step_avg:41.69ms
+step:728/1600 train_time:30368ms step_avg:41.71ms
+step:729/1600 train_time:30434ms step_avg:41.75ms
+step:730/1600 train_time:30491ms step_avg:41.77ms
+step:731/1600 train_time:30553ms step_avg:41.80ms
+step:732/1600 train_time:30612ms step_avg:41.82ms
+step:733/1600 train_time:30677ms step_avg:41.85ms
+step:734/1600 train_time:30736ms step_avg:41.87ms
+step:735/1600 train_time:30798ms step_avg:41.90ms
+step:736/1600 train_time:30857ms step_avg:41.92ms
+step:737/1600 train_time:30919ms step_avg:41.95ms
+step:738/1600 train_time:30978ms step_avg:41.98ms
+step:739/1600 train_time:31041ms step_avg:42.00ms
+step:740/1600 train_time:31100ms step_avg:42.03ms
+step:741/1600 train_time:31162ms step_avg:42.05ms
+step:742/1600 train_time:31221ms step_avg:42.08ms
+step:743/1600 train_time:31284ms step_avg:42.10ms
+step:744/1600 train_time:31343ms step_avg:42.13ms
+step:745/1600 train_time:31406ms step_avg:42.16ms
+step:746/1600 train_time:31466ms step_avg:42.18ms
+step:747/1600 train_time:31528ms step_avg:42.21ms
+step:748/1600 train_time:31588ms step_avg:42.23ms
+step:749/1600 train_time:31650ms step_avg:42.26ms
+step:750/1600 train_time:31709ms step_avg:42.28ms
+step:750/1600 val_loss:3.8933 train_time:31756ms step_avg:42.34ms
+step:751/1600 train_time:31778ms step_avg:42.31ms
+step:752/1600 train_time:31834ms step_avg:42.33ms
+step:753/1600 train_time:31897ms step_avg:42.36ms
+step:754/1600 train_time:31958ms step_avg:42.38ms
+step:755/1600 train_time:32020ms step_avg:42.41ms
+step:756/1600 train_time:32080ms step_avg:42.43ms
+step:757/1600 train_time:32142ms step_avg:42.46ms
+step:758/1600 train_time:32201ms step_avg:42.48ms
+step:759/1600 train_time:32265ms step_avg:42.51ms
+step:760/1600 train_time:32323ms step_avg:42.53ms
+step:761/1600 train_time:32386ms step_avg:42.56ms
+step:762/1600 train_time:32445ms step_avg:42.58ms
+step:763/1600 train_time:32505ms step_avg:42.60ms
+step:764/1600 train_time:32564ms step_avg:42.62ms
+step:765/1600 train_time:32625ms step_avg:42.65ms
+step:766/1600 train_time:32684ms step_avg:42.67ms
+step:767/1600 train_time:32747ms step_avg:42.69ms
+step:768/1600 train_time:32808ms step_avg:42.72ms
+step:769/1600 train_time:32870ms step_avg:42.74ms
+step:770/1600 train_time:32930ms step_avg:42.77ms
+step:771/1600 train_time:32994ms step_avg:42.79ms
+step:772/1600 train_time:33053ms step_avg:42.82ms
+step:773/1600 train_time:33116ms step_avg:42.84ms
+step:774/1600 train_time:33174ms step_avg:42.86ms
+step:775/1600 train_time:33237ms step_avg:42.89ms
+step:776/1600 train_time:33295ms step_avg:42.91ms
+step:777/1600 train_time:33357ms step_avg:42.93ms
+step:778/1600 train_time:33416ms step_avg:42.95ms
+step:779/1600 train_time:33479ms step_avg:42.98ms
+step:780/1600 train_time:33537ms step_avg:43.00ms
+step:781/1600 train_time:33599ms step_avg:43.02ms
+step:782/1600 train_time:33658ms step_avg:43.04ms
+step:783/1600 train_time:33721ms step_avg:43.07ms
+step:784/1600 train_time:33780ms step_avg:43.09ms
+step:785/1600 train_time:33843ms step_avg:43.11ms
+step:786/1600 train_time:33903ms step_avg:43.13ms
+step:787/1600 train_time:33966ms step_avg:43.16ms
+step:788/1600 train_time:34025ms step_avg:43.18ms
+step:789/1600 train_time:34089ms step_avg:43.21ms
+step:790/1600 train_time:34146ms step_avg:43.22ms
+step:791/1600 train_time:34208ms step_avg:43.25ms
+step:792/1600 train_time:34267ms step_avg:43.27ms
+step:793/1600 train_time:34329ms step_avg:43.29ms
+step:794/1600 train_time:34388ms step_avg:43.31ms
+step:795/1600 train_time:34450ms step_avg:43.33ms
+step:796/1600 train_time:34509ms step_avg:43.35ms
+step:797/1600 train_time:34572ms step_avg:43.38ms
+step:798/1600 train_time:34631ms step_avg:43.40ms
+step:799/1600 train_time:34693ms step_avg:43.42ms
+step:800/1600 train_time:34752ms step_avg:43.44ms
+step:801/1600 train_time:34815ms step_avg:43.46ms
+step:802/1600 train_time:34874ms step_avg:43.48ms
+step:803/1600 train_time:34938ms step_avg:43.51ms
+step:804/1600 train_time:34996ms step_avg:43.53ms
+step:805/1600 train_time:35059ms step_avg:43.55ms
+step:806/1600 train_time:35118ms step_avg:43.57ms
+step:807/1600 train_time:35181ms step_avg:43.60ms
+step:808/1600 train_time:35242ms step_avg:43.62ms
+step:809/1600 train_time:35304ms step_avg:43.64ms
+step:810/1600 train_time:35363ms step_avg:43.66ms
+step:811/1600 train_time:35425ms step_avg:43.68ms
+step:812/1600 train_time:35484ms step_avg:43.70ms
+step:813/1600 train_time:35546ms step_avg:43.72ms
+step:814/1600 train_time:35605ms step_avg:43.74ms
+step:815/1600 train_time:35667ms step_avg:43.76ms
+step:816/1600 train_time:35726ms step_avg:43.78ms
+step:817/1600 train_time:35788ms step_avg:43.80ms
+step:818/1600 train_time:35847ms step_avg:43.82ms
+step:819/1600 train_time:35910ms step_avg:43.85ms
+step:820/1600 train_time:35969ms step_avg:43.86ms
+step:821/1600 train_time:36032ms step_avg:43.89ms
+step:822/1600 train_time:36092ms step_avg:43.91ms
+step:823/1600 train_time:36154ms step_avg:43.93ms
+step:824/1600 train_time:36213ms step_avg:43.95ms
+step:825/1600 train_time:36276ms step_avg:43.97ms
+step:826/1600 train_time:36334ms step_avg:43.99ms
+step:827/1600 train_time:36396ms step_avg:44.01ms
+step:828/1600 train_time:36454ms step_avg:44.03ms
+step:829/1600 train_time:36517ms step_avg:44.05ms
+step:830/1600 train_time:36576ms step_avg:44.07ms
+step:831/1600 train_time:36642ms step_avg:44.09ms
+step:832/1600 train_time:36699ms step_avg:44.11ms
+step:833/1600 train_time:36762ms step_avg:44.13ms
+step:834/1600 train_time:36821ms step_avg:44.15ms
+step:835/1600 train_time:36883ms step_avg:44.17ms
+step:836/1600 train_time:36943ms step_avg:44.19ms
+step:837/1600 train_time:37006ms step_avg:44.21ms
+step:838/1600 train_time:37065ms step_avg:44.23ms
+step:839/1600 train_time:37127ms step_avg:44.25ms
+step:840/1600 train_time:37186ms step_avg:44.27ms
+step:841/1600 train_time:37248ms step_avg:44.29ms
+step:842/1600 train_time:37307ms step_avg:44.31ms
+step:843/1600 train_time:37369ms step_avg:44.33ms
+step:844/1600 train_time:37428ms step_avg:44.35ms
+step:845/1600 train_time:37490ms step_avg:44.37ms
+step:846/1600 train_time:37549ms step_avg:44.38ms
+step:847/1600 train_time:37611ms step_avg:44.41ms
+step:848/1600 train_time:37672ms step_avg:44.42ms
+step:849/1600 train_time:37734ms step_avg:44.45ms
+step:850/1600 train_time:37794ms step_avg:44.46ms
+step:851/1600 train_time:37856ms step_avg:44.48ms
+step:852/1600 train_time:37915ms step_avg:44.50ms
+step:853/1600 train_time:37978ms step_avg:44.52ms
+step:854/1600 train_time:38037ms step_avg:44.54ms
+step:855/1600 train_time:38100ms step_avg:44.56ms
+step:856/1600 train_time:38160ms step_avg:44.58ms
+step:857/1600 train_time:38222ms step_avg:44.60ms
+step:858/1600 train_time:38281ms step_avg:44.62ms
+step:859/1600 train_time:38344ms step_avg:44.64ms
+step:860/1600 train_time:38403ms step_avg:44.65ms
+step:861/1600 train_time:38465ms step_avg:44.67ms
+step:862/1600 train_time:38524ms step_avg:44.69ms
+step:863/1600 train_time:38586ms step_avg:44.71ms
+step:864/1600 train_time:38645ms step_avg:44.73ms
+step:865/1600 train_time:38708ms step_avg:44.75ms
+step:866/1600 train_time:38766ms step_avg:44.76ms
+step:867/1600 train_time:38828ms step_avg:44.78ms
+step:868/1600 train_time:38887ms step_avg:44.80ms
+step:869/1600 train_time:38950ms step_avg:44.82ms
+step:870/1600 train_time:39009ms step_avg:44.84ms
+step:871/1600 train_time:39072ms step_avg:44.86ms
+step:872/1600 train_time:39132ms step_avg:44.88ms
+step:873/1600 train_time:39194ms step_avg:44.90ms
+step:874/1600 train_time:39253ms step_avg:44.91ms
+step:875/1600 train_time:39315ms step_avg:44.93ms
+step:876/1600 train_time:39374ms step_avg:44.95ms
+step:877/1600 train_time:39436ms step_avg:44.97ms
+step:878/1600 train_time:39495ms step_avg:44.98ms
+step:879/1600 train_time:39557ms step_avg:45.00ms
+step:880/1600 train_time:39617ms step_avg:45.02ms
+step:881/1600 train_time:39680ms step_avg:45.04ms
+step:882/1600 train_time:39739ms step_avg:45.06ms
+step:883/1600 train_time:39802ms step_avg:45.08ms
+step:884/1600 train_time:39861ms step_avg:45.09ms
+step:885/1600 train_time:39925ms step_avg:45.11ms
+step:886/1600 train_time:39983ms step_avg:45.13ms
+step:887/1600 train_time:40046ms step_avg:45.15ms
+step:888/1600 train_time:40105ms step_avg:45.16ms
+step:889/1600 train_time:40167ms step_avg:45.18ms
+step:890/1600 train_time:40231ms step_avg:45.20ms
+step:891/1600 train_time:40289ms step_avg:45.22ms
+step:892/1600 train_time:40348ms step_avg:45.23ms
+step:893/1600 train_time:40412ms step_avg:45.25ms
+step:894/1600 train_time:40469ms step_avg:45.27ms
+step:895/1600 train_time:40532ms step_avg:45.29ms
+step:896/1600 train_time:40591ms step_avg:45.30ms
+step:897/1600 train_time:40653ms step_avg:45.32ms
+step:898/1600 train_time:40712ms step_avg:45.34ms
+step:899/1600 train_time:40774ms step_avg:45.36ms
+step:900/1600 train_time:40833ms step_avg:45.37ms
+step:901/1600 train_time:40897ms step_avg:45.39ms
+step:902/1600 train_time:40955ms step_avg:45.40ms
+step:903/1600 train_time:41018ms step_avg:45.42ms
+step:904/1600 train_time:41077ms step_avg:45.44ms
+step:905/1600 train_time:41139ms step_avg:45.46ms
+step:906/1600 train_time:41198ms step_avg:45.47ms
+step:907/1600 train_time:41261ms step_avg:45.49ms
+step:908/1600 train_time:41320ms step_avg:45.51ms
+step:909/1600 train_time:41383ms step_avg:45.53ms
+step:910/1600 train_time:41442ms step_avg:45.54ms
+step:911/1600 train_time:41504ms step_avg:45.56ms
+step:912/1600 train_time:41563ms step_avg:45.57ms
+step:913/1600 train_time:41626ms step_avg:45.59ms
+step:914/1600 train_time:41685ms step_avg:45.61ms
+step:915/1600 train_time:41747ms step_avg:45.63ms
+step:916/1600 train_time:41806ms step_avg:45.64ms
+step:917/1600 train_time:41868ms step_avg:45.66ms
+step:918/1600 train_time:41927ms step_avg:45.67ms
+step:919/1600 train_time:41990ms step_avg:45.69ms
+step:920/1600 train_time:42049ms step_avg:45.71ms
+step:921/1600 train_time:42111ms step_avg:45.72ms
+step:922/1600 train_time:42171ms step_avg:45.74ms
+step:923/1600 train_time:42233ms step_avg:45.76ms
+step:924/1600 train_time:42293ms step_avg:45.77ms
+step:925/1600 train_time:42356ms step_avg:45.79ms
+step:926/1600 train_time:42414ms step_avg:45.80ms
+step:927/1600 train_time:42476ms step_avg:45.82ms
+step:928/1600 train_time:42536ms step_avg:45.84ms
+step:929/1600 train_time:42598ms step_avg:45.85ms
+step:930/1600 train_time:42657ms step_avg:45.87ms
+step:931/1600 train_time:42719ms step_avg:45.89ms
+step:932/1600 train_time:42778ms step_avg:45.90ms
+step:933/1600 train_time:42841ms step_avg:45.92ms
+step:934/1600 train_time:42900ms step_avg:45.93ms
+step:935/1600 train_time:42963ms step_avg:45.95ms
+step:936/1600 train_time:43023ms step_avg:45.96ms
+step:937/1600 train_time:43085ms step_avg:45.98ms
+step:938/1600 train_time:43144ms step_avg:46.00ms
+step:939/1600 train_time:43207ms step_avg:46.01ms
+step:940/1600 train_time:43267ms step_avg:46.03ms
+step:941/1600 train_time:43329ms step_avg:46.05ms
+step:942/1600 train_time:43387ms step_avg:46.06ms
+step:943/1600 train_time:43450ms step_avg:46.08ms
+step:944/1600 train_time:43510ms step_avg:46.09ms
+step:945/1600 train_time:43572ms step_avg:46.11ms
+step:946/1600 train_time:43631ms step_avg:46.12ms
+step:947/1600 train_time:43694ms step_avg:46.14ms
+step:948/1600 train_time:43752ms step_avg:46.15ms
+step:949/1600 train_time:43815ms step_avg:46.17ms
+step:950/1600 train_time:43874ms step_avg:46.18ms
+step:951/1600 train_time:43936ms step_avg:46.20ms
+step:952/1600 train_time:43995ms step_avg:46.21ms
+step:953/1600 train_time:44058ms step_avg:46.23ms
+step:954/1600 train_time:44117ms step_avg:46.24ms
+step:955/1600 train_time:44180ms step_avg:46.26ms
+step:956/1600 train_time:44240ms step_avg:46.28ms
+step:957/1600 train_time:44303ms step_avg:46.29ms
+step:958/1600 train_time:44362ms step_avg:46.31ms
+step:959/1600 train_time:44425ms step_avg:46.32ms
+step:960/1600 train_time:44484ms step_avg:46.34ms
+step:961/1600 train_time:44547ms step_avg:46.35ms
+step:962/1600 train_time:44606ms step_avg:46.37ms
+step:963/1600 train_time:44668ms step_avg:46.38ms
+step:964/1600 train_time:44727ms step_avg:46.40ms
+step:965/1600 train_time:44789ms step_avg:46.41ms
+step:966/1600 train_time:44847ms step_avg:46.43ms
+step:967/1600 train_time:44910ms step_avg:46.44ms
+step:968/1600 train_time:44970ms step_avg:46.46ms
+step:969/1600 train_time:45032ms step_avg:46.47ms
+step:970/1600 train_time:45092ms step_avg:46.49ms
+step:971/1600 train_time:45156ms step_avg:46.50ms
+step:972/1600 train_time:45215ms step_avg:46.52ms
+step:973/1600 train_time:45277ms step_avg:46.53ms
+step:974/1600 train_time:45336ms step_avg:46.55ms
+step:975/1600 train_time:45398ms step_avg:46.56ms
+step:976/1600 train_time:45457ms step_avg:46.57ms
+step:977/1600 train_time:45523ms step_avg:46.60ms
+step:978/1600 train_time:45582ms step_avg:46.61ms
+step:979/1600 train_time:45642ms step_avg:46.62ms
+step:980/1600 train_time:45701ms step_avg:46.63ms
+step:981/1600 train_time:45765ms step_avg:46.65ms
+step:982/1600 train_time:45824ms step_avg:46.66ms
+step:983/1600 train_time:45887ms step_avg:46.68ms
+step:984/1600 train_time:45946ms step_avg:46.69ms
+step:985/1600 train_time:46008ms step_avg:46.71ms
+step:986/1600 train_time:46067ms step_avg:46.72ms
+step:987/1600 train_time:46129ms step_avg:46.74ms
+step:988/1600 train_time:46189ms step_avg:46.75ms
+step:989/1600 train_time:46252ms step_avg:46.77ms
+step:990/1600 train_time:46312ms step_avg:46.78ms
+step:991/1600 train_time:46375ms step_avg:46.80ms
+step:992/1600 train_time:46434ms step_avg:46.81ms
+step:993/1600 train_time:46497ms step_avg:46.82ms
+step:994/1600 train_time:46555ms step_avg:46.84ms
+step:995/1600 train_time:46617ms step_avg:46.85ms
+step:996/1600 train_time:46677ms step_avg:46.86ms
+step:997/1600 train_time:46743ms step_avg:46.88ms
+step:998/1600 train_time:46800ms step_avg:46.89ms
+step:999/1600 train_time:46864ms step_avg:46.91ms
+step:1000/1600 train_time:46922ms step_avg:46.92ms
+step:1000/1600 val_loss:3.5972 train_time:46968ms step_avg:46.97ms
+step:1001/1600 train_time:46989ms step_avg:46.94ms
+step:1002/1600 train_time:47046ms step_avg:46.95ms
+step:1003/1600 train_time:47110ms step_avg:46.97ms
+step:1004/1600 train_time:47169ms step_avg:46.98ms
+step:1005/1600 train_time:47231ms step_avg:47.00ms
+step:1006/1600 train_time:47290ms step_avg:47.01ms
+step:1007/1600 train_time:47352ms step_avg:47.02ms
+step:1008/1600 train_time:47410ms step_avg:47.03ms
+step:1009/1600 train_time:47472ms step_avg:47.05ms
+step:1010/1600 train_time:47530ms step_avg:47.06ms
+step:1011/1600 train_time:47593ms step_avg:47.07ms
+step:1012/1600 train_time:47651ms step_avg:47.09ms
+step:1013/1600 train_time:47713ms step_avg:47.10ms
+step:1014/1600 train_time:47772ms step_avg:47.11ms
+step:1015/1600 train_time:47833ms step_avg:47.13ms
+step:1016/1600 train_time:47893ms step_avg:47.14ms
+step:1017/1600 train_time:47958ms step_avg:47.16ms
+step:1018/1600 train_time:48019ms step_avg:47.17ms
+step:1019/1600 train_time:48082ms step_avg:47.19ms
+step:1020/1600 train_time:48141ms step_avg:47.20ms
+step:1021/1600 train_time:48203ms step_avg:47.21ms
+step:1022/1600 train_time:48262ms step_avg:47.22ms
+step:1023/1600 train_time:48325ms step_avg:47.24ms
+step:1024/1600 train_time:48384ms step_avg:47.25ms
+step:1025/1600 train_time:48446ms step_avg:47.26ms
+step:1026/1600 train_time:48504ms step_avg:47.28ms
+step:1027/1600 train_time:48567ms step_avg:47.29ms
+step:1028/1600 train_time:48626ms step_avg:47.30ms
+step:1029/1600 train_time:48688ms step_avg:47.32ms
+step:1030/1600 train_time:48748ms step_avg:47.33ms
+step:1031/1600 train_time:48810ms step_avg:47.34ms
+step:1032/1600 train_time:48868ms step_avg:47.35ms
+step:1033/1600 train_time:48932ms step_avg:47.37ms
+step:1034/1600 train_time:48991ms step_avg:47.38ms
+step:1035/1600 train_time:49053ms step_avg:47.39ms
+step:1036/1600 train_time:49112ms step_avg:47.41ms
+step:1037/1600 train_time:49174ms step_avg:47.42ms
+step:1038/1600 train_time:49233ms step_avg:47.43ms
+step:1039/1600 train_time:49296ms step_avg:47.45ms
+step:1040/1600 train_time:49355ms step_avg:47.46ms
+step:1041/1600 train_time:49426ms step_avg:47.48ms
+step:1042/1600 train_time:49509ms step_avg:47.51ms
+step:1043/1600 train_time:49598ms step_avg:47.55ms
+step:1044/1600 train_time:49682ms step_avg:47.59ms
+step:1045/1600 train_time:49771ms step_avg:47.63ms
+step:1046/1600 train_time:49855ms step_avg:47.66ms
+step:1047/1600 train_time:49945ms step_avg:47.70ms
+step:1048/1600 train_time:50031ms step_avg:47.74ms
+step:1049/1600 train_time:50121ms step_avg:47.78ms
+step:1050/1600 train_time:50207ms step_avg:47.82ms
+step:1051/1600 train_time:50296ms step_avg:47.85ms
+step:1052/1600 train_time:50381ms step_avg:47.89ms
+step:1053/1600 train_time:50469ms step_avg:47.93ms
+step:1054/1600 train_time:50554ms step_avg:47.96ms
+step:1055/1600 train_time:50642ms step_avg:48.00ms
+step:1056/1600 train_time:50729ms step_avg:48.04ms
+step:1057/1600 train_time:50816ms step_avg:48.08ms
+step:1058/1600 train_time:50900ms step_avg:48.11ms
+step:1059/1600 train_time:50989ms step_avg:48.15ms
+step:1060/1600 train_time:51074ms step_avg:48.18ms
+step:1061/1600 train_time:51164ms step_avg:48.22ms
+step:1062/1600 train_time:51249ms step_avg:48.26ms
+step:1063/1600 train_time:51337ms step_avg:48.29ms
+step:1064/1600 train_time:51422ms step_avg:48.33ms
+step:1065/1600 train_time:51509ms step_avg:48.37ms
+step:1066/1600 train_time:51594ms step_avg:48.40ms
+step:1067/1600 train_time:51683ms step_avg:48.44ms
+step:1068/1600 train_time:51768ms step_avg:48.47ms
+step:1069/1600 train_time:51857ms step_avg:48.51ms
+step:1070/1600 train_time:51941ms step_avg:48.54ms
+step:1071/1600 train_time:52029ms step_avg:48.58ms
+step:1072/1600 train_time:52115ms step_avg:48.61ms
+step:1073/1600 train_time:52204ms step_avg:48.65ms
+step:1074/1600 train_time:52289ms step_avg:48.69ms
+step:1075/1600 train_time:52377ms step_avg:48.72ms
+step:1076/1600 train_time:52462ms step_avg:48.76ms
+step:1077/1600 train_time:52551ms step_avg:48.79ms
+step:1078/1600 train_time:52635ms step_avg:48.83ms
+step:1079/1600 train_time:52724ms step_avg:48.86ms
+step:1080/1600 train_time:52809ms step_avg:48.90ms
+step:1081/1600 train_time:52897ms step_avg:48.93ms
+step:1082/1600 train_time:52983ms step_avg:48.97ms
+step:1083/1600 train_time:53071ms step_avg:49.00ms
+step:1084/1600 train_time:53156ms step_avg:49.04ms
+step:1085/1600 train_time:53245ms step_avg:49.07ms
+step:1086/1600 train_time:53331ms step_avg:49.11ms
+step:1087/1600 train_time:53420ms step_avg:49.14ms
+step:1088/1600 train_time:53504ms step_avg:49.18ms
+step:1089/1600 train_time:53592ms step_avg:49.21ms
+step:1090/1600 train_time:53678ms step_avg:49.25ms
+step:1091/1600 train_time:53766ms step_avg:49.28ms
+step:1092/1600 train_time:53851ms step_avg:49.31ms
+step:1093/1600 train_time:53939ms step_avg:49.35ms
+step:1094/1600 train_time:54023ms step_avg:49.38ms
+step:1095/1600 train_time:54112ms step_avg:49.42ms
+step:1096/1600 train_time:54198ms step_avg:49.45ms
+step:1097/1600 train_time:54287ms step_avg:49.49ms
+step:1098/1600 train_time:54372ms step_avg:49.52ms
+step:1099/1600 train_time:54461ms step_avg:49.55ms
+step:1100/1600 train_time:54546ms step_avg:49.59ms
+step:1101/1600 train_time:54635ms step_avg:49.62ms
+step:1102/1600 train_time:54719ms step_avg:49.65ms
+step:1103/1600 train_time:54808ms step_avg:49.69ms
+step:1104/1600 train_time:54893ms step_avg:49.72ms
+step:1105/1600 train_time:54982ms step_avg:49.76ms
+step:1106/1600 train_time:55067ms step_avg:49.79ms
+step:1107/1600 train_time:55156ms step_avg:49.82ms
+step:1108/1600 train_time:55240ms step_avg:49.86ms
+step:1109/1600 train_time:55329ms step_avg:49.89ms
+step:1110/1600 train_time:55414ms step_avg:49.92ms
+step:1111/1600 train_time:55503ms step_avg:49.96ms
+step:1112/1600 train_time:55588ms step_avg:49.99ms
+step:1113/1600 train_time:55676ms step_avg:50.02ms
+step:1114/1600 train_time:55761ms step_avg:50.05ms
+step:1115/1600 train_time:55851ms step_avg:50.09ms
+step:1116/1600 train_time:55935ms step_avg:50.12ms
+step:1117/1600 train_time:56024ms step_avg:50.16ms
+step:1118/1600 train_time:56109ms step_avg:50.19ms
+step:1119/1600 train_time:56198ms step_avg:50.22ms
+step:1120/1600 train_time:56282ms step_avg:50.25ms
+step:1121/1600 train_time:56369ms step_avg:50.28ms
+step:1122/1600 train_time:56455ms step_avg:50.32ms
+step:1123/1600 train_time:56543ms step_avg:50.35ms
+step:1124/1600 train_time:56629ms step_avg:50.38ms
+step:1125/1600 train_time:56717ms step_avg:50.42ms
+step:1126/1600 train_time:56803ms step_avg:50.45ms
+step:1127/1600 train_time:56891ms step_avg:50.48ms
+step:1128/1600 train_time:56977ms step_avg:50.51ms
+step:1129/1600 train_time:57065ms step_avg:50.54ms
+step:1130/1600 train_time:57150ms step_avg:50.58ms
+step:1131/1600 train_time:57238ms step_avg:50.61ms
+step:1132/1600 train_time:57323ms step_avg:50.64ms
+step:1133/1600 train_time:57411ms step_avg:50.67ms
+step:1134/1600 train_time:57497ms step_avg:50.70ms
+step:1135/1600 train_time:57585ms step_avg:50.74ms
+step:1136/1600 train_time:57670ms step_avg:50.77ms
+step:1137/1600 train_time:57758ms step_avg:50.80ms
+step:1138/1600 train_time:57843ms step_avg:50.83ms
+step:1139/1600 train_time:57933ms step_avg:50.86ms
+step:1140/1600 train_time:58017ms step_avg:50.89ms
+step:1141/1600 train_time:58106ms step_avg:50.93ms
+step:1142/1600 train_time:58190ms step_avg:50.95ms
+step:1143/1600 train_time:58279ms step_avg:50.99ms
+step:1144/1600 train_time:58363ms step_avg:51.02ms
+step:1145/1600 train_time:58453ms step_avg:51.05ms
+step:1146/1600 train_time:58538ms step_avg:51.08ms
+step:1147/1600 train_time:58626ms step_avg:51.11ms
+step:1148/1600 train_time:58711ms step_avg:51.14ms
+step:1149/1600 train_time:58805ms step_avg:51.18ms
+step:1150/1600 train_time:58889ms step_avg:51.21ms
+step:1151/1600 train_time:58973ms step_avg:51.24ms
+step:1152/1600 train_time:59058ms step_avg:51.27ms
+step:1153/1600 train_time:59146ms step_avg:51.30ms
+step:1154/1600 train_time:59235ms step_avg:51.33ms
+step:1155/1600 train_time:59323ms step_avg:51.36ms
+step:1156/1600 train_time:59408ms step_avg:51.39ms
+step:1157/1600 train_time:59496ms step_avg:51.42ms
+step:1158/1600 train_time:59581ms step_avg:51.45ms
+step:1159/1600 train_time:59668ms step_avg:51.48ms
+step:1160/1600 train_time:59754ms step_avg:51.51ms
+step:1161/1600 train_time:59842ms step_avg:51.54ms
+step:1162/1600 train_time:59927ms step_avg:51.57ms
+step:1163/1600 train_time:60018ms step_avg:51.61ms
+step:1164/1600 train_time:60101ms step_avg:51.63ms
+step:1165/1600 train_time:60190ms step_avg:51.66ms
+step:1166/1600 train_time:60277ms step_avg:51.70ms
+step:1167/1600 train_time:60364ms step_avg:51.73ms
+step:1168/1600 train_time:60449ms step_avg:51.75ms
+step:1169/1600 train_time:60537ms step_avg:51.78ms
+step:1170/1600 train_time:60622ms step_avg:51.81ms
+step:1171/1600 train_time:60710ms step_avg:51.84ms
+step:1172/1600 train_time:60795ms step_avg:51.87ms
+step:1173/1600 train_time:60887ms step_avg:51.91ms
+step:1174/1600 train_time:60969ms step_avg:51.93ms
+step:1175/1600 train_time:61057ms step_avg:51.96ms
+step:1176/1600 train_time:61142ms step_avg:51.99ms
+step:1177/1600 train_time:61229ms step_avg:52.02ms
+step:1178/1600 train_time:61314ms step_avg:52.05ms
+step:1179/1600 train_time:61403ms step_avg:52.08ms
+step:1180/1600 train_time:61488ms step_avg:52.11ms
+step:1181/1600 train_time:61577ms step_avg:52.14ms
+step:1182/1600 train_time:61662ms step_avg:52.17ms
+step:1183/1600 train_time:61750ms step_avg:52.20ms
+step:1184/1600 train_time:61835ms step_avg:52.23ms
+step:1185/1600 train_time:61922ms step_avg:52.25ms
+step:1186/1600 train_time:62007ms step_avg:52.28ms
+step:1187/1600 train_time:62095ms step_avg:52.31ms
+step:1188/1600 train_time:62180ms step_avg:52.34ms
+step:1189/1600 train_time:62269ms step_avg:52.37ms
+step:1190/1600 train_time:62354ms step_avg:52.40ms
+step:1191/1600 train_time:62443ms step_avg:52.43ms
+step:1192/1600 train_time:62528ms step_avg:52.46ms
+step:1193/1600 train_time:62617ms step_avg:52.49ms
+step:1194/1600 train_time:62702ms step_avg:52.51ms
+step:1195/1600 train_time:62790ms step_avg:52.54ms
+step:1196/1600 train_time:62876ms step_avg:52.57ms
+step:1197/1600 train_time:62964ms step_avg:52.60ms
+step:1198/1600 train_time:63050ms step_avg:52.63ms
+step:1199/1600 train_time:63137ms step_avg:52.66ms
+step:1200/1600 train_time:63223ms step_avg:52.69ms
+step:1201/1600 train_time:63311ms step_avg:52.72ms
+step:1202/1600 train_time:63396ms step_avg:52.74ms
+step:1203/1600 train_time:63484ms step_avg:52.77ms
+step:1204/1600 train_time:63570ms step_avg:52.80ms
+step:1205/1600 train_time:63658ms step_avg:52.83ms
+step:1206/1600 train_time:63744ms step_avg:52.86ms
+step:1207/1600 train_time:63833ms step_avg:52.89ms
+step:1208/1600 train_time:63919ms step_avg:52.91ms
+step:1209/1600 train_time:64008ms step_avg:52.94ms
+step:1210/1600 train_time:64093ms step_avg:52.97ms
+step:1211/1600 train_time:64182ms step_avg:53.00ms
+step:1212/1600 train_time:64267ms step_avg:53.03ms
+step:1213/1600 train_time:64355ms step_avg:53.05ms
+step:1214/1600 train_time:64441ms step_avg:53.08ms
+step:1215/1600 train_time:64529ms step_avg:53.11ms
+step:1216/1600 train_time:64614ms step_avg:53.14ms
+step:1217/1600 train_time:64703ms step_avg:53.17ms
+step:1218/1600 train_time:64788ms step_avg:53.19ms
+step:1219/1600 train_time:64877ms step_avg:53.22ms
+step:1220/1600 train_time:64962ms step_avg:53.25ms
+step:1221/1600 train_time:65051ms step_avg:53.28ms
+step:1222/1600 train_time:65136ms step_avg:53.30ms
+step:1223/1600 train_time:65223ms step_avg:53.33ms
+step:1224/1600 train_time:65309ms step_avg:53.36ms
+step:1225/1600 train_time:65398ms step_avg:53.39ms
+step:1226/1600 train_time:65482ms step_avg:53.41ms
+step:1227/1600 train_time:65571ms step_avg:53.44ms
+step:1228/1600 train_time:65656ms step_avg:53.47ms
+step:1229/1600 train_time:65747ms step_avg:53.50ms
+step:1230/1600 train_time:65831ms step_avg:53.52ms
+step:1231/1600 train_time:65919ms step_avg:53.55ms
+step:1232/1600 train_time:66004ms step_avg:53.57ms
+step:1233/1600 train_time:66093ms step_avg:53.60ms
+step:1234/1600 train_time:66178ms step_avg:53.63ms
+step:1235/1600 train_time:66266ms step_avg:53.66ms
+step:1236/1600 train_time:66351ms step_avg:53.68ms
+step:1237/1600 train_time:66440ms step_avg:53.71ms
+step:1238/1600 train_time:66525ms step_avg:53.74ms
+step:1239/1600 train_time:66613ms step_avg:53.76ms
+step:1240/1600 train_time:66698ms step_avg:53.79ms
+step:1241/1600 train_time:66786ms step_avg:53.82ms
+step:1242/1600 train_time:66872ms step_avg:53.84ms
+step:1243/1600 train_time:66960ms step_avg:53.87ms
+step:1244/1600 train_time:67045ms step_avg:53.89ms
+step:1245/1600 train_time:67135ms step_avg:53.92ms
+step:1246/1600 train_time:67220ms step_avg:53.95ms
+step:1247/1600 train_time:67308ms step_avg:53.98ms
+step:1248/1600 train_time:67393ms step_avg:54.00ms
+step:1249/1600 train_time:67481ms step_avg:54.03ms
+step:1250/1600 train_time:67566ms step_avg:54.05ms
+step:1250/1600 val_loss:3.4174 train_time:67638ms step_avg:54.11ms
+step:1251/1600 train_time:67658ms step_avg:54.08ms
+step:1252/1600 train_time:67744ms step_avg:54.11ms
+step:1253/1600 train_time:67839ms step_avg:54.14ms
+step:1254/1600 train_time:67924ms step_avg:54.17ms
+step:1255/1600 train_time:68014ms step_avg:54.19ms
+step:1256/1600 train_time:68101ms step_avg:54.22ms
+step:1257/1600 train_time:68184ms step_avg:54.24ms
+step:1258/1600 train_time:68268ms step_avg:54.27ms
+step:1259/1600 train_time:68355ms step_avg:54.29ms
+step:1260/1600 train_time:68440ms step_avg:54.32ms
+step:1261/1600 train_time:68528ms step_avg:54.34ms
+step:1262/1600 train_time:68613ms step_avg:54.37ms
+step:1263/1600 train_time:68704ms step_avg:54.40ms
+step:1264/1600 train_time:68791ms step_avg:54.42ms
+step:1265/1600 train_time:68880ms step_avg:54.45ms
+step:1266/1600 train_time:68967ms step_avg:54.48ms
+step:1267/1600 train_time:69055ms step_avg:54.50ms
+step:1268/1600 train_time:69140ms step_avg:54.53ms
+step:1269/1600 train_time:69227ms step_avg:54.55ms
+step:1270/1600 train_time:69312ms step_avg:54.58ms
+step:1271/1600 train_time:69403ms step_avg:54.60ms
+step:1272/1600 train_time:69484ms step_avg:54.63ms
+step:1273/1600 train_time:69572ms step_avg:54.65ms
+step:1274/1600 train_time:69659ms step_avg:54.68ms
+step:1275/1600 train_time:69748ms step_avg:54.70ms
+step:1276/1600 train_time:69834ms step_avg:54.73ms
+step:1277/1600 train_time:69923ms step_avg:54.76ms
+step:1278/1600 train_time:70009ms step_avg:54.78ms
+step:1279/1600 train_time:70097ms step_avg:54.81ms
+step:1280/1600 train_time:70182ms step_avg:54.83ms
+step:1281/1600 train_time:70270ms step_avg:54.86ms
+step:1282/1600 train_time:70354ms step_avg:54.88ms
+step:1283/1600 train_time:70442ms step_avg:54.90ms
+step:1284/1600 train_time:70527ms step_avg:54.93ms
+step:1285/1600 train_time:70615ms step_avg:54.95ms
+step:1286/1600 train_time:70701ms step_avg:54.98ms
+step:1287/1600 train_time:70789ms step_avg:55.00ms
+step:1288/1600 train_time:70875ms step_avg:55.03ms
+step:1289/1600 train_time:70964ms step_avg:55.05ms
+step:1290/1600 train_time:71049ms step_avg:55.08ms
+step:1291/1600 train_time:71137ms step_avg:55.10ms
+step:1292/1600 train_time:71221ms step_avg:55.12ms
+step:1293/1600 train_time:71309ms step_avg:55.15ms
+step:1294/1600 train_time:71394ms step_avg:55.17ms
+step:1295/1600 train_time:71482ms step_avg:55.20ms
+step:1296/1600 train_time:71567ms step_avg:55.22ms
+step:1297/1600 train_time:71656ms step_avg:55.25ms
+step:1298/1600 train_time:71742ms step_avg:55.27ms
+step:1299/1600 train_time:71830ms step_avg:55.30ms
+step:1300/1600 train_time:71917ms step_avg:55.32ms
+step:1301/1600 train_time:72004ms step_avg:55.34ms
+step:1302/1600 train_time:72089ms step_avg:55.37ms
+step:1303/1600 train_time:72177ms step_avg:55.39ms
+step:1304/1600 train_time:72262ms step_avg:55.42ms
+step:1305/1600 train_time:72350ms step_avg:55.44ms
+step:1306/1600 train_time:72435ms step_avg:55.46ms
+step:1307/1600 train_time:72524ms step_avg:55.49ms
+step:1308/1600 train_time:72609ms step_avg:55.51ms
+step:1309/1600 train_time:72697ms step_avg:55.54ms
+step:1310/1600 train_time:72782ms step_avg:55.56ms
+step:1311/1600 train_time:72870ms step_avg:55.58ms
+step:1312/1600 train_time:72955ms step_avg:55.61ms
+step:1313/1600 train_time:73044ms step_avg:55.63ms
+step:1314/1600 train_time:73129ms step_avg:55.65ms
+step:1315/1600 train_time:73217ms step_avg:55.68ms
+step:1316/1600 train_time:73302ms step_avg:55.70ms
+step:1317/1600 train_time:73389ms step_avg:55.72ms
+step:1318/1600 train_time:73474ms step_avg:55.75ms
+step:1319/1600 train_time:73563ms step_avg:55.77ms
+step:1320/1600 train_time:73648ms step_avg:55.79ms
+step:1321/1600 train_time:73736ms step_avg:55.82ms
+step:1322/1600 train_time:73822ms step_avg:55.84ms
+step:1323/1600 train_time:73910ms step_avg:55.87ms
+step:1324/1600 train_time:73996ms step_avg:55.89ms
+step:1325/1600 train_time:74084ms step_avg:55.91ms
+step:1326/1600 train_time:74170ms step_avg:55.93ms
+step:1327/1600 train_time:74257ms step_avg:55.96ms
+step:1328/1600 train_time:74343ms step_avg:55.98ms
+step:1329/1600 train_time:74431ms step_avg:56.00ms
+step:1330/1600 train_time:74518ms step_avg:56.03ms
+step:1331/1600 train_time:74605ms step_avg:56.05ms
+step:1332/1600 train_time:74690ms step_avg:56.07ms
+step:1333/1600 train_time:74779ms step_avg:56.10ms
+step:1334/1600 train_time:74863ms step_avg:56.12ms
+step:1335/1600 train_time:74953ms step_avg:56.14ms
+step:1336/1600 train_time:75040ms step_avg:56.17ms
+step:1337/1600 train_time:75126ms step_avg:56.19ms
+step:1338/1600 train_time:75210ms step_avg:56.21ms
+step:1339/1600 train_time:75298ms step_avg:56.23ms
+step:1340/1600 train_time:75384ms step_avg:56.26ms
+step:1341/1600 train_time:75472ms step_avg:56.28ms
+step:1342/1600 train_time:75558ms step_avg:56.30ms
+step:1343/1600 train_time:75645ms step_avg:56.33ms
+step:1344/1600 train_time:75730ms step_avg:56.35ms
+step:1345/1600 train_time:75818ms step_avg:56.37ms
+step:1346/1600 train_time:75903ms step_avg:56.39ms
+step:1347/1600 train_time:75991ms step_avg:56.42ms
+step:1348/1600 train_time:76077ms step_avg:56.44ms
+step:1349/1600 train_time:76165ms step_avg:56.46ms
+step:1350/1600 train_time:76251ms step_avg:56.48ms
+step:1351/1600 train_time:76339ms step_avg:56.51ms
+step:1352/1600 train_time:76423ms step_avg:56.53ms
+step:1353/1600 train_time:76512ms step_avg:56.55ms
+step:1354/1600 train_time:76598ms step_avg:56.57ms
+step:1355/1600 train_time:76686ms step_avg:56.59ms
+step:1356/1600 train_time:76771ms step_avg:56.62ms
+step:1357/1600 train_time:76860ms step_avg:56.64ms
+step:1358/1600 train_time:76946ms step_avg:56.66ms
+step:1359/1600 train_time:77033ms step_avg:56.68ms
+step:1360/1600 train_time:77119ms step_avg:56.70ms
+step:1361/1600 train_time:77206ms step_avg:56.73ms
+step:1362/1600 train_time:77292ms step_avg:56.75ms
+step:1363/1600 train_time:77380ms step_avg:56.77ms
+step:1364/1600 train_time:77465ms step_avg:56.79ms
+step:1365/1600 train_time:77553ms step_avg:56.82ms
+step:1366/1600 train_time:77642ms step_avg:56.84ms
+step:1367/1600 train_time:77728ms step_avg:56.86ms
+step:1368/1600 train_time:77813ms step_avg:56.88ms
+step:1369/1600 train_time:77902ms step_avg:56.90ms
+step:1370/1600 train_time:77987ms step_avg:56.92ms
+step:1371/1600 train_time:78076ms step_avg:56.95ms
+step:1372/1600 train_time:78161ms step_avg:56.97ms
+step:1373/1600 train_time:78249ms step_avg:56.99ms
+step:1374/1600 train_time:78335ms step_avg:57.01ms
+step:1375/1600 train_time:78424ms step_avg:57.04ms
+step:1376/1600 train_time:78509ms step_avg:57.06ms
+step:1377/1600 train_time:78598ms step_avg:57.08ms
+step:1378/1600 train_time:78683ms step_avg:57.10ms
+step:1379/1600 train_time:78772ms step_avg:57.12ms
+step:1380/1600 train_time:78858ms step_avg:57.14ms
+step:1381/1600 train_time:78945ms step_avg:57.17ms
+step:1382/1600 train_time:79031ms step_avg:57.19ms
+step:1383/1600 train_time:79119ms step_avg:57.21ms
+step:1384/1600 train_time:79204ms step_avg:57.23ms
+step:1385/1600 train_time:79294ms step_avg:57.25ms
+step:1386/1600 train_time:79378ms step_avg:57.27ms
+step:1387/1600 train_time:79467ms step_avg:57.29ms
+step:1388/1600 train_time:79552ms step_avg:57.31ms
+step:1389/1600 train_time:79641ms step_avg:57.34ms
+step:1390/1600 train_time:79726ms step_avg:57.36ms
+step:1391/1600 train_time:79815ms step_avg:57.38ms
+step:1392/1600 train_time:79903ms step_avg:57.40ms
+step:1393/1600 train_time:79989ms step_avg:57.42ms
+step:1394/1600 train_time:80074ms step_avg:57.44ms
+step:1395/1600 train_time:80163ms step_avg:57.46ms
+step:1396/1600 train_time:80249ms step_avg:57.49ms
+step:1397/1600 train_time:80338ms step_avg:57.51ms
+step:1398/1600 train_time:80423ms step_avg:57.53ms
+step:1399/1600 train_time:80511ms step_avg:57.55ms
+step:1400/1600 train_time:80596ms step_avg:57.57ms
+step:1401/1600 train_time:80685ms step_avg:57.59ms
+step:1402/1600 train_time:80770ms step_avg:57.61ms
+step:1403/1600 train_time:80858ms step_avg:57.63ms
+step:1404/1600 train_time:80943ms step_avg:57.65ms
+step:1405/1600 train_time:81032ms step_avg:57.67ms
+step:1406/1600 train_time:81117ms step_avg:57.69ms
+step:1407/1600 train_time:81205ms step_avg:57.71ms
+step:1408/1600 train_time:81290ms step_avg:57.73ms
+step:1409/1600 train_time:81378ms step_avg:57.76ms
+step:1410/1600 train_time:81463ms step_avg:57.78ms
+step:1411/1600 train_time:81552ms step_avg:57.80ms
+step:1412/1600 train_time:81636ms step_avg:57.82ms
+step:1413/1600 train_time:81724ms step_avg:57.84ms
+step:1414/1600 train_time:81809ms step_avg:57.86ms
+step:1415/1600 train_time:81898ms step_avg:57.88ms
+step:1416/1600 train_time:81984ms step_avg:57.90ms
+step:1417/1600 train_time:82072ms step_avg:57.92ms
+step:1418/1600 train_time:82157ms step_avg:57.94ms
+step:1419/1600 train_time:82245ms step_avg:57.96ms
+step:1420/1600 train_time:82331ms step_avg:57.98ms
+step:1421/1600 train_time:82418ms step_avg:58.00ms
+step:1422/1600 train_time:82502ms step_avg:58.02ms
+step:1423/1600 train_time:82590ms step_avg:58.04ms
+step:1424/1600 train_time:82675ms step_avg:58.06ms
+step:1425/1600 train_time:82764ms step_avg:58.08ms
+step:1426/1600 train_time:82850ms step_avg:58.10ms
+step:1427/1600 train_time:82939ms step_avg:58.12ms
+step:1428/1600 train_time:83024ms step_avg:58.14ms
+step:1429/1600 train_time:83113ms step_avg:58.16ms
+step:1430/1600 train_time:83199ms step_avg:58.18ms
+step:1431/1600 train_time:83287ms step_avg:58.20ms
+step:1432/1600 train_time:83371ms step_avg:58.22ms
+step:1433/1600 train_time:83459ms step_avg:58.24ms
+step:1434/1600 train_time:83544ms step_avg:58.26ms
+step:1435/1600 train_time:83633ms step_avg:58.28ms
+step:1436/1600 train_time:83718ms step_avg:58.30ms
+step:1437/1600 train_time:83806ms step_avg:58.32ms
+step:1438/1600 train_time:83893ms step_avg:58.34ms
+step:1439/1600 train_time:83981ms step_avg:58.36ms
+step:1440/1600 train_time:84066ms step_avg:58.38ms
+step:1441/1600 train_time:84154ms step_avg:58.40ms
+step:1442/1600 train_time:84239ms step_avg:58.42ms
+step:1443/1600 train_time:84327ms step_avg:58.44ms
+step:1444/1600 train_time:84412ms step_avg:58.46ms
+step:1445/1600 train_time:84500ms step_avg:58.48ms
+step:1446/1600 train_time:84585ms step_avg:58.50ms
+step:1447/1600 train_time:84675ms step_avg:58.52ms
+step:1448/1600 train_time:84760ms step_avg:58.54ms
+step:1449/1600 train_time:84849ms step_avg:58.56ms
+step:1450/1600 train_time:84933ms step_avg:58.57ms
+step:1451/1600 train_time:85022ms step_avg:58.60ms
+step:1452/1600 train_time:85107ms step_avg:58.61ms
+step:1453/1600 train_time:85196ms step_avg:58.63ms
+step:1454/1600 train_time:85280ms step_avg:58.65ms
+step:1455/1600 train_time:85369ms step_avg:58.67ms
+step:1456/1600 train_time:85453ms step_avg:58.69ms
+step:1457/1600 train_time:85542ms step_avg:58.71ms
+step:1458/1600 train_time:85627ms step_avg:58.73ms
+step:1459/1600 train_time:85716ms step_avg:58.75ms
+step:1460/1600 train_time:85801ms step_avg:58.77ms
+step:1461/1600 train_time:85890ms step_avg:58.79ms
+step:1462/1600 train_time:85975ms step_avg:58.81ms
+step:1463/1600 train_time:86064ms step_avg:58.83ms
+step:1464/1600 train_time:86149ms step_avg:58.84ms
+step:1465/1600 train_time:86238ms step_avg:58.87ms
+step:1466/1600 train_time:86323ms step_avg:58.88ms
+step:1467/1600 train_time:86412ms step_avg:58.90ms
+step:1468/1600 train_time:86497ms step_avg:58.92ms
+step:1469/1600 train_time:86585ms step_avg:58.94ms
+step:1470/1600 train_time:86670ms step_avg:58.96ms
+step:1471/1600 train_time:86758ms step_avg:58.98ms
+step:1472/1600 train_time:86844ms step_avg:59.00ms
+step:1473/1600 train_time:86932ms step_avg:59.02ms
+step:1474/1600 train_time:87017ms step_avg:59.03ms
+step:1475/1600 train_time:87105ms step_avg:59.05ms
+step:1476/1600 train_time:87191ms step_avg:59.07ms
+step:1477/1600 train_time:87279ms step_avg:59.09ms
+step:1478/1600 train_time:87364ms step_avg:59.11ms
+step:1479/1600 train_time:87452ms step_avg:59.13ms
+step:1480/1600 train_time:87537ms step_avg:59.15ms
+step:1481/1600 train_time:87625ms step_avg:59.17ms
+step:1482/1600 train_time:87711ms step_avg:59.18ms
+step:1483/1600 train_time:87799ms step_avg:59.20ms
+step:1484/1600 train_time:87884ms step_avg:59.22ms
+step:1485/1600 train_time:87972ms step_avg:59.24ms
+step:1486/1600 train_time:88057ms step_avg:59.26ms
+step:1487/1600 train_time:88145ms step_avg:59.28ms
+step:1488/1600 train_time:88230ms step_avg:59.29ms
+step:1489/1600 train_time:88318ms step_avg:59.31ms
+step:1490/1600 train_time:88403ms step_avg:59.33ms
+step:1491/1600 train_time:88492ms step_avg:59.35ms
+step:1492/1600 train_time:88577ms step_avg:59.37ms
+step:1493/1600 train_time:88665ms step_avg:59.39ms
+step:1494/1600 train_time:88750ms step_avg:59.40ms
+step:1495/1600 train_time:88838ms step_avg:59.42ms
+step:1496/1600 train_time:88924ms step_avg:59.44ms
+step:1497/1600 train_time:89013ms step_avg:59.46ms
+step:1498/1600 train_time:89098ms step_avg:59.48ms
+step:1499/1600 train_time:89186ms step_avg:59.50ms
+step:1500/1600 train_time:89272ms step_avg:59.51ms
+step:1500/1600 val_loss:3.3075 train_time:89345ms step_avg:59.56ms
+step:1501/1600 train_time:89364ms step_avg:59.54ms
+step:1502/1600 train_time:89449ms step_avg:59.55ms
+step:1503/1600 train_time:89540ms step_avg:59.57ms
+step:1504/1600 train_time:89625ms step_avg:59.59ms
+step:1505/1600 train_time:89713ms step_avg:59.61ms
+step:1506/1600 train_time:89798ms step_avg:59.63ms
+step:1507/1600 train_time:89885ms step_avg:59.64ms
+step:1508/1600 train_time:89969ms step_avg:59.66ms
+step:1509/1600 train_time:90056ms step_avg:59.68ms
+step:1510/1600 train_time:90141ms step_avg:59.70ms
+step:1511/1600 train_time:90229ms step_avg:59.71ms
+step:1512/1600 train_time:90315ms step_avg:59.73ms
+step:1513/1600 train_time:90405ms step_avg:59.75ms
+step:1514/1600 train_time:90492ms step_avg:59.77ms
+step:1515/1600 train_time:90582ms step_avg:59.79ms
+step:1516/1600 train_time:90668ms step_avg:59.81ms
+step:1517/1600 train_time:90756ms step_avg:59.83ms
+step:1518/1600 train_time:90841ms step_avg:59.84ms
+step:1519/1600 train_time:90928ms step_avg:59.86ms
+step:1520/1600 train_time:91012ms step_avg:59.88ms
+step:1521/1600 train_time:91100ms step_avg:59.89ms
+step:1522/1600 train_time:91184ms step_avg:59.91ms
+step:1523/1600 train_time:91272ms step_avg:59.93ms
+step:1524/1600 train_time:91358ms step_avg:59.95ms
+step:1525/1600 train_time:91447ms step_avg:59.97ms
+step:1526/1600 train_time:91535ms step_avg:59.98ms
+step:1527/1600 train_time:91622ms step_avg:60.00ms
+step:1528/1600 train_time:91708ms step_avg:60.02ms
+step:1529/1600 train_time:91797ms step_avg:60.04ms
+step:1530/1600 train_time:91881ms step_avg:60.05ms
+step:1531/1600 train_time:91968ms step_avg:60.07ms
+step:1532/1600 train_time:92053ms step_avg:60.09ms
+step:1533/1600 train_time:92140ms step_avg:60.10ms
+step:1534/1600 train_time:92225ms step_avg:60.12ms
+step:1535/1600 train_time:92314ms step_avg:60.14ms
+step:1536/1600 train_time:92401ms step_avg:60.16ms
+step:1537/1600 train_time:92490ms step_avg:60.18ms
+step:1538/1600 train_time:92576ms step_avg:60.19ms
+step:1539/1600 train_time:92664ms step_avg:60.21ms
+step:1540/1600 train_time:92749ms step_avg:60.23ms
+step:1541/1600 train_time:92838ms step_avg:60.25ms
+step:1542/1600 train_time:92922ms step_avg:60.26ms
+step:1543/1600 train_time:93010ms step_avg:60.28ms
+step:1544/1600 train_time:93094ms step_avg:60.29ms
+step:1545/1600 train_time:93182ms step_avg:60.31ms
+step:1546/1600 train_time:93267ms step_avg:60.33ms
+step:1547/1600 train_time:93356ms step_avg:60.35ms
+step:1548/1600 train_time:93441ms step_avg:60.36ms
+step:1549/1600 train_time:93532ms step_avg:60.38ms
+step:1550/1600 train_time:93617ms step_avg:60.40ms
+step:1551/1600 train_time:93705ms step_avg:60.42ms
+step:1552/1600 train_time:93790ms step_avg:60.43ms
+step:1553/1600 train_time:93879ms step_avg:60.45ms
+step:1554/1600 train_time:93966ms step_avg:60.47ms
+step:1555/1600 train_time:94052ms step_avg:60.48ms
+step:1556/1600 train_time:94136ms step_avg:60.50ms
+step:1557/1600 train_time:94224ms step_avg:60.52ms
+step:1558/1600 train_time:94309ms step_avg:60.53ms
+step:1559/1600 train_time:94398ms step_avg:60.55ms
+step:1560/1600 train_time:94484ms step_avg:60.57ms
+step:1561/1600 train_time:94582ms step_avg:60.59ms
+step:1562/1600 train_time:94666ms step_avg:60.61ms
+step:1563/1600 train_time:94754ms step_avg:60.62ms
+step:1564/1600 train_time:94840ms step_avg:60.64ms
+step:1565/1600 train_time:94928ms step_avg:60.66ms
+step:1566/1600 train_time:95014ms step_avg:60.67ms
+step:1567/1600 train_time:95102ms step_avg:60.69ms
+step:1568/1600 train_time:95188ms step_avg:60.71ms
+step:1569/1600 train_time:95276ms step_avg:60.72ms
+step:1570/1600 train_time:95361ms step_avg:60.74ms
+step:1571/1600 train_time:95451ms step_avg:60.76ms
+step:1572/1600 train_time:95538ms step_avg:60.77ms
+step:1573/1600 train_time:95626ms step_avg:60.79ms
+step:1574/1600 train_time:95712ms step_avg:60.81ms
+step:1575/1600 train_time:95802ms step_avg:60.83ms
+step:1576/1600 train_time:95887ms step_avg:60.84ms
+step:1577/1600 train_time:95978ms step_avg:60.86ms
+step:1578/1600 train_time:96062ms step_avg:60.88ms
+step:1579/1600 train_time:96150ms step_avg:60.89ms
+step:1580/1600 train_time:96235ms step_avg:60.91ms
+step:1581/1600 train_time:96323ms step_avg:60.93ms
+step:1582/1600 train_time:96408ms step_avg:60.94ms
+step:1583/1600 train_time:96498ms step_avg:60.96ms
+step:1584/1600 train_time:96583ms step_avg:60.97ms
+step:1585/1600 train_time:96673ms step_avg:60.99ms
+step:1586/1600 train_time:96759ms step_avg:61.01ms
+step:1587/1600 train_time:96846ms step_avg:61.02ms
+step:1588/1600 train_time:96933ms step_avg:61.04ms
+step:1589/1600 train_time:97021ms step_avg:61.06ms
+step:1590/1600 train_time:97106ms step_avg:61.07ms
+step:1591/1600 train_time:97195ms step_avg:61.09ms
+step:1592/1600 train_time:97280ms step_avg:61.11ms
+step:1593/1600 train_time:97370ms step_avg:61.12ms
+step:1594/1600 train_time:97455ms step_avg:61.14ms
+step:1595/1600 train_time:97544ms step_avg:61.16ms
+step:1596/1600 train_time:97630ms step_avg:61.17ms
+step:1597/1600 train_time:97719ms step_avg:61.19ms
+step:1598/1600 train_time:97804ms step_avg:61.20ms
+step:1599/1600 train_time:97892ms step_avg:61.22ms
+step:1600/1600 train_time:97979ms step_avg:61.24ms
+step:1600/1600 val_loss:3.2785 train_time:98053ms step_avg:61.28ms
+peak memory allocated: 30264 MiB reserved: 46240 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/c6beb75f-7491-49d2-80c3-04fcc690ce8e.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/c6beb75f-7491-49d2-80c3-04fcc690ce8e.txt
@@ -1,0 +1,4096 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 01 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # shifting first layer updates this to 01 ... 01 @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:13:29 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   39C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   41C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            129W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   39C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          233856      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          233857      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          233858      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          233859      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          233860      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          233861      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          233862      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          233863      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 511, 512, 513, 1023, 1024, 1025, 1534, 1535, 1536] for warmup
+Resetting Model
+step:0/1575 val_loss:10.8299 train_time:0ms step_avg:0.04ms
+step:1/1575 train_time:89ms step_avg:88.62ms
+step:2/1575 train_time:114ms step_avg:56.77ms
+step:3/1575 train_time:135ms step_avg:44.87ms
+step:4/1575 train_time:162ms step_avg:40.55ms
+step:5/1575 train_time:193ms step_avg:38.51ms
+step:6/1575 train_time:289ms step_avg:48.08ms
+step:7/1575 train_time:307ms step_avg:43.87ms
+step:8/1575 train_time:336ms step_avg:42.04ms
+step:9/1575 train_time:367ms step_avg:40.75ms
+step:10/1575 train_time:405ms step_avg:40.53ms
+step:11/1575 train_time:436ms step_avg:39.64ms
+step:12/1575 train_time:475ms step_avg:39.57ms
+step:13/1575 train_time:506ms step_avg:38.92ms
+step:14/1575 train_time:545ms step_avg:38.91ms
+step:15/1575 train_time:576ms step_avg:38.39ms
+step:16/1575 train_time:614ms step_avg:38.40ms
+step:17/1575 train_time:646ms step_avg:37.98ms
+step:18/1575 train_time:685ms step_avg:38.03ms
+step:19/1575 train_time:716ms step_avg:37.66ms
+step:20/1575 train_time:754ms step_avg:37.72ms
+step:21/1575 train_time:786ms step_avg:37.41ms
+step:22/1575 train_time:825ms step_avg:37.49ms
+step:23/1575 train_time:856ms step_avg:37.21ms
+step:24/1575 train_time:895ms step_avg:37.28ms
+step:25/1575 train_time:925ms step_avg:37.02ms
+step:26/1575 train_time:964ms step_avg:37.08ms
+step:27/1575 train_time:995ms step_avg:36.86ms
+step:28/1575 train_time:1034ms step_avg:36.92ms
+step:29/1575 train_time:1065ms step_avg:36.72ms
+step:30/1575 train_time:1104ms step_avg:36.80ms
+step:31/1575 train_time:1135ms step_avg:36.61ms
+step:32/1575 train_time:1174ms step_avg:36.68ms
+step:33/1575 train_time:1204ms step_avg:36.50ms
+step:34/1575 train_time:1243ms step_avg:36.57ms
+step:35/1575 train_time:1274ms step_avg:36.41ms
+step:36/1575 train_time:1313ms step_avg:36.47ms
+step:37/1575 train_time:1344ms step_avg:36.32ms
+step:38/1575 train_time:1382ms step_avg:36.38ms
+step:39/1575 train_time:1414ms step_avg:36.25ms
+step:40/1575 train_time:1452ms step_avg:36.31ms
+step:41/1575 train_time:1483ms step_avg:36.18ms
+step:42/1575 train_time:1522ms step_avg:36.25ms
+step:43/1575 train_time:1553ms step_avg:36.12ms
+step:44/1575 train_time:1592ms step_avg:36.18ms
+step:45/1575 train_time:1623ms step_avg:36.07ms
+step:46/1575 train_time:1663ms step_avg:36.15ms
+step:47/1575 train_time:1693ms step_avg:36.01ms
+step:48/1575 train_time:1731ms step_avg:36.06ms
+step:49/1575 train_time:1762ms step_avg:35.97ms
+step:50/1575 train_time:1801ms step_avg:36.02ms
+step:51/1575 train_time:1832ms step_avg:35.91ms
+step:52/1575 train_time:1870ms step_avg:35.96ms
+step:53/1575 train_time:1901ms step_avg:35.87ms
+step:54/1575 train_time:1939ms step_avg:35.92ms
+step:55/1575 train_time:1970ms step_avg:35.83ms
+step:56/1575 train_time:2009ms step_avg:35.88ms
+step:57/1575 train_time:2040ms step_avg:35.80ms
+step:58/1575 train_time:2079ms step_avg:35.85ms
+step:59/1575 train_time:2110ms step_avg:35.77ms
+step:60/1575 train_time:2149ms step_avg:35.82ms
+step:61/1575 train_time:2180ms step_avg:35.74ms
+step:62/1575 train_time:2218ms step_avg:35.78ms
+step:63/1575 train_time:2249ms step_avg:35.70ms
+step:64/1575 train_time:2288ms step_avg:35.76ms
+step:65/1575 train_time:2319ms step_avg:35.68ms
+step:66/1575 train_time:2357ms step_avg:35.72ms
+step:67/1575 train_time:2388ms step_avg:35.65ms
+step:68/1575 train_time:2427ms step_avg:35.69ms
+step:69/1575 train_time:2458ms step_avg:35.63ms
+step:70/1575 train_time:2497ms step_avg:35.68ms
+step:71/1575 train_time:2528ms step_avg:35.61ms
+step:72/1575 train_time:2567ms step_avg:35.65ms
+step:73/1575 train_time:2597ms step_avg:35.58ms
+step:74/1575 train_time:2636ms step_avg:35.63ms
+step:75/1575 train_time:2667ms step_avg:35.56ms
+step:76/1575 train_time:2707ms step_avg:35.61ms
+step:77/1575 train_time:2738ms step_avg:35.55ms
+step:78/1575 train_time:2776ms step_avg:35.59ms
+step:79/1575 train_time:2807ms step_avg:35.54ms
+step:80/1575 train_time:2846ms step_avg:35.58ms
+step:81/1575 train_time:2878ms step_avg:35.53ms
+step:82/1575 train_time:2916ms step_avg:35.56ms
+step:83/1575 train_time:2947ms step_avg:35.51ms
+step:84/1575 train_time:2987ms step_avg:35.56ms
+step:85/1575 train_time:3018ms step_avg:35.50ms
+step:86/1575 train_time:3056ms step_avg:35.54ms
+step:87/1575 train_time:3087ms step_avg:35.49ms
+step:88/1575 train_time:3126ms step_avg:35.53ms
+step:89/1575 train_time:3157ms step_avg:35.48ms
+step:90/1575 train_time:3196ms step_avg:35.51ms
+step:91/1575 train_time:3227ms step_avg:35.46ms
+step:92/1575 train_time:3268ms step_avg:35.52ms
+step:93/1575 train_time:3296ms step_avg:35.45ms
+step:94/1575 train_time:3336ms step_avg:35.48ms
+step:95/1575 train_time:3366ms step_avg:35.43ms
+step:96/1575 train_time:3405ms step_avg:35.46ms
+step:97/1575 train_time:3435ms step_avg:35.41ms
+step:98/1575 train_time:3474ms step_avg:35.45ms
+step:99/1575 train_time:3505ms step_avg:35.41ms
+step:100/1575 train_time:3544ms step_avg:35.44ms
+step:101/1575 train_time:3575ms step_avg:35.39ms
+step:102/1575 train_time:3613ms step_avg:35.42ms
+step:103/1575 train_time:3644ms step_avg:35.38ms
+step:104/1575 train_time:3683ms step_avg:35.42ms
+step:105/1575 train_time:3714ms step_avg:35.37ms
+step:106/1575 train_time:3753ms step_avg:35.40ms
+step:107/1575 train_time:3783ms step_avg:35.36ms
+step:108/1575 train_time:3823ms step_avg:35.39ms
+step:109/1575 train_time:3853ms step_avg:35.35ms
+step:110/1575 train_time:3892ms step_avg:35.38ms
+step:111/1575 train_time:3922ms step_avg:35.34ms
+step:112/1575 train_time:3961ms step_avg:35.37ms
+step:113/1575 train_time:3992ms step_avg:35.33ms
+step:114/1575 train_time:4031ms step_avg:35.36ms
+step:115/1575 train_time:4062ms step_avg:35.32ms
+step:116/1575 train_time:4101ms step_avg:35.35ms
+step:117/1575 train_time:4132ms step_avg:35.31ms
+step:118/1575 train_time:4170ms step_avg:35.34ms
+step:119/1575 train_time:4201ms step_avg:35.30ms
+step:120/1575 train_time:4240ms step_avg:35.33ms
+step:121/1575 train_time:4270ms step_avg:35.29ms
+step:122/1575 train_time:4309ms step_avg:35.32ms
+step:123/1575 train_time:4340ms step_avg:35.28ms
+step:124/1575 train_time:4378ms step_avg:35.31ms
+step:125/1575 train_time:4409ms step_avg:35.27ms
+step:126/1575 train_time:4448ms step_avg:35.30ms
+step:127/1575 train_time:4479ms step_avg:35.27ms
+step:128/1575 train_time:4517ms step_avg:35.29ms
+step:129/1575 train_time:4548ms step_avg:35.26ms
+step:130/1575 train_time:4587ms step_avg:35.29ms
+step:131/1575 train_time:4618ms step_avg:35.25ms
+step:132/1575 train_time:4657ms step_avg:35.28ms
+step:133/1575 train_time:4687ms step_avg:35.24ms
+step:134/1575 train_time:4726ms step_avg:35.27ms
+step:135/1575 train_time:4757ms step_avg:35.24ms
+step:136/1575 train_time:4796ms step_avg:35.26ms
+step:137/1575 train_time:4827ms step_avg:35.23ms
+step:138/1575 train_time:4865ms step_avg:35.26ms
+step:139/1575 train_time:4897ms step_avg:35.23ms
+step:140/1575 train_time:4936ms step_avg:35.25ms
+step:141/1575 train_time:4966ms step_avg:35.22ms
+step:142/1575 train_time:5005ms step_avg:35.25ms
+step:143/1575 train_time:5036ms step_avg:35.22ms
+step:144/1575 train_time:5074ms step_avg:35.24ms
+step:145/1575 train_time:5105ms step_avg:35.21ms
+step:146/1575 train_time:5145ms step_avg:35.24ms
+step:147/1575 train_time:5176ms step_avg:35.21ms
+step:148/1575 train_time:5214ms step_avg:35.23ms
+step:149/1575 train_time:5246ms step_avg:35.21ms
+step:150/1575 train_time:5284ms step_avg:35.23ms
+step:151/1575 train_time:5315ms step_avg:35.20ms
+step:152/1575 train_time:5354ms step_avg:35.22ms
+step:153/1575 train_time:5385ms step_avg:35.20ms
+step:154/1575 train_time:5423ms step_avg:35.22ms
+step:155/1575 train_time:5454ms step_avg:35.19ms
+step:156/1575 train_time:5493ms step_avg:35.21ms
+step:157/1575 train_time:5524ms step_avg:35.18ms
+step:158/1575 train_time:5563ms step_avg:35.21ms
+step:159/1575 train_time:5594ms step_avg:35.18ms
+step:160/1575 train_time:5634ms step_avg:35.21ms
+step:161/1575 train_time:5664ms step_avg:35.18ms
+step:162/1575 train_time:5703ms step_avg:35.20ms
+step:163/1575 train_time:5734ms step_avg:35.18ms
+step:164/1575 train_time:5772ms step_avg:35.20ms
+step:165/1575 train_time:5803ms step_avg:35.17ms
+step:166/1575 train_time:5841ms step_avg:35.19ms
+step:167/1575 train_time:5872ms step_avg:35.16ms
+step:168/1575 train_time:5911ms step_avg:35.19ms
+step:169/1575 train_time:5942ms step_avg:35.16ms
+step:170/1575 train_time:5980ms step_avg:35.18ms
+step:171/1575 train_time:6011ms step_avg:35.15ms
+step:172/1575 train_time:6050ms step_avg:35.17ms
+step:173/1575 train_time:6080ms step_avg:35.15ms
+step:174/1575 train_time:6119ms step_avg:35.16ms
+step:175/1575 train_time:6150ms step_avg:35.14ms
+step:176/1575 train_time:6189ms step_avg:35.17ms
+step:177/1575 train_time:6220ms step_avg:35.14ms
+step:178/1575 train_time:6258ms step_avg:35.16ms
+step:179/1575 train_time:6289ms step_avg:35.13ms
+step:180/1575 train_time:6327ms step_avg:35.15ms
+step:181/1575 train_time:6358ms step_avg:35.13ms
+step:182/1575 train_time:6396ms step_avg:35.14ms
+step:183/1575 train_time:6427ms step_avg:35.12ms
+step:184/1575 train_time:6466ms step_avg:35.14ms
+step:185/1575 train_time:6496ms step_avg:35.11ms
+step:186/1575 train_time:6535ms step_avg:35.13ms
+step:187/1575 train_time:6566ms step_avg:35.11ms
+step:188/1575 train_time:6605ms step_avg:35.13ms
+step:189/1575 train_time:6635ms step_avg:35.11ms
+step:190/1575 train_time:6674ms step_avg:35.13ms
+step:191/1575 train_time:6705ms step_avg:35.10ms
+step:192/1575 train_time:6743ms step_avg:35.12ms
+step:193/1575 train_time:6774ms step_avg:35.10ms
+step:194/1575 train_time:6813ms step_avg:35.12ms
+step:195/1575 train_time:6843ms step_avg:35.09ms
+step:196/1575 train_time:6882ms step_avg:35.11ms
+step:197/1575 train_time:6913ms step_avg:35.09ms
+step:198/1575 train_time:6951ms step_avg:35.11ms
+step:199/1575 train_time:6982ms step_avg:35.09ms
+step:200/1575 train_time:7021ms step_avg:35.10ms
+step:201/1575 train_time:7051ms step_avg:35.08ms
+step:202/1575 train_time:7090ms step_avg:35.10ms
+step:203/1575 train_time:7120ms step_avg:35.08ms
+step:204/1575 train_time:7159ms step_avg:35.09ms
+step:205/1575 train_time:7190ms step_avg:35.07ms
+step:206/1575 train_time:7229ms step_avg:35.09ms
+step:207/1575 train_time:7260ms step_avg:35.07ms
+step:208/1575 train_time:7298ms step_avg:35.09ms
+step:209/1575 train_time:7329ms step_avg:35.07ms
+step:210/1575 train_time:7367ms step_avg:35.08ms
+step:211/1575 train_time:7398ms step_avg:35.06ms
+step:212/1575 train_time:7437ms step_avg:35.08ms
+step:213/1575 train_time:7468ms step_avg:35.06ms
+step:214/1575 train_time:7506ms step_avg:35.08ms
+step:215/1575 train_time:7537ms step_avg:35.06ms
+step:216/1575 train_time:7576ms step_avg:35.07ms
+step:217/1575 train_time:7607ms step_avg:35.05ms
+step:218/1575 train_time:7645ms step_avg:35.07ms
+step:219/1575 train_time:7676ms step_avg:35.05ms
+step:220/1575 train_time:7715ms step_avg:35.07ms
+step:221/1575 train_time:7746ms step_avg:35.05ms
+step:222/1575 train_time:7785ms step_avg:35.07ms
+step:223/1575 train_time:7816ms step_avg:35.05ms
+step:224/1575 train_time:7855ms step_avg:35.06ms
+step:225/1575 train_time:7885ms step_avg:35.05ms
+step:226/1575 train_time:7924ms step_avg:35.06ms
+step:227/1575 train_time:7955ms step_avg:35.04ms
+step:228/1575 train_time:7994ms step_avg:35.06ms
+step:229/1575 train_time:8024ms step_avg:35.04ms
+step:230/1575 train_time:8063ms step_avg:35.06ms
+step:231/1575 train_time:8094ms step_avg:35.04ms
+step:232/1575 train_time:8132ms step_avg:35.05ms
+step:233/1575 train_time:8163ms step_avg:35.04ms
+step:234/1575 train_time:8202ms step_avg:35.05ms
+step:235/1575 train_time:8232ms step_avg:35.03ms
+step:236/1575 train_time:8272ms step_avg:35.05ms
+step:237/1575 train_time:8303ms step_avg:35.03ms
+step:238/1575 train_time:8342ms step_avg:35.05ms
+step:239/1575 train_time:8372ms step_avg:35.03ms
+step:240/1575 train_time:8411ms step_avg:35.05ms
+step:241/1575 train_time:8441ms step_avg:35.03ms
+step:242/1575 train_time:8480ms step_avg:35.04ms
+step:243/1575 train_time:8511ms step_avg:35.02ms
+step:244/1575 train_time:8550ms step_avg:35.04ms
+step:245/1575 train_time:8581ms step_avg:35.02ms
+step:246/1575 train_time:8619ms step_avg:35.04ms
+step:247/1575 train_time:8650ms step_avg:35.02ms
+step:248/1575 train_time:8689ms step_avg:35.03ms
+step:249/1575 train_time:8719ms step_avg:35.02ms
+step:250/1575 train_time:8758ms step_avg:35.03ms
+step:250/1575 val_loss:4.5772 train_time:8806ms step_avg:35.22ms
+step:251/1575 train_time:8827ms step_avg:35.17ms
+step:252/1575 train_time:8848ms step_avg:35.11ms
+step:253/1575 train_time:8865ms step_avg:35.04ms
+step:254/1575 train_time:8900ms step_avg:35.04ms
+step:255/1575 train_time:8933ms step_avg:35.03ms
+step:256/1575 train_time:8973ms step_avg:35.05ms
+step:257/1575 train_time:9004ms step_avg:35.04ms
+step:258/1575 train_time:9043ms step_avg:35.05ms
+step:259/1575 train_time:9074ms step_avg:35.04ms
+step:260/1575 train_time:9113ms step_avg:35.05ms
+step:261/1575 train_time:9144ms step_avg:35.04ms
+step:262/1575 train_time:9183ms step_avg:35.05ms
+step:263/1575 train_time:9213ms step_avg:35.03ms
+step:264/1575 train_time:9252ms step_avg:35.05ms
+step:265/1575 train_time:9283ms step_avg:35.03ms
+step:266/1575 train_time:9322ms step_avg:35.05ms
+step:267/1575 train_time:9353ms step_avg:35.03ms
+step:268/1575 train_time:9392ms step_avg:35.04ms
+step:269/1575 train_time:9422ms step_avg:35.03ms
+step:270/1575 train_time:9461ms step_avg:35.04ms
+step:271/1575 train_time:9492ms step_avg:35.02ms
+step:272/1575 train_time:9530ms step_avg:35.04ms
+step:273/1575 train_time:9561ms step_avg:35.02ms
+step:274/1575 train_time:9599ms step_avg:35.03ms
+step:275/1575 train_time:9630ms step_avg:35.02ms
+step:276/1575 train_time:9669ms step_avg:35.03ms
+step:277/1575 train_time:9700ms step_avg:35.02ms
+step:278/1575 train_time:9738ms step_avg:35.03ms
+step:279/1575 train_time:9769ms step_avg:35.01ms
+step:280/1575 train_time:9807ms step_avg:35.03ms
+step:281/1575 train_time:9838ms step_avg:35.01ms
+step:282/1575 train_time:9877ms step_avg:35.02ms
+step:283/1575 train_time:9908ms step_avg:35.01ms
+step:284/1575 train_time:9946ms step_avg:35.02ms
+step:285/1575 train_time:9977ms step_avg:35.01ms
+step:286/1575 train_time:10016ms step_avg:35.02ms
+step:287/1575 train_time:10048ms step_avg:35.01ms
+step:288/1575 train_time:10086ms step_avg:35.02ms
+step:289/1575 train_time:10117ms step_avg:35.01ms
+step:290/1575 train_time:10156ms step_avg:35.02ms
+step:291/1575 train_time:10187ms step_avg:35.01ms
+step:292/1575 train_time:10225ms step_avg:35.02ms
+step:293/1575 train_time:10256ms step_avg:35.00ms
+step:294/1575 train_time:10294ms step_avg:35.01ms
+step:295/1575 train_time:10325ms step_avg:35.00ms
+step:296/1575 train_time:10363ms step_avg:35.01ms
+step:297/1575 train_time:10394ms step_avg:35.00ms
+step:298/1575 train_time:10433ms step_avg:35.01ms
+step:299/1575 train_time:10463ms step_avg:34.99ms
+step:300/1575 train_time:10502ms step_avg:35.01ms
+step:301/1575 train_time:10532ms step_avg:34.99ms
+step:302/1575 train_time:10571ms step_avg:35.00ms
+step:303/1575 train_time:10602ms step_avg:34.99ms
+step:304/1575 train_time:10640ms step_avg:35.00ms
+step:305/1575 train_time:10671ms step_avg:34.99ms
+step:306/1575 train_time:10710ms step_avg:35.00ms
+step:307/1575 train_time:10741ms step_avg:34.99ms
+step:308/1575 train_time:10779ms step_avg:35.00ms
+step:309/1575 train_time:10810ms step_avg:34.99ms
+step:310/1575 train_time:10849ms step_avg:35.00ms
+step:311/1575 train_time:10879ms step_avg:34.98ms
+step:312/1575 train_time:10918ms step_avg:34.99ms
+step:313/1575 train_time:10948ms step_avg:34.98ms
+step:314/1575 train_time:10987ms step_avg:34.99ms
+step:315/1575 train_time:11017ms step_avg:34.98ms
+step:316/1575 train_time:11056ms step_avg:34.99ms
+step:317/1575 train_time:11087ms step_avg:34.97ms
+step:318/1575 train_time:11125ms step_avg:34.99ms
+step:319/1575 train_time:11156ms step_avg:34.97ms
+step:320/1575 train_time:11195ms step_avg:34.98ms
+step:321/1575 train_time:11225ms step_avg:34.97ms
+step:322/1575 train_time:11264ms step_avg:34.98ms
+step:323/1575 train_time:11294ms step_avg:34.97ms
+step:324/1575 train_time:11333ms step_avg:34.98ms
+step:325/1575 train_time:11364ms step_avg:34.97ms
+step:326/1575 train_time:11403ms step_avg:34.98ms
+step:327/1575 train_time:11434ms step_avg:34.96ms
+step:328/1575 train_time:11472ms step_avg:34.98ms
+step:329/1575 train_time:11503ms step_avg:34.96ms
+step:330/1575 train_time:11542ms step_avg:34.97ms
+step:331/1575 train_time:11572ms step_avg:34.96ms
+step:332/1575 train_time:11611ms step_avg:34.97ms
+step:333/1575 train_time:11642ms step_avg:34.96ms
+step:334/1575 train_time:11680ms step_avg:34.97ms
+step:335/1575 train_time:11711ms step_avg:34.96ms
+step:336/1575 train_time:11750ms step_avg:34.97ms
+step:337/1575 train_time:11780ms step_avg:34.96ms
+step:338/1575 train_time:11819ms step_avg:34.97ms
+step:339/1575 train_time:11850ms step_avg:34.95ms
+step:340/1575 train_time:11888ms step_avg:34.96ms
+step:341/1575 train_time:11919ms step_avg:34.95ms
+step:342/1575 train_time:11957ms step_avg:34.96ms
+step:343/1575 train_time:11988ms step_avg:34.95ms
+step:344/1575 train_time:12026ms step_avg:34.96ms
+step:345/1575 train_time:12057ms step_avg:34.95ms
+step:346/1575 train_time:12096ms step_avg:34.96ms
+step:347/1575 train_time:12127ms step_avg:34.95ms
+step:348/1575 train_time:12165ms step_avg:34.96ms
+step:349/1575 train_time:12196ms step_avg:34.95ms
+step:350/1575 train_time:12234ms step_avg:34.96ms
+step:351/1575 train_time:12265ms step_avg:34.94ms
+step:352/1575 train_time:12303ms step_avg:34.95ms
+step:353/1575 train_time:12334ms step_avg:34.94ms
+step:354/1575 train_time:12373ms step_avg:34.95ms
+step:355/1575 train_time:12404ms step_avg:34.94ms
+step:356/1575 train_time:12443ms step_avg:34.95ms
+step:357/1575 train_time:12473ms step_avg:34.94ms
+step:358/1575 train_time:12512ms step_avg:34.95ms
+step:359/1575 train_time:12543ms step_avg:34.94ms
+step:360/1575 train_time:12582ms step_avg:34.95ms
+step:361/1575 train_time:12612ms step_avg:34.94ms
+step:362/1575 train_time:12652ms step_avg:34.95ms
+step:363/1575 train_time:12682ms step_avg:34.94ms
+step:364/1575 train_time:12721ms step_avg:34.95ms
+step:365/1575 train_time:12751ms step_avg:34.94ms
+step:366/1575 train_time:12790ms step_avg:34.95ms
+step:367/1575 train_time:12821ms step_avg:34.93ms
+step:368/1575 train_time:12859ms step_avg:34.94ms
+step:369/1575 train_time:12890ms step_avg:34.93ms
+step:370/1575 train_time:12928ms step_avg:34.94ms
+step:371/1575 train_time:12959ms step_avg:34.93ms
+step:372/1575 train_time:12998ms step_avg:34.94ms
+step:373/1575 train_time:13029ms step_avg:34.93ms
+step:374/1575 train_time:13067ms step_avg:34.94ms
+step:375/1575 train_time:13098ms step_avg:34.93ms
+step:376/1575 train_time:13137ms step_avg:34.94ms
+step:377/1575 train_time:13167ms step_avg:34.93ms
+step:378/1575 train_time:13205ms step_avg:34.93ms
+step:379/1575 train_time:13236ms step_avg:34.92ms
+step:380/1575 train_time:13275ms step_avg:34.93ms
+step:381/1575 train_time:13306ms step_avg:34.92ms
+step:382/1575 train_time:13344ms step_avg:34.93ms
+step:383/1575 train_time:13375ms step_avg:34.92ms
+step:384/1575 train_time:13414ms step_avg:34.93ms
+step:385/1575 train_time:13445ms step_avg:34.92ms
+step:386/1575 train_time:13484ms step_avg:34.93ms
+step:387/1575 train_time:13514ms step_avg:34.92ms
+step:388/1575 train_time:13553ms step_avg:34.93ms
+step:389/1575 train_time:13584ms step_avg:34.92ms
+step:390/1575 train_time:13623ms step_avg:34.93ms
+step:391/1575 train_time:13653ms step_avg:34.92ms
+step:392/1575 train_time:13692ms step_avg:34.93ms
+step:393/1575 train_time:13723ms step_avg:34.92ms
+step:394/1575 train_time:13762ms step_avg:34.93ms
+step:395/1575 train_time:13792ms step_avg:34.92ms
+step:396/1575 train_time:13831ms step_avg:34.93ms
+step:397/1575 train_time:13862ms step_avg:34.92ms
+step:398/1575 train_time:13901ms step_avg:34.93ms
+step:399/1575 train_time:13931ms step_avg:34.92ms
+step:400/1575 train_time:13970ms step_avg:34.93ms
+step:401/1575 train_time:14001ms step_avg:34.92ms
+step:402/1575 train_time:14040ms step_avg:34.92ms
+step:403/1575 train_time:14071ms step_avg:34.91ms
+step:404/1575 train_time:14109ms step_avg:34.92ms
+step:405/1575 train_time:14140ms step_avg:34.91ms
+step:406/1575 train_time:14179ms step_avg:34.92ms
+step:407/1575 train_time:14209ms step_avg:34.91ms
+step:408/1575 train_time:14248ms step_avg:34.92ms
+step:409/1575 train_time:14279ms step_avg:34.91ms
+step:410/1575 train_time:14318ms step_avg:34.92ms
+step:411/1575 train_time:14348ms step_avg:34.91ms
+step:412/1575 train_time:14387ms step_avg:34.92ms
+step:413/1575 train_time:14417ms step_avg:34.91ms
+step:414/1575 train_time:14456ms step_avg:34.92ms
+step:415/1575 train_time:14487ms step_avg:34.91ms
+step:416/1575 train_time:14525ms step_avg:34.92ms
+step:417/1575 train_time:14556ms step_avg:34.91ms
+step:418/1575 train_time:14595ms step_avg:34.92ms
+step:419/1575 train_time:14625ms step_avg:34.90ms
+step:420/1575 train_time:14664ms step_avg:34.91ms
+step:421/1575 train_time:14695ms step_avg:34.90ms
+step:422/1575 train_time:14733ms step_avg:34.91ms
+step:423/1575 train_time:14764ms step_avg:34.90ms
+step:424/1575 train_time:14802ms step_avg:34.91ms
+step:425/1575 train_time:14833ms step_avg:34.90ms
+step:426/1575 train_time:14873ms step_avg:34.91ms
+step:427/1575 train_time:14903ms step_avg:34.90ms
+step:428/1575 train_time:14942ms step_avg:34.91ms
+step:429/1575 train_time:14972ms step_avg:34.90ms
+step:430/1575 train_time:15011ms step_avg:34.91ms
+step:431/1575 train_time:15042ms step_avg:34.90ms
+step:432/1575 train_time:15082ms step_avg:34.91ms
+step:433/1575 train_time:15112ms step_avg:34.90ms
+step:434/1575 train_time:15151ms step_avg:34.91ms
+step:435/1575 train_time:15181ms step_avg:34.90ms
+step:436/1575 train_time:15220ms step_avg:34.91ms
+step:437/1575 train_time:15251ms step_avg:34.90ms
+step:438/1575 train_time:15290ms step_avg:34.91ms
+step:439/1575 train_time:15320ms step_avg:34.90ms
+step:440/1575 train_time:15358ms step_avg:34.91ms
+step:441/1575 train_time:15389ms step_avg:34.90ms
+step:442/1575 train_time:15428ms step_avg:34.90ms
+step:443/1575 train_time:15458ms step_avg:34.89ms
+step:444/1575 train_time:15497ms step_avg:34.90ms
+step:445/1575 train_time:15528ms step_avg:34.89ms
+step:446/1575 train_time:15566ms step_avg:34.90ms
+step:447/1575 train_time:15597ms step_avg:34.89ms
+step:448/1575 train_time:15635ms step_avg:34.90ms
+step:449/1575 train_time:15666ms step_avg:34.89ms
+step:450/1575 train_time:15705ms step_avg:34.90ms
+step:451/1575 train_time:15736ms step_avg:34.89ms
+step:452/1575 train_time:15775ms step_avg:34.90ms
+step:453/1575 train_time:15805ms step_avg:34.89ms
+step:454/1575 train_time:15843ms step_avg:34.90ms
+step:455/1575 train_time:15874ms step_avg:34.89ms
+step:456/1575 train_time:15913ms step_avg:34.90ms
+step:457/1575 train_time:15944ms step_avg:34.89ms
+step:458/1575 train_time:15982ms step_avg:34.90ms
+step:459/1575 train_time:16013ms step_avg:34.89ms
+step:460/1575 train_time:16052ms step_avg:34.89ms
+step:461/1575 train_time:16083ms step_avg:34.89ms
+step:462/1575 train_time:16121ms step_avg:34.89ms
+step:463/1575 train_time:16152ms step_avg:34.89ms
+step:464/1575 train_time:16191ms step_avg:34.89ms
+step:465/1575 train_time:16222ms step_avg:34.89ms
+step:466/1575 train_time:16260ms step_avg:34.89ms
+step:467/1575 train_time:16291ms step_avg:34.88ms
+step:468/1575 train_time:16329ms step_avg:34.89ms
+step:469/1575 train_time:16360ms step_avg:34.88ms
+step:470/1575 train_time:16399ms step_avg:34.89ms
+step:471/1575 train_time:16430ms step_avg:34.88ms
+step:472/1575 train_time:16468ms step_avg:34.89ms
+step:473/1575 train_time:16499ms step_avg:34.88ms
+step:474/1575 train_time:16537ms step_avg:34.89ms
+step:475/1575 train_time:16568ms step_avg:34.88ms
+step:476/1575 train_time:16606ms step_avg:34.89ms
+step:477/1575 train_time:16637ms step_avg:34.88ms
+step:478/1575 train_time:16676ms step_avg:34.89ms
+step:479/1575 train_time:16706ms step_avg:34.88ms
+step:480/1575 train_time:16744ms step_avg:34.88ms
+step:481/1575 train_time:16775ms step_avg:34.88ms
+step:482/1575 train_time:16814ms step_avg:34.88ms
+step:483/1575 train_time:16845ms step_avg:34.88ms
+step:484/1575 train_time:16883ms step_avg:34.88ms
+step:485/1575 train_time:16914ms step_avg:34.87ms
+step:486/1575 train_time:16953ms step_avg:34.88ms
+step:487/1575 train_time:16984ms step_avg:34.88ms
+step:488/1575 train_time:17023ms step_avg:34.88ms
+step:489/1575 train_time:17054ms step_avg:34.87ms
+step:490/1575 train_time:17092ms step_avg:34.88ms
+step:491/1575 train_time:17123ms step_avg:34.87ms
+step:492/1575 train_time:17162ms step_avg:34.88ms
+step:493/1575 train_time:17192ms step_avg:34.87ms
+step:494/1575 train_time:17230ms step_avg:34.88ms
+step:495/1575 train_time:17261ms step_avg:34.87ms
+step:496/1575 train_time:17300ms step_avg:34.88ms
+step:497/1575 train_time:17330ms step_avg:34.87ms
+step:498/1575 train_time:17369ms step_avg:34.88ms
+step:499/1575 train_time:17400ms step_avg:34.87ms
+step:500/1575 train_time:17438ms step_avg:34.88ms
+step:500/1575 val_loss:4.2311 train_time:17486ms step_avg:34.97ms
+step:501/1575 train_time:17508ms step_avg:34.95ms
+step:502/1575 train_time:17528ms step_avg:34.92ms
+step:503/1575 train_time:17546ms step_avg:34.88ms
+step:504/1575 train_time:17580ms step_avg:34.88ms
+step:505/1575 train_time:17612ms step_avg:34.87ms
+step:506/1575 train_time:17651ms step_avg:34.88ms
+step:507/1575 train_time:17683ms step_avg:34.88ms
+step:508/1575 train_time:17722ms step_avg:34.88ms
+step:509/1575 train_time:17752ms step_avg:34.88ms
+step:510/1575 train_time:17791ms step_avg:34.88ms
+step:511/1575 train_time:17822ms step_avg:34.88ms
+step:512/1575 train_time:17860ms step_avg:34.88ms
+step:513/1575 train_time:17937ms step_avg:34.97ms
+step:514/1575 train_time:17990ms step_avg:35.00ms
+step:515/1575 train_time:18052ms step_avg:35.05ms
+step:516/1575 train_time:18111ms step_avg:35.10ms
+step:517/1575 train_time:18173ms step_avg:35.15ms
+step:518/1575 train_time:18232ms step_avg:35.20ms
+step:519/1575 train_time:18294ms step_avg:35.25ms
+step:520/1575 train_time:18353ms step_avg:35.29ms
+step:521/1575 train_time:18416ms step_avg:35.35ms
+step:522/1575 train_time:18475ms step_avg:35.39ms
+step:523/1575 train_time:18539ms step_avg:35.45ms
+step:524/1575 train_time:18600ms step_avg:35.50ms
+step:525/1575 train_time:18664ms step_avg:35.55ms
+step:526/1575 train_time:18725ms step_avg:35.60ms
+step:527/1575 train_time:18790ms step_avg:35.65ms
+step:528/1575 train_time:18857ms step_avg:35.71ms
+step:529/1575 train_time:18916ms step_avg:35.76ms
+step:530/1575 train_time:18974ms step_avg:35.80ms
+step:531/1575 train_time:19037ms step_avg:35.85ms
+step:532/1575 train_time:19096ms step_avg:35.89ms
+step:533/1575 train_time:19159ms step_avg:35.95ms
+step:534/1575 train_time:19219ms step_avg:35.99ms
+step:535/1575 train_time:19283ms step_avg:36.04ms
+step:536/1575 train_time:19342ms step_avg:36.09ms
+step:537/1575 train_time:19406ms step_avg:36.14ms
+step:538/1575 train_time:19465ms step_avg:36.18ms
+step:539/1575 train_time:19529ms step_avg:36.23ms
+step:540/1575 train_time:19589ms step_avg:36.28ms
+step:541/1575 train_time:19652ms step_avg:36.33ms
+step:542/1575 train_time:19713ms step_avg:36.37ms
+step:543/1575 train_time:19777ms step_avg:36.42ms
+step:544/1575 train_time:19837ms step_avg:36.46ms
+step:545/1575 train_time:19901ms step_avg:36.52ms
+step:546/1575 train_time:19960ms step_avg:36.56ms
+step:547/1575 train_time:20024ms step_avg:36.61ms
+step:548/1575 train_time:20083ms step_avg:36.65ms
+step:549/1575 train_time:20146ms step_avg:36.70ms
+step:550/1575 train_time:20205ms step_avg:36.74ms
+step:551/1575 train_time:20269ms step_avg:36.79ms
+step:552/1575 train_time:20328ms step_avg:36.83ms
+step:553/1575 train_time:20392ms step_avg:36.87ms
+step:554/1575 train_time:20451ms step_avg:36.91ms
+step:555/1575 train_time:20515ms step_avg:36.96ms
+step:556/1575 train_time:20573ms step_avg:37.00ms
+step:557/1575 train_time:20637ms step_avg:37.05ms
+step:558/1575 train_time:20695ms step_avg:37.09ms
+step:559/1575 train_time:20758ms step_avg:37.13ms
+step:560/1575 train_time:20818ms step_avg:37.18ms
+step:561/1575 train_time:20882ms step_avg:37.22ms
+step:562/1575 train_time:20941ms step_avg:37.26ms
+step:563/1575 train_time:21005ms step_avg:37.31ms
+step:564/1575 train_time:21064ms step_avg:37.35ms
+step:565/1575 train_time:21127ms step_avg:37.39ms
+step:566/1575 train_time:21187ms step_avg:37.43ms
+step:567/1575 train_time:21250ms step_avg:37.48ms
+step:568/1575 train_time:21310ms step_avg:37.52ms
+step:569/1575 train_time:21378ms step_avg:37.57ms
+step:570/1575 train_time:21434ms step_avg:37.60ms
+step:571/1575 train_time:21497ms step_avg:37.65ms
+step:572/1575 train_time:21556ms step_avg:37.69ms
+step:573/1575 train_time:21618ms step_avg:37.73ms
+step:574/1575 train_time:21677ms step_avg:37.76ms
+step:575/1575 train_time:21741ms step_avg:37.81ms
+step:576/1575 train_time:21800ms step_avg:37.85ms
+step:577/1575 train_time:21864ms step_avg:37.89ms
+step:578/1575 train_time:21923ms step_avg:37.93ms
+step:579/1575 train_time:21989ms step_avg:37.98ms
+step:580/1575 train_time:22048ms step_avg:38.01ms
+step:581/1575 train_time:22113ms step_avg:38.06ms
+step:582/1575 train_time:22169ms step_avg:38.09ms
+step:583/1575 train_time:22232ms step_avg:38.13ms
+step:584/1575 train_time:22291ms step_avg:38.17ms
+step:585/1575 train_time:22354ms step_avg:38.21ms
+step:586/1575 train_time:22413ms step_avg:38.25ms
+step:587/1575 train_time:22476ms step_avg:38.29ms
+step:588/1575 train_time:22536ms step_avg:38.33ms
+step:589/1575 train_time:22599ms step_avg:38.37ms
+step:590/1575 train_time:22658ms step_avg:38.40ms
+step:591/1575 train_time:22720ms step_avg:38.44ms
+step:592/1575 train_time:22780ms step_avg:38.48ms
+step:593/1575 train_time:22843ms step_avg:38.52ms
+step:594/1575 train_time:22903ms step_avg:38.56ms
+step:595/1575 train_time:22965ms step_avg:38.60ms
+step:596/1575 train_time:23026ms step_avg:38.63ms
+step:597/1575 train_time:23089ms step_avg:38.68ms
+step:598/1575 train_time:23148ms step_avg:38.71ms
+step:599/1575 train_time:23212ms step_avg:38.75ms
+step:600/1575 train_time:23271ms step_avg:38.79ms
+step:601/1575 train_time:23335ms step_avg:38.83ms
+step:602/1575 train_time:23394ms step_avg:38.86ms
+step:603/1575 train_time:23457ms step_avg:38.90ms
+step:604/1575 train_time:23517ms step_avg:38.94ms
+step:605/1575 train_time:23579ms step_avg:38.97ms
+step:606/1575 train_time:23639ms step_avg:39.01ms
+step:607/1575 train_time:23701ms step_avg:39.05ms
+step:608/1575 train_time:23760ms step_avg:39.08ms
+step:609/1575 train_time:23824ms step_avg:39.12ms
+step:610/1575 train_time:23884ms step_avg:39.15ms
+step:611/1575 train_time:23947ms step_avg:39.19ms
+step:612/1575 train_time:24007ms step_avg:39.23ms
+step:613/1575 train_time:24070ms step_avg:39.27ms
+step:614/1575 train_time:24130ms step_avg:39.30ms
+step:615/1575 train_time:24193ms step_avg:39.34ms
+step:616/1575 train_time:24253ms step_avg:39.37ms
+step:617/1575 train_time:24315ms step_avg:39.41ms
+step:618/1575 train_time:24375ms step_avg:39.44ms
+step:619/1575 train_time:24440ms step_avg:39.48ms
+step:620/1575 train_time:24498ms step_avg:39.51ms
+step:621/1575 train_time:24560ms step_avg:39.55ms
+step:622/1575 train_time:24620ms step_avg:39.58ms
+step:623/1575 train_time:24683ms step_avg:39.62ms
+step:624/1575 train_time:24742ms step_avg:39.65ms
+step:625/1575 train_time:24806ms step_avg:39.69ms
+step:626/1575 train_time:24866ms step_avg:39.72ms
+step:627/1575 train_time:24929ms step_avg:39.76ms
+step:628/1575 train_time:24988ms step_avg:39.79ms
+step:629/1575 train_time:25051ms step_avg:39.83ms
+step:630/1575 train_time:25110ms step_avg:39.86ms
+step:631/1575 train_time:25174ms step_avg:39.89ms
+step:632/1575 train_time:25233ms step_avg:39.93ms
+step:633/1575 train_time:25297ms step_avg:39.96ms
+step:634/1575 train_time:25356ms step_avg:39.99ms
+step:635/1575 train_time:25419ms step_avg:40.03ms
+step:636/1575 train_time:25479ms step_avg:40.06ms
+step:637/1575 train_time:25542ms step_avg:40.10ms
+step:638/1575 train_time:25602ms step_avg:40.13ms
+step:639/1575 train_time:25664ms step_avg:40.16ms
+step:640/1575 train_time:25724ms step_avg:40.19ms
+step:641/1575 train_time:25787ms step_avg:40.23ms
+step:642/1575 train_time:25847ms step_avg:40.26ms
+step:643/1575 train_time:25909ms step_avg:40.29ms
+step:644/1575 train_time:25969ms step_avg:40.32ms
+step:645/1575 train_time:26033ms step_avg:40.36ms
+step:646/1575 train_time:26092ms step_avg:40.39ms
+step:647/1575 train_time:26155ms step_avg:40.42ms
+step:648/1575 train_time:26214ms step_avg:40.45ms
+step:649/1575 train_time:26277ms step_avg:40.49ms
+step:650/1575 train_time:26336ms step_avg:40.52ms
+step:651/1575 train_time:26399ms step_avg:40.55ms
+step:652/1575 train_time:26459ms step_avg:40.58ms
+step:653/1575 train_time:26522ms step_avg:40.62ms
+step:654/1575 train_time:26581ms step_avg:40.64ms
+step:655/1575 train_time:26644ms step_avg:40.68ms
+step:656/1575 train_time:26703ms step_avg:40.71ms
+step:657/1575 train_time:26766ms step_avg:40.74ms
+step:658/1575 train_time:26825ms step_avg:40.77ms
+step:659/1575 train_time:26891ms step_avg:40.81ms
+step:660/1575 train_time:26950ms step_avg:40.83ms
+step:661/1575 train_time:27013ms step_avg:40.87ms
+step:662/1575 train_time:27071ms step_avg:40.89ms
+step:663/1575 train_time:27137ms step_avg:40.93ms
+step:664/1575 train_time:27196ms step_avg:40.96ms
+step:665/1575 train_time:27258ms step_avg:40.99ms
+step:666/1575 train_time:27317ms step_avg:41.02ms
+step:667/1575 train_time:27380ms step_avg:41.05ms
+step:668/1575 train_time:27440ms step_avg:41.08ms
+step:669/1575 train_time:27503ms step_avg:41.11ms
+step:670/1575 train_time:27562ms step_avg:41.14ms
+step:671/1575 train_time:27625ms step_avg:41.17ms
+step:672/1575 train_time:27685ms step_avg:41.20ms
+step:673/1575 train_time:27748ms step_avg:41.23ms
+step:674/1575 train_time:27807ms step_avg:41.26ms
+step:675/1575 train_time:27871ms step_avg:41.29ms
+step:676/1575 train_time:27930ms step_avg:41.32ms
+step:677/1575 train_time:27993ms step_avg:41.35ms
+step:678/1575 train_time:28053ms step_avg:41.38ms
+step:679/1575 train_time:28117ms step_avg:41.41ms
+step:680/1575 train_time:28176ms step_avg:41.43ms
+step:681/1575 train_time:28239ms step_avg:41.47ms
+step:682/1575 train_time:28298ms step_avg:41.49ms
+step:683/1575 train_time:28361ms step_avg:41.52ms
+step:684/1575 train_time:28420ms step_avg:41.55ms
+step:685/1575 train_time:28484ms step_avg:41.58ms
+step:686/1575 train_time:28543ms step_avg:41.61ms
+step:687/1575 train_time:28606ms step_avg:41.64ms
+step:688/1575 train_time:28666ms step_avg:41.67ms
+step:689/1575 train_time:28729ms step_avg:41.70ms
+step:690/1575 train_time:28789ms step_avg:41.72ms
+step:691/1575 train_time:28853ms step_avg:41.75ms
+step:692/1575 train_time:28912ms step_avg:41.78ms
+step:693/1575 train_time:28976ms step_avg:41.81ms
+step:694/1575 train_time:29035ms step_avg:41.84ms
+step:695/1575 train_time:29098ms step_avg:41.87ms
+step:696/1575 train_time:29157ms step_avg:41.89ms
+step:697/1575 train_time:29220ms step_avg:41.92ms
+step:698/1575 train_time:29280ms step_avg:41.95ms
+step:699/1575 train_time:29343ms step_avg:41.98ms
+step:700/1575 train_time:29401ms step_avg:42.00ms
+step:701/1575 train_time:29465ms step_avg:42.03ms
+step:702/1575 train_time:29525ms step_avg:42.06ms
+step:703/1575 train_time:29588ms step_avg:42.09ms
+step:704/1575 train_time:29647ms step_avg:42.11ms
+step:705/1575 train_time:29710ms step_avg:42.14ms
+step:706/1575 train_time:29769ms step_avg:42.17ms
+step:707/1575 train_time:29832ms step_avg:42.20ms
+step:708/1575 train_time:29892ms step_avg:42.22ms
+step:709/1575 train_time:29955ms step_avg:42.25ms
+step:710/1575 train_time:30015ms step_avg:42.28ms
+step:711/1575 train_time:30078ms step_avg:42.30ms
+step:712/1575 train_time:30138ms step_avg:42.33ms
+step:713/1575 train_time:30200ms step_avg:42.36ms
+step:714/1575 train_time:30259ms step_avg:42.38ms
+step:715/1575 train_time:30323ms step_avg:42.41ms
+step:716/1575 train_time:30382ms step_avg:42.43ms
+step:717/1575 train_time:30445ms step_avg:42.46ms
+step:718/1575 train_time:30504ms step_avg:42.48ms
+step:719/1575 train_time:30568ms step_avg:42.51ms
+step:720/1575 train_time:30628ms step_avg:42.54ms
+step:721/1575 train_time:30692ms step_avg:42.57ms
+step:722/1575 train_time:30750ms step_avg:42.59ms
+step:723/1575 train_time:30813ms step_avg:42.62ms
+step:724/1575 train_time:30873ms step_avg:42.64ms
+step:725/1575 train_time:30937ms step_avg:42.67ms
+step:726/1575 train_time:30996ms step_avg:42.69ms
+step:727/1575 train_time:31059ms step_avg:42.72ms
+step:728/1575 train_time:31118ms step_avg:42.74ms
+step:729/1575 train_time:31181ms step_avg:42.77ms
+step:730/1575 train_time:31240ms step_avg:42.79ms
+step:731/1575 train_time:31303ms step_avg:42.82ms
+step:732/1575 train_time:31362ms step_avg:42.84ms
+step:733/1575 train_time:31426ms step_avg:42.87ms
+step:734/1575 train_time:31485ms step_avg:42.89ms
+step:735/1575 train_time:31548ms step_avg:42.92ms
+step:736/1575 train_time:31609ms step_avg:42.95ms
+step:737/1575 train_time:31672ms step_avg:42.97ms
+step:738/1575 train_time:31731ms step_avg:43.00ms
+step:739/1575 train_time:31794ms step_avg:43.02ms
+step:740/1575 train_time:31853ms step_avg:43.05ms
+step:741/1575 train_time:31917ms step_avg:43.07ms
+step:742/1575 train_time:31976ms step_avg:43.09ms
+step:743/1575 train_time:32040ms step_avg:43.12ms
+step:744/1575 train_time:32099ms step_avg:43.14ms
+step:745/1575 train_time:32162ms step_avg:43.17ms
+step:746/1575 train_time:32225ms step_avg:43.20ms
+step:747/1575 train_time:32287ms step_avg:43.22ms
+step:748/1575 train_time:32346ms step_avg:43.24ms
+step:749/1575 train_time:32408ms step_avg:43.27ms
+step:750/1575 train_time:32467ms step_avg:43.29ms
+step:750/1575 val_loss:3.8816 train_time:32513ms step_avg:43.35ms
+step:751/1575 train_time:32534ms step_avg:43.32ms
+step:752/1575 train_time:32591ms step_avg:43.34ms
+step:753/1575 train_time:32658ms step_avg:43.37ms
+step:754/1575 train_time:32718ms step_avg:43.39ms
+step:755/1575 train_time:32782ms step_avg:43.42ms
+step:756/1575 train_time:32841ms step_avg:43.44ms
+step:757/1575 train_time:32904ms step_avg:43.47ms
+step:758/1575 train_time:32963ms step_avg:43.49ms
+step:759/1575 train_time:33026ms step_avg:43.51ms
+step:760/1575 train_time:33085ms step_avg:43.53ms
+step:761/1575 train_time:33150ms step_avg:43.56ms
+step:762/1575 train_time:33207ms step_avg:43.58ms
+step:763/1575 train_time:33270ms step_avg:43.60ms
+step:764/1575 train_time:33329ms step_avg:43.62ms
+step:765/1575 train_time:33392ms step_avg:43.65ms
+step:766/1575 train_time:33452ms step_avg:43.67ms
+step:767/1575 train_time:33516ms step_avg:43.70ms
+step:768/1575 train_time:33576ms step_avg:43.72ms
+step:769/1575 train_time:33640ms step_avg:43.75ms
+step:770/1575 train_time:33700ms step_avg:43.77ms
+step:771/1575 train_time:33764ms step_avg:43.79ms
+step:772/1575 train_time:33823ms step_avg:43.81ms
+step:773/1575 train_time:33887ms step_avg:43.84ms
+step:774/1575 train_time:33946ms step_avg:43.86ms
+step:775/1575 train_time:34010ms step_avg:43.88ms
+step:776/1575 train_time:34069ms step_avg:43.90ms
+step:777/1575 train_time:34132ms step_avg:43.93ms
+step:778/1575 train_time:34191ms step_avg:43.95ms
+step:779/1575 train_time:34254ms step_avg:43.97ms
+step:780/1575 train_time:34313ms step_avg:43.99ms
+step:781/1575 train_time:34376ms step_avg:44.01ms
+step:782/1575 train_time:34438ms step_avg:44.04ms
+step:783/1575 train_time:34499ms step_avg:44.06ms
+step:784/1575 train_time:34558ms step_avg:44.08ms
+step:785/1575 train_time:34621ms step_avg:44.10ms
+step:786/1575 train_time:34681ms step_avg:44.12ms
+step:787/1575 train_time:34745ms step_avg:44.15ms
+step:788/1575 train_time:34804ms step_avg:44.17ms
+step:789/1575 train_time:34868ms step_avg:44.19ms
+step:790/1575 train_time:34927ms step_avg:44.21ms
+step:791/1575 train_time:34990ms step_avg:44.24ms
+step:792/1575 train_time:35049ms step_avg:44.25ms
+step:793/1575 train_time:35113ms step_avg:44.28ms
+step:794/1575 train_time:35173ms step_avg:44.30ms
+step:795/1575 train_time:35236ms step_avg:44.32ms
+step:796/1575 train_time:35295ms step_avg:44.34ms
+step:797/1575 train_time:35357ms step_avg:44.36ms
+step:798/1575 train_time:35417ms step_avg:44.38ms
+step:799/1575 train_time:35480ms step_avg:44.41ms
+step:800/1575 train_time:35539ms step_avg:44.42ms
+step:801/1575 train_time:35603ms step_avg:44.45ms
+step:802/1575 train_time:35663ms step_avg:44.47ms
+step:803/1575 train_time:35726ms step_avg:44.49ms
+step:804/1575 train_time:35785ms step_avg:44.51ms
+step:805/1575 train_time:35849ms step_avg:44.53ms
+step:806/1575 train_time:35908ms step_avg:44.55ms
+step:807/1575 train_time:35971ms step_avg:44.57ms
+step:808/1575 train_time:36032ms step_avg:44.59ms
+step:809/1575 train_time:36095ms step_avg:44.62ms
+step:810/1575 train_time:36157ms step_avg:44.64ms
+step:811/1575 train_time:36220ms step_avg:44.66ms
+step:812/1575 train_time:36277ms step_avg:44.68ms
+step:813/1575 train_time:36340ms step_avg:44.70ms
+step:814/1575 train_time:36399ms step_avg:44.72ms
+step:815/1575 train_time:36464ms step_avg:44.74ms
+step:816/1575 train_time:36524ms step_avg:44.76ms
+step:817/1575 train_time:36586ms step_avg:44.78ms
+step:818/1575 train_time:36646ms step_avg:44.80ms
+step:819/1575 train_time:36709ms step_avg:44.82ms
+step:820/1575 train_time:36768ms step_avg:44.84ms
+step:821/1575 train_time:36833ms step_avg:44.86ms
+step:822/1575 train_time:36892ms step_avg:44.88ms
+step:823/1575 train_time:36955ms step_avg:44.90ms
+step:824/1575 train_time:37014ms step_avg:44.92ms
+step:825/1575 train_time:37078ms step_avg:44.94ms
+step:826/1575 train_time:37138ms step_avg:44.96ms
+step:827/1575 train_time:37201ms step_avg:44.98ms
+step:828/1575 train_time:37260ms step_avg:45.00ms
+step:829/1575 train_time:37324ms step_avg:45.02ms
+step:830/1575 train_time:37383ms step_avg:45.04ms
+step:831/1575 train_time:37447ms step_avg:45.06ms
+step:832/1575 train_time:37506ms step_avg:45.08ms
+step:833/1575 train_time:37569ms step_avg:45.10ms
+step:834/1575 train_time:37629ms step_avg:45.12ms
+step:835/1575 train_time:37692ms step_avg:45.14ms
+step:836/1575 train_time:37752ms step_avg:45.16ms
+step:837/1575 train_time:37815ms step_avg:45.18ms
+step:838/1575 train_time:37874ms step_avg:45.20ms
+step:839/1575 train_time:37937ms step_avg:45.22ms
+step:840/1575 train_time:37996ms step_avg:45.23ms
+step:841/1575 train_time:38060ms step_avg:45.26ms
+step:842/1575 train_time:38119ms step_avg:45.27ms
+step:843/1575 train_time:38183ms step_avg:45.29ms
+step:844/1575 train_time:38242ms step_avg:45.31ms
+step:845/1575 train_time:38306ms step_avg:45.33ms
+step:846/1575 train_time:38365ms step_avg:45.35ms
+step:847/1575 train_time:38429ms step_avg:45.37ms
+step:848/1575 train_time:38488ms step_avg:45.39ms
+step:849/1575 train_time:38553ms step_avg:45.41ms
+step:850/1575 train_time:38611ms step_avg:45.42ms
+step:851/1575 train_time:38675ms step_avg:45.45ms
+step:852/1575 train_time:38734ms step_avg:45.46ms
+step:853/1575 train_time:38798ms step_avg:45.48ms
+step:854/1575 train_time:38857ms step_avg:45.50ms
+step:855/1575 train_time:38920ms step_avg:45.52ms
+step:856/1575 train_time:38979ms step_avg:45.54ms
+step:857/1575 train_time:39042ms step_avg:45.56ms
+step:858/1575 train_time:39101ms step_avg:45.57ms
+step:859/1575 train_time:39165ms step_avg:45.59ms
+step:860/1575 train_time:39225ms step_avg:45.61ms
+step:861/1575 train_time:39288ms step_avg:45.63ms
+step:862/1575 train_time:39348ms step_avg:45.65ms
+step:863/1575 train_time:39411ms step_avg:45.67ms
+step:864/1575 train_time:39470ms step_avg:45.68ms
+step:865/1575 train_time:39534ms step_avg:45.70ms
+step:866/1575 train_time:39593ms step_avg:45.72ms
+step:867/1575 train_time:39658ms step_avg:45.74ms
+step:868/1575 train_time:39715ms step_avg:45.76ms
+step:869/1575 train_time:39779ms step_avg:45.78ms
+step:870/1575 train_time:39838ms step_avg:45.79ms
+step:871/1575 train_time:39902ms step_avg:45.81ms
+step:872/1575 train_time:39961ms step_avg:45.83ms
+step:873/1575 train_time:40025ms step_avg:45.85ms
+step:874/1575 train_time:40084ms step_avg:45.86ms
+step:875/1575 train_time:40147ms step_avg:45.88ms
+step:876/1575 train_time:40207ms step_avg:45.90ms
+step:877/1575 train_time:40270ms step_avg:45.92ms
+step:878/1575 train_time:40329ms step_avg:45.93ms
+step:879/1575 train_time:40393ms step_avg:45.95ms
+step:880/1575 train_time:40452ms step_avg:45.97ms
+step:881/1575 train_time:40515ms step_avg:45.99ms
+step:882/1575 train_time:40575ms step_avg:46.00ms
+step:883/1575 train_time:40638ms step_avg:46.02ms
+step:884/1575 train_time:40697ms step_avg:46.04ms
+step:885/1575 train_time:40760ms step_avg:46.06ms
+step:886/1575 train_time:40825ms step_avg:46.08ms
+step:887/1575 train_time:40885ms step_avg:46.09ms
+step:888/1575 train_time:40945ms step_avg:46.11ms
+step:889/1575 train_time:41009ms step_avg:46.13ms
+step:890/1575 train_time:41066ms step_avg:46.14ms
+step:891/1575 train_time:41129ms step_avg:46.16ms
+step:892/1575 train_time:41189ms step_avg:46.18ms
+step:893/1575 train_time:41252ms step_avg:46.19ms
+step:894/1575 train_time:41311ms step_avg:46.21ms
+step:895/1575 train_time:41375ms step_avg:46.23ms
+step:896/1575 train_time:41434ms step_avg:46.24ms
+step:897/1575 train_time:41497ms step_avg:46.26ms
+step:898/1575 train_time:41557ms step_avg:46.28ms
+step:899/1575 train_time:41622ms step_avg:46.30ms
+step:900/1575 train_time:41681ms step_avg:46.31ms
+step:901/1575 train_time:41743ms step_avg:46.33ms
+step:902/1575 train_time:41802ms step_avg:46.34ms
+step:903/1575 train_time:41865ms step_avg:46.36ms
+step:904/1575 train_time:41925ms step_avg:46.38ms
+step:905/1575 train_time:41988ms step_avg:46.40ms
+step:906/1575 train_time:42049ms step_avg:46.41ms
+step:907/1575 train_time:42112ms step_avg:46.43ms
+step:908/1575 train_time:42171ms step_avg:46.44ms
+step:909/1575 train_time:42234ms step_avg:46.46ms
+step:910/1575 train_time:42294ms step_avg:46.48ms
+step:911/1575 train_time:42357ms step_avg:46.50ms
+step:912/1575 train_time:42416ms step_avg:46.51ms
+step:913/1575 train_time:42479ms step_avg:46.53ms
+step:914/1575 train_time:42539ms step_avg:46.54ms
+step:915/1575 train_time:42603ms step_avg:46.56ms
+step:916/1575 train_time:42664ms step_avg:46.58ms
+step:917/1575 train_time:42726ms step_avg:46.59ms
+step:918/1575 train_time:42785ms step_avg:46.61ms
+step:919/1575 train_time:42849ms step_avg:46.63ms
+step:920/1575 train_time:42908ms step_avg:46.64ms
+step:921/1575 train_time:42972ms step_avg:46.66ms
+step:922/1575 train_time:43032ms step_avg:46.67ms
+step:923/1575 train_time:43096ms step_avg:46.69ms
+step:924/1575 train_time:43154ms step_avg:46.70ms
+step:925/1575 train_time:43217ms step_avg:46.72ms
+step:926/1575 train_time:43276ms step_avg:46.73ms
+step:927/1575 train_time:43340ms step_avg:46.75ms
+step:928/1575 train_time:43399ms step_avg:46.77ms
+step:929/1575 train_time:43462ms step_avg:46.78ms
+step:930/1575 train_time:43522ms step_avg:46.80ms
+step:931/1575 train_time:43585ms step_avg:46.82ms
+step:932/1575 train_time:43645ms step_avg:46.83ms
+step:933/1575 train_time:43708ms step_avg:46.85ms
+step:934/1575 train_time:43767ms step_avg:46.86ms
+step:935/1575 train_time:43831ms step_avg:46.88ms
+step:936/1575 train_time:43890ms step_avg:46.89ms
+step:937/1575 train_time:43954ms step_avg:46.91ms
+step:938/1575 train_time:44013ms step_avg:46.92ms
+step:939/1575 train_time:44077ms step_avg:46.94ms
+step:940/1575 train_time:44136ms step_avg:46.95ms
+step:941/1575 train_time:44199ms step_avg:46.97ms
+step:942/1575 train_time:44258ms step_avg:46.98ms
+step:943/1575 train_time:44323ms step_avg:47.00ms
+step:944/1575 train_time:44382ms step_avg:47.01ms
+step:945/1575 train_time:44445ms step_avg:47.03ms
+step:946/1575 train_time:44505ms step_avg:47.05ms
+step:947/1575 train_time:44567ms step_avg:47.06ms
+step:948/1575 train_time:44627ms step_avg:47.07ms
+step:949/1575 train_time:44690ms step_avg:47.09ms
+step:950/1575 train_time:44749ms step_avg:47.10ms
+step:951/1575 train_time:44812ms step_avg:47.12ms
+step:952/1575 train_time:44872ms step_avg:47.13ms
+step:953/1575 train_time:44936ms step_avg:47.15ms
+step:954/1575 train_time:44995ms step_avg:47.16ms
+step:955/1575 train_time:45058ms step_avg:47.18ms
+step:956/1575 train_time:45117ms step_avg:47.19ms
+step:957/1575 train_time:45181ms step_avg:47.21ms
+step:958/1575 train_time:45240ms step_avg:47.22ms
+step:959/1575 train_time:45303ms step_avg:47.24ms
+step:960/1575 train_time:45362ms step_avg:47.25ms
+step:961/1575 train_time:45426ms step_avg:47.27ms
+step:962/1575 train_time:45486ms step_avg:47.28ms
+step:963/1575 train_time:45549ms step_avg:47.30ms
+step:964/1575 train_time:45608ms step_avg:47.31ms
+step:965/1575 train_time:45672ms step_avg:47.33ms
+step:966/1575 train_time:45731ms step_avg:47.34ms
+step:967/1575 train_time:45794ms step_avg:47.36ms
+step:968/1575 train_time:45857ms step_avg:47.37ms
+step:969/1575 train_time:45918ms step_avg:47.39ms
+step:970/1575 train_time:45977ms step_avg:47.40ms
+step:971/1575 train_time:46041ms step_avg:47.42ms
+step:972/1575 train_time:46099ms step_avg:47.43ms
+step:973/1575 train_time:46164ms step_avg:47.44ms
+step:974/1575 train_time:46222ms step_avg:47.46ms
+step:975/1575 train_time:46286ms step_avg:47.47ms
+step:976/1575 train_time:46346ms step_avg:47.49ms
+step:977/1575 train_time:46409ms step_avg:47.50ms
+step:978/1575 train_time:46468ms step_avg:47.51ms
+step:979/1575 train_time:46531ms step_avg:47.53ms
+step:980/1575 train_time:46590ms step_avg:47.54ms
+step:981/1575 train_time:46653ms step_avg:47.56ms
+step:982/1575 train_time:46715ms step_avg:47.57ms
+step:983/1575 train_time:46777ms step_avg:47.59ms
+step:984/1575 train_time:46836ms step_avg:47.60ms
+step:985/1575 train_time:46899ms step_avg:47.61ms
+step:986/1575 train_time:46958ms step_avg:47.62ms
+step:987/1575 train_time:47021ms step_avg:47.64ms
+step:988/1575 train_time:47080ms step_avg:47.65ms
+step:989/1575 train_time:47143ms step_avg:47.67ms
+step:990/1575 train_time:47203ms step_avg:47.68ms
+step:991/1575 train_time:47266ms step_avg:47.70ms
+step:992/1575 train_time:47326ms step_avg:47.71ms
+step:993/1575 train_time:47389ms step_avg:47.72ms
+step:994/1575 train_time:47448ms step_avg:47.73ms
+step:995/1575 train_time:47512ms step_avg:47.75ms
+step:996/1575 train_time:47571ms step_avg:47.76ms
+step:997/1575 train_time:47634ms step_avg:47.78ms
+step:998/1575 train_time:47693ms step_avg:47.79ms
+step:999/1575 train_time:47757ms step_avg:47.80ms
+step:1000/1575 train_time:47816ms step_avg:47.82ms
+step:1000/1575 val_loss:3.5830 train_time:47862ms step_avg:47.86ms
+step:1001/1575 train_time:47884ms step_avg:47.84ms
+step:1002/1575 train_time:47944ms step_avg:47.85ms
+step:1003/1575 train_time:48012ms step_avg:47.87ms
+step:1004/1575 train_time:48075ms step_avg:47.88ms
+step:1005/1575 train_time:48138ms step_avg:47.90ms
+step:1006/1575 train_time:48198ms step_avg:47.91ms
+step:1007/1575 train_time:48262ms step_avg:47.93ms
+step:1008/1575 train_time:48322ms step_avg:47.94ms
+step:1009/1575 train_time:48385ms step_avg:47.95ms
+step:1010/1575 train_time:48444ms step_avg:47.96ms
+step:1011/1575 train_time:48507ms step_avg:47.98ms
+step:1012/1575 train_time:48566ms step_avg:47.99ms
+step:1013/1575 train_time:48630ms step_avg:48.01ms
+step:1014/1575 train_time:48688ms step_avg:48.02ms
+step:1015/1575 train_time:48750ms step_avg:48.03ms
+step:1016/1575 train_time:48810ms step_avg:48.04ms
+step:1017/1575 train_time:48873ms step_avg:48.06ms
+step:1018/1575 train_time:48934ms step_avg:48.07ms
+step:1019/1575 train_time:48999ms step_avg:48.09ms
+step:1020/1575 train_time:49058ms step_avg:48.10ms
+step:1021/1575 train_time:49123ms step_avg:48.11ms
+step:1022/1575 train_time:49183ms step_avg:48.12ms
+step:1023/1575 train_time:49245ms step_avg:48.14ms
+step:1024/1575 train_time:49305ms step_avg:48.15ms
+step:1025/1575 train_time:49380ms step_avg:48.18ms
+step:1026/1575 train_time:49459ms step_avg:48.21ms
+step:1027/1575 train_time:49549ms step_avg:48.25ms
+step:1028/1575 train_time:49636ms step_avg:48.28ms
+step:1029/1575 train_time:49724ms step_avg:48.32ms
+step:1030/1575 train_time:49811ms step_avg:48.36ms
+step:1031/1575 train_time:49900ms step_avg:48.40ms
+step:1032/1575 train_time:49986ms step_avg:48.44ms
+step:1033/1575 train_time:50078ms step_avg:48.48ms
+step:1034/1575 train_time:50164ms step_avg:48.51ms
+step:1035/1575 train_time:50254ms step_avg:48.56ms
+step:1036/1575 train_time:50341ms step_avg:48.59ms
+step:1037/1575 train_time:50432ms step_avg:48.63ms
+step:1038/1575 train_time:50516ms step_avg:48.67ms
+step:1039/1575 train_time:50605ms step_avg:48.71ms
+step:1040/1575 train_time:50690ms step_avg:48.74ms
+step:1041/1575 train_time:50780ms step_avg:48.78ms
+step:1042/1575 train_time:50868ms step_avg:48.82ms
+step:1043/1575 train_time:50961ms step_avg:48.86ms
+step:1044/1575 train_time:51046ms step_avg:48.89ms
+step:1045/1575 train_time:51134ms step_avg:48.93ms
+step:1046/1575 train_time:51220ms step_avg:48.97ms
+step:1047/1575 train_time:51310ms step_avg:49.01ms
+step:1048/1575 train_time:51395ms step_avg:49.04ms
+step:1049/1575 train_time:51485ms step_avg:49.08ms
+step:1050/1575 train_time:51570ms step_avg:49.11ms
+step:1051/1575 train_time:51661ms step_avg:49.15ms
+step:1052/1575 train_time:51746ms step_avg:49.19ms
+step:1053/1575 train_time:51835ms step_avg:49.23ms
+step:1054/1575 train_time:51922ms step_avg:49.26ms
+step:1055/1575 train_time:52011ms step_avg:49.30ms
+step:1056/1575 train_time:52098ms step_avg:49.33ms
+step:1057/1575 train_time:52187ms step_avg:49.37ms
+step:1058/1575 train_time:52273ms step_avg:49.41ms
+step:1059/1575 train_time:52362ms step_avg:49.44ms
+step:1060/1575 train_time:52450ms step_avg:49.48ms
+step:1061/1575 train_time:52538ms step_avg:49.52ms
+step:1062/1575 train_time:52624ms step_avg:49.55ms
+step:1063/1575 train_time:52714ms step_avg:49.59ms
+step:1064/1575 train_time:52800ms step_avg:49.62ms
+step:1065/1575 train_time:52889ms step_avg:49.66ms
+step:1066/1575 train_time:52976ms step_avg:49.70ms
+step:1067/1575 train_time:53065ms step_avg:49.73ms
+step:1068/1575 train_time:53152ms step_avg:49.77ms
+step:1069/1575 train_time:53241ms step_avg:49.80ms
+step:1070/1575 train_time:53327ms step_avg:49.84ms
+step:1071/1575 train_time:53419ms step_avg:49.88ms
+step:1072/1575 train_time:53503ms step_avg:49.91ms
+step:1073/1575 train_time:53592ms step_avg:49.95ms
+step:1074/1575 train_time:53679ms step_avg:49.98ms
+step:1075/1575 train_time:53768ms step_avg:50.02ms
+step:1076/1575 train_time:53854ms step_avg:50.05ms
+step:1077/1575 train_time:53943ms step_avg:50.09ms
+step:1078/1575 train_time:54029ms step_avg:50.12ms
+step:1079/1575 train_time:54119ms step_avg:50.16ms
+step:1080/1575 train_time:54204ms step_avg:50.19ms
+step:1081/1575 train_time:54294ms step_avg:50.23ms
+step:1082/1575 train_time:54380ms step_avg:50.26ms
+step:1083/1575 train_time:54469ms step_avg:50.29ms
+step:1084/1575 train_time:54555ms step_avg:50.33ms
+step:1085/1575 train_time:54645ms step_avg:50.36ms
+step:1086/1575 train_time:54731ms step_avg:50.40ms
+step:1087/1575 train_time:54820ms step_avg:50.43ms
+step:1088/1575 train_time:54906ms step_avg:50.46ms
+step:1089/1575 train_time:54996ms step_avg:50.50ms
+step:1090/1575 train_time:55082ms step_avg:50.53ms
+step:1091/1575 train_time:55172ms step_avg:50.57ms
+step:1092/1575 train_time:55257ms step_avg:50.60ms
+step:1093/1575 train_time:55349ms step_avg:50.64ms
+step:1094/1575 train_time:55433ms step_avg:50.67ms
+step:1095/1575 train_time:55523ms step_avg:50.71ms
+step:1096/1575 train_time:55608ms step_avg:50.74ms
+step:1097/1575 train_time:55699ms step_avg:50.77ms
+step:1098/1575 train_time:55784ms step_avg:50.80ms
+step:1099/1575 train_time:55873ms step_avg:50.84ms
+step:1100/1575 train_time:55959ms step_avg:50.87ms
+step:1101/1575 train_time:56051ms step_avg:50.91ms
+step:1102/1575 train_time:56137ms step_avg:50.94ms
+step:1103/1575 train_time:56224ms step_avg:50.97ms
+step:1104/1575 train_time:56310ms step_avg:51.01ms
+step:1105/1575 train_time:56399ms step_avg:51.04ms
+step:1106/1575 train_time:56485ms step_avg:51.07ms
+step:1107/1575 train_time:56574ms step_avg:51.11ms
+step:1108/1575 train_time:56660ms step_avg:51.14ms
+step:1109/1575 train_time:56749ms step_avg:51.17ms
+step:1110/1575 train_time:56835ms step_avg:51.20ms
+step:1111/1575 train_time:56924ms step_avg:51.24ms
+step:1112/1575 train_time:57011ms step_avg:51.27ms
+step:1113/1575 train_time:57100ms step_avg:51.30ms
+step:1114/1575 train_time:57186ms step_avg:51.33ms
+step:1115/1575 train_time:57276ms step_avg:51.37ms
+step:1116/1575 train_time:57362ms step_avg:51.40ms
+step:1117/1575 train_time:57452ms step_avg:51.43ms
+step:1118/1575 train_time:57536ms step_avg:51.46ms
+step:1119/1575 train_time:57627ms step_avg:51.50ms
+step:1120/1575 train_time:57712ms step_avg:51.53ms
+step:1121/1575 train_time:57802ms step_avg:51.56ms
+step:1122/1575 train_time:57887ms step_avg:51.59ms
+step:1123/1575 train_time:57977ms step_avg:51.63ms
+step:1124/1575 train_time:58062ms step_avg:51.66ms
+step:1125/1575 train_time:58152ms step_avg:51.69ms
+step:1126/1575 train_time:58238ms step_avg:51.72ms
+step:1127/1575 train_time:58328ms step_avg:51.76ms
+step:1128/1575 train_time:58421ms step_avg:51.79ms
+step:1129/1575 train_time:58505ms step_avg:51.82ms
+step:1130/1575 train_time:58590ms step_avg:51.85ms
+step:1131/1575 train_time:58679ms step_avg:51.88ms
+step:1132/1575 train_time:58767ms step_avg:51.91ms
+step:1133/1575 train_time:58855ms step_avg:51.95ms
+step:1134/1575 train_time:58941ms step_avg:51.98ms
+step:1135/1575 train_time:59030ms step_avg:52.01ms
+step:1136/1575 train_time:59116ms step_avg:52.04ms
+step:1137/1575 train_time:59205ms step_avg:52.07ms
+step:1138/1575 train_time:59291ms step_avg:52.10ms
+step:1139/1575 train_time:59381ms step_avg:52.13ms
+step:1140/1575 train_time:59467ms step_avg:52.16ms
+step:1141/1575 train_time:59560ms step_avg:52.20ms
+step:1142/1575 train_time:59642ms step_avg:52.23ms
+step:1143/1575 train_time:59732ms step_avg:52.26ms
+step:1144/1575 train_time:59817ms step_avg:52.29ms
+step:1145/1575 train_time:59905ms step_avg:52.32ms
+step:1146/1575 train_time:59996ms step_avg:52.35ms
+step:1147/1575 train_time:60083ms step_avg:52.38ms
+step:1148/1575 train_time:60169ms step_avg:52.41ms
+step:1149/1575 train_time:60260ms step_avg:52.45ms
+step:1150/1575 train_time:60345ms step_avg:52.47ms
+step:1151/1575 train_time:60434ms step_avg:52.51ms
+step:1152/1575 train_time:60520ms step_avg:52.53ms
+step:1153/1575 train_time:60609ms step_avg:52.57ms
+step:1154/1575 train_time:60695ms step_avg:52.60ms
+step:1155/1575 train_time:60784ms step_avg:52.63ms
+step:1156/1575 train_time:60871ms step_avg:52.66ms
+step:1157/1575 train_time:60960ms step_avg:52.69ms
+step:1158/1575 train_time:61046ms step_avg:52.72ms
+step:1159/1575 train_time:61136ms step_avg:52.75ms
+step:1160/1575 train_time:61223ms step_avg:52.78ms
+step:1161/1575 train_time:61313ms step_avg:52.81ms
+step:1162/1575 train_time:61397ms step_avg:52.84ms
+step:1163/1575 train_time:61486ms step_avg:52.87ms
+step:1164/1575 train_time:61572ms step_avg:52.90ms
+step:1165/1575 train_time:61662ms step_avg:52.93ms
+step:1166/1575 train_time:61747ms step_avg:52.96ms
+step:1167/1575 train_time:61837ms step_avg:52.99ms
+step:1168/1575 train_time:61923ms step_avg:53.02ms
+step:1169/1575 train_time:62013ms step_avg:53.05ms
+step:1170/1575 train_time:62098ms step_avg:53.08ms
+step:1171/1575 train_time:62188ms step_avg:53.11ms
+step:1172/1575 train_time:62274ms step_avg:53.13ms
+step:1173/1575 train_time:62364ms step_avg:53.17ms
+step:1174/1575 train_time:62449ms step_avg:53.19ms
+step:1175/1575 train_time:62540ms step_avg:53.23ms
+step:1176/1575 train_time:62625ms step_avg:53.25ms
+step:1177/1575 train_time:62714ms step_avg:53.28ms
+step:1178/1575 train_time:62801ms step_avg:53.31ms
+step:1179/1575 train_time:62890ms step_avg:53.34ms
+step:1180/1575 train_time:62976ms step_avg:53.37ms
+step:1181/1575 train_time:63065ms step_avg:53.40ms
+step:1182/1575 train_time:63152ms step_avg:53.43ms
+step:1183/1575 train_time:63242ms step_avg:53.46ms
+step:1184/1575 train_time:63329ms step_avg:53.49ms
+step:1185/1575 train_time:63418ms step_avg:53.52ms
+step:1186/1575 train_time:63504ms step_avg:53.54ms
+step:1187/1575 train_time:63593ms step_avg:53.57ms
+step:1188/1575 train_time:63679ms step_avg:53.60ms
+step:1189/1575 train_time:63768ms step_avg:53.63ms
+step:1190/1575 train_time:63854ms step_avg:53.66ms
+step:1191/1575 train_time:63943ms step_avg:53.69ms
+step:1192/1575 train_time:64029ms step_avg:53.72ms
+step:1193/1575 train_time:64119ms step_avg:53.75ms
+step:1194/1575 train_time:64205ms step_avg:53.77ms
+step:1195/1575 train_time:64295ms step_avg:53.80ms
+step:1196/1575 train_time:64380ms step_avg:53.83ms
+step:1197/1575 train_time:64470ms step_avg:53.86ms
+step:1198/1575 train_time:64556ms step_avg:53.89ms
+step:1199/1575 train_time:64645ms step_avg:53.92ms
+step:1200/1575 train_time:64732ms step_avg:53.94ms
+step:1201/1575 train_time:64822ms step_avg:53.97ms
+step:1202/1575 train_time:64906ms step_avg:54.00ms
+step:1203/1575 train_time:64996ms step_avg:54.03ms
+step:1204/1575 train_time:65082ms step_avg:54.05ms
+step:1205/1575 train_time:65172ms step_avg:54.08ms
+step:1206/1575 train_time:65257ms step_avg:54.11ms
+step:1207/1575 train_time:65346ms step_avg:54.14ms
+step:1208/1575 train_time:65433ms step_avg:54.17ms
+step:1209/1575 train_time:65522ms step_avg:54.20ms
+step:1210/1575 train_time:65608ms step_avg:54.22ms
+step:1211/1575 train_time:65698ms step_avg:54.25ms
+step:1212/1575 train_time:65784ms step_avg:54.28ms
+step:1213/1575 train_time:65873ms step_avg:54.31ms
+step:1214/1575 train_time:65959ms step_avg:54.33ms
+step:1215/1575 train_time:66048ms step_avg:54.36ms
+step:1216/1575 train_time:66135ms step_avg:54.39ms
+step:1217/1575 train_time:66224ms step_avg:54.42ms
+step:1218/1575 train_time:66311ms step_avg:54.44ms
+step:1219/1575 train_time:66401ms step_avg:54.47ms
+step:1220/1575 train_time:66486ms step_avg:54.50ms
+step:1221/1575 train_time:66575ms step_avg:54.53ms
+step:1222/1575 train_time:66661ms step_avg:54.55ms
+step:1223/1575 train_time:66751ms step_avg:54.58ms
+step:1224/1575 train_time:66838ms step_avg:54.61ms
+step:1225/1575 train_time:66926ms step_avg:54.63ms
+step:1226/1575 train_time:67011ms step_avg:54.66ms
+step:1227/1575 train_time:67101ms step_avg:54.69ms
+step:1228/1575 train_time:67187ms step_avg:54.71ms
+step:1229/1575 train_time:67277ms step_avg:54.74ms
+step:1230/1575 train_time:67362ms step_avg:54.77ms
+step:1231/1575 train_time:67452ms step_avg:54.79ms
+step:1232/1575 train_time:67537ms step_avg:54.82ms
+step:1233/1575 train_time:67626ms step_avg:54.85ms
+step:1234/1575 train_time:67713ms step_avg:54.87ms
+step:1235/1575 train_time:67802ms step_avg:54.90ms
+step:1236/1575 train_time:67888ms step_avg:54.93ms
+step:1237/1575 train_time:67978ms step_avg:54.95ms
+step:1238/1575 train_time:68062ms step_avg:54.98ms
+step:1239/1575 train_time:68152ms step_avg:55.01ms
+step:1240/1575 train_time:68237ms step_avg:55.03ms
+step:1241/1575 train_time:68328ms step_avg:55.06ms
+step:1242/1575 train_time:68415ms step_avg:55.08ms
+step:1243/1575 train_time:68503ms step_avg:55.11ms
+step:1244/1575 train_time:68589ms step_avg:55.14ms
+step:1245/1575 train_time:68679ms step_avg:55.16ms
+step:1246/1575 train_time:68764ms step_avg:55.19ms
+step:1247/1575 train_time:68854ms step_avg:55.22ms
+step:1248/1575 train_time:68940ms step_avg:55.24ms
+step:1249/1575 train_time:69029ms step_avg:55.27ms
+step:1250/1575 train_time:69115ms step_avg:55.29ms
+step:1250/1575 val_loss:3.4050 train_time:69187ms step_avg:55.35ms
+step:1251/1575 train_time:69209ms step_avg:55.32ms
+step:1252/1575 train_time:69296ms step_avg:55.35ms
+step:1253/1575 train_time:69388ms step_avg:55.38ms
+step:1254/1575 train_time:69476ms step_avg:55.40ms
+step:1255/1575 train_time:69563ms step_avg:55.43ms
+step:1256/1575 train_time:69649ms step_avg:55.45ms
+step:1257/1575 train_time:69736ms step_avg:55.48ms
+step:1258/1575 train_time:69821ms step_avg:55.50ms
+step:1259/1575 train_time:69910ms step_avg:55.53ms
+step:1260/1575 train_time:69994ms step_avg:55.55ms
+step:1261/1575 train_time:70082ms step_avg:55.58ms
+step:1262/1575 train_time:70168ms step_avg:55.60ms
+step:1263/1575 train_time:70261ms step_avg:55.63ms
+step:1264/1575 train_time:70349ms step_avg:55.66ms
+step:1265/1575 train_time:70440ms step_avg:55.68ms
+step:1266/1575 train_time:70527ms step_avg:55.71ms
+step:1267/1575 train_time:70617ms step_avg:55.74ms
+step:1268/1575 train_time:70701ms step_avg:55.76ms
+step:1269/1575 train_time:70790ms step_avg:55.78ms
+step:1270/1575 train_time:70875ms step_avg:55.81ms
+step:1271/1575 train_time:70964ms step_avg:55.83ms
+step:1272/1575 train_time:71048ms step_avg:55.86ms
+step:1273/1575 train_time:71137ms step_avg:55.88ms
+step:1274/1575 train_time:71224ms step_avg:55.91ms
+step:1275/1575 train_time:71315ms step_avg:55.93ms
+step:1276/1575 train_time:71401ms step_avg:55.96ms
+step:1277/1575 train_time:71491ms step_avg:55.98ms
+step:1278/1575 train_time:71578ms step_avg:56.01ms
+step:1279/1575 train_time:71667ms step_avg:56.03ms
+step:1280/1575 train_time:71751ms step_avg:56.06ms
+step:1281/1575 train_time:71841ms step_avg:56.08ms
+step:1282/1575 train_time:71926ms step_avg:56.10ms
+step:1283/1575 train_time:72014ms step_avg:56.13ms
+step:1284/1575 train_time:72099ms step_avg:56.15ms
+step:1285/1575 train_time:72188ms step_avg:56.18ms
+step:1286/1575 train_time:72275ms step_avg:56.20ms
+step:1287/1575 train_time:72365ms step_avg:56.23ms
+step:1288/1575 train_time:72452ms step_avg:56.25ms
+step:1289/1575 train_time:72541ms step_avg:56.28ms
+step:1290/1575 train_time:72627ms step_avg:56.30ms
+step:1291/1575 train_time:72716ms step_avg:56.33ms
+step:1292/1575 train_time:72801ms step_avg:56.35ms
+step:1293/1575 train_time:72889ms step_avg:56.37ms
+step:1294/1575 train_time:72976ms step_avg:56.40ms
+step:1295/1575 train_time:73065ms step_avg:56.42ms
+step:1296/1575 train_time:73151ms step_avg:56.44ms
+step:1297/1575 train_time:73241ms step_avg:56.47ms
+step:1298/1575 train_time:73327ms step_avg:56.49ms
+step:1299/1575 train_time:73418ms step_avg:56.52ms
+step:1300/1575 train_time:73504ms step_avg:56.54ms
+step:1301/1575 train_time:73594ms step_avg:56.57ms
+step:1302/1575 train_time:73679ms step_avg:56.59ms
+step:1303/1575 train_time:73769ms step_avg:56.61ms
+step:1304/1575 train_time:73854ms step_avg:56.64ms
+step:1305/1575 train_time:73942ms step_avg:56.66ms
+step:1306/1575 train_time:74028ms step_avg:56.68ms
+step:1307/1575 train_time:74119ms step_avg:56.71ms
+step:1308/1575 train_time:74204ms step_avg:56.73ms
+step:1309/1575 train_time:74294ms step_avg:56.76ms
+step:1310/1575 train_time:74380ms step_avg:56.78ms
+step:1311/1575 train_time:74470ms step_avg:56.80ms
+step:1312/1575 train_time:74556ms step_avg:56.83ms
+step:1313/1575 train_time:74645ms step_avg:56.85ms
+step:1314/1575 train_time:74732ms step_avg:56.87ms
+step:1315/1575 train_time:74822ms step_avg:56.90ms
+step:1316/1575 train_time:74907ms step_avg:56.92ms
+step:1317/1575 train_time:74996ms step_avg:56.94ms
+step:1318/1575 train_time:75082ms step_avg:56.97ms
+step:1319/1575 train_time:75171ms step_avg:56.99ms
+step:1320/1575 train_time:75256ms step_avg:57.01ms
+step:1321/1575 train_time:75345ms step_avg:57.04ms
+step:1322/1575 train_time:75431ms step_avg:57.06ms
+step:1323/1575 train_time:75522ms step_avg:57.08ms
+step:1324/1575 train_time:75607ms step_avg:57.11ms
+step:1325/1575 train_time:75698ms step_avg:57.13ms
+step:1326/1575 train_time:75785ms step_avg:57.15ms
+step:1327/1575 train_time:75873ms step_avg:57.18ms
+step:1328/1575 train_time:75958ms step_avg:57.20ms
+step:1329/1575 train_time:76046ms step_avg:57.22ms
+step:1330/1575 train_time:76132ms step_avg:57.24ms
+step:1331/1575 train_time:76222ms step_avg:57.27ms
+step:1332/1575 train_time:76310ms step_avg:57.29ms
+step:1333/1575 train_time:76397ms step_avg:57.31ms
+step:1334/1575 train_time:76483ms step_avg:57.33ms
+step:1335/1575 train_time:76573ms step_avg:57.36ms
+step:1336/1575 train_time:76658ms step_avg:57.38ms
+step:1337/1575 train_time:76748ms step_avg:57.40ms
+step:1338/1575 train_time:76834ms step_avg:57.42ms
+step:1339/1575 train_time:76923ms step_avg:57.45ms
+step:1340/1575 train_time:77009ms step_avg:57.47ms
+step:1341/1575 train_time:77098ms step_avg:57.49ms
+step:1342/1575 train_time:77183ms step_avg:57.51ms
+step:1343/1575 train_time:77273ms step_avg:57.54ms
+step:1344/1575 train_time:77358ms step_avg:57.56ms
+step:1345/1575 train_time:77448ms step_avg:57.58ms
+step:1346/1575 train_time:77534ms step_avg:57.60ms
+step:1347/1575 train_time:77624ms step_avg:57.63ms
+step:1348/1575 train_time:77710ms step_avg:57.65ms
+step:1349/1575 train_time:77800ms step_avg:57.67ms
+step:1350/1575 train_time:77886ms step_avg:57.69ms
+step:1351/1575 train_time:77976ms step_avg:57.72ms
+step:1352/1575 train_time:78060ms step_avg:57.74ms
+step:1353/1575 train_time:78149ms step_avg:57.76ms
+step:1354/1575 train_time:78236ms step_avg:57.78ms
+step:1355/1575 train_time:78325ms step_avg:57.80ms
+step:1356/1575 train_time:78411ms step_avg:57.83ms
+step:1357/1575 train_time:78500ms step_avg:57.85ms
+step:1358/1575 train_time:78591ms step_avg:57.87ms
+step:1359/1575 train_time:78679ms step_avg:57.89ms
+step:1360/1575 train_time:78765ms step_avg:57.92ms
+step:1361/1575 train_time:78853ms step_avg:57.94ms
+step:1362/1575 train_time:78938ms step_avg:57.96ms
+step:1363/1575 train_time:79028ms step_avg:57.98ms
+step:1364/1575 train_time:79113ms step_avg:58.00ms
+step:1365/1575 train_time:79203ms step_avg:58.02ms
+step:1366/1575 train_time:79289ms step_avg:58.04ms
+step:1367/1575 train_time:79379ms step_avg:58.07ms
+step:1368/1575 train_time:79466ms step_avg:58.09ms
+step:1369/1575 train_time:79555ms step_avg:58.11ms
+step:1370/1575 train_time:79640ms step_avg:58.13ms
+step:1371/1575 train_time:79730ms step_avg:58.15ms
+step:1372/1575 train_time:79817ms step_avg:58.18ms
+step:1373/1575 train_time:79906ms step_avg:58.20ms
+step:1374/1575 train_time:79991ms step_avg:58.22ms
+step:1375/1575 train_time:80082ms step_avg:58.24ms
+step:1376/1575 train_time:80168ms step_avg:58.26ms
+step:1377/1575 train_time:80257ms step_avg:58.28ms
+step:1378/1575 train_time:80342ms step_avg:58.30ms
+step:1379/1575 train_time:80431ms step_avg:58.33ms
+step:1380/1575 train_time:80517ms step_avg:58.35ms
+step:1381/1575 train_time:80606ms step_avg:58.37ms
+step:1382/1575 train_time:80692ms step_avg:58.39ms
+step:1383/1575 train_time:80782ms step_avg:58.41ms
+step:1384/1575 train_time:80870ms step_avg:58.43ms
+step:1385/1575 train_time:80958ms step_avg:58.45ms
+step:1386/1575 train_time:81044ms step_avg:58.47ms
+step:1387/1575 train_time:81136ms step_avg:58.50ms
+step:1388/1575 train_time:81220ms step_avg:58.52ms
+step:1389/1575 train_time:81308ms step_avg:58.54ms
+step:1390/1575 train_time:81395ms step_avg:58.56ms
+step:1391/1575 train_time:81484ms step_avg:58.58ms
+step:1392/1575 train_time:81570ms step_avg:58.60ms
+step:1393/1575 train_time:81660ms step_avg:58.62ms
+step:1394/1575 train_time:81745ms step_avg:58.64ms
+step:1395/1575 train_time:81835ms step_avg:58.66ms
+step:1396/1575 train_time:81920ms step_avg:58.68ms
+step:1397/1575 train_time:82009ms step_avg:58.70ms
+step:1398/1575 train_time:82095ms step_avg:58.72ms
+step:1399/1575 train_time:82184ms step_avg:58.74ms
+step:1400/1575 train_time:82269ms step_avg:58.76ms
+step:1401/1575 train_time:82360ms step_avg:58.79ms
+step:1402/1575 train_time:82446ms step_avg:58.81ms
+step:1403/1575 train_time:82536ms step_avg:58.83ms
+step:1404/1575 train_time:82621ms step_avg:58.85ms
+step:1405/1575 train_time:82711ms step_avg:58.87ms
+step:1406/1575 train_time:82796ms step_avg:58.89ms
+step:1407/1575 train_time:82886ms step_avg:58.91ms
+step:1408/1575 train_time:82973ms step_avg:58.93ms
+step:1409/1575 train_time:83061ms step_avg:58.95ms
+step:1410/1575 train_time:83147ms step_avg:58.97ms
+step:1411/1575 train_time:83236ms step_avg:58.99ms
+step:1412/1575 train_time:83322ms step_avg:59.01ms
+step:1413/1575 train_time:83412ms step_avg:59.03ms
+step:1414/1575 train_time:83497ms step_avg:59.05ms
+step:1415/1575 train_time:83587ms step_avg:59.07ms
+step:1416/1575 train_time:83674ms step_avg:59.09ms
+step:1417/1575 train_time:83763ms step_avg:59.11ms
+step:1418/1575 train_time:83849ms step_avg:59.13ms
+step:1419/1575 train_time:83939ms step_avg:59.15ms
+step:1420/1575 train_time:84025ms step_avg:59.17ms
+step:1421/1575 train_time:84114ms step_avg:59.19ms
+step:1422/1575 train_time:84199ms step_avg:59.21ms
+step:1423/1575 train_time:84291ms step_avg:59.23ms
+step:1424/1575 train_time:84377ms step_avg:59.25ms
+step:1425/1575 train_time:84466ms step_avg:59.27ms
+step:1426/1575 train_time:84551ms step_avg:59.29ms
+step:1427/1575 train_time:84641ms step_avg:59.31ms
+step:1428/1575 train_time:84726ms step_avg:59.33ms
+step:1429/1575 train_time:84816ms step_avg:59.35ms
+step:1430/1575 train_time:84901ms step_avg:59.37ms
+step:1431/1575 train_time:84992ms step_avg:59.39ms
+step:1432/1575 train_time:85076ms step_avg:59.41ms
+step:1433/1575 train_time:85166ms step_avg:59.43ms
+step:1434/1575 train_time:85252ms step_avg:59.45ms
+step:1435/1575 train_time:85342ms step_avg:59.47ms
+step:1436/1575 train_time:85428ms step_avg:59.49ms
+step:1437/1575 train_time:85518ms step_avg:59.51ms
+step:1438/1575 train_time:85603ms step_avg:59.53ms
+step:1439/1575 train_time:85693ms step_avg:59.55ms
+step:1440/1575 train_time:85778ms step_avg:59.57ms
+step:1441/1575 train_time:85867ms step_avg:59.59ms
+step:1442/1575 train_time:85955ms step_avg:59.61ms
+step:1443/1575 train_time:86043ms step_avg:59.63ms
+step:1444/1575 train_time:86128ms step_avg:59.65ms
+step:1445/1575 train_time:86217ms step_avg:59.67ms
+step:1446/1575 train_time:86303ms step_avg:59.68ms
+step:1447/1575 train_time:86393ms step_avg:59.70ms
+step:1448/1575 train_time:86479ms step_avg:59.72ms
+step:1449/1575 train_time:86568ms step_avg:59.74ms
+step:1450/1575 train_time:86655ms step_avg:59.76ms
+step:1451/1575 train_time:86744ms step_avg:59.78ms
+step:1452/1575 train_time:86830ms step_avg:59.80ms
+step:1453/1575 train_time:86920ms step_avg:59.82ms
+step:1454/1575 train_time:87005ms step_avg:59.84ms
+step:1455/1575 train_time:87095ms step_avg:59.86ms
+step:1456/1575 train_time:87180ms step_avg:59.88ms
+step:1457/1575 train_time:87270ms step_avg:59.90ms
+step:1458/1575 train_time:87355ms step_avg:59.91ms
+step:1459/1575 train_time:87444ms step_avg:59.93ms
+step:1460/1575 train_time:87530ms step_avg:59.95ms
+step:1461/1575 train_time:87620ms step_avg:59.97ms
+step:1462/1575 train_time:87706ms step_avg:59.99ms
+step:1463/1575 train_time:87794ms step_avg:60.01ms
+step:1464/1575 train_time:87880ms step_avg:60.03ms
+step:1465/1575 train_time:87969ms step_avg:60.05ms
+step:1466/1575 train_time:88054ms step_avg:60.06ms
+step:1467/1575 train_time:88144ms step_avg:60.08ms
+step:1468/1575 train_time:88229ms step_avg:60.10ms
+step:1469/1575 train_time:88319ms step_avg:60.12ms
+step:1470/1575 train_time:88405ms step_avg:60.14ms
+step:1471/1575 train_time:88494ms step_avg:60.16ms
+step:1472/1575 train_time:88580ms step_avg:60.18ms
+step:1473/1575 train_time:88670ms step_avg:60.20ms
+step:1474/1575 train_time:88756ms step_avg:60.21ms
+step:1475/1575 train_time:88845ms step_avg:60.23ms
+step:1476/1575 train_time:88930ms step_avg:60.25ms
+step:1477/1575 train_time:89020ms step_avg:60.27ms
+step:1478/1575 train_time:89106ms step_avg:60.29ms
+step:1479/1575 train_time:89196ms step_avg:60.31ms
+step:1480/1575 train_time:89281ms step_avg:60.33ms
+step:1481/1575 train_time:89371ms step_avg:60.34ms
+step:1482/1575 train_time:89456ms step_avg:60.36ms
+step:1483/1575 train_time:89546ms step_avg:60.38ms
+step:1484/1575 train_time:89631ms step_avg:60.40ms
+step:1485/1575 train_time:89723ms step_avg:60.42ms
+step:1486/1575 train_time:89808ms step_avg:60.44ms
+step:1487/1575 train_time:89898ms step_avg:60.46ms
+step:1488/1575 train_time:89985ms step_avg:60.47ms
+step:1489/1575 train_time:90073ms step_avg:60.49ms
+step:1490/1575 train_time:90158ms step_avg:60.51ms
+step:1491/1575 train_time:90247ms step_avg:60.53ms
+step:1492/1575 train_time:90333ms step_avg:60.55ms
+step:1493/1575 train_time:90423ms step_avg:60.56ms
+step:1494/1575 train_time:90509ms step_avg:60.58ms
+step:1495/1575 train_time:90598ms step_avg:60.60ms
+step:1496/1575 train_time:90684ms step_avg:60.62ms
+step:1497/1575 train_time:90773ms step_avg:60.64ms
+step:1498/1575 train_time:90859ms step_avg:60.65ms
+step:1499/1575 train_time:90948ms step_avg:60.67ms
+step:1500/1575 train_time:91037ms step_avg:60.69ms
+step:1500/1575 val_loss:3.2993 train_time:91107ms step_avg:60.74ms
+step:1501/1575 train_time:91128ms step_avg:60.71ms
+step:1502/1575 train_time:91216ms step_avg:60.73ms
+step:1503/1575 train_time:91310ms step_avg:60.75ms
+step:1504/1575 train_time:91398ms step_avg:60.77ms
+step:1505/1575 train_time:91486ms step_avg:60.79ms
+step:1506/1575 train_time:91572ms step_avg:60.80ms
+step:1507/1575 train_time:91660ms step_avg:60.82ms
+step:1508/1575 train_time:91744ms step_avg:60.84ms
+step:1509/1575 train_time:91832ms step_avg:60.86ms
+step:1510/1575 train_time:91917ms step_avg:60.87ms
+step:1511/1575 train_time:92005ms step_avg:60.89ms
+step:1512/1575 train_time:92090ms step_avg:60.91ms
+step:1513/1575 train_time:92182ms step_avg:60.93ms
+step:1514/1575 train_time:92270ms step_avg:60.94ms
+step:1515/1575 train_time:92361ms step_avg:60.96ms
+step:1516/1575 train_time:92448ms step_avg:60.98ms
+step:1517/1575 train_time:92537ms step_avg:61.00ms
+step:1518/1575 train_time:92622ms step_avg:61.02ms
+step:1519/1575 train_time:92710ms step_avg:61.03ms
+step:1520/1575 train_time:92796ms step_avg:61.05ms
+step:1521/1575 train_time:92884ms step_avg:61.07ms
+step:1522/1575 train_time:92968ms step_avg:61.08ms
+step:1523/1575 train_time:93059ms step_avg:61.10ms
+step:1524/1575 train_time:93147ms step_avg:61.12ms
+step:1525/1575 train_time:93235ms step_avg:61.14ms
+step:1526/1575 train_time:93321ms step_avg:61.15ms
+step:1527/1575 train_time:93412ms step_avg:61.17ms
+step:1528/1575 train_time:93500ms step_avg:61.19ms
+step:1529/1575 train_time:93589ms step_avg:61.21ms
+step:1530/1575 train_time:93674ms step_avg:61.22ms
+step:1531/1575 train_time:93762ms step_avg:61.24ms
+step:1532/1575 train_time:93848ms step_avg:61.26ms
+step:1533/1575 train_time:93937ms step_avg:61.28ms
+step:1534/1575 train_time:94022ms step_avg:61.29ms
+step:1535/1575 train_time:94113ms step_avg:61.31ms
+step:1536/1575 train_time:94208ms step_avg:61.33ms
+step:1537/1575 train_time:94294ms step_avg:61.35ms
+step:1538/1575 train_time:94380ms step_avg:61.37ms
+step:1539/1575 train_time:94470ms step_avg:61.38ms
+step:1540/1575 train_time:94557ms step_avg:61.40ms
+step:1541/1575 train_time:94646ms step_avg:61.42ms
+step:1542/1575 train_time:94732ms step_avg:61.43ms
+step:1543/1575 train_time:94821ms step_avg:61.45ms
+step:1544/1575 train_time:94907ms step_avg:61.47ms
+step:1545/1575 train_time:94998ms step_avg:61.49ms
+step:1546/1575 train_time:95083ms step_avg:61.50ms
+step:1547/1575 train_time:95174ms step_avg:61.52ms
+step:1548/1575 train_time:95260ms step_avg:61.54ms
+step:1549/1575 train_time:95351ms step_avg:61.56ms
+step:1550/1575 train_time:95437ms step_avg:61.57ms
+step:1551/1575 train_time:95527ms step_avg:61.59ms
+step:1552/1575 train_time:95614ms step_avg:61.61ms
+step:1553/1575 train_time:95702ms step_avg:61.62ms
+step:1554/1575 train_time:95787ms step_avg:61.64ms
+step:1555/1575 train_time:95877ms step_avg:61.66ms
+step:1556/1575 train_time:95962ms step_avg:61.67ms
+step:1557/1575 train_time:96052ms step_avg:61.69ms
+step:1558/1575 train_time:96138ms step_avg:61.71ms
+step:1559/1575 train_time:96228ms step_avg:61.72ms
+step:1560/1575 train_time:96314ms step_avg:61.74ms
+step:1561/1575 train_time:96404ms step_avg:61.76ms
+step:1562/1575 train_time:96491ms step_avg:61.77ms
+step:1563/1575 train_time:96581ms step_avg:61.79ms
+step:1564/1575 train_time:96666ms step_avg:61.81ms
+step:1565/1575 train_time:96757ms step_avg:61.83ms
+step:1566/1575 train_time:96843ms step_avg:61.84ms
+step:1567/1575 train_time:96932ms step_avg:61.86ms
+step:1568/1575 train_time:97018ms step_avg:61.87ms
+step:1569/1575 train_time:97114ms step_avg:61.90ms
+step:1570/1575 train_time:97198ms step_avg:61.91ms
+step:1571/1575 train_time:97286ms step_avg:61.93ms
+step:1572/1575 train_time:97372ms step_avg:61.94ms
+step:1573/1575 train_time:97464ms step_avg:61.96ms
+step:1574/1575 train_time:97548ms step_avg:61.97ms
+step:1575/1575 train_time:97638ms step_avg:61.99ms
+step:1575/1575 val_loss:3.2778 train_time:97704ms step_avg:62.03ms
+peak memory allocated: 30933 MiB reserved: 47000 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/dad99ac4-6d41-43a8-8a09-6dcaf7035d6f.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/dad99ac4-6d41-43a8-8a09-6dcaf7035d6f.txt
@@ -1,0 +1,4119 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 03:03:19 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   39C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            130W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          281831      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          281832      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          281833      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          281834      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          281835      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          281836      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          281837      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          281838      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8275 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:73ms step_avg:72.94ms
+step:2/1600 train_time:96ms step_avg:47.78ms
+step:3/1600 train_time:115ms step_avg:38.33ms
+step:4/1600 train_time:137ms step_avg:34.30ms
+step:5/1600 train_time:167ms step_avg:33.43ms
+step:6/1600 train_time:274ms step_avg:45.60ms
+step:7/1600 train_time:292ms step_avg:41.70ms
+step:8/1600 train_time:369ms step_avg:46.16ms
+step:9/1600 train_time:400ms step_avg:44.39ms
+step:10/1600 train_time:437ms step_avg:43.66ms
+step:11/1600 train_time:467ms step_avg:42.46ms
+step:12/1600 train_time:505ms step_avg:42.05ms
+step:13/1600 train_time:535ms step_avg:41.16ms
+step:14/1600 train_time:572ms step_avg:40.89ms
+step:15/1600 train_time:603ms step_avg:40.21ms
+step:16/1600 train_time:641ms step_avg:40.06ms
+step:17/1600 train_time:672ms step_avg:39.51ms
+step:18/1600 train_time:709ms step_avg:39.39ms
+step:19/1600 train_time:740ms step_avg:38.92ms
+step:20/1600 train_time:777ms step_avg:38.84ms
+step:21/1600 train_time:807ms step_avg:38.43ms
+step:22/1600 train_time:845ms step_avg:38.39ms
+step:23/1600 train_time:875ms step_avg:38.04ms
+step:24/1600 train_time:912ms step_avg:38.01ms
+step:25/1600 train_time:943ms step_avg:37.71ms
+step:26/1600 train_time:981ms step_avg:37.72ms
+step:27/1600 train_time:1011ms step_avg:37.45ms
+step:28/1600 train_time:1048ms step_avg:37.44ms
+step:29/1600 train_time:1079ms step_avg:37.21ms
+step:30/1600 train_time:1116ms step_avg:37.20ms
+step:31/1600 train_time:1147ms step_avg:36.99ms
+step:32/1600 train_time:1185ms step_avg:37.03ms
+step:33/1600 train_time:1215ms step_avg:36.82ms
+step:34/1600 train_time:1252ms step_avg:36.83ms
+step:35/1600 train_time:1284ms step_avg:36.68ms
+step:36/1600 train_time:1321ms step_avg:36.70ms
+step:37/1600 train_time:1352ms step_avg:36.54ms
+step:38/1600 train_time:1390ms step_avg:36.57ms
+step:39/1600 train_time:1420ms step_avg:36.42ms
+step:40/1600 train_time:1458ms step_avg:36.45ms
+step:41/1600 train_time:1488ms step_avg:36.30ms
+step:42/1600 train_time:1526ms step_avg:36.33ms
+step:43/1600 train_time:1557ms step_avg:36.20ms
+step:44/1600 train_time:1594ms step_avg:36.22ms
+step:45/1600 train_time:1624ms step_avg:36.09ms
+step:46/1600 train_time:1662ms step_avg:36.13ms
+step:47/1600 train_time:1692ms step_avg:36.01ms
+step:48/1600 train_time:1730ms step_avg:36.04ms
+step:49/1600 train_time:1761ms step_avg:35.93ms
+step:50/1600 train_time:1798ms step_avg:35.97ms
+step:51/1600 train_time:1829ms step_avg:35.86ms
+step:52/1600 train_time:1866ms step_avg:35.88ms
+step:53/1600 train_time:1896ms step_avg:35.78ms
+step:54/1600 train_time:1933ms step_avg:35.80ms
+step:55/1600 train_time:1964ms step_avg:35.71ms
+step:56/1600 train_time:2001ms step_avg:35.74ms
+step:57/1600 train_time:2032ms step_avg:35.65ms
+step:58/1600 train_time:2070ms step_avg:35.68ms
+step:59/1600 train_time:2100ms step_avg:35.60ms
+step:60/1600 train_time:2137ms step_avg:35.62ms
+step:61/1600 train_time:2168ms step_avg:35.54ms
+step:62/1600 train_time:2206ms step_avg:35.57ms
+step:63/1600 train_time:2236ms step_avg:35.49ms
+step:64/1600 train_time:2273ms step_avg:35.52ms
+step:65/1600 train_time:2304ms step_avg:35.45ms
+step:66/1600 train_time:2342ms step_avg:35.49ms
+step:67/1600 train_time:2373ms step_avg:35.41ms
+step:68/1600 train_time:2410ms step_avg:35.44ms
+step:69/1600 train_time:2440ms step_avg:35.37ms
+step:70/1600 train_time:2477ms step_avg:35.39ms
+step:71/1600 train_time:2508ms step_avg:35.32ms
+step:72/1600 train_time:2545ms step_avg:35.35ms
+step:73/1600 train_time:2576ms step_avg:35.29ms
+step:74/1600 train_time:2613ms step_avg:35.31ms
+step:75/1600 train_time:2644ms step_avg:35.25ms
+step:76/1600 train_time:2681ms step_avg:35.27ms
+step:77/1600 train_time:2712ms step_avg:35.22ms
+step:78/1600 train_time:2749ms step_avg:35.25ms
+step:79/1600 train_time:2780ms step_avg:35.19ms
+step:80/1600 train_time:2818ms step_avg:35.22ms
+step:81/1600 train_time:2848ms step_avg:35.16ms
+step:82/1600 train_time:2886ms step_avg:35.19ms
+step:83/1600 train_time:2916ms step_avg:35.13ms
+step:84/1600 train_time:2953ms step_avg:35.16ms
+step:85/1600 train_time:2984ms step_avg:35.11ms
+step:86/1600 train_time:3022ms step_avg:35.14ms
+step:87/1600 train_time:3052ms step_avg:35.09ms
+step:88/1600 train_time:3090ms step_avg:35.11ms
+step:89/1600 train_time:3121ms step_avg:35.06ms
+step:90/1600 train_time:3158ms step_avg:35.09ms
+step:91/1600 train_time:3189ms step_avg:35.05ms
+step:92/1600 train_time:3226ms step_avg:35.07ms
+step:93/1600 train_time:3257ms step_avg:35.02ms
+step:94/1600 train_time:3294ms step_avg:35.04ms
+step:95/1600 train_time:3325ms step_avg:35.00ms
+step:96/1600 train_time:3363ms step_avg:35.03ms
+step:97/1600 train_time:3394ms step_avg:34.99ms
+step:98/1600 train_time:3431ms step_avg:35.01ms
+step:99/1600 train_time:3462ms step_avg:34.97ms
+step:100/1600 train_time:3499ms step_avg:34.99ms
+step:101/1600 train_time:3530ms step_avg:34.95ms
+step:102/1600 train_time:3567ms step_avg:34.97ms
+step:103/1600 train_time:3598ms step_avg:34.93ms
+step:104/1600 train_time:3635ms step_avg:34.95ms
+step:105/1600 train_time:3666ms step_avg:34.91ms
+step:106/1600 train_time:3704ms step_avg:34.94ms
+step:107/1600 train_time:3735ms step_avg:34.90ms
+step:108/1600 train_time:3772ms step_avg:34.92ms
+step:109/1600 train_time:3802ms step_avg:34.88ms
+step:110/1600 train_time:3840ms step_avg:34.90ms
+step:111/1600 train_time:3870ms step_avg:34.87ms
+step:112/1600 train_time:3907ms step_avg:34.89ms
+step:113/1600 train_time:3938ms step_avg:34.85ms
+step:114/1600 train_time:3975ms step_avg:34.87ms
+step:115/1600 train_time:4005ms step_avg:34.83ms
+step:116/1600 train_time:4043ms step_avg:34.85ms
+step:117/1600 train_time:4073ms step_avg:34.82ms
+step:118/1600 train_time:4111ms step_avg:34.84ms
+step:119/1600 train_time:4142ms step_avg:34.80ms
+step:120/1600 train_time:4179ms step_avg:34.83ms
+step:121/1600 train_time:4210ms step_avg:34.79ms
+step:122/1600 train_time:4247ms step_avg:34.81ms
+step:123/1600 train_time:4278ms step_avg:34.78ms
+step:124/1600 train_time:4315ms step_avg:34.80ms
+step:125/1600 train_time:4346ms step_avg:34.77ms
+step:126/1600 train_time:4383ms step_avg:34.79ms
+step:127/1600 train_time:4415ms step_avg:34.76ms
+step:128/1600 train_time:4452ms step_avg:34.78ms
+step:129/1600 train_time:4482ms step_avg:34.75ms
+step:130/1600 train_time:4520ms step_avg:34.77ms
+step:131/1600 train_time:4550ms step_avg:34.73ms
+step:132/1600 train_time:4588ms step_avg:34.75ms
+step:133/1600 train_time:4618ms step_avg:34.72ms
+step:134/1600 train_time:4656ms step_avg:34.74ms
+step:135/1600 train_time:4686ms step_avg:34.71ms
+step:136/1600 train_time:4723ms step_avg:34.73ms
+step:137/1600 train_time:4754ms step_avg:34.70ms
+step:138/1600 train_time:4791ms step_avg:34.72ms
+step:139/1600 train_time:4822ms step_avg:34.69ms
+step:140/1600 train_time:4859ms step_avg:34.71ms
+step:141/1600 train_time:4890ms step_avg:34.68ms
+step:142/1600 train_time:4927ms step_avg:34.70ms
+step:143/1600 train_time:4957ms step_avg:34.67ms
+step:144/1600 train_time:4994ms step_avg:34.68ms
+step:145/1600 train_time:5025ms step_avg:34.65ms
+step:146/1600 train_time:5062ms step_avg:34.67ms
+step:147/1600 train_time:5093ms step_avg:34.64ms
+step:148/1600 train_time:5130ms step_avg:34.67ms
+step:149/1600 train_time:5161ms step_avg:34.64ms
+step:150/1600 train_time:5198ms step_avg:34.65ms
+step:151/1600 train_time:5228ms step_avg:34.62ms
+step:152/1600 train_time:5266ms step_avg:34.64ms
+step:153/1600 train_time:5296ms step_avg:34.62ms
+step:154/1600 train_time:5334ms step_avg:34.63ms
+step:155/1600 train_time:5365ms step_avg:34.61ms
+step:156/1600 train_time:5402ms step_avg:34.63ms
+step:157/1600 train_time:5433ms step_avg:34.60ms
+step:158/1600 train_time:5470ms step_avg:34.62ms
+step:159/1600 train_time:5500ms step_avg:34.59ms
+step:160/1600 train_time:5538ms step_avg:34.61ms
+step:161/1600 train_time:5568ms step_avg:34.59ms
+step:162/1600 train_time:5606ms step_avg:34.60ms
+step:163/1600 train_time:5636ms step_avg:34.58ms
+step:164/1600 train_time:5673ms step_avg:34.59ms
+step:165/1600 train_time:5705ms step_avg:34.57ms
+step:166/1600 train_time:5742ms step_avg:34.59ms
+step:167/1600 train_time:5773ms step_avg:34.57ms
+step:168/1600 train_time:5811ms step_avg:34.59ms
+step:169/1600 train_time:5841ms step_avg:34.56ms
+step:170/1600 train_time:5879ms step_avg:34.58ms
+step:171/1600 train_time:5909ms step_avg:34.56ms
+step:172/1600 train_time:5946ms step_avg:34.57ms
+step:173/1600 train_time:5977ms step_avg:34.55ms
+step:174/1600 train_time:6014ms step_avg:34.56ms
+step:175/1600 train_time:6045ms step_avg:34.54ms
+step:176/1600 train_time:6083ms step_avg:34.56ms
+step:177/1600 train_time:6113ms step_avg:34.54ms
+step:178/1600 train_time:6151ms step_avg:34.55ms
+step:179/1600 train_time:6182ms step_avg:34.53ms
+step:180/1600 train_time:6219ms step_avg:34.55ms
+step:181/1600 train_time:6250ms step_avg:34.53ms
+step:182/1600 train_time:6287ms step_avg:34.54ms
+step:183/1600 train_time:6317ms step_avg:34.52ms
+step:184/1600 train_time:6354ms step_avg:34.53ms
+step:185/1600 train_time:6385ms step_avg:34.51ms
+step:186/1600 train_time:6422ms step_avg:34.53ms
+step:187/1600 train_time:6453ms step_avg:34.51ms
+step:188/1600 train_time:6490ms step_avg:34.52ms
+step:189/1600 train_time:6520ms step_avg:34.50ms
+step:190/1600 train_time:6558ms step_avg:34.51ms
+step:191/1600 train_time:6588ms step_avg:34.49ms
+step:192/1600 train_time:6626ms step_avg:34.51ms
+step:193/1600 train_time:6656ms step_avg:34.49ms
+step:194/1600 train_time:6693ms step_avg:34.50ms
+step:195/1600 train_time:6724ms step_avg:34.48ms
+step:196/1600 train_time:6762ms step_avg:34.50ms
+step:197/1600 train_time:6793ms step_avg:34.48ms
+step:198/1600 train_time:6830ms step_avg:34.50ms
+step:199/1600 train_time:6861ms step_avg:34.48ms
+step:200/1600 train_time:6898ms step_avg:34.49ms
+step:201/1600 train_time:6928ms step_avg:34.47ms
+step:202/1600 train_time:6966ms step_avg:34.48ms
+step:203/1600 train_time:6996ms step_avg:34.46ms
+step:204/1600 train_time:7033ms step_avg:34.48ms
+step:205/1600 train_time:7064ms step_avg:34.46ms
+step:206/1600 train_time:7102ms step_avg:34.48ms
+step:207/1600 train_time:7133ms step_avg:34.46ms
+step:208/1600 train_time:7171ms step_avg:34.47ms
+step:209/1600 train_time:7201ms step_avg:34.45ms
+step:210/1600 train_time:7239ms step_avg:34.47ms
+step:211/1600 train_time:7269ms step_avg:34.45ms
+step:212/1600 train_time:7307ms step_avg:34.46ms
+step:213/1600 train_time:7337ms step_avg:34.45ms
+step:214/1600 train_time:7374ms step_avg:34.46ms
+step:215/1600 train_time:7405ms step_avg:34.44ms
+step:216/1600 train_time:7443ms step_avg:34.46ms
+step:217/1600 train_time:7473ms step_avg:34.44ms
+step:218/1600 train_time:7510ms step_avg:34.45ms
+step:219/1600 train_time:7541ms step_avg:34.43ms
+step:220/1600 train_time:7579ms step_avg:34.45ms
+step:221/1600 train_time:7609ms step_avg:34.43ms
+step:222/1600 train_time:7646ms step_avg:34.44ms
+step:223/1600 train_time:7676ms step_avg:34.42ms
+step:224/1600 train_time:7713ms step_avg:34.43ms
+step:225/1600 train_time:7743ms step_avg:34.42ms
+step:226/1600 train_time:7781ms step_avg:34.43ms
+step:227/1600 train_time:7811ms step_avg:34.41ms
+step:228/1600 train_time:7848ms step_avg:34.42ms
+step:229/1600 train_time:7879ms step_avg:34.41ms
+step:230/1600 train_time:7916ms step_avg:34.42ms
+step:231/1600 train_time:7947ms step_avg:34.40ms
+step:232/1600 train_time:7984ms step_avg:34.42ms
+step:233/1600 train_time:8015ms step_avg:34.40ms
+step:234/1600 train_time:8052ms step_avg:34.41ms
+step:235/1600 train_time:8083ms step_avg:34.39ms
+step:236/1600 train_time:8120ms step_avg:34.41ms
+step:237/1600 train_time:8150ms step_avg:34.39ms
+step:238/1600 train_time:8188ms step_avg:34.40ms
+step:239/1600 train_time:8218ms step_avg:34.38ms
+step:240/1600 train_time:8255ms step_avg:34.40ms
+step:241/1600 train_time:8286ms step_avg:34.38ms
+step:242/1600 train_time:8324ms step_avg:34.39ms
+step:243/1600 train_time:8354ms step_avg:34.38ms
+step:244/1600 train_time:8392ms step_avg:34.39ms
+step:245/1600 train_time:8422ms step_avg:34.38ms
+step:246/1600 train_time:8459ms step_avg:34.39ms
+step:247/1600 train_time:8490ms step_avg:34.37ms
+step:248/1600 train_time:8527ms step_avg:34.39ms
+step:249/1600 train_time:8558ms step_avg:34.37ms
+step:250/1600 train_time:8595ms step_avg:34.38ms
+step:250/1600 val_loss:4.5815 train_time:8642ms step_avg:34.57ms
+step:251/1600 train_time:8663ms step_avg:34.51ms
+step:252/1600 train_time:8683ms step_avg:34.45ms
+step:253/1600 train_time:8700ms step_avg:34.39ms
+step:254/1600 train_time:8733ms step_avg:34.38ms
+step:255/1600 train_time:8765ms step_avg:34.37ms
+step:256/1600 train_time:8804ms step_avg:34.39ms
+step:257/1600 train_time:8835ms step_avg:34.38ms
+step:258/1600 train_time:8873ms step_avg:34.39ms
+step:259/1600 train_time:8904ms step_avg:34.38ms
+step:260/1600 train_time:8941ms step_avg:34.39ms
+step:261/1600 train_time:8972ms step_avg:34.37ms
+step:262/1600 train_time:9009ms step_avg:34.39ms
+step:263/1600 train_time:9040ms step_avg:34.37ms
+step:264/1600 train_time:9077ms step_avg:34.38ms
+step:265/1600 train_time:9108ms step_avg:34.37ms
+step:266/1600 train_time:9145ms step_avg:34.38ms
+step:267/1600 train_time:9176ms step_avg:34.37ms
+step:268/1600 train_time:9213ms step_avg:34.38ms
+step:269/1600 train_time:9243ms step_avg:34.36ms
+step:270/1600 train_time:9280ms step_avg:34.37ms
+step:271/1600 train_time:9311ms step_avg:34.36ms
+step:272/1600 train_time:9348ms step_avg:34.37ms
+step:273/1600 train_time:9378ms step_avg:34.35ms
+step:274/1600 train_time:9415ms step_avg:34.36ms
+step:275/1600 train_time:9446ms step_avg:34.35ms
+step:276/1600 train_time:9483ms step_avg:34.36ms
+step:277/1600 train_time:9513ms step_avg:34.34ms
+step:278/1600 train_time:9551ms step_avg:34.36ms
+step:279/1600 train_time:9581ms step_avg:34.34ms
+step:280/1600 train_time:9618ms step_avg:34.35ms
+step:281/1600 train_time:9649ms step_avg:34.34ms
+step:282/1600 train_time:9686ms step_avg:34.35ms
+step:283/1600 train_time:9716ms step_avg:34.33ms
+step:284/1600 train_time:9754ms step_avg:34.34ms
+step:285/1600 train_time:9784ms step_avg:34.33ms
+step:286/1600 train_time:9821ms step_avg:34.34ms
+step:287/1600 train_time:9853ms step_avg:34.33ms
+step:288/1600 train_time:9890ms step_avg:34.34ms
+step:289/1600 train_time:9921ms step_avg:34.33ms
+step:290/1600 train_time:9958ms step_avg:34.34ms
+step:291/1600 train_time:9989ms step_avg:34.33ms
+step:292/1600 train_time:10026ms step_avg:34.34ms
+step:293/1600 train_time:10057ms step_avg:34.32ms
+step:294/1600 train_time:10094ms step_avg:34.33ms
+step:295/1600 train_time:10125ms step_avg:34.32ms
+step:296/1600 train_time:10162ms step_avg:34.33ms
+step:297/1600 train_time:10192ms step_avg:34.32ms
+step:298/1600 train_time:10230ms step_avg:34.33ms
+step:299/1600 train_time:10260ms step_avg:34.31ms
+step:300/1600 train_time:10297ms step_avg:34.32ms
+step:301/1600 train_time:10328ms step_avg:34.31ms
+step:302/1600 train_time:10365ms step_avg:34.32ms
+step:303/1600 train_time:10396ms step_avg:34.31ms
+step:304/1600 train_time:10433ms step_avg:34.32ms
+step:305/1600 train_time:10463ms step_avg:34.31ms
+step:306/1600 train_time:10501ms step_avg:34.32ms
+step:307/1600 train_time:10531ms step_avg:34.30ms
+step:308/1600 train_time:10569ms step_avg:34.31ms
+step:309/1600 train_time:10599ms step_avg:34.30ms
+step:310/1600 train_time:10636ms step_avg:34.31ms
+step:311/1600 train_time:10667ms step_avg:34.30ms
+step:312/1600 train_time:10704ms step_avg:34.31ms
+step:313/1600 train_time:10734ms step_avg:34.30ms
+step:314/1600 train_time:10772ms step_avg:34.31ms
+step:315/1600 train_time:10803ms step_avg:34.29ms
+step:316/1600 train_time:10840ms step_avg:34.30ms
+step:317/1600 train_time:10871ms step_avg:34.29ms
+step:318/1600 train_time:10908ms step_avg:34.30ms
+step:319/1600 train_time:10939ms step_avg:34.29ms
+step:320/1600 train_time:10977ms step_avg:34.30ms
+step:321/1600 train_time:11007ms step_avg:34.29ms
+step:322/1600 train_time:11044ms step_avg:34.30ms
+step:323/1600 train_time:11074ms step_avg:34.29ms
+step:324/1600 train_time:11112ms step_avg:34.30ms
+step:325/1600 train_time:11142ms step_avg:34.28ms
+step:326/1600 train_time:11179ms step_avg:34.29ms
+step:327/1600 train_time:11210ms step_avg:34.28ms
+step:328/1600 train_time:11247ms step_avg:34.29ms
+step:329/1600 train_time:11277ms step_avg:34.28ms
+step:330/1600 train_time:11315ms step_avg:34.29ms
+step:331/1600 train_time:11345ms step_avg:34.28ms
+step:332/1600 train_time:11382ms step_avg:34.28ms
+step:333/1600 train_time:11413ms step_avg:34.27ms
+step:334/1600 train_time:11451ms step_avg:34.28ms
+step:335/1600 train_time:11481ms step_avg:34.27ms
+step:336/1600 train_time:11518ms step_avg:34.28ms
+step:337/1600 train_time:11549ms step_avg:34.27ms
+step:338/1600 train_time:11586ms step_avg:34.28ms
+step:339/1600 train_time:11616ms step_avg:34.27ms
+step:340/1600 train_time:11654ms step_avg:34.28ms
+step:341/1600 train_time:11684ms step_avg:34.26ms
+step:342/1600 train_time:11721ms step_avg:34.27ms
+step:343/1600 train_time:11752ms step_avg:34.26ms
+step:344/1600 train_time:11790ms step_avg:34.27ms
+step:345/1600 train_time:11820ms step_avg:34.26ms
+step:346/1600 train_time:11858ms step_avg:34.27ms
+step:347/1600 train_time:11889ms step_avg:34.26ms
+step:348/1600 train_time:11926ms step_avg:34.27ms
+step:349/1600 train_time:11957ms step_avg:34.26ms
+step:350/1600 train_time:11994ms step_avg:34.27ms
+step:351/1600 train_time:12024ms step_avg:34.26ms
+step:352/1600 train_time:12061ms step_avg:34.27ms
+step:353/1600 train_time:12092ms step_avg:34.25ms
+step:354/1600 train_time:12129ms step_avg:34.26ms
+step:355/1600 train_time:12160ms step_avg:34.25ms
+step:356/1600 train_time:12197ms step_avg:34.26ms
+step:357/1600 train_time:12228ms step_avg:34.25ms
+step:358/1600 train_time:12265ms step_avg:34.26ms
+step:359/1600 train_time:12295ms step_avg:34.25ms
+step:360/1600 train_time:12333ms step_avg:34.26ms
+step:361/1600 train_time:12364ms step_avg:34.25ms
+step:362/1600 train_time:12401ms step_avg:34.26ms
+step:363/1600 train_time:12431ms step_avg:34.25ms
+step:364/1600 train_time:12469ms step_avg:34.25ms
+step:365/1600 train_time:12499ms step_avg:34.24ms
+step:366/1600 train_time:12536ms step_avg:34.25ms
+step:367/1600 train_time:12567ms step_avg:34.24ms
+step:368/1600 train_time:12604ms step_avg:34.25ms
+step:369/1600 train_time:12635ms step_avg:34.24ms
+step:370/1600 train_time:12672ms step_avg:34.25ms
+step:371/1600 train_time:12702ms step_avg:34.24ms
+step:372/1600 train_time:12739ms step_avg:34.24ms
+step:373/1600 train_time:12769ms step_avg:34.23ms
+step:374/1600 train_time:12807ms step_avg:34.24ms
+step:375/1600 train_time:12837ms step_avg:34.23ms
+step:376/1600 train_time:12874ms step_avg:34.24ms
+step:377/1600 train_time:12904ms step_avg:34.23ms
+step:378/1600 train_time:12942ms step_avg:34.24ms
+step:379/1600 train_time:12973ms step_avg:34.23ms
+step:380/1600 train_time:13011ms step_avg:34.24ms
+step:381/1600 train_time:13041ms step_avg:34.23ms
+step:382/1600 train_time:13078ms step_avg:34.24ms
+step:383/1600 train_time:13109ms step_avg:34.23ms
+step:384/1600 train_time:13146ms step_avg:34.23ms
+step:385/1600 train_time:13177ms step_avg:34.23ms
+step:386/1600 train_time:13214ms step_avg:34.23ms
+step:387/1600 train_time:13244ms step_avg:34.22ms
+step:388/1600 train_time:13281ms step_avg:34.23ms
+step:389/1600 train_time:13311ms step_avg:34.22ms
+step:390/1600 train_time:13349ms step_avg:34.23ms
+step:391/1600 train_time:13380ms step_avg:34.22ms
+step:392/1600 train_time:13417ms step_avg:34.23ms
+step:393/1600 train_time:13447ms step_avg:34.22ms
+step:394/1600 train_time:13485ms step_avg:34.23ms
+step:395/1600 train_time:13515ms step_avg:34.22ms
+step:396/1600 train_time:13552ms step_avg:34.22ms
+step:397/1600 train_time:13583ms step_avg:34.21ms
+step:398/1600 train_time:13620ms step_avg:34.22ms
+step:399/1600 train_time:13651ms step_avg:34.21ms
+step:400/1600 train_time:13688ms step_avg:34.22ms
+step:401/1600 train_time:13719ms step_avg:34.21ms
+step:402/1600 train_time:13756ms step_avg:34.22ms
+step:403/1600 train_time:13786ms step_avg:34.21ms
+step:404/1600 train_time:13823ms step_avg:34.22ms
+step:405/1600 train_time:13854ms step_avg:34.21ms
+step:406/1600 train_time:13891ms step_avg:34.22ms
+step:407/1600 train_time:13922ms step_avg:34.21ms
+step:408/1600 train_time:13959ms step_avg:34.21ms
+step:409/1600 train_time:13990ms step_avg:34.21ms
+step:410/1600 train_time:14027ms step_avg:34.21ms
+step:411/1600 train_time:14058ms step_avg:34.20ms
+step:412/1600 train_time:14095ms step_avg:34.21ms
+step:413/1600 train_time:14126ms step_avg:34.20ms
+step:414/1600 train_time:14163ms step_avg:34.21ms
+step:415/1600 train_time:14193ms step_avg:34.20ms
+step:416/1600 train_time:14231ms step_avg:34.21ms
+step:417/1600 train_time:14261ms step_avg:34.20ms
+step:418/1600 train_time:14299ms step_avg:34.21ms
+step:419/1600 train_time:14329ms step_avg:34.20ms
+step:420/1600 train_time:14366ms step_avg:34.21ms
+step:421/1600 train_time:14397ms step_avg:34.20ms
+step:422/1600 train_time:14434ms step_avg:34.20ms
+step:423/1600 train_time:14465ms step_avg:34.20ms
+step:424/1600 train_time:14502ms step_avg:34.20ms
+step:425/1600 train_time:14532ms step_avg:34.19ms
+step:426/1600 train_time:14570ms step_avg:34.20ms
+step:427/1600 train_time:14601ms step_avg:34.19ms
+step:428/1600 train_time:14638ms step_avg:34.20ms
+step:429/1600 train_time:14669ms step_avg:34.19ms
+step:430/1600 train_time:14706ms step_avg:34.20ms
+step:431/1600 train_time:14737ms step_avg:34.19ms
+step:432/1600 train_time:14774ms step_avg:34.20ms
+step:433/1600 train_time:14805ms step_avg:34.19ms
+step:434/1600 train_time:14842ms step_avg:34.20ms
+step:435/1600 train_time:14872ms step_avg:34.19ms
+step:436/1600 train_time:14910ms step_avg:34.20ms
+step:437/1600 train_time:14940ms step_avg:34.19ms
+step:438/1600 train_time:14978ms step_avg:34.20ms
+step:439/1600 train_time:15008ms step_avg:34.19ms
+step:440/1600 train_time:15045ms step_avg:34.19ms
+step:441/1600 train_time:15075ms step_avg:34.18ms
+step:442/1600 train_time:15113ms step_avg:34.19ms
+step:443/1600 train_time:15144ms step_avg:34.18ms
+step:444/1600 train_time:15181ms step_avg:34.19ms
+step:445/1600 train_time:15211ms step_avg:34.18ms
+step:446/1600 train_time:15249ms step_avg:34.19ms
+step:447/1600 train_time:15279ms step_avg:34.18ms
+step:448/1600 train_time:15316ms step_avg:34.19ms
+step:449/1600 train_time:15347ms step_avg:34.18ms
+step:450/1600 train_time:15384ms step_avg:34.19ms
+step:451/1600 train_time:15415ms step_avg:34.18ms
+step:452/1600 train_time:15452ms step_avg:34.19ms
+step:453/1600 train_time:15482ms step_avg:34.18ms
+step:454/1600 train_time:15520ms step_avg:34.18ms
+step:455/1600 train_time:15551ms step_avg:34.18ms
+step:456/1600 train_time:15588ms step_avg:34.18ms
+step:457/1600 train_time:15618ms step_avg:34.18ms
+step:458/1600 train_time:15656ms step_avg:34.18ms
+step:459/1600 train_time:15686ms step_avg:34.17ms
+step:460/1600 train_time:15723ms step_avg:34.18ms
+step:461/1600 train_time:15754ms step_avg:34.17ms
+step:462/1600 train_time:15791ms step_avg:34.18ms
+step:463/1600 train_time:15822ms step_avg:34.17ms
+step:464/1600 train_time:15859ms step_avg:34.18ms
+step:465/1600 train_time:15889ms step_avg:34.17ms
+step:466/1600 train_time:15926ms step_avg:34.18ms
+step:467/1600 train_time:15957ms step_avg:34.17ms
+step:468/1600 train_time:15994ms step_avg:34.18ms
+step:469/1600 train_time:16025ms step_avg:34.17ms
+step:470/1600 train_time:16061ms step_avg:34.17ms
+step:471/1600 train_time:16092ms step_avg:34.17ms
+step:472/1600 train_time:16130ms step_avg:34.17ms
+step:473/1600 train_time:16161ms step_avg:34.17ms
+step:474/1600 train_time:16198ms step_avg:34.17ms
+step:475/1600 train_time:16229ms step_avg:34.17ms
+step:476/1600 train_time:16267ms step_avg:34.17ms
+step:477/1600 train_time:16297ms step_avg:34.16ms
+step:478/1600 train_time:16334ms step_avg:34.17ms
+step:479/1600 train_time:16364ms step_avg:34.16ms
+step:480/1600 train_time:16401ms step_avg:34.17ms
+step:481/1600 train_time:16432ms step_avg:34.16ms
+step:482/1600 train_time:16469ms step_avg:34.17ms
+step:483/1600 train_time:16499ms step_avg:34.16ms
+step:484/1600 train_time:16536ms step_avg:34.17ms
+step:485/1600 train_time:16567ms step_avg:34.16ms
+step:486/1600 train_time:16605ms step_avg:34.17ms
+step:487/1600 train_time:16636ms step_avg:34.16ms
+step:488/1600 train_time:16673ms step_avg:34.17ms
+step:489/1600 train_time:16703ms step_avg:34.16ms
+step:490/1600 train_time:16740ms step_avg:34.16ms
+step:491/1600 train_time:16771ms step_avg:34.16ms
+step:492/1600 train_time:16808ms step_avg:34.16ms
+step:493/1600 train_time:16839ms step_avg:34.16ms
+step:494/1600 train_time:16877ms step_avg:34.16ms
+step:495/1600 train_time:16907ms step_avg:34.16ms
+step:496/1600 train_time:16944ms step_avg:34.16ms
+step:497/1600 train_time:16974ms step_avg:34.15ms
+step:498/1600 train_time:17012ms step_avg:34.16ms
+step:499/1600 train_time:17043ms step_avg:34.15ms
+step:500/1600 train_time:17080ms step_avg:34.16ms
+step:500/1600 val_loss:4.2462 train_time:17128ms step_avg:34.26ms
+step:501/1600 train_time:17148ms step_avg:34.23ms
+step:502/1600 train_time:17168ms step_avg:34.20ms
+step:503/1600 train_time:17186ms step_avg:34.17ms
+step:504/1600 train_time:17222ms step_avg:34.17ms
+step:505/1600 train_time:17254ms step_avg:34.17ms
+step:506/1600 train_time:17292ms step_avg:34.17ms
+step:507/1600 train_time:17324ms step_avg:34.17ms
+step:508/1600 train_time:17361ms step_avg:34.18ms
+step:509/1600 train_time:17392ms step_avg:34.17ms
+step:510/1600 train_time:17429ms step_avg:34.17ms
+step:511/1600 train_time:17459ms step_avg:34.17ms
+step:512/1600 train_time:17497ms step_avg:34.17ms
+step:513/1600 train_time:17527ms step_avg:34.17ms
+step:514/1600 train_time:17564ms step_avg:34.17ms
+step:515/1600 train_time:17595ms step_avg:34.16ms
+step:516/1600 train_time:17632ms step_avg:34.17ms
+step:517/1600 train_time:17662ms step_avg:34.16ms
+step:518/1600 train_time:17699ms step_avg:34.17ms
+step:519/1600 train_time:17729ms step_avg:34.16ms
+step:520/1600 train_time:17766ms step_avg:34.17ms
+step:521/1600 train_time:17838ms step_avg:34.24ms
+step:522/1600 train_time:17895ms step_avg:34.28ms
+step:523/1600 train_time:17956ms step_avg:34.33ms
+step:524/1600 train_time:18014ms step_avg:34.38ms
+step:525/1600 train_time:18075ms step_avg:34.43ms
+step:526/1600 train_time:18134ms step_avg:34.48ms
+step:527/1600 train_time:18198ms step_avg:34.53ms
+step:528/1600 train_time:18259ms step_avg:34.58ms
+step:529/1600 train_time:18323ms step_avg:34.64ms
+step:530/1600 train_time:18381ms step_avg:34.68ms
+step:531/1600 train_time:18446ms step_avg:34.74ms
+step:532/1600 train_time:18504ms step_avg:34.78ms
+step:533/1600 train_time:18567ms step_avg:34.83ms
+step:534/1600 train_time:18627ms step_avg:34.88ms
+step:535/1600 train_time:18689ms step_avg:34.93ms
+step:536/1600 train_time:18748ms step_avg:34.98ms
+step:537/1600 train_time:18810ms step_avg:35.03ms
+step:538/1600 train_time:18869ms step_avg:35.07ms
+step:539/1600 train_time:18931ms step_avg:35.12ms
+step:540/1600 train_time:18991ms step_avg:35.17ms
+step:541/1600 train_time:19052ms step_avg:35.22ms
+step:542/1600 train_time:19110ms step_avg:35.26ms
+step:543/1600 train_time:19172ms step_avg:35.31ms
+step:544/1600 train_time:19231ms step_avg:35.35ms
+step:545/1600 train_time:19293ms step_avg:35.40ms
+step:546/1600 train_time:19352ms step_avg:35.44ms
+step:547/1600 train_time:19414ms step_avg:35.49ms
+step:548/1600 train_time:19473ms step_avg:35.53ms
+step:549/1600 train_time:19536ms step_avg:35.59ms
+step:550/1600 train_time:19597ms step_avg:35.63ms
+step:551/1600 train_time:19660ms step_avg:35.68ms
+step:552/1600 train_time:19719ms step_avg:35.72ms
+step:553/1600 train_time:19782ms step_avg:35.77ms
+step:554/1600 train_time:19841ms step_avg:35.81ms
+step:555/1600 train_time:19903ms step_avg:35.86ms
+step:556/1600 train_time:19961ms step_avg:35.90ms
+step:557/1600 train_time:20024ms step_avg:35.95ms
+step:558/1600 train_time:20084ms step_avg:35.99ms
+step:559/1600 train_time:20147ms step_avg:36.04ms
+step:560/1600 train_time:20207ms step_avg:36.08ms
+step:561/1600 train_time:20269ms step_avg:36.13ms
+step:562/1600 train_time:20328ms step_avg:36.17ms
+step:563/1600 train_time:20391ms step_avg:36.22ms
+step:564/1600 train_time:20449ms step_avg:36.26ms
+step:565/1600 train_time:20512ms step_avg:36.30ms
+step:566/1600 train_time:20571ms step_avg:36.35ms
+step:567/1600 train_time:20633ms step_avg:36.39ms
+step:568/1600 train_time:20692ms step_avg:36.43ms
+step:569/1600 train_time:20754ms step_avg:36.48ms
+step:570/1600 train_time:20813ms step_avg:36.51ms
+step:571/1600 train_time:20875ms step_avg:36.56ms
+step:572/1600 train_time:20936ms step_avg:36.60ms
+step:573/1600 train_time:21002ms step_avg:36.65ms
+step:574/1600 train_time:21058ms step_avg:36.69ms
+step:575/1600 train_time:21121ms step_avg:36.73ms
+step:576/1600 train_time:21179ms step_avg:36.77ms
+step:577/1600 train_time:21240ms step_avg:36.81ms
+step:578/1600 train_time:21300ms step_avg:36.85ms
+step:579/1600 train_time:21362ms step_avg:36.90ms
+step:580/1600 train_time:21421ms step_avg:36.93ms
+step:581/1600 train_time:21483ms step_avg:36.98ms
+step:582/1600 train_time:21543ms step_avg:37.02ms
+step:583/1600 train_time:21604ms step_avg:37.06ms
+step:584/1600 train_time:21665ms step_avg:37.10ms
+step:585/1600 train_time:21727ms step_avg:37.14ms
+step:586/1600 train_time:21786ms step_avg:37.18ms
+step:587/1600 train_time:21848ms step_avg:37.22ms
+step:588/1600 train_time:21908ms step_avg:37.26ms
+step:589/1600 train_time:21971ms step_avg:37.30ms
+step:590/1600 train_time:22029ms step_avg:37.34ms
+step:591/1600 train_time:22091ms step_avg:37.38ms
+step:592/1600 train_time:22150ms step_avg:37.42ms
+step:593/1600 train_time:22212ms step_avg:37.46ms
+step:594/1600 train_time:22271ms step_avg:37.49ms
+step:595/1600 train_time:22333ms step_avg:37.53ms
+step:596/1600 train_time:22393ms step_avg:37.57ms
+step:597/1600 train_time:22455ms step_avg:37.61ms
+step:598/1600 train_time:22513ms step_avg:37.65ms
+step:599/1600 train_time:22576ms step_avg:37.69ms
+step:600/1600 train_time:22635ms step_avg:37.73ms
+step:601/1600 train_time:22698ms step_avg:37.77ms
+step:602/1600 train_time:22758ms step_avg:37.80ms
+step:603/1600 train_time:22820ms step_avg:37.84ms
+step:604/1600 train_time:22880ms step_avg:37.88ms
+step:605/1600 train_time:22942ms step_avg:37.92ms
+step:606/1600 train_time:23002ms step_avg:37.96ms
+step:607/1600 train_time:23063ms step_avg:38.00ms
+step:608/1600 train_time:23122ms step_avg:38.03ms
+step:609/1600 train_time:23185ms step_avg:38.07ms
+step:610/1600 train_time:23245ms step_avg:38.11ms
+step:611/1600 train_time:23307ms step_avg:38.15ms
+step:612/1600 train_time:23366ms step_avg:38.18ms
+step:613/1600 train_time:23429ms step_avg:38.22ms
+step:614/1600 train_time:23488ms step_avg:38.25ms
+step:615/1600 train_time:23551ms step_avg:38.29ms
+step:616/1600 train_time:23610ms step_avg:38.33ms
+step:617/1600 train_time:23672ms step_avg:38.37ms
+step:618/1600 train_time:23731ms step_avg:38.40ms
+step:619/1600 train_time:23793ms step_avg:38.44ms
+step:620/1600 train_time:23851ms step_avg:38.47ms
+step:621/1600 train_time:23913ms step_avg:38.51ms
+step:622/1600 train_time:23971ms step_avg:38.54ms
+step:623/1600 train_time:24033ms step_avg:38.58ms
+step:624/1600 train_time:24092ms step_avg:38.61ms
+step:625/1600 train_time:24153ms step_avg:38.65ms
+step:626/1600 train_time:24212ms step_avg:38.68ms
+step:627/1600 train_time:24275ms step_avg:38.72ms
+step:628/1600 train_time:24334ms step_avg:38.75ms
+step:629/1600 train_time:24396ms step_avg:38.79ms
+step:630/1600 train_time:24455ms step_avg:38.82ms
+step:631/1600 train_time:24518ms step_avg:38.86ms
+step:632/1600 train_time:24578ms step_avg:38.89ms
+step:633/1600 train_time:24641ms step_avg:38.93ms
+step:634/1600 train_time:24700ms step_avg:38.96ms
+step:635/1600 train_time:24763ms step_avg:39.00ms
+step:636/1600 train_time:24822ms step_avg:39.03ms
+step:637/1600 train_time:24884ms step_avg:39.07ms
+step:638/1600 train_time:24944ms step_avg:39.10ms
+step:639/1600 train_time:25007ms step_avg:39.14ms
+step:640/1600 train_time:25066ms step_avg:39.17ms
+step:641/1600 train_time:25129ms step_avg:39.20ms
+step:642/1600 train_time:25187ms step_avg:39.23ms
+step:643/1600 train_time:25250ms step_avg:39.27ms
+step:644/1600 train_time:25309ms step_avg:39.30ms
+step:645/1600 train_time:25371ms step_avg:39.34ms
+step:646/1600 train_time:25430ms step_avg:39.37ms
+step:647/1600 train_time:25493ms step_avg:39.40ms
+step:648/1600 train_time:25551ms step_avg:39.43ms
+step:649/1600 train_time:25612ms step_avg:39.46ms
+step:650/1600 train_time:25671ms step_avg:39.49ms
+step:651/1600 train_time:25733ms step_avg:39.53ms
+step:652/1600 train_time:25792ms step_avg:39.56ms
+step:653/1600 train_time:25855ms step_avg:39.59ms
+step:654/1600 train_time:25914ms step_avg:39.62ms
+step:655/1600 train_time:25976ms step_avg:39.66ms
+step:656/1600 train_time:26036ms step_avg:39.69ms
+step:657/1600 train_time:26098ms step_avg:39.72ms
+step:658/1600 train_time:26157ms step_avg:39.75ms
+step:659/1600 train_time:26222ms step_avg:39.79ms
+step:660/1600 train_time:26279ms step_avg:39.82ms
+step:661/1600 train_time:26342ms step_avg:39.85ms
+step:662/1600 train_time:26401ms step_avg:39.88ms
+step:663/1600 train_time:26464ms step_avg:39.92ms
+step:664/1600 train_time:26523ms step_avg:39.94ms
+step:665/1600 train_time:26586ms step_avg:39.98ms
+step:666/1600 train_time:26645ms step_avg:40.01ms
+step:667/1600 train_time:26707ms step_avg:40.04ms
+step:668/1600 train_time:26766ms step_avg:40.07ms
+step:669/1600 train_time:26829ms step_avg:40.10ms
+step:670/1600 train_time:26888ms step_avg:40.13ms
+step:671/1600 train_time:26950ms step_avg:40.16ms
+step:672/1600 train_time:27010ms step_avg:40.19ms
+step:673/1600 train_time:27071ms step_avg:40.23ms
+step:674/1600 train_time:27130ms step_avg:40.25ms
+step:675/1600 train_time:27191ms step_avg:40.28ms
+step:676/1600 train_time:27250ms step_avg:40.31ms
+step:677/1600 train_time:27313ms step_avg:40.34ms
+step:678/1600 train_time:27371ms step_avg:40.37ms
+step:679/1600 train_time:27432ms step_avg:40.40ms
+step:680/1600 train_time:27491ms step_avg:40.43ms
+step:681/1600 train_time:27553ms step_avg:40.46ms
+step:682/1600 train_time:27612ms step_avg:40.49ms
+step:683/1600 train_time:27674ms step_avg:40.52ms
+step:684/1600 train_time:27732ms step_avg:40.54ms
+step:685/1600 train_time:27795ms step_avg:40.58ms
+step:686/1600 train_time:27854ms step_avg:40.60ms
+step:687/1600 train_time:27917ms step_avg:40.64ms
+step:688/1600 train_time:27976ms step_avg:40.66ms
+step:689/1600 train_time:28038ms step_avg:40.69ms
+step:690/1600 train_time:28097ms step_avg:40.72ms
+step:691/1600 train_time:28159ms step_avg:40.75ms
+step:692/1600 train_time:28219ms step_avg:40.78ms
+step:693/1600 train_time:28281ms step_avg:40.81ms
+step:694/1600 train_time:28341ms step_avg:40.84ms
+step:695/1600 train_time:28404ms step_avg:40.87ms
+step:696/1600 train_time:28463ms step_avg:40.90ms
+step:697/1600 train_time:28525ms step_avg:40.93ms
+step:698/1600 train_time:28584ms step_avg:40.95ms
+step:699/1600 train_time:28647ms step_avg:40.98ms
+step:700/1600 train_time:28706ms step_avg:41.01ms
+step:701/1600 train_time:28769ms step_avg:41.04ms
+step:702/1600 train_time:28828ms step_avg:41.07ms
+step:703/1600 train_time:28891ms step_avg:41.10ms
+step:704/1600 train_time:28950ms step_avg:41.12ms
+step:705/1600 train_time:29012ms step_avg:41.15ms
+step:706/1600 train_time:29071ms step_avg:41.18ms
+step:707/1600 train_time:29133ms step_avg:41.21ms
+step:708/1600 train_time:29192ms step_avg:41.23ms
+step:709/1600 train_time:29254ms step_avg:41.26ms
+step:710/1600 train_time:29312ms step_avg:41.28ms
+step:711/1600 train_time:29375ms step_avg:41.31ms
+step:712/1600 train_time:29433ms step_avg:41.34ms
+step:713/1600 train_time:29496ms step_avg:41.37ms
+step:714/1600 train_time:29553ms step_avg:41.39ms
+step:715/1600 train_time:29616ms step_avg:41.42ms
+step:716/1600 train_time:29675ms step_avg:41.45ms
+step:717/1600 train_time:29738ms step_avg:41.48ms
+step:718/1600 train_time:29798ms step_avg:41.50ms
+step:719/1600 train_time:29861ms step_avg:41.53ms
+step:720/1600 train_time:29920ms step_avg:41.56ms
+step:721/1600 train_time:29982ms step_avg:41.58ms
+step:722/1600 train_time:30041ms step_avg:41.61ms
+step:723/1600 train_time:30104ms step_avg:41.64ms
+step:724/1600 train_time:30163ms step_avg:41.66ms
+step:725/1600 train_time:30225ms step_avg:41.69ms
+step:726/1600 train_time:30284ms step_avg:41.71ms
+step:727/1600 train_time:30347ms step_avg:41.74ms
+step:728/1600 train_time:30406ms step_avg:41.77ms
+step:729/1600 train_time:30469ms step_avg:41.80ms
+step:730/1600 train_time:30527ms step_avg:41.82ms
+step:731/1600 train_time:30590ms step_avg:41.85ms
+step:732/1600 train_time:30648ms step_avg:41.87ms
+step:733/1600 train_time:30711ms step_avg:41.90ms
+step:734/1600 train_time:30770ms step_avg:41.92ms
+step:735/1600 train_time:30832ms step_avg:41.95ms
+step:736/1600 train_time:30891ms step_avg:41.97ms
+step:737/1600 train_time:30952ms step_avg:42.00ms
+step:738/1600 train_time:31013ms step_avg:42.02ms
+step:739/1600 train_time:31075ms step_avg:42.05ms
+step:740/1600 train_time:31133ms step_avg:42.07ms
+step:741/1600 train_time:31193ms step_avg:42.10ms
+step:742/1600 train_time:31251ms step_avg:42.12ms
+step:743/1600 train_time:31315ms step_avg:42.15ms
+step:744/1600 train_time:31374ms step_avg:42.17ms
+step:745/1600 train_time:31435ms step_avg:42.19ms
+step:746/1600 train_time:31494ms step_avg:42.22ms
+step:747/1600 train_time:31556ms step_avg:42.24ms
+step:748/1600 train_time:31615ms step_avg:42.27ms
+step:749/1600 train_time:31677ms step_avg:42.29ms
+step:750/1600 train_time:31737ms step_avg:42.32ms
+step:750/1600 val_loss:3.8946 train_time:31783ms step_avg:42.38ms
+step:751/1600 train_time:31804ms step_avg:42.35ms
+step:752/1600 train_time:31865ms step_avg:42.37ms
+step:753/1600 train_time:31929ms step_avg:42.40ms
+step:754/1600 train_time:31990ms step_avg:42.43ms
+step:755/1600 train_time:32052ms step_avg:42.45ms
+step:756/1600 train_time:32111ms step_avg:42.48ms
+step:757/1600 train_time:32173ms step_avg:42.50ms
+step:758/1600 train_time:32232ms step_avg:42.52ms
+step:759/1600 train_time:32294ms step_avg:42.55ms
+step:760/1600 train_time:32353ms step_avg:42.57ms
+step:761/1600 train_time:32415ms step_avg:42.59ms
+step:762/1600 train_time:32474ms step_avg:42.62ms
+step:763/1600 train_time:32535ms step_avg:42.64ms
+step:764/1600 train_time:32594ms step_avg:42.66ms
+step:765/1600 train_time:32654ms step_avg:42.69ms
+step:766/1600 train_time:32714ms step_avg:42.71ms
+step:767/1600 train_time:32778ms step_avg:42.74ms
+step:768/1600 train_time:32839ms step_avg:42.76ms
+step:769/1600 train_time:32902ms step_avg:42.79ms
+step:770/1600 train_time:32961ms step_avg:42.81ms
+step:771/1600 train_time:33023ms step_avg:42.83ms
+step:772/1600 train_time:33081ms step_avg:42.85ms
+step:773/1600 train_time:33144ms step_avg:42.88ms
+step:774/1600 train_time:33202ms step_avg:42.90ms
+step:775/1600 train_time:33265ms step_avg:42.92ms
+step:776/1600 train_time:33324ms step_avg:42.94ms
+step:777/1600 train_time:33386ms step_avg:42.97ms
+step:778/1600 train_time:33445ms step_avg:42.99ms
+step:779/1600 train_time:33507ms step_avg:43.01ms
+step:780/1600 train_time:33567ms step_avg:43.03ms
+step:781/1600 train_time:33629ms step_avg:43.06ms
+step:782/1600 train_time:33688ms step_avg:43.08ms
+step:783/1600 train_time:33751ms step_avg:43.10ms
+step:784/1600 train_time:33810ms step_avg:43.13ms
+step:785/1600 train_time:33875ms step_avg:43.15ms
+step:786/1600 train_time:33935ms step_avg:43.17ms
+step:787/1600 train_time:33998ms step_avg:43.20ms
+step:788/1600 train_time:34057ms step_avg:43.22ms
+step:789/1600 train_time:34119ms step_avg:43.24ms
+step:790/1600 train_time:34178ms step_avg:43.26ms
+step:791/1600 train_time:34240ms step_avg:43.29ms
+step:792/1600 train_time:34298ms step_avg:43.31ms
+step:793/1600 train_time:34361ms step_avg:43.33ms
+step:794/1600 train_time:34419ms step_avg:43.35ms
+step:795/1600 train_time:34482ms step_avg:43.37ms
+step:796/1600 train_time:34540ms step_avg:43.39ms
+step:797/1600 train_time:34602ms step_avg:43.42ms
+step:798/1600 train_time:34660ms step_avg:43.43ms
+step:799/1600 train_time:34722ms step_avg:43.46ms
+step:800/1600 train_time:34782ms step_avg:43.48ms
+step:801/1600 train_time:34845ms step_avg:43.50ms
+step:802/1600 train_time:34905ms step_avg:43.52ms
+step:803/1600 train_time:34968ms step_avg:43.55ms
+step:804/1600 train_time:35029ms step_avg:43.57ms
+step:805/1600 train_time:35091ms step_avg:43.59ms
+step:806/1600 train_time:35150ms step_avg:43.61ms
+step:807/1600 train_time:35211ms step_avg:43.63ms
+step:808/1600 train_time:35271ms step_avg:43.65ms
+step:809/1600 train_time:35335ms step_avg:43.68ms
+step:810/1600 train_time:35394ms step_avg:43.70ms
+step:811/1600 train_time:35456ms step_avg:43.72ms
+step:812/1600 train_time:35514ms step_avg:43.74ms
+step:813/1600 train_time:35578ms step_avg:43.76ms
+step:814/1600 train_time:35638ms step_avg:43.78ms
+step:815/1600 train_time:35699ms step_avg:43.80ms
+step:816/1600 train_time:35757ms step_avg:43.82ms
+step:817/1600 train_time:35820ms step_avg:43.84ms
+step:818/1600 train_time:35878ms step_avg:43.86ms
+step:819/1600 train_time:35940ms step_avg:43.88ms
+step:820/1600 train_time:36000ms step_avg:43.90ms
+step:821/1600 train_time:36061ms step_avg:43.92ms
+step:822/1600 train_time:36120ms step_avg:43.94ms
+step:823/1600 train_time:36182ms step_avg:43.96ms
+step:824/1600 train_time:36240ms step_avg:43.98ms
+step:825/1600 train_time:36303ms step_avg:44.00ms
+step:826/1600 train_time:36362ms step_avg:44.02ms
+step:827/1600 train_time:36425ms step_avg:44.04ms
+step:828/1600 train_time:36484ms step_avg:44.06ms
+step:829/1600 train_time:36547ms step_avg:44.09ms
+step:830/1600 train_time:36606ms step_avg:44.10ms
+step:831/1600 train_time:36669ms step_avg:44.13ms
+step:832/1600 train_time:36728ms step_avg:44.14ms
+step:833/1600 train_time:36791ms step_avg:44.17ms
+step:834/1600 train_time:36849ms step_avg:44.18ms
+step:835/1600 train_time:36913ms step_avg:44.21ms
+step:836/1600 train_time:36972ms step_avg:44.22ms
+step:837/1600 train_time:37035ms step_avg:44.25ms
+step:838/1600 train_time:37094ms step_avg:44.27ms
+step:839/1600 train_time:37156ms step_avg:44.29ms
+step:840/1600 train_time:37216ms step_avg:44.30ms
+step:841/1600 train_time:37279ms step_avg:44.33ms
+step:842/1600 train_time:37338ms step_avg:44.34ms
+step:843/1600 train_time:37399ms step_avg:44.36ms
+step:844/1600 train_time:37458ms step_avg:44.38ms
+step:845/1600 train_time:37520ms step_avg:44.40ms
+step:846/1600 train_time:37578ms step_avg:44.42ms
+step:847/1600 train_time:37643ms step_avg:44.44ms
+step:848/1600 train_time:37700ms step_avg:44.46ms
+step:849/1600 train_time:37761ms step_avg:44.48ms
+step:850/1600 train_time:37819ms step_avg:44.49ms
+step:851/1600 train_time:37881ms step_avg:44.51ms
+step:852/1600 train_time:37941ms step_avg:44.53ms
+step:853/1600 train_time:38005ms step_avg:44.55ms
+step:854/1600 train_time:38063ms step_avg:44.57ms
+step:855/1600 train_time:38126ms step_avg:44.59ms
+step:856/1600 train_time:38186ms step_avg:44.61ms
+step:857/1600 train_time:38248ms step_avg:44.63ms
+step:858/1600 train_time:38307ms step_avg:44.65ms
+step:859/1600 train_time:38370ms step_avg:44.67ms
+step:860/1600 train_time:38430ms step_avg:44.69ms
+step:861/1600 train_time:38491ms step_avg:44.71ms
+step:862/1600 train_time:38550ms step_avg:44.72ms
+step:863/1600 train_time:38612ms step_avg:44.74ms
+step:864/1600 train_time:38672ms step_avg:44.76ms
+step:865/1600 train_time:38734ms step_avg:44.78ms
+step:866/1600 train_time:38793ms step_avg:44.80ms
+step:867/1600 train_time:38856ms step_avg:44.82ms
+step:868/1600 train_time:38915ms step_avg:44.83ms
+step:869/1600 train_time:38978ms step_avg:44.85ms
+step:870/1600 train_time:39038ms step_avg:44.87ms
+step:871/1600 train_time:39100ms step_avg:44.89ms
+step:872/1600 train_time:39159ms step_avg:44.91ms
+step:873/1600 train_time:39222ms step_avg:44.93ms
+step:874/1600 train_time:39280ms step_avg:44.94ms
+step:875/1600 train_time:39342ms step_avg:44.96ms
+step:876/1600 train_time:39401ms step_avg:44.98ms
+step:877/1600 train_time:39462ms step_avg:45.00ms
+step:878/1600 train_time:39521ms step_avg:45.01ms
+step:879/1600 train_time:39584ms step_avg:45.03ms
+step:880/1600 train_time:39644ms step_avg:45.05ms
+step:881/1600 train_time:39707ms step_avg:45.07ms
+step:882/1600 train_time:39766ms step_avg:45.09ms
+step:883/1600 train_time:39828ms step_avg:45.11ms
+step:884/1600 train_time:39888ms step_avg:45.12ms
+step:885/1600 train_time:39951ms step_avg:45.14ms
+step:886/1600 train_time:40010ms step_avg:45.16ms
+step:887/1600 train_time:40072ms step_avg:45.18ms
+step:888/1600 train_time:40132ms step_avg:45.19ms
+step:889/1600 train_time:40195ms step_avg:45.21ms
+step:890/1600 train_time:40259ms step_avg:45.23ms
+step:891/1600 train_time:40318ms step_avg:45.25ms
+step:892/1600 train_time:40377ms step_avg:45.27ms
+step:893/1600 train_time:40440ms step_avg:45.29ms
+step:894/1600 train_time:40498ms step_avg:45.30ms
+step:895/1600 train_time:40560ms step_avg:45.32ms
+step:896/1600 train_time:40618ms step_avg:45.33ms
+step:897/1600 train_time:40682ms step_avg:45.35ms
+step:898/1600 train_time:40741ms step_avg:45.37ms
+step:899/1600 train_time:40803ms step_avg:45.39ms
+step:900/1600 train_time:40861ms step_avg:45.40ms
+step:901/1600 train_time:40923ms step_avg:45.42ms
+step:902/1600 train_time:40981ms step_avg:45.43ms
+step:903/1600 train_time:41044ms step_avg:45.45ms
+step:904/1600 train_time:41103ms step_avg:45.47ms
+step:905/1600 train_time:41165ms step_avg:45.49ms
+step:906/1600 train_time:41225ms step_avg:45.50ms
+step:907/1600 train_time:41288ms step_avg:45.52ms
+step:908/1600 train_time:41348ms step_avg:45.54ms
+step:909/1600 train_time:41410ms step_avg:45.56ms
+step:910/1600 train_time:41469ms step_avg:45.57ms
+step:911/1600 train_time:41531ms step_avg:45.59ms
+step:912/1600 train_time:41590ms step_avg:45.60ms
+step:913/1600 train_time:41654ms step_avg:45.62ms
+step:914/1600 train_time:41713ms step_avg:45.64ms
+step:915/1600 train_time:41776ms step_avg:45.66ms
+step:916/1600 train_time:41835ms step_avg:45.67ms
+step:917/1600 train_time:41898ms step_avg:45.69ms
+step:918/1600 train_time:41957ms step_avg:45.71ms
+step:919/1600 train_time:42020ms step_avg:45.72ms
+step:920/1600 train_time:42080ms step_avg:45.74ms
+step:921/1600 train_time:42141ms step_avg:45.76ms
+step:922/1600 train_time:42199ms step_avg:45.77ms
+step:923/1600 train_time:42260ms step_avg:45.79ms
+step:924/1600 train_time:42320ms step_avg:45.80ms
+step:925/1600 train_time:42382ms step_avg:45.82ms
+step:926/1600 train_time:42440ms step_avg:45.83ms
+step:927/1600 train_time:42503ms step_avg:45.85ms
+step:928/1600 train_time:42562ms step_avg:45.86ms
+step:929/1600 train_time:42624ms step_avg:45.88ms
+step:930/1600 train_time:42682ms step_avg:45.90ms
+step:931/1600 train_time:42746ms step_avg:45.91ms
+step:932/1600 train_time:42805ms step_avg:45.93ms
+step:933/1600 train_time:42868ms step_avg:45.95ms
+step:934/1600 train_time:42927ms step_avg:45.96ms
+step:935/1600 train_time:42990ms step_avg:45.98ms
+step:936/1600 train_time:43048ms step_avg:45.99ms
+step:937/1600 train_time:43111ms step_avg:46.01ms
+step:938/1600 train_time:43170ms step_avg:46.02ms
+step:939/1600 train_time:43233ms step_avg:46.04ms
+step:940/1600 train_time:43292ms step_avg:46.06ms
+step:941/1600 train_time:43354ms step_avg:46.07ms
+step:942/1600 train_time:43414ms step_avg:46.09ms
+step:943/1600 train_time:43477ms step_avg:46.10ms
+step:944/1600 train_time:43535ms step_avg:46.12ms
+step:945/1600 train_time:43597ms step_avg:46.13ms
+step:946/1600 train_time:43658ms step_avg:46.15ms
+step:947/1600 train_time:43720ms step_avg:46.17ms
+step:948/1600 train_time:43778ms step_avg:46.18ms
+step:949/1600 train_time:43841ms step_avg:46.20ms
+step:950/1600 train_time:43899ms step_avg:46.21ms
+step:951/1600 train_time:43961ms step_avg:46.23ms
+step:952/1600 train_time:44019ms step_avg:46.24ms
+step:953/1600 train_time:44081ms step_avg:46.25ms
+step:954/1600 train_time:44140ms step_avg:46.27ms
+step:955/1600 train_time:44201ms step_avg:46.28ms
+step:956/1600 train_time:44260ms step_avg:46.30ms
+step:957/1600 train_time:44322ms step_avg:46.31ms
+step:958/1600 train_time:44381ms step_avg:46.33ms
+step:959/1600 train_time:44444ms step_avg:46.34ms
+step:960/1600 train_time:44503ms step_avg:46.36ms
+step:961/1600 train_time:44566ms step_avg:46.38ms
+step:962/1600 train_time:44627ms step_avg:46.39ms
+step:963/1600 train_time:44690ms step_avg:46.41ms
+step:964/1600 train_time:44748ms step_avg:46.42ms
+step:965/1600 train_time:44811ms step_avg:46.44ms
+step:966/1600 train_time:44870ms step_avg:46.45ms
+step:967/1600 train_time:44934ms step_avg:46.47ms
+step:968/1600 train_time:44992ms step_avg:46.48ms
+step:969/1600 train_time:45055ms step_avg:46.50ms
+step:970/1600 train_time:45114ms step_avg:46.51ms
+step:971/1600 train_time:45177ms step_avg:46.53ms
+step:972/1600 train_time:45238ms step_avg:46.54ms
+step:973/1600 train_time:45299ms step_avg:46.56ms
+step:974/1600 train_time:45357ms step_avg:46.57ms
+step:975/1600 train_time:45419ms step_avg:46.58ms
+step:976/1600 train_time:45478ms step_avg:46.60ms
+step:977/1600 train_time:45540ms step_avg:46.61ms
+step:978/1600 train_time:45599ms step_avg:46.62ms
+step:979/1600 train_time:45662ms step_avg:46.64ms
+step:980/1600 train_time:45719ms step_avg:46.65ms
+step:981/1600 train_time:45782ms step_avg:46.67ms
+step:982/1600 train_time:45842ms step_avg:46.68ms
+step:983/1600 train_time:45904ms step_avg:46.70ms
+step:984/1600 train_time:45961ms step_avg:46.71ms
+step:985/1600 train_time:46023ms step_avg:46.72ms
+step:986/1600 train_time:46081ms step_avg:46.74ms
+step:987/1600 train_time:46143ms step_avg:46.75ms
+step:988/1600 train_time:46203ms step_avg:46.76ms
+step:989/1600 train_time:46266ms step_avg:46.78ms
+step:990/1600 train_time:46325ms step_avg:46.79ms
+step:991/1600 train_time:46388ms step_avg:46.81ms
+step:992/1600 train_time:46447ms step_avg:46.82ms
+step:993/1600 train_time:46509ms step_avg:46.84ms
+step:994/1600 train_time:46568ms step_avg:46.85ms
+step:995/1600 train_time:46631ms step_avg:46.87ms
+step:996/1600 train_time:46690ms step_avg:46.88ms
+step:997/1600 train_time:46753ms step_avg:46.89ms
+step:998/1600 train_time:46812ms step_avg:46.91ms
+step:999/1600 train_time:46875ms step_avg:46.92ms
+step:1000/1600 train_time:46934ms step_avg:46.93ms
+step:1000/1600 val_loss:3.5959 train_time:46980ms step_avg:46.98ms
+step:1001/1600 train_time:47001ms step_avg:46.95ms
+step:1002/1600 train_time:47059ms step_avg:46.97ms
+step:1003/1600 train_time:47124ms step_avg:46.98ms
+step:1004/1600 train_time:47185ms step_avg:47.00ms
+step:1005/1600 train_time:47246ms step_avg:47.01ms
+step:1006/1600 train_time:47306ms step_avg:47.02ms
+step:1007/1600 train_time:47367ms step_avg:47.04ms
+step:1008/1600 train_time:47425ms step_avg:47.05ms
+step:1009/1600 train_time:47486ms step_avg:47.06ms
+step:1010/1600 train_time:47544ms step_avg:47.07ms
+step:1011/1600 train_time:47606ms step_avg:47.09ms
+step:1012/1600 train_time:47664ms step_avg:47.10ms
+step:1013/1600 train_time:47725ms step_avg:47.11ms
+step:1014/1600 train_time:47785ms step_avg:47.13ms
+step:1015/1600 train_time:47845ms step_avg:47.14ms
+step:1016/1600 train_time:47903ms step_avg:47.15ms
+step:1017/1600 train_time:47966ms step_avg:47.16ms
+step:1018/1600 train_time:48026ms step_avg:47.18ms
+step:1019/1600 train_time:48088ms step_avg:47.19ms
+step:1020/1600 train_time:48148ms step_avg:47.20ms
+step:1021/1600 train_time:48211ms step_avg:47.22ms
+step:1022/1600 train_time:48270ms step_avg:47.23ms
+step:1023/1600 train_time:48333ms step_avg:47.25ms
+step:1024/1600 train_time:48392ms step_avg:47.26ms
+step:1025/1600 train_time:48455ms step_avg:47.27ms
+step:1026/1600 train_time:48514ms step_avg:47.28ms
+step:1027/1600 train_time:48578ms step_avg:47.30ms
+step:1028/1600 train_time:48636ms step_avg:47.31ms
+step:1029/1600 train_time:48698ms step_avg:47.33ms
+step:1030/1600 train_time:48757ms step_avg:47.34ms
+step:1031/1600 train_time:48818ms step_avg:47.35ms
+step:1032/1600 train_time:48877ms step_avg:47.36ms
+step:1033/1600 train_time:48940ms step_avg:47.38ms
+step:1034/1600 train_time:49000ms step_avg:47.39ms
+step:1035/1600 train_time:49064ms step_avg:47.40ms
+step:1036/1600 train_time:49123ms step_avg:47.42ms
+step:1037/1600 train_time:49188ms step_avg:47.43ms
+step:1038/1600 train_time:49246ms step_avg:47.44ms
+step:1039/1600 train_time:49308ms step_avg:47.46ms
+step:1040/1600 train_time:49367ms step_avg:47.47ms
+step:1041/1600 train_time:49436ms step_avg:47.49ms
+step:1042/1600 train_time:49519ms step_avg:47.52ms
+step:1043/1600 train_time:49607ms step_avg:47.56ms
+step:1044/1600 train_time:49691ms step_avg:47.60ms
+step:1045/1600 train_time:49779ms step_avg:47.64ms
+step:1046/1600 train_time:49864ms step_avg:47.67ms
+step:1047/1600 train_time:49953ms step_avg:47.71ms
+step:1048/1600 train_time:50040ms step_avg:47.75ms
+step:1049/1600 train_time:50131ms step_avg:47.79ms
+step:1050/1600 train_time:50215ms step_avg:47.82ms
+step:1051/1600 train_time:50304ms step_avg:47.86ms
+step:1052/1600 train_time:50391ms step_avg:47.90ms
+step:1053/1600 train_time:50479ms step_avg:47.94ms
+step:1054/1600 train_time:50564ms step_avg:47.97ms
+step:1055/1600 train_time:50652ms step_avg:48.01ms
+step:1056/1600 train_time:50736ms step_avg:48.05ms
+step:1057/1600 train_time:50825ms step_avg:48.08ms
+step:1058/1600 train_time:50909ms step_avg:48.12ms
+step:1059/1600 train_time:50997ms step_avg:48.16ms
+step:1060/1600 train_time:51083ms step_avg:48.19ms
+step:1061/1600 train_time:51173ms step_avg:48.23ms
+step:1062/1600 train_time:51259ms step_avg:48.27ms
+step:1063/1600 train_time:51347ms step_avg:48.30ms
+step:1064/1600 train_time:51433ms step_avg:48.34ms
+step:1065/1600 train_time:51520ms step_avg:48.38ms
+step:1066/1600 train_time:51605ms step_avg:48.41ms
+step:1067/1600 train_time:51693ms step_avg:48.45ms
+step:1068/1600 train_time:51778ms step_avg:48.48ms
+step:1069/1600 train_time:51866ms step_avg:48.52ms
+step:1070/1600 train_time:51951ms step_avg:48.55ms
+step:1071/1600 train_time:52040ms step_avg:48.59ms
+step:1072/1600 train_time:52126ms step_avg:48.63ms
+step:1073/1600 train_time:52215ms step_avg:48.66ms
+step:1074/1600 train_time:52301ms step_avg:48.70ms
+step:1075/1600 train_time:52389ms step_avg:48.73ms
+step:1076/1600 train_time:52473ms step_avg:48.77ms
+step:1077/1600 train_time:52561ms step_avg:48.80ms
+step:1078/1600 train_time:52646ms step_avg:48.84ms
+step:1079/1600 train_time:52734ms step_avg:48.87ms
+step:1080/1600 train_time:52819ms step_avg:48.91ms
+step:1081/1600 train_time:52908ms step_avg:48.94ms
+step:1082/1600 train_time:52993ms step_avg:48.98ms
+step:1083/1600 train_time:53082ms step_avg:49.01ms
+step:1084/1600 train_time:53167ms step_avg:49.05ms
+step:1085/1600 train_time:53256ms step_avg:49.08ms
+step:1086/1600 train_time:53343ms step_avg:49.12ms
+step:1087/1600 train_time:53432ms step_avg:49.16ms
+step:1088/1600 train_time:53516ms step_avg:49.19ms
+step:1089/1600 train_time:53603ms step_avg:49.22ms
+step:1090/1600 train_time:53689ms step_avg:49.26ms
+step:1091/1600 train_time:53776ms step_avg:49.29ms
+step:1092/1600 train_time:53862ms step_avg:49.32ms
+step:1093/1600 train_time:53951ms step_avg:49.36ms
+step:1094/1600 train_time:54035ms step_avg:49.39ms
+step:1095/1600 train_time:54124ms step_avg:49.43ms
+step:1096/1600 train_time:54209ms step_avg:49.46ms
+step:1097/1600 train_time:54300ms step_avg:49.50ms
+step:1098/1600 train_time:54384ms step_avg:49.53ms
+step:1099/1600 train_time:54472ms step_avg:49.56ms
+step:1100/1600 train_time:54556ms step_avg:49.60ms
+step:1101/1600 train_time:54644ms step_avg:49.63ms
+step:1102/1600 train_time:54729ms step_avg:49.66ms
+step:1103/1600 train_time:54817ms step_avg:49.70ms
+step:1104/1600 train_time:54902ms step_avg:49.73ms
+step:1105/1600 train_time:54991ms step_avg:49.77ms
+step:1106/1600 train_time:55076ms step_avg:49.80ms
+step:1107/1600 train_time:55165ms step_avg:49.83ms
+step:1108/1600 train_time:55252ms step_avg:49.87ms
+step:1109/1600 train_time:55338ms step_avg:49.90ms
+step:1110/1600 train_time:55423ms step_avg:49.93ms
+step:1111/1600 train_time:55512ms step_avg:49.97ms
+step:1112/1600 train_time:55596ms step_avg:50.00ms
+step:1113/1600 train_time:55684ms step_avg:50.03ms
+step:1114/1600 train_time:55768ms step_avg:50.06ms
+step:1115/1600 train_time:55858ms step_avg:50.10ms
+step:1116/1600 train_time:55944ms step_avg:50.13ms
+step:1117/1600 train_time:56032ms step_avg:50.16ms
+step:1118/1600 train_time:56118ms step_avg:50.20ms
+step:1119/1600 train_time:56207ms step_avg:50.23ms
+step:1120/1600 train_time:56292ms step_avg:50.26ms
+step:1121/1600 train_time:56379ms step_avg:50.29ms
+step:1122/1600 train_time:56465ms step_avg:50.33ms
+step:1123/1600 train_time:56554ms step_avg:50.36ms
+step:1124/1600 train_time:56638ms step_avg:50.39ms
+step:1125/1600 train_time:56728ms step_avg:50.42ms
+step:1126/1600 train_time:56812ms step_avg:50.45ms
+step:1127/1600 train_time:56900ms step_avg:50.49ms
+step:1128/1600 train_time:56986ms step_avg:50.52ms
+step:1129/1600 train_time:57074ms step_avg:50.55ms
+step:1130/1600 train_time:57159ms step_avg:50.58ms
+step:1131/1600 train_time:57247ms step_avg:50.62ms
+step:1132/1600 train_time:57333ms step_avg:50.65ms
+step:1133/1600 train_time:57420ms step_avg:50.68ms
+step:1134/1600 train_time:57506ms step_avg:50.71ms
+step:1135/1600 train_time:57595ms step_avg:50.74ms
+step:1136/1600 train_time:57684ms step_avg:50.78ms
+step:1137/1600 train_time:57770ms step_avg:50.81ms
+step:1138/1600 train_time:57856ms step_avg:50.84ms
+step:1139/1600 train_time:57943ms step_avg:50.87ms
+step:1140/1600 train_time:58027ms step_avg:50.90ms
+step:1141/1600 train_time:58115ms step_avg:50.93ms
+step:1142/1600 train_time:58200ms step_avg:50.96ms
+step:1143/1600 train_time:58288ms step_avg:51.00ms
+step:1144/1600 train_time:58373ms step_avg:51.03ms
+step:1145/1600 train_time:58461ms step_avg:51.06ms
+step:1146/1600 train_time:58546ms step_avg:51.09ms
+step:1147/1600 train_time:58635ms step_avg:51.12ms
+step:1148/1600 train_time:58721ms step_avg:51.15ms
+step:1149/1600 train_time:58810ms step_avg:51.18ms
+step:1150/1600 train_time:58894ms step_avg:51.21ms
+step:1151/1600 train_time:58983ms step_avg:51.25ms
+step:1152/1600 train_time:59068ms step_avg:51.27ms
+step:1153/1600 train_time:59157ms step_avg:51.31ms
+step:1154/1600 train_time:59247ms step_avg:51.34ms
+step:1155/1600 train_time:59334ms step_avg:51.37ms
+step:1156/1600 train_time:59417ms step_avg:51.40ms
+step:1157/1600 train_time:59505ms step_avg:51.43ms
+step:1158/1600 train_time:59590ms step_avg:51.46ms
+step:1159/1600 train_time:59677ms step_avg:51.49ms
+step:1160/1600 train_time:59762ms step_avg:51.52ms
+step:1161/1600 train_time:59851ms step_avg:51.55ms
+step:1162/1600 train_time:59935ms step_avg:51.58ms
+step:1163/1600 train_time:60024ms step_avg:51.61ms
+step:1164/1600 train_time:60109ms step_avg:51.64ms
+step:1165/1600 train_time:60198ms step_avg:51.67ms
+step:1166/1600 train_time:60284ms step_avg:51.70ms
+step:1167/1600 train_time:60373ms step_avg:51.73ms
+step:1168/1600 train_time:60457ms step_avg:51.76ms
+step:1169/1600 train_time:60545ms step_avg:51.79ms
+step:1170/1600 train_time:60631ms step_avg:51.82ms
+step:1171/1600 train_time:60718ms step_avg:51.85ms
+step:1172/1600 train_time:60805ms step_avg:51.88ms
+step:1173/1600 train_time:60893ms step_avg:51.91ms
+step:1174/1600 train_time:60979ms step_avg:51.94ms
+step:1175/1600 train_time:61067ms step_avg:51.97ms
+step:1176/1600 train_time:61152ms step_avg:52.00ms
+step:1177/1600 train_time:61239ms step_avg:52.03ms
+step:1178/1600 train_time:61324ms step_avg:52.06ms
+step:1179/1600 train_time:61413ms step_avg:52.09ms
+step:1180/1600 train_time:61498ms step_avg:52.12ms
+step:1181/1600 train_time:61587ms step_avg:52.15ms
+step:1182/1600 train_time:61671ms step_avg:52.18ms
+step:1183/1600 train_time:61760ms step_avg:52.21ms
+step:1184/1600 train_time:61845ms step_avg:52.23ms
+step:1185/1600 train_time:61934ms step_avg:52.26ms
+step:1186/1600 train_time:62019ms step_avg:52.29ms
+step:1187/1600 train_time:62108ms step_avg:52.32ms
+step:1188/1600 train_time:62193ms step_avg:52.35ms
+step:1189/1600 train_time:62281ms step_avg:52.38ms
+step:1190/1600 train_time:62366ms step_avg:52.41ms
+step:1191/1600 train_time:62455ms step_avg:52.44ms
+step:1192/1600 train_time:62540ms step_avg:52.47ms
+step:1193/1600 train_time:62628ms step_avg:52.50ms
+step:1194/1600 train_time:62713ms step_avg:52.52ms
+step:1195/1600 train_time:62801ms step_avg:52.55ms
+step:1196/1600 train_time:62888ms step_avg:52.58ms
+step:1197/1600 train_time:62976ms step_avg:52.61ms
+step:1198/1600 train_time:63061ms step_avg:52.64ms
+step:1199/1600 train_time:63151ms step_avg:52.67ms
+step:1200/1600 train_time:63236ms step_avg:52.70ms
+step:1201/1600 train_time:63324ms step_avg:52.73ms
+step:1202/1600 train_time:63409ms step_avg:52.75ms
+step:1203/1600 train_time:63498ms step_avg:52.78ms
+step:1204/1600 train_time:63583ms step_avg:52.81ms
+step:1205/1600 train_time:63671ms step_avg:52.84ms
+step:1206/1600 train_time:63756ms step_avg:52.87ms
+step:1207/1600 train_time:63844ms step_avg:52.89ms
+step:1208/1600 train_time:63930ms step_avg:52.92ms
+step:1209/1600 train_time:64018ms step_avg:52.95ms
+step:1210/1600 train_time:64103ms step_avg:52.98ms
+step:1211/1600 train_time:64194ms step_avg:53.01ms
+step:1212/1600 train_time:64278ms step_avg:53.03ms
+step:1213/1600 train_time:64366ms step_avg:53.06ms
+step:1214/1600 train_time:64451ms step_avg:53.09ms
+step:1215/1600 train_time:64539ms step_avg:53.12ms
+step:1216/1600 train_time:64624ms step_avg:53.14ms
+step:1217/1600 train_time:64712ms step_avg:53.17ms
+step:1218/1600 train_time:64797ms step_avg:53.20ms
+step:1219/1600 train_time:64885ms step_avg:53.23ms
+step:1220/1600 train_time:64970ms step_avg:53.25ms
+step:1221/1600 train_time:65057ms step_avg:53.28ms
+step:1222/1600 train_time:65143ms step_avg:53.31ms
+step:1223/1600 train_time:65231ms step_avg:53.34ms
+step:1224/1600 train_time:65317ms step_avg:53.36ms
+step:1225/1600 train_time:65406ms step_avg:53.39ms
+step:1226/1600 train_time:65492ms step_avg:53.42ms
+step:1227/1600 train_time:65579ms step_avg:53.45ms
+step:1228/1600 train_time:65664ms step_avg:53.47ms
+step:1229/1600 train_time:65752ms step_avg:53.50ms
+step:1230/1600 train_time:65837ms step_avg:53.53ms
+step:1231/1600 train_time:65925ms step_avg:53.55ms
+step:1232/1600 train_time:66010ms step_avg:53.58ms
+step:1233/1600 train_time:66099ms step_avg:53.61ms
+step:1234/1600 train_time:66184ms step_avg:53.63ms
+step:1235/1600 train_time:66273ms step_avg:53.66ms
+step:1236/1600 train_time:66358ms step_avg:53.69ms
+step:1237/1600 train_time:66446ms step_avg:53.72ms
+step:1238/1600 train_time:66531ms step_avg:53.74ms
+step:1239/1600 train_time:66619ms step_avg:53.77ms
+step:1240/1600 train_time:66704ms step_avg:53.79ms
+step:1241/1600 train_time:66792ms step_avg:53.82ms
+step:1242/1600 train_time:66877ms step_avg:53.85ms
+step:1243/1600 train_time:66965ms step_avg:53.87ms
+step:1244/1600 train_time:67050ms step_avg:53.90ms
+step:1245/1600 train_time:67139ms step_avg:53.93ms
+step:1246/1600 train_time:67225ms step_avg:53.95ms
+step:1247/1600 train_time:67313ms step_avg:53.98ms
+step:1248/1600 train_time:67397ms step_avg:54.00ms
+step:1249/1600 train_time:67486ms step_avg:54.03ms
+step:1250/1600 train_time:67571ms step_avg:54.06ms
+step:1250/1600 val_loss:3.4169 train_time:67642ms step_avg:54.11ms
+step:1251/1600 train_time:67663ms step_avg:54.09ms
+step:1252/1600 train_time:67751ms step_avg:54.11ms
+step:1253/1600 train_time:67845ms step_avg:54.15ms
+step:1254/1600 train_time:67931ms step_avg:54.17ms
+step:1255/1600 train_time:68017ms step_avg:54.20ms
+step:1256/1600 train_time:68102ms step_avg:54.22ms
+step:1257/1600 train_time:68189ms step_avg:54.25ms
+step:1258/1600 train_time:68273ms step_avg:54.27ms
+step:1259/1600 train_time:68360ms step_avg:54.30ms
+step:1260/1600 train_time:68446ms step_avg:54.32ms
+step:1261/1600 train_time:68532ms step_avg:54.35ms
+step:1262/1600 train_time:68617ms step_avg:54.37ms
+step:1263/1600 train_time:68708ms step_avg:54.40ms
+step:1264/1600 train_time:68795ms step_avg:54.43ms
+step:1265/1600 train_time:68885ms step_avg:54.45ms
+step:1266/1600 train_time:68972ms step_avg:54.48ms
+step:1267/1600 train_time:69059ms step_avg:54.51ms
+step:1268/1600 train_time:69145ms step_avg:54.53ms
+step:1269/1600 train_time:69234ms step_avg:54.56ms
+step:1270/1600 train_time:69318ms step_avg:54.58ms
+step:1271/1600 train_time:69405ms step_avg:54.61ms
+step:1272/1600 train_time:69491ms step_avg:54.63ms
+step:1273/1600 train_time:69578ms step_avg:54.66ms
+step:1274/1600 train_time:69667ms step_avg:54.68ms
+step:1275/1600 train_time:69757ms step_avg:54.71ms
+step:1276/1600 train_time:69842ms step_avg:54.73ms
+step:1277/1600 train_time:69931ms step_avg:54.76ms
+step:1278/1600 train_time:70016ms step_avg:54.79ms
+step:1279/1600 train_time:70104ms step_avg:54.81ms
+step:1280/1600 train_time:70188ms step_avg:54.83ms
+step:1281/1600 train_time:70276ms step_avg:54.86ms
+step:1282/1600 train_time:70360ms step_avg:54.88ms
+step:1283/1600 train_time:70449ms step_avg:54.91ms
+step:1284/1600 train_time:70533ms step_avg:54.93ms
+step:1285/1600 train_time:70621ms step_avg:54.96ms
+step:1286/1600 train_time:70708ms step_avg:54.98ms
+step:1287/1600 train_time:70797ms step_avg:55.01ms
+step:1288/1600 train_time:70883ms step_avg:55.03ms
+step:1289/1600 train_time:70972ms step_avg:55.06ms
+step:1290/1600 train_time:71058ms step_avg:55.08ms
+step:1291/1600 train_time:71145ms step_avg:55.11ms
+step:1292/1600 train_time:71230ms step_avg:55.13ms
+step:1293/1600 train_time:71317ms step_avg:55.16ms
+step:1294/1600 train_time:71402ms step_avg:55.18ms
+step:1295/1600 train_time:71490ms step_avg:55.20ms
+step:1296/1600 train_time:71574ms step_avg:55.23ms
+step:1297/1600 train_time:71664ms step_avg:55.25ms
+step:1298/1600 train_time:71750ms step_avg:55.28ms
+step:1299/1600 train_time:71839ms step_avg:55.30ms
+step:1300/1600 train_time:71924ms step_avg:55.33ms
+step:1301/1600 train_time:72013ms step_avg:55.35ms
+step:1302/1600 train_time:72098ms step_avg:55.38ms
+step:1303/1600 train_time:72186ms step_avg:55.40ms
+step:1304/1600 train_time:72272ms step_avg:55.42ms
+step:1305/1600 train_time:72359ms step_avg:55.45ms
+step:1306/1600 train_time:72446ms step_avg:55.47ms
+step:1307/1600 train_time:72532ms step_avg:55.50ms
+step:1308/1600 train_time:72619ms step_avg:55.52ms
+step:1309/1600 train_time:72707ms step_avg:55.54ms
+step:1310/1600 train_time:72792ms step_avg:55.57ms
+step:1311/1600 train_time:72881ms step_avg:55.59ms
+step:1312/1600 train_time:72966ms step_avg:55.61ms
+step:1313/1600 train_time:73055ms step_avg:55.64ms
+step:1314/1600 train_time:73140ms step_avg:55.66ms
+step:1315/1600 train_time:73229ms step_avg:55.69ms
+step:1316/1600 train_time:73313ms step_avg:55.71ms
+step:1317/1600 train_time:73402ms step_avg:55.73ms
+step:1318/1600 train_time:73486ms step_avg:55.76ms
+step:1319/1600 train_time:73574ms step_avg:55.78ms
+step:1320/1600 train_time:73659ms step_avg:55.80ms
+step:1321/1600 train_time:73748ms step_avg:55.83ms
+step:1322/1600 train_time:73834ms step_avg:55.85ms
+step:1323/1600 train_time:73922ms step_avg:55.87ms
+step:1324/1600 train_time:74009ms step_avg:55.90ms
+step:1325/1600 train_time:74095ms step_avg:55.92ms
+step:1326/1600 train_time:74180ms step_avg:55.94ms
+step:1327/1600 train_time:74269ms step_avg:55.97ms
+step:1328/1600 train_time:74353ms step_avg:55.99ms
+step:1329/1600 train_time:74442ms step_avg:56.01ms
+step:1330/1600 train_time:74526ms step_avg:56.03ms
+step:1331/1600 train_time:74615ms step_avg:56.06ms
+step:1332/1600 train_time:74699ms step_avg:56.08ms
+step:1333/1600 train_time:74790ms step_avg:56.11ms
+step:1334/1600 train_time:74874ms step_avg:56.13ms
+step:1335/1600 train_time:74962ms step_avg:56.15ms
+step:1336/1600 train_time:75047ms step_avg:56.17ms
+step:1337/1600 train_time:75135ms step_avg:56.20ms
+step:1338/1600 train_time:75220ms step_avg:56.22ms
+step:1339/1600 train_time:75308ms step_avg:56.24ms
+step:1340/1600 train_time:75392ms step_avg:56.26ms
+step:1341/1600 train_time:75481ms step_avg:56.29ms
+step:1342/1600 train_time:75566ms step_avg:56.31ms
+step:1343/1600 train_time:75655ms step_avg:56.33ms
+step:1344/1600 train_time:75740ms step_avg:56.35ms
+step:1345/1600 train_time:75830ms step_avg:56.38ms
+step:1346/1600 train_time:75914ms step_avg:56.40ms
+step:1347/1600 train_time:76002ms step_avg:56.42ms
+step:1348/1600 train_time:76087ms step_avg:56.44ms
+step:1349/1600 train_time:76174ms step_avg:56.47ms
+step:1350/1600 train_time:76259ms step_avg:56.49ms
+step:1351/1600 train_time:76347ms step_avg:56.51ms
+step:1352/1600 train_time:76432ms step_avg:56.53ms
+step:1353/1600 train_time:76520ms step_avg:56.56ms
+step:1354/1600 train_time:76606ms step_avg:56.58ms
+step:1355/1600 train_time:76695ms step_avg:56.60ms
+step:1356/1600 train_time:76780ms step_avg:56.62ms
+step:1357/1600 train_time:76870ms step_avg:56.65ms
+step:1358/1600 train_time:76955ms step_avg:56.67ms
+step:1359/1600 train_time:77043ms step_avg:56.69ms
+step:1360/1600 train_time:77128ms step_avg:56.71ms
+step:1361/1600 train_time:77217ms step_avg:56.74ms
+step:1362/1600 train_time:77302ms step_avg:56.76ms
+step:1363/1600 train_time:77390ms step_avg:56.78ms
+step:1364/1600 train_time:77475ms step_avg:56.80ms
+step:1365/1600 train_time:77562ms step_avg:56.82ms
+step:1366/1600 train_time:77652ms step_avg:56.85ms
+step:1367/1600 train_time:77739ms step_avg:56.87ms
+step:1368/1600 train_time:77824ms step_avg:56.89ms
+step:1369/1600 train_time:77912ms step_avg:56.91ms
+step:1370/1600 train_time:77997ms step_avg:56.93ms
+step:1371/1600 train_time:78085ms step_avg:56.95ms
+step:1372/1600 train_time:78170ms step_avg:56.98ms
+step:1373/1600 train_time:78261ms step_avg:57.00ms
+step:1374/1600 train_time:78345ms step_avg:57.02ms
+step:1375/1600 train_time:78433ms step_avg:57.04ms
+step:1376/1600 train_time:78517ms step_avg:57.06ms
+step:1377/1600 train_time:78606ms step_avg:57.08ms
+step:1378/1600 train_time:78691ms step_avg:57.11ms
+step:1379/1600 train_time:78778ms step_avg:57.13ms
+step:1380/1600 train_time:78865ms step_avg:57.15ms
+step:1381/1600 train_time:78954ms step_avg:57.17ms
+step:1382/1600 train_time:79038ms step_avg:57.19ms
+step:1383/1600 train_time:79127ms step_avg:57.21ms
+step:1384/1600 train_time:79212ms step_avg:57.23ms
+step:1385/1600 train_time:79300ms step_avg:57.26ms
+step:1386/1600 train_time:79385ms step_avg:57.28ms
+step:1387/1600 train_time:79475ms step_avg:57.30ms
+step:1388/1600 train_time:79561ms step_avg:57.32ms
+step:1389/1600 train_time:79649ms step_avg:57.34ms
+step:1390/1600 train_time:79734ms step_avg:57.36ms
+step:1391/1600 train_time:79904ms step_avg:57.44ms
+step:1392/1600 train_time:79937ms step_avg:57.43ms
+step:1393/1600 train_time:80011ms step_avg:57.44ms
+step:1394/1600 train_time:80094ms step_avg:57.46ms
+step:1395/1600 train_time:80180ms step_avg:57.48ms
+step:1396/1600 train_time:80266ms step_avg:57.50ms
+step:1397/1600 train_time:80354ms step_avg:57.52ms
+step:1398/1600 train_time:80438ms step_avg:57.54ms
+step:1399/1600 train_time:80528ms step_avg:57.56ms
+step:1400/1600 train_time:80613ms step_avg:57.58ms
+step:1401/1600 train_time:80701ms step_avg:57.60ms
+step:1402/1600 train_time:80787ms step_avg:57.62ms
+step:1403/1600 train_time:80877ms step_avg:57.65ms
+step:1404/1600 train_time:80963ms step_avg:57.67ms
+step:1405/1600 train_time:81052ms step_avg:57.69ms
+step:1406/1600 train_time:81136ms step_avg:57.71ms
+step:1407/1600 train_time:81224ms step_avg:57.73ms
+step:1408/1600 train_time:81309ms step_avg:57.75ms
+step:1409/1600 train_time:81396ms step_avg:57.77ms
+step:1410/1600 train_time:81482ms step_avg:57.79ms
+step:1411/1600 train_time:81570ms step_avg:57.81ms
+step:1412/1600 train_time:81655ms step_avg:57.83ms
+step:1413/1600 train_time:81744ms step_avg:57.85ms
+step:1414/1600 train_time:81829ms step_avg:57.87ms
+step:1415/1600 train_time:81918ms step_avg:57.89ms
+step:1416/1600 train_time:82004ms step_avg:57.91ms
+step:1417/1600 train_time:82092ms step_avg:57.93ms
+step:1418/1600 train_time:82177ms step_avg:57.95ms
+step:1419/1600 train_time:82265ms step_avg:57.97ms
+step:1420/1600 train_time:82350ms step_avg:57.99ms
+step:1421/1600 train_time:82439ms step_avg:58.01ms
+step:1422/1600 train_time:82525ms step_avg:58.03ms
+step:1423/1600 train_time:82613ms step_avg:58.06ms
+step:1424/1600 train_time:82698ms step_avg:58.07ms
+step:1425/1600 train_time:82787ms step_avg:58.10ms
+step:1426/1600 train_time:82872ms step_avg:58.12ms
+step:1427/1600 train_time:82961ms step_avg:58.14ms
+step:1428/1600 train_time:83046ms step_avg:58.16ms
+step:1429/1600 train_time:83135ms step_avg:58.18ms
+step:1430/1600 train_time:83219ms step_avg:58.19ms
+step:1431/1600 train_time:83307ms step_avg:58.22ms
+step:1432/1600 train_time:83392ms step_avg:58.23ms
+step:1433/1600 train_time:83479ms step_avg:58.25ms
+step:1434/1600 train_time:83564ms step_avg:58.27ms
+step:1435/1600 train_time:83653ms step_avg:58.29ms
+step:1436/1600 train_time:83738ms step_avg:58.31ms
+step:1437/1600 train_time:83827ms step_avg:58.33ms
+step:1438/1600 train_time:83912ms step_avg:58.35ms
+step:1439/1600 train_time:84000ms step_avg:58.37ms
+step:1440/1600 train_time:84085ms step_avg:58.39ms
+step:1441/1600 train_time:84173ms step_avg:58.41ms
+step:1442/1600 train_time:84259ms step_avg:58.43ms
+step:1443/1600 train_time:84348ms step_avg:58.45ms
+step:1444/1600 train_time:84433ms step_avg:58.47ms
+step:1445/1600 train_time:84520ms step_avg:58.49ms
+step:1446/1600 train_time:84606ms step_avg:58.51ms
+step:1447/1600 train_time:84695ms step_avg:58.53ms
+step:1448/1600 train_time:84780ms step_avg:58.55ms
+step:1449/1600 train_time:84868ms step_avg:58.57ms
+step:1450/1600 train_time:84954ms step_avg:58.59ms
+step:1451/1600 train_time:85043ms step_avg:58.61ms
+step:1452/1600 train_time:85126ms step_avg:58.63ms
+step:1453/1600 train_time:85215ms step_avg:58.65ms
+step:1454/1600 train_time:85301ms step_avg:58.67ms
+step:1455/1600 train_time:85389ms step_avg:58.69ms
+step:1456/1600 train_time:85474ms step_avg:58.70ms
+step:1457/1600 train_time:85562ms step_avg:58.73ms
+step:1458/1600 train_time:85647ms step_avg:58.74ms
+step:1459/1600 train_time:85736ms step_avg:58.76ms
+step:1460/1600 train_time:85821ms step_avg:58.78ms
+step:1461/1600 train_time:85910ms step_avg:58.80ms
+step:1462/1600 train_time:85995ms step_avg:58.82ms
+step:1463/1600 train_time:86083ms step_avg:58.84ms
+step:1464/1600 train_time:86168ms step_avg:58.86ms
+step:1465/1600 train_time:86257ms step_avg:58.88ms
+step:1466/1600 train_time:86343ms step_avg:58.90ms
+step:1467/1600 train_time:86431ms step_avg:58.92ms
+step:1468/1600 train_time:86516ms step_avg:58.93ms
+step:1469/1600 train_time:86604ms step_avg:58.95ms
+step:1470/1600 train_time:86689ms step_avg:58.97ms
+step:1471/1600 train_time:86777ms step_avg:58.99ms
+step:1472/1600 train_time:86862ms step_avg:59.01ms
+step:1473/1600 train_time:86951ms step_avg:59.03ms
+step:1474/1600 train_time:87036ms step_avg:59.05ms
+step:1475/1600 train_time:87124ms step_avg:59.07ms
+step:1476/1600 train_time:87211ms step_avg:59.09ms
+step:1477/1600 train_time:87298ms step_avg:59.11ms
+step:1478/1600 train_time:87384ms step_avg:59.12ms
+step:1479/1600 train_time:87472ms step_avg:59.14ms
+step:1480/1600 train_time:87557ms step_avg:59.16ms
+step:1481/1600 train_time:87645ms step_avg:59.18ms
+step:1482/1600 train_time:87731ms step_avg:59.20ms
+step:1483/1600 train_time:87819ms step_avg:59.22ms
+step:1484/1600 train_time:87904ms step_avg:59.23ms
+step:1485/1600 train_time:87993ms step_avg:59.25ms
+step:1486/1600 train_time:88079ms step_avg:59.27ms
+step:1487/1600 train_time:88169ms step_avg:59.29ms
+step:1488/1600 train_time:88253ms step_avg:59.31ms
+step:1489/1600 train_time:88341ms step_avg:59.33ms
+step:1490/1600 train_time:88427ms step_avg:59.35ms
+step:1491/1600 train_time:88516ms step_avg:59.37ms
+step:1492/1600 train_time:88599ms step_avg:59.38ms
+step:1493/1600 train_time:88688ms step_avg:59.40ms
+step:1494/1600 train_time:88774ms step_avg:59.42ms
+step:1495/1600 train_time:88862ms step_avg:59.44ms
+step:1496/1600 train_time:88947ms step_avg:59.46ms
+step:1497/1600 train_time:89036ms step_avg:59.48ms
+step:1498/1600 train_time:89122ms step_avg:59.49ms
+step:1499/1600 train_time:89211ms step_avg:59.51ms
+step:1500/1600 train_time:89296ms step_avg:59.53ms
+step:1500/1600 val_loss:3.3070 train_time:89367ms step_avg:59.58ms
+step:1501/1600 train_time:89389ms step_avg:59.55ms
+step:1502/1600 train_time:89474ms step_avg:59.57ms
+step:1503/1600 train_time:89566ms step_avg:59.59ms
+step:1504/1600 train_time:89652ms step_avg:59.61ms
+step:1505/1600 train_time:89739ms step_avg:59.63ms
+step:1506/1600 train_time:89824ms step_avg:59.64ms
+step:1507/1600 train_time:89912ms step_avg:59.66ms
+step:1508/1600 train_time:89996ms step_avg:59.68ms
+step:1509/1600 train_time:90083ms step_avg:59.70ms
+step:1510/1600 train_time:90166ms step_avg:59.71ms
+step:1511/1600 train_time:90253ms step_avg:59.73ms
+step:1512/1600 train_time:90341ms step_avg:59.75ms
+step:1513/1600 train_time:90432ms step_avg:59.77ms
+step:1514/1600 train_time:90520ms step_avg:59.79ms
+step:1515/1600 train_time:90610ms step_avg:59.81ms
+step:1516/1600 train_time:90696ms step_avg:59.83ms
+step:1517/1600 train_time:90783ms step_avg:59.84ms
+step:1518/1600 train_time:90868ms step_avg:59.86ms
+step:1519/1600 train_time:90956ms step_avg:59.88ms
+step:1520/1600 train_time:91039ms step_avg:59.89ms
+step:1521/1600 train_time:91128ms step_avg:59.91ms
+step:1522/1600 train_time:91212ms step_avg:59.93ms
+step:1523/1600 train_time:91300ms step_avg:59.95ms
+step:1524/1600 train_time:91387ms step_avg:59.97ms
+step:1525/1600 train_time:91477ms step_avg:59.99ms
+step:1526/1600 train_time:91563ms step_avg:60.00ms
+step:1527/1600 train_time:91652ms step_avg:60.02ms
+step:1528/1600 train_time:91738ms step_avg:60.04ms
+step:1529/1600 train_time:91827ms step_avg:60.06ms
+step:1530/1600 train_time:91911ms step_avg:60.07ms
+step:1531/1600 train_time:91999ms step_avg:60.09ms
+step:1532/1600 train_time:92086ms step_avg:60.11ms
+step:1533/1600 train_time:92172ms step_avg:60.13ms
+step:1534/1600 train_time:92256ms step_avg:60.14ms
+step:1535/1600 train_time:92345ms step_avg:60.16ms
+step:1536/1600 train_time:92432ms step_avg:60.18ms
+step:1537/1600 train_time:92520ms step_avg:60.20ms
+step:1538/1600 train_time:92608ms step_avg:60.21ms
+step:1539/1600 train_time:92696ms step_avg:60.23ms
+step:1540/1600 train_time:92782ms step_avg:60.25ms
+step:1541/1600 train_time:92870ms step_avg:60.27ms
+step:1542/1600 train_time:92955ms step_avg:60.28ms
+step:1543/1600 train_time:93043ms step_avg:60.30ms
+step:1544/1600 train_time:93128ms step_avg:60.32ms
+step:1545/1600 train_time:93215ms step_avg:60.33ms
+step:1546/1600 train_time:93300ms step_avg:60.35ms
+step:1547/1600 train_time:93389ms step_avg:60.37ms
+step:1548/1600 train_time:93475ms step_avg:60.38ms
+step:1549/1600 train_time:93564ms step_avg:60.40ms
+step:1550/1600 train_time:93650ms step_avg:60.42ms
+step:1551/1600 train_time:93738ms step_avg:60.44ms
+step:1552/1600 train_time:93823ms step_avg:60.45ms
+step:1553/1600 train_time:93912ms step_avg:60.47ms
+step:1554/1600 train_time:93998ms step_avg:60.49ms
+step:1555/1600 train_time:94086ms step_avg:60.51ms
+step:1556/1600 train_time:94170ms step_avg:60.52ms
+step:1557/1600 train_time:94258ms step_avg:60.54ms
+step:1558/1600 train_time:94344ms step_avg:60.55ms
+step:1559/1600 train_time:94434ms step_avg:60.57ms
+step:1560/1600 train_time:94518ms step_avg:60.59ms
+step:1561/1600 train_time:94613ms step_avg:60.61ms
+step:1562/1600 train_time:94697ms step_avg:60.63ms
+step:1563/1600 train_time:94785ms step_avg:60.64ms
+step:1564/1600 train_time:94871ms step_avg:60.66ms
+step:1565/1600 train_time:94960ms step_avg:60.68ms
+step:1566/1600 train_time:95045ms step_avg:60.69ms
+step:1567/1600 train_time:95133ms step_avg:60.71ms
+step:1568/1600 train_time:95218ms step_avg:60.73ms
+step:1569/1600 train_time:95307ms step_avg:60.74ms
+step:1570/1600 train_time:95393ms step_avg:60.76ms
+step:1571/1600 train_time:95482ms step_avg:60.78ms
+step:1572/1600 train_time:95569ms step_avg:60.79ms
+step:1573/1600 train_time:95658ms step_avg:60.81ms
+step:1574/1600 train_time:95744ms step_avg:60.83ms
+step:1575/1600 train_time:95833ms step_avg:60.85ms
+step:1576/1600 train_time:95918ms step_avg:60.86ms
+step:1577/1600 train_time:96011ms step_avg:60.88ms
+step:1578/1600 train_time:96096ms step_avg:60.90ms
+step:1579/1600 train_time:96183ms step_avg:60.91ms
+step:1580/1600 train_time:96268ms step_avg:60.93ms
+step:1581/1600 train_time:96356ms step_avg:60.95ms
+step:1582/1600 train_time:96442ms step_avg:60.96ms
+step:1583/1600 train_time:96531ms step_avg:60.98ms
+step:1584/1600 train_time:96617ms step_avg:61.00ms
+step:1585/1600 train_time:96705ms step_avg:61.01ms
+step:1586/1600 train_time:96791ms step_avg:61.03ms
+step:1587/1600 train_time:96879ms step_avg:61.05ms
+step:1588/1600 train_time:96965ms step_avg:61.06ms
+step:1589/1600 train_time:97053ms step_avg:61.08ms
+step:1590/1600 train_time:97138ms step_avg:61.09ms
+step:1591/1600 train_time:97227ms step_avg:61.11ms
+step:1592/1600 train_time:97313ms step_avg:61.13ms
+step:1593/1600 train_time:97401ms step_avg:61.14ms
+step:1594/1600 train_time:97487ms step_avg:61.16ms
+step:1595/1600 train_time:97576ms step_avg:61.18ms
+step:1596/1600 train_time:97662ms step_avg:61.19ms
+step:1597/1600 train_time:97751ms step_avg:61.21ms
+step:1598/1600 train_time:97836ms step_avg:61.22ms
+step:1599/1600 train_time:97924ms step_avg:61.24ms
+step:1600/1600 train_time:98010ms step_avg:61.26ms
+step:1600/1600 val_loss:3.2776 train_time:98081ms step_avg:61.30ms
+peak memory allocated: 30789 MiB reserved: 46238 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/dccf8664-b13c-44d0-9ad6-d2552b108c85.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/dccf8664-b13c-44d0-9ad6-d2552b108c85.txt
@@ -1,0 +1,4119 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 03:26:38 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   34C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   40C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   34C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   34C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   41C    P0            132W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   39C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          307242      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          307243      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          307244      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          307245      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          307246      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          307247      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          307248      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          307249      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8298 train_time:0ms step_avg:0.04ms
+step:1/1600 train_time:85ms step_avg:84.73ms
+step:2/1600 train_time:105ms step_avg:52.74ms
+step:3/1600 train_time:124ms step_avg:41.42ms
+step:4/1600 train_time:156ms step_avg:38.91ms
+step:5/1600 train_time:185ms step_avg:37.06ms
+step:6/1600 train_time:308ms step_avg:51.34ms
+step:7/1600 train_time:325ms step_avg:46.38ms
+step:8/1600 train_time:449ms step_avg:56.09ms
+step:9/1600 train_time:479ms step_avg:53.23ms
+step:10/1600 train_time:516ms step_avg:51.62ms
+step:11/1600 train_time:547ms step_avg:49.76ms
+step:12/1600 train_time:584ms step_avg:48.67ms
+step:13/1600 train_time:615ms step_avg:47.32ms
+step:14/1600 train_time:653ms step_avg:46.62ms
+step:15/1600 train_time:684ms step_avg:45.61ms
+step:16/1600 train_time:721ms step_avg:45.07ms
+step:17/1600 train_time:752ms step_avg:44.24ms
+step:18/1600 train_time:789ms step_avg:43.84ms
+step:19/1600 train_time:820ms step_avg:43.15ms
+step:20/1600 train_time:857ms step_avg:42.87ms
+step:21/1600 train_time:889ms step_avg:42.32ms
+step:22/1600 train_time:926ms step_avg:42.07ms
+step:23/1600 train_time:957ms step_avg:41.59ms
+step:24/1600 train_time:993ms step_avg:41.39ms
+step:25/1600 train_time:1024ms step_avg:40.97ms
+step:26/1600 train_time:1061ms step_avg:40.82ms
+step:27/1600 train_time:1092ms step_avg:40.46ms
+step:28/1600 train_time:1130ms step_avg:40.34ms
+step:29/1600 train_time:1160ms step_avg:40.02ms
+step:30/1600 train_time:1197ms step_avg:39.91ms
+step:31/1600 train_time:1229ms step_avg:39.63ms
+step:32/1600 train_time:1265ms step_avg:39.54ms
+step:33/1600 train_time:1296ms step_avg:39.28ms
+step:34/1600 train_time:1334ms step_avg:39.22ms
+step:35/1600 train_time:1365ms step_avg:38.99ms
+step:36/1600 train_time:1401ms step_avg:38.93ms
+step:37/1600 train_time:1433ms step_avg:38.73ms
+step:38/1600 train_time:1470ms step_avg:38.69ms
+step:39/1600 train_time:1501ms step_avg:38.48ms
+step:40/1600 train_time:1539ms step_avg:38.47ms
+step:41/1600 train_time:1570ms step_avg:38.29ms
+step:42/1600 train_time:1607ms step_avg:38.26ms
+step:43/1600 train_time:1638ms step_avg:38.10ms
+step:44/1600 train_time:1676ms step_avg:38.09ms
+step:45/1600 train_time:1707ms step_avg:37.93ms
+step:46/1600 train_time:1744ms step_avg:37.91ms
+step:47/1600 train_time:1775ms step_avg:37.76ms
+step:48/1600 train_time:1812ms step_avg:37.76ms
+step:49/1600 train_time:1843ms step_avg:37.62ms
+step:50/1600 train_time:1880ms step_avg:37.61ms
+step:51/1600 train_time:1911ms step_avg:37.47ms
+step:52/1600 train_time:1948ms step_avg:37.46ms
+step:53/1600 train_time:1979ms step_avg:37.33ms
+step:54/1600 train_time:2016ms step_avg:37.33ms
+step:55/1600 train_time:2047ms step_avg:37.21ms
+step:56/1600 train_time:2084ms step_avg:37.21ms
+step:57/1600 train_time:2115ms step_avg:37.10ms
+step:58/1600 train_time:2152ms step_avg:37.11ms
+step:59/1600 train_time:2183ms step_avg:37.01ms
+step:60/1600 train_time:2220ms step_avg:37.00ms
+step:61/1600 train_time:2251ms step_avg:36.90ms
+step:62/1600 train_time:2288ms step_avg:36.91ms
+step:63/1600 train_time:2319ms step_avg:36.81ms
+step:64/1600 train_time:2356ms step_avg:36.81ms
+step:65/1600 train_time:2387ms step_avg:36.73ms
+step:66/1600 train_time:2424ms step_avg:36.73ms
+step:67/1600 train_time:2455ms step_avg:36.65ms
+step:68/1600 train_time:2492ms step_avg:36.65ms
+step:69/1600 train_time:2523ms step_avg:36.56ms
+step:70/1600 train_time:2560ms step_avg:36.57ms
+step:71/1600 train_time:2591ms step_avg:36.49ms
+step:72/1600 train_time:2628ms step_avg:36.50ms
+step:73/1600 train_time:2659ms step_avg:36.43ms
+step:74/1600 train_time:2697ms step_avg:36.45ms
+step:75/1600 train_time:2728ms step_avg:36.37ms
+step:76/1600 train_time:2765ms step_avg:36.38ms
+step:77/1600 train_time:2795ms step_avg:36.30ms
+step:78/1600 train_time:2832ms step_avg:36.31ms
+step:79/1600 train_time:2863ms step_avg:36.24ms
+step:80/1600 train_time:2900ms step_avg:36.25ms
+step:81/1600 train_time:2931ms step_avg:36.18ms
+step:82/1600 train_time:2968ms step_avg:36.19ms
+step:83/1600 train_time:2999ms step_avg:36.13ms
+step:84/1600 train_time:3037ms step_avg:36.15ms
+step:85/1600 train_time:3068ms step_avg:36.09ms
+step:86/1600 train_time:3105ms step_avg:36.10ms
+step:87/1600 train_time:3136ms step_avg:36.05ms
+step:88/1600 train_time:3173ms step_avg:36.06ms
+step:89/1600 train_time:3204ms step_avg:36.00ms
+step:90/1600 train_time:3242ms step_avg:36.02ms
+step:91/1600 train_time:3272ms step_avg:35.96ms
+step:92/1600 train_time:3309ms step_avg:35.97ms
+step:93/1600 train_time:3340ms step_avg:35.92ms
+step:94/1600 train_time:3377ms step_avg:35.93ms
+step:95/1600 train_time:3408ms step_avg:35.88ms
+step:96/1600 train_time:3445ms step_avg:35.89ms
+step:97/1600 train_time:3476ms step_avg:35.83ms
+step:98/1600 train_time:3513ms step_avg:35.85ms
+step:99/1600 train_time:3544ms step_avg:35.80ms
+step:100/1600 train_time:3581ms step_avg:35.81ms
+step:101/1600 train_time:3612ms step_avg:35.77ms
+step:102/1600 train_time:3649ms step_avg:35.78ms
+step:103/1600 train_time:3680ms step_avg:35.73ms
+step:104/1600 train_time:3717ms step_avg:35.74ms
+step:105/1600 train_time:3748ms step_avg:35.70ms
+step:106/1600 train_time:3785ms step_avg:35.71ms
+step:107/1600 train_time:3816ms step_avg:35.67ms
+step:108/1600 train_time:3853ms step_avg:35.68ms
+step:109/1600 train_time:3884ms step_avg:35.63ms
+step:110/1600 train_time:3921ms step_avg:35.64ms
+step:111/1600 train_time:3952ms step_avg:35.60ms
+step:112/1600 train_time:3989ms step_avg:35.62ms
+step:113/1600 train_time:4020ms step_avg:35.58ms
+step:114/1600 train_time:4057ms step_avg:35.59ms
+step:115/1600 train_time:4088ms step_avg:35.55ms
+step:116/1600 train_time:4125ms step_avg:35.56ms
+step:117/1600 train_time:4156ms step_avg:35.52ms
+step:118/1600 train_time:4193ms step_avg:35.54ms
+step:119/1600 train_time:4225ms step_avg:35.50ms
+step:120/1600 train_time:4262ms step_avg:35.51ms
+step:121/1600 train_time:4293ms step_avg:35.48ms
+step:122/1600 train_time:4330ms step_avg:35.49ms
+step:123/1600 train_time:4361ms step_avg:35.45ms
+step:124/1600 train_time:4398ms step_avg:35.47ms
+step:125/1600 train_time:4429ms step_avg:35.43ms
+step:126/1600 train_time:4466ms step_avg:35.45ms
+step:127/1600 train_time:4497ms step_avg:35.41ms
+step:128/1600 train_time:4534ms step_avg:35.42ms
+step:129/1600 train_time:4565ms step_avg:35.39ms
+step:130/1600 train_time:4602ms step_avg:35.40ms
+step:131/1600 train_time:4633ms step_avg:35.36ms
+step:132/1600 train_time:4670ms step_avg:35.38ms
+step:133/1600 train_time:4701ms step_avg:35.35ms
+step:134/1600 train_time:4739ms step_avg:35.36ms
+step:135/1600 train_time:4769ms step_avg:35.33ms
+step:136/1600 train_time:4806ms step_avg:35.34ms
+step:137/1600 train_time:4837ms step_avg:35.30ms
+step:138/1600 train_time:4874ms step_avg:35.32ms
+step:139/1600 train_time:4905ms step_avg:35.29ms
+step:140/1600 train_time:4942ms step_avg:35.30ms
+step:141/1600 train_time:4973ms step_avg:35.27ms
+step:142/1600 train_time:5011ms step_avg:35.29ms
+step:143/1600 train_time:5042ms step_avg:35.26ms
+step:144/1600 train_time:5079ms step_avg:35.27ms
+step:145/1600 train_time:5110ms step_avg:35.24ms
+step:146/1600 train_time:5147ms step_avg:35.25ms
+step:147/1600 train_time:5177ms step_avg:35.22ms
+step:148/1600 train_time:5215ms step_avg:35.23ms
+step:149/1600 train_time:5246ms step_avg:35.21ms
+step:150/1600 train_time:5284ms step_avg:35.22ms
+step:151/1600 train_time:5314ms step_avg:35.19ms
+step:152/1600 train_time:5352ms step_avg:35.21ms
+step:153/1600 train_time:5382ms step_avg:35.17ms
+step:154/1600 train_time:5419ms step_avg:35.19ms
+step:155/1600 train_time:5450ms step_avg:35.16ms
+step:156/1600 train_time:5487ms step_avg:35.17ms
+step:157/1600 train_time:5517ms step_avg:35.14ms
+step:158/1600 train_time:5556ms step_avg:35.16ms
+step:159/1600 train_time:5586ms step_avg:35.13ms
+step:160/1600 train_time:5623ms step_avg:35.15ms
+step:161/1600 train_time:5654ms step_avg:35.12ms
+step:162/1600 train_time:5691ms step_avg:35.13ms
+step:163/1600 train_time:5721ms step_avg:35.10ms
+step:164/1600 train_time:5759ms step_avg:35.11ms
+step:165/1600 train_time:5789ms step_avg:35.09ms
+step:166/1600 train_time:5826ms step_avg:35.10ms
+step:167/1600 train_time:5857ms step_avg:35.07ms
+step:168/1600 train_time:5894ms step_avg:35.08ms
+step:169/1600 train_time:5925ms step_avg:35.06ms
+step:170/1600 train_time:5962ms step_avg:35.07ms
+step:171/1600 train_time:5993ms step_avg:35.04ms
+step:172/1600 train_time:6030ms step_avg:35.06ms
+step:173/1600 train_time:6060ms step_avg:35.03ms
+step:174/1600 train_time:6097ms step_avg:35.04ms
+step:175/1600 train_time:6128ms step_avg:35.02ms
+step:176/1600 train_time:6165ms step_avg:35.03ms
+step:177/1600 train_time:6196ms step_avg:35.01ms
+step:178/1600 train_time:6234ms step_avg:35.02ms
+step:179/1600 train_time:6264ms step_avg:35.00ms
+step:180/1600 train_time:6301ms step_avg:35.01ms
+step:181/1600 train_time:6332ms step_avg:34.98ms
+step:182/1600 train_time:6369ms step_avg:35.00ms
+step:183/1600 train_time:6400ms step_avg:34.97ms
+step:184/1600 train_time:6437ms step_avg:34.98ms
+step:185/1600 train_time:6468ms step_avg:34.96ms
+step:186/1600 train_time:6505ms step_avg:34.97ms
+step:187/1600 train_time:6536ms step_avg:34.95ms
+step:188/1600 train_time:6572ms step_avg:34.96ms
+step:189/1600 train_time:6603ms step_avg:34.94ms
+step:190/1600 train_time:6640ms step_avg:34.95ms
+step:191/1600 train_time:6671ms step_avg:34.93ms
+step:192/1600 train_time:6708ms step_avg:34.94ms
+step:193/1600 train_time:6739ms step_avg:34.92ms
+step:194/1600 train_time:6776ms step_avg:34.93ms
+step:195/1600 train_time:6807ms step_avg:34.91ms
+step:196/1600 train_time:6844ms step_avg:34.92ms
+step:197/1600 train_time:6875ms step_avg:34.90ms
+step:198/1600 train_time:6912ms step_avg:34.91ms
+step:199/1600 train_time:6943ms step_avg:34.89ms
+step:200/1600 train_time:6980ms step_avg:34.90ms
+step:201/1600 train_time:7010ms step_avg:34.88ms
+step:202/1600 train_time:7047ms step_avg:34.89ms
+step:203/1600 train_time:7078ms step_avg:34.87ms
+step:204/1600 train_time:7115ms step_avg:34.88ms
+step:205/1600 train_time:7146ms step_avg:34.86ms
+step:206/1600 train_time:7184ms step_avg:34.87ms
+step:207/1600 train_time:7216ms step_avg:34.86ms
+step:208/1600 train_time:7253ms step_avg:34.87ms
+step:209/1600 train_time:7284ms step_avg:34.85ms
+step:210/1600 train_time:7320ms step_avg:34.86ms
+step:211/1600 train_time:7351ms step_avg:34.84ms
+step:212/1600 train_time:7388ms step_avg:34.85ms
+step:213/1600 train_time:7419ms step_avg:34.83ms
+step:214/1600 train_time:7456ms step_avg:34.84ms
+step:215/1600 train_time:7487ms step_avg:34.82ms
+step:216/1600 train_time:7524ms step_avg:34.83ms
+step:217/1600 train_time:7555ms step_avg:34.82ms
+step:218/1600 train_time:7592ms step_avg:34.83ms
+step:219/1600 train_time:7623ms step_avg:34.81ms
+step:220/1600 train_time:7660ms step_avg:34.82ms
+step:221/1600 train_time:7690ms step_avg:34.80ms
+step:222/1600 train_time:7727ms step_avg:34.81ms
+step:223/1600 train_time:7758ms step_avg:34.79ms
+step:224/1600 train_time:7795ms step_avg:34.80ms
+step:225/1600 train_time:7826ms step_avg:34.78ms
+step:226/1600 train_time:7864ms step_avg:34.79ms
+step:227/1600 train_time:7894ms step_avg:34.78ms
+step:228/1600 train_time:7931ms step_avg:34.79ms
+step:229/1600 train_time:7962ms step_avg:34.77ms
+step:230/1600 train_time:7999ms step_avg:34.78ms
+step:231/1600 train_time:8029ms step_avg:34.76ms
+step:232/1600 train_time:8066ms step_avg:34.77ms
+step:233/1600 train_time:8097ms step_avg:34.75ms
+step:234/1600 train_time:8134ms step_avg:34.76ms
+step:235/1600 train_time:8165ms step_avg:34.74ms
+step:236/1600 train_time:8202ms step_avg:34.75ms
+step:237/1600 train_time:8233ms step_avg:34.74ms
+step:238/1600 train_time:8270ms step_avg:34.75ms
+step:239/1600 train_time:8300ms step_avg:34.73ms
+step:240/1600 train_time:8337ms step_avg:34.74ms
+step:241/1600 train_time:8368ms step_avg:34.72ms
+step:242/1600 train_time:8405ms step_avg:34.73ms
+step:243/1600 train_time:8436ms step_avg:34.71ms
+step:244/1600 train_time:8472ms step_avg:34.72ms
+step:245/1600 train_time:8503ms step_avg:34.71ms
+step:246/1600 train_time:8540ms step_avg:34.72ms
+step:247/1600 train_time:8571ms step_avg:34.70ms
+step:248/1600 train_time:8608ms step_avg:34.71ms
+step:249/1600 train_time:8639ms step_avg:34.69ms
+step:250/1600 train_time:8676ms step_avg:34.71ms
+step:250/1600 val_loss:4.5759 train_time:8724ms step_avg:34.90ms
+step:251/1600 train_time:8743ms step_avg:34.83ms
+step:252/1600 train_time:8761ms step_avg:34.77ms
+step:253/1600 train_time:8777ms step_avg:34.69ms
+step:254/1600 train_time:8814ms step_avg:34.70ms
+step:255/1600 train_time:8846ms step_avg:34.69ms
+step:256/1600 train_time:8886ms step_avg:34.71ms
+step:257/1600 train_time:8917ms step_avg:34.70ms
+step:258/1600 train_time:8954ms step_avg:34.71ms
+step:259/1600 train_time:8985ms step_avg:34.69ms
+step:260/1600 train_time:9023ms step_avg:34.70ms
+step:261/1600 train_time:9053ms step_avg:34.69ms
+step:262/1600 train_time:9090ms step_avg:34.69ms
+step:263/1600 train_time:9120ms step_avg:34.68ms
+step:264/1600 train_time:9158ms step_avg:34.69ms
+step:265/1600 train_time:9189ms step_avg:34.67ms
+step:266/1600 train_time:9226ms step_avg:34.68ms
+step:267/1600 train_time:9257ms step_avg:34.67ms
+step:268/1600 train_time:9294ms step_avg:34.68ms
+step:269/1600 train_time:9324ms step_avg:34.66ms
+step:270/1600 train_time:9361ms step_avg:34.67ms
+step:271/1600 train_time:9392ms step_avg:34.66ms
+step:272/1600 train_time:9429ms step_avg:34.67ms
+step:273/1600 train_time:9460ms step_avg:34.65ms
+step:274/1600 train_time:9496ms step_avg:34.66ms
+step:275/1600 train_time:9527ms step_avg:34.64ms
+step:276/1600 train_time:9564ms step_avg:34.65ms
+step:277/1600 train_time:9595ms step_avg:34.64ms
+step:278/1600 train_time:9632ms step_avg:34.65ms
+step:279/1600 train_time:9662ms step_avg:34.63ms
+step:280/1600 train_time:9699ms step_avg:34.64ms
+step:281/1600 train_time:9730ms step_avg:34.63ms
+step:282/1600 train_time:9767ms step_avg:34.63ms
+step:283/1600 train_time:9798ms step_avg:34.62ms
+step:284/1600 train_time:9835ms step_avg:34.63ms
+step:285/1600 train_time:9865ms step_avg:34.62ms
+step:286/1600 train_time:9902ms step_avg:34.62ms
+step:287/1600 train_time:9934ms step_avg:34.61ms
+step:288/1600 train_time:9971ms step_avg:34.62ms
+step:289/1600 train_time:10002ms step_avg:34.61ms
+step:290/1600 train_time:10039ms step_avg:34.62ms
+step:291/1600 train_time:10069ms step_avg:34.60ms
+step:292/1600 train_time:10106ms step_avg:34.61ms
+step:293/1600 train_time:10137ms step_avg:34.60ms
+step:294/1600 train_time:10174ms step_avg:34.60ms
+step:295/1600 train_time:10205ms step_avg:34.59ms
+step:296/1600 train_time:10242ms step_avg:34.60ms
+step:297/1600 train_time:10273ms step_avg:34.59ms
+step:298/1600 train_time:10310ms step_avg:34.60ms
+step:299/1600 train_time:10340ms step_avg:34.58ms
+step:300/1600 train_time:10377ms step_avg:34.59ms
+step:301/1600 train_time:10408ms step_avg:34.58ms
+step:302/1600 train_time:10445ms step_avg:34.59ms
+step:303/1600 train_time:10476ms step_avg:34.57ms
+step:304/1600 train_time:10513ms step_avg:34.58ms
+step:305/1600 train_time:10544ms step_avg:34.57ms
+step:306/1600 train_time:10581ms step_avg:34.58ms
+step:307/1600 train_time:10612ms step_avg:34.57ms
+step:308/1600 train_time:10649ms step_avg:34.57ms
+step:309/1600 train_time:10680ms step_avg:34.56ms
+step:310/1600 train_time:10717ms step_avg:34.57ms
+step:311/1600 train_time:10748ms step_avg:34.56ms
+step:312/1600 train_time:10785ms step_avg:34.57ms
+step:313/1600 train_time:10816ms step_avg:34.56ms
+step:314/1600 train_time:10853ms step_avg:34.56ms
+step:315/1600 train_time:10884ms step_avg:34.55ms
+step:316/1600 train_time:10921ms step_avg:34.56ms
+step:317/1600 train_time:10952ms step_avg:34.55ms
+step:318/1600 train_time:10989ms step_avg:34.56ms
+step:319/1600 train_time:11020ms step_avg:34.55ms
+step:320/1600 train_time:11057ms step_avg:34.55ms
+step:321/1600 train_time:11088ms step_avg:34.54ms
+step:322/1600 train_time:11125ms step_avg:34.55ms
+step:323/1600 train_time:11156ms step_avg:34.54ms
+step:324/1600 train_time:11193ms step_avg:34.54ms
+step:325/1600 train_time:11223ms step_avg:34.53ms
+step:326/1600 train_time:11261ms step_avg:34.54ms
+step:327/1600 train_time:11292ms step_avg:34.53ms
+step:328/1600 train_time:11329ms step_avg:34.54ms
+step:329/1600 train_time:11360ms step_avg:34.53ms
+step:330/1600 train_time:11398ms step_avg:34.54ms
+step:331/1600 train_time:11429ms step_avg:34.53ms
+step:332/1600 train_time:11466ms step_avg:34.54ms
+step:333/1600 train_time:11497ms step_avg:34.52ms
+step:334/1600 train_time:11534ms step_avg:34.53ms
+step:335/1600 train_time:11564ms step_avg:34.52ms
+step:336/1600 train_time:11601ms step_avg:34.53ms
+step:337/1600 train_time:11632ms step_avg:34.52ms
+step:338/1600 train_time:11668ms step_avg:34.52ms
+step:339/1600 train_time:11699ms step_avg:34.51ms
+step:340/1600 train_time:11736ms step_avg:34.52ms
+step:341/1600 train_time:11766ms step_avg:34.51ms
+step:342/1600 train_time:11804ms step_avg:34.51ms
+step:343/1600 train_time:11835ms step_avg:34.50ms
+step:344/1600 train_time:11872ms step_avg:34.51ms
+step:345/1600 train_time:11902ms step_avg:34.50ms
+step:346/1600 train_time:11940ms step_avg:34.51ms
+step:347/1600 train_time:11971ms step_avg:34.50ms
+step:348/1600 train_time:12008ms step_avg:34.51ms
+step:349/1600 train_time:12039ms step_avg:34.49ms
+step:350/1600 train_time:12075ms step_avg:34.50ms
+step:351/1600 train_time:12106ms step_avg:34.49ms
+step:352/1600 train_time:12143ms step_avg:34.50ms
+step:353/1600 train_time:12174ms step_avg:34.49ms
+step:354/1600 train_time:12211ms step_avg:34.49ms
+step:355/1600 train_time:12242ms step_avg:34.48ms
+step:356/1600 train_time:12279ms step_avg:34.49ms
+step:357/1600 train_time:12310ms step_avg:34.48ms
+step:358/1600 train_time:12347ms step_avg:34.49ms
+step:359/1600 train_time:12378ms step_avg:34.48ms
+step:360/1600 train_time:12415ms step_avg:34.48ms
+step:361/1600 train_time:12445ms step_avg:34.47ms
+step:362/1600 train_time:12482ms step_avg:34.48ms
+step:363/1600 train_time:12513ms step_avg:34.47ms
+step:364/1600 train_time:12550ms step_avg:34.48ms
+step:365/1600 train_time:12581ms step_avg:34.47ms
+step:366/1600 train_time:12618ms step_avg:34.48ms
+step:367/1600 train_time:12649ms step_avg:34.47ms
+step:368/1600 train_time:12686ms step_avg:34.47ms
+step:369/1600 train_time:12717ms step_avg:34.46ms
+step:370/1600 train_time:12754ms step_avg:34.47ms
+step:371/1600 train_time:12785ms step_avg:34.46ms
+step:372/1600 train_time:12822ms step_avg:34.47ms
+step:373/1600 train_time:12853ms step_avg:34.46ms
+step:374/1600 train_time:12890ms step_avg:34.46ms
+step:375/1600 train_time:12920ms step_avg:34.45ms
+step:376/1600 train_time:12958ms step_avg:34.46ms
+step:377/1600 train_time:12989ms step_avg:34.45ms
+step:378/1600 train_time:13026ms step_avg:34.46ms
+step:379/1600 train_time:13056ms step_avg:34.45ms
+step:380/1600 train_time:13093ms step_avg:34.46ms
+step:381/1600 train_time:13124ms step_avg:34.45ms
+step:382/1600 train_time:13161ms step_avg:34.45ms
+step:383/1600 train_time:13192ms step_avg:34.44ms
+step:384/1600 train_time:13229ms step_avg:34.45ms
+step:385/1600 train_time:13259ms step_avg:34.44ms
+step:386/1600 train_time:13296ms step_avg:34.45ms
+step:387/1600 train_time:13327ms step_avg:34.44ms
+step:388/1600 train_time:13364ms step_avg:34.44ms
+step:389/1600 train_time:13395ms step_avg:34.43ms
+step:390/1600 train_time:13432ms step_avg:34.44ms
+step:391/1600 train_time:13463ms step_avg:34.43ms
+step:392/1600 train_time:13500ms step_avg:34.44ms
+step:393/1600 train_time:13531ms step_avg:34.43ms
+step:394/1600 train_time:13568ms step_avg:34.44ms
+step:395/1600 train_time:13599ms step_avg:34.43ms
+step:396/1600 train_time:13635ms step_avg:34.43ms
+step:397/1600 train_time:13666ms step_avg:34.42ms
+step:398/1600 train_time:13703ms step_avg:34.43ms
+step:399/1600 train_time:13734ms step_avg:34.42ms
+step:400/1600 train_time:13771ms step_avg:34.43ms
+step:401/1600 train_time:13801ms step_avg:34.42ms
+step:402/1600 train_time:13839ms step_avg:34.43ms
+step:403/1600 train_time:13870ms step_avg:34.42ms
+step:404/1600 train_time:13907ms step_avg:34.42ms
+step:405/1600 train_time:13938ms step_avg:34.42ms
+step:406/1600 train_time:13975ms step_avg:34.42ms
+step:407/1600 train_time:14005ms step_avg:34.41ms
+step:408/1600 train_time:14043ms step_avg:34.42ms
+step:409/1600 train_time:14073ms step_avg:34.41ms
+step:410/1600 train_time:14110ms step_avg:34.41ms
+step:411/1600 train_time:14141ms step_avg:34.41ms
+step:412/1600 train_time:14178ms step_avg:34.41ms
+step:413/1600 train_time:14209ms step_avg:34.40ms
+step:414/1600 train_time:14246ms step_avg:34.41ms
+step:415/1600 train_time:14277ms step_avg:34.40ms
+step:416/1600 train_time:14313ms step_avg:34.41ms
+step:417/1600 train_time:14344ms step_avg:34.40ms
+step:418/1600 train_time:14381ms step_avg:34.40ms
+step:419/1600 train_time:14412ms step_avg:34.40ms
+step:420/1600 train_time:14449ms step_avg:34.40ms
+step:421/1600 train_time:14480ms step_avg:34.39ms
+step:422/1600 train_time:14517ms step_avg:34.40ms
+step:423/1600 train_time:14548ms step_avg:34.39ms
+step:424/1600 train_time:14585ms step_avg:34.40ms
+step:425/1600 train_time:14615ms step_avg:34.39ms
+step:426/1600 train_time:14652ms step_avg:34.40ms
+step:427/1600 train_time:14684ms step_avg:34.39ms
+step:428/1600 train_time:14721ms step_avg:34.39ms
+step:429/1600 train_time:14751ms step_avg:34.39ms
+step:430/1600 train_time:14788ms step_avg:34.39ms
+step:431/1600 train_time:14820ms step_avg:34.38ms
+step:432/1600 train_time:14857ms step_avg:34.39ms
+step:433/1600 train_time:14887ms step_avg:34.38ms
+step:434/1600 train_time:14924ms step_avg:34.39ms
+step:435/1600 train_time:14956ms step_avg:34.38ms
+step:436/1600 train_time:14993ms step_avg:34.39ms
+step:437/1600 train_time:15024ms step_avg:34.38ms
+step:438/1600 train_time:15061ms step_avg:34.39ms
+step:439/1600 train_time:15092ms step_avg:34.38ms
+step:440/1600 train_time:15129ms step_avg:34.38ms
+step:441/1600 train_time:15159ms step_avg:34.38ms
+step:442/1600 train_time:15196ms step_avg:34.38ms
+step:443/1600 train_time:15227ms step_avg:34.37ms
+step:444/1600 train_time:15264ms step_avg:34.38ms
+step:445/1600 train_time:15294ms step_avg:34.37ms
+step:446/1600 train_time:15331ms step_avg:34.38ms
+step:447/1600 train_time:15362ms step_avg:34.37ms
+step:448/1600 train_time:15399ms step_avg:34.37ms
+step:449/1600 train_time:15431ms step_avg:34.37ms
+step:450/1600 train_time:15468ms step_avg:34.37ms
+step:451/1600 train_time:15499ms step_avg:34.36ms
+step:452/1600 train_time:15536ms step_avg:34.37ms
+step:453/1600 train_time:15567ms step_avg:34.36ms
+step:454/1600 train_time:15604ms step_avg:34.37ms
+step:455/1600 train_time:15635ms step_avg:34.36ms
+step:456/1600 train_time:15672ms step_avg:34.37ms
+step:457/1600 train_time:15703ms step_avg:34.36ms
+step:458/1600 train_time:15740ms step_avg:34.37ms
+step:459/1600 train_time:15771ms step_avg:34.36ms
+step:460/1600 train_time:15807ms step_avg:34.36ms
+step:461/1600 train_time:15839ms step_avg:34.36ms
+step:462/1600 train_time:15876ms step_avg:34.36ms
+step:463/1600 train_time:15907ms step_avg:34.36ms
+step:464/1600 train_time:15944ms step_avg:34.36ms
+step:465/1600 train_time:15974ms step_avg:34.35ms
+step:466/1600 train_time:16011ms step_avg:34.36ms
+step:467/1600 train_time:16042ms step_avg:34.35ms
+step:468/1600 train_time:16080ms step_avg:34.36ms
+step:469/1600 train_time:16110ms step_avg:34.35ms
+step:470/1600 train_time:16147ms step_avg:34.36ms
+step:471/1600 train_time:16179ms step_avg:34.35ms
+step:472/1600 train_time:16216ms step_avg:34.36ms
+step:473/1600 train_time:16247ms step_avg:34.35ms
+step:474/1600 train_time:16283ms step_avg:34.35ms
+step:475/1600 train_time:16314ms step_avg:34.34ms
+step:476/1600 train_time:16351ms step_avg:34.35ms
+step:477/1600 train_time:16381ms step_avg:34.34ms
+step:478/1600 train_time:16418ms step_avg:34.35ms
+step:479/1600 train_time:16449ms step_avg:34.34ms
+step:480/1600 train_time:16486ms step_avg:34.35ms
+step:481/1600 train_time:16517ms step_avg:34.34ms
+step:482/1600 train_time:16554ms step_avg:34.34ms
+step:483/1600 train_time:16584ms step_avg:34.34ms
+step:484/1600 train_time:16621ms step_avg:34.34ms
+step:485/1600 train_time:16652ms step_avg:34.33ms
+step:486/1600 train_time:16689ms step_avg:34.34ms
+step:487/1600 train_time:16720ms step_avg:34.33ms
+step:488/1600 train_time:16757ms step_avg:34.34ms
+step:489/1600 train_time:16787ms step_avg:34.33ms
+step:490/1600 train_time:16825ms step_avg:34.34ms
+step:491/1600 train_time:16855ms step_avg:34.33ms
+step:492/1600 train_time:16892ms step_avg:34.33ms
+step:493/1600 train_time:16923ms step_avg:34.33ms
+step:494/1600 train_time:16960ms step_avg:34.33ms
+step:495/1600 train_time:16990ms step_avg:34.32ms
+step:496/1600 train_time:17027ms step_avg:34.33ms
+step:497/1600 train_time:17058ms step_avg:34.32ms
+step:498/1600 train_time:17095ms step_avg:34.33ms
+step:499/1600 train_time:17126ms step_avg:34.32ms
+step:500/1600 train_time:17163ms step_avg:34.33ms
+step:500/1600 val_loss:4.2440 train_time:17211ms step_avg:34.42ms
+step:501/1600 train_time:17228ms step_avg:34.39ms
+step:502/1600 train_time:17247ms step_avg:34.36ms
+step:503/1600 train_time:17265ms step_avg:34.32ms
+step:504/1600 train_time:17304ms step_avg:34.33ms
+step:505/1600 train_time:17337ms step_avg:34.33ms
+step:506/1600 train_time:17375ms step_avg:34.34ms
+step:507/1600 train_time:17406ms step_avg:34.33ms
+step:508/1600 train_time:17443ms step_avg:34.34ms
+step:509/1600 train_time:17474ms step_avg:34.33ms
+step:510/1600 train_time:17512ms step_avg:34.34ms
+step:511/1600 train_time:17542ms step_avg:34.33ms
+step:512/1600 train_time:17580ms step_avg:34.34ms
+step:513/1600 train_time:17610ms step_avg:34.33ms
+step:514/1600 train_time:17647ms step_avg:34.33ms
+step:515/1600 train_time:17678ms step_avg:34.33ms
+step:516/1600 train_time:17715ms step_avg:34.33ms
+step:517/1600 train_time:17746ms step_avg:34.32ms
+step:518/1600 train_time:17782ms step_avg:34.33ms
+step:519/1600 train_time:17813ms step_avg:34.32ms
+step:520/1600 train_time:17849ms step_avg:34.33ms
+step:521/1600 train_time:17920ms step_avg:34.40ms
+step:522/1600 train_time:17976ms step_avg:34.44ms
+step:523/1600 train_time:18037ms step_avg:34.49ms
+step:524/1600 train_time:18096ms step_avg:34.53ms
+step:525/1600 train_time:18157ms step_avg:34.59ms
+step:526/1600 train_time:18216ms step_avg:34.63ms
+step:527/1600 train_time:18280ms step_avg:34.69ms
+step:528/1600 train_time:18340ms step_avg:34.74ms
+step:529/1600 train_time:18404ms step_avg:34.79ms
+step:530/1600 train_time:18463ms step_avg:34.84ms
+step:531/1600 train_time:18526ms step_avg:34.89ms
+step:532/1600 train_time:18585ms step_avg:34.93ms
+step:533/1600 train_time:18648ms step_avg:34.99ms
+step:534/1600 train_time:18707ms step_avg:35.03ms
+step:535/1600 train_time:18769ms step_avg:35.08ms
+step:536/1600 train_time:18829ms step_avg:35.13ms
+step:537/1600 train_time:18891ms step_avg:35.18ms
+step:538/1600 train_time:18952ms step_avg:35.23ms
+step:539/1600 train_time:19014ms step_avg:35.28ms
+step:540/1600 train_time:19070ms step_avg:35.32ms
+step:541/1600 train_time:19133ms step_avg:35.37ms
+step:542/1600 train_time:19191ms step_avg:35.41ms
+step:543/1600 train_time:19254ms step_avg:35.46ms
+step:544/1600 train_time:19313ms step_avg:35.50ms
+step:545/1600 train_time:19376ms step_avg:35.55ms
+step:546/1600 train_time:19436ms step_avg:35.60ms
+step:547/1600 train_time:19499ms step_avg:35.65ms
+step:548/1600 train_time:19558ms step_avg:35.69ms
+step:549/1600 train_time:19622ms step_avg:35.74ms
+step:550/1600 train_time:19682ms step_avg:35.78ms
+step:551/1600 train_time:19745ms step_avg:35.83ms
+step:552/1600 train_time:19804ms step_avg:35.88ms
+step:553/1600 train_time:19866ms step_avg:35.92ms
+step:554/1600 train_time:19925ms step_avg:35.97ms
+step:555/1600 train_time:19987ms step_avg:36.01ms
+step:556/1600 train_time:20046ms step_avg:36.05ms
+step:557/1600 train_time:20108ms step_avg:36.10ms
+step:558/1600 train_time:20168ms step_avg:36.14ms
+step:559/1600 train_time:20232ms step_avg:36.19ms
+step:560/1600 train_time:20292ms step_avg:36.24ms
+step:561/1600 train_time:20356ms step_avg:36.28ms
+step:562/1600 train_time:20414ms step_avg:36.32ms
+step:563/1600 train_time:20476ms step_avg:36.37ms
+step:564/1600 train_time:20536ms step_avg:36.41ms
+step:565/1600 train_time:20599ms step_avg:36.46ms
+step:566/1600 train_time:20659ms step_avg:36.50ms
+step:567/1600 train_time:20722ms step_avg:36.55ms
+step:568/1600 train_time:20781ms step_avg:36.59ms
+step:569/1600 train_time:20844ms step_avg:36.63ms
+step:570/1600 train_time:20903ms step_avg:36.67ms
+step:571/1600 train_time:20966ms step_avg:36.72ms
+step:572/1600 train_time:21025ms step_avg:36.76ms
+step:573/1600 train_time:21092ms step_avg:36.81ms
+step:574/1600 train_time:21149ms step_avg:36.85ms
+step:575/1600 train_time:21211ms step_avg:36.89ms
+step:576/1600 train_time:21269ms step_avg:36.93ms
+step:577/1600 train_time:21333ms step_avg:36.97ms
+step:578/1600 train_time:21391ms step_avg:37.01ms
+step:579/1600 train_time:21456ms step_avg:37.06ms
+step:580/1600 train_time:21514ms step_avg:37.09ms
+step:581/1600 train_time:21576ms step_avg:37.14ms
+step:582/1600 train_time:21635ms step_avg:37.17ms
+step:583/1600 train_time:21698ms step_avg:37.22ms
+step:584/1600 train_time:21757ms step_avg:37.25ms
+step:585/1600 train_time:21820ms step_avg:37.30ms
+step:586/1600 train_time:21879ms step_avg:37.34ms
+step:587/1600 train_time:21942ms step_avg:37.38ms
+step:588/1600 train_time:22001ms step_avg:37.42ms
+step:589/1600 train_time:22064ms step_avg:37.46ms
+step:590/1600 train_time:22124ms step_avg:37.50ms
+step:591/1600 train_time:22186ms step_avg:37.54ms
+step:592/1600 train_time:22245ms step_avg:37.58ms
+step:593/1600 train_time:22308ms step_avg:37.62ms
+step:594/1600 train_time:22366ms step_avg:37.65ms
+step:595/1600 train_time:22428ms step_avg:37.69ms
+step:596/1600 train_time:22487ms step_avg:37.73ms
+step:597/1600 train_time:22551ms step_avg:37.77ms
+step:598/1600 train_time:22612ms step_avg:37.81ms
+step:599/1600 train_time:22673ms step_avg:37.85ms
+step:600/1600 train_time:22733ms step_avg:37.89ms
+step:601/1600 train_time:22795ms step_avg:37.93ms
+step:602/1600 train_time:22854ms step_avg:37.96ms
+step:603/1600 train_time:22916ms step_avg:38.00ms
+step:604/1600 train_time:22975ms step_avg:38.04ms
+step:605/1600 train_time:23040ms step_avg:38.08ms
+step:606/1600 train_time:23098ms step_avg:38.12ms
+step:607/1600 train_time:23161ms step_avg:38.16ms
+step:608/1600 train_time:23220ms step_avg:38.19ms
+step:609/1600 train_time:23283ms step_avg:38.23ms
+step:610/1600 train_time:23342ms step_avg:38.27ms
+step:611/1600 train_time:23405ms step_avg:38.31ms
+step:612/1600 train_time:23464ms step_avg:38.34ms
+step:613/1600 train_time:23527ms step_avg:38.38ms
+step:614/1600 train_time:23585ms step_avg:38.41ms
+step:615/1600 train_time:23647ms step_avg:38.45ms
+step:616/1600 train_time:23706ms step_avg:38.48ms
+step:617/1600 train_time:23769ms step_avg:38.52ms
+step:618/1600 train_time:23828ms step_avg:38.56ms
+step:619/1600 train_time:23890ms step_avg:38.60ms
+step:620/1600 train_time:23951ms step_avg:38.63ms
+step:621/1600 train_time:24013ms step_avg:38.67ms
+step:622/1600 train_time:24074ms step_avg:38.70ms
+step:623/1600 train_time:24137ms step_avg:38.74ms
+step:624/1600 train_time:24195ms step_avg:38.77ms
+step:625/1600 train_time:24258ms step_avg:38.81ms
+step:626/1600 train_time:24318ms step_avg:38.85ms
+step:627/1600 train_time:24381ms step_avg:38.88ms
+step:628/1600 train_time:24440ms step_avg:38.92ms
+step:629/1600 train_time:24503ms step_avg:38.96ms
+step:630/1600 train_time:24562ms step_avg:38.99ms
+step:631/1600 train_time:24625ms step_avg:39.02ms
+step:632/1600 train_time:24683ms step_avg:39.06ms
+step:633/1600 train_time:24746ms step_avg:39.09ms
+step:634/1600 train_time:24804ms step_avg:39.12ms
+step:635/1600 train_time:24866ms step_avg:39.16ms
+step:636/1600 train_time:24924ms step_avg:39.19ms
+step:637/1600 train_time:24987ms step_avg:39.23ms
+step:638/1600 train_time:25047ms step_avg:39.26ms
+step:639/1600 train_time:25110ms step_avg:39.30ms
+step:640/1600 train_time:25170ms step_avg:39.33ms
+step:641/1600 train_time:25233ms step_avg:39.37ms
+step:642/1600 train_time:25292ms step_avg:39.40ms
+step:643/1600 train_time:25355ms step_avg:39.43ms
+step:644/1600 train_time:25414ms step_avg:39.46ms
+step:645/1600 train_time:25477ms step_avg:39.50ms
+step:646/1600 train_time:25536ms step_avg:39.53ms
+step:647/1600 train_time:25599ms step_avg:39.56ms
+step:648/1600 train_time:25658ms step_avg:39.59ms
+step:649/1600 train_time:25721ms step_avg:39.63ms
+step:650/1600 train_time:25780ms step_avg:39.66ms
+step:651/1600 train_time:25843ms step_avg:39.70ms
+step:652/1600 train_time:25903ms step_avg:39.73ms
+step:653/1600 train_time:25966ms step_avg:39.76ms
+step:654/1600 train_time:26024ms step_avg:39.79ms
+step:655/1600 train_time:26086ms step_avg:39.83ms
+step:656/1600 train_time:26147ms step_avg:39.86ms
+step:657/1600 train_time:26209ms step_avg:39.89ms
+step:658/1600 train_time:26267ms step_avg:39.92ms
+step:659/1600 train_time:26330ms step_avg:39.95ms
+step:660/1600 train_time:26389ms step_avg:39.98ms
+step:661/1600 train_time:26453ms step_avg:40.02ms
+step:662/1600 train_time:26512ms step_avg:40.05ms
+step:663/1600 train_time:26575ms step_avg:40.08ms
+step:664/1600 train_time:26633ms step_avg:40.11ms
+step:665/1600 train_time:26696ms step_avg:40.14ms
+step:666/1600 train_time:26755ms step_avg:40.17ms
+step:667/1600 train_time:26817ms step_avg:40.21ms
+step:668/1600 train_time:26877ms step_avg:40.23ms
+step:669/1600 train_time:26941ms step_avg:40.27ms
+step:670/1600 train_time:27000ms step_avg:40.30ms
+step:671/1600 train_time:27063ms step_avg:40.33ms
+step:672/1600 train_time:27122ms step_avg:40.36ms
+step:673/1600 train_time:27188ms step_avg:40.40ms
+step:674/1600 train_time:27244ms step_avg:40.42ms
+step:675/1600 train_time:27306ms step_avg:40.45ms
+step:676/1600 train_time:27365ms step_avg:40.48ms
+step:677/1600 train_time:27428ms step_avg:40.51ms
+step:678/1600 train_time:27486ms step_avg:40.54ms
+step:679/1600 train_time:27549ms step_avg:40.57ms
+step:680/1600 train_time:27608ms step_avg:40.60ms
+step:681/1600 train_time:27673ms step_avg:40.64ms
+step:682/1600 train_time:27732ms step_avg:40.66ms
+step:683/1600 train_time:27794ms step_avg:40.69ms
+step:684/1600 train_time:27853ms step_avg:40.72ms
+step:685/1600 train_time:27915ms step_avg:40.75ms
+step:686/1600 train_time:27975ms step_avg:40.78ms
+step:687/1600 train_time:28037ms step_avg:40.81ms
+step:688/1600 train_time:28097ms step_avg:40.84ms
+step:689/1600 train_time:28159ms step_avg:40.87ms
+step:690/1600 train_time:28218ms step_avg:40.90ms
+step:691/1600 train_time:28282ms step_avg:40.93ms
+step:692/1600 train_time:28342ms step_avg:40.96ms
+step:693/1600 train_time:28405ms step_avg:40.99ms
+step:694/1600 train_time:28463ms step_avg:41.01ms
+step:695/1600 train_time:28527ms step_avg:41.05ms
+step:696/1600 train_time:28585ms step_avg:41.07ms
+step:697/1600 train_time:28648ms step_avg:41.10ms
+step:698/1600 train_time:28707ms step_avg:41.13ms
+step:699/1600 train_time:28769ms step_avg:41.16ms
+step:700/1600 train_time:28829ms step_avg:41.18ms
+step:701/1600 train_time:28891ms step_avg:41.21ms
+step:702/1600 train_time:28951ms step_avg:41.24ms
+step:703/1600 train_time:29014ms step_avg:41.27ms
+step:704/1600 train_time:29073ms step_avg:41.30ms
+step:705/1600 train_time:29135ms step_avg:41.33ms
+step:706/1600 train_time:29196ms step_avg:41.35ms
+step:707/1600 train_time:29258ms step_avg:41.38ms
+step:708/1600 train_time:29316ms step_avg:41.41ms
+step:709/1600 train_time:29380ms step_avg:41.44ms
+step:710/1600 train_time:29439ms step_avg:41.46ms
+step:711/1600 train_time:29502ms step_avg:41.49ms
+step:712/1600 train_time:29562ms step_avg:41.52ms
+step:713/1600 train_time:29624ms step_avg:41.55ms
+step:714/1600 train_time:29683ms step_avg:41.57ms
+step:715/1600 train_time:29746ms step_avg:41.60ms
+step:716/1600 train_time:29804ms step_avg:41.63ms
+step:717/1600 train_time:29867ms step_avg:41.66ms
+step:718/1600 train_time:29927ms step_avg:41.68ms
+step:719/1600 train_time:29989ms step_avg:41.71ms
+step:720/1600 train_time:30048ms step_avg:41.73ms
+step:721/1600 train_time:30111ms step_avg:41.76ms
+step:722/1600 train_time:30171ms step_avg:41.79ms
+step:723/1600 train_time:30233ms step_avg:41.82ms
+step:724/1600 train_time:30293ms step_avg:41.84ms
+step:725/1600 train_time:30356ms step_avg:41.87ms
+step:726/1600 train_time:30416ms step_avg:41.89ms
+step:727/1600 train_time:30478ms step_avg:41.92ms
+step:728/1600 train_time:30537ms step_avg:41.95ms
+step:729/1600 train_time:30600ms step_avg:41.98ms
+step:730/1600 train_time:30660ms step_avg:42.00ms
+step:731/1600 train_time:30723ms step_avg:42.03ms
+step:732/1600 train_time:30782ms step_avg:42.05ms
+step:733/1600 train_time:30845ms step_avg:42.08ms
+step:734/1600 train_time:30904ms step_avg:42.10ms
+step:735/1600 train_time:30969ms step_avg:42.14ms
+step:736/1600 train_time:31028ms step_avg:42.16ms
+step:737/1600 train_time:31088ms step_avg:42.18ms
+step:738/1600 train_time:31147ms step_avg:42.21ms
+step:739/1600 train_time:31210ms step_avg:42.23ms
+step:740/1600 train_time:31269ms step_avg:42.26ms
+step:741/1600 train_time:31333ms step_avg:42.28ms
+step:742/1600 train_time:31392ms step_avg:42.31ms
+step:743/1600 train_time:31455ms step_avg:42.34ms
+step:744/1600 train_time:31514ms step_avg:42.36ms
+step:745/1600 train_time:31576ms step_avg:42.38ms
+step:746/1600 train_time:31636ms step_avg:42.41ms
+step:747/1600 train_time:31700ms step_avg:42.44ms
+step:748/1600 train_time:31758ms step_avg:42.46ms
+step:749/1600 train_time:31821ms step_avg:42.48ms
+step:750/1600 train_time:31880ms step_avg:42.51ms
+step:750/1600 val_loss:3.8896 train_time:31927ms step_avg:42.57ms
+step:751/1600 train_time:31946ms step_avg:42.54ms
+step:752/1600 train_time:32003ms step_avg:42.56ms
+step:753/1600 train_time:32068ms step_avg:42.59ms
+step:754/1600 train_time:32129ms step_avg:42.61ms
+step:755/1600 train_time:32191ms step_avg:42.64ms
+step:756/1600 train_time:32249ms step_avg:42.66ms
+step:757/1600 train_time:32311ms step_avg:42.68ms
+step:758/1600 train_time:32371ms step_avg:42.71ms
+step:759/1600 train_time:32432ms step_avg:42.73ms
+step:760/1600 train_time:32491ms step_avg:42.75ms
+step:761/1600 train_time:32553ms step_avg:42.78ms
+step:762/1600 train_time:32611ms step_avg:42.80ms
+step:763/1600 train_time:32672ms step_avg:42.82ms
+step:764/1600 train_time:32731ms step_avg:42.84ms
+step:765/1600 train_time:32792ms step_avg:42.86ms
+step:766/1600 train_time:32850ms step_avg:42.89ms
+step:767/1600 train_time:32913ms step_avg:42.91ms
+step:768/1600 train_time:32973ms step_avg:42.93ms
+step:769/1600 train_time:33038ms step_avg:42.96ms
+step:770/1600 train_time:33098ms step_avg:42.99ms
+step:771/1600 train_time:33163ms step_avg:43.01ms
+step:772/1600 train_time:33221ms step_avg:43.03ms
+step:773/1600 train_time:33283ms step_avg:43.06ms
+step:774/1600 train_time:33342ms step_avg:43.08ms
+step:775/1600 train_time:33404ms step_avg:43.10ms
+step:776/1600 train_time:33463ms step_avg:43.12ms
+step:777/1600 train_time:33525ms step_avg:43.15ms
+step:778/1600 train_time:33584ms step_avg:43.17ms
+step:779/1600 train_time:33646ms step_avg:43.19ms
+step:780/1600 train_time:33704ms step_avg:43.21ms
+step:781/1600 train_time:33767ms step_avg:43.24ms
+step:782/1600 train_time:33825ms step_avg:43.25ms
+step:783/1600 train_time:33888ms step_avg:43.28ms
+step:784/1600 train_time:33948ms step_avg:43.30ms
+step:785/1600 train_time:34012ms step_avg:43.33ms
+step:786/1600 train_time:34071ms step_avg:43.35ms
+step:787/1600 train_time:34134ms step_avg:43.37ms
+step:788/1600 train_time:34193ms step_avg:43.39ms
+step:789/1600 train_time:34255ms step_avg:43.42ms
+step:790/1600 train_time:34314ms step_avg:43.44ms
+step:791/1600 train_time:34377ms step_avg:43.46ms
+step:792/1600 train_time:34435ms step_avg:43.48ms
+step:793/1600 train_time:34497ms step_avg:43.50ms
+step:794/1600 train_time:34557ms step_avg:43.52ms
+step:795/1600 train_time:34619ms step_avg:43.55ms
+step:796/1600 train_time:34678ms step_avg:43.57ms
+step:797/1600 train_time:34740ms step_avg:43.59ms
+step:798/1600 train_time:34800ms step_avg:43.61ms
+step:799/1600 train_time:34862ms step_avg:43.63ms
+step:800/1600 train_time:34921ms step_avg:43.65ms
+step:801/1600 train_time:34985ms step_avg:43.68ms
+step:802/1600 train_time:35044ms step_avg:43.70ms
+step:803/1600 train_time:35107ms step_avg:43.72ms
+step:804/1600 train_time:35166ms step_avg:43.74ms
+step:805/1600 train_time:35228ms step_avg:43.76ms
+step:806/1600 train_time:35288ms step_avg:43.78ms
+step:807/1600 train_time:35350ms step_avg:43.80ms
+step:808/1600 train_time:35409ms step_avg:43.82ms
+step:809/1600 train_time:35472ms step_avg:43.85ms
+step:810/1600 train_time:35531ms step_avg:43.87ms
+step:811/1600 train_time:35593ms step_avg:43.89ms
+step:812/1600 train_time:35651ms step_avg:43.91ms
+step:813/1600 train_time:35714ms step_avg:43.93ms
+step:814/1600 train_time:35772ms step_avg:43.95ms
+step:815/1600 train_time:35835ms step_avg:43.97ms
+step:816/1600 train_time:35894ms step_avg:43.99ms
+step:817/1600 train_time:35957ms step_avg:44.01ms
+step:818/1600 train_time:36017ms step_avg:44.03ms
+step:819/1600 train_time:36080ms step_avg:44.05ms
+step:820/1600 train_time:36139ms step_avg:44.07ms
+step:821/1600 train_time:36202ms step_avg:44.09ms
+step:822/1600 train_time:36261ms step_avg:44.11ms
+step:823/1600 train_time:36322ms step_avg:44.13ms
+step:824/1600 train_time:36382ms step_avg:44.15ms
+step:825/1600 train_time:36444ms step_avg:44.18ms
+step:826/1600 train_time:36503ms step_avg:44.19ms
+step:827/1600 train_time:36565ms step_avg:44.21ms
+step:828/1600 train_time:36625ms step_avg:44.23ms
+step:829/1600 train_time:36687ms step_avg:44.26ms
+step:830/1600 train_time:36747ms step_avg:44.27ms
+step:831/1600 train_time:36809ms step_avg:44.30ms
+step:832/1600 train_time:36869ms step_avg:44.31ms
+step:833/1600 train_time:36932ms step_avg:44.34ms
+step:834/1600 train_time:36991ms step_avg:44.35ms
+step:835/1600 train_time:37053ms step_avg:44.38ms
+step:836/1600 train_time:37112ms step_avg:44.39ms
+step:837/1600 train_time:37176ms step_avg:44.42ms
+step:838/1600 train_time:37234ms step_avg:44.43ms
+step:839/1600 train_time:37296ms step_avg:44.45ms
+step:840/1600 train_time:37355ms step_avg:44.47ms
+step:841/1600 train_time:37418ms step_avg:44.49ms
+step:842/1600 train_time:37477ms step_avg:44.51ms
+step:843/1600 train_time:37540ms step_avg:44.53ms
+step:844/1600 train_time:37599ms step_avg:44.55ms
+step:845/1600 train_time:37661ms step_avg:44.57ms
+step:846/1600 train_time:37720ms step_avg:44.59ms
+step:847/1600 train_time:37782ms step_avg:44.61ms
+step:848/1600 train_time:37841ms step_avg:44.62ms
+step:849/1600 train_time:37904ms step_avg:44.65ms
+step:850/1600 train_time:37963ms step_avg:44.66ms
+step:851/1600 train_time:38026ms step_avg:44.68ms
+step:852/1600 train_time:38085ms step_avg:44.70ms
+step:853/1600 train_time:38148ms step_avg:44.72ms
+step:854/1600 train_time:38207ms step_avg:44.74ms
+step:855/1600 train_time:38269ms step_avg:44.76ms
+step:856/1600 train_time:38328ms step_avg:44.78ms
+step:857/1600 train_time:38391ms step_avg:44.80ms
+step:858/1600 train_time:38450ms step_avg:44.81ms
+step:859/1600 train_time:38512ms step_avg:44.83ms
+step:860/1600 train_time:38571ms step_avg:44.85ms
+step:861/1600 train_time:38633ms step_avg:44.87ms
+step:862/1600 train_time:38692ms step_avg:44.89ms
+step:863/1600 train_time:38755ms step_avg:44.91ms
+step:864/1600 train_time:38814ms step_avg:44.92ms
+step:865/1600 train_time:38877ms step_avg:44.94ms
+step:866/1600 train_time:38936ms step_avg:44.96ms
+step:867/1600 train_time:38998ms step_avg:44.98ms
+step:868/1600 train_time:39058ms step_avg:45.00ms
+step:869/1600 train_time:39121ms step_avg:45.02ms
+step:870/1600 train_time:39180ms step_avg:45.03ms
+step:871/1600 train_time:39243ms step_avg:45.05ms
+step:872/1600 train_time:39302ms step_avg:45.07ms
+step:873/1600 train_time:39365ms step_avg:45.09ms
+step:874/1600 train_time:39424ms step_avg:45.11ms
+step:875/1600 train_time:39488ms step_avg:45.13ms
+step:876/1600 train_time:39546ms step_avg:45.14ms
+step:877/1600 train_time:39608ms step_avg:45.16ms
+step:878/1600 train_time:39669ms step_avg:45.18ms
+step:879/1600 train_time:39731ms step_avg:45.20ms
+step:880/1600 train_time:39790ms step_avg:45.22ms
+step:881/1600 train_time:39852ms step_avg:45.24ms
+step:882/1600 train_time:39911ms step_avg:45.25ms
+step:883/1600 train_time:39974ms step_avg:45.27ms
+step:884/1600 train_time:40034ms step_avg:45.29ms
+step:885/1600 train_time:40096ms step_avg:45.31ms
+step:886/1600 train_time:40154ms step_avg:45.32ms
+step:887/1600 train_time:40219ms step_avg:45.34ms
+step:888/1600 train_time:40278ms step_avg:45.36ms
+step:889/1600 train_time:40340ms step_avg:45.38ms
+step:890/1600 train_time:40403ms step_avg:45.40ms
+step:891/1600 train_time:40464ms step_avg:45.41ms
+step:892/1600 train_time:40525ms step_avg:45.43ms
+step:893/1600 train_time:40586ms step_avg:45.45ms
+step:894/1600 train_time:40645ms step_avg:45.46ms
+step:895/1600 train_time:40708ms step_avg:45.48ms
+step:896/1600 train_time:40767ms step_avg:45.50ms
+step:897/1600 train_time:40829ms step_avg:45.52ms
+step:898/1600 train_time:40888ms step_avg:45.53ms
+step:899/1600 train_time:40951ms step_avg:45.55ms
+step:900/1600 train_time:41010ms step_avg:45.57ms
+step:901/1600 train_time:41073ms step_avg:45.59ms
+step:902/1600 train_time:41132ms step_avg:45.60ms
+step:903/1600 train_time:41195ms step_avg:45.62ms
+step:904/1600 train_time:41254ms step_avg:45.63ms
+step:905/1600 train_time:41316ms step_avg:45.65ms
+step:906/1600 train_time:41375ms step_avg:45.67ms
+step:907/1600 train_time:41437ms step_avg:45.69ms
+step:908/1600 train_time:41497ms step_avg:45.70ms
+step:909/1600 train_time:41560ms step_avg:45.72ms
+step:910/1600 train_time:41620ms step_avg:45.74ms
+step:911/1600 train_time:41684ms step_avg:45.76ms
+step:912/1600 train_time:41742ms step_avg:45.77ms
+step:913/1600 train_time:41805ms step_avg:45.79ms
+step:914/1600 train_time:41864ms step_avg:45.80ms
+step:915/1600 train_time:41926ms step_avg:45.82ms
+step:916/1600 train_time:41985ms step_avg:45.84ms
+step:917/1600 train_time:42048ms step_avg:45.85ms
+step:918/1600 train_time:42107ms step_avg:45.87ms
+step:919/1600 train_time:42170ms step_avg:45.89ms
+step:920/1600 train_time:42229ms step_avg:45.90ms
+step:921/1600 train_time:42292ms step_avg:45.92ms
+step:922/1600 train_time:42351ms step_avg:45.93ms
+step:923/1600 train_time:42414ms step_avg:45.95ms
+step:924/1600 train_time:42474ms step_avg:45.97ms
+step:925/1600 train_time:42536ms step_avg:45.99ms
+step:926/1600 train_time:42595ms step_avg:46.00ms
+step:927/1600 train_time:42657ms step_avg:46.02ms
+step:928/1600 train_time:42717ms step_avg:46.03ms
+step:929/1600 train_time:42780ms step_avg:46.05ms
+step:930/1600 train_time:42839ms step_avg:46.06ms
+step:931/1600 train_time:42902ms step_avg:46.08ms
+step:932/1600 train_time:42961ms step_avg:46.10ms
+step:933/1600 train_time:43023ms step_avg:46.11ms
+step:934/1600 train_time:43082ms step_avg:46.13ms
+step:935/1600 train_time:43145ms step_avg:46.14ms
+step:936/1600 train_time:43204ms step_avg:46.16ms
+step:937/1600 train_time:43267ms step_avg:46.18ms
+step:938/1600 train_time:43326ms step_avg:46.19ms
+step:939/1600 train_time:43388ms step_avg:46.21ms
+step:940/1600 train_time:43447ms step_avg:46.22ms
+step:941/1600 train_time:43510ms step_avg:46.24ms
+step:942/1600 train_time:43570ms step_avg:46.25ms
+step:943/1600 train_time:43633ms step_avg:46.27ms
+step:944/1600 train_time:43692ms step_avg:46.28ms
+step:945/1600 train_time:43754ms step_avg:46.30ms
+step:946/1600 train_time:43813ms step_avg:46.31ms
+step:947/1600 train_time:43876ms step_avg:46.33ms
+step:948/1600 train_time:43934ms step_avg:46.34ms
+step:949/1600 train_time:43997ms step_avg:46.36ms
+step:950/1600 train_time:44056ms step_avg:46.38ms
+step:951/1600 train_time:44120ms step_avg:46.39ms
+step:952/1600 train_time:44180ms step_avg:46.41ms
+step:953/1600 train_time:44242ms step_avg:46.42ms
+step:954/1600 train_time:44302ms step_avg:46.44ms
+step:955/1600 train_time:44364ms step_avg:46.45ms
+step:956/1600 train_time:44423ms step_avg:46.47ms
+step:957/1600 train_time:44485ms step_avg:46.48ms
+step:958/1600 train_time:44544ms step_avg:46.50ms
+step:959/1600 train_time:44608ms step_avg:46.51ms
+step:960/1600 train_time:44669ms step_avg:46.53ms
+step:961/1600 train_time:44730ms step_avg:46.55ms
+step:962/1600 train_time:44789ms step_avg:46.56ms
+step:963/1600 train_time:44851ms step_avg:46.57ms
+step:964/1600 train_time:44911ms step_avg:46.59ms
+step:965/1600 train_time:44973ms step_avg:46.60ms
+step:966/1600 train_time:45032ms step_avg:46.62ms
+step:967/1600 train_time:45096ms step_avg:46.64ms
+step:968/1600 train_time:45156ms step_avg:46.65ms
+step:969/1600 train_time:45217ms step_avg:46.66ms
+step:970/1600 train_time:45276ms step_avg:46.68ms
+step:971/1600 train_time:45338ms step_avg:46.69ms
+step:972/1600 train_time:45399ms step_avg:46.71ms
+step:973/1600 train_time:45461ms step_avg:46.72ms
+step:974/1600 train_time:45520ms step_avg:46.73ms
+step:975/1600 train_time:45583ms step_avg:46.75ms
+step:976/1600 train_time:45643ms step_avg:46.77ms
+step:977/1600 train_time:45706ms step_avg:46.78ms
+step:978/1600 train_time:45764ms step_avg:46.79ms
+step:979/1600 train_time:45827ms step_avg:46.81ms
+step:980/1600 train_time:45886ms step_avg:46.82ms
+step:981/1600 train_time:45949ms step_avg:46.84ms
+step:982/1600 train_time:46009ms step_avg:46.85ms
+step:983/1600 train_time:46071ms step_avg:46.87ms
+step:984/1600 train_time:46131ms step_avg:46.88ms
+step:985/1600 train_time:46193ms step_avg:46.90ms
+step:986/1600 train_time:46251ms step_avg:46.91ms
+step:987/1600 train_time:46313ms step_avg:46.92ms
+step:988/1600 train_time:46373ms step_avg:46.94ms
+step:989/1600 train_time:46435ms step_avg:46.95ms
+step:990/1600 train_time:46494ms step_avg:46.96ms
+step:991/1600 train_time:46557ms step_avg:46.98ms
+step:992/1600 train_time:46617ms step_avg:46.99ms
+step:993/1600 train_time:46680ms step_avg:47.01ms
+step:994/1600 train_time:46739ms step_avg:47.02ms
+step:995/1600 train_time:46802ms step_avg:47.04ms
+step:996/1600 train_time:46860ms step_avg:47.05ms
+step:997/1600 train_time:46922ms step_avg:47.06ms
+step:998/1600 train_time:46981ms step_avg:47.08ms
+step:999/1600 train_time:47045ms step_avg:47.09ms
+step:1000/1600 train_time:47105ms step_avg:47.10ms
+step:1000/1600 val_loss:3.5989 train_time:47152ms step_avg:47.15ms
+step:1001/1600 train_time:47172ms step_avg:47.13ms
+step:1002/1600 train_time:47228ms step_avg:47.13ms
+step:1003/1600 train_time:47293ms step_avg:47.15ms
+step:1004/1600 train_time:47353ms step_avg:47.16ms
+step:1005/1600 train_time:47415ms step_avg:47.18ms
+step:1006/1600 train_time:47475ms step_avg:47.19ms
+step:1007/1600 train_time:47537ms step_avg:47.21ms
+step:1008/1600 train_time:47595ms step_avg:47.22ms
+step:1009/1600 train_time:47657ms step_avg:47.23ms
+step:1010/1600 train_time:47715ms step_avg:47.24ms
+step:1011/1600 train_time:47777ms step_avg:47.26ms
+step:1012/1600 train_time:47835ms step_avg:47.27ms
+step:1013/1600 train_time:47896ms step_avg:47.28ms
+step:1014/1600 train_time:47954ms step_avg:47.29ms
+step:1015/1600 train_time:48016ms step_avg:47.31ms
+step:1016/1600 train_time:48075ms step_avg:47.32ms
+step:1017/1600 train_time:48139ms step_avg:47.33ms
+step:1018/1600 train_time:48201ms step_avg:47.35ms
+step:1019/1600 train_time:48266ms step_avg:47.37ms
+step:1020/1600 train_time:48325ms step_avg:47.38ms
+step:1021/1600 train_time:48386ms step_avg:47.39ms
+step:1022/1600 train_time:48445ms step_avg:47.40ms
+step:1023/1600 train_time:48507ms step_avg:47.42ms
+step:1024/1600 train_time:48567ms step_avg:47.43ms
+step:1025/1600 train_time:48630ms step_avg:47.44ms
+step:1026/1600 train_time:48689ms step_avg:47.45ms
+step:1027/1600 train_time:48751ms step_avg:47.47ms
+step:1028/1600 train_time:48809ms step_avg:47.48ms
+step:1029/1600 train_time:48871ms step_avg:47.49ms
+step:1030/1600 train_time:48930ms step_avg:47.50ms
+step:1031/1600 train_time:48992ms step_avg:47.52ms
+step:1032/1600 train_time:49051ms step_avg:47.53ms
+step:1033/1600 train_time:49114ms step_avg:47.54ms
+step:1034/1600 train_time:49173ms step_avg:47.56ms
+step:1035/1600 train_time:49236ms step_avg:47.57ms
+step:1036/1600 train_time:49295ms step_avg:47.58ms
+step:1037/1600 train_time:49358ms step_avg:47.60ms
+step:1038/1600 train_time:49418ms step_avg:47.61ms
+step:1039/1600 train_time:49480ms step_avg:47.62ms
+step:1040/1600 train_time:49538ms step_avg:47.63ms
+step:1041/1600 train_time:49609ms step_avg:47.66ms
+step:1042/1600 train_time:49693ms step_avg:47.69ms
+step:1043/1600 train_time:49781ms step_avg:47.73ms
+step:1044/1600 train_time:49867ms step_avg:47.77ms
+step:1045/1600 train_time:49955ms step_avg:47.80ms
+step:1046/1600 train_time:50040ms step_avg:47.84ms
+step:1047/1600 train_time:50128ms step_avg:47.88ms
+step:1048/1600 train_time:50213ms step_avg:47.91ms
+step:1049/1600 train_time:50303ms step_avg:47.95ms
+step:1050/1600 train_time:50388ms step_avg:47.99ms
+step:1051/1600 train_time:50476ms step_avg:48.03ms
+step:1052/1600 train_time:50562ms step_avg:48.06ms
+step:1053/1600 train_time:50650ms step_avg:48.10ms
+step:1054/1600 train_time:50735ms step_avg:48.14ms
+step:1055/1600 train_time:50824ms step_avg:48.17ms
+step:1056/1600 train_time:50908ms step_avg:48.21ms
+step:1057/1600 train_time:50997ms step_avg:48.25ms
+step:1058/1600 train_time:51082ms step_avg:48.28ms
+step:1059/1600 train_time:51171ms step_avg:48.32ms
+step:1060/1600 train_time:51256ms step_avg:48.35ms
+step:1061/1600 train_time:51345ms step_avg:48.39ms
+step:1062/1600 train_time:51429ms step_avg:48.43ms
+step:1063/1600 train_time:51517ms step_avg:48.46ms
+step:1064/1600 train_time:51603ms step_avg:48.50ms
+step:1065/1600 train_time:51691ms step_avg:48.54ms
+step:1066/1600 train_time:51775ms step_avg:48.57ms
+step:1067/1600 train_time:51863ms step_avg:48.61ms
+step:1068/1600 train_time:51948ms step_avg:48.64ms
+step:1069/1600 train_time:52036ms step_avg:48.68ms
+step:1070/1600 train_time:52120ms step_avg:48.71ms
+step:1071/1600 train_time:52208ms step_avg:48.75ms
+step:1072/1600 train_time:52294ms step_avg:48.78ms
+step:1073/1600 train_time:52382ms step_avg:48.82ms
+step:1074/1600 train_time:52468ms step_avg:48.85ms
+step:1075/1600 train_time:52557ms step_avg:48.89ms
+step:1076/1600 train_time:52641ms step_avg:48.92ms
+step:1077/1600 train_time:52731ms step_avg:48.96ms
+step:1078/1600 train_time:52815ms step_avg:48.99ms
+step:1079/1600 train_time:52903ms step_avg:49.03ms
+step:1080/1600 train_time:52988ms step_avg:49.06ms
+step:1081/1600 train_time:53076ms step_avg:49.10ms
+step:1082/1600 train_time:53161ms step_avg:49.13ms
+step:1083/1600 train_time:53250ms step_avg:49.17ms
+step:1084/1600 train_time:53334ms step_avg:49.20ms
+step:1085/1600 train_time:53423ms step_avg:49.24ms
+step:1086/1600 train_time:53509ms step_avg:49.27ms
+step:1087/1600 train_time:53597ms step_avg:49.31ms
+step:1088/1600 train_time:53683ms step_avg:49.34ms
+step:1089/1600 train_time:53771ms step_avg:49.38ms
+step:1090/1600 train_time:53856ms step_avg:49.41ms
+step:1091/1600 train_time:53944ms step_avg:49.44ms
+step:1092/1600 train_time:54029ms step_avg:49.48ms
+step:1093/1600 train_time:54117ms step_avg:49.51ms
+step:1094/1600 train_time:54202ms step_avg:49.54ms
+step:1095/1600 train_time:54290ms step_avg:49.58ms
+step:1096/1600 train_time:54377ms step_avg:49.61ms
+step:1097/1600 train_time:54465ms step_avg:49.65ms
+step:1098/1600 train_time:54550ms step_avg:49.68ms
+step:1099/1600 train_time:54639ms step_avg:49.72ms
+step:1100/1600 train_time:54725ms step_avg:49.75ms
+step:1101/1600 train_time:54813ms step_avg:49.78ms
+step:1102/1600 train_time:54898ms step_avg:49.82ms
+step:1103/1600 train_time:54986ms step_avg:49.85ms
+step:1104/1600 train_time:55071ms step_avg:49.88ms
+step:1105/1600 train_time:55160ms step_avg:49.92ms
+step:1106/1600 train_time:55245ms step_avg:49.95ms
+step:1107/1600 train_time:55334ms step_avg:49.99ms
+step:1108/1600 train_time:55419ms step_avg:50.02ms
+step:1109/1600 train_time:55507ms step_avg:50.05ms
+step:1110/1600 train_time:55593ms step_avg:50.08ms
+step:1111/1600 train_time:55681ms step_avg:50.12ms
+step:1112/1600 train_time:55766ms step_avg:50.15ms
+step:1113/1600 train_time:55855ms step_avg:50.18ms
+step:1114/1600 train_time:55939ms step_avg:50.21ms
+step:1115/1600 train_time:56027ms step_avg:50.25ms
+step:1116/1600 train_time:56112ms step_avg:50.28ms
+step:1117/1600 train_time:56200ms step_avg:50.31ms
+step:1118/1600 train_time:56285ms step_avg:50.34ms
+step:1119/1600 train_time:56373ms step_avg:50.38ms
+step:1120/1600 train_time:56458ms step_avg:50.41ms
+step:1121/1600 train_time:56547ms step_avg:50.44ms
+step:1122/1600 train_time:56633ms step_avg:50.48ms
+step:1123/1600 train_time:56722ms step_avg:50.51ms
+step:1124/1600 train_time:56811ms step_avg:50.54ms
+step:1125/1600 train_time:56895ms step_avg:50.57ms
+step:1126/1600 train_time:56981ms step_avg:50.60ms
+step:1127/1600 train_time:57071ms step_avg:50.64ms
+step:1128/1600 train_time:57158ms step_avg:50.67ms
+step:1129/1600 train_time:57248ms step_avg:50.71ms
+step:1130/1600 train_time:57330ms step_avg:50.73ms
+step:1131/1600 train_time:57414ms step_avg:50.76ms
+step:1132/1600 train_time:57499ms step_avg:50.79ms
+step:1133/1600 train_time:57589ms step_avg:50.83ms
+step:1134/1600 train_time:57674ms step_avg:50.86ms
+step:1135/1600 train_time:57762ms step_avg:50.89ms
+step:1136/1600 train_time:57847ms step_avg:50.92ms
+step:1137/1600 train_time:57936ms step_avg:50.96ms
+step:1138/1600 train_time:58021ms step_avg:50.99ms
+step:1139/1600 train_time:58109ms step_avg:51.02ms
+step:1140/1600 train_time:58195ms step_avg:51.05ms
+step:1141/1600 train_time:58283ms step_avg:51.08ms
+step:1142/1600 train_time:58369ms step_avg:51.11ms
+step:1143/1600 train_time:58458ms step_avg:51.14ms
+step:1144/1600 train_time:58542ms step_avg:51.17ms
+step:1145/1600 train_time:58631ms step_avg:51.21ms
+step:1146/1600 train_time:58716ms step_avg:51.24ms
+step:1147/1600 train_time:58804ms step_avg:51.27ms
+step:1148/1600 train_time:58889ms step_avg:51.30ms
+step:1149/1600 train_time:58977ms step_avg:51.33ms
+step:1150/1600 train_time:59062ms step_avg:51.36ms
+step:1151/1600 train_time:59151ms step_avg:51.39ms
+step:1152/1600 train_time:59239ms step_avg:51.42ms
+step:1153/1600 train_time:59325ms step_avg:51.45ms
+step:1154/1600 train_time:59414ms step_avg:51.49ms
+step:1155/1600 train_time:59501ms step_avg:51.52ms
+step:1156/1600 train_time:59586ms step_avg:51.54ms
+step:1157/1600 train_time:59673ms step_avg:51.58ms
+step:1158/1600 train_time:59758ms step_avg:51.60ms
+step:1159/1600 train_time:59846ms step_avg:51.64ms
+step:1160/1600 train_time:59932ms step_avg:51.67ms
+step:1161/1600 train_time:60021ms step_avg:51.70ms
+step:1162/1600 train_time:60105ms step_avg:51.73ms
+step:1163/1600 train_time:60193ms step_avg:51.76ms
+step:1164/1600 train_time:60280ms step_avg:51.79ms
+step:1165/1600 train_time:60367ms step_avg:51.82ms
+step:1166/1600 train_time:60454ms step_avg:51.85ms
+step:1167/1600 train_time:60541ms step_avg:51.88ms
+step:1168/1600 train_time:60626ms step_avg:51.91ms
+step:1169/1600 train_time:60714ms step_avg:51.94ms
+step:1170/1600 train_time:60799ms step_avg:51.96ms
+step:1171/1600 train_time:60888ms step_avg:52.00ms
+step:1172/1600 train_time:60973ms step_avg:52.03ms
+step:1173/1600 train_time:61062ms step_avg:52.06ms
+step:1174/1600 train_time:61147ms step_avg:52.08ms
+step:1175/1600 train_time:61235ms step_avg:52.11ms
+step:1176/1600 train_time:61321ms step_avg:52.14ms
+step:1177/1600 train_time:61408ms step_avg:52.17ms
+step:1178/1600 train_time:61493ms step_avg:52.20ms
+step:1179/1600 train_time:61582ms step_avg:52.23ms
+step:1180/1600 train_time:61668ms step_avg:52.26ms
+step:1181/1600 train_time:61756ms step_avg:52.29ms
+step:1182/1600 train_time:61841ms step_avg:52.32ms
+step:1183/1600 train_time:61929ms step_avg:52.35ms
+step:1184/1600 train_time:62014ms step_avg:52.38ms
+step:1185/1600 train_time:62103ms step_avg:52.41ms
+step:1186/1600 train_time:62187ms step_avg:52.43ms
+step:1187/1600 train_time:62276ms step_avg:52.47ms
+step:1188/1600 train_time:62361ms step_avg:52.49ms
+step:1189/1600 train_time:62450ms step_avg:52.52ms
+step:1190/1600 train_time:62535ms step_avg:52.55ms
+step:1191/1600 train_time:62624ms step_avg:52.58ms
+step:1192/1600 train_time:62709ms step_avg:52.61ms
+step:1193/1600 train_time:62798ms step_avg:52.64ms
+step:1194/1600 train_time:62883ms step_avg:52.67ms
+step:1195/1600 train_time:62971ms step_avg:52.70ms
+step:1196/1600 train_time:63056ms step_avg:52.72ms
+step:1197/1600 train_time:63145ms step_avg:52.75ms
+step:1198/1600 train_time:63231ms step_avg:52.78ms
+step:1199/1600 train_time:63319ms step_avg:52.81ms
+step:1200/1600 train_time:63405ms step_avg:52.84ms
+step:1201/1600 train_time:63493ms step_avg:52.87ms
+step:1202/1600 train_time:63578ms step_avg:52.89ms
+step:1203/1600 train_time:63666ms step_avg:52.92ms
+step:1204/1600 train_time:63751ms step_avg:52.95ms
+step:1205/1600 train_time:63839ms step_avg:52.98ms
+step:1206/1600 train_time:63925ms step_avg:53.01ms
+step:1207/1600 train_time:64013ms step_avg:53.04ms
+step:1208/1600 train_time:64099ms step_avg:53.06ms
+step:1209/1600 train_time:64187ms step_avg:53.09ms
+step:1210/1600 train_time:64273ms step_avg:53.12ms
+step:1211/1600 train_time:64361ms step_avg:53.15ms
+step:1212/1600 train_time:64447ms step_avg:53.17ms
+step:1213/1600 train_time:64537ms step_avg:53.20ms
+step:1214/1600 train_time:64621ms step_avg:53.23ms
+step:1215/1600 train_time:64709ms step_avg:53.26ms
+step:1216/1600 train_time:64794ms step_avg:53.28ms
+step:1217/1600 train_time:64882ms step_avg:53.31ms
+step:1218/1600 train_time:64968ms step_avg:53.34ms
+step:1219/1600 train_time:65056ms step_avg:53.37ms
+step:1220/1600 train_time:65140ms step_avg:53.39ms
+step:1221/1600 train_time:65228ms step_avg:53.42ms
+step:1222/1600 train_time:65313ms step_avg:53.45ms
+step:1223/1600 train_time:65402ms step_avg:53.48ms
+step:1224/1600 train_time:65487ms step_avg:53.50ms
+step:1225/1600 train_time:65575ms step_avg:53.53ms
+step:1226/1600 train_time:65660ms step_avg:53.56ms
+step:1227/1600 train_time:65749ms step_avg:53.59ms
+step:1228/1600 train_time:65834ms step_avg:53.61ms
+step:1229/1600 train_time:65925ms step_avg:53.64ms
+step:1230/1600 train_time:66008ms step_avg:53.67ms
+step:1231/1600 train_time:66096ms step_avg:53.69ms
+step:1232/1600 train_time:66181ms step_avg:53.72ms
+step:1233/1600 train_time:66269ms step_avg:53.75ms
+step:1234/1600 train_time:66354ms step_avg:53.77ms
+step:1235/1600 train_time:66443ms step_avg:53.80ms
+step:1236/1600 train_time:66528ms step_avg:53.83ms
+step:1237/1600 train_time:66616ms step_avg:53.85ms
+step:1238/1600 train_time:66701ms step_avg:53.88ms
+step:1239/1600 train_time:66790ms step_avg:53.91ms
+step:1240/1600 train_time:66875ms step_avg:53.93ms
+step:1241/1600 train_time:66964ms step_avg:53.96ms
+step:1242/1600 train_time:67048ms step_avg:53.98ms
+step:1243/1600 train_time:67138ms step_avg:54.01ms
+step:1244/1600 train_time:67223ms step_avg:54.04ms
+step:1245/1600 train_time:67311ms step_avg:54.07ms
+step:1246/1600 train_time:67397ms step_avg:54.09ms
+step:1247/1600 train_time:67485ms step_avg:54.12ms
+step:1248/1600 train_time:67570ms step_avg:54.14ms
+step:1249/1600 train_time:67658ms step_avg:54.17ms
+step:1250/1600 train_time:67744ms step_avg:54.20ms
+step:1250/1600 val_loss:3.4172 train_time:67818ms step_avg:54.25ms
+step:1251/1600 train_time:67837ms step_avg:54.23ms
+step:1252/1600 train_time:67923ms step_avg:54.25ms
+step:1253/1600 train_time:68015ms step_avg:54.28ms
+step:1254/1600 train_time:68100ms step_avg:54.31ms
+step:1255/1600 train_time:68189ms step_avg:54.33ms
+step:1256/1600 train_time:68274ms step_avg:54.36ms
+step:1257/1600 train_time:68361ms step_avg:54.38ms
+step:1258/1600 train_time:68446ms step_avg:54.41ms
+step:1259/1600 train_time:68535ms step_avg:54.44ms
+step:1260/1600 train_time:68617ms step_avg:54.46ms
+step:1261/1600 train_time:68703ms step_avg:54.48ms
+step:1262/1600 train_time:68789ms step_avg:54.51ms
+step:1263/1600 train_time:68878ms step_avg:54.54ms
+step:1264/1600 train_time:68966ms step_avg:54.56ms
+step:1265/1600 train_time:69055ms step_avg:54.59ms
+step:1266/1600 train_time:69141ms step_avg:54.61ms
+step:1267/1600 train_time:69230ms step_avg:54.64ms
+step:1268/1600 train_time:69314ms step_avg:54.66ms
+step:1269/1600 train_time:69403ms step_avg:54.69ms
+step:1270/1600 train_time:69487ms step_avg:54.71ms
+step:1271/1600 train_time:69575ms step_avg:54.74ms
+step:1272/1600 train_time:69658ms step_avg:54.76ms
+step:1273/1600 train_time:69747ms step_avg:54.79ms
+step:1274/1600 train_time:69832ms step_avg:54.81ms
+step:1275/1600 train_time:69923ms step_avg:54.84ms
+step:1276/1600 train_time:70010ms step_avg:54.87ms
+step:1277/1600 train_time:70098ms step_avg:54.89ms
+step:1278/1600 train_time:70184ms step_avg:54.92ms
+step:1279/1600 train_time:70272ms step_avg:54.94ms
+step:1280/1600 train_time:70357ms step_avg:54.97ms
+step:1281/1600 train_time:70445ms step_avg:54.99ms
+step:1282/1600 train_time:70529ms step_avg:55.01ms
+step:1283/1600 train_time:70616ms step_avg:55.04ms
+step:1284/1600 train_time:70701ms step_avg:55.06ms
+step:1285/1600 train_time:70790ms step_avg:55.09ms
+step:1286/1600 train_time:70875ms step_avg:55.11ms
+step:1287/1600 train_time:70965ms step_avg:55.14ms
+step:1288/1600 train_time:71051ms step_avg:55.16ms
+step:1289/1600 train_time:71139ms step_avg:55.19ms
+step:1290/1600 train_time:71224ms step_avg:55.21ms
+step:1291/1600 train_time:71313ms step_avg:55.24ms
+step:1292/1600 train_time:71397ms step_avg:55.26ms
+step:1293/1600 train_time:71484ms step_avg:55.29ms
+step:1294/1600 train_time:71569ms step_avg:55.31ms
+step:1295/1600 train_time:71658ms step_avg:55.33ms
+step:1296/1600 train_time:71742ms step_avg:55.36ms
+step:1297/1600 train_time:71831ms step_avg:55.38ms
+step:1298/1600 train_time:71916ms step_avg:55.41ms
+step:1299/1600 train_time:72005ms step_avg:55.43ms
+step:1300/1600 train_time:72091ms step_avg:55.45ms
+step:1301/1600 train_time:72179ms step_avg:55.48ms
+step:1302/1600 train_time:72264ms step_avg:55.50ms
+step:1303/1600 train_time:72352ms step_avg:55.53ms
+step:1304/1600 train_time:72437ms step_avg:55.55ms
+step:1305/1600 train_time:72524ms step_avg:55.57ms
+step:1306/1600 train_time:72609ms step_avg:55.60ms
+step:1307/1600 train_time:72697ms step_avg:55.62ms
+step:1308/1600 train_time:72782ms step_avg:55.64ms
+step:1309/1600 train_time:72871ms step_avg:55.67ms
+step:1310/1600 train_time:72956ms step_avg:55.69ms
+step:1311/1600 train_time:73045ms step_avg:55.72ms
+step:1312/1600 train_time:73132ms step_avg:55.74ms
+step:1313/1600 train_time:73220ms step_avg:55.77ms
+step:1314/1600 train_time:73306ms step_avg:55.79ms
+step:1315/1600 train_time:73395ms step_avg:55.81ms
+step:1316/1600 train_time:73480ms step_avg:55.84ms
+step:1317/1600 train_time:73567ms step_avg:55.86ms
+step:1318/1600 train_time:73652ms step_avg:55.88ms
+step:1319/1600 train_time:73740ms step_avg:55.91ms
+step:1320/1600 train_time:73825ms step_avg:55.93ms
+step:1321/1600 train_time:73913ms step_avg:55.95ms
+step:1322/1600 train_time:73998ms step_avg:55.97ms
+step:1323/1600 train_time:74087ms step_avg:56.00ms
+step:1324/1600 train_time:74173ms step_avg:56.02ms
+step:1325/1600 train_time:74263ms step_avg:56.05ms
+step:1326/1600 train_time:74348ms step_avg:56.07ms
+step:1327/1600 train_time:74437ms step_avg:56.09ms
+step:1328/1600 train_time:74522ms step_avg:56.12ms
+step:1329/1600 train_time:74609ms step_avg:56.14ms
+step:1330/1600 train_time:74694ms step_avg:56.16ms
+step:1331/1600 train_time:74783ms step_avg:56.19ms
+step:1332/1600 train_time:74868ms step_avg:56.21ms
+step:1333/1600 train_time:74956ms step_avg:56.23ms
+step:1334/1600 train_time:75041ms step_avg:56.25ms
+step:1335/1600 train_time:75129ms step_avg:56.28ms
+step:1336/1600 train_time:75214ms step_avg:56.30ms
+step:1337/1600 train_time:75302ms step_avg:56.32ms
+step:1338/1600 train_time:75388ms step_avg:56.34ms
+step:1339/1600 train_time:75476ms step_avg:56.37ms
+step:1340/1600 train_time:75561ms step_avg:56.39ms
+step:1341/1600 train_time:75649ms step_avg:56.41ms
+step:1342/1600 train_time:75734ms step_avg:56.43ms
+step:1343/1600 train_time:75823ms step_avg:56.46ms
+step:1344/1600 train_time:75908ms step_avg:56.48ms
+step:1345/1600 train_time:75997ms step_avg:56.50ms
+step:1346/1600 train_time:76082ms step_avg:56.52ms
+step:1347/1600 train_time:76170ms step_avg:56.55ms
+step:1348/1600 train_time:76255ms step_avg:56.57ms
+step:1349/1600 train_time:76343ms step_avg:56.59ms
+step:1350/1600 train_time:76428ms step_avg:56.61ms
+step:1351/1600 train_time:76517ms step_avg:56.64ms
+step:1352/1600 train_time:76601ms step_avg:56.66ms
+step:1353/1600 train_time:76689ms step_avg:56.68ms
+step:1354/1600 train_time:76774ms step_avg:56.70ms
+step:1355/1600 train_time:76862ms step_avg:56.72ms
+step:1356/1600 train_time:76949ms step_avg:56.75ms
+step:1357/1600 train_time:77036ms step_avg:56.77ms
+step:1358/1600 train_time:77122ms step_avg:56.79ms
+step:1359/1600 train_time:77210ms step_avg:56.81ms
+step:1360/1600 train_time:77296ms step_avg:56.84ms
+step:1361/1600 train_time:77384ms step_avg:56.86ms
+step:1362/1600 train_time:77469ms step_avg:56.88ms
+step:1363/1600 train_time:77557ms step_avg:56.90ms
+step:1364/1600 train_time:77642ms step_avg:56.92ms
+step:1365/1600 train_time:77731ms step_avg:56.95ms
+step:1366/1600 train_time:77820ms step_avg:56.97ms
+step:1367/1600 train_time:77906ms step_avg:56.99ms
+step:1368/1600 train_time:77990ms step_avg:57.01ms
+step:1369/1600 train_time:78077ms step_avg:57.03ms
+step:1370/1600 train_time:78162ms step_avg:57.05ms
+step:1371/1600 train_time:78250ms step_avg:57.08ms
+step:1372/1600 train_time:78337ms step_avg:57.10ms
+step:1373/1600 train_time:78424ms step_avg:57.12ms
+step:1374/1600 train_time:78509ms step_avg:57.14ms
+step:1375/1600 train_time:78598ms step_avg:57.16ms
+step:1376/1600 train_time:78683ms step_avg:57.18ms
+step:1377/1600 train_time:78772ms step_avg:57.21ms
+step:1378/1600 train_time:78858ms step_avg:57.23ms
+step:1379/1600 train_time:78946ms step_avg:57.25ms
+step:1380/1600 train_time:79032ms step_avg:57.27ms
+step:1381/1600 train_time:79120ms step_avg:57.29ms
+step:1382/1600 train_time:79205ms step_avg:57.31ms
+step:1383/1600 train_time:79293ms step_avg:57.33ms
+step:1384/1600 train_time:79378ms step_avg:57.35ms
+step:1385/1600 train_time:79467ms step_avg:57.38ms
+step:1386/1600 train_time:79551ms step_avg:57.40ms
+step:1387/1600 train_time:79640ms step_avg:57.42ms
+step:1388/1600 train_time:79724ms step_avg:57.44ms
+step:1389/1600 train_time:79814ms step_avg:57.46ms
+step:1390/1600 train_time:79899ms step_avg:57.48ms
+step:1391/1600 train_time:79987ms step_avg:57.50ms
+step:1392/1600 train_time:80072ms step_avg:57.52ms
+step:1393/1600 train_time:80161ms step_avg:57.55ms
+step:1394/1600 train_time:80246ms step_avg:57.57ms
+step:1395/1600 train_time:80334ms step_avg:57.59ms
+step:1396/1600 train_time:80421ms step_avg:57.61ms
+step:1397/1600 train_time:80507ms step_avg:57.63ms
+step:1398/1600 train_time:80593ms step_avg:57.65ms
+step:1399/1600 train_time:80681ms step_avg:57.67ms
+step:1400/1600 train_time:80766ms step_avg:57.69ms
+step:1401/1600 train_time:80855ms step_avg:57.71ms
+step:1402/1600 train_time:80940ms step_avg:57.73ms
+step:1403/1600 train_time:81028ms step_avg:57.75ms
+step:1404/1600 train_time:81112ms step_avg:57.77ms
+step:1405/1600 train_time:81201ms step_avg:57.79ms
+step:1406/1600 train_time:81286ms step_avg:57.81ms
+step:1407/1600 train_time:81375ms step_avg:57.84ms
+step:1408/1600 train_time:81461ms step_avg:57.86ms
+step:1409/1600 train_time:81549ms step_avg:57.88ms
+step:1410/1600 train_time:81635ms step_avg:57.90ms
+step:1411/1600 train_time:81724ms step_avg:57.92ms
+step:1412/1600 train_time:81809ms step_avg:57.94ms
+step:1413/1600 train_time:81897ms step_avg:57.96ms
+step:1414/1600 train_time:81982ms step_avg:57.98ms
+step:1415/1600 train_time:82070ms step_avg:58.00ms
+step:1416/1600 train_time:82155ms step_avg:58.02ms
+step:1417/1600 train_time:82244ms step_avg:58.04ms
+step:1418/1600 train_time:82329ms step_avg:58.06ms
+step:1419/1600 train_time:82417ms step_avg:58.08ms
+step:1420/1600 train_time:82502ms step_avg:58.10ms
+step:1421/1600 train_time:82590ms step_avg:58.12ms
+step:1422/1600 train_time:82676ms step_avg:58.14ms
+step:1423/1600 train_time:82765ms step_avg:58.16ms
+step:1424/1600 train_time:82850ms step_avg:58.18ms
+step:1425/1600 train_time:82938ms step_avg:58.20ms
+step:1426/1600 train_time:83023ms step_avg:58.22ms
+step:1427/1600 train_time:83111ms step_avg:58.24ms
+step:1428/1600 train_time:83197ms step_avg:58.26ms
+step:1429/1600 train_time:83285ms step_avg:58.28ms
+step:1430/1600 train_time:83371ms step_avg:58.30ms
+step:1431/1600 train_time:83463ms step_avg:58.32ms
+step:1432/1600 train_time:83549ms step_avg:58.34ms
+step:1433/1600 train_time:83636ms step_avg:58.36ms
+step:1434/1600 train_time:83720ms step_avg:58.38ms
+step:1435/1600 train_time:83808ms step_avg:58.40ms
+step:1436/1600 train_time:83893ms step_avg:58.42ms
+step:1437/1600 train_time:83981ms step_avg:58.44ms
+step:1438/1600 train_time:84067ms step_avg:58.46ms
+step:1439/1600 train_time:84155ms step_avg:58.48ms
+step:1440/1600 train_time:84240ms step_avg:58.50ms
+step:1441/1600 train_time:84328ms step_avg:58.52ms
+step:1442/1600 train_time:84412ms step_avg:58.54ms
+step:1443/1600 train_time:84502ms step_avg:58.56ms
+step:1444/1600 train_time:84587ms step_avg:58.58ms
+step:1445/1600 train_time:84676ms step_avg:58.60ms
+step:1446/1600 train_time:84760ms step_avg:58.62ms
+step:1447/1600 train_time:84848ms step_avg:58.64ms
+step:1448/1600 train_time:84933ms step_avg:58.66ms
+step:1449/1600 train_time:85021ms step_avg:58.68ms
+step:1450/1600 train_time:85106ms step_avg:58.69ms
+step:1451/1600 train_time:85194ms step_avg:58.71ms
+step:1452/1600 train_time:85280ms step_avg:58.73ms
+step:1453/1600 train_time:85367ms step_avg:58.75ms
+step:1454/1600 train_time:85452ms step_avg:58.77ms
+step:1455/1600 train_time:85541ms step_avg:58.79ms
+step:1456/1600 train_time:85626ms step_avg:58.81ms
+step:1457/1600 train_time:85715ms step_avg:58.83ms
+step:1458/1600 train_time:85800ms step_avg:58.85ms
+step:1459/1600 train_time:85888ms step_avg:58.87ms
+step:1460/1600 train_time:85973ms step_avg:58.89ms
+step:1461/1600 train_time:86062ms step_avg:58.91ms
+step:1462/1600 train_time:86148ms step_avg:58.92ms
+step:1463/1600 train_time:86236ms step_avg:58.94ms
+step:1464/1600 train_time:86322ms step_avg:58.96ms
+step:1465/1600 train_time:86410ms step_avg:58.98ms
+step:1466/1600 train_time:86495ms step_avg:59.00ms
+step:1467/1600 train_time:86585ms step_avg:59.02ms
+step:1468/1600 train_time:86670ms step_avg:59.04ms
+step:1469/1600 train_time:86758ms step_avg:59.06ms
+step:1470/1600 train_time:86843ms step_avg:59.08ms
+step:1471/1600 train_time:86932ms step_avg:59.10ms
+step:1472/1600 train_time:87017ms step_avg:59.11ms
+step:1473/1600 train_time:87105ms step_avg:59.13ms
+step:1474/1600 train_time:87190ms step_avg:59.15ms
+step:1475/1600 train_time:87279ms step_avg:59.17ms
+step:1476/1600 train_time:87363ms step_avg:59.19ms
+step:1477/1600 train_time:87452ms step_avg:59.21ms
+step:1478/1600 train_time:87537ms step_avg:59.23ms
+step:1479/1600 train_time:87626ms step_avg:59.25ms
+step:1480/1600 train_time:87712ms step_avg:59.26ms
+step:1481/1600 train_time:87801ms step_avg:59.28ms
+step:1482/1600 train_time:87885ms step_avg:59.30ms
+step:1483/1600 train_time:87974ms step_avg:59.32ms
+step:1484/1600 train_time:88059ms step_avg:59.34ms
+step:1485/1600 train_time:88147ms step_avg:59.36ms
+step:1486/1600 train_time:88231ms step_avg:59.38ms
+step:1487/1600 train_time:88320ms step_avg:59.39ms
+step:1488/1600 train_time:88407ms step_avg:59.41ms
+step:1489/1600 train_time:88494ms step_avg:59.43ms
+step:1490/1600 train_time:88579ms step_avg:59.45ms
+step:1491/1600 train_time:88667ms step_avg:59.47ms
+step:1492/1600 train_time:88753ms step_avg:59.49ms
+step:1493/1600 train_time:88840ms step_avg:59.50ms
+step:1494/1600 train_time:88925ms step_avg:59.52ms
+step:1495/1600 train_time:89014ms step_avg:59.54ms
+step:1496/1600 train_time:89100ms step_avg:59.56ms
+step:1497/1600 train_time:89188ms step_avg:59.58ms
+step:1498/1600 train_time:89273ms step_avg:59.59ms
+step:1499/1600 train_time:89362ms step_avg:59.61ms
+step:1500/1600 train_time:89447ms step_avg:59.63ms
+step:1500/1600 val_loss:3.3084 train_time:89519ms step_avg:59.68ms
+step:1501/1600 train_time:89539ms step_avg:59.65ms
+step:1502/1600 train_time:89624ms step_avg:59.67ms
+step:1503/1600 train_time:89716ms step_avg:59.69ms
+step:1504/1600 train_time:89801ms step_avg:59.71ms
+step:1505/1600 train_time:89889ms step_avg:59.73ms
+step:1506/1600 train_time:89973ms step_avg:59.74ms
+step:1507/1600 train_time:90060ms step_avg:59.76ms
+step:1508/1600 train_time:90145ms step_avg:59.78ms
+step:1509/1600 train_time:90232ms step_avg:59.80ms
+step:1510/1600 train_time:90317ms step_avg:59.81ms
+step:1511/1600 train_time:90405ms step_avg:59.83ms
+step:1512/1600 train_time:90491ms step_avg:59.85ms
+step:1513/1600 train_time:90582ms step_avg:59.87ms
+step:1514/1600 train_time:90669ms step_avg:59.89ms
+step:1515/1600 train_time:90759ms step_avg:59.91ms
+step:1516/1600 train_time:90844ms step_avg:59.92ms
+step:1517/1600 train_time:90932ms step_avg:59.94ms
+step:1518/1600 train_time:91017ms step_avg:59.96ms
+step:1519/1600 train_time:91104ms step_avg:59.98ms
+step:1520/1600 train_time:91190ms step_avg:59.99ms
+step:1521/1600 train_time:91277ms step_avg:60.01ms
+step:1522/1600 train_time:91362ms step_avg:60.03ms
+step:1523/1600 train_time:91450ms step_avg:60.05ms
+step:1524/1600 train_time:91537ms step_avg:60.06ms
+step:1525/1600 train_time:91627ms step_avg:60.08ms
+step:1526/1600 train_time:91713ms step_avg:60.10ms
+step:1527/1600 train_time:91801ms step_avg:60.12ms
+step:1528/1600 train_time:91887ms step_avg:60.14ms
+step:1529/1600 train_time:91976ms step_avg:60.15ms
+step:1530/1600 train_time:92060ms step_avg:60.17ms
+step:1531/1600 train_time:92147ms step_avg:60.19ms
+step:1532/1600 train_time:92233ms step_avg:60.20ms
+step:1533/1600 train_time:92320ms step_avg:60.22ms
+step:1534/1600 train_time:92405ms step_avg:60.24ms
+step:1535/1600 train_time:92494ms step_avg:60.26ms
+step:1536/1600 train_time:92581ms step_avg:60.27ms
+step:1537/1600 train_time:92670ms step_avg:60.29ms
+step:1538/1600 train_time:92757ms step_avg:60.31ms
+step:1539/1600 train_time:92844ms step_avg:60.33ms
+step:1540/1600 train_time:92929ms step_avg:60.34ms
+step:1541/1600 train_time:93017ms step_avg:60.36ms
+step:1542/1600 train_time:93102ms step_avg:60.38ms
+step:1543/1600 train_time:93189ms step_avg:60.39ms
+step:1544/1600 train_time:93273ms step_avg:60.41ms
+step:1545/1600 train_time:93361ms step_avg:60.43ms
+step:1546/1600 train_time:93446ms step_avg:60.44ms
+step:1547/1600 train_time:93536ms step_avg:60.46ms
+step:1548/1600 train_time:93622ms step_avg:60.48ms
+step:1549/1600 train_time:93711ms step_avg:60.50ms
+step:1550/1600 train_time:93796ms step_avg:60.51ms
+step:1551/1600 train_time:93885ms step_avg:60.53ms
+step:1552/1600 train_time:93970ms step_avg:60.55ms
+step:1553/1600 train_time:94058ms step_avg:60.57ms
+step:1554/1600 train_time:94143ms step_avg:60.58ms
+step:1555/1600 train_time:94230ms step_avg:60.60ms
+step:1556/1600 train_time:94315ms step_avg:60.61ms
+step:1557/1600 train_time:94404ms step_avg:60.63ms
+step:1558/1600 train_time:94489ms step_avg:60.65ms
+step:1559/1600 train_time:94578ms step_avg:60.67ms
+step:1560/1600 train_time:94663ms step_avg:60.68ms
+step:1561/1600 train_time:94759ms step_avg:60.70ms
+step:1562/1600 train_time:94844ms step_avg:60.72ms
+step:1563/1600 train_time:94932ms step_avg:60.74ms
+step:1564/1600 train_time:95018ms step_avg:60.75ms
+step:1565/1600 train_time:95106ms step_avg:60.77ms
+step:1566/1600 train_time:95191ms step_avg:60.79ms
+step:1567/1600 train_time:95279ms step_avg:60.80ms
+step:1568/1600 train_time:95365ms step_avg:60.82ms
+step:1569/1600 train_time:95453ms step_avg:60.84ms
+step:1570/1600 train_time:95538ms step_avg:60.85ms
+step:1571/1600 train_time:95627ms step_avg:60.87ms
+step:1572/1600 train_time:95714ms step_avg:60.89ms
+step:1573/1600 train_time:95802ms step_avg:60.90ms
+step:1574/1600 train_time:95889ms step_avg:60.92ms
+step:1575/1600 train_time:95978ms step_avg:60.94ms
+step:1576/1600 train_time:96063ms step_avg:60.95ms
+step:1577/1600 train_time:96154ms step_avg:60.97ms
+step:1578/1600 train_time:96238ms step_avg:60.99ms
+step:1579/1600 train_time:96327ms step_avg:61.01ms
+step:1580/1600 train_time:96412ms step_avg:61.02ms
+step:1581/1600 train_time:96500ms step_avg:61.04ms
+step:1582/1600 train_time:96586ms step_avg:61.05ms
+step:1583/1600 train_time:96676ms step_avg:61.07ms
+step:1584/1600 train_time:96761ms step_avg:61.09ms
+step:1585/1600 train_time:96850ms step_avg:61.10ms
+step:1586/1600 train_time:96935ms step_avg:61.12ms
+step:1587/1600 train_time:97024ms step_avg:61.14ms
+step:1588/1600 train_time:97108ms step_avg:61.15ms
+step:1589/1600 train_time:97196ms step_avg:61.17ms
+step:1590/1600 train_time:97282ms step_avg:61.18ms
+step:1591/1600 train_time:97370ms step_avg:61.20ms
+step:1592/1600 train_time:97456ms step_avg:61.22ms
+step:1593/1600 train_time:97545ms step_avg:61.23ms
+step:1594/1600 train_time:97632ms step_avg:61.25ms
+step:1595/1600 train_time:97719ms step_avg:61.27ms
+step:1596/1600 train_time:97804ms step_avg:61.28ms
+step:1597/1600 train_time:97893ms step_avg:61.30ms
+step:1598/1600 train_time:97978ms step_avg:61.31ms
+step:1599/1600 train_time:98067ms step_avg:61.33ms
+step:1600/1600 train_time:98152ms step_avg:61.34ms
+step:1600/1600 val_loss:3.2791 train_time:98225ms step_avg:61.39ms
+peak memory allocated: 30264 MiB reserved: 46238 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/e521e545-7bdb-4668-b050-f465813cba4a.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/e521e545-7bdb-4668-b050-f465813cba4a.txt
@@ -1,0 +1,4096 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 01 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # shifting first layer updates this to 01 ... 01 @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:16:48 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   34C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   40C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   34C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   34C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   41C    P0            129W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   39C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   35C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          237197      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          237198      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          237199      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          237200      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          237201      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          237202      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          237203      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          237204      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 511, 512, 513, 1023, 1024, 1025, 1534, 1535, 1536] for warmup
+Resetting Model
+step:0/1575 val_loss:10.8310 train_time:0ms step_avg:0.03ms
+step:1/1575 train_time:83ms step_avg:83.13ms
+step:2/1575 train_time:105ms step_avg:52.28ms
+step:3/1575 train_time:123ms step_avg:40.87ms
+step:4/1575 train_time:155ms step_avg:38.66ms
+step:5/1575 train_time:185ms step_avg:37.07ms
+step:6/1575 train_time:257ms step_avg:42.88ms
+step:7/1575 train_time:274ms step_avg:39.20ms
+step:8/1575 train_time:330ms step_avg:41.30ms
+step:9/1575 train_time:361ms step_avg:40.15ms
+step:10/1575 train_time:400ms step_avg:39.98ms
+step:11/1575 train_time:431ms step_avg:39.17ms
+step:12/1575 train_time:470ms step_avg:39.13ms
+step:13/1575 train_time:501ms step_avg:38.51ms
+step:14/1575 train_time:539ms step_avg:38.50ms
+step:15/1575 train_time:571ms step_avg:38.06ms
+step:16/1575 train_time:610ms step_avg:38.11ms
+step:17/1575 train_time:641ms step_avg:37.69ms
+step:18/1575 train_time:680ms step_avg:37.77ms
+step:19/1575 train_time:711ms step_avg:37.41ms
+step:20/1575 train_time:749ms step_avg:37.47ms
+step:21/1575 train_time:781ms step_avg:37.19ms
+step:22/1575 train_time:820ms step_avg:37.28ms
+step:23/1575 train_time:851ms step_avg:37.02ms
+step:24/1575 train_time:890ms step_avg:37.08ms
+step:25/1575 train_time:921ms step_avg:36.83ms
+step:26/1575 train_time:959ms step_avg:36.90ms
+step:27/1575 train_time:991ms step_avg:36.71ms
+step:28/1575 train_time:1030ms step_avg:36.79ms
+step:29/1575 train_time:1061ms step_avg:36.58ms
+step:30/1575 train_time:1099ms step_avg:36.65ms
+step:31/1575 train_time:1131ms step_avg:36.47ms
+step:32/1575 train_time:1169ms step_avg:36.54ms
+step:33/1575 train_time:1201ms step_avg:36.38ms
+step:34/1575 train_time:1239ms step_avg:36.44ms
+step:35/1575 train_time:1271ms step_avg:36.30ms
+step:36/1575 train_time:1310ms step_avg:36.39ms
+step:37/1575 train_time:1340ms step_avg:36.23ms
+step:38/1575 train_time:1380ms step_avg:36.32ms
+step:39/1575 train_time:1412ms step_avg:36.20ms
+step:40/1575 train_time:1450ms step_avg:36.26ms
+step:41/1575 train_time:1482ms step_avg:36.14ms
+step:42/1575 train_time:1520ms step_avg:36.19ms
+step:43/1575 train_time:1551ms step_avg:36.08ms
+step:44/1575 train_time:1590ms step_avg:36.13ms
+step:45/1575 train_time:1621ms step_avg:36.02ms
+step:46/1575 train_time:1659ms step_avg:36.07ms
+step:47/1575 train_time:1690ms step_avg:35.97ms
+step:48/1575 train_time:1729ms step_avg:36.02ms
+step:49/1575 train_time:1760ms step_avg:35.92ms
+step:50/1575 train_time:1799ms step_avg:35.97ms
+step:51/1575 train_time:1829ms step_avg:35.87ms
+step:52/1575 train_time:1868ms step_avg:35.92ms
+step:53/1575 train_time:1899ms step_avg:35.82ms
+step:54/1575 train_time:1937ms step_avg:35.88ms
+step:55/1575 train_time:1968ms step_avg:35.79ms
+step:56/1575 train_time:2007ms step_avg:35.84ms
+step:57/1575 train_time:2038ms step_avg:35.76ms
+step:58/1575 train_time:2077ms step_avg:35.80ms
+step:59/1575 train_time:2108ms step_avg:35.73ms
+step:60/1575 train_time:2146ms step_avg:35.77ms
+step:61/1575 train_time:2178ms step_avg:35.70ms
+step:62/1575 train_time:2216ms step_avg:35.74ms
+step:63/1575 train_time:2247ms step_avg:35.67ms
+step:64/1575 train_time:2286ms step_avg:35.72ms
+step:65/1575 train_time:2317ms step_avg:35.65ms
+step:66/1575 train_time:2356ms step_avg:35.69ms
+step:67/1575 train_time:2387ms step_avg:35.63ms
+step:68/1575 train_time:2426ms step_avg:35.67ms
+step:69/1575 train_time:2457ms step_avg:35.61ms
+step:70/1575 train_time:2495ms step_avg:35.64ms
+step:71/1575 train_time:2527ms step_avg:35.59ms
+step:72/1575 train_time:2566ms step_avg:35.64ms
+step:73/1575 train_time:2597ms step_avg:35.57ms
+step:74/1575 train_time:2635ms step_avg:35.61ms
+step:75/1575 train_time:2666ms step_avg:35.55ms
+step:76/1575 train_time:2705ms step_avg:35.60ms
+step:77/1575 train_time:2737ms step_avg:35.54ms
+step:78/1575 train_time:2775ms step_avg:35.58ms
+step:79/1575 train_time:2806ms step_avg:35.52ms
+step:80/1575 train_time:2844ms step_avg:35.55ms
+step:81/1575 train_time:2875ms step_avg:35.50ms
+step:82/1575 train_time:2914ms step_avg:35.54ms
+step:83/1575 train_time:2945ms step_avg:35.48ms
+step:84/1575 train_time:2984ms step_avg:35.52ms
+step:85/1575 train_time:3014ms step_avg:35.46ms
+step:86/1575 train_time:3053ms step_avg:35.50ms
+step:87/1575 train_time:3084ms step_avg:35.45ms
+step:88/1575 train_time:3123ms step_avg:35.49ms
+step:89/1575 train_time:3154ms step_avg:35.44ms
+step:90/1575 train_time:3192ms step_avg:35.47ms
+step:91/1575 train_time:3223ms step_avg:35.42ms
+step:92/1575 train_time:3262ms step_avg:35.46ms
+step:93/1575 train_time:3293ms step_avg:35.41ms
+step:94/1575 train_time:3332ms step_avg:35.45ms
+step:95/1575 train_time:3363ms step_avg:35.40ms
+step:96/1575 train_time:3402ms step_avg:35.43ms
+step:97/1575 train_time:3433ms step_avg:35.39ms
+step:98/1575 train_time:3471ms step_avg:35.42ms
+step:99/1575 train_time:3503ms step_avg:35.38ms
+step:100/1575 train_time:3541ms step_avg:35.41ms
+step:101/1575 train_time:3572ms step_avg:35.37ms
+step:102/1575 train_time:3611ms step_avg:35.40ms
+step:103/1575 train_time:3642ms step_avg:35.36ms
+step:104/1575 train_time:3680ms step_avg:35.39ms
+step:105/1575 train_time:3712ms step_avg:35.35ms
+step:106/1575 train_time:3750ms step_avg:35.37ms
+step:107/1575 train_time:3781ms step_avg:35.33ms
+step:108/1575 train_time:3820ms step_avg:35.37ms
+step:109/1575 train_time:3851ms step_avg:35.33ms
+step:110/1575 train_time:3890ms step_avg:35.36ms
+step:111/1575 train_time:3921ms step_avg:35.32ms
+step:112/1575 train_time:3959ms step_avg:35.35ms
+step:113/1575 train_time:3990ms step_avg:35.31ms
+step:114/1575 train_time:4030ms step_avg:35.35ms
+step:115/1575 train_time:4061ms step_avg:35.31ms
+step:116/1575 train_time:4100ms step_avg:35.34ms
+step:117/1575 train_time:4131ms step_avg:35.31ms
+step:118/1575 train_time:4169ms step_avg:35.33ms
+step:119/1575 train_time:4200ms step_avg:35.30ms
+step:120/1575 train_time:4240ms step_avg:35.33ms
+step:121/1575 train_time:4271ms step_avg:35.30ms
+step:122/1575 train_time:4310ms step_avg:35.33ms
+step:123/1575 train_time:4341ms step_avg:35.29ms
+step:124/1575 train_time:4379ms step_avg:35.32ms
+step:125/1575 train_time:4410ms step_avg:35.28ms
+step:126/1575 train_time:4449ms step_avg:35.31ms
+step:127/1575 train_time:4480ms step_avg:35.28ms
+step:128/1575 train_time:4519ms step_avg:35.31ms
+step:129/1575 train_time:4550ms step_avg:35.27ms
+step:130/1575 train_time:4589ms step_avg:35.30ms
+step:131/1575 train_time:4620ms step_avg:35.27ms
+step:132/1575 train_time:4658ms step_avg:35.29ms
+step:133/1575 train_time:4689ms step_avg:35.26ms
+step:134/1575 train_time:4728ms step_avg:35.28ms
+step:135/1575 train_time:4759ms step_avg:35.25ms
+step:136/1575 train_time:4798ms step_avg:35.28ms
+step:137/1575 train_time:4828ms step_avg:35.24ms
+step:138/1575 train_time:4867ms step_avg:35.27ms
+step:139/1575 train_time:4898ms step_avg:35.24ms
+step:140/1575 train_time:4936ms step_avg:35.26ms
+step:141/1575 train_time:4967ms step_avg:35.23ms
+step:142/1575 train_time:5006ms step_avg:35.26ms
+step:143/1575 train_time:5037ms step_avg:35.23ms
+step:144/1575 train_time:5076ms step_avg:35.25ms
+step:145/1575 train_time:5106ms step_avg:35.22ms
+step:146/1575 train_time:5145ms step_avg:35.24ms
+step:147/1575 train_time:5176ms step_avg:35.21ms
+step:148/1575 train_time:5214ms step_avg:35.23ms
+step:149/1575 train_time:5246ms step_avg:35.21ms
+step:150/1575 train_time:5285ms step_avg:35.23ms
+step:151/1575 train_time:5316ms step_avg:35.21ms
+step:152/1575 train_time:5354ms step_avg:35.22ms
+step:153/1575 train_time:5385ms step_avg:35.20ms
+step:154/1575 train_time:5423ms step_avg:35.22ms
+step:155/1575 train_time:5454ms step_avg:35.19ms
+step:156/1575 train_time:5493ms step_avg:35.21ms
+step:157/1575 train_time:5524ms step_avg:35.18ms
+step:158/1575 train_time:5563ms step_avg:35.21ms
+step:159/1575 train_time:5593ms step_avg:35.18ms
+step:160/1575 train_time:5632ms step_avg:35.20ms
+step:161/1575 train_time:5663ms step_avg:35.17ms
+step:162/1575 train_time:5701ms step_avg:35.19ms
+step:163/1575 train_time:5732ms step_avg:35.17ms
+step:164/1575 train_time:5770ms step_avg:35.18ms
+step:165/1575 train_time:5801ms step_avg:35.16ms
+step:166/1575 train_time:5840ms step_avg:35.18ms
+step:167/1575 train_time:5871ms step_avg:35.16ms
+step:168/1575 train_time:5910ms step_avg:35.18ms
+step:169/1575 train_time:5941ms step_avg:35.15ms
+step:170/1575 train_time:5979ms step_avg:35.17ms
+step:171/1575 train_time:6011ms step_avg:35.15ms
+step:172/1575 train_time:6049ms step_avg:35.17ms
+step:173/1575 train_time:6080ms step_avg:35.15ms
+step:174/1575 train_time:6119ms step_avg:35.17ms
+step:175/1575 train_time:6150ms step_avg:35.14ms
+step:176/1575 train_time:6188ms step_avg:35.16ms
+step:177/1575 train_time:6219ms step_avg:35.14ms
+step:178/1575 train_time:6258ms step_avg:35.16ms
+step:179/1575 train_time:6289ms step_avg:35.13ms
+step:180/1575 train_time:6328ms step_avg:35.15ms
+step:181/1575 train_time:6359ms step_avg:35.13ms
+step:182/1575 train_time:6398ms step_avg:35.15ms
+step:183/1575 train_time:6429ms step_avg:35.13ms
+step:184/1575 train_time:6467ms step_avg:35.15ms
+step:185/1575 train_time:6498ms step_avg:35.13ms
+step:186/1575 train_time:6536ms step_avg:35.14ms
+step:187/1575 train_time:6567ms step_avg:35.12ms
+step:188/1575 train_time:6606ms step_avg:35.14ms
+step:189/1575 train_time:6637ms step_avg:35.12ms
+step:190/1575 train_time:6675ms step_avg:35.13ms
+step:191/1575 train_time:6707ms step_avg:35.11ms
+step:192/1575 train_time:6746ms step_avg:35.13ms
+step:193/1575 train_time:6777ms step_avg:35.11ms
+step:194/1575 train_time:6817ms step_avg:35.14ms
+step:195/1575 train_time:6846ms step_avg:35.11ms
+step:196/1575 train_time:6885ms step_avg:35.13ms
+step:197/1575 train_time:6915ms step_avg:35.10ms
+step:198/1575 train_time:6954ms step_avg:35.12ms
+step:199/1575 train_time:6985ms step_avg:35.10ms
+step:200/1575 train_time:7024ms step_avg:35.12ms
+step:201/1575 train_time:7055ms step_avg:35.10ms
+step:202/1575 train_time:7093ms step_avg:35.11ms
+step:203/1575 train_time:7124ms step_avg:35.09ms
+step:204/1575 train_time:7163ms step_avg:35.11ms
+step:205/1575 train_time:7194ms step_avg:35.09ms
+step:206/1575 train_time:7232ms step_avg:35.11ms
+step:207/1575 train_time:7263ms step_avg:35.09ms
+step:208/1575 train_time:7302ms step_avg:35.11ms
+step:209/1575 train_time:7333ms step_avg:35.09ms
+step:210/1575 train_time:7372ms step_avg:35.10ms
+step:211/1575 train_time:7403ms step_avg:35.08ms
+step:212/1575 train_time:7441ms step_avg:35.10ms
+step:213/1575 train_time:7472ms step_avg:35.08ms
+step:214/1575 train_time:7511ms step_avg:35.10ms
+step:215/1575 train_time:7542ms step_avg:35.08ms
+step:216/1575 train_time:7580ms step_avg:35.09ms
+step:217/1575 train_time:7611ms step_avg:35.07ms
+step:218/1575 train_time:7649ms step_avg:35.09ms
+step:219/1575 train_time:7680ms step_avg:35.07ms
+step:220/1575 train_time:7719ms step_avg:35.08ms
+step:221/1575 train_time:7750ms step_avg:35.07ms
+step:222/1575 train_time:7788ms step_avg:35.08ms
+step:223/1575 train_time:7819ms step_avg:35.06ms
+step:224/1575 train_time:7857ms step_avg:35.08ms
+step:225/1575 train_time:7889ms step_avg:35.06ms
+step:226/1575 train_time:7928ms step_avg:35.08ms
+step:227/1575 train_time:7959ms step_avg:35.06ms
+step:228/1575 train_time:7998ms step_avg:35.08ms
+step:229/1575 train_time:8028ms step_avg:35.06ms
+step:230/1575 train_time:8067ms step_avg:35.07ms
+step:231/1575 train_time:8098ms step_avg:35.06ms
+step:232/1575 train_time:8136ms step_avg:35.07ms
+step:233/1575 train_time:8168ms step_avg:35.06ms
+step:234/1575 train_time:8206ms step_avg:35.07ms
+step:235/1575 train_time:8237ms step_avg:35.05ms
+step:236/1575 train_time:8276ms step_avg:35.07ms
+step:237/1575 train_time:8307ms step_avg:35.05ms
+step:238/1575 train_time:8346ms step_avg:35.07ms
+step:239/1575 train_time:8377ms step_avg:35.05ms
+step:240/1575 train_time:8415ms step_avg:35.06ms
+step:241/1575 train_time:8446ms step_avg:35.05ms
+step:242/1575 train_time:8485ms step_avg:35.06ms
+step:243/1575 train_time:8516ms step_avg:35.04ms
+step:244/1575 train_time:8554ms step_avg:35.06ms
+step:245/1575 train_time:8585ms step_avg:35.04ms
+step:246/1575 train_time:8624ms step_avg:35.06ms
+step:247/1575 train_time:8655ms step_avg:35.04ms
+step:248/1575 train_time:8693ms step_avg:35.05ms
+step:249/1575 train_time:8724ms step_avg:35.04ms
+step:250/1575 train_time:8763ms step_avg:35.05ms
+step:250/1575 val_loss:4.5744 train_time:8812ms step_avg:35.25ms
+step:251/1575 train_time:8831ms step_avg:35.18ms
+step:252/1575 train_time:8850ms step_avg:35.12ms
+step:253/1575 train_time:8867ms step_avg:35.05ms
+step:254/1575 train_time:8906ms step_avg:35.06ms
+step:255/1575 train_time:8938ms step_avg:35.05ms
+step:256/1575 train_time:8977ms step_avg:35.07ms
+step:257/1575 train_time:9009ms step_avg:35.05ms
+step:258/1575 train_time:9048ms step_avg:35.07ms
+step:259/1575 train_time:9079ms step_avg:35.05ms
+step:260/1575 train_time:9117ms step_avg:35.07ms
+step:261/1575 train_time:9149ms step_avg:35.05ms
+step:262/1575 train_time:9187ms step_avg:35.07ms
+step:263/1575 train_time:9218ms step_avg:35.05ms
+step:264/1575 train_time:9257ms step_avg:35.06ms
+step:265/1575 train_time:9288ms step_avg:35.05ms
+step:266/1575 train_time:9326ms step_avg:35.06ms
+step:267/1575 train_time:9357ms step_avg:35.04ms
+step:268/1575 train_time:9395ms step_avg:35.06ms
+step:269/1575 train_time:9427ms step_avg:35.04ms
+step:270/1575 train_time:9466ms step_avg:35.06ms
+step:271/1575 train_time:9496ms step_avg:35.04ms
+step:272/1575 train_time:9534ms step_avg:35.05ms
+step:273/1575 train_time:9565ms step_avg:35.04ms
+step:274/1575 train_time:9604ms step_avg:35.05ms
+step:275/1575 train_time:9635ms step_avg:35.04ms
+step:276/1575 train_time:9673ms step_avg:35.05ms
+step:277/1575 train_time:9704ms step_avg:35.03ms
+step:278/1575 train_time:9743ms step_avg:35.05ms
+step:279/1575 train_time:9774ms step_avg:35.03ms
+step:280/1575 train_time:9812ms step_avg:35.04ms
+step:281/1575 train_time:9843ms step_avg:35.03ms
+step:282/1575 train_time:9881ms step_avg:35.04ms
+step:283/1575 train_time:9912ms step_avg:35.02ms
+step:284/1575 train_time:9951ms step_avg:35.04ms
+step:285/1575 train_time:9982ms step_avg:35.02ms
+step:286/1575 train_time:10020ms step_avg:35.03ms
+step:287/1575 train_time:10051ms step_avg:35.02ms
+step:288/1575 train_time:10089ms step_avg:35.03ms
+step:289/1575 train_time:10120ms step_avg:35.02ms
+step:290/1575 train_time:10158ms step_avg:35.03ms
+step:291/1575 train_time:10190ms step_avg:35.02ms
+step:292/1575 train_time:10228ms step_avg:35.03ms
+step:293/1575 train_time:10259ms step_avg:35.01ms
+step:294/1575 train_time:10297ms step_avg:35.02ms
+step:295/1575 train_time:10328ms step_avg:35.01ms
+step:296/1575 train_time:10367ms step_avg:35.02ms
+step:297/1575 train_time:10397ms step_avg:35.01ms
+step:298/1575 train_time:10436ms step_avg:35.02ms
+step:299/1575 train_time:10467ms step_avg:35.01ms
+step:300/1575 train_time:10505ms step_avg:35.02ms
+step:301/1575 train_time:10536ms step_avg:35.00ms
+step:302/1575 train_time:10575ms step_avg:35.02ms
+step:303/1575 train_time:10606ms step_avg:35.00ms
+step:304/1575 train_time:10644ms step_avg:35.01ms
+step:305/1575 train_time:10676ms step_avg:35.00ms
+step:306/1575 train_time:10714ms step_avg:35.01ms
+step:307/1575 train_time:10745ms step_avg:35.00ms
+step:308/1575 train_time:10783ms step_avg:35.01ms
+step:309/1575 train_time:10814ms step_avg:35.00ms
+step:310/1575 train_time:10853ms step_avg:35.01ms
+step:311/1575 train_time:10884ms step_avg:35.00ms
+step:312/1575 train_time:10922ms step_avg:35.01ms
+step:313/1575 train_time:10954ms step_avg:35.00ms
+step:314/1575 train_time:10992ms step_avg:35.01ms
+step:315/1575 train_time:11023ms step_avg:34.99ms
+step:316/1575 train_time:11062ms step_avg:35.01ms
+step:317/1575 train_time:11093ms step_avg:34.99ms
+step:318/1575 train_time:11131ms step_avg:35.00ms
+step:319/1575 train_time:11162ms step_avg:34.99ms
+step:320/1575 train_time:11200ms step_avg:35.00ms
+step:321/1575 train_time:11231ms step_avg:34.99ms
+step:322/1575 train_time:11270ms step_avg:35.00ms
+step:323/1575 train_time:11301ms step_avg:34.99ms
+step:324/1575 train_time:11339ms step_avg:35.00ms
+step:325/1575 train_time:11370ms step_avg:34.98ms
+step:326/1575 train_time:11408ms step_avg:34.99ms
+step:327/1575 train_time:11439ms step_avg:34.98ms
+step:328/1575 train_time:11477ms step_avg:34.99ms
+step:329/1575 train_time:11508ms step_avg:34.98ms
+step:330/1575 train_time:11547ms step_avg:34.99ms
+step:331/1575 train_time:11578ms step_avg:34.98ms
+step:332/1575 train_time:11616ms step_avg:34.99ms
+step:333/1575 train_time:11647ms step_avg:34.98ms
+step:334/1575 train_time:11686ms step_avg:34.99ms
+step:335/1575 train_time:11717ms step_avg:34.98ms
+step:336/1575 train_time:11755ms step_avg:34.99ms
+step:337/1575 train_time:11786ms step_avg:34.97ms
+step:338/1575 train_time:11824ms step_avg:34.98ms
+step:339/1575 train_time:11856ms step_avg:34.97ms
+step:340/1575 train_time:11894ms step_avg:34.98ms
+step:341/1575 train_time:11925ms step_avg:34.97ms
+step:342/1575 train_time:11965ms step_avg:34.98ms
+step:343/1575 train_time:11995ms step_avg:34.97ms
+step:344/1575 train_time:12033ms step_avg:34.98ms
+step:345/1575 train_time:12064ms step_avg:34.97ms
+step:346/1575 train_time:12103ms step_avg:34.98ms
+step:347/1575 train_time:12134ms step_avg:34.97ms
+step:348/1575 train_time:12172ms step_avg:34.98ms
+step:349/1575 train_time:12203ms step_avg:34.97ms
+step:350/1575 train_time:12241ms step_avg:34.97ms
+step:351/1575 train_time:12272ms step_avg:34.96ms
+step:352/1575 train_time:12310ms step_avg:34.97ms
+step:353/1575 train_time:12341ms step_avg:34.96ms
+step:354/1575 train_time:12379ms step_avg:34.97ms
+step:355/1575 train_time:12410ms step_avg:34.96ms
+step:356/1575 train_time:12449ms step_avg:34.97ms
+step:357/1575 train_time:12480ms step_avg:34.96ms
+step:358/1575 train_time:12518ms step_avg:34.97ms
+step:359/1575 train_time:12549ms step_avg:34.95ms
+step:360/1575 train_time:12587ms step_avg:34.96ms
+step:361/1575 train_time:12618ms step_avg:34.95ms
+step:362/1575 train_time:12656ms step_avg:34.96ms
+step:363/1575 train_time:12687ms step_avg:34.95ms
+step:364/1575 train_time:12726ms step_avg:34.96ms
+step:365/1575 train_time:12756ms step_avg:34.95ms
+step:366/1575 train_time:12795ms step_avg:34.96ms
+step:367/1575 train_time:12826ms step_avg:34.95ms
+step:368/1575 train_time:12865ms step_avg:34.96ms
+step:369/1575 train_time:12896ms step_avg:34.95ms
+step:370/1575 train_time:12934ms step_avg:34.96ms
+step:371/1575 train_time:12965ms step_avg:34.95ms
+step:372/1575 train_time:13003ms step_avg:34.96ms
+step:373/1575 train_time:13034ms step_avg:34.94ms
+step:374/1575 train_time:13073ms step_avg:34.96ms
+step:375/1575 train_time:13104ms step_avg:34.94ms
+step:376/1575 train_time:13143ms step_avg:34.95ms
+step:377/1575 train_time:13174ms step_avg:34.94ms
+step:378/1575 train_time:13212ms step_avg:34.95ms
+step:379/1575 train_time:13243ms step_avg:34.94ms
+step:380/1575 train_time:13281ms step_avg:34.95ms
+step:381/1575 train_time:13312ms step_avg:34.94ms
+step:382/1575 train_time:13350ms step_avg:34.95ms
+step:383/1575 train_time:13381ms step_avg:34.94ms
+step:384/1575 train_time:13420ms step_avg:34.95ms
+step:385/1575 train_time:13451ms step_avg:34.94ms
+step:386/1575 train_time:13489ms step_avg:34.95ms
+step:387/1575 train_time:13520ms step_avg:34.93ms
+step:388/1575 train_time:13558ms step_avg:34.94ms
+step:389/1575 train_time:13588ms step_avg:34.93ms
+step:390/1575 train_time:13627ms step_avg:34.94ms
+step:391/1575 train_time:13658ms step_avg:34.93ms
+step:392/1575 train_time:13696ms step_avg:34.94ms
+step:393/1575 train_time:13727ms step_avg:34.93ms
+step:394/1575 train_time:13765ms step_avg:34.94ms
+step:395/1575 train_time:13796ms step_avg:34.93ms
+step:396/1575 train_time:13834ms step_avg:34.94ms
+step:397/1575 train_time:13865ms step_avg:34.93ms
+step:398/1575 train_time:13904ms step_avg:34.93ms
+step:399/1575 train_time:13935ms step_avg:34.92ms
+step:400/1575 train_time:13974ms step_avg:34.93ms
+step:401/1575 train_time:14004ms step_avg:34.92ms
+step:402/1575 train_time:14042ms step_avg:34.93ms
+step:403/1575 train_time:14073ms step_avg:34.92ms
+step:404/1575 train_time:14112ms step_avg:34.93ms
+step:405/1575 train_time:14143ms step_avg:34.92ms
+step:406/1575 train_time:14181ms step_avg:34.93ms
+step:407/1575 train_time:14213ms step_avg:34.92ms
+step:408/1575 train_time:14251ms step_avg:34.93ms
+step:409/1575 train_time:14282ms step_avg:34.92ms
+step:410/1575 train_time:14320ms step_avg:34.93ms
+step:411/1575 train_time:14351ms step_avg:34.92ms
+step:412/1575 train_time:14390ms step_avg:34.93ms
+step:413/1575 train_time:14421ms step_avg:34.92ms
+step:414/1575 train_time:14459ms step_avg:34.92ms
+step:415/1575 train_time:14490ms step_avg:34.92ms
+step:416/1575 train_time:14528ms step_avg:34.92ms
+step:417/1575 train_time:14559ms step_avg:34.91ms
+step:418/1575 train_time:14597ms step_avg:34.92ms
+step:419/1575 train_time:14629ms step_avg:34.91ms
+step:420/1575 train_time:14667ms step_avg:34.92ms
+step:421/1575 train_time:14698ms step_avg:34.91ms
+step:422/1575 train_time:14736ms step_avg:34.92ms
+step:423/1575 train_time:14767ms step_avg:34.91ms
+step:424/1575 train_time:14806ms step_avg:34.92ms
+step:425/1575 train_time:14837ms step_avg:34.91ms
+step:426/1575 train_time:14875ms step_avg:34.92ms
+step:427/1575 train_time:14906ms step_avg:34.91ms
+step:428/1575 train_time:14946ms step_avg:34.92ms
+step:429/1575 train_time:14975ms step_avg:34.91ms
+step:430/1575 train_time:15013ms step_avg:34.91ms
+step:431/1575 train_time:15044ms step_avg:34.91ms
+step:432/1575 train_time:15082ms step_avg:34.91ms
+step:433/1575 train_time:15113ms step_avg:34.90ms
+step:434/1575 train_time:15152ms step_avg:34.91ms
+step:435/1575 train_time:15183ms step_avg:34.90ms
+step:436/1575 train_time:15221ms step_avg:34.91ms
+step:437/1575 train_time:15252ms step_avg:34.90ms
+step:438/1575 train_time:15291ms step_avg:34.91ms
+step:439/1575 train_time:15322ms step_avg:34.90ms
+step:440/1575 train_time:15361ms step_avg:34.91ms
+step:441/1575 train_time:15392ms step_avg:34.90ms
+step:442/1575 train_time:15430ms step_avg:34.91ms
+step:443/1575 train_time:15461ms step_avg:34.90ms
+step:444/1575 train_time:15500ms step_avg:34.91ms
+step:445/1575 train_time:15531ms step_avg:34.90ms
+step:446/1575 train_time:15569ms step_avg:34.91ms
+step:447/1575 train_time:15600ms step_avg:34.90ms
+step:448/1575 train_time:15638ms step_avg:34.91ms
+step:449/1575 train_time:15670ms step_avg:34.90ms
+step:450/1575 train_time:15708ms step_avg:34.91ms
+step:451/1575 train_time:15739ms step_avg:34.90ms
+step:452/1575 train_time:15777ms step_avg:34.91ms
+step:453/1575 train_time:15808ms step_avg:34.90ms
+step:454/1575 train_time:15847ms step_avg:34.90ms
+step:455/1575 train_time:15878ms step_avg:34.90ms
+step:456/1575 train_time:15916ms step_avg:34.90ms
+step:457/1575 train_time:15947ms step_avg:34.90ms
+step:458/1575 train_time:15986ms step_avg:34.90ms
+step:459/1575 train_time:16017ms step_avg:34.90ms
+step:460/1575 train_time:16055ms step_avg:34.90ms
+step:461/1575 train_time:16086ms step_avg:34.89ms
+step:462/1575 train_time:16124ms step_avg:34.90ms
+step:463/1575 train_time:16155ms step_avg:34.89ms
+step:464/1575 train_time:16194ms step_avg:34.90ms
+step:465/1575 train_time:16225ms step_avg:34.89ms
+step:466/1575 train_time:16264ms step_avg:34.90ms
+step:467/1575 train_time:16294ms step_avg:34.89ms
+step:468/1575 train_time:16332ms step_avg:34.90ms
+step:469/1575 train_time:16364ms step_avg:34.89ms
+step:470/1575 train_time:16402ms step_avg:34.90ms
+step:471/1575 train_time:16433ms step_avg:34.89ms
+step:472/1575 train_time:16473ms step_avg:34.90ms
+step:473/1575 train_time:16503ms step_avg:34.89ms
+step:474/1575 train_time:16541ms step_avg:34.90ms
+step:475/1575 train_time:16573ms step_avg:34.89ms
+step:476/1575 train_time:16611ms step_avg:34.90ms
+step:477/1575 train_time:16642ms step_avg:34.89ms
+step:478/1575 train_time:16680ms step_avg:34.90ms
+step:479/1575 train_time:16711ms step_avg:34.89ms
+step:480/1575 train_time:16750ms step_avg:34.90ms
+step:481/1575 train_time:16781ms step_avg:34.89ms
+step:482/1575 train_time:16819ms step_avg:34.89ms
+step:483/1575 train_time:16850ms step_avg:34.89ms
+step:484/1575 train_time:16889ms step_avg:34.90ms
+step:485/1575 train_time:16920ms step_avg:34.89ms
+step:486/1575 train_time:16958ms step_avg:34.89ms
+step:487/1575 train_time:16989ms step_avg:34.89ms
+step:488/1575 train_time:17027ms step_avg:34.89ms
+step:489/1575 train_time:17058ms step_avg:34.88ms
+step:490/1575 train_time:17096ms step_avg:34.89ms
+step:491/1575 train_time:17128ms step_avg:34.88ms
+step:492/1575 train_time:17167ms step_avg:34.89ms
+step:493/1575 train_time:17198ms step_avg:34.88ms
+step:494/1575 train_time:17236ms step_avg:34.89ms
+step:495/1575 train_time:17267ms step_avg:34.88ms
+step:496/1575 train_time:17305ms step_avg:34.89ms
+step:497/1575 train_time:17336ms step_avg:34.88ms
+step:498/1575 train_time:17375ms step_avg:34.89ms
+step:499/1575 train_time:17406ms step_avg:34.88ms
+step:500/1575 train_time:17444ms step_avg:34.89ms
+step:500/1575 val_loss:4.2393 train_time:17493ms step_avg:34.99ms
+step:501/1575 train_time:17512ms step_avg:34.95ms
+step:502/1575 train_time:17531ms step_avg:34.92ms
+step:503/1575 train_time:17549ms step_avg:34.89ms
+step:504/1575 train_time:17588ms step_avg:34.90ms
+step:505/1575 train_time:17621ms step_avg:34.89ms
+step:506/1575 train_time:17660ms step_avg:34.90ms
+step:507/1575 train_time:17692ms step_avg:34.90ms
+step:508/1575 train_time:17731ms step_avg:34.90ms
+step:509/1575 train_time:17763ms step_avg:34.90ms
+step:510/1575 train_time:17802ms step_avg:34.91ms
+step:511/1575 train_time:17833ms step_avg:34.90ms
+step:512/1575 train_time:17871ms step_avg:34.90ms
+step:513/1575 train_time:17945ms step_avg:34.98ms
+step:514/1575 train_time:18001ms step_avg:35.02ms
+step:515/1575 train_time:18063ms step_avg:35.07ms
+step:516/1575 train_time:18123ms step_avg:35.12ms
+step:517/1575 train_time:18185ms step_avg:35.17ms
+step:518/1575 train_time:18243ms step_avg:35.22ms
+step:519/1575 train_time:18307ms step_avg:35.27ms
+step:520/1575 train_time:18364ms step_avg:35.32ms
+step:521/1575 train_time:18427ms step_avg:35.37ms
+step:522/1575 train_time:18486ms step_avg:35.41ms
+step:523/1575 train_time:18550ms step_avg:35.47ms
+step:524/1575 train_time:18610ms step_avg:35.51ms
+step:525/1575 train_time:18674ms step_avg:35.57ms
+step:526/1575 train_time:18734ms step_avg:35.62ms
+step:527/1575 train_time:18799ms step_avg:35.67ms
+step:528/1575 train_time:18858ms step_avg:35.72ms
+step:529/1575 train_time:18922ms step_avg:35.77ms
+step:530/1575 train_time:18983ms step_avg:35.82ms
+step:531/1575 train_time:19044ms step_avg:35.86ms
+step:532/1575 train_time:19103ms step_avg:35.91ms
+step:533/1575 train_time:19166ms step_avg:35.96ms
+step:534/1575 train_time:19225ms step_avg:36.00ms
+step:535/1575 train_time:19288ms step_avg:36.05ms
+step:536/1575 train_time:19347ms step_avg:36.10ms
+step:537/1575 train_time:19410ms step_avg:36.14ms
+step:538/1575 train_time:19469ms step_avg:36.19ms
+step:539/1575 train_time:19532ms step_avg:36.24ms
+step:540/1575 train_time:19592ms step_avg:36.28ms
+step:541/1575 train_time:19656ms step_avg:36.33ms
+step:542/1575 train_time:19716ms step_avg:36.38ms
+step:543/1575 train_time:19781ms step_avg:36.43ms
+step:544/1575 train_time:19840ms step_avg:36.47ms
+step:545/1575 train_time:19904ms step_avg:36.52ms
+step:546/1575 train_time:19964ms step_avg:36.56ms
+step:547/1575 train_time:20027ms step_avg:36.61ms
+step:548/1575 train_time:20086ms step_avg:36.65ms
+step:549/1575 train_time:20149ms step_avg:36.70ms
+step:550/1575 train_time:20208ms step_avg:36.74ms
+step:551/1575 train_time:20270ms step_avg:36.79ms
+step:552/1575 train_time:20329ms step_avg:36.83ms
+step:553/1575 train_time:20392ms step_avg:36.88ms
+step:554/1575 train_time:20451ms step_avg:36.92ms
+step:555/1575 train_time:20514ms step_avg:36.96ms
+step:556/1575 train_time:20577ms step_avg:37.01ms
+step:557/1575 train_time:20640ms step_avg:37.06ms
+step:558/1575 train_time:20697ms step_avg:37.09ms
+step:559/1575 train_time:20761ms step_avg:37.14ms
+step:560/1575 train_time:20820ms step_avg:37.18ms
+step:561/1575 train_time:20884ms step_avg:37.23ms
+step:562/1575 train_time:20943ms step_avg:37.27ms
+step:563/1575 train_time:21006ms step_avg:37.31ms
+step:564/1575 train_time:21065ms step_avg:37.35ms
+step:565/1575 train_time:21130ms step_avg:37.40ms
+step:566/1575 train_time:21188ms step_avg:37.43ms
+step:567/1575 train_time:21250ms step_avg:37.48ms
+step:568/1575 train_time:21309ms step_avg:37.52ms
+step:569/1575 train_time:21377ms step_avg:37.57ms
+step:570/1575 train_time:21433ms step_avg:37.60ms
+step:571/1575 train_time:21495ms step_avg:37.64ms
+step:572/1575 train_time:21555ms step_avg:37.68ms
+step:573/1575 train_time:21617ms step_avg:37.73ms
+step:574/1575 train_time:21677ms step_avg:37.76ms
+step:575/1575 train_time:21741ms step_avg:37.81ms
+step:576/1575 train_time:21800ms step_avg:37.85ms
+step:577/1575 train_time:21864ms step_avg:37.89ms
+step:578/1575 train_time:21923ms step_avg:37.93ms
+step:579/1575 train_time:21986ms step_avg:37.97ms
+step:580/1575 train_time:22045ms step_avg:38.01ms
+step:581/1575 train_time:22109ms step_avg:38.05ms
+step:582/1575 train_time:22168ms step_avg:38.09ms
+step:583/1575 train_time:22231ms step_avg:38.13ms
+step:584/1575 train_time:22290ms step_avg:38.17ms
+step:585/1575 train_time:22354ms step_avg:38.21ms
+step:586/1575 train_time:22413ms step_avg:38.25ms
+step:587/1575 train_time:22476ms step_avg:38.29ms
+step:588/1575 train_time:22535ms step_avg:38.32ms
+step:589/1575 train_time:22598ms step_avg:38.37ms
+step:590/1575 train_time:22657ms step_avg:38.40ms
+step:591/1575 train_time:22720ms step_avg:38.44ms
+step:592/1575 train_time:22780ms step_avg:38.48ms
+step:593/1575 train_time:22844ms step_avg:38.52ms
+step:594/1575 train_time:22905ms step_avg:38.56ms
+step:595/1575 train_time:22968ms step_avg:38.60ms
+step:596/1575 train_time:23028ms step_avg:38.64ms
+step:597/1575 train_time:23092ms step_avg:38.68ms
+step:598/1575 train_time:23151ms step_avg:38.71ms
+step:599/1575 train_time:23213ms step_avg:38.75ms
+step:600/1575 train_time:23272ms step_avg:38.79ms
+step:601/1575 train_time:23335ms step_avg:38.83ms
+step:602/1575 train_time:23395ms step_avg:38.86ms
+step:603/1575 train_time:23457ms step_avg:38.90ms
+step:604/1575 train_time:23517ms step_avg:38.94ms
+step:605/1575 train_time:23580ms step_avg:38.98ms
+step:606/1575 train_time:23642ms step_avg:39.01ms
+step:607/1575 train_time:23703ms step_avg:39.05ms
+step:608/1575 train_time:23762ms step_avg:39.08ms
+step:609/1575 train_time:23825ms step_avg:39.12ms
+step:610/1575 train_time:23885ms step_avg:39.16ms
+step:611/1575 train_time:23948ms step_avg:39.19ms
+step:612/1575 train_time:24007ms step_avg:39.23ms
+step:613/1575 train_time:24071ms step_avg:39.27ms
+step:614/1575 train_time:24132ms step_avg:39.30ms
+step:615/1575 train_time:24194ms step_avg:39.34ms
+step:616/1575 train_time:24252ms step_avg:39.37ms
+step:617/1575 train_time:24315ms step_avg:39.41ms
+step:618/1575 train_time:24374ms step_avg:39.44ms
+step:619/1575 train_time:24437ms step_avg:39.48ms
+step:620/1575 train_time:24496ms step_avg:39.51ms
+step:621/1575 train_time:24560ms step_avg:39.55ms
+step:622/1575 train_time:24619ms step_avg:39.58ms
+step:623/1575 train_time:24683ms step_avg:39.62ms
+step:624/1575 train_time:24742ms step_avg:39.65ms
+step:625/1575 train_time:24806ms step_avg:39.69ms
+step:626/1575 train_time:24865ms step_avg:39.72ms
+step:627/1575 train_time:24928ms step_avg:39.76ms
+step:628/1575 train_time:24988ms step_avg:39.79ms
+step:629/1575 train_time:25051ms step_avg:39.83ms
+step:630/1575 train_time:25111ms step_avg:39.86ms
+step:631/1575 train_time:25174ms step_avg:39.90ms
+step:632/1575 train_time:25233ms step_avg:39.93ms
+step:633/1575 train_time:25296ms step_avg:39.96ms
+step:634/1575 train_time:25355ms step_avg:39.99ms
+step:635/1575 train_time:25419ms step_avg:40.03ms
+step:636/1575 train_time:25478ms step_avg:40.06ms
+step:637/1575 train_time:25542ms step_avg:40.10ms
+step:638/1575 train_time:25601ms step_avg:40.13ms
+step:639/1575 train_time:25666ms step_avg:40.17ms
+step:640/1575 train_time:25727ms step_avg:40.20ms
+step:641/1575 train_time:25787ms step_avg:40.23ms
+step:642/1575 train_time:25846ms step_avg:40.26ms
+step:643/1575 train_time:25909ms step_avg:40.29ms
+step:644/1575 train_time:25968ms step_avg:40.32ms
+step:645/1575 train_time:26032ms step_avg:40.36ms
+step:646/1575 train_time:26091ms step_avg:40.39ms
+step:647/1575 train_time:26154ms step_avg:40.42ms
+step:648/1575 train_time:26213ms step_avg:40.45ms
+step:649/1575 train_time:26276ms step_avg:40.49ms
+step:650/1575 train_time:26335ms step_avg:40.52ms
+step:651/1575 train_time:26398ms step_avg:40.55ms
+step:652/1575 train_time:26457ms step_avg:40.58ms
+step:653/1575 train_time:26521ms step_avg:40.61ms
+step:654/1575 train_time:26581ms step_avg:40.64ms
+step:655/1575 train_time:26646ms step_avg:40.68ms
+step:656/1575 train_time:26704ms step_avg:40.71ms
+step:657/1575 train_time:26767ms step_avg:40.74ms
+step:658/1575 train_time:26826ms step_avg:40.77ms
+step:659/1575 train_time:26890ms step_avg:40.80ms
+step:660/1575 train_time:26949ms step_avg:40.83ms
+step:661/1575 train_time:27012ms step_avg:40.87ms
+step:662/1575 train_time:27071ms step_avg:40.89ms
+step:663/1575 train_time:27136ms step_avg:40.93ms
+step:664/1575 train_time:27194ms step_avg:40.95ms
+step:665/1575 train_time:27257ms step_avg:40.99ms
+step:666/1575 train_time:27316ms step_avg:41.02ms
+step:667/1575 train_time:27380ms step_avg:41.05ms
+step:668/1575 train_time:27439ms step_avg:41.08ms
+step:669/1575 train_time:27502ms step_avg:41.11ms
+step:670/1575 train_time:27562ms step_avg:41.14ms
+step:671/1575 train_time:27625ms step_avg:41.17ms
+step:672/1575 train_time:27684ms step_avg:41.20ms
+step:673/1575 train_time:27749ms step_avg:41.23ms
+step:674/1575 train_time:27810ms step_avg:41.26ms
+step:675/1575 train_time:27871ms step_avg:41.29ms
+step:676/1575 train_time:27930ms step_avg:41.32ms
+step:677/1575 train_time:27994ms step_avg:41.35ms
+step:678/1575 train_time:28053ms step_avg:41.38ms
+step:679/1575 train_time:28116ms step_avg:41.41ms
+step:680/1575 train_time:28175ms step_avg:41.43ms
+step:681/1575 train_time:28238ms step_avg:41.47ms
+step:682/1575 train_time:28298ms step_avg:41.49ms
+step:683/1575 train_time:28361ms step_avg:41.52ms
+step:684/1575 train_time:28421ms step_avg:41.55ms
+step:685/1575 train_time:28484ms step_avg:41.58ms
+step:686/1575 train_time:28543ms step_avg:41.61ms
+step:687/1575 train_time:28607ms step_avg:41.64ms
+step:688/1575 train_time:28666ms step_avg:41.67ms
+step:689/1575 train_time:28729ms step_avg:41.70ms
+step:690/1575 train_time:28789ms step_avg:41.72ms
+step:691/1575 train_time:28852ms step_avg:41.75ms
+step:692/1575 train_time:28911ms step_avg:41.78ms
+step:693/1575 train_time:28974ms step_avg:41.81ms
+step:694/1575 train_time:29034ms step_avg:41.84ms
+step:695/1575 train_time:29097ms step_avg:41.87ms
+step:696/1575 train_time:29157ms step_avg:41.89ms
+step:697/1575 train_time:29219ms step_avg:41.92ms
+step:698/1575 train_time:29279ms step_avg:41.95ms
+step:699/1575 train_time:29342ms step_avg:41.98ms
+step:700/1575 train_time:29402ms step_avg:42.00ms
+step:701/1575 train_time:29464ms step_avg:42.03ms
+step:702/1575 train_time:29524ms step_avg:42.06ms
+step:703/1575 train_time:29587ms step_avg:42.09ms
+step:704/1575 train_time:29648ms step_avg:42.11ms
+step:705/1575 train_time:29709ms step_avg:42.14ms
+step:706/1575 train_time:29768ms step_avg:42.16ms
+step:707/1575 train_time:29832ms step_avg:42.20ms
+step:708/1575 train_time:29892ms step_avg:42.22ms
+step:709/1575 train_time:29955ms step_avg:42.25ms
+step:710/1575 train_time:30015ms step_avg:42.27ms
+step:711/1575 train_time:30077ms step_avg:42.30ms
+step:712/1575 train_time:30138ms step_avg:42.33ms
+step:713/1575 train_time:30201ms step_avg:42.36ms
+step:714/1575 train_time:30259ms step_avg:42.38ms
+step:715/1575 train_time:30322ms step_avg:42.41ms
+step:716/1575 train_time:30382ms step_avg:42.43ms
+step:717/1575 train_time:30445ms step_avg:42.46ms
+step:718/1575 train_time:30505ms step_avg:42.49ms
+step:719/1575 train_time:30568ms step_avg:42.52ms
+step:720/1575 train_time:30628ms step_avg:42.54ms
+step:721/1575 train_time:30692ms step_avg:42.57ms
+step:722/1575 train_time:30751ms step_avg:42.59ms
+step:723/1575 train_time:30815ms step_avg:42.62ms
+step:724/1575 train_time:30874ms step_avg:42.64ms
+step:725/1575 train_time:30937ms step_avg:42.67ms
+step:726/1575 train_time:30996ms step_avg:42.69ms
+step:727/1575 train_time:31059ms step_avg:42.72ms
+step:728/1575 train_time:31118ms step_avg:42.74ms
+step:729/1575 train_time:31182ms step_avg:42.77ms
+step:730/1575 train_time:31242ms step_avg:42.80ms
+step:731/1575 train_time:31305ms step_avg:42.82ms
+step:732/1575 train_time:31363ms step_avg:42.85ms
+step:733/1575 train_time:31427ms step_avg:42.87ms
+step:734/1575 train_time:31486ms step_avg:42.90ms
+step:735/1575 train_time:31550ms step_avg:42.92ms
+step:736/1575 train_time:31609ms step_avg:42.95ms
+step:737/1575 train_time:31672ms step_avg:42.97ms
+step:738/1575 train_time:31731ms step_avg:43.00ms
+step:739/1575 train_time:31795ms step_avg:43.02ms
+step:740/1575 train_time:31855ms step_avg:43.05ms
+step:741/1575 train_time:31918ms step_avg:43.07ms
+step:742/1575 train_time:31977ms step_avg:43.10ms
+step:743/1575 train_time:32042ms step_avg:43.12ms
+step:744/1575 train_time:32101ms step_avg:43.15ms
+step:745/1575 train_time:32164ms step_avg:43.17ms
+step:746/1575 train_time:32224ms step_avg:43.20ms
+step:747/1575 train_time:32286ms step_avg:43.22ms
+step:748/1575 train_time:32346ms step_avg:43.24ms
+step:749/1575 train_time:32409ms step_avg:43.27ms
+step:750/1575 train_time:32467ms step_avg:43.29ms
+step:750/1575 val_loss:3.8754 train_time:32515ms step_avg:43.35ms
+step:751/1575 train_time:32534ms step_avg:43.32ms
+step:752/1575 train_time:32594ms step_avg:43.34ms
+step:753/1575 train_time:32658ms step_avg:43.37ms
+step:754/1575 train_time:32721ms step_avg:43.40ms
+step:755/1575 train_time:32785ms step_avg:43.42ms
+step:756/1575 train_time:32844ms step_avg:43.44ms
+step:757/1575 train_time:32906ms step_avg:43.47ms
+step:758/1575 train_time:32965ms step_avg:43.49ms
+step:759/1575 train_time:33028ms step_avg:43.52ms
+step:760/1575 train_time:33087ms step_avg:43.54ms
+step:761/1575 train_time:33150ms step_avg:43.56ms
+step:762/1575 train_time:33209ms step_avg:43.58ms
+step:763/1575 train_time:33273ms step_avg:43.61ms
+step:764/1575 train_time:33331ms step_avg:43.63ms
+step:765/1575 train_time:33394ms step_avg:43.65ms
+step:766/1575 train_time:33453ms step_avg:43.67ms
+step:767/1575 train_time:33517ms step_avg:43.70ms
+step:768/1575 train_time:33578ms step_avg:43.72ms
+step:769/1575 train_time:33642ms step_avg:43.75ms
+step:770/1575 train_time:33703ms step_avg:43.77ms
+step:771/1575 train_time:33767ms step_avg:43.80ms
+step:772/1575 train_time:33827ms step_avg:43.82ms
+step:773/1575 train_time:33891ms step_avg:43.84ms
+step:774/1575 train_time:33950ms step_avg:43.86ms
+step:775/1575 train_time:34014ms step_avg:43.89ms
+step:776/1575 train_time:34074ms step_avg:43.91ms
+step:777/1575 train_time:34137ms step_avg:43.93ms
+step:778/1575 train_time:34196ms step_avg:43.95ms
+step:779/1575 train_time:34258ms step_avg:43.98ms
+step:780/1575 train_time:34317ms step_avg:44.00ms
+step:781/1575 train_time:34380ms step_avg:44.02ms
+step:782/1575 train_time:34440ms step_avg:44.04ms
+step:783/1575 train_time:34502ms step_avg:44.06ms
+step:784/1575 train_time:34562ms step_avg:44.08ms
+step:785/1575 train_time:34626ms step_avg:44.11ms
+step:786/1575 train_time:34686ms step_avg:44.13ms
+step:787/1575 train_time:34749ms step_avg:44.15ms
+step:788/1575 train_time:34808ms step_avg:44.17ms
+step:789/1575 train_time:34872ms step_avg:44.20ms
+step:790/1575 train_time:34933ms step_avg:44.22ms
+step:791/1575 train_time:34996ms step_avg:44.24ms
+step:792/1575 train_time:35057ms step_avg:44.26ms
+step:793/1575 train_time:35120ms step_avg:44.29ms
+step:794/1575 train_time:35177ms step_avg:44.30ms
+step:795/1575 train_time:35240ms step_avg:44.33ms
+step:796/1575 train_time:35299ms step_avg:44.35ms
+step:797/1575 train_time:35362ms step_avg:44.37ms
+step:798/1575 train_time:35421ms step_avg:44.39ms
+step:799/1575 train_time:35484ms step_avg:44.41ms
+step:800/1575 train_time:35543ms step_avg:44.43ms
+step:801/1575 train_time:35606ms step_avg:44.45ms
+step:802/1575 train_time:35666ms step_avg:44.47ms
+step:803/1575 train_time:35730ms step_avg:44.50ms
+step:804/1575 train_time:35790ms step_avg:44.51ms
+step:805/1575 train_time:35852ms step_avg:44.54ms
+step:806/1575 train_time:35912ms step_avg:44.56ms
+step:807/1575 train_time:35976ms step_avg:44.58ms
+step:808/1575 train_time:36035ms step_avg:44.60ms
+step:809/1575 train_time:36099ms step_avg:44.62ms
+step:810/1575 train_time:36158ms step_avg:44.64ms
+step:811/1575 train_time:36221ms step_avg:44.66ms
+step:812/1575 train_time:36282ms step_avg:44.68ms
+step:813/1575 train_time:36343ms step_avg:44.70ms
+step:814/1575 train_time:36402ms step_avg:44.72ms
+step:815/1575 train_time:36465ms step_avg:44.74ms
+step:816/1575 train_time:36525ms step_avg:44.76ms
+step:817/1575 train_time:36588ms step_avg:44.78ms
+step:818/1575 train_time:36647ms step_avg:44.80ms
+step:819/1575 train_time:36710ms step_avg:44.82ms
+step:820/1575 train_time:36770ms step_avg:44.84ms
+step:821/1575 train_time:36833ms step_avg:44.86ms
+step:822/1575 train_time:36893ms step_avg:44.88ms
+step:823/1575 train_time:36956ms step_avg:44.90ms
+step:824/1575 train_time:37017ms step_avg:44.92ms
+step:825/1575 train_time:37080ms step_avg:44.95ms
+step:826/1575 train_time:37139ms step_avg:44.96ms
+step:827/1575 train_time:37202ms step_avg:44.98ms
+step:828/1575 train_time:37262ms step_avg:45.00ms
+step:829/1575 train_time:37325ms step_avg:45.02ms
+step:830/1575 train_time:37384ms step_avg:45.04ms
+step:831/1575 train_time:37447ms step_avg:45.06ms
+step:832/1575 train_time:37507ms step_avg:45.08ms
+step:833/1575 train_time:37569ms step_avg:45.10ms
+step:834/1575 train_time:37628ms step_avg:45.12ms
+step:835/1575 train_time:37691ms step_avg:45.14ms
+step:836/1575 train_time:37751ms step_avg:45.16ms
+step:837/1575 train_time:37814ms step_avg:45.18ms
+step:838/1575 train_time:37874ms step_avg:45.20ms
+step:839/1575 train_time:37938ms step_avg:45.22ms
+step:840/1575 train_time:37998ms step_avg:45.24ms
+step:841/1575 train_time:38061ms step_avg:45.26ms
+step:842/1575 train_time:38120ms step_avg:45.27ms
+step:843/1575 train_time:38183ms step_avg:45.29ms
+step:844/1575 train_time:38242ms step_avg:45.31ms
+step:845/1575 train_time:38306ms step_avg:45.33ms
+step:846/1575 train_time:38365ms step_avg:45.35ms
+step:847/1575 train_time:38428ms step_avg:45.37ms
+step:848/1575 train_time:38487ms step_avg:45.39ms
+step:849/1575 train_time:38550ms step_avg:45.41ms
+step:850/1575 train_time:38609ms step_avg:45.42ms
+step:851/1575 train_time:38673ms step_avg:45.44ms
+step:852/1575 train_time:38732ms step_avg:45.46ms
+step:853/1575 train_time:38796ms step_avg:45.48ms
+step:854/1575 train_time:38855ms step_avg:45.50ms
+step:855/1575 train_time:38918ms step_avg:45.52ms
+step:856/1575 train_time:38977ms step_avg:45.53ms
+step:857/1575 train_time:39041ms step_avg:45.56ms
+step:858/1575 train_time:39101ms step_avg:45.57ms
+step:859/1575 train_time:39164ms step_avg:45.59ms
+step:860/1575 train_time:39224ms step_avg:45.61ms
+step:861/1575 train_time:39288ms step_avg:45.63ms
+step:862/1575 train_time:39346ms step_avg:45.65ms
+step:863/1575 train_time:39409ms step_avg:45.67ms
+step:864/1575 train_time:39469ms step_avg:45.68ms
+step:865/1575 train_time:39532ms step_avg:45.70ms
+step:866/1575 train_time:39591ms step_avg:45.72ms
+step:867/1575 train_time:39654ms step_avg:45.74ms
+step:868/1575 train_time:39714ms step_avg:45.75ms
+step:869/1575 train_time:39778ms step_avg:45.77ms
+step:870/1575 train_time:39837ms step_avg:45.79ms
+step:871/1575 train_time:39900ms step_avg:45.81ms
+step:872/1575 train_time:39959ms step_avg:45.82ms
+step:873/1575 train_time:40022ms step_avg:45.84ms
+step:874/1575 train_time:40081ms step_avg:45.86ms
+step:875/1575 train_time:40146ms step_avg:45.88ms
+step:876/1575 train_time:40204ms step_avg:45.89ms
+step:877/1575 train_time:40267ms step_avg:45.91ms
+step:878/1575 train_time:40326ms step_avg:45.93ms
+step:879/1575 train_time:40389ms step_avg:45.95ms
+step:880/1575 train_time:40449ms step_avg:45.96ms
+step:881/1575 train_time:40512ms step_avg:45.98ms
+step:882/1575 train_time:40571ms step_avg:46.00ms
+step:883/1575 train_time:40634ms step_avg:46.02ms
+step:884/1575 train_time:40693ms step_avg:46.03ms
+step:885/1575 train_time:40757ms step_avg:46.05ms
+step:886/1575 train_time:40821ms step_avg:46.07ms
+step:887/1575 train_time:40883ms step_avg:46.09ms
+step:888/1575 train_time:40942ms step_avg:46.11ms
+step:889/1575 train_time:41005ms step_avg:46.13ms
+step:890/1575 train_time:41065ms step_avg:46.14ms
+step:891/1575 train_time:41128ms step_avg:46.16ms
+step:892/1575 train_time:41187ms step_avg:46.17ms
+step:893/1575 train_time:41251ms step_avg:46.19ms
+step:894/1575 train_time:41310ms step_avg:46.21ms
+step:895/1575 train_time:41373ms step_avg:46.23ms
+step:896/1575 train_time:41432ms step_avg:46.24ms
+step:897/1575 train_time:41495ms step_avg:46.26ms
+step:898/1575 train_time:41554ms step_avg:46.27ms
+step:899/1575 train_time:41617ms step_avg:46.29ms
+step:900/1575 train_time:41678ms step_avg:46.31ms
+step:901/1575 train_time:41741ms step_avg:46.33ms
+step:902/1575 train_time:41801ms step_avg:46.34ms
+step:903/1575 train_time:41862ms step_avg:46.36ms
+step:904/1575 train_time:41921ms step_avg:46.37ms
+step:905/1575 train_time:41985ms step_avg:46.39ms
+step:906/1575 train_time:42044ms step_avg:46.41ms
+step:907/1575 train_time:42107ms step_avg:46.42ms
+step:908/1575 train_time:42166ms step_avg:46.44ms
+step:909/1575 train_time:42230ms step_avg:46.46ms
+step:910/1575 train_time:42291ms step_avg:46.47ms
+step:911/1575 train_time:42352ms step_avg:46.49ms
+step:912/1575 train_time:42412ms step_avg:46.50ms
+step:913/1575 train_time:42475ms step_avg:46.52ms
+step:914/1575 train_time:42535ms step_avg:46.54ms
+step:915/1575 train_time:42599ms step_avg:46.56ms
+step:916/1575 train_time:42658ms step_avg:46.57ms
+step:917/1575 train_time:42721ms step_avg:46.59ms
+step:918/1575 train_time:42782ms step_avg:46.60ms
+step:919/1575 train_time:42844ms step_avg:46.62ms
+step:920/1575 train_time:42903ms step_avg:46.63ms
+step:921/1575 train_time:42966ms step_avg:46.65ms
+step:922/1575 train_time:43026ms step_avg:46.67ms
+step:923/1575 train_time:43089ms step_avg:46.68ms
+step:924/1575 train_time:43149ms step_avg:46.70ms
+step:925/1575 train_time:43213ms step_avg:46.72ms
+step:926/1575 train_time:43272ms step_avg:46.73ms
+step:927/1575 train_time:43335ms step_avg:46.75ms
+step:928/1575 train_time:43394ms step_avg:46.76ms
+step:929/1575 train_time:43458ms step_avg:46.78ms
+step:930/1575 train_time:43517ms step_avg:46.79ms
+step:931/1575 train_time:43580ms step_avg:46.81ms
+step:932/1575 train_time:43639ms step_avg:46.82ms
+step:933/1575 train_time:43703ms step_avg:46.84ms
+step:934/1575 train_time:43762ms step_avg:46.85ms
+step:935/1575 train_time:43826ms step_avg:46.87ms
+step:936/1575 train_time:43885ms step_avg:46.89ms
+step:937/1575 train_time:43948ms step_avg:46.90ms
+step:938/1575 train_time:44008ms step_avg:46.92ms
+step:939/1575 train_time:44071ms step_avg:46.93ms
+step:940/1575 train_time:44131ms step_avg:46.95ms
+step:941/1575 train_time:44195ms step_avg:46.97ms
+step:942/1575 train_time:44254ms step_avg:46.98ms
+step:943/1575 train_time:44319ms step_avg:47.00ms
+step:944/1575 train_time:44376ms step_avg:47.01ms
+step:945/1575 train_time:44439ms step_avg:47.03ms
+step:946/1575 train_time:44498ms step_avg:47.04ms
+step:947/1575 train_time:44562ms step_avg:47.06ms
+step:948/1575 train_time:44621ms step_avg:47.07ms
+step:949/1575 train_time:44685ms step_avg:47.09ms
+step:950/1575 train_time:44744ms step_avg:47.10ms
+step:951/1575 train_time:44807ms step_avg:47.12ms
+step:952/1575 train_time:44866ms step_avg:47.13ms
+step:953/1575 train_time:44929ms step_avg:47.14ms
+step:954/1575 train_time:44989ms step_avg:47.16ms
+step:955/1575 train_time:45052ms step_avg:47.18ms
+step:956/1575 train_time:45111ms step_avg:47.19ms
+step:957/1575 train_time:45175ms step_avg:47.20ms
+step:958/1575 train_time:45234ms step_avg:47.22ms
+step:959/1575 train_time:45299ms step_avg:47.24ms
+step:960/1575 train_time:45357ms step_avg:47.25ms
+step:961/1575 train_time:45421ms step_avg:47.26ms
+step:962/1575 train_time:45480ms step_avg:47.28ms
+step:963/1575 train_time:45543ms step_avg:47.29ms
+step:964/1575 train_time:45602ms step_avg:47.31ms
+step:965/1575 train_time:45666ms step_avg:47.32ms
+step:966/1575 train_time:45726ms step_avg:47.33ms
+step:967/1575 train_time:45790ms step_avg:47.35ms
+step:968/1575 train_time:45848ms step_avg:47.36ms
+step:969/1575 train_time:45911ms step_avg:47.38ms
+step:970/1575 train_time:45970ms step_avg:47.39ms
+step:971/1575 train_time:46034ms step_avg:47.41ms
+step:972/1575 train_time:46093ms step_avg:47.42ms
+step:973/1575 train_time:46156ms step_avg:47.44ms
+step:974/1575 train_time:46216ms step_avg:47.45ms
+step:975/1575 train_time:46280ms step_avg:47.47ms
+step:976/1575 train_time:46340ms step_avg:47.48ms
+step:977/1575 train_time:46402ms step_avg:47.49ms
+step:978/1575 train_time:46461ms step_avg:47.51ms
+step:979/1575 train_time:46524ms step_avg:47.52ms
+step:980/1575 train_time:46584ms step_avg:47.53ms
+step:981/1575 train_time:46647ms step_avg:47.55ms
+step:982/1575 train_time:46706ms step_avg:47.56ms
+step:983/1575 train_time:46769ms step_avg:47.58ms
+step:984/1575 train_time:46829ms step_avg:47.59ms
+step:985/1575 train_time:46894ms step_avg:47.61ms
+step:986/1575 train_time:46952ms step_avg:47.62ms
+step:987/1575 train_time:47014ms step_avg:47.63ms
+step:988/1575 train_time:47074ms step_avg:47.65ms
+step:989/1575 train_time:47137ms step_avg:47.66ms
+step:990/1575 train_time:47197ms step_avg:47.67ms
+step:991/1575 train_time:47260ms step_avg:47.69ms
+step:992/1575 train_time:47319ms step_avg:47.70ms
+step:993/1575 train_time:47383ms step_avg:47.72ms
+step:994/1575 train_time:47444ms step_avg:47.73ms
+step:995/1575 train_time:47505ms step_avg:47.74ms
+step:996/1575 train_time:47565ms step_avg:47.76ms
+step:997/1575 train_time:47628ms step_avg:47.77ms
+step:998/1575 train_time:47687ms step_avg:47.78ms
+step:999/1575 train_time:47750ms step_avg:47.80ms
+step:1000/1575 train_time:47810ms step_avg:47.81ms
+step:1000/1575 val_loss:3.5853 train_time:47857ms step_avg:47.86ms
+step:1001/1575 train_time:47877ms step_avg:47.83ms
+step:1002/1575 train_time:47936ms step_avg:47.84ms
+step:1003/1575 train_time:48000ms step_avg:47.86ms
+step:1004/1575 train_time:48062ms step_avg:47.87ms
+step:1005/1575 train_time:48126ms step_avg:47.89ms
+step:1006/1575 train_time:48185ms step_avg:47.90ms
+step:1007/1575 train_time:48248ms step_avg:47.91ms
+step:1008/1575 train_time:48308ms step_avg:47.92ms
+step:1009/1575 train_time:48370ms step_avg:47.94ms
+step:1010/1575 train_time:48431ms step_avg:47.95ms
+step:1011/1575 train_time:48493ms step_avg:47.97ms
+step:1012/1575 train_time:48552ms step_avg:47.98ms
+step:1013/1575 train_time:48614ms step_avg:47.99ms
+step:1014/1575 train_time:48673ms step_avg:48.00ms
+step:1015/1575 train_time:48736ms step_avg:48.02ms
+step:1016/1575 train_time:48795ms step_avg:48.03ms
+step:1017/1575 train_time:48859ms step_avg:48.04ms
+step:1018/1575 train_time:48920ms step_avg:48.05ms
+step:1019/1575 train_time:48983ms step_avg:48.07ms
+step:1020/1575 train_time:49043ms step_avg:48.08ms
+step:1021/1575 train_time:49109ms step_avg:48.10ms
+step:1022/1575 train_time:49169ms step_avg:48.11ms
+step:1023/1575 train_time:49230ms step_avg:48.12ms
+step:1024/1575 train_time:49291ms step_avg:48.14ms
+step:1025/1575 train_time:49361ms step_avg:48.16ms
+step:1026/1575 train_time:49445ms step_avg:48.19ms
+step:1027/1575 train_time:49535ms step_avg:48.23ms
+step:1028/1575 train_time:49620ms step_avg:48.27ms
+step:1029/1575 train_time:49708ms step_avg:48.31ms
+step:1030/1575 train_time:49794ms step_avg:48.34ms
+step:1031/1575 train_time:49885ms step_avg:48.39ms
+step:1032/1575 train_time:49971ms step_avg:48.42ms
+step:1033/1575 train_time:50061ms step_avg:48.46ms
+step:1034/1575 train_time:50147ms step_avg:48.50ms
+step:1035/1575 train_time:50239ms step_avg:48.54ms
+step:1036/1575 train_time:50325ms step_avg:48.58ms
+step:1037/1575 train_time:50415ms step_avg:48.62ms
+step:1038/1575 train_time:50500ms step_avg:48.65ms
+step:1039/1575 train_time:50590ms step_avg:48.69ms
+step:1040/1575 train_time:50675ms step_avg:48.73ms
+step:1041/1575 train_time:50765ms step_avg:48.77ms
+step:1042/1575 train_time:50851ms step_avg:48.80ms
+step:1043/1575 train_time:50941ms step_avg:48.84ms
+step:1044/1575 train_time:51027ms step_avg:48.88ms
+step:1045/1575 train_time:51118ms step_avg:48.92ms
+step:1046/1575 train_time:51203ms step_avg:48.95ms
+step:1047/1575 train_time:51293ms step_avg:48.99ms
+step:1048/1575 train_time:51379ms step_avg:49.03ms
+step:1049/1575 train_time:51468ms step_avg:49.06ms
+step:1050/1575 train_time:51555ms step_avg:49.10ms
+step:1051/1575 train_time:51642ms step_avg:49.14ms
+step:1052/1575 train_time:51727ms step_avg:49.17ms
+step:1053/1575 train_time:51818ms step_avg:49.21ms
+step:1054/1575 train_time:51904ms step_avg:49.24ms
+step:1055/1575 train_time:51994ms step_avg:49.28ms
+step:1056/1575 train_time:52079ms step_avg:49.32ms
+step:1057/1575 train_time:52169ms step_avg:49.36ms
+step:1058/1575 train_time:52256ms step_avg:49.39ms
+step:1059/1575 train_time:52346ms step_avg:49.43ms
+step:1060/1575 train_time:52434ms step_avg:49.47ms
+step:1061/1575 train_time:52522ms step_avg:49.50ms
+step:1062/1575 train_time:52608ms step_avg:49.54ms
+step:1063/1575 train_time:52697ms step_avg:49.57ms
+step:1064/1575 train_time:52783ms step_avg:49.61ms
+step:1065/1575 train_time:52873ms step_avg:49.65ms
+step:1066/1575 train_time:52960ms step_avg:49.68ms
+step:1067/1575 train_time:53049ms step_avg:49.72ms
+step:1068/1575 train_time:53135ms step_avg:49.75ms
+step:1069/1575 train_time:53225ms step_avg:49.79ms
+step:1070/1575 train_time:53310ms step_avg:49.82ms
+step:1071/1575 train_time:53400ms step_avg:49.86ms
+step:1072/1575 train_time:53485ms step_avg:49.89ms
+step:1073/1575 train_time:53576ms step_avg:49.93ms
+step:1074/1575 train_time:53661ms step_avg:49.96ms
+step:1075/1575 train_time:53750ms step_avg:50.00ms
+step:1076/1575 train_time:53836ms step_avg:50.03ms
+step:1077/1575 train_time:53926ms step_avg:50.07ms
+step:1078/1575 train_time:54011ms step_avg:50.10ms
+step:1079/1575 train_time:54101ms step_avg:50.14ms
+step:1080/1575 train_time:54187ms step_avg:50.17ms
+step:1081/1575 train_time:54277ms step_avg:50.21ms
+step:1082/1575 train_time:54364ms step_avg:50.24ms
+step:1083/1575 train_time:54453ms step_avg:50.28ms
+step:1084/1575 train_time:54539ms step_avg:50.31ms
+step:1085/1575 train_time:54635ms step_avg:50.35ms
+step:1086/1575 train_time:54722ms step_avg:50.39ms
+step:1087/1575 train_time:54805ms step_avg:50.42ms
+step:1088/1575 train_time:54890ms step_avg:50.45ms
+step:1089/1575 train_time:54980ms step_avg:50.49ms
+step:1090/1575 train_time:55066ms step_avg:50.52ms
+step:1091/1575 train_time:55156ms step_avg:50.56ms
+step:1092/1575 train_time:55241ms step_avg:50.59ms
+step:1093/1575 train_time:55330ms step_avg:50.62ms
+step:1094/1575 train_time:55416ms step_avg:50.65ms
+step:1095/1575 train_time:55505ms step_avg:50.69ms
+step:1096/1575 train_time:55592ms step_avg:50.72ms
+step:1097/1575 train_time:55682ms step_avg:50.76ms
+step:1098/1575 train_time:55767ms step_avg:50.79ms
+step:1099/1575 train_time:55857ms step_avg:50.83ms
+step:1100/1575 train_time:55944ms step_avg:50.86ms
+step:1101/1575 train_time:56034ms step_avg:50.89ms
+step:1102/1575 train_time:56119ms step_avg:50.92ms
+step:1103/1575 train_time:56218ms step_avg:50.97ms
+step:1104/1575 train_time:56295ms step_avg:50.99ms
+step:1105/1575 train_time:56384ms step_avg:51.03ms
+step:1106/1575 train_time:56470ms step_avg:51.06ms
+step:1107/1575 train_time:56560ms step_avg:51.09ms
+step:1108/1575 train_time:56645ms step_avg:51.12ms
+step:1109/1575 train_time:56735ms step_avg:51.16ms
+step:1110/1575 train_time:56824ms step_avg:51.19ms
+step:1111/1575 train_time:56911ms step_avg:51.23ms
+step:1112/1575 train_time:57000ms step_avg:51.26ms
+step:1113/1575 train_time:57086ms step_avg:51.29ms
+step:1114/1575 train_time:57172ms step_avg:51.32ms
+step:1115/1575 train_time:57261ms step_avg:51.36ms
+step:1116/1575 train_time:57347ms step_avg:51.39ms
+step:1117/1575 train_time:57439ms step_avg:51.42ms
+step:1118/1575 train_time:57528ms step_avg:51.46ms
+step:1119/1575 train_time:57614ms step_avg:51.49ms
+step:1120/1575 train_time:57702ms step_avg:51.52ms
+step:1121/1575 train_time:57789ms step_avg:51.55ms
+step:1122/1575 train_time:57874ms step_avg:51.58ms
+step:1123/1575 train_time:57963ms step_avg:51.61ms
+step:1124/1575 train_time:58049ms step_avg:51.64ms
+step:1125/1575 train_time:58139ms step_avg:51.68ms
+step:1126/1575 train_time:58225ms step_avg:51.71ms
+step:1127/1575 train_time:58315ms step_avg:51.74ms
+step:1128/1575 train_time:58400ms step_avg:51.77ms
+step:1129/1575 train_time:58489ms step_avg:51.81ms
+step:1130/1575 train_time:58575ms step_avg:51.84ms
+step:1131/1575 train_time:58665ms step_avg:51.87ms
+step:1132/1575 train_time:58750ms step_avg:51.90ms
+step:1133/1575 train_time:58843ms step_avg:51.94ms
+step:1134/1575 train_time:58927ms step_avg:51.96ms
+step:1135/1575 train_time:59015ms step_avg:52.00ms
+step:1136/1575 train_time:59101ms step_avg:52.03ms
+step:1137/1575 train_time:59191ms step_avg:52.06ms
+step:1138/1575 train_time:59277ms step_avg:52.09ms
+step:1139/1575 train_time:59365ms step_avg:52.12ms
+step:1140/1575 train_time:59454ms step_avg:52.15ms
+step:1141/1575 train_time:59543ms step_avg:52.18ms
+step:1142/1575 train_time:59628ms step_avg:52.21ms
+step:1143/1575 train_time:59717ms step_avg:52.25ms
+step:1144/1575 train_time:59803ms step_avg:52.27ms
+step:1145/1575 train_time:59892ms step_avg:52.31ms
+step:1146/1575 train_time:59983ms step_avg:52.34ms
+step:1147/1575 train_time:60072ms step_avg:52.37ms
+step:1148/1575 train_time:60155ms step_avg:52.40ms
+step:1149/1575 train_time:60245ms step_avg:52.43ms
+step:1150/1575 train_time:60330ms step_avg:52.46ms
+step:1151/1575 train_time:60420ms step_avg:52.49ms
+step:1152/1575 train_time:60506ms step_avg:52.52ms
+step:1153/1575 train_time:60595ms step_avg:52.55ms
+step:1154/1575 train_time:60682ms step_avg:52.58ms
+step:1155/1575 train_time:60771ms step_avg:52.62ms
+step:1156/1575 train_time:60857ms step_avg:52.64ms
+step:1157/1575 train_time:60948ms step_avg:52.68ms
+step:1158/1575 train_time:61033ms step_avg:52.71ms
+step:1159/1575 train_time:61122ms step_avg:52.74ms
+step:1160/1575 train_time:61207ms step_avg:52.77ms
+step:1161/1575 train_time:61297ms step_avg:52.80ms
+step:1162/1575 train_time:61383ms step_avg:52.83ms
+step:1163/1575 train_time:61472ms step_avg:52.86ms
+step:1164/1575 train_time:61558ms step_avg:52.88ms
+step:1165/1575 train_time:61647ms step_avg:52.92ms
+step:1166/1575 train_time:61733ms step_avg:52.94ms
+step:1167/1575 train_time:61824ms step_avg:52.98ms
+step:1168/1575 train_time:61911ms step_avg:53.01ms
+step:1169/1575 train_time:61999ms step_avg:53.04ms
+step:1170/1575 train_time:62085ms step_avg:53.06ms
+step:1171/1575 train_time:62174ms step_avg:53.09ms
+step:1172/1575 train_time:62259ms step_avg:53.12ms
+step:1173/1575 train_time:62349ms step_avg:53.15ms
+step:1174/1575 train_time:62438ms step_avg:53.18ms
+step:1175/1575 train_time:62526ms step_avg:53.21ms
+step:1176/1575 train_time:62612ms step_avg:53.24ms
+step:1177/1575 train_time:62701ms step_avg:53.27ms
+step:1178/1575 train_time:62787ms step_avg:53.30ms
+step:1179/1575 train_time:62877ms step_avg:53.33ms
+step:1180/1575 train_time:62963ms step_avg:53.36ms
+step:1181/1575 train_time:63052ms step_avg:53.39ms
+step:1182/1575 train_time:63139ms step_avg:53.42ms
+step:1183/1575 train_time:63228ms step_avg:53.45ms
+step:1184/1575 train_time:63313ms step_avg:53.47ms
+step:1185/1575 train_time:63404ms step_avg:53.51ms
+step:1186/1575 train_time:63490ms step_avg:53.53ms
+step:1187/1575 train_time:63580ms step_avg:53.56ms
+step:1188/1575 train_time:63666ms step_avg:53.59ms
+step:1189/1575 train_time:63756ms step_avg:53.62ms
+step:1190/1575 train_time:63841ms step_avg:53.65ms
+step:1191/1575 train_time:63931ms step_avg:53.68ms
+step:1192/1575 train_time:64019ms step_avg:53.71ms
+step:1193/1575 train_time:64106ms step_avg:53.74ms
+step:1194/1575 train_time:64192ms step_avg:53.76ms
+step:1195/1575 train_time:64282ms step_avg:53.79ms
+step:1196/1575 train_time:64367ms step_avg:53.82ms
+step:1197/1575 train_time:64457ms step_avg:53.85ms
+step:1198/1575 train_time:64543ms step_avg:53.88ms
+step:1199/1575 train_time:64632ms step_avg:53.90ms
+step:1200/1575 train_time:64719ms step_avg:53.93ms
+step:1201/1575 train_time:64808ms step_avg:53.96ms
+step:1202/1575 train_time:64895ms step_avg:53.99ms
+step:1203/1575 train_time:64984ms step_avg:54.02ms
+step:1204/1575 train_time:65071ms step_avg:54.05ms
+step:1205/1575 train_time:65160ms step_avg:54.07ms
+step:1206/1575 train_time:65245ms step_avg:54.10ms
+step:1207/1575 train_time:65335ms step_avg:54.13ms
+step:1208/1575 train_time:65421ms step_avg:54.16ms
+step:1209/1575 train_time:65513ms step_avg:54.19ms
+step:1210/1575 train_time:65597ms step_avg:54.21ms
+step:1211/1575 train_time:65687ms step_avg:54.24ms
+step:1212/1575 train_time:65772ms step_avg:54.27ms
+step:1213/1575 train_time:65862ms step_avg:54.30ms
+step:1214/1575 train_time:65950ms step_avg:54.32ms
+step:1215/1575 train_time:66037ms step_avg:54.35ms
+step:1216/1575 train_time:66123ms step_avg:54.38ms
+step:1217/1575 train_time:66211ms step_avg:54.41ms
+step:1218/1575 train_time:66298ms step_avg:54.43ms
+step:1219/1575 train_time:66387ms step_avg:54.46ms
+step:1220/1575 train_time:66473ms step_avg:54.49ms
+step:1221/1575 train_time:66563ms step_avg:54.51ms
+step:1222/1575 train_time:66648ms step_avg:54.54ms
+step:1223/1575 train_time:66738ms step_avg:54.57ms
+step:1224/1575 train_time:66823ms step_avg:54.59ms
+step:1225/1575 train_time:66913ms step_avg:54.62ms
+step:1226/1575 train_time:66998ms step_avg:54.65ms
+step:1227/1575 train_time:67088ms step_avg:54.68ms
+step:1228/1575 train_time:67174ms step_avg:54.70ms
+step:1229/1575 train_time:67264ms step_avg:54.73ms
+step:1230/1575 train_time:67350ms step_avg:54.76ms
+step:1231/1575 train_time:67440ms step_avg:54.79ms
+step:1232/1575 train_time:67525ms step_avg:54.81ms
+step:1233/1575 train_time:67615ms step_avg:54.84ms
+step:1234/1575 train_time:67702ms step_avg:54.86ms
+step:1235/1575 train_time:67790ms step_avg:54.89ms
+step:1236/1575 train_time:67877ms step_avg:54.92ms
+step:1237/1575 train_time:67967ms step_avg:54.94ms
+step:1238/1575 train_time:68052ms step_avg:54.97ms
+step:1239/1575 train_time:68142ms step_avg:55.00ms
+step:1240/1575 train_time:68227ms step_avg:55.02ms
+step:1241/1575 train_time:68317ms step_avg:55.05ms
+step:1242/1575 train_time:68402ms step_avg:55.07ms
+step:1243/1575 train_time:68492ms step_avg:55.10ms
+step:1244/1575 train_time:68577ms step_avg:55.13ms
+step:1245/1575 train_time:68666ms step_avg:55.15ms
+step:1246/1575 train_time:68752ms step_avg:55.18ms
+step:1247/1575 train_time:68842ms step_avg:55.21ms
+step:1248/1575 train_time:68928ms step_avg:55.23ms
+step:1249/1575 train_time:69018ms step_avg:55.26ms
+step:1250/1575 train_time:69104ms step_avg:55.28ms
+step:1250/1575 val_loss:3.4078 train_time:69177ms step_avg:55.34ms
+step:1251/1575 train_time:69197ms step_avg:55.31ms
+step:1252/1575 train_time:69285ms step_avg:55.34ms
+step:1253/1575 train_time:69377ms step_avg:55.37ms
+step:1254/1575 train_time:69463ms step_avg:55.39ms
+step:1255/1575 train_time:69554ms step_avg:55.42ms
+step:1256/1575 train_time:69638ms step_avg:55.44ms
+step:1257/1575 train_time:69726ms step_avg:55.47ms
+step:1258/1575 train_time:69811ms step_avg:55.49ms
+step:1259/1575 train_time:69899ms step_avg:55.52ms
+step:1260/1575 train_time:69984ms step_avg:55.54ms
+step:1261/1575 train_time:70073ms step_avg:55.57ms
+step:1262/1575 train_time:70158ms step_avg:55.59ms
+step:1263/1575 train_time:70250ms step_avg:55.62ms
+step:1264/1575 train_time:70337ms step_avg:55.65ms
+step:1265/1575 train_time:70428ms step_avg:55.67ms
+step:1266/1575 train_time:70514ms step_avg:55.70ms
+step:1267/1575 train_time:70604ms step_avg:55.73ms
+step:1268/1575 train_time:70689ms step_avg:55.75ms
+step:1269/1575 train_time:70778ms step_avg:55.77ms
+step:1270/1575 train_time:70862ms step_avg:55.80ms
+step:1271/1575 train_time:70950ms step_avg:55.82ms
+step:1272/1575 train_time:71035ms step_avg:55.85ms
+step:1273/1575 train_time:71125ms step_avg:55.87ms
+step:1274/1575 train_time:71210ms step_avg:55.90ms
+step:1275/1575 train_time:71303ms step_avg:55.92ms
+step:1276/1575 train_time:71390ms step_avg:55.95ms
+step:1277/1575 train_time:71480ms step_avg:55.97ms
+step:1278/1575 train_time:71565ms step_avg:56.00ms
+step:1279/1575 train_time:71655ms step_avg:56.02ms
+step:1280/1575 train_time:71740ms step_avg:56.05ms
+step:1281/1575 train_time:71828ms step_avg:56.07ms
+step:1282/1575 train_time:71913ms step_avg:56.09ms
+step:1283/1575 train_time:72003ms step_avg:56.12ms
+step:1284/1575 train_time:72088ms step_avg:56.14ms
+step:1285/1575 train_time:72178ms step_avg:56.17ms
+step:1286/1575 train_time:72266ms step_avg:56.19ms
+step:1287/1575 train_time:72355ms step_avg:56.22ms
+step:1288/1575 train_time:72443ms step_avg:56.24ms
+step:1289/1575 train_time:72533ms step_avg:56.27ms
+step:1290/1575 train_time:72619ms step_avg:56.29ms
+step:1291/1575 train_time:72708ms step_avg:56.32ms
+step:1292/1575 train_time:72794ms step_avg:56.34ms
+step:1293/1575 train_time:72883ms step_avg:56.37ms
+step:1294/1575 train_time:72968ms step_avg:56.39ms
+step:1295/1575 train_time:73058ms step_avg:56.42ms
+step:1296/1575 train_time:73143ms step_avg:56.44ms
+step:1297/1575 train_time:73233ms step_avg:56.46ms
+step:1298/1575 train_time:73319ms step_avg:56.49ms
+step:1299/1575 train_time:73409ms step_avg:56.51ms
+step:1300/1575 train_time:73495ms step_avg:56.53ms
+step:1301/1575 train_time:73585ms step_avg:56.56ms
+step:1302/1575 train_time:73670ms step_avg:56.58ms
+step:1303/1575 train_time:73760ms step_avg:56.61ms
+step:1304/1575 train_time:73844ms step_avg:56.63ms
+step:1305/1575 train_time:73934ms step_avg:56.65ms
+step:1306/1575 train_time:74019ms step_avg:56.68ms
+step:1307/1575 train_time:74109ms step_avg:56.70ms
+step:1308/1575 train_time:74195ms step_avg:56.72ms
+step:1309/1575 train_time:74286ms step_avg:56.75ms
+step:1310/1575 train_time:74371ms step_avg:56.77ms
+step:1311/1575 train_time:74461ms step_avg:56.80ms
+step:1312/1575 train_time:74547ms step_avg:56.82ms
+step:1313/1575 train_time:74636ms step_avg:56.84ms
+step:1314/1575 train_time:74722ms step_avg:56.87ms
+step:1315/1575 train_time:74811ms step_avg:56.89ms
+step:1316/1575 train_time:74898ms step_avg:56.91ms
+step:1317/1575 train_time:74987ms step_avg:56.94ms
+step:1318/1575 train_time:75072ms step_avg:56.96ms
+step:1319/1575 train_time:75163ms step_avg:56.99ms
+step:1320/1575 train_time:75250ms step_avg:57.01ms
+step:1321/1575 train_time:75340ms step_avg:57.03ms
+step:1322/1575 train_time:75426ms step_avg:57.05ms
+step:1323/1575 train_time:75515ms step_avg:57.08ms
+step:1324/1575 train_time:75601ms step_avg:57.10ms
+step:1325/1575 train_time:75691ms step_avg:57.13ms
+step:1326/1575 train_time:75779ms step_avg:57.15ms
+step:1327/1575 train_time:75865ms step_avg:57.17ms
+step:1328/1575 train_time:75951ms step_avg:57.19ms
+step:1329/1575 train_time:76040ms step_avg:57.22ms
+step:1330/1575 train_time:76125ms step_avg:57.24ms
+step:1331/1575 train_time:76215ms step_avg:57.26ms
+step:1332/1575 train_time:76301ms step_avg:57.28ms
+step:1333/1575 train_time:76391ms step_avg:57.31ms
+step:1334/1575 train_time:76477ms step_avg:57.33ms
+step:1335/1575 train_time:76567ms step_avg:57.35ms
+step:1336/1575 train_time:76652ms step_avg:57.37ms
+step:1337/1575 train_time:76742ms step_avg:57.40ms
+step:1338/1575 train_time:76828ms step_avg:57.42ms
+step:1339/1575 train_time:76917ms step_avg:57.44ms
+step:1340/1575 train_time:77003ms step_avg:57.46ms
+step:1341/1575 train_time:77091ms step_avg:57.49ms
+step:1342/1575 train_time:77178ms step_avg:57.51ms
+step:1343/1575 train_time:77269ms step_avg:57.53ms
+step:1344/1575 train_time:77354ms step_avg:57.55ms
+step:1345/1575 train_time:77444ms step_avg:57.58ms
+step:1346/1575 train_time:77530ms step_avg:57.60ms
+step:1347/1575 train_time:77620ms step_avg:57.62ms
+step:1348/1575 train_time:77705ms step_avg:57.65ms
+step:1349/1575 train_time:77795ms step_avg:57.67ms
+step:1350/1575 train_time:77881ms step_avg:57.69ms
+step:1351/1575 train_time:77971ms step_avg:57.71ms
+step:1352/1575 train_time:78055ms step_avg:57.73ms
+step:1353/1575 train_time:78145ms step_avg:57.76ms
+step:1354/1575 train_time:78232ms step_avg:57.78ms
+step:1355/1575 train_time:78321ms step_avg:57.80ms
+step:1356/1575 train_time:78406ms step_avg:57.82ms
+step:1357/1575 train_time:78496ms step_avg:57.85ms
+step:1358/1575 train_time:78586ms step_avg:57.87ms
+step:1359/1575 train_time:78673ms step_avg:57.89ms
+step:1360/1575 train_time:78760ms step_avg:57.91ms
+step:1361/1575 train_time:78849ms step_avg:57.93ms
+step:1362/1575 train_time:78933ms step_avg:57.95ms
+step:1363/1575 train_time:79023ms step_avg:57.98ms
+step:1364/1575 train_time:79108ms step_avg:58.00ms
+step:1365/1575 train_time:79197ms step_avg:58.02ms
+step:1366/1575 train_time:79285ms step_avg:58.04ms
+step:1367/1575 train_time:79375ms step_avg:58.07ms
+step:1368/1575 train_time:79460ms step_avg:58.09ms
+step:1369/1575 train_time:79548ms step_avg:58.11ms
+step:1370/1575 train_time:79635ms step_avg:58.13ms
+step:1371/1575 train_time:79725ms step_avg:58.15ms
+step:1372/1575 train_time:79811ms step_avg:58.17ms
+step:1373/1575 train_time:79900ms step_avg:58.19ms
+step:1374/1575 train_time:79986ms step_avg:58.21ms
+step:1375/1575 train_time:80075ms step_avg:58.24ms
+step:1376/1575 train_time:80160ms step_avg:58.26ms
+step:1377/1575 train_time:80250ms step_avg:58.28ms
+step:1378/1575 train_time:80336ms step_avg:58.30ms
+step:1379/1575 train_time:80426ms step_avg:58.32ms
+step:1380/1575 train_time:80512ms step_avg:58.34ms
+step:1381/1575 train_time:80603ms step_avg:58.37ms
+step:1382/1575 train_time:80690ms step_avg:58.39ms
+step:1383/1575 train_time:80782ms step_avg:58.41ms
+step:1384/1575 train_time:80867ms step_avg:58.43ms
+step:1385/1575 train_time:80954ms step_avg:58.45ms
+step:1386/1575 train_time:81041ms step_avg:58.47ms
+step:1387/1575 train_time:81130ms step_avg:58.49ms
+step:1388/1575 train_time:81215ms step_avg:58.51ms
+step:1389/1575 train_time:81305ms step_avg:58.53ms
+step:1390/1575 train_time:81391ms step_avg:58.55ms
+step:1391/1575 train_time:81480ms step_avg:58.58ms
+step:1392/1575 train_time:81565ms step_avg:58.60ms
+step:1393/1575 train_time:81655ms step_avg:58.62ms
+step:1394/1575 train_time:81741ms step_avg:58.64ms
+step:1395/1575 train_time:81831ms step_avg:58.66ms
+step:1396/1575 train_time:81917ms step_avg:58.68ms
+step:1397/1575 train_time:82007ms step_avg:58.70ms
+step:1398/1575 train_time:82092ms step_avg:58.72ms
+step:1399/1575 train_time:82182ms step_avg:58.74ms
+step:1400/1575 train_time:82267ms step_avg:58.76ms
+step:1401/1575 train_time:82356ms step_avg:58.78ms
+step:1402/1575 train_time:82442ms step_avg:58.80ms
+step:1403/1575 train_time:82532ms step_avg:58.83ms
+step:1404/1575 train_time:82618ms step_avg:58.84ms
+step:1405/1575 train_time:82707ms step_avg:58.87ms
+step:1406/1575 train_time:82794ms step_avg:58.89ms
+step:1407/1575 train_time:82885ms step_avg:58.91ms
+step:1408/1575 train_time:82969ms step_avg:58.93ms
+step:1409/1575 train_time:83059ms step_avg:58.95ms
+step:1410/1575 train_time:83145ms step_avg:58.97ms
+step:1411/1575 train_time:83235ms step_avg:58.99ms
+step:1412/1575 train_time:83321ms step_avg:59.01ms
+step:1413/1575 train_time:83412ms step_avg:59.03ms
+step:1414/1575 train_time:83498ms step_avg:59.05ms
+step:1415/1575 train_time:83588ms step_avg:59.07ms
+step:1416/1575 train_time:83673ms step_avg:59.09ms
+step:1417/1575 train_time:83764ms step_avg:59.11ms
+step:1418/1575 train_time:83849ms step_avg:59.13ms
+step:1419/1575 train_time:83940ms step_avg:59.15ms
+step:1420/1575 train_time:84024ms step_avg:59.17ms
+step:1421/1575 train_time:84114ms step_avg:59.19ms
+step:1422/1575 train_time:84200ms step_avg:59.21ms
+step:1423/1575 train_time:84291ms step_avg:59.23ms
+step:1424/1575 train_time:84375ms step_avg:59.25ms
+step:1425/1575 train_time:84465ms step_avg:59.27ms
+step:1426/1575 train_time:84554ms step_avg:59.29ms
+step:1427/1575 train_time:84640ms step_avg:59.31ms
+step:1428/1575 train_time:84726ms step_avg:59.33ms
+step:1429/1575 train_time:84816ms step_avg:59.35ms
+step:1430/1575 train_time:84902ms step_avg:59.37ms
+step:1431/1575 train_time:84992ms step_avg:59.39ms
+step:1432/1575 train_time:85077ms step_avg:59.41ms
+step:1433/1575 train_time:85167ms step_avg:59.43ms
+step:1434/1575 train_time:85253ms step_avg:59.45ms
+step:1435/1575 train_time:85343ms step_avg:59.47ms
+step:1436/1575 train_time:85428ms step_avg:59.49ms
+step:1437/1575 train_time:85518ms step_avg:59.51ms
+step:1438/1575 train_time:85603ms step_avg:59.53ms
+step:1439/1575 train_time:85693ms step_avg:59.55ms
+step:1440/1575 train_time:85780ms step_avg:59.57ms
+step:1441/1575 train_time:85868ms step_avg:59.59ms
+step:1442/1575 train_time:85954ms step_avg:59.61ms
+step:1443/1575 train_time:86044ms step_avg:59.63ms
+step:1444/1575 train_time:86130ms step_avg:59.65ms
+step:1445/1575 train_time:86219ms step_avg:59.67ms
+step:1446/1575 train_time:86306ms step_avg:59.69ms
+step:1447/1575 train_time:86394ms step_avg:59.71ms
+step:1448/1575 train_time:86480ms step_avg:59.72ms
+step:1449/1575 train_time:86569ms step_avg:59.74ms
+step:1450/1575 train_time:86656ms step_avg:59.76ms
+step:1451/1575 train_time:86746ms step_avg:59.78ms
+step:1452/1575 train_time:86831ms step_avg:59.80ms
+step:1453/1575 train_time:86923ms step_avg:59.82ms
+step:1454/1575 train_time:87007ms step_avg:59.84ms
+step:1455/1575 train_time:87098ms step_avg:59.86ms
+step:1456/1575 train_time:87184ms step_avg:59.88ms
+step:1457/1575 train_time:87273ms step_avg:59.90ms
+step:1458/1575 train_time:87359ms step_avg:59.92ms
+step:1459/1575 train_time:87448ms step_avg:59.94ms
+step:1460/1575 train_time:87535ms step_avg:59.96ms
+step:1461/1575 train_time:87624ms step_avg:59.98ms
+step:1462/1575 train_time:87710ms step_avg:59.99ms
+step:1463/1575 train_time:87800ms step_avg:60.01ms
+step:1464/1575 train_time:87885ms step_avg:60.03ms
+step:1465/1575 train_time:87974ms step_avg:60.05ms
+step:1466/1575 train_time:88060ms step_avg:60.07ms
+step:1467/1575 train_time:88149ms step_avg:60.09ms
+step:1468/1575 train_time:88236ms step_avg:60.11ms
+step:1469/1575 train_time:88326ms step_avg:60.13ms
+step:1470/1575 train_time:88412ms step_avg:60.14ms
+step:1471/1575 train_time:88501ms step_avg:60.16ms
+step:1472/1575 train_time:88586ms step_avg:60.18ms
+step:1473/1575 train_time:88676ms step_avg:60.20ms
+step:1474/1575 train_time:88761ms step_avg:60.22ms
+step:1475/1575 train_time:88851ms step_avg:60.24ms
+step:1476/1575 train_time:88938ms step_avg:60.26ms
+step:1477/1575 train_time:89025ms step_avg:60.27ms
+step:1478/1575 train_time:89111ms step_avg:60.29ms
+step:1479/1575 train_time:89202ms step_avg:60.31ms
+step:1480/1575 train_time:89289ms step_avg:60.33ms
+step:1481/1575 train_time:89376ms step_avg:60.35ms
+step:1482/1575 train_time:89461ms step_avg:60.37ms
+step:1483/1575 train_time:89551ms step_avg:60.39ms
+step:1484/1575 train_time:89641ms step_avg:60.41ms
+step:1485/1575 train_time:89728ms step_avg:60.42ms
+step:1486/1575 train_time:89814ms step_avg:60.44ms
+step:1487/1575 train_time:89903ms step_avg:60.46ms
+step:1488/1575 train_time:89989ms step_avg:60.48ms
+step:1489/1575 train_time:90079ms step_avg:60.50ms
+step:1490/1575 train_time:90164ms step_avg:60.51ms
+step:1491/1575 train_time:90254ms step_avg:60.53ms
+step:1492/1575 train_time:90340ms step_avg:60.55ms
+step:1493/1575 train_time:90429ms step_avg:60.57ms
+step:1494/1575 train_time:90515ms step_avg:60.59ms
+step:1495/1575 train_time:90605ms step_avg:60.61ms
+step:1496/1575 train_time:90692ms step_avg:60.62ms
+step:1497/1575 train_time:90782ms step_avg:60.64ms
+step:1498/1575 train_time:90866ms step_avg:60.66ms
+step:1499/1575 train_time:90957ms step_avg:60.68ms
+step:1500/1575 train_time:91041ms step_avg:60.69ms
+step:1500/1575 val_loss:3.3013 train_time:91115ms step_avg:60.74ms
+step:1501/1575 train_time:91135ms step_avg:60.72ms
+step:1502/1575 train_time:91223ms step_avg:60.73ms
+step:1503/1575 train_time:91318ms step_avg:60.76ms
+step:1504/1575 train_time:91403ms step_avg:60.77ms
+step:1505/1575 train_time:91492ms step_avg:60.79ms
+step:1506/1575 train_time:91577ms step_avg:60.81ms
+step:1507/1575 train_time:91665ms step_avg:60.83ms
+step:1508/1575 train_time:91750ms step_avg:60.84ms
+step:1509/1575 train_time:91840ms step_avg:60.86ms
+step:1510/1575 train_time:91924ms step_avg:60.88ms
+step:1511/1575 train_time:92012ms step_avg:60.90ms
+step:1512/1575 train_time:92099ms step_avg:60.91ms
+step:1513/1575 train_time:92189ms step_avg:60.93ms
+step:1514/1575 train_time:92281ms step_avg:60.95ms
+step:1515/1575 train_time:92369ms step_avg:60.97ms
+step:1516/1575 train_time:92456ms step_avg:60.99ms
+step:1517/1575 train_time:92545ms step_avg:61.01ms
+step:1518/1575 train_time:92630ms step_avg:61.02ms
+step:1519/1575 train_time:92719ms step_avg:61.04ms
+step:1520/1575 train_time:92804ms step_avg:61.05ms
+step:1521/1575 train_time:92892ms step_avg:61.07ms
+step:1522/1575 train_time:92978ms step_avg:61.09ms
+step:1523/1575 train_time:93067ms step_avg:61.11ms
+step:1524/1575 train_time:93155ms step_avg:61.13ms
+step:1525/1575 train_time:93248ms step_avg:61.15ms
+step:1526/1575 train_time:93335ms step_avg:61.16ms
+step:1527/1575 train_time:93427ms step_avg:61.18ms
+step:1528/1575 train_time:93512ms step_avg:61.20ms
+step:1529/1575 train_time:93601ms step_avg:61.22ms
+step:1530/1575 train_time:93686ms step_avg:61.23ms
+step:1531/1575 train_time:93775ms step_avg:61.25ms
+step:1532/1575 train_time:93863ms step_avg:61.27ms
+step:1533/1575 train_time:93949ms step_avg:61.28ms
+step:1534/1575 train_time:94034ms step_avg:61.30ms
+step:1535/1575 train_time:94124ms step_avg:61.32ms
+step:1536/1575 train_time:94218ms step_avg:61.34ms
+step:1537/1575 train_time:94307ms step_avg:61.36ms
+step:1538/1575 train_time:94394ms step_avg:61.37ms
+step:1539/1575 train_time:94485ms step_avg:61.39ms
+step:1540/1575 train_time:94570ms step_avg:61.41ms
+step:1541/1575 train_time:94660ms step_avg:61.43ms
+step:1542/1575 train_time:94746ms step_avg:61.44ms
+step:1543/1575 train_time:94835ms step_avg:61.46ms
+step:1544/1575 train_time:94922ms step_avg:61.48ms
+step:1545/1575 train_time:95009ms step_avg:61.49ms
+step:1546/1575 train_time:95096ms step_avg:61.51ms
+step:1547/1575 train_time:95187ms step_avg:61.53ms
+step:1548/1575 train_time:95274ms step_avg:61.55ms
+step:1549/1575 train_time:95365ms step_avg:61.57ms
+step:1550/1575 train_time:95451ms step_avg:61.58ms
+step:1551/1575 train_time:95542ms step_avg:61.60ms
+step:1552/1575 train_time:95627ms step_avg:61.62ms
+step:1553/1575 train_time:95717ms step_avg:61.63ms
+step:1554/1575 train_time:95802ms step_avg:61.65ms
+step:1555/1575 train_time:95891ms step_avg:61.67ms
+step:1556/1575 train_time:95977ms step_avg:61.68ms
+step:1557/1575 train_time:96067ms step_avg:61.70ms
+step:1558/1575 train_time:96153ms step_avg:61.72ms
+step:1559/1575 train_time:96245ms step_avg:61.73ms
+step:1560/1575 train_time:96331ms step_avg:61.75ms
+step:1561/1575 train_time:96422ms step_avg:61.77ms
+step:1562/1575 train_time:96507ms step_avg:61.78ms
+step:1563/1575 train_time:96598ms step_avg:61.80ms
+step:1564/1575 train_time:96685ms step_avg:61.82ms
+step:1565/1575 train_time:96773ms step_avg:61.84ms
+step:1566/1575 train_time:96859ms step_avg:61.85ms
+step:1567/1575 train_time:96949ms step_avg:61.87ms
+step:1568/1575 train_time:97035ms step_avg:61.88ms
+step:1569/1575 train_time:97130ms step_avg:61.91ms
+step:1570/1575 train_time:97214ms step_avg:61.92ms
+step:1571/1575 train_time:97303ms step_avg:61.94ms
+step:1572/1575 train_time:97389ms step_avg:61.95ms
+step:1573/1575 train_time:97480ms step_avg:61.97ms
+step:1574/1575 train_time:97565ms step_avg:61.99ms
+step:1575/1575 train_time:97657ms step_avg:62.00ms
+step:1575/1575 val_loss:3.2792 train_time:97725ms step_avg:62.05ms
+peak memory allocated: 31016 MiB reserved: 47000 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/e6833d19-b9b8-4327-9e6d-456237c131ed.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/e6833d19-b9b8-4327-9e6d-456237c131ed.txt
@@ -1,0 +1,4096 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 01 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # shifting first layer updates this to 01 ... 01 @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:10:09 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   32C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   31C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   31C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   33C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   33C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   32C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          230448      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          230449      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          230450      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          230451      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          230452      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          230453      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          230454      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          230455      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 511, 512, 513, 1023, 1024, 1025, 1534, 1535, 1536] for warmup
+Resetting Model
+step:0/1575 val_loss:10.8326 train_time:0ms step_avg:0.04ms
+step:1/1575 train_time:76ms step_avg:75.56ms
+step:2/1575 train_time:98ms step_avg:48.85ms
+step:3/1575 train_time:120ms step_avg:40.15ms
+step:4/1575 train_time:143ms step_avg:35.74ms
+step:5/1575 train_time:174ms step_avg:34.70ms
+step:6/1575 train_time:275ms step_avg:45.88ms
+step:7/1575 train_time:293ms step_avg:41.86ms
+step:8/1575 train_time:315ms step_avg:39.36ms
+step:9/1575 train_time:346ms step_avg:38.41ms
+step:10/1575 train_time:384ms step_avg:38.39ms
+step:11/1575 train_time:415ms step_avg:37.72ms
+step:12/1575 train_time:453ms step_avg:37.75ms
+step:13/1575 train_time:484ms step_avg:37.24ms
+step:14/1575 train_time:523ms step_avg:37.36ms
+step:15/1575 train_time:555ms step_avg:36.97ms
+step:16/1575 train_time:593ms step_avg:37.06ms
+step:17/1575 train_time:624ms step_avg:36.72ms
+step:18/1575 train_time:664ms step_avg:36.87ms
+step:19/1575 train_time:694ms step_avg:36.54ms
+step:20/1575 train_time:733ms step_avg:36.63ms
+step:21/1575 train_time:764ms step_avg:36.38ms
+step:22/1575 train_time:803ms step_avg:36.50ms
+step:23/1575 train_time:834ms step_avg:36.27ms
+step:24/1575 train_time:873ms step_avg:36.37ms
+step:25/1575 train_time:904ms step_avg:36.14ms
+step:26/1575 train_time:942ms step_avg:36.23ms
+step:27/1575 train_time:973ms step_avg:36.04ms
+step:28/1575 train_time:1011ms step_avg:36.12ms
+step:29/1575 train_time:1043ms step_avg:35.95ms
+step:30/1575 train_time:1081ms step_avg:36.04ms
+step:31/1575 train_time:1112ms step_avg:35.88ms
+step:32/1575 train_time:1151ms step_avg:35.96ms
+step:33/1575 train_time:1182ms step_avg:35.81ms
+step:34/1575 train_time:1220ms step_avg:35.89ms
+step:35/1575 train_time:1252ms step_avg:35.76ms
+step:36/1575 train_time:1290ms step_avg:35.83ms
+step:37/1575 train_time:1321ms step_avg:35.70ms
+step:38/1575 train_time:1360ms step_avg:35.79ms
+step:39/1575 train_time:1391ms step_avg:35.67ms
+step:40/1575 train_time:1430ms step_avg:35.74ms
+step:41/1575 train_time:1461ms step_avg:35.64ms
+step:42/1575 train_time:1501ms step_avg:35.73ms
+step:43/1575 train_time:1532ms step_avg:35.62ms
+step:44/1575 train_time:1571ms step_avg:35.70ms
+step:45/1575 train_time:1602ms step_avg:35.59ms
+step:46/1575 train_time:1640ms step_avg:35.66ms
+step:47/1575 train_time:1671ms step_avg:35.55ms
+step:48/1575 train_time:1710ms step_avg:35.62ms
+step:49/1575 train_time:1741ms step_avg:35.52ms
+step:50/1575 train_time:1780ms step_avg:35.60ms
+step:51/1575 train_time:1811ms step_avg:35.51ms
+step:52/1575 train_time:1850ms step_avg:35.57ms
+step:53/1575 train_time:1881ms step_avg:35.49ms
+step:54/1575 train_time:1920ms step_avg:35.56ms
+step:55/1575 train_time:1951ms step_avg:35.48ms
+step:56/1575 train_time:1990ms step_avg:35.53ms
+step:57/1575 train_time:2021ms step_avg:35.45ms
+step:58/1575 train_time:2060ms step_avg:35.52ms
+step:59/1575 train_time:2092ms step_avg:35.46ms
+step:60/1575 train_time:2130ms step_avg:35.51ms
+step:61/1575 train_time:2161ms step_avg:35.43ms
+step:62/1575 train_time:2200ms step_avg:35.49ms
+step:63/1575 train_time:2232ms step_avg:35.43ms
+step:64/1575 train_time:2271ms step_avg:35.48ms
+step:65/1575 train_time:2302ms step_avg:35.41ms
+step:66/1575 train_time:2341ms step_avg:35.47ms
+step:67/1575 train_time:2372ms step_avg:35.40ms
+step:68/1575 train_time:2411ms step_avg:35.45ms
+step:69/1575 train_time:2442ms step_avg:35.39ms
+step:70/1575 train_time:2481ms step_avg:35.44ms
+step:71/1575 train_time:2512ms step_avg:35.38ms
+step:72/1575 train_time:2550ms step_avg:35.42ms
+step:73/1575 train_time:2582ms step_avg:35.37ms
+step:74/1575 train_time:2621ms step_avg:35.41ms
+step:75/1575 train_time:2652ms step_avg:35.35ms
+step:76/1575 train_time:2690ms step_avg:35.40ms
+step:77/1575 train_time:2722ms step_avg:35.34ms
+step:78/1575 train_time:2761ms step_avg:35.40ms
+step:79/1575 train_time:2792ms step_avg:35.34ms
+step:80/1575 train_time:2834ms step_avg:35.42ms
+step:81/1575 train_time:2861ms step_avg:35.32ms
+step:82/1575 train_time:2900ms step_avg:35.37ms
+step:83/1575 train_time:2931ms step_avg:35.32ms
+step:84/1575 train_time:2970ms step_avg:35.36ms
+step:85/1575 train_time:3001ms step_avg:35.30ms
+step:86/1575 train_time:3040ms step_avg:35.35ms
+step:87/1575 train_time:3071ms step_avg:35.30ms
+step:88/1575 train_time:3110ms step_avg:35.34ms
+step:89/1575 train_time:3141ms step_avg:35.29ms
+step:90/1575 train_time:3180ms step_avg:35.33ms
+step:91/1575 train_time:3211ms step_avg:35.28ms
+step:92/1575 train_time:3249ms step_avg:35.31ms
+step:93/1575 train_time:3280ms step_avg:35.27ms
+step:94/1575 train_time:3319ms step_avg:35.31ms
+step:95/1575 train_time:3350ms step_avg:35.26ms
+step:96/1575 train_time:3389ms step_avg:35.30ms
+step:97/1575 train_time:3420ms step_avg:35.25ms
+step:98/1575 train_time:3458ms step_avg:35.29ms
+step:99/1575 train_time:3489ms step_avg:35.24ms
+step:100/1575 train_time:3527ms step_avg:35.27ms
+step:101/1575 train_time:3558ms step_avg:35.23ms
+step:102/1575 train_time:3597ms step_avg:35.27ms
+step:103/1575 train_time:3628ms step_avg:35.23ms
+step:104/1575 train_time:3667ms step_avg:35.26ms
+step:105/1575 train_time:3698ms step_avg:35.22ms
+step:106/1575 train_time:3736ms step_avg:35.25ms
+step:107/1575 train_time:3768ms step_avg:35.21ms
+step:108/1575 train_time:3806ms step_avg:35.24ms
+step:109/1575 train_time:3837ms step_avg:35.21ms
+step:110/1575 train_time:3876ms step_avg:35.24ms
+step:111/1575 train_time:3907ms step_avg:35.20ms
+step:112/1575 train_time:3945ms step_avg:35.23ms
+step:113/1575 train_time:3977ms step_avg:35.19ms
+step:114/1575 train_time:4015ms step_avg:35.22ms
+step:115/1575 train_time:4046ms step_avg:35.18ms
+step:116/1575 train_time:4085ms step_avg:35.21ms
+step:117/1575 train_time:4115ms step_avg:35.17ms
+step:118/1575 train_time:4153ms step_avg:35.20ms
+step:119/1575 train_time:4185ms step_avg:35.17ms
+step:120/1575 train_time:4224ms step_avg:35.20ms
+step:121/1575 train_time:4255ms step_avg:35.16ms
+step:122/1575 train_time:4293ms step_avg:35.19ms
+step:123/1575 train_time:4324ms step_avg:35.15ms
+step:124/1575 train_time:4363ms step_avg:35.18ms
+step:125/1575 train_time:4393ms step_avg:35.15ms
+step:126/1575 train_time:4431ms step_avg:35.17ms
+step:127/1575 train_time:4462ms step_avg:35.14ms
+step:128/1575 train_time:4501ms step_avg:35.16ms
+step:129/1575 train_time:4532ms step_avg:35.13ms
+step:130/1575 train_time:4571ms step_avg:35.16ms
+step:131/1575 train_time:4602ms step_avg:35.13ms
+step:132/1575 train_time:4641ms step_avg:35.16ms
+step:133/1575 train_time:4672ms step_avg:35.13ms
+step:134/1575 train_time:4710ms step_avg:35.15ms
+step:135/1575 train_time:4741ms step_avg:35.12ms
+step:136/1575 train_time:4780ms step_avg:35.15ms
+step:137/1575 train_time:4811ms step_avg:35.12ms
+step:138/1575 train_time:4849ms step_avg:35.14ms
+step:139/1575 train_time:4880ms step_avg:35.11ms
+step:140/1575 train_time:4919ms step_avg:35.14ms
+step:141/1575 train_time:4950ms step_avg:35.11ms
+step:142/1575 train_time:4989ms step_avg:35.13ms
+step:143/1575 train_time:5019ms step_avg:35.10ms
+step:144/1575 train_time:5058ms step_avg:35.12ms
+step:145/1575 train_time:5089ms step_avg:35.10ms
+step:146/1575 train_time:5127ms step_avg:35.12ms
+step:147/1575 train_time:5158ms step_avg:35.09ms
+step:148/1575 train_time:5197ms step_avg:35.12ms
+step:149/1575 train_time:5228ms step_avg:35.09ms
+step:150/1575 train_time:5267ms step_avg:35.11ms
+step:151/1575 train_time:5298ms step_avg:35.08ms
+step:152/1575 train_time:5336ms step_avg:35.11ms
+step:153/1575 train_time:5368ms step_avg:35.08ms
+step:154/1575 train_time:5406ms step_avg:35.10ms
+step:155/1575 train_time:5437ms step_avg:35.08ms
+step:156/1575 train_time:5475ms step_avg:35.10ms
+step:157/1575 train_time:5506ms step_avg:35.07ms
+step:158/1575 train_time:5545ms step_avg:35.09ms
+step:159/1575 train_time:5575ms step_avg:35.07ms
+step:160/1575 train_time:5614ms step_avg:35.09ms
+step:161/1575 train_time:5645ms step_avg:35.06ms
+step:162/1575 train_time:5684ms step_avg:35.09ms
+step:163/1575 train_time:5715ms step_avg:35.06ms
+step:164/1575 train_time:5753ms step_avg:35.08ms
+step:165/1575 train_time:5784ms step_avg:35.05ms
+step:166/1575 train_time:5823ms step_avg:35.08ms
+step:167/1575 train_time:5854ms step_avg:35.05ms
+step:168/1575 train_time:5892ms step_avg:35.07ms
+step:169/1575 train_time:5923ms step_avg:35.05ms
+step:170/1575 train_time:5962ms step_avg:35.07ms
+step:171/1575 train_time:5993ms step_avg:35.05ms
+step:172/1575 train_time:6031ms step_avg:35.06ms
+step:173/1575 train_time:6062ms step_avg:35.04ms
+step:174/1575 train_time:6101ms step_avg:35.06ms
+step:175/1575 train_time:6132ms step_avg:35.04ms
+step:176/1575 train_time:6170ms step_avg:35.06ms
+step:177/1575 train_time:6201ms step_avg:35.03ms
+step:178/1575 train_time:6240ms step_avg:35.06ms
+step:179/1575 train_time:6271ms step_avg:35.03ms
+step:180/1575 train_time:6309ms step_avg:35.05ms
+step:181/1575 train_time:6340ms step_avg:35.03ms
+step:182/1575 train_time:6379ms step_avg:35.05ms
+step:183/1575 train_time:6410ms step_avg:35.03ms
+step:184/1575 train_time:6449ms step_avg:35.05ms
+step:185/1575 train_time:6480ms step_avg:35.03ms
+step:186/1575 train_time:6518ms step_avg:35.04ms
+step:187/1575 train_time:6549ms step_avg:35.02ms
+step:188/1575 train_time:6588ms step_avg:35.04ms
+step:189/1575 train_time:6619ms step_avg:35.02ms
+step:190/1575 train_time:6657ms step_avg:35.04ms
+step:191/1575 train_time:6688ms step_avg:35.02ms
+step:192/1575 train_time:6727ms step_avg:35.03ms
+step:193/1575 train_time:6757ms step_avg:35.01ms
+step:194/1575 train_time:6796ms step_avg:35.03ms
+step:195/1575 train_time:6827ms step_avg:35.01ms
+step:196/1575 train_time:6866ms step_avg:35.03ms
+step:197/1575 train_time:6896ms step_avg:35.01ms
+step:198/1575 train_time:6935ms step_avg:35.02ms
+step:199/1575 train_time:6966ms step_avg:35.00ms
+step:200/1575 train_time:7004ms step_avg:35.02ms
+step:201/1575 train_time:7035ms step_avg:35.00ms
+step:202/1575 train_time:7073ms step_avg:35.02ms
+step:203/1575 train_time:7104ms step_avg:35.00ms
+step:204/1575 train_time:7142ms step_avg:35.01ms
+step:205/1575 train_time:7173ms step_avg:34.99ms
+step:206/1575 train_time:7212ms step_avg:35.01ms
+step:207/1575 train_time:7243ms step_avg:34.99ms
+step:208/1575 train_time:7282ms step_avg:35.01ms
+step:209/1575 train_time:7314ms step_avg:34.99ms
+step:210/1575 train_time:7352ms step_avg:35.01ms
+step:211/1575 train_time:7383ms step_avg:34.99ms
+step:212/1575 train_time:7422ms step_avg:35.01ms
+step:213/1575 train_time:7453ms step_avg:34.99ms
+step:214/1575 train_time:7491ms step_avg:35.00ms
+step:215/1575 train_time:7522ms step_avg:34.99ms
+step:216/1575 train_time:7561ms step_avg:35.00ms
+step:217/1575 train_time:7592ms step_avg:34.99ms
+step:218/1575 train_time:7631ms step_avg:35.00ms
+step:219/1575 train_time:7661ms step_avg:34.98ms
+step:220/1575 train_time:7700ms step_avg:35.00ms
+step:221/1575 train_time:7732ms step_avg:34.99ms
+step:222/1575 train_time:7770ms step_avg:35.00ms
+step:223/1575 train_time:7802ms step_avg:34.98ms
+step:224/1575 train_time:7841ms step_avg:35.00ms
+step:225/1575 train_time:7871ms step_avg:34.98ms
+step:226/1575 train_time:7910ms step_avg:35.00ms
+step:227/1575 train_time:7941ms step_avg:34.98ms
+step:228/1575 train_time:7979ms step_avg:35.00ms
+step:229/1575 train_time:8010ms step_avg:34.98ms
+step:230/1575 train_time:8049ms step_avg:34.99ms
+step:231/1575 train_time:8080ms step_avg:34.98ms
+step:232/1575 train_time:8119ms step_avg:35.00ms
+step:233/1575 train_time:8150ms step_avg:34.98ms
+step:234/1575 train_time:8188ms step_avg:34.99ms
+step:235/1575 train_time:8219ms step_avg:34.97ms
+step:236/1575 train_time:8257ms step_avg:34.99ms
+step:237/1575 train_time:8288ms step_avg:34.97ms
+step:238/1575 train_time:8327ms step_avg:34.99ms
+step:239/1575 train_time:8358ms step_avg:34.97ms
+step:240/1575 train_time:8396ms step_avg:34.99ms
+step:241/1575 train_time:8427ms step_avg:34.97ms
+step:242/1575 train_time:8466ms step_avg:34.98ms
+step:243/1575 train_time:8497ms step_avg:34.97ms
+step:244/1575 train_time:8535ms step_avg:34.98ms
+step:245/1575 train_time:8566ms step_avg:34.96ms
+step:246/1575 train_time:8605ms step_avg:34.98ms
+step:247/1575 train_time:8636ms step_avg:34.96ms
+step:248/1575 train_time:8674ms step_avg:34.98ms
+step:249/1575 train_time:8705ms step_avg:34.96ms
+step:250/1575 train_time:8743ms step_avg:34.97ms
+step:250/1575 val_loss:4.5841 train_time:8792ms step_avg:35.17ms
+step:251/1575 train_time:8811ms step_avg:35.10ms
+step:252/1575 train_time:8831ms step_avg:35.04ms
+step:253/1575 train_time:8848ms step_avg:34.97ms
+step:254/1575 train_time:8885ms step_avg:34.98ms
+step:255/1575 train_time:8917ms step_avg:34.97ms
+step:256/1575 train_time:8956ms step_avg:34.98ms
+step:257/1575 train_time:8987ms step_avg:34.97ms
+step:258/1575 train_time:9026ms step_avg:34.99ms
+step:259/1575 train_time:9057ms step_avg:34.97ms
+step:260/1575 train_time:9095ms step_avg:34.98ms
+step:261/1575 train_time:9126ms step_avg:34.97ms
+step:262/1575 train_time:9166ms step_avg:34.98ms
+step:263/1575 train_time:9196ms step_avg:34.96ms
+step:264/1575 train_time:9234ms step_avg:34.98ms
+step:265/1575 train_time:9265ms step_avg:34.96ms
+step:266/1575 train_time:9303ms step_avg:34.97ms
+step:267/1575 train_time:9334ms step_avg:34.96ms
+step:268/1575 train_time:9372ms step_avg:34.97ms
+step:269/1575 train_time:9403ms step_avg:34.96ms
+step:270/1575 train_time:9442ms step_avg:34.97ms
+step:271/1575 train_time:9472ms step_avg:34.95ms
+step:272/1575 train_time:9511ms step_avg:34.97ms
+step:273/1575 train_time:9542ms step_avg:34.95ms
+step:274/1575 train_time:9581ms step_avg:34.97ms
+step:275/1575 train_time:9612ms step_avg:34.95ms
+step:276/1575 train_time:9650ms step_avg:34.96ms
+step:277/1575 train_time:9681ms step_avg:34.95ms
+step:278/1575 train_time:9720ms step_avg:34.96ms
+step:279/1575 train_time:9751ms step_avg:34.95ms
+step:280/1575 train_time:9790ms step_avg:34.96ms
+step:281/1575 train_time:9821ms step_avg:34.95ms
+step:282/1575 train_time:9860ms step_avg:34.96ms
+step:283/1575 train_time:9891ms step_avg:34.95ms
+step:284/1575 train_time:9930ms step_avg:34.96ms
+step:285/1575 train_time:9960ms step_avg:34.95ms
+step:286/1575 train_time:9999ms step_avg:34.96ms
+step:287/1575 train_time:10030ms step_avg:34.95ms
+step:288/1575 train_time:10068ms step_avg:34.96ms
+step:289/1575 train_time:10099ms step_avg:34.95ms
+step:290/1575 train_time:10138ms step_avg:34.96ms
+step:291/1575 train_time:10169ms step_avg:34.94ms
+step:292/1575 train_time:10208ms step_avg:34.96ms
+step:293/1575 train_time:10239ms step_avg:34.94ms
+step:294/1575 train_time:10277ms step_avg:34.96ms
+step:295/1575 train_time:10308ms step_avg:34.94ms
+step:296/1575 train_time:10347ms step_avg:34.95ms
+step:297/1575 train_time:10377ms step_avg:34.94ms
+step:298/1575 train_time:10416ms step_avg:34.95ms
+step:299/1575 train_time:10446ms step_avg:34.94ms
+step:300/1575 train_time:10485ms step_avg:34.95ms
+step:301/1575 train_time:10516ms step_avg:34.94ms
+step:302/1575 train_time:10554ms step_avg:34.95ms
+step:303/1575 train_time:10585ms step_avg:34.93ms
+step:304/1575 train_time:10623ms step_avg:34.94ms
+step:305/1575 train_time:10654ms step_avg:34.93ms
+step:306/1575 train_time:10693ms step_avg:34.94ms
+step:307/1575 train_time:10723ms step_avg:34.93ms
+step:308/1575 train_time:10762ms step_avg:34.94ms
+step:309/1575 train_time:10793ms step_avg:34.93ms
+step:310/1575 train_time:10831ms step_avg:34.94ms
+step:311/1575 train_time:10862ms step_avg:34.93ms
+step:312/1575 train_time:10901ms step_avg:34.94ms
+step:313/1575 train_time:10932ms step_avg:34.93ms
+step:314/1575 train_time:10971ms step_avg:34.94ms
+step:315/1575 train_time:11002ms step_avg:34.93ms
+step:316/1575 train_time:11040ms step_avg:34.94ms
+step:317/1575 train_time:11071ms step_avg:34.93ms
+step:318/1575 train_time:11110ms step_avg:34.94ms
+step:319/1575 train_time:11142ms step_avg:34.93ms
+step:320/1575 train_time:11180ms step_avg:34.94ms
+step:321/1575 train_time:11211ms step_avg:34.93ms
+step:322/1575 train_time:11250ms step_avg:34.94ms
+step:323/1575 train_time:11281ms step_avg:34.93ms
+step:324/1575 train_time:11320ms step_avg:34.94ms
+step:325/1575 train_time:11351ms step_avg:34.93ms
+step:326/1575 train_time:11389ms step_avg:34.94ms
+step:327/1575 train_time:11420ms step_avg:34.92ms
+step:328/1575 train_time:11459ms step_avg:34.94ms
+step:329/1575 train_time:11491ms step_avg:34.93ms
+step:330/1575 train_time:11529ms step_avg:34.94ms
+step:331/1575 train_time:11560ms step_avg:34.93ms
+step:332/1575 train_time:11599ms step_avg:34.94ms
+step:333/1575 train_time:11631ms step_avg:34.93ms
+step:334/1575 train_time:11669ms step_avg:34.94ms
+step:335/1575 train_time:11700ms step_avg:34.93ms
+step:336/1575 train_time:11739ms step_avg:34.94ms
+step:337/1575 train_time:11770ms step_avg:34.93ms
+step:338/1575 train_time:11808ms step_avg:34.94ms
+step:339/1575 train_time:11839ms step_avg:34.92ms
+step:340/1575 train_time:11877ms step_avg:34.93ms
+step:341/1575 train_time:11908ms step_avg:34.92ms
+step:342/1575 train_time:11947ms step_avg:34.93ms
+step:343/1575 train_time:11978ms step_avg:34.92ms
+step:344/1575 train_time:12017ms step_avg:34.93ms
+step:345/1575 train_time:12047ms step_avg:34.92ms
+step:346/1575 train_time:12086ms step_avg:34.93ms
+step:347/1575 train_time:12116ms step_avg:34.92ms
+step:348/1575 train_time:12156ms step_avg:34.93ms
+step:349/1575 train_time:12185ms step_avg:34.92ms
+step:350/1575 train_time:12224ms step_avg:34.93ms
+step:351/1575 train_time:12255ms step_avg:34.91ms
+step:352/1575 train_time:12293ms step_avg:34.92ms
+step:353/1575 train_time:12324ms step_avg:34.91ms
+step:354/1575 train_time:12362ms step_avg:34.92ms
+step:355/1575 train_time:12393ms step_avg:34.91ms
+step:356/1575 train_time:12431ms step_avg:34.92ms
+step:357/1575 train_time:12462ms step_avg:34.91ms
+step:358/1575 train_time:12501ms step_avg:34.92ms
+step:359/1575 train_time:12532ms step_avg:34.91ms
+step:360/1575 train_time:12570ms step_avg:34.92ms
+step:361/1575 train_time:12601ms step_avg:34.91ms
+step:362/1575 train_time:12640ms step_avg:34.92ms
+step:363/1575 train_time:12670ms step_avg:34.90ms
+step:364/1575 train_time:12709ms step_avg:34.91ms
+step:365/1575 train_time:12740ms step_avg:34.90ms
+step:366/1575 train_time:12778ms step_avg:34.91ms
+step:367/1575 train_time:12809ms step_avg:34.90ms
+step:368/1575 train_time:12848ms step_avg:34.91ms
+step:369/1575 train_time:12878ms step_avg:34.90ms
+step:370/1575 train_time:12917ms step_avg:34.91ms
+step:371/1575 train_time:12948ms step_avg:34.90ms
+step:372/1575 train_time:12986ms step_avg:34.91ms
+step:373/1575 train_time:13017ms step_avg:34.90ms
+step:374/1575 train_time:13055ms step_avg:34.91ms
+step:375/1575 train_time:13086ms step_avg:34.90ms
+step:376/1575 train_time:13125ms step_avg:34.91ms
+step:377/1575 train_time:13156ms step_avg:34.90ms
+step:378/1575 train_time:13194ms step_avg:34.90ms
+step:379/1575 train_time:13225ms step_avg:34.89ms
+step:380/1575 train_time:13263ms step_avg:34.90ms
+step:381/1575 train_time:13294ms step_avg:34.89ms
+step:382/1575 train_time:13332ms step_avg:34.90ms
+step:383/1575 train_time:13363ms step_avg:34.89ms
+step:384/1575 train_time:13402ms step_avg:34.90ms
+step:385/1575 train_time:13433ms step_avg:34.89ms
+step:386/1575 train_time:13472ms step_avg:34.90ms
+step:387/1575 train_time:13503ms step_avg:34.89ms
+step:388/1575 train_time:13541ms step_avg:34.90ms
+step:389/1575 train_time:13572ms step_avg:34.89ms
+step:390/1575 train_time:13610ms step_avg:34.90ms
+step:391/1575 train_time:13641ms step_avg:34.89ms
+step:392/1575 train_time:13680ms step_avg:34.90ms
+step:393/1575 train_time:13711ms step_avg:34.89ms
+step:394/1575 train_time:13749ms step_avg:34.90ms
+step:395/1575 train_time:13780ms step_avg:34.89ms
+step:396/1575 train_time:13818ms step_avg:34.89ms
+step:397/1575 train_time:13849ms step_avg:34.88ms
+step:398/1575 train_time:13887ms step_avg:34.89ms
+step:399/1575 train_time:13919ms step_avg:34.88ms
+step:400/1575 train_time:13957ms step_avg:34.89ms
+step:401/1575 train_time:13988ms step_avg:34.88ms
+step:402/1575 train_time:14027ms step_avg:34.89ms
+step:403/1575 train_time:14058ms step_avg:34.88ms
+step:404/1575 train_time:14096ms step_avg:34.89ms
+step:405/1575 train_time:14127ms step_avg:34.88ms
+step:406/1575 train_time:14166ms step_avg:34.89ms
+step:407/1575 train_time:14197ms step_avg:34.88ms
+step:408/1575 train_time:14235ms step_avg:34.89ms
+step:409/1575 train_time:14266ms step_avg:34.88ms
+step:410/1575 train_time:14304ms step_avg:34.89ms
+step:411/1575 train_time:14335ms step_avg:34.88ms
+step:412/1575 train_time:14374ms step_avg:34.89ms
+step:413/1575 train_time:14404ms step_avg:34.88ms
+step:414/1575 train_time:14443ms step_avg:34.89ms
+step:415/1575 train_time:14474ms step_avg:34.88ms
+step:416/1575 train_time:14512ms step_avg:34.89ms
+step:417/1575 train_time:14543ms step_avg:34.88ms
+step:418/1575 train_time:14581ms step_avg:34.88ms
+step:419/1575 train_time:14612ms step_avg:34.87ms
+step:420/1575 train_time:14651ms step_avg:34.88ms
+step:421/1575 train_time:14681ms step_avg:34.87ms
+step:422/1575 train_time:14720ms step_avg:34.88ms
+step:423/1575 train_time:14751ms step_avg:34.87ms
+step:424/1575 train_time:14789ms step_avg:34.88ms
+step:425/1575 train_time:14820ms step_avg:34.87ms
+step:426/1575 train_time:14859ms step_avg:34.88ms
+step:427/1575 train_time:14891ms step_avg:34.87ms
+step:428/1575 train_time:14930ms step_avg:34.88ms
+step:429/1575 train_time:14961ms step_avg:34.87ms
+step:430/1575 train_time:15000ms step_avg:34.88ms
+step:431/1575 train_time:15032ms step_avg:34.88ms
+step:432/1575 train_time:15070ms step_avg:34.88ms
+step:433/1575 train_time:15101ms step_avg:34.88ms
+step:434/1575 train_time:15140ms step_avg:34.89ms
+step:435/1575 train_time:15172ms step_avg:34.88ms
+step:436/1575 train_time:15210ms step_avg:34.89ms
+step:437/1575 train_time:15241ms step_avg:34.88ms
+step:438/1575 train_time:15280ms step_avg:34.89ms
+step:439/1575 train_time:15311ms step_avg:34.88ms
+step:440/1575 train_time:15350ms step_avg:34.89ms
+step:441/1575 train_time:15380ms step_avg:34.88ms
+step:442/1575 train_time:15419ms step_avg:34.88ms
+step:443/1575 train_time:15450ms step_avg:34.88ms
+step:444/1575 train_time:15489ms step_avg:34.88ms
+step:445/1575 train_time:15520ms step_avg:34.88ms
+step:446/1575 train_time:15558ms step_avg:34.88ms
+step:447/1575 train_time:15589ms step_avg:34.88ms
+step:448/1575 train_time:15628ms step_avg:34.88ms
+step:449/1575 train_time:15659ms step_avg:34.87ms
+step:450/1575 train_time:15697ms step_avg:34.88ms
+step:451/1575 train_time:15728ms step_avg:34.87ms
+step:452/1575 train_time:15766ms step_avg:34.88ms
+step:453/1575 train_time:15797ms step_avg:34.87ms
+step:454/1575 train_time:15835ms step_avg:34.88ms
+step:455/1575 train_time:15866ms step_avg:34.87ms
+step:456/1575 train_time:15905ms step_avg:34.88ms
+step:457/1575 train_time:15936ms step_avg:34.87ms
+step:458/1575 train_time:15974ms step_avg:34.88ms
+step:459/1575 train_time:16005ms step_avg:34.87ms
+step:460/1575 train_time:16044ms step_avg:34.88ms
+step:461/1575 train_time:16074ms step_avg:34.87ms
+step:462/1575 train_time:16113ms step_avg:34.88ms
+step:463/1575 train_time:16144ms step_avg:34.87ms
+step:464/1575 train_time:16183ms step_avg:34.88ms
+step:465/1575 train_time:16214ms step_avg:34.87ms
+step:466/1575 train_time:16252ms step_avg:34.88ms
+step:467/1575 train_time:16283ms step_avg:34.87ms
+step:468/1575 train_time:16321ms step_avg:34.87ms
+step:469/1575 train_time:16352ms step_avg:34.87ms
+step:470/1575 train_time:16391ms step_avg:34.87ms
+step:471/1575 train_time:16422ms step_avg:34.87ms
+step:472/1575 train_time:16460ms step_avg:34.87ms
+step:473/1575 train_time:16491ms step_avg:34.87ms
+step:474/1575 train_time:16529ms step_avg:34.87ms
+step:475/1575 train_time:16561ms step_avg:34.86ms
+step:476/1575 train_time:16599ms step_avg:34.87ms
+step:477/1575 train_time:16631ms step_avg:34.87ms
+step:478/1575 train_time:16670ms step_avg:34.87ms
+step:479/1575 train_time:16700ms step_avg:34.87ms
+step:480/1575 train_time:16739ms step_avg:34.87ms
+step:481/1575 train_time:16769ms step_avg:34.86ms
+step:482/1575 train_time:16808ms step_avg:34.87ms
+step:483/1575 train_time:16839ms step_avg:34.86ms
+step:484/1575 train_time:16878ms step_avg:34.87ms
+step:485/1575 train_time:16908ms step_avg:34.86ms
+step:486/1575 train_time:16947ms step_avg:34.87ms
+step:487/1575 train_time:16978ms step_avg:34.86ms
+step:488/1575 train_time:17016ms step_avg:34.87ms
+step:489/1575 train_time:17047ms step_avg:34.86ms
+step:490/1575 train_time:17086ms step_avg:34.87ms
+step:491/1575 train_time:17116ms step_avg:34.86ms
+step:492/1575 train_time:17155ms step_avg:34.87ms
+step:493/1575 train_time:17185ms step_avg:34.86ms
+step:494/1575 train_time:17224ms step_avg:34.87ms
+step:495/1575 train_time:17255ms step_avg:34.86ms
+step:496/1575 train_time:17294ms step_avg:34.87ms
+step:497/1575 train_time:17324ms step_avg:34.86ms
+step:498/1575 train_time:17363ms step_avg:34.87ms
+step:499/1575 train_time:17394ms step_avg:34.86ms
+step:500/1575 train_time:17432ms step_avg:34.86ms
+step:500/1575 val_loss:4.2451 train_time:17481ms step_avg:34.96ms
+step:501/1575 train_time:17500ms step_avg:34.93ms
+step:502/1575 train_time:17520ms step_avg:34.90ms
+step:503/1575 train_time:17537ms step_avg:34.87ms
+step:504/1575 train_time:17575ms step_avg:34.87ms
+step:505/1575 train_time:17608ms step_avg:34.87ms
+step:506/1575 train_time:17648ms step_avg:34.88ms
+step:507/1575 train_time:17680ms step_avg:34.87ms
+step:508/1575 train_time:17719ms step_avg:34.88ms
+step:509/1575 train_time:17750ms step_avg:34.87ms
+step:510/1575 train_time:17788ms step_avg:34.88ms
+step:511/1575 train_time:17819ms step_avg:34.87ms
+step:512/1575 train_time:17857ms step_avg:34.88ms
+step:513/1575 train_time:17929ms step_avg:34.95ms
+step:514/1575 train_time:17987ms step_avg:34.99ms
+step:515/1575 train_time:18048ms step_avg:35.05ms
+step:516/1575 train_time:18108ms step_avg:35.09ms
+step:517/1575 train_time:18170ms step_avg:35.15ms
+step:518/1575 train_time:18229ms step_avg:35.19ms
+step:519/1575 train_time:18291ms step_avg:35.24ms
+step:520/1575 train_time:18350ms step_avg:35.29ms
+step:521/1575 train_time:18413ms step_avg:35.34ms
+step:522/1575 train_time:18473ms step_avg:35.39ms
+step:523/1575 train_time:18538ms step_avg:35.44ms
+step:524/1575 train_time:18599ms step_avg:35.49ms
+step:525/1575 train_time:18663ms step_avg:35.55ms
+step:526/1575 train_time:18724ms step_avg:35.60ms
+step:527/1575 train_time:18787ms step_avg:35.65ms
+step:528/1575 train_time:18848ms step_avg:35.70ms
+step:529/1575 train_time:18912ms step_avg:35.75ms
+step:530/1575 train_time:18971ms step_avg:35.79ms
+step:531/1575 train_time:19033ms step_avg:35.84ms
+step:532/1575 train_time:19094ms step_avg:35.89ms
+step:533/1575 train_time:19158ms step_avg:35.94ms
+step:534/1575 train_time:19219ms step_avg:35.99ms
+step:535/1575 train_time:19280ms step_avg:36.04ms
+step:536/1575 train_time:19339ms step_avg:36.08ms
+step:537/1575 train_time:19402ms step_avg:36.13ms
+step:538/1575 train_time:19461ms step_avg:36.17ms
+step:539/1575 train_time:19525ms step_avg:36.22ms
+step:540/1575 train_time:19586ms step_avg:36.27ms
+step:541/1575 train_time:19650ms step_avg:36.32ms
+step:542/1575 train_time:19709ms step_avg:36.36ms
+step:543/1575 train_time:19773ms step_avg:36.41ms
+step:544/1575 train_time:19833ms step_avg:36.46ms
+step:545/1575 train_time:19897ms step_avg:36.51ms
+step:546/1575 train_time:19957ms step_avg:36.55ms
+step:547/1575 train_time:20020ms step_avg:36.60ms
+step:548/1575 train_time:20080ms step_avg:36.64ms
+step:549/1575 train_time:20144ms step_avg:36.69ms
+step:550/1575 train_time:20204ms step_avg:36.73ms
+step:551/1575 train_time:20266ms step_avg:36.78ms
+step:552/1575 train_time:20325ms step_avg:36.82ms
+step:553/1575 train_time:20388ms step_avg:36.87ms
+step:554/1575 train_time:20448ms step_avg:36.91ms
+step:555/1575 train_time:20512ms step_avg:36.96ms
+step:556/1575 train_time:20571ms step_avg:37.00ms
+step:557/1575 train_time:20636ms step_avg:37.05ms
+step:558/1575 train_time:20696ms step_avg:37.09ms
+step:559/1575 train_time:20760ms step_avg:37.14ms
+step:560/1575 train_time:20820ms step_avg:37.18ms
+step:561/1575 train_time:20883ms step_avg:37.22ms
+step:562/1575 train_time:20943ms step_avg:37.26ms
+step:563/1575 train_time:21007ms step_avg:37.31ms
+step:564/1575 train_time:21067ms step_avg:37.35ms
+step:565/1575 train_time:21130ms step_avg:37.40ms
+step:566/1575 train_time:21190ms step_avg:37.44ms
+step:567/1575 train_time:21253ms step_avg:37.48ms
+step:568/1575 train_time:21312ms step_avg:37.52ms
+step:569/1575 train_time:21380ms step_avg:37.57ms
+step:570/1575 train_time:21437ms step_avg:37.61ms
+step:571/1575 train_time:21502ms step_avg:37.66ms
+step:572/1575 train_time:21562ms step_avg:37.70ms
+step:573/1575 train_time:21622ms step_avg:37.73ms
+step:574/1575 train_time:21681ms step_avg:37.77ms
+step:575/1575 train_time:21746ms step_avg:37.82ms
+step:576/1575 train_time:21806ms step_avg:37.86ms
+step:577/1575 train_time:21869ms step_avg:37.90ms
+step:578/1575 train_time:21928ms step_avg:37.94ms
+step:579/1575 train_time:21991ms step_avg:37.98ms
+step:580/1575 train_time:22051ms step_avg:38.02ms
+step:581/1575 train_time:22114ms step_avg:38.06ms
+step:582/1575 train_time:22173ms step_avg:38.10ms
+step:583/1575 train_time:22237ms step_avg:38.14ms
+step:584/1575 train_time:22297ms step_avg:38.18ms
+step:585/1575 train_time:22360ms step_avg:38.22ms
+step:586/1575 train_time:22420ms step_avg:38.26ms
+step:587/1575 train_time:22483ms step_avg:38.30ms
+step:588/1575 train_time:22542ms step_avg:38.34ms
+step:589/1575 train_time:22605ms step_avg:38.38ms
+step:590/1575 train_time:22665ms step_avg:38.41ms
+step:591/1575 train_time:22729ms step_avg:38.46ms
+step:592/1575 train_time:22789ms step_avg:38.49ms
+step:593/1575 train_time:22852ms step_avg:38.54ms
+step:594/1575 train_time:22912ms step_avg:38.57ms
+step:595/1575 train_time:22974ms step_avg:38.61ms
+step:596/1575 train_time:23034ms step_avg:38.65ms
+step:597/1575 train_time:23098ms step_avg:38.69ms
+step:598/1575 train_time:23157ms step_avg:38.72ms
+step:599/1575 train_time:23220ms step_avg:38.77ms
+step:600/1575 train_time:23279ms step_avg:38.80ms
+step:601/1575 train_time:23343ms step_avg:38.84ms
+step:602/1575 train_time:23402ms step_avg:38.87ms
+step:603/1575 train_time:23465ms step_avg:38.91ms
+step:604/1575 train_time:23525ms step_avg:38.95ms
+step:605/1575 train_time:23588ms step_avg:38.99ms
+step:606/1575 train_time:23648ms step_avg:39.02ms
+step:607/1575 train_time:23711ms step_avg:39.06ms
+step:608/1575 train_time:23771ms step_avg:39.10ms
+step:609/1575 train_time:23834ms step_avg:39.14ms
+step:610/1575 train_time:23894ms step_avg:39.17ms
+step:611/1575 train_time:23957ms step_avg:39.21ms
+step:612/1575 train_time:24017ms step_avg:39.24ms
+step:613/1575 train_time:24080ms step_avg:39.28ms
+step:614/1575 train_time:24140ms step_avg:39.32ms
+step:615/1575 train_time:24202ms step_avg:39.35ms
+step:616/1575 train_time:24263ms step_avg:39.39ms
+step:617/1575 train_time:24325ms step_avg:39.42ms
+step:618/1575 train_time:24385ms step_avg:39.46ms
+step:619/1575 train_time:24448ms step_avg:39.50ms
+step:620/1575 train_time:24508ms step_avg:39.53ms
+step:621/1575 train_time:24570ms step_avg:39.57ms
+step:622/1575 train_time:24630ms step_avg:39.60ms
+step:623/1575 train_time:24693ms step_avg:39.64ms
+step:624/1575 train_time:24753ms step_avg:39.67ms
+step:625/1575 train_time:24816ms step_avg:39.71ms
+step:626/1575 train_time:24876ms step_avg:39.74ms
+step:627/1575 train_time:24939ms step_avg:39.78ms
+step:628/1575 train_time:24999ms step_avg:39.81ms
+step:629/1575 train_time:25062ms step_avg:39.84ms
+step:630/1575 train_time:25122ms step_avg:39.88ms
+step:631/1575 train_time:25185ms step_avg:39.91ms
+step:632/1575 train_time:25245ms step_avg:39.94ms
+step:633/1575 train_time:25308ms step_avg:39.98ms
+step:634/1575 train_time:25368ms step_avg:40.01ms
+step:635/1575 train_time:25430ms step_avg:40.05ms
+step:636/1575 train_time:25490ms step_avg:40.08ms
+step:637/1575 train_time:25554ms step_avg:40.12ms
+step:638/1575 train_time:25613ms step_avg:40.15ms
+step:639/1575 train_time:25677ms step_avg:40.18ms
+step:640/1575 train_time:25736ms step_avg:40.21ms
+step:641/1575 train_time:25799ms step_avg:40.25ms
+step:642/1575 train_time:25859ms step_avg:40.28ms
+step:643/1575 train_time:25922ms step_avg:40.31ms
+step:644/1575 train_time:25982ms step_avg:40.34ms
+step:645/1575 train_time:26045ms step_avg:40.38ms
+step:646/1575 train_time:26105ms step_avg:40.41ms
+step:647/1575 train_time:26168ms step_avg:40.45ms
+step:648/1575 train_time:26230ms step_avg:40.48ms
+step:649/1575 train_time:26294ms step_avg:40.51ms
+step:650/1575 train_time:26351ms step_avg:40.54ms
+step:651/1575 train_time:26415ms step_avg:40.58ms
+step:652/1575 train_time:26473ms step_avg:40.60ms
+step:653/1575 train_time:26537ms step_avg:40.64ms
+step:654/1575 train_time:26597ms step_avg:40.67ms
+step:655/1575 train_time:26662ms step_avg:40.71ms
+step:656/1575 train_time:26720ms step_avg:40.73ms
+step:657/1575 train_time:26782ms step_avg:40.76ms
+step:658/1575 train_time:26841ms step_avg:40.79ms
+step:659/1575 train_time:26904ms step_avg:40.83ms
+step:660/1575 train_time:26964ms step_avg:40.85ms
+step:661/1575 train_time:27027ms step_avg:40.89ms
+step:662/1575 train_time:27087ms step_avg:40.92ms
+step:663/1575 train_time:27150ms step_avg:40.95ms
+step:664/1575 train_time:27210ms step_avg:40.98ms
+step:665/1575 train_time:27273ms step_avg:41.01ms
+step:666/1575 train_time:27333ms step_avg:41.04ms
+step:667/1575 train_time:27396ms step_avg:41.07ms
+step:668/1575 train_time:27455ms step_avg:41.10ms
+step:669/1575 train_time:27518ms step_avg:41.13ms
+step:670/1575 train_time:27578ms step_avg:41.16ms
+step:671/1575 train_time:27641ms step_avg:41.19ms
+step:672/1575 train_time:27700ms step_avg:41.22ms
+step:673/1575 train_time:27763ms step_avg:41.25ms
+step:674/1575 train_time:27823ms step_avg:41.28ms
+step:675/1575 train_time:27886ms step_avg:41.31ms
+step:676/1575 train_time:27945ms step_avg:41.34ms
+step:677/1575 train_time:28008ms step_avg:41.37ms
+step:678/1575 train_time:28068ms step_avg:41.40ms
+step:679/1575 train_time:28132ms step_avg:41.43ms
+step:680/1575 train_time:28191ms step_avg:41.46ms
+step:681/1575 train_time:28255ms step_avg:41.49ms
+step:682/1575 train_time:28315ms step_avg:41.52ms
+step:683/1575 train_time:28379ms step_avg:41.55ms
+step:684/1575 train_time:28438ms step_avg:41.58ms
+step:685/1575 train_time:28501ms step_avg:41.61ms
+step:686/1575 train_time:28560ms step_avg:41.63ms
+step:687/1575 train_time:28626ms step_avg:41.67ms
+step:688/1575 train_time:28683ms step_avg:41.69ms
+step:689/1575 train_time:28746ms step_avg:41.72ms
+step:690/1575 train_time:28807ms step_avg:41.75ms
+step:691/1575 train_time:28870ms step_avg:41.78ms
+step:692/1575 train_time:28929ms step_avg:41.80ms
+step:693/1575 train_time:28992ms step_avg:41.84ms
+step:694/1575 train_time:29052ms step_avg:41.86ms
+step:695/1575 train_time:29115ms step_avg:41.89ms
+step:696/1575 train_time:29175ms step_avg:41.92ms
+step:697/1575 train_time:29238ms step_avg:41.95ms
+step:698/1575 train_time:29298ms step_avg:41.97ms
+step:699/1575 train_time:29361ms step_avg:42.00ms
+step:700/1575 train_time:29421ms step_avg:42.03ms
+step:701/1575 train_time:29484ms step_avg:42.06ms
+step:702/1575 train_time:29543ms step_avg:42.08ms
+step:703/1575 train_time:29606ms step_avg:42.11ms
+step:704/1575 train_time:29666ms step_avg:42.14ms
+step:705/1575 train_time:29729ms step_avg:42.17ms
+step:706/1575 train_time:29789ms step_avg:42.19ms
+step:707/1575 train_time:29852ms step_avg:42.22ms
+step:708/1575 train_time:29912ms step_avg:42.25ms
+step:709/1575 train_time:29975ms step_avg:42.28ms
+step:710/1575 train_time:30035ms step_avg:42.30ms
+step:711/1575 train_time:30098ms step_avg:42.33ms
+step:712/1575 train_time:30158ms step_avg:42.36ms
+step:713/1575 train_time:30221ms step_avg:42.39ms
+step:714/1575 train_time:30281ms step_avg:42.41ms
+step:715/1575 train_time:30344ms step_avg:42.44ms
+step:716/1575 train_time:30405ms step_avg:42.46ms
+step:717/1575 train_time:30467ms step_avg:42.49ms
+step:718/1575 train_time:30527ms step_avg:42.52ms
+step:719/1575 train_time:30589ms step_avg:42.54ms
+step:720/1575 train_time:30649ms step_avg:42.57ms
+step:721/1575 train_time:30712ms step_avg:42.60ms
+step:722/1575 train_time:30771ms step_avg:42.62ms
+step:723/1575 train_time:30834ms step_avg:42.65ms
+step:724/1575 train_time:30895ms step_avg:42.67ms
+step:725/1575 train_time:30958ms step_avg:42.70ms
+step:726/1575 train_time:31020ms step_avg:42.73ms
+step:727/1575 train_time:31083ms step_avg:42.76ms
+step:728/1575 train_time:31140ms step_avg:42.77ms
+step:729/1575 train_time:31203ms step_avg:42.80ms
+step:730/1575 train_time:31263ms step_avg:42.83ms
+step:731/1575 train_time:31326ms step_avg:42.85ms
+step:732/1575 train_time:31385ms step_avg:42.88ms
+step:733/1575 train_time:31448ms step_avg:42.90ms
+step:734/1575 train_time:31508ms step_avg:42.93ms
+step:735/1575 train_time:31571ms step_avg:42.95ms
+step:736/1575 train_time:31630ms step_avg:42.98ms
+step:737/1575 train_time:31693ms step_avg:43.00ms
+step:738/1575 train_time:31756ms step_avg:43.03ms
+step:739/1575 train_time:31819ms step_avg:43.06ms
+step:740/1575 train_time:31876ms step_avg:43.08ms
+step:741/1575 train_time:31938ms step_avg:43.10ms
+step:742/1575 train_time:31998ms step_avg:43.12ms
+step:743/1575 train_time:32061ms step_avg:43.15ms
+step:744/1575 train_time:32120ms step_avg:43.17ms
+step:745/1575 train_time:32183ms step_avg:43.20ms
+step:746/1575 train_time:32243ms step_avg:43.22ms
+step:747/1575 train_time:32306ms step_avg:43.25ms
+step:748/1575 train_time:32365ms step_avg:43.27ms
+step:749/1575 train_time:32429ms step_avg:43.30ms
+step:750/1575 train_time:32488ms step_avg:43.32ms
+step:750/1575 val_loss:3.8908 train_time:32535ms step_avg:43.38ms
+step:751/1575 train_time:32556ms step_avg:43.35ms
+step:752/1575 train_time:32615ms step_avg:43.37ms
+step:753/1575 train_time:32680ms step_avg:43.40ms
+step:754/1575 train_time:32742ms step_avg:43.42ms
+step:755/1575 train_time:32806ms step_avg:43.45ms
+step:756/1575 train_time:32865ms step_avg:43.47ms
+step:757/1575 train_time:32928ms step_avg:43.50ms
+step:758/1575 train_time:32987ms step_avg:43.52ms
+step:759/1575 train_time:33050ms step_avg:43.54ms
+step:760/1575 train_time:33109ms step_avg:43.56ms
+step:761/1575 train_time:33173ms step_avg:43.59ms
+step:762/1575 train_time:33232ms step_avg:43.61ms
+step:763/1575 train_time:33294ms step_avg:43.64ms
+step:764/1575 train_time:33354ms step_avg:43.66ms
+step:765/1575 train_time:33416ms step_avg:43.68ms
+step:766/1575 train_time:33475ms step_avg:43.70ms
+step:767/1575 train_time:33538ms step_avg:43.73ms
+step:768/1575 train_time:33598ms step_avg:43.75ms
+step:769/1575 train_time:33663ms step_avg:43.78ms
+step:770/1575 train_time:33723ms step_avg:43.80ms
+step:771/1575 train_time:33789ms step_avg:43.82ms
+step:772/1575 train_time:33848ms step_avg:43.84ms
+step:773/1575 train_time:33912ms step_avg:43.87ms
+step:774/1575 train_time:33971ms step_avg:43.89ms
+step:775/1575 train_time:34034ms step_avg:43.92ms
+step:776/1575 train_time:34094ms step_avg:43.94ms
+step:777/1575 train_time:34156ms step_avg:43.96ms
+step:778/1575 train_time:34215ms step_avg:43.98ms
+step:779/1575 train_time:34278ms step_avg:44.00ms
+step:780/1575 train_time:34337ms step_avg:44.02ms
+step:781/1575 train_time:34400ms step_avg:44.05ms
+step:782/1575 train_time:34459ms step_avg:44.07ms
+step:783/1575 train_time:34522ms step_avg:44.09ms
+step:784/1575 train_time:34583ms step_avg:44.11ms
+step:785/1575 train_time:34646ms step_avg:44.13ms
+step:786/1575 train_time:34706ms step_avg:44.16ms
+step:787/1575 train_time:34770ms step_avg:44.18ms
+step:788/1575 train_time:34830ms step_avg:44.20ms
+step:789/1575 train_time:34893ms step_avg:44.22ms
+step:790/1575 train_time:34953ms step_avg:44.24ms
+step:791/1575 train_time:35016ms step_avg:44.27ms
+step:792/1575 train_time:35075ms step_avg:44.29ms
+step:793/1575 train_time:35138ms step_avg:44.31ms
+step:794/1575 train_time:35197ms step_avg:44.33ms
+step:795/1575 train_time:35259ms step_avg:44.35ms
+step:796/1575 train_time:35319ms step_avg:44.37ms
+step:797/1575 train_time:35382ms step_avg:44.39ms
+step:798/1575 train_time:35441ms step_avg:44.41ms
+step:799/1575 train_time:35504ms step_avg:44.44ms
+step:800/1575 train_time:35564ms step_avg:44.45ms
+step:801/1575 train_time:35627ms step_avg:44.48ms
+step:802/1575 train_time:35686ms step_avg:44.50ms
+step:803/1575 train_time:35750ms step_avg:44.52ms
+step:804/1575 train_time:35809ms step_avg:44.54ms
+step:805/1575 train_time:35873ms step_avg:44.56ms
+step:806/1575 train_time:35933ms step_avg:44.58ms
+step:807/1575 train_time:36000ms step_avg:44.61ms
+step:808/1575 train_time:36060ms step_avg:44.63ms
+step:809/1575 train_time:36120ms step_avg:44.65ms
+step:810/1575 train_time:36179ms step_avg:44.67ms
+step:811/1575 train_time:36241ms step_avg:44.69ms
+step:812/1575 train_time:36301ms step_avg:44.71ms
+step:813/1575 train_time:36364ms step_avg:44.73ms
+step:814/1575 train_time:36423ms step_avg:44.75ms
+step:815/1575 train_time:36486ms step_avg:44.77ms
+step:816/1575 train_time:36546ms step_avg:44.79ms
+step:817/1575 train_time:36609ms step_avg:44.81ms
+step:818/1575 train_time:36668ms step_avg:44.83ms
+step:819/1575 train_time:36732ms step_avg:44.85ms
+step:820/1575 train_time:36792ms step_avg:44.87ms
+step:821/1575 train_time:36856ms step_avg:44.89ms
+step:822/1575 train_time:36915ms step_avg:44.91ms
+step:823/1575 train_time:36979ms step_avg:44.93ms
+step:824/1575 train_time:37038ms step_avg:44.95ms
+step:825/1575 train_time:37103ms step_avg:44.97ms
+step:826/1575 train_time:37161ms step_avg:44.99ms
+step:827/1575 train_time:37224ms step_avg:45.01ms
+step:828/1575 train_time:37284ms step_avg:45.03ms
+step:829/1575 train_time:37347ms step_avg:45.05ms
+step:830/1575 train_time:37407ms step_avg:45.07ms
+step:831/1575 train_time:37470ms step_avg:45.09ms
+step:832/1575 train_time:37529ms step_avg:45.11ms
+step:833/1575 train_time:37592ms step_avg:45.13ms
+step:834/1575 train_time:37651ms step_avg:45.15ms
+step:835/1575 train_time:37714ms step_avg:45.17ms
+step:836/1575 train_time:37774ms step_avg:45.18ms
+step:837/1575 train_time:37836ms step_avg:45.20ms
+step:838/1575 train_time:37896ms step_avg:45.22ms
+step:839/1575 train_time:37959ms step_avg:45.24ms
+step:840/1575 train_time:38019ms step_avg:45.26ms
+step:841/1575 train_time:38082ms step_avg:45.28ms
+step:842/1575 train_time:38141ms step_avg:45.30ms
+step:843/1575 train_time:38204ms step_avg:45.32ms
+step:844/1575 train_time:38264ms step_avg:45.34ms
+step:845/1575 train_time:38326ms step_avg:45.36ms
+step:846/1575 train_time:38385ms step_avg:45.37ms
+step:847/1575 train_time:38449ms step_avg:45.39ms
+step:848/1575 train_time:38508ms step_avg:45.41ms
+step:849/1575 train_time:38571ms step_avg:45.43ms
+step:850/1575 train_time:38631ms step_avg:45.45ms
+step:851/1575 train_time:38693ms step_avg:45.47ms
+step:852/1575 train_time:38753ms step_avg:45.48ms
+step:853/1575 train_time:38816ms step_avg:45.51ms
+step:854/1575 train_time:38875ms step_avg:45.52ms
+step:855/1575 train_time:38938ms step_avg:45.54ms
+step:856/1575 train_time:38998ms step_avg:45.56ms
+step:857/1575 train_time:39062ms step_avg:45.58ms
+step:858/1575 train_time:39121ms step_avg:45.60ms
+step:859/1575 train_time:39184ms step_avg:45.62ms
+step:860/1575 train_time:39244ms step_avg:45.63ms
+step:861/1575 train_time:39307ms step_avg:45.65ms
+step:862/1575 train_time:39367ms step_avg:45.67ms
+step:863/1575 train_time:39430ms step_avg:45.69ms
+step:864/1575 train_time:39489ms step_avg:45.71ms
+step:865/1575 train_time:39553ms step_avg:45.73ms
+step:866/1575 train_time:39612ms step_avg:45.74ms
+step:867/1575 train_time:39675ms step_avg:45.76ms
+step:868/1575 train_time:39735ms step_avg:45.78ms
+step:869/1575 train_time:39797ms step_avg:45.80ms
+step:870/1575 train_time:39857ms step_avg:45.81ms
+step:871/1575 train_time:39920ms step_avg:45.83ms
+step:872/1575 train_time:39980ms step_avg:45.85ms
+step:873/1575 train_time:40043ms step_avg:45.87ms
+step:874/1575 train_time:40102ms step_avg:45.88ms
+step:875/1575 train_time:40165ms step_avg:45.90ms
+step:876/1575 train_time:40225ms step_avg:45.92ms
+step:877/1575 train_time:40290ms step_avg:45.94ms
+step:878/1575 train_time:40351ms step_avg:45.96ms
+step:879/1575 train_time:40414ms step_avg:45.98ms
+step:880/1575 train_time:40472ms step_avg:45.99ms
+step:881/1575 train_time:40535ms step_avg:46.01ms
+step:882/1575 train_time:40594ms step_avg:46.03ms
+step:883/1575 train_time:40657ms step_avg:46.04ms
+step:884/1575 train_time:40716ms step_avg:46.06ms
+step:885/1575 train_time:40779ms step_avg:46.08ms
+step:886/1575 train_time:40843ms step_avg:46.10ms
+step:887/1575 train_time:40904ms step_avg:46.12ms
+step:888/1575 train_time:40964ms step_avg:46.13ms
+step:889/1575 train_time:41027ms step_avg:46.15ms
+step:890/1575 train_time:41086ms step_avg:46.16ms
+step:891/1575 train_time:41151ms step_avg:46.19ms
+step:892/1575 train_time:41212ms step_avg:46.20ms
+step:893/1575 train_time:41271ms step_avg:46.22ms
+step:894/1575 train_time:41330ms step_avg:46.23ms
+step:895/1575 train_time:41393ms step_avg:46.25ms
+step:896/1575 train_time:41452ms step_avg:46.26ms
+step:897/1575 train_time:41516ms step_avg:46.28ms
+step:898/1575 train_time:41575ms step_avg:46.30ms
+step:899/1575 train_time:41637ms step_avg:46.32ms
+step:900/1575 train_time:41697ms step_avg:46.33ms
+step:901/1575 train_time:41760ms step_avg:46.35ms
+step:902/1575 train_time:41820ms step_avg:46.36ms
+step:903/1575 train_time:41883ms step_avg:46.38ms
+step:904/1575 train_time:41943ms step_avg:46.40ms
+step:905/1575 train_time:42006ms step_avg:46.42ms
+step:906/1575 train_time:42065ms step_avg:46.43ms
+step:907/1575 train_time:42129ms step_avg:46.45ms
+step:908/1575 train_time:42190ms step_avg:46.46ms
+step:909/1575 train_time:42252ms step_avg:46.48ms
+step:910/1575 train_time:42311ms step_avg:46.50ms
+step:911/1575 train_time:42375ms step_avg:46.51ms
+step:912/1575 train_time:42434ms step_avg:46.53ms
+step:913/1575 train_time:42497ms step_avg:46.55ms
+step:914/1575 train_time:42557ms step_avg:46.56ms
+step:915/1575 train_time:42620ms step_avg:46.58ms
+step:916/1575 train_time:42679ms step_avg:46.59ms
+step:917/1575 train_time:42744ms step_avg:46.61ms
+step:918/1575 train_time:42802ms step_avg:46.62ms
+step:919/1575 train_time:42865ms step_avg:46.64ms
+step:920/1575 train_time:42925ms step_avg:46.66ms
+step:921/1575 train_time:42988ms step_avg:46.68ms
+step:922/1575 train_time:43047ms step_avg:46.69ms
+step:923/1575 train_time:43110ms step_avg:46.71ms
+step:924/1575 train_time:43170ms step_avg:46.72ms
+step:925/1575 train_time:43233ms step_avg:46.74ms
+step:926/1575 train_time:43293ms step_avg:46.75ms
+step:927/1575 train_time:43356ms step_avg:46.77ms
+step:928/1575 train_time:43416ms step_avg:46.78ms
+step:929/1575 train_time:43479ms step_avg:46.80ms
+step:930/1575 train_time:43539ms step_avg:46.82ms
+step:931/1575 train_time:43601ms step_avg:46.83ms
+step:932/1575 train_time:43660ms step_avg:46.85ms
+step:933/1575 train_time:43724ms step_avg:46.86ms
+step:934/1575 train_time:43784ms step_avg:46.88ms
+step:935/1575 train_time:43847ms step_avg:46.90ms
+step:936/1575 train_time:43906ms step_avg:46.91ms
+step:937/1575 train_time:43969ms step_avg:46.93ms
+step:938/1575 train_time:44030ms step_avg:46.94ms
+step:939/1575 train_time:44092ms step_avg:46.96ms
+step:940/1575 train_time:44151ms step_avg:46.97ms
+step:941/1575 train_time:44215ms step_avg:46.99ms
+step:942/1575 train_time:44274ms step_avg:47.00ms
+step:943/1575 train_time:44337ms step_avg:47.02ms
+step:944/1575 train_time:44396ms step_avg:47.03ms
+step:945/1575 train_time:44459ms step_avg:47.05ms
+step:946/1575 train_time:44519ms step_avg:47.06ms
+step:947/1575 train_time:44582ms step_avg:47.08ms
+step:948/1575 train_time:44642ms step_avg:47.09ms
+step:949/1575 train_time:44705ms step_avg:47.11ms
+step:950/1575 train_time:44764ms step_avg:47.12ms
+step:951/1575 train_time:44829ms step_avg:47.14ms
+step:952/1575 train_time:44888ms step_avg:47.15ms
+step:953/1575 train_time:44951ms step_avg:47.17ms
+step:954/1575 train_time:45010ms step_avg:47.18ms
+step:955/1575 train_time:45073ms step_avg:47.20ms
+step:956/1575 train_time:45135ms step_avg:47.21ms
+step:957/1575 train_time:45196ms step_avg:47.23ms
+step:958/1575 train_time:45255ms step_avg:47.24ms
+step:959/1575 train_time:45318ms step_avg:47.26ms
+step:960/1575 train_time:45377ms step_avg:47.27ms
+step:961/1575 train_time:45441ms step_avg:47.29ms
+step:962/1575 train_time:45503ms step_avg:47.30ms
+step:963/1575 train_time:45564ms step_avg:47.31ms
+step:964/1575 train_time:45625ms step_avg:47.33ms
+step:965/1575 train_time:45688ms step_avg:47.34ms
+step:966/1575 train_time:45747ms step_avg:47.36ms
+step:967/1575 train_time:45810ms step_avg:47.37ms
+step:968/1575 train_time:45869ms step_avg:47.39ms
+step:969/1575 train_time:45932ms step_avg:47.40ms
+step:970/1575 train_time:45992ms step_avg:47.41ms
+step:971/1575 train_time:46054ms step_avg:47.43ms
+step:972/1575 train_time:46114ms step_avg:47.44ms
+step:973/1575 train_time:46177ms step_avg:47.46ms
+step:974/1575 train_time:46238ms step_avg:47.47ms
+step:975/1575 train_time:46300ms step_avg:47.49ms
+step:976/1575 train_time:46359ms step_avg:47.50ms
+step:977/1575 train_time:46425ms step_avg:47.52ms
+step:978/1575 train_time:46483ms step_avg:47.53ms
+step:979/1575 train_time:46546ms step_avg:47.54ms
+step:980/1575 train_time:46605ms step_avg:47.56ms
+step:981/1575 train_time:46668ms step_avg:47.57ms
+step:982/1575 train_time:46728ms step_avg:47.58ms
+step:983/1575 train_time:46791ms step_avg:47.60ms
+step:984/1575 train_time:46850ms step_avg:47.61ms
+step:985/1575 train_time:46914ms step_avg:47.63ms
+step:986/1575 train_time:46973ms step_avg:47.64ms
+step:987/1575 train_time:47037ms step_avg:47.66ms
+step:988/1575 train_time:47096ms step_avg:47.67ms
+step:989/1575 train_time:47159ms step_avg:47.68ms
+step:990/1575 train_time:47219ms step_avg:47.70ms
+step:991/1575 train_time:47281ms step_avg:47.71ms
+step:992/1575 train_time:47340ms step_avg:47.72ms
+step:993/1575 train_time:47404ms step_avg:47.74ms
+step:994/1575 train_time:47463ms step_avg:47.75ms
+step:995/1575 train_time:47526ms step_avg:47.77ms
+step:996/1575 train_time:47587ms step_avg:47.78ms
+step:997/1575 train_time:47650ms step_avg:47.79ms
+step:998/1575 train_time:47709ms step_avg:47.80ms
+step:999/1575 train_time:47773ms step_avg:47.82ms
+step:1000/1575 train_time:47833ms step_avg:47.83ms
+step:1000/1575 val_loss:3.5834 train_time:47879ms step_avg:47.88ms
+step:1001/1575 train_time:47899ms step_avg:47.85ms
+step:1002/1575 train_time:47960ms step_avg:47.86ms
+step:1003/1575 train_time:48025ms step_avg:47.88ms
+step:1004/1575 train_time:48086ms step_avg:47.89ms
+step:1005/1575 train_time:48150ms step_avg:47.91ms
+step:1006/1575 train_time:48209ms step_avg:47.92ms
+step:1007/1575 train_time:48273ms step_avg:47.94ms
+step:1008/1575 train_time:48331ms step_avg:47.95ms
+step:1009/1575 train_time:48394ms step_avg:47.96ms
+step:1010/1575 train_time:48455ms step_avg:47.97ms
+step:1011/1575 train_time:48518ms step_avg:47.99ms
+step:1012/1575 train_time:48577ms step_avg:48.00ms
+step:1013/1575 train_time:48639ms step_avg:48.02ms
+step:1014/1575 train_time:48698ms step_avg:48.03ms
+step:1015/1575 train_time:48760ms step_avg:48.04ms
+step:1016/1575 train_time:48820ms step_avg:48.05ms
+step:1017/1575 train_time:48884ms step_avg:48.07ms
+step:1018/1575 train_time:48945ms step_avg:48.08ms
+step:1019/1575 train_time:49009ms step_avg:48.09ms
+step:1020/1575 train_time:49069ms step_avg:48.11ms
+step:1021/1575 train_time:49133ms step_avg:48.12ms
+step:1022/1575 train_time:49193ms step_avg:48.13ms
+step:1023/1575 train_time:49256ms step_avg:48.15ms
+step:1024/1575 train_time:49315ms step_avg:48.16ms
+step:1025/1575 train_time:49388ms step_avg:48.18ms
+step:1026/1575 train_time:49470ms step_avg:48.22ms
+step:1027/1575 train_time:49561ms step_avg:48.26ms
+step:1028/1575 train_time:49646ms step_avg:48.29ms
+step:1029/1575 train_time:49735ms step_avg:48.33ms
+step:1030/1575 train_time:49821ms step_avg:48.37ms
+step:1031/1575 train_time:49911ms step_avg:48.41ms
+step:1032/1575 train_time:49997ms step_avg:48.45ms
+step:1033/1575 train_time:50089ms step_avg:48.49ms
+step:1034/1575 train_time:50175ms step_avg:48.52ms
+step:1035/1575 train_time:50265ms step_avg:48.57ms
+step:1036/1575 train_time:50351ms step_avg:48.60ms
+step:1037/1575 train_time:50440ms step_avg:48.64ms
+step:1038/1575 train_time:50529ms step_avg:48.68ms
+step:1039/1575 train_time:50615ms step_avg:48.72ms
+step:1040/1575 train_time:50700ms step_avg:48.75ms
+step:1041/1575 train_time:50790ms step_avg:48.79ms
+step:1042/1575 train_time:50876ms step_avg:48.83ms
+step:1043/1575 train_time:50966ms step_avg:48.86ms
+step:1044/1575 train_time:51052ms step_avg:48.90ms
+step:1045/1575 train_time:51142ms step_avg:48.94ms
+step:1046/1575 train_time:51228ms step_avg:48.97ms
+step:1047/1575 train_time:51317ms step_avg:49.01ms
+step:1048/1575 train_time:51403ms step_avg:49.05ms
+step:1049/1575 train_time:51493ms step_avg:49.09ms
+step:1050/1575 train_time:51578ms step_avg:49.12ms
+step:1051/1575 train_time:51667ms step_avg:49.16ms
+step:1052/1575 train_time:51753ms step_avg:49.19ms
+step:1053/1575 train_time:51842ms step_avg:49.23ms
+step:1054/1575 train_time:51928ms step_avg:49.27ms
+step:1055/1575 train_time:52017ms step_avg:49.31ms
+step:1056/1575 train_time:52104ms step_avg:49.34ms
+step:1057/1575 train_time:52194ms step_avg:49.38ms
+step:1058/1575 train_time:52280ms step_avg:49.41ms
+step:1059/1575 train_time:52370ms step_avg:49.45ms
+step:1060/1575 train_time:52456ms step_avg:49.49ms
+step:1061/1575 train_time:52545ms step_avg:49.52ms
+step:1062/1575 train_time:52631ms step_avg:49.56ms
+step:1063/1575 train_time:52720ms step_avg:49.60ms
+step:1064/1575 train_time:52806ms step_avg:49.63ms
+step:1065/1575 train_time:52896ms step_avg:49.67ms
+step:1066/1575 train_time:52982ms step_avg:49.70ms
+step:1067/1575 train_time:53072ms step_avg:49.74ms
+step:1068/1575 train_time:53158ms step_avg:49.77ms
+step:1069/1575 train_time:53247ms step_avg:49.81ms
+step:1070/1575 train_time:53333ms step_avg:49.84ms
+step:1071/1575 train_time:53422ms step_avg:49.88ms
+step:1072/1575 train_time:53510ms step_avg:49.92ms
+step:1073/1575 train_time:53597ms step_avg:49.95ms
+step:1074/1575 train_time:53683ms step_avg:49.98ms
+step:1075/1575 train_time:53773ms step_avg:50.02ms
+step:1076/1575 train_time:53859ms step_avg:50.06ms
+step:1077/1575 train_time:53948ms step_avg:50.09ms
+step:1078/1575 train_time:54034ms step_avg:50.12ms
+step:1079/1575 train_time:54123ms step_avg:50.16ms
+step:1080/1575 train_time:54209ms step_avg:50.19ms
+step:1081/1575 train_time:54298ms step_avg:50.23ms
+step:1082/1575 train_time:54385ms step_avg:50.26ms
+step:1083/1575 train_time:54474ms step_avg:50.30ms
+step:1084/1575 train_time:54565ms step_avg:50.34ms
+step:1085/1575 train_time:54651ms step_avg:50.37ms
+step:1086/1575 train_time:54737ms step_avg:50.40ms
+step:1087/1575 train_time:54826ms step_avg:50.44ms
+step:1088/1575 train_time:54912ms step_avg:50.47ms
+step:1089/1575 train_time:55002ms step_avg:50.51ms
+step:1090/1575 train_time:55088ms step_avg:50.54ms
+step:1091/1575 train_time:55177ms step_avg:50.57ms
+step:1092/1575 train_time:55264ms step_avg:50.61ms
+step:1093/1575 train_time:55353ms step_avg:50.64ms
+step:1094/1575 train_time:55438ms step_avg:50.67ms
+step:1095/1575 train_time:55528ms step_avg:50.71ms
+step:1096/1575 train_time:55617ms step_avg:50.75ms
+step:1097/1575 train_time:55704ms step_avg:50.78ms
+step:1098/1575 train_time:55789ms step_avg:50.81ms
+step:1099/1575 train_time:55878ms step_avg:50.84ms
+step:1100/1575 train_time:55964ms step_avg:50.88ms
+step:1101/1575 train_time:56054ms step_avg:50.91ms
+step:1102/1575 train_time:56140ms step_avg:50.94ms
+step:1103/1575 train_time:56231ms step_avg:50.98ms
+step:1104/1575 train_time:56317ms step_avg:51.01ms
+step:1105/1575 train_time:56406ms step_avg:51.05ms
+step:1106/1575 train_time:56492ms step_avg:51.08ms
+step:1107/1575 train_time:56582ms step_avg:51.11ms
+step:1108/1575 train_time:56668ms step_avg:51.14ms
+step:1109/1575 train_time:56757ms step_avg:51.18ms
+step:1110/1575 train_time:56843ms step_avg:51.21ms
+step:1111/1575 train_time:56932ms step_avg:51.24ms
+step:1112/1575 train_time:57019ms step_avg:51.28ms
+step:1113/1575 train_time:57108ms step_avg:51.31ms
+step:1114/1575 train_time:57193ms step_avg:51.34ms
+step:1115/1575 train_time:57283ms step_avg:51.37ms
+step:1116/1575 train_time:57368ms step_avg:51.41ms
+step:1117/1575 train_time:57457ms step_avg:51.44ms
+step:1118/1575 train_time:57543ms step_avg:51.47ms
+step:1119/1575 train_time:57633ms step_avg:51.50ms
+step:1120/1575 train_time:57719ms step_avg:51.53ms
+step:1121/1575 train_time:57808ms step_avg:51.57ms
+step:1122/1575 train_time:57894ms step_avg:51.60ms
+step:1123/1575 train_time:57984ms step_avg:51.63ms
+step:1124/1575 train_time:58069ms step_avg:51.66ms
+step:1125/1575 train_time:58159ms step_avg:51.70ms
+step:1126/1575 train_time:58245ms step_avg:51.73ms
+step:1127/1575 train_time:58335ms step_avg:51.76ms
+step:1128/1575 train_time:58420ms step_avg:51.79ms
+step:1129/1575 train_time:58510ms step_avg:51.82ms
+step:1130/1575 train_time:58598ms step_avg:51.86ms
+step:1131/1575 train_time:58687ms step_avg:51.89ms
+step:1132/1575 train_time:58783ms step_avg:51.93ms
+step:1133/1575 train_time:58868ms step_avg:51.96ms
+step:1134/1575 train_time:58953ms step_avg:51.99ms
+step:1135/1575 train_time:59041ms step_avg:52.02ms
+step:1136/1575 train_time:59127ms step_avg:52.05ms
+step:1137/1575 train_time:59216ms step_avg:52.08ms
+step:1138/1575 train_time:59303ms step_avg:52.11ms
+step:1139/1575 train_time:59394ms step_avg:52.15ms
+step:1140/1575 train_time:59473ms step_avg:52.17ms
+step:1141/1575 train_time:59561ms step_avg:52.20ms
+step:1142/1575 train_time:59646ms step_avg:52.23ms
+step:1143/1575 train_time:59736ms step_avg:52.26ms
+step:1144/1575 train_time:59822ms step_avg:52.29ms
+step:1145/1575 train_time:59911ms step_avg:52.32ms
+step:1146/1575 train_time:60001ms step_avg:52.36ms
+step:1147/1575 train_time:60089ms step_avg:52.39ms
+step:1148/1575 train_time:60174ms step_avg:52.42ms
+step:1149/1575 train_time:60264ms step_avg:52.45ms
+step:1150/1575 train_time:60350ms step_avg:52.48ms
+step:1151/1575 train_time:60439ms step_avg:52.51ms
+step:1152/1575 train_time:60526ms step_avg:52.54ms
+step:1153/1575 train_time:60614ms step_avg:52.57ms
+step:1154/1575 train_time:60701ms step_avg:52.60ms
+step:1155/1575 train_time:60792ms step_avg:52.63ms
+step:1156/1575 train_time:60875ms step_avg:52.66ms
+step:1157/1575 train_time:60965ms step_avg:52.69ms
+step:1158/1575 train_time:61051ms step_avg:52.72ms
+step:1159/1575 train_time:61140ms step_avg:52.75ms
+step:1160/1575 train_time:61226ms step_avg:52.78ms
+step:1161/1575 train_time:61316ms step_avg:52.81ms
+step:1162/1575 train_time:61402ms step_avg:52.84ms
+step:1163/1575 train_time:61492ms step_avg:52.87ms
+step:1164/1575 train_time:61577ms step_avg:52.90ms
+step:1165/1575 train_time:61667ms step_avg:52.93ms
+step:1166/1575 train_time:61752ms step_avg:52.96ms
+step:1167/1575 train_time:61842ms step_avg:52.99ms
+step:1168/1575 train_time:61927ms step_avg:53.02ms
+step:1169/1575 train_time:62017ms step_avg:53.05ms
+step:1170/1575 train_time:62103ms step_avg:53.08ms
+step:1171/1575 train_time:62193ms step_avg:53.11ms
+step:1172/1575 train_time:62279ms step_avg:53.14ms
+step:1173/1575 train_time:62369ms step_avg:53.17ms
+step:1174/1575 train_time:62455ms step_avg:53.20ms
+step:1175/1575 train_time:62544ms step_avg:53.23ms
+step:1176/1575 train_time:62629ms step_avg:53.26ms
+step:1177/1575 train_time:62718ms step_avg:53.29ms
+step:1178/1575 train_time:62804ms step_avg:53.31ms
+step:1179/1575 train_time:62894ms step_avg:53.34ms
+step:1180/1575 train_time:62980ms step_avg:53.37ms
+step:1181/1575 train_time:63069ms step_avg:53.40ms
+step:1182/1575 train_time:63155ms step_avg:53.43ms
+step:1183/1575 train_time:63245ms step_avg:53.46ms
+step:1184/1575 train_time:63330ms step_avg:53.49ms
+step:1185/1575 train_time:63420ms step_avg:53.52ms
+step:1186/1575 train_time:63505ms step_avg:53.55ms
+step:1187/1575 train_time:63595ms step_avg:53.58ms
+step:1188/1575 train_time:63680ms step_avg:53.60ms
+step:1189/1575 train_time:63771ms step_avg:53.63ms
+step:1190/1575 train_time:63856ms step_avg:53.66ms
+step:1191/1575 train_time:63945ms step_avg:53.69ms
+step:1192/1575 train_time:64031ms step_avg:53.72ms
+step:1193/1575 train_time:64120ms step_avg:53.75ms
+step:1194/1575 train_time:64206ms step_avg:53.77ms
+step:1195/1575 train_time:64296ms step_avg:53.80ms
+step:1196/1575 train_time:64382ms step_avg:53.83ms
+step:1197/1575 train_time:64472ms step_avg:53.86ms
+step:1198/1575 train_time:64558ms step_avg:53.89ms
+step:1199/1575 train_time:64648ms step_avg:53.92ms
+step:1200/1575 train_time:64733ms step_avg:53.94ms
+step:1201/1575 train_time:64822ms step_avg:53.97ms
+step:1202/1575 train_time:64908ms step_avg:54.00ms
+step:1203/1575 train_time:64998ms step_avg:54.03ms
+step:1204/1575 train_time:65084ms step_avg:54.06ms
+step:1205/1575 train_time:65173ms step_avg:54.09ms
+step:1206/1575 train_time:65259ms step_avg:54.11ms
+step:1207/1575 train_time:65349ms step_avg:54.14ms
+step:1208/1575 train_time:65435ms step_avg:54.17ms
+step:1209/1575 train_time:65525ms step_avg:54.20ms
+step:1210/1575 train_time:65611ms step_avg:54.22ms
+step:1211/1575 train_time:65701ms step_avg:54.25ms
+step:1212/1575 train_time:65787ms step_avg:54.28ms
+step:1213/1575 train_time:65879ms step_avg:54.31ms
+step:1214/1575 train_time:65962ms step_avg:54.33ms
+step:1215/1575 train_time:66051ms step_avg:54.36ms
+step:1216/1575 train_time:66138ms step_avg:54.39ms
+step:1217/1575 train_time:66227ms step_avg:54.42ms
+step:1218/1575 train_time:66313ms step_avg:54.44ms
+step:1219/1575 train_time:66402ms step_avg:54.47ms
+step:1220/1575 train_time:66488ms step_avg:54.50ms
+step:1221/1575 train_time:66577ms step_avg:54.53ms
+step:1222/1575 train_time:66663ms step_avg:54.55ms
+step:1223/1575 train_time:66753ms step_avg:54.58ms
+step:1224/1575 train_time:66838ms step_avg:54.61ms
+step:1225/1575 train_time:66929ms step_avg:54.64ms
+step:1226/1575 train_time:67014ms step_avg:54.66ms
+step:1227/1575 train_time:67105ms step_avg:54.69ms
+step:1228/1575 train_time:67190ms step_avg:54.72ms
+step:1229/1575 train_time:67279ms step_avg:54.74ms
+step:1230/1575 train_time:67365ms step_avg:54.77ms
+step:1231/1575 train_time:67454ms step_avg:54.80ms
+step:1232/1575 train_time:67540ms step_avg:54.82ms
+step:1233/1575 train_time:67631ms step_avg:54.85ms
+step:1234/1575 train_time:67717ms step_avg:54.88ms
+step:1235/1575 train_time:67807ms step_avg:54.90ms
+step:1236/1575 train_time:67892ms step_avg:54.93ms
+step:1237/1575 train_time:67981ms step_avg:54.96ms
+step:1238/1575 train_time:68067ms step_avg:54.98ms
+step:1239/1575 train_time:68157ms step_avg:55.01ms
+step:1240/1575 train_time:68242ms step_avg:55.03ms
+step:1241/1575 train_time:68332ms step_avg:55.06ms
+step:1242/1575 train_time:68418ms step_avg:55.09ms
+step:1243/1575 train_time:68508ms step_avg:55.11ms
+step:1244/1575 train_time:68594ms step_avg:55.14ms
+step:1245/1575 train_time:68683ms step_avg:55.17ms
+step:1246/1575 train_time:68769ms step_avg:55.19ms
+step:1247/1575 train_time:68858ms step_avg:55.22ms
+step:1248/1575 train_time:68944ms step_avg:55.24ms
+step:1249/1575 train_time:69034ms step_avg:55.27ms
+step:1250/1575 train_time:69120ms step_avg:55.30ms
+step:1250/1575 val_loss:3.4073 train_time:69194ms step_avg:55.36ms
+step:1251/1575 train_time:69214ms step_avg:55.33ms
+step:1252/1575 train_time:69301ms step_avg:55.35ms
+step:1253/1575 train_time:69393ms step_avg:55.38ms
+step:1254/1575 train_time:69482ms step_avg:55.41ms
+step:1255/1575 train_time:69569ms step_avg:55.43ms
+step:1256/1575 train_time:69654ms step_avg:55.46ms
+step:1257/1575 train_time:69742ms step_avg:55.48ms
+step:1258/1575 train_time:69827ms step_avg:55.51ms
+step:1259/1575 train_time:69916ms step_avg:55.53ms
+step:1260/1575 train_time:70000ms step_avg:55.56ms
+step:1261/1575 train_time:70091ms step_avg:55.58ms
+step:1262/1575 train_time:70177ms step_avg:55.61ms
+step:1263/1575 train_time:70267ms step_avg:55.63ms
+step:1264/1575 train_time:70354ms step_avg:55.66ms
+step:1265/1575 train_time:70446ms step_avg:55.69ms
+step:1266/1575 train_time:70531ms step_avg:55.71ms
+step:1267/1575 train_time:70620ms step_avg:55.74ms
+step:1268/1575 train_time:70705ms step_avg:55.76ms
+step:1269/1575 train_time:70794ms step_avg:55.79ms
+step:1270/1575 train_time:70878ms step_avg:55.81ms
+step:1271/1575 train_time:70967ms step_avg:55.84ms
+step:1272/1575 train_time:71052ms step_avg:55.86ms
+step:1273/1575 train_time:71142ms step_avg:55.89ms
+step:1274/1575 train_time:71229ms step_avg:55.91ms
+step:1275/1575 train_time:71320ms step_avg:55.94ms
+step:1276/1575 train_time:71406ms step_avg:55.96ms
+step:1277/1575 train_time:71496ms step_avg:55.99ms
+step:1278/1575 train_time:71582ms step_avg:56.01ms
+step:1279/1575 train_time:71671ms step_avg:56.04ms
+step:1280/1575 train_time:71757ms step_avg:56.06ms
+step:1281/1575 train_time:71847ms step_avg:56.09ms
+step:1282/1575 train_time:71931ms step_avg:56.11ms
+step:1283/1575 train_time:72019ms step_avg:56.13ms
+step:1284/1575 train_time:72105ms step_avg:56.16ms
+step:1285/1575 train_time:72194ms step_avg:56.18ms
+step:1286/1575 train_time:72281ms step_avg:56.21ms
+step:1287/1575 train_time:72372ms step_avg:56.23ms
+step:1288/1575 train_time:72458ms step_avg:56.26ms
+step:1289/1575 train_time:72549ms step_avg:56.28ms
+step:1290/1575 train_time:72634ms step_avg:56.31ms
+step:1291/1575 train_time:72723ms step_avg:56.33ms
+step:1292/1575 train_time:72808ms step_avg:56.35ms
+step:1293/1575 train_time:72897ms step_avg:56.38ms
+step:1294/1575 train_time:72982ms step_avg:56.40ms
+step:1295/1575 train_time:73071ms step_avg:56.43ms
+step:1296/1575 train_time:73157ms step_avg:56.45ms
+step:1297/1575 train_time:73248ms step_avg:56.47ms
+step:1298/1575 train_time:73335ms step_avg:56.50ms
+step:1299/1575 train_time:73428ms step_avg:56.53ms
+step:1300/1575 train_time:73512ms step_avg:56.55ms
+step:1301/1575 train_time:73601ms step_avg:56.57ms
+step:1302/1575 train_time:73687ms step_avg:56.59ms
+step:1303/1575 train_time:73776ms step_avg:56.62ms
+step:1304/1575 train_time:73861ms step_avg:56.64ms
+step:1305/1575 train_time:73950ms step_avg:56.67ms
+step:1306/1575 train_time:74036ms step_avg:56.69ms
+step:1307/1575 train_time:74125ms step_avg:56.71ms
+step:1308/1575 train_time:74211ms step_avg:56.74ms
+step:1309/1575 train_time:74300ms step_avg:56.76ms
+step:1310/1575 train_time:74387ms step_avg:56.78ms
+step:1311/1575 train_time:74477ms step_avg:56.81ms
+step:1312/1575 train_time:74562ms step_avg:56.83ms
+step:1313/1575 train_time:74652ms step_avg:56.86ms
+step:1314/1575 train_time:74738ms step_avg:56.88ms
+step:1315/1575 train_time:74828ms step_avg:56.90ms
+step:1316/1575 train_time:74913ms step_avg:56.92ms
+step:1317/1575 train_time:75002ms step_avg:56.95ms
+step:1318/1575 train_time:75087ms step_avg:56.97ms
+step:1319/1575 train_time:75178ms step_avg:57.00ms
+step:1320/1575 train_time:75266ms step_avg:57.02ms
+step:1321/1575 train_time:75353ms step_avg:57.04ms
+step:1322/1575 train_time:75438ms step_avg:57.06ms
+step:1323/1575 train_time:75529ms step_avg:57.09ms
+step:1324/1575 train_time:75615ms step_avg:57.11ms
+step:1325/1575 train_time:75705ms step_avg:57.14ms
+step:1326/1575 train_time:75792ms step_avg:57.16ms
+step:1327/1575 train_time:75880ms step_avg:57.18ms
+step:1328/1575 train_time:75965ms step_avg:57.20ms
+step:1329/1575 train_time:76054ms step_avg:57.23ms
+step:1330/1575 train_time:76139ms step_avg:57.25ms
+step:1331/1575 train_time:76228ms step_avg:57.27ms
+step:1332/1575 train_time:76315ms step_avg:57.29ms
+step:1333/1575 train_time:76404ms step_avg:57.32ms
+step:1334/1575 train_time:76490ms step_avg:57.34ms
+step:1335/1575 train_time:76580ms step_avg:57.36ms
+step:1336/1575 train_time:76666ms step_avg:57.38ms
+step:1337/1575 train_time:76755ms step_avg:57.41ms
+step:1338/1575 train_time:76841ms step_avg:57.43ms
+step:1339/1575 train_time:76930ms step_avg:57.45ms
+step:1340/1575 train_time:77015ms step_avg:57.47ms
+step:1341/1575 train_time:77105ms step_avg:57.50ms
+step:1342/1575 train_time:77190ms step_avg:57.52ms
+step:1343/1575 train_time:77280ms step_avg:57.54ms
+step:1344/1575 train_time:77366ms step_avg:57.56ms
+step:1345/1575 train_time:77456ms step_avg:57.59ms
+step:1346/1575 train_time:77542ms step_avg:57.61ms
+step:1347/1575 train_time:77632ms step_avg:57.63ms
+step:1348/1575 train_time:77718ms step_avg:57.65ms
+step:1349/1575 train_time:77807ms step_avg:57.68ms
+step:1350/1575 train_time:77894ms step_avg:57.70ms
+step:1351/1575 train_time:77983ms step_avg:57.72ms
+step:1352/1575 train_time:78068ms step_avg:57.74ms
+step:1353/1575 train_time:78157ms step_avg:57.77ms
+step:1354/1575 train_time:78245ms step_avg:57.79ms
+step:1355/1575 train_time:78334ms step_avg:57.81ms
+step:1356/1575 train_time:78419ms step_avg:57.83ms
+step:1357/1575 train_time:78510ms step_avg:57.86ms
+step:1358/1575 train_time:78599ms step_avg:57.88ms
+step:1359/1575 train_time:78688ms step_avg:57.90ms
+step:1360/1575 train_time:78773ms step_avg:57.92ms
+step:1361/1575 train_time:78862ms step_avg:57.94ms
+step:1362/1575 train_time:78947ms step_avg:57.96ms
+step:1363/1575 train_time:79035ms step_avg:57.99ms
+step:1364/1575 train_time:79122ms step_avg:58.01ms
+step:1365/1575 train_time:79211ms step_avg:58.03ms
+step:1366/1575 train_time:79296ms step_avg:58.05ms
+step:1367/1575 train_time:79387ms step_avg:58.07ms
+step:1368/1575 train_time:79472ms step_avg:58.09ms
+step:1369/1575 train_time:79562ms step_avg:58.12ms
+step:1370/1575 train_time:79648ms step_avg:58.14ms
+step:1371/1575 train_time:79738ms step_avg:58.16ms
+step:1372/1575 train_time:79824ms step_avg:58.18ms
+step:1373/1575 train_time:79913ms step_avg:58.20ms
+step:1374/1575 train_time:79999ms step_avg:58.22ms
+step:1375/1575 train_time:80089ms step_avg:58.25ms
+step:1376/1575 train_time:80176ms step_avg:58.27ms
+step:1377/1575 train_time:80264ms step_avg:58.29ms
+step:1378/1575 train_time:80353ms step_avg:58.31ms
+step:1379/1575 train_time:80442ms step_avg:58.33ms
+step:1380/1575 train_time:80526ms step_avg:58.35ms
+step:1381/1575 train_time:80614ms step_avg:58.37ms
+step:1382/1575 train_time:80701ms step_avg:58.39ms
+step:1383/1575 train_time:80790ms step_avg:58.42ms
+step:1384/1575 train_time:80877ms step_avg:58.44ms
+step:1385/1575 train_time:80966ms step_avg:58.46ms
+step:1386/1575 train_time:81052ms step_avg:58.48ms
+step:1387/1575 train_time:81141ms step_avg:58.50ms
+step:1388/1575 train_time:81227ms step_avg:58.52ms
+step:1389/1575 train_time:81316ms step_avg:58.54ms
+step:1390/1575 train_time:81402ms step_avg:58.56ms
+step:1391/1575 train_time:81492ms step_avg:58.59ms
+step:1392/1575 train_time:81578ms step_avg:58.61ms
+step:1393/1575 train_time:81668ms step_avg:58.63ms
+step:1394/1575 train_time:81754ms step_avg:58.65ms
+step:1395/1575 train_time:81844ms step_avg:58.67ms
+step:1396/1575 train_time:81930ms step_avg:58.69ms
+step:1397/1575 train_time:82020ms step_avg:58.71ms
+step:1398/1575 train_time:82105ms step_avg:58.73ms
+step:1399/1575 train_time:82195ms step_avg:58.75ms
+step:1400/1575 train_time:82281ms step_avg:58.77ms
+step:1401/1575 train_time:82370ms step_avg:58.79ms
+step:1402/1575 train_time:82457ms step_avg:58.81ms
+step:1403/1575 train_time:82546ms step_avg:58.84ms
+step:1404/1575 train_time:82632ms step_avg:58.85ms
+step:1405/1575 train_time:82721ms step_avg:58.88ms
+step:1406/1575 train_time:82807ms step_avg:58.90ms
+step:1407/1575 train_time:82896ms step_avg:58.92ms
+step:1408/1575 train_time:82983ms step_avg:58.94ms
+step:1409/1575 train_time:83071ms step_avg:58.96ms
+step:1410/1575 train_time:83157ms step_avg:58.98ms
+step:1411/1575 train_time:83247ms step_avg:59.00ms
+step:1412/1575 train_time:83334ms step_avg:59.02ms
+step:1413/1575 train_time:83423ms step_avg:59.04ms
+step:1414/1575 train_time:83509ms step_avg:59.06ms
+step:1415/1575 train_time:83600ms step_avg:59.08ms
+step:1416/1575 train_time:83686ms step_avg:59.10ms
+step:1417/1575 train_time:83775ms step_avg:59.12ms
+step:1418/1575 train_time:83861ms step_avg:59.14ms
+step:1419/1575 train_time:83949ms step_avg:59.16ms
+step:1420/1575 train_time:84036ms step_avg:59.18ms
+step:1421/1575 train_time:84125ms step_avg:59.20ms
+step:1422/1575 train_time:84211ms step_avg:59.22ms
+step:1423/1575 train_time:84300ms step_avg:59.24ms
+step:1424/1575 train_time:84385ms step_avg:59.26ms
+step:1425/1575 train_time:84474ms step_avg:59.28ms
+step:1426/1575 train_time:84559ms step_avg:59.30ms
+step:1427/1575 train_time:84650ms step_avg:59.32ms
+step:1428/1575 train_time:84736ms step_avg:59.34ms
+step:1429/1575 train_time:84825ms step_avg:59.36ms
+step:1430/1575 train_time:84911ms step_avg:59.38ms
+step:1431/1575 train_time:85000ms step_avg:59.40ms
+step:1432/1575 train_time:85085ms step_avg:59.42ms
+step:1433/1575 train_time:85175ms step_avg:59.44ms
+step:1434/1575 train_time:85262ms step_avg:59.46ms
+step:1435/1575 train_time:85351ms step_avg:59.48ms
+step:1436/1575 train_time:85440ms step_avg:59.50ms
+step:1437/1575 train_time:85528ms step_avg:59.52ms
+step:1438/1575 train_time:85613ms step_avg:59.54ms
+step:1439/1575 train_time:85703ms step_avg:59.56ms
+step:1440/1575 train_time:85788ms step_avg:59.57ms
+step:1441/1575 train_time:85877ms step_avg:59.60ms
+step:1442/1575 train_time:85963ms step_avg:59.61ms
+step:1443/1575 train_time:86052ms step_avg:59.63ms
+step:1444/1575 train_time:86138ms step_avg:59.65ms
+step:1445/1575 train_time:86227ms step_avg:59.67ms
+step:1446/1575 train_time:86313ms step_avg:59.69ms
+step:1447/1575 train_time:86401ms step_avg:59.71ms
+step:1448/1575 train_time:86487ms step_avg:59.73ms
+step:1449/1575 train_time:86576ms step_avg:59.75ms
+step:1450/1575 train_time:86663ms step_avg:59.77ms
+step:1451/1575 train_time:86752ms step_avg:59.79ms
+step:1452/1575 train_time:86838ms step_avg:59.81ms
+step:1453/1575 train_time:86928ms step_avg:59.83ms
+step:1454/1575 train_time:87014ms step_avg:59.84ms
+step:1455/1575 train_time:87103ms step_avg:59.86ms
+step:1456/1575 train_time:87189ms step_avg:59.88ms
+step:1457/1575 train_time:87278ms step_avg:59.90ms
+step:1458/1575 train_time:87364ms step_avg:59.92ms
+step:1459/1575 train_time:87454ms step_avg:59.94ms
+step:1460/1575 train_time:87541ms step_avg:59.96ms
+step:1461/1575 train_time:87630ms step_avg:59.98ms
+step:1462/1575 train_time:87716ms step_avg:60.00ms
+step:1463/1575 train_time:87806ms step_avg:60.02ms
+step:1464/1575 train_time:87891ms step_avg:60.04ms
+step:1465/1575 train_time:87981ms step_avg:60.06ms
+step:1466/1575 train_time:88066ms step_avg:60.07ms
+step:1467/1575 train_time:88155ms step_avg:60.09ms
+step:1468/1575 train_time:88242ms step_avg:60.11ms
+step:1469/1575 train_time:88331ms step_avg:60.13ms
+step:1470/1575 train_time:88420ms step_avg:60.15ms
+step:1471/1575 train_time:88508ms step_avg:60.17ms
+step:1472/1575 train_time:88593ms step_avg:60.19ms
+step:1473/1575 train_time:88682ms step_avg:60.20ms
+step:1474/1575 train_time:88767ms step_avg:60.22ms
+step:1475/1575 train_time:88856ms step_avg:60.24ms
+step:1476/1575 train_time:88943ms step_avg:60.26ms
+step:1477/1575 train_time:89033ms step_avg:60.28ms
+step:1478/1575 train_time:89118ms step_avg:60.30ms
+step:1479/1575 train_time:89208ms step_avg:60.32ms
+step:1480/1575 train_time:89293ms step_avg:60.33ms
+step:1481/1575 train_time:89383ms step_avg:60.35ms
+step:1482/1575 train_time:89468ms step_avg:60.37ms
+step:1483/1575 train_time:89557ms step_avg:60.39ms
+step:1484/1575 train_time:89644ms step_avg:60.41ms
+step:1485/1575 train_time:89733ms step_avg:60.43ms
+step:1486/1575 train_time:89818ms step_avg:60.44ms
+step:1487/1575 train_time:89908ms step_avg:60.46ms
+step:1488/1575 train_time:89994ms step_avg:60.48ms
+step:1489/1575 train_time:90083ms step_avg:60.50ms
+step:1490/1575 train_time:90169ms step_avg:60.52ms
+step:1491/1575 train_time:90259ms step_avg:60.54ms
+step:1492/1575 train_time:90345ms step_avg:60.55ms
+step:1493/1575 train_time:90435ms step_avg:60.57ms
+step:1494/1575 train_time:90521ms step_avg:60.59ms
+step:1495/1575 train_time:90613ms step_avg:60.61ms
+step:1496/1575 train_time:90696ms step_avg:60.63ms
+step:1497/1575 train_time:90786ms step_avg:60.65ms
+step:1498/1575 train_time:90872ms step_avg:60.66ms
+step:1499/1575 train_time:90961ms step_avg:60.68ms
+step:1500/1575 train_time:91047ms step_avg:60.70ms
+step:1500/1575 val_loss:3.3006 train_time:91119ms step_avg:60.75ms
+step:1501/1575 train_time:91139ms step_avg:60.72ms
+step:1502/1575 train_time:91226ms step_avg:60.74ms
+step:1503/1575 train_time:91318ms step_avg:60.76ms
+step:1504/1575 train_time:91404ms step_avg:60.77ms
+step:1505/1575 train_time:91493ms step_avg:60.79ms
+step:1506/1575 train_time:91577ms step_avg:60.81ms
+step:1507/1575 train_time:91665ms step_avg:60.83ms
+step:1508/1575 train_time:91750ms step_avg:60.84ms
+step:1509/1575 train_time:91839ms step_avg:60.86ms
+step:1510/1575 train_time:91925ms step_avg:60.88ms
+step:1511/1575 train_time:92014ms step_avg:60.90ms
+step:1512/1575 train_time:92100ms step_avg:60.91ms
+step:1513/1575 train_time:92191ms step_avg:60.93ms
+step:1514/1575 train_time:92279ms step_avg:60.95ms
+step:1515/1575 train_time:92369ms step_avg:60.97ms
+step:1516/1575 train_time:92456ms step_avg:60.99ms
+step:1517/1575 train_time:92546ms step_avg:61.01ms
+step:1518/1575 train_time:92630ms step_avg:61.02ms
+step:1519/1575 train_time:92719ms step_avg:61.04ms
+step:1520/1575 train_time:92804ms step_avg:61.06ms
+step:1521/1575 train_time:92892ms step_avg:61.07ms
+step:1522/1575 train_time:92977ms step_avg:61.09ms
+step:1523/1575 train_time:93067ms step_avg:61.11ms
+step:1524/1575 train_time:93153ms step_avg:61.12ms
+step:1525/1575 train_time:93245ms step_avg:61.14ms
+step:1526/1575 train_time:93331ms step_avg:61.16ms
+step:1527/1575 train_time:93421ms step_avg:61.18ms
+step:1528/1575 train_time:93507ms step_avg:61.20ms
+step:1529/1575 train_time:93596ms step_avg:61.21ms
+step:1530/1575 train_time:93682ms step_avg:61.23ms
+step:1531/1575 train_time:93770ms step_avg:61.25ms
+step:1532/1575 train_time:93856ms step_avg:61.26ms
+step:1533/1575 train_time:93945ms step_avg:61.28ms
+step:1534/1575 train_time:94031ms step_avg:61.30ms
+step:1535/1575 train_time:94120ms step_avg:61.32ms
+step:1536/1575 train_time:94214ms step_avg:61.34ms
+step:1537/1575 train_time:94303ms step_avg:61.36ms
+step:1538/1575 train_time:94388ms step_avg:61.37ms
+step:1539/1575 train_time:94478ms step_avg:61.39ms
+step:1540/1575 train_time:94564ms step_avg:61.41ms
+step:1541/1575 train_time:94653ms step_avg:61.42ms
+step:1542/1575 train_time:94739ms step_avg:61.44ms
+step:1543/1575 train_time:94831ms step_avg:61.46ms
+step:1544/1575 train_time:94915ms step_avg:61.47ms
+step:1545/1575 train_time:95005ms step_avg:61.49ms
+step:1546/1575 train_time:95091ms step_avg:61.51ms
+step:1547/1575 train_time:95181ms step_avg:61.53ms
+step:1548/1575 train_time:95268ms step_avg:61.54ms
+step:1549/1575 train_time:95357ms step_avg:61.56ms
+step:1550/1575 train_time:95444ms step_avg:61.58ms
+step:1551/1575 train_time:95534ms step_avg:61.59ms
+step:1552/1575 train_time:95620ms step_avg:61.61ms
+step:1553/1575 train_time:95709ms step_avg:61.63ms
+step:1554/1575 train_time:95795ms step_avg:61.64ms
+step:1555/1575 train_time:95885ms step_avg:61.66ms
+step:1556/1575 train_time:95970ms step_avg:61.68ms
+step:1557/1575 train_time:96060ms step_avg:61.70ms
+step:1558/1575 train_time:96146ms step_avg:61.71ms
+step:1559/1575 train_time:96236ms step_avg:61.73ms
+step:1560/1575 train_time:96323ms step_avg:61.75ms
+step:1561/1575 train_time:96413ms step_avg:61.76ms
+step:1562/1575 train_time:96499ms step_avg:61.78ms
+step:1563/1575 train_time:96589ms step_avg:61.80ms
+step:1564/1575 train_time:96674ms step_avg:61.81ms
+step:1565/1575 train_time:96764ms step_avg:61.83ms
+step:1566/1575 train_time:96850ms step_avg:61.85ms
+step:1567/1575 train_time:96942ms step_avg:61.86ms
+step:1568/1575 train_time:97027ms step_avg:61.88ms
+step:1569/1575 train_time:97121ms step_avg:61.90ms
+step:1570/1575 train_time:97205ms step_avg:61.91ms
+step:1571/1575 train_time:97295ms step_avg:61.93ms
+step:1572/1575 train_time:97381ms step_avg:61.95ms
+step:1573/1575 train_time:97470ms step_avg:61.96ms
+step:1574/1575 train_time:97557ms step_avg:61.98ms
+step:1575/1575 train_time:97647ms step_avg:62.00ms
+step:1575/1575 val_loss:3.2784 train_time:97715ms step_avg:62.04ms
+peak memory allocated: 31016 MiB reserved: 46998 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/ee5c88bd-7632-4b36-a3c3-4c1bd6b0131d.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/ee5c88bd-7632-4b36-a3c3-4c1bd6b0131d.txt
@@ -1,0 +1,4096 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(5)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2, ve3, ve4
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 unique gates
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 01 ... 01 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # shifting first layer updates this to 01 ... 01 @photomz
+        ve = [ve[0], ve[1]] + [None] * (self.num_layers - 5) + [ve[2], ve[3], ve[4]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve3":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve4":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "ve3", "ve4", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1535  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 02:30:12 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   34C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   38C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   40C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            132W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            126W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          250711      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          250712      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          250713      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          250714      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          250715      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          250716      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          250717      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          250718      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 511, 512, 513, 1023, 1024, 1025, 1534, 1535, 1536] for warmup
+Resetting Model
+step:0/1575 val_loss:10.8328 train_time:0ms step_avg:0.04ms
+step:1/1575 train_time:88ms step_avg:87.92ms
+step:2/1575 train_time:111ms step_avg:55.44ms
+step:3/1575 train_time:132ms step_avg:43.93ms
+step:4/1575 train_time:166ms step_avg:41.50ms
+step:5/1575 train_time:197ms step_avg:39.35ms
+step:6/1575 train_time:296ms step_avg:49.29ms
+step:7/1575 train_time:314ms step_avg:44.87ms
+step:8/1575 train_time:337ms step_avg:42.14ms
+step:9/1575 train_time:368ms step_avg:40.86ms
+step:10/1575 train_time:406ms step_avg:40.63ms
+step:11/1575 train_time:437ms step_avg:39.72ms
+step:12/1575 train_time:476ms step_avg:39.68ms
+step:13/1575 train_time:507ms step_avg:38.99ms
+step:14/1575 train_time:546ms step_avg:38.99ms
+step:15/1575 train_time:576ms step_avg:38.43ms
+step:16/1575 train_time:615ms step_avg:38.44ms
+step:17/1575 train_time:646ms step_avg:38.00ms
+step:18/1575 train_time:685ms step_avg:38.04ms
+step:19/1575 train_time:716ms step_avg:37.67ms
+step:20/1575 train_time:755ms step_avg:37.73ms
+step:21/1575 train_time:786ms step_avg:37.43ms
+step:22/1575 train_time:825ms step_avg:37.49ms
+step:23/1575 train_time:855ms step_avg:37.19ms
+step:24/1575 train_time:894ms step_avg:37.26ms
+step:25/1575 train_time:925ms step_avg:37.01ms
+step:26/1575 train_time:964ms step_avg:37.08ms
+step:27/1575 train_time:995ms step_avg:36.84ms
+step:28/1575 train_time:1034ms step_avg:36.92ms
+step:29/1575 train_time:1065ms step_avg:36.71ms
+step:30/1575 train_time:1103ms step_avg:36.78ms
+step:31/1575 train_time:1134ms step_avg:36.59ms
+step:32/1575 train_time:1173ms step_avg:36.66ms
+step:33/1575 train_time:1204ms step_avg:36.49ms
+step:34/1575 train_time:1243ms step_avg:36.56ms
+step:35/1575 train_time:1274ms step_avg:36.40ms
+step:36/1575 train_time:1313ms step_avg:36.46ms
+step:37/1575 train_time:1344ms step_avg:36.31ms
+step:38/1575 train_time:1382ms step_avg:36.37ms
+step:39/1575 train_time:1413ms step_avg:36.24ms
+step:40/1575 train_time:1452ms step_avg:36.30ms
+step:41/1575 train_time:1483ms step_avg:36.17ms
+step:42/1575 train_time:1522ms step_avg:36.25ms
+step:43/1575 train_time:1552ms step_avg:36.10ms
+step:44/1575 train_time:1592ms step_avg:36.17ms
+step:45/1575 train_time:1622ms step_avg:36.05ms
+step:46/1575 train_time:1661ms step_avg:36.11ms
+step:47/1575 train_time:1692ms step_avg:36.00ms
+step:48/1575 train_time:1731ms step_avg:36.06ms
+step:49/1575 train_time:1762ms step_avg:35.96ms
+step:50/1575 train_time:1801ms step_avg:36.02ms
+step:51/1575 train_time:1832ms step_avg:35.92ms
+step:52/1575 train_time:1871ms step_avg:35.98ms
+step:53/1575 train_time:1902ms step_avg:35.88ms
+step:54/1575 train_time:1941ms step_avg:35.94ms
+step:55/1575 train_time:1972ms step_avg:35.85ms
+step:56/1575 train_time:2011ms step_avg:35.90ms
+step:57/1575 train_time:2041ms step_avg:35.81ms
+step:58/1575 train_time:2080ms step_avg:35.86ms
+step:59/1575 train_time:2111ms step_avg:35.78ms
+step:60/1575 train_time:2150ms step_avg:35.83ms
+step:61/1575 train_time:2181ms step_avg:35.75ms
+step:62/1575 train_time:2220ms step_avg:35.80ms
+step:63/1575 train_time:2251ms step_avg:35.73ms
+step:64/1575 train_time:2290ms step_avg:35.77ms
+step:65/1575 train_time:2320ms step_avg:35.70ms
+step:66/1575 train_time:2359ms step_avg:35.75ms
+step:67/1575 train_time:2390ms step_avg:35.67ms
+step:68/1575 train_time:2429ms step_avg:35.71ms
+step:69/1575 train_time:2459ms step_avg:35.64ms
+step:70/1575 train_time:2498ms step_avg:35.69ms
+step:71/1575 train_time:2529ms step_avg:35.62ms
+step:72/1575 train_time:2568ms step_avg:35.67ms
+step:73/1575 train_time:2599ms step_avg:35.60ms
+step:74/1575 train_time:2638ms step_avg:35.64ms
+step:75/1575 train_time:2669ms step_avg:35.58ms
+step:76/1575 train_time:2707ms step_avg:35.62ms
+step:77/1575 train_time:2738ms step_avg:35.56ms
+step:78/1575 train_time:2777ms step_avg:35.60ms
+step:79/1575 train_time:2808ms step_avg:35.54ms
+step:80/1575 train_time:2847ms step_avg:35.58ms
+step:81/1575 train_time:2878ms step_avg:35.53ms
+step:82/1575 train_time:2916ms step_avg:35.57ms
+step:83/1575 train_time:2947ms step_avg:35.51ms
+step:84/1575 train_time:2986ms step_avg:35.55ms
+step:85/1575 train_time:3017ms step_avg:35.50ms
+step:86/1575 train_time:3056ms step_avg:35.53ms
+step:87/1575 train_time:3086ms step_avg:35.48ms
+step:88/1575 train_time:3125ms step_avg:35.51ms
+step:89/1575 train_time:3156ms step_avg:35.46ms
+step:90/1575 train_time:3194ms step_avg:35.49ms
+step:91/1575 train_time:3226ms step_avg:35.45ms
+step:92/1575 train_time:3265ms step_avg:35.48ms
+step:93/1575 train_time:3295ms step_avg:35.43ms
+step:94/1575 train_time:3334ms step_avg:35.47ms
+step:95/1575 train_time:3365ms step_avg:35.42ms
+step:96/1575 train_time:3404ms step_avg:35.46ms
+step:97/1575 train_time:3435ms step_avg:35.41ms
+step:98/1575 train_time:3473ms step_avg:35.44ms
+step:99/1575 train_time:3504ms step_avg:35.40ms
+step:100/1575 train_time:3543ms step_avg:35.43ms
+step:101/1575 train_time:3573ms step_avg:35.38ms
+step:102/1575 train_time:3612ms step_avg:35.42ms
+step:103/1575 train_time:3643ms step_avg:35.37ms
+step:104/1575 train_time:3682ms step_avg:35.41ms
+step:105/1575 train_time:3713ms step_avg:35.36ms
+step:106/1575 train_time:3752ms step_avg:35.39ms
+step:107/1575 train_time:3783ms step_avg:35.35ms
+step:108/1575 train_time:3821ms step_avg:35.38ms
+step:109/1575 train_time:3852ms step_avg:35.34ms
+step:110/1575 train_time:3891ms step_avg:35.37ms
+step:111/1575 train_time:3922ms step_avg:35.33ms
+step:112/1575 train_time:3961ms step_avg:35.36ms
+step:113/1575 train_time:3992ms step_avg:35.32ms
+step:114/1575 train_time:4031ms step_avg:35.36ms
+step:115/1575 train_time:4061ms step_avg:35.31ms
+step:116/1575 train_time:4100ms step_avg:35.34ms
+step:117/1575 train_time:4131ms step_avg:35.31ms
+step:118/1575 train_time:4169ms step_avg:35.33ms
+step:119/1575 train_time:4200ms step_avg:35.30ms
+step:120/1575 train_time:4239ms step_avg:35.32ms
+step:121/1575 train_time:4270ms step_avg:35.29ms
+step:122/1575 train_time:4308ms step_avg:35.31ms
+step:123/1575 train_time:4339ms step_avg:35.28ms
+step:124/1575 train_time:4378ms step_avg:35.31ms
+step:125/1575 train_time:4409ms step_avg:35.27ms
+step:126/1575 train_time:4447ms step_avg:35.30ms
+step:127/1575 train_time:4478ms step_avg:35.26ms
+step:128/1575 train_time:4517ms step_avg:35.29ms
+step:129/1575 train_time:4548ms step_avg:35.25ms
+step:130/1575 train_time:4586ms step_avg:35.28ms
+step:131/1575 train_time:4617ms step_avg:35.24ms
+step:132/1575 train_time:4656ms step_avg:35.27ms
+step:133/1575 train_time:4687ms step_avg:35.24ms
+step:134/1575 train_time:4725ms step_avg:35.26ms
+step:135/1575 train_time:4756ms step_avg:35.23ms
+step:136/1575 train_time:4795ms step_avg:35.25ms
+step:137/1575 train_time:4825ms step_avg:35.22ms
+step:138/1575 train_time:4864ms step_avg:35.25ms
+step:139/1575 train_time:4895ms step_avg:35.21ms
+step:140/1575 train_time:4934ms step_avg:35.24ms
+step:141/1575 train_time:4964ms step_avg:35.21ms
+step:142/1575 train_time:5004ms step_avg:35.24ms
+step:143/1575 train_time:5034ms step_avg:35.21ms
+step:144/1575 train_time:5073ms step_avg:35.23ms
+step:145/1575 train_time:5104ms step_avg:35.20ms
+step:146/1575 train_time:5143ms step_avg:35.22ms
+step:147/1575 train_time:5173ms step_avg:35.19ms
+step:148/1575 train_time:5212ms step_avg:35.22ms
+step:149/1575 train_time:5243ms step_avg:35.19ms
+step:150/1575 train_time:5281ms step_avg:35.21ms
+step:151/1575 train_time:5312ms step_avg:35.18ms
+step:152/1575 train_time:5351ms step_avg:35.21ms
+step:153/1575 train_time:5382ms step_avg:35.18ms
+step:154/1575 train_time:5421ms step_avg:35.20ms
+step:155/1575 train_time:5452ms step_avg:35.17ms
+step:156/1575 train_time:5491ms step_avg:35.20ms
+step:157/1575 train_time:5522ms step_avg:35.17ms
+step:158/1575 train_time:5560ms step_avg:35.19ms
+step:159/1575 train_time:5591ms step_avg:35.16ms
+step:160/1575 train_time:5630ms step_avg:35.19ms
+step:161/1575 train_time:5661ms step_avg:35.16ms
+step:162/1575 train_time:5700ms step_avg:35.18ms
+step:163/1575 train_time:5731ms step_avg:35.16ms
+step:164/1575 train_time:5769ms step_avg:35.18ms
+step:165/1575 train_time:5800ms step_avg:35.15ms
+step:166/1575 train_time:5840ms step_avg:35.18ms
+step:167/1575 train_time:5870ms step_avg:35.15ms
+step:168/1575 train_time:5908ms step_avg:35.17ms
+step:169/1575 train_time:5939ms step_avg:35.14ms
+step:170/1575 train_time:5978ms step_avg:35.16ms
+step:171/1575 train_time:6009ms step_avg:35.14ms
+step:172/1575 train_time:6047ms step_avg:35.16ms
+step:173/1575 train_time:6078ms step_avg:35.13ms
+step:174/1575 train_time:6117ms step_avg:35.16ms
+step:175/1575 train_time:6148ms step_avg:35.13ms
+step:176/1575 train_time:6186ms step_avg:35.15ms
+step:177/1575 train_time:6217ms step_avg:35.12ms
+step:178/1575 train_time:6256ms step_avg:35.14ms
+step:179/1575 train_time:6287ms step_avg:35.12ms
+step:180/1575 train_time:6325ms step_avg:35.14ms
+step:181/1575 train_time:6356ms step_avg:35.11ms
+step:182/1575 train_time:6394ms step_avg:35.13ms
+step:183/1575 train_time:6425ms step_avg:35.11ms
+step:184/1575 train_time:6464ms step_avg:35.13ms
+step:185/1575 train_time:6495ms step_avg:35.11ms
+step:186/1575 train_time:6534ms step_avg:35.13ms
+step:187/1575 train_time:6564ms step_avg:35.10ms
+step:188/1575 train_time:6603ms step_avg:35.12ms
+step:189/1575 train_time:6633ms step_avg:35.10ms
+step:190/1575 train_time:6673ms step_avg:35.12ms
+step:191/1575 train_time:6703ms step_avg:35.10ms
+step:192/1575 train_time:6742ms step_avg:35.12ms
+step:193/1575 train_time:6773ms step_avg:35.09ms
+step:194/1575 train_time:6812ms step_avg:35.11ms
+step:195/1575 train_time:6844ms step_avg:35.10ms
+step:196/1575 train_time:6883ms step_avg:35.12ms
+step:197/1575 train_time:6914ms step_avg:35.09ms
+step:198/1575 train_time:6952ms step_avg:35.11ms
+step:199/1575 train_time:6983ms step_avg:35.09ms
+step:200/1575 train_time:7022ms step_avg:35.11ms
+step:201/1575 train_time:7053ms step_avg:35.09ms
+step:202/1575 train_time:7092ms step_avg:35.11ms
+step:203/1575 train_time:7123ms step_avg:35.09ms
+step:204/1575 train_time:7161ms step_avg:35.10ms
+step:205/1575 train_time:7193ms step_avg:35.09ms
+step:206/1575 train_time:7231ms step_avg:35.10ms
+step:207/1575 train_time:7262ms step_avg:35.08ms
+step:208/1575 train_time:7301ms step_avg:35.10ms
+step:209/1575 train_time:7332ms step_avg:35.08ms
+step:210/1575 train_time:7371ms step_avg:35.10ms
+step:211/1575 train_time:7401ms step_avg:35.08ms
+step:212/1575 train_time:7440ms step_avg:35.09ms
+step:213/1575 train_time:7471ms step_avg:35.07ms
+step:214/1575 train_time:7510ms step_avg:35.09ms
+step:215/1575 train_time:7540ms step_avg:35.07ms
+step:216/1575 train_time:7579ms step_avg:35.09ms
+step:217/1575 train_time:7610ms step_avg:35.07ms
+step:218/1575 train_time:7649ms step_avg:35.09ms
+step:219/1575 train_time:7680ms step_avg:35.07ms
+step:220/1575 train_time:7718ms step_avg:35.08ms
+step:221/1575 train_time:7749ms step_avg:35.06ms
+step:222/1575 train_time:7788ms step_avg:35.08ms
+step:223/1575 train_time:7819ms step_avg:35.06ms
+step:224/1575 train_time:7857ms step_avg:35.08ms
+step:225/1575 train_time:7888ms step_avg:35.06ms
+step:226/1575 train_time:7926ms step_avg:35.07ms
+step:227/1575 train_time:7957ms step_avg:35.05ms
+step:228/1575 train_time:7996ms step_avg:35.07ms
+step:229/1575 train_time:8026ms step_avg:35.05ms
+step:230/1575 train_time:8065ms step_avg:35.07ms
+step:231/1575 train_time:8095ms step_avg:35.05ms
+step:232/1575 train_time:8134ms step_avg:35.06ms
+step:233/1575 train_time:8165ms step_avg:35.04ms
+step:234/1575 train_time:8204ms step_avg:35.06ms
+step:235/1575 train_time:8235ms step_avg:35.04ms
+step:236/1575 train_time:8274ms step_avg:35.06ms
+step:237/1575 train_time:8305ms step_avg:35.04ms
+step:238/1575 train_time:8344ms step_avg:35.06ms
+step:239/1575 train_time:8375ms step_avg:35.04ms
+step:240/1575 train_time:8413ms step_avg:35.05ms
+step:241/1575 train_time:8444ms step_avg:35.04ms
+step:242/1575 train_time:8483ms step_avg:35.05ms
+step:243/1575 train_time:8514ms step_avg:35.04ms
+step:244/1575 train_time:8553ms step_avg:35.05ms
+step:245/1575 train_time:8584ms step_avg:35.04ms
+step:246/1575 train_time:8622ms step_avg:35.05ms
+step:247/1575 train_time:8653ms step_avg:35.03ms
+step:248/1575 train_time:8691ms step_avg:35.05ms
+step:249/1575 train_time:8722ms step_avg:35.03ms
+step:250/1575 train_time:8761ms step_avg:35.05ms
+step:250/1575 val_loss:4.5770 train_time:8810ms step_avg:35.24ms
+step:251/1575 train_time:8830ms step_avg:35.18ms
+step:252/1575 train_time:8850ms step_avg:35.12ms
+step:253/1575 train_time:8867ms step_avg:35.05ms
+step:254/1575 train_time:8904ms step_avg:35.05ms
+step:255/1575 train_time:8936ms step_avg:35.04ms
+step:256/1575 train_time:8976ms step_avg:35.06ms
+step:257/1575 train_time:9008ms step_avg:35.05ms
+step:258/1575 train_time:9047ms step_avg:35.06ms
+step:259/1575 train_time:9078ms step_avg:35.05ms
+step:260/1575 train_time:9116ms step_avg:35.06ms
+step:261/1575 train_time:9147ms step_avg:35.05ms
+step:262/1575 train_time:9186ms step_avg:35.06ms
+step:263/1575 train_time:9216ms step_avg:35.04ms
+step:264/1575 train_time:9255ms step_avg:35.06ms
+step:265/1575 train_time:9286ms step_avg:35.04ms
+step:266/1575 train_time:9325ms step_avg:35.05ms
+step:267/1575 train_time:9356ms step_avg:35.04ms
+step:268/1575 train_time:9395ms step_avg:35.05ms
+step:269/1575 train_time:9426ms step_avg:35.04ms
+step:270/1575 train_time:9464ms step_avg:35.05ms
+step:271/1575 train_time:9495ms step_avg:35.04ms
+step:272/1575 train_time:9533ms step_avg:35.05ms
+step:273/1575 train_time:9564ms step_avg:35.03ms
+step:274/1575 train_time:9603ms step_avg:35.05ms
+step:275/1575 train_time:9633ms step_avg:35.03ms
+step:276/1575 train_time:9672ms step_avg:35.04ms
+step:277/1575 train_time:9703ms step_avg:35.03ms
+step:278/1575 train_time:9741ms step_avg:35.04ms
+step:279/1575 train_time:9772ms step_avg:35.03ms
+step:280/1575 train_time:9811ms step_avg:35.04ms
+step:281/1575 train_time:9841ms step_avg:35.02ms
+step:282/1575 train_time:9880ms step_avg:35.04ms
+step:283/1575 train_time:9911ms step_avg:35.02ms
+step:284/1575 train_time:9950ms step_avg:35.03ms
+step:285/1575 train_time:9980ms step_avg:35.02ms
+step:286/1575 train_time:10019ms step_avg:35.03ms
+step:287/1575 train_time:10050ms step_avg:35.02ms
+step:288/1575 train_time:10088ms step_avg:35.03ms
+step:289/1575 train_time:10119ms step_avg:35.01ms
+step:290/1575 train_time:10157ms step_avg:35.03ms
+step:291/1575 train_time:10188ms step_avg:35.01ms
+step:292/1575 train_time:10227ms step_avg:35.03ms
+step:293/1575 train_time:10258ms step_avg:35.01ms
+step:294/1575 train_time:10297ms step_avg:35.02ms
+step:295/1575 train_time:10328ms step_avg:35.01ms
+step:296/1575 train_time:10366ms step_avg:35.02ms
+step:297/1575 train_time:10397ms step_avg:35.01ms
+step:298/1575 train_time:10436ms step_avg:35.02ms
+step:299/1575 train_time:10467ms step_avg:35.01ms
+step:300/1575 train_time:10506ms step_avg:35.02ms
+step:301/1575 train_time:10537ms step_avg:35.01ms
+step:302/1575 train_time:10575ms step_avg:35.02ms
+step:303/1575 train_time:10606ms step_avg:35.00ms
+step:304/1575 train_time:10645ms step_avg:35.02ms
+step:305/1575 train_time:10676ms step_avg:35.00ms
+step:306/1575 train_time:10715ms step_avg:35.02ms
+step:307/1575 train_time:10745ms step_avg:35.00ms
+step:308/1575 train_time:10784ms step_avg:35.01ms
+step:309/1575 train_time:10814ms step_avg:35.00ms
+step:310/1575 train_time:10853ms step_avg:35.01ms
+step:311/1575 train_time:10884ms step_avg:35.00ms
+step:312/1575 train_time:10924ms step_avg:35.01ms
+step:313/1575 train_time:10954ms step_avg:35.00ms
+step:314/1575 train_time:10994ms step_avg:35.01ms
+step:315/1575 train_time:11024ms step_avg:35.00ms
+step:316/1575 train_time:11062ms step_avg:35.01ms
+step:317/1575 train_time:11093ms step_avg:34.99ms
+step:318/1575 train_time:11132ms step_avg:35.01ms
+step:319/1575 train_time:11163ms step_avg:34.99ms
+step:320/1575 train_time:11201ms step_avg:35.00ms
+step:321/1575 train_time:11232ms step_avg:34.99ms
+step:322/1575 train_time:11270ms step_avg:35.00ms
+step:323/1575 train_time:11301ms step_avg:34.99ms
+step:324/1575 train_time:11339ms step_avg:35.00ms
+step:325/1575 train_time:11370ms step_avg:34.98ms
+step:326/1575 train_time:11408ms step_avg:35.00ms
+step:327/1575 train_time:11439ms step_avg:34.98ms
+step:328/1575 train_time:11478ms step_avg:34.99ms
+step:329/1575 train_time:11509ms step_avg:34.98ms
+step:330/1575 train_time:11547ms step_avg:34.99ms
+step:331/1575 train_time:11577ms step_avg:34.98ms
+step:332/1575 train_time:11616ms step_avg:34.99ms
+step:333/1575 train_time:11647ms step_avg:34.98ms
+step:334/1575 train_time:11686ms step_avg:34.99ms
+step:335/1575 train_time:11717ms step_avg:34.97ms
+step:336/1575 train_time:11755ms step_avg:34.99ms
+step:337/1575 train_time:11786ms step_avg:34.97ms
+step:338/1575 train_time:11825ms step_avg:34.98ms
+step:339/1575 train_time:11855ms step_avg:34.97ms
+step:340/1575 train_time:11894ms step_avg:34.98ms
+step:341/1575 train_time:11925ms step_avg:34.97ms
+step:342/1575 train_time:11963ms step_avg:34.98ms
+step:343/1575 train_time:11994ms step_avg:34.97ms
+step:344/1575 train_time:12033ms step_avg:34.98ms
+step:345/1575 train_time:12064ms step_avg:34.97ms
+step:346/1575 train_time:12102ms step_avg:34.98ms
+step:347/1575 train_time:12133ms step_avg:34.96ms
+step:348/1575 train_time:12172ms step_avg:34.98ms
+step:349/1575 train_time:12202ms step_avg:34.96ms
+step:350/1575 train_time:12241ms step_avg:34.97ms
+step:351/1575 train_time:12272ms step_avg:34.96ms
+step:352/1575 train_time:12310ms step_avg:34.97ms
+step:353/1575 train_time:12341ms step_avg:34.96ms
+step:354/1575 train_time:12379ms step_avg:34.97ms
+step:355/1575 train_time:12410ms step_avg:34.96ms
+step:356/1575 train_time:12449ms step_avg:34.97ms
+step:357/1575 train_time:12480ms step_avg:34.96ms
+step:358/1575 train_time:12518ms step_avg:34.97ms
+step:359/1575 train_time:12549ms step_avg:34.95ms
+step:360/1575 train_time:12588ms step_avg:34.97ms
+step:361/1575 train_time:12618ms step_avg:34.95ms
+step:362/1575 train_time:12657ms step_avg:34.96ms
+step:363/1575 train_time:12687ms step_avg:34.95ms
+step:364/1575 train_time:12726ms step_avg:34.96ms
+step:365/1575 train_time:12756ms step_avg:34.95ms
+step:366/1575 train_time:12795ms step_avg:34.96ms
+step:367/1575 train_time:12826ms step_avg:34.95ms
+step:368/1575 train_time:12864ms step_avg:34.96ms
+step:369/1575 train_time:12895ms step_avg:34.95ms
+step:370/1575 train_time:12934ms step_avg:34.96ms
+step:371/1575 train_time:12965ms step_avg:34.95ms
+step:372/1575 train_time:13004ms step_avg:34.96ms
+step:373/1575 train_time:13035ms step_avg:34.95ms
+step:374/1575 train_time:13073ms step_avg:34.96ms
+step:375/1575 train_time:13104ms step_avg:34.94ms
+step:376/1575 train_time:13143ms step_avg:34.95ms
+step:377/1575 train_time:13173ms step_avg:34.94ms
+step:378/1575 train_time:13212ms step_avg:34.95ms
+step:379/1575 train_time:13242ms step_avg:34.94ms
+step:380/1575 train_time:13281ms step_avg:34.95ms
+step:381/1575 train_time:13312ms step_avg:34.94ms
+step:382/1575 train_time:13350ms step_avg:34.95ms
+step:383/1575 train_time:13381ms step_avg:34.94ms
+step:384/1575 train_time:13420ms step_avg:34.95ms
+step:385/1575 train_time:13451ms step_avg:34.94ms
+step:386/1575 train_time:13489ms step_avg:34.95ms
+step:387/1575 train_time:13520ms step_avg:34.94ms
+step:388/1575 train_time:13558ms step_avg:34.94ms
+step:389/1575 train_time:13589ms step_avg:34.93ms
+step:390/1575 train_time:13628ms step_avg:34.94ms
+step:391/1575 train_time:13659ms step_avg:34.93ms
+step:392/1575 train_time:13697ms step_avg:34.94ms
+step:393/1575 train_time:13728ms step_avg:34.93ms
+step:394/1575 train_time:13766ms step_avg:34.94ms
+step:395/1575 train_time:13797ms step_avg:34.93ms
+step:396/1575 train_time:13836ms step_avg:34.94ms
+step:397/1575 train_time:13867ms step_avg:34.93ms
+step:398/1575 train_time:13906ms step_avg:34.94ms
+step:399/1575 train_time:13936ms step_avg:34.93ms
+step:400/1575 train_time:13975ms step_avg:34.94ms
+step:401/1575 train_time:14006ms step_avg:34.93ms
+step:402/1575 train_time:14044ms step_avg:34.94ms
+step:403/1575 train_time:14075ms step_avg:34.93ms
+step:404/1575 train_time:14114ms step_avg:34.94ms
+step:405/1575 train_time:14145ms step_avg:34.93ms
+step:406/1575 train_time:14184ms step_avg:34.93ms
+step:407/1575 train_time:14215ms step_avg:34.93ms
+step:408/1575 train_time:14253ms step_avg:34.93ms
+step:409/1575 train_time:14284ms step_avg:34.92ms
+step:410/1575 train_time:14322ms step_avg:34.93ms
+step:411/1575 train_time:14353ms step_avg:34.92ms
+step:412/1575 train_time:14391ms step_avg:34.93ms
+step:413/1575 train_time:14422ms step_avg:34.92ms
+step:414/1575 train_time:14460ms step_avg:34.93ms
+step:415/1575 train_time:14491ms step_avg:34.92ms
+step:416/1575 train_time:14530ms step_avg:34.93ms
+step:417/1575 train_time:14561ms step_avg:34.92ms
+step:418/1575 train_time:14599ms step_avg:34.93ms
+step:419/1575 train_time:14630ms step_avg:34.92ms
+step:420/1575 train_time:14668ms step_avg:34.92ms
+step:421/1575 train_time:14699ms step_avg:34.91ms
+step:422/1575 train_time:14738ms step_avg:34.92ms
+step:423/1575 train_time:14768ms step_avg:34.91ms
+step:424/1575 train_time:14808ms step_avg:34.92ms
+step:425/1575 train_time:14838ms step_avg:34.91ms
+step:426/1575 train_time:14877ms step_avg:34.92ms
+step:427/1575 train_time:14908ms step_avg:34.91ms
+step:428/1575 train_time:14946ms step_avg:34.92ms
+step:429/1575 train_time:14977ms step_avg:34.91ms
+step:430/1575 train_time:15016ms step_avg:34.92ms
+step:431/1575 train_time:15047ms step_avg:34.91ms
+step:432/1575 train_time:15085ms step_avg:34.92ms
+step:433/1575 train_time:15116ms step_avg:34.91ms
+step:434/1575 train_time:15154ms step_avg:34.92ms
+step:435/1575 train_time:15185ms step_avg:34.91ms
+step:436/1575 train_time:15224ms step_avg:34.92ms
+step:437/1575 train_time:15255ms step_avg:34.91ms
+step:438/1575 train_time:15293ms step_avg:34.92ms
+step:439/1575 train_time:15324ms step_avg:34.91ms
+step:440/1575 train_time:15363ms step_avg:34.92ms
+step:441/1575 train_time:15394ms step_avg:34.91ms
+step:442/1575 train_time:15432ms step_avg:34.91ms
+step:443/1575 train_time:15463ms step_avg:34.91ms
+step:444/1575 train_time:15502ms step_avg:34.91ms
+step:445/1575 train_time:15532ms step_avg:34.90ms
+step:446/1575 train_time:15571ms step_avg:34.91ms
+step:447/1575 train_time:15601ms step_avg:34.90ms
+step:448/1575 train_time:15640ms step_avg:34.91ms
+step:449/1575 train_time:15671ms step_avg:34.90ms
+step:450/1575 train_time:15710ms step_avg:34.91ms
+step:451/1575 train_time:15740ms step_avg:34.90ms
+step:452/1575 train_time:15779ms step_avg:34.91ms
+step:453/1575 train_time:15810ms step_avg:34.90ms
+step:454/1575 train_time:15848ms step_avg:34.91ms
+step:455/1575 train_time:15879ms step_avg:34.90ms
+step:456/1575 train_time:15917ms step_avg:34.91ms
+step:457/1575 train_time:15948ms step_avg:34.90ms
+step:458/1575 train_time:15987ms step_avg:34.91ms
+step:459/1575 train_time:16017ms step_avg:34.90ms
+step:460/1575 train_time:16056ms step_avg:34.91ms
+step:461/1575 train_time:16087ms step_avg:34.89ms
+step:462/1575 train_time:16126ms step_avg:34.90ms
+step:463/1575 train_time:16156ms step_avg:34.89ms
+step:464/1575 train_time:16194ms step_avg:34.90ms
+step:465/1575 train_time:16225ms step_avg:34.89ms
+step:466/1575 train_time:16264ms step_avg:34.90ms
+step:467/1575 train_time:16295ms step_avg:34.89ms
+step:468/1575 train_time:16334ms step_avg:34.90ms
+step:469/1575 train_time:16364ms step_avg:34.89ms
+step:470/1575 train_time:16403ms step_avg:34.90ms
+step:471/1575 train_time:16434ms step_avg:34.89ms
+step:472/1575 train_time:16473ms step_avg:34.90ms
+step:473/1575 train_time:16503ms step_avg:34.89ms
+step:474/1575 train_time:16542ms step_avg:34.90ms
+step:475/1575 train_time:16573ms step_avg:34.89ms
+step:476/1575 train_time:16611ms step_avg:34.90ms
+step:477/1575 train_time:16642ms step_avg:34.89ms
+step:478/1575 train_time:16680ms step_avg:34.90ms
+step:479/1575 train_time:16711ms step_avg:34.89ms
+step:480/1575 train_time:16749ms step_avg:34.89ms
+step:481/1575 train_time:16780ms step_avg:34.89ms
+step:482/1575 train_time:16819ms step_avg:34.89ms
+step:483/1575 train_time:16850ms step_avg:34.89ms
+step:484/1575 train_time:16888ms step_avg:34.89ms
+step:485/1575 train_time:16919ms step_avg:34.88ms
+step:486/1575 train_time:16957ms step_avg:34.89ms
+step:487/1575 train_time:16989ms step_avg:34.88ms
+step:488/1575 train_time:17028ms step_avg:34.89ms
+step:489/1575 train_time:17058ms step_avg:34.88ms
+step:490/1575 train_time:17097ms step_avg:34.89ms
+step:491/1575 train_time:17128ms step_avg:34.88ms
+step:492/1575 train_time:17167ms step_avg:34.89ms
+step:493/1575 train_time:17197ms step_avg:34.88ms
+step:494/1575 train_time:17236ms step_avg:34.89ms
+step:495/1575 train_time:17266ms step_avg:34.88ms
+step:496/1575 train_time:17305ms step_avg:34.89ms
+step:497/1575 train_time:17335ms step_avg:34.88ms
+step:498/1575 train_time:17374ms step_avg:34.89ms
+step:499/1575 train_time:17405ms step_avg:34.88ms
+step:500/1575 train_time:17444ms step_avg:34.89ms
+step:500/1575 val_loss:4.2260 train_time:17492ms step_avg:34.98ms
+step:501/1575 train_time:17512ms step_avg:34.95ms
+step:502/1575 train_time:17532ms step_avg:34.92ms
+step:503/1575 train_time:17550ms step_avg:34.89ms
+step:504/1575 train_time:17587ms step_avg:34.89ms
+step:505/1575 train_time:17619ms step_avg:34.89ms
+step:506/1575 train_time:17659ms step_avg:34.90ms
+step:507/1575 train_time:17690ms step_avg:34.89ms
+step:508/1575 train_time:17729ms step_avg:34.90ms
+step:509/1575 train_time:17760ms step_avg:34.89ms
+step:510/1575 train_time:17798ms step_avg:34.90ms
+step:511/1575 train_time:17829ms step_avg:34.89ms
+step:512/1575 train_time:17867ms step_avg:34.90ms
+step:513/1575 train_time:17940ms step_avg:34.97ms
+step:514/1575 train_time:17996ms step_avg:35.01ms
+step:515/1575 train_time:18058ms step_avg:35.06ms
+step:516/1575 train_time:18117ms step_avg:35.11ms
+step:517/1575 train_time:18180ms step_avg:35.16ms
+step:518/1575 train_time:18238ms step_avg:35.21ms
+step:519/1575 train_time:18301ms step_avg:35.26ms
+step:520/1575 train_time:18360ms step_avg:35.31ms
+step:521/1575 train_time:18422ms step_avg:35.36ms
+step:522/1575 train_time:18483ms step_avg:35.41ms
+step:523/1575 train_time:18548ms step_avg:35.46ms
+step:524/1575 train_time:18609ms step_avg:35.51ms
+step:525/1575 train_time:18673ms step_avg:35.57ms
+step:526/1575 train_time:18733ms step_avg:35.61ms
+step:527/1575 train_time:18799ms step_avg:35.67ms
+step:528/1575 train_time:18859ms step_avg:35.72ms
+step:529/1575 train_time:18922ms step_avg:35.77ms
+step:530/1575 train_time:18981ms step_avg:35.81ms
+step:531/1575 train_time:19044ms step_avg:35.86ms
+step:532/1575 train_time:19103ms step_avg:35.91ms
+step:533/1575 train_time:19166ms step_avg:35.96ms
+step:534/1575 train_time:19225ms step_avg:36.00ms
+step:535/1575 train_time:19289ms step_avg:36.05ms
+step:536/1575 train_time:19349ms step_avg:36.10ms
+step:537/1575 train_time:19411ms step_avg:36.15ms
+step:538/1575 train_time:19471ms step_avg:36.19ms
+step:539/1575 train_time:19535ms step_avg:36.24ms
+step:540/1575 train_time:19594ms step_avg:36.29ms
+step:541/1575 train_time:19659ms step_avg:36.34ms
+step:542/1575 train_time:19719ms step_avg:36.38ms
+step:543/1575 train_time:19783ms step_avg:36.43ms
+step:544/1575 train_time:19843ms step_avg:36.48ms
+step:545/1575 train_time:19906ms step_avg:36.52ms
+step:546/1575 train_time:19966ms step_avg:36.57ms
+step:547/1575 train_time:20029ms step_avg:36.62ms
+step:548/1575 train_time:20088ms step_avg:36.66ms
+step:549/1575 train_time:20152ms step_avg:36.71ms
+step:550/1575 train_time:20211ms step_avg:36.75ms
+step:551/1575 train_time:20274ms step_avg:36.80ms
+step:552/1575 train_time:20335ms step_avg:36.84ms
+step:553/1575 train_time:20399ms step_avg:36.89ms
+step:554/1575 train_time:20456ms step_avg:36.92ms
+step:555/1575 train_time:20520ms step_avg:36.97ms
+step:556/1575 train_time:20579ms step_avg:37.01ms
+step:557/1575 train_time:20643ms step_avg:37.06ms
+step:558/1575 train_time:20702ms step_avg:37.10ms
+step:559/1575 train_time:20766ms step_avg:37.15ms
+step:560/1575 train_time:20826ms step_avg:37.19ms
+step:561/1575 train_time:20889ms step_avg:37.24ms
+step:562/1575 train_time:20949ms step_avg:37.28ms
+step:563/1575 train_time:21013ms step_avg:37.32ms
+step:564/1575 train_time:21072ms step_avg:37.36ms
+step:565/1575 train_time:21136ms step_avg:37.41ms
+step:566/1575 train_time:21196ms step_avg:37.45ms
+step:567/1575 train_time:21259ms step_avg:37.49ms
+step:568/1575 train_time:21318ms step_avg:37.53ms
+step:569/1575 train_time:21385ms step_avg:37.58ms
+step:570/1575 train_time:21442ms step_avg:37.62ms
+step:571/1575 train_time:21506ms step_avg:37.66ms
+step:572/1575 train_time:21565ms step_avg:37.70ms
+step:573/1575 train_time:21628ms step_avg:37.74ms
+step:574/1575 train_time:21686ms step_avg:37.78ms
+step:575/1575 train_time:21750ms step_avg:37.83ms
+step:576/1575 train_time:21810ms step_avg:37.86ms
+step:577/1575 train_time:21874ms step_avg:37.91ms
+step:578/1575 train_time:21932ms step_avg:37.95ms
+step:579/1575 train_time:21996ms step_avg:37.99ms
+step:580/1575 train_time:22055ms step_avg:38.03ms
+step:581/1575 train_time:22118ms step_avg:38.07ms
+step:582/1575 train_time:22177ms step_avg:38.11ms
+step:583/1575 train_time:22241ms step_avg:38.15ms
+step:584/1575 train_time:22300ms step_avg:38.19ms
+step:585/1575 train_time:22364ms step_avg:38.23ms
+step:586/1575 train_time:22423ms step_avg:38.26ms
+step:587/1575 train_time:22487ms step_avg:38.31ms
+step:588/1575 train_time:22546ms step_avg:38.34ms
+step:589/1575 train_time:22609ms step_avg:38.39ms
+step:590/1575 train_time:22668ms step_avg:38.42ms
+step:591/1575 train_time:22731ms step_avg:38.46ms
+step:592/1575 train_time:22791ms step_avg:38.50ms
+step:593/1575 train_time:22856ms step_avg:38.54ms
+step:594/1575 train_time:22914ms step_avg:38.58ms
+step:595/1575 train_time:22977ms step_avg:38.62ms
+step:596/1575 train_time:23036ms step_avg:38.65ms
+step:597/1575 train_time:23099ms step_avg:38.69ms
+step:598/1575 train_time:23158ms step_avg:38.73ms
+step:599/1575 train_time:23222ms step_avg:38.77ms
+step:600/1575 train_time:23282ms step_avg:38.80ms
+step:601/1575 train_time:23345ms step_avg:38.84ms
+step:602/1575 train_time:23404ms step_avg:38.88ms
+step:603/1575 train_time:23467ms step_avg:38.92ms
+step:604/1575 train_time:23527ms step_avg:38.95ms
+step:605/1575 train_time:23590ms step_avg:38.99ms
+step:606/1575 train_time:23649ms step_avg:39.02ms
+step:607/1575 train_time:23713ms step_avg:39.07ms
+step:608/1575 train_time:23772ms step_avg:39.10ms
+step:609/1575 train_time:23835ms step_avg:39.14ms
+step:610/1575 train_time:23895ms step_avg:39.17ms
+step:611/1575 train_time:23959ms step_avg:39.21ms
+step:612/1575 train_time:24017ms step_avg:39.24ms
+step:613/1575 train_time:24081ms step_avg:39.28ms
+step:614/1575 train_time:24140ms step_avg:39.32ms
+step:615/1575 train_time:24204ms step_avg:39.36ms
+step:616/1575 train_time:24263ms step_avg:39.39ms
+step:617/1575 train_time:24326ms step_avg:39.43ms
+step:618/1575 train_time:24385ms step_avg:39.46ms
+step:619/1575 train_time:24448ms step_avg:39.50ms
+step:620/1575 train_time:24507ms step_avg:39.53ms
+step:621/1575 train_time:24571ms step_avg:39.57ms
+step:622/1575 train_time:24630ms step_avg:39.60ms
+step:623/1575 train_time:24693ms step_avg:39.64ms
+step:624/1575 train_time:24752ms step_avg:39.67ms
+step:625/1575 train_time:24816ms step_avg:39.71ms
+step:626/1575 train_time:24876ms step_avg:39.74ms
+step:627/1575 train_time:24939ms step_avg:39.78ms
+step:628/1575 train_time:24998ms step_avg:39.81ms
+step:629/1575 train_time:25062ms step_avg:39.84ms
+step:630/1575 train_time:25121ms step_avg:39.87ms
+step:631/1575 train_time:25184ms step_avg:39.91ms
+step:632/1575 train_time:25243ms step_avg:39.94ms
+step:633/1575 train_time:25306ms step_avg:39.98ms
+step:634/1575 train_time:25367ms step_avg:40.01ms
+step:635/1575 train_time:25431ms step_avg:40.05ms
+step:636/1575 train_time:25490ms step_avg:40.08ms
+step:637/1575 train_time:25552ms step_avg:40.11ms
+step:638/1575 train_time:25611ms step_avg:40.14ms
+step:639/1575 train_time:25674ms step_avg:40.18ms
+step:640/1575 train_time:25734ms step_avg:40.21ms
+step:641/1575 train_time:25798ms step_avg:40.25ms
+step:642/1575 train_time:25858ms step_avg:40.28ms
+step:643/1575 train_time:25921ms step_avg:40.31ms
+step:644/1575 train_time:25980ms step_avg:40.34ms
+step:645/1575 train_time:26043ms step_avg:40.38ms
+step:646/1575 train_time:26102ms step_avg:40.41ms
+step:647/1575 train_time:26165ms step_avg:40.44ms
+step:648/1575 train_time:26225ms step_avg:40.47ms
+step:649/1575 train_time:26288ms step_avg:40.51ms
+step:650/1575 train_time:26347ms step_avg:40.53ms
+step:651/1575 train_time:26410ms step_avg:40.57ms
+step:652/1575 train_time:26470ms step_avg:40.60ms
+step:653/1575 train_time:26533ms step_avg:40.63ms
+step:654/1575 train_time:26592ms step_avg:40.66ms
+step:655/1575 train_time:26657ms step_avg:40.70ms
+step:656/1575 train_time:26716ms step_avg:40.73ms
+step:657/1575 train_time:26779ms step_avg:40.76ms
+step:658/1575 train_time:26838ms step_avg:40.79ms
+step:659/1575 train_time:26902ms step_avg:40.82ms
+step:660/1575 train_time:26961ms step_avg:40.85ms
+step:661/1575 train_time:27024ms step_avg:40.88ms
+step:662/1575 train_time:27084ms step_avg:40.91ms
+step:663/1575 train_time:27147ms step_avg:40.95ms
+step:664/1575 train_time:27207ms step_avg:40.97ms
+step:665/1575 train_time:27270ms step_avg:41.01ms
+step:666/1575 train_time:27330ms step_avg:41.04ms
+step:667/1575 train_time:27394ms step_avg:41.07ms
+step:668/1575 train_time:27453ms step_avg:41.10ms
+step:669/1575 train_time:27517ms step_avg:41.13ms
+step:670/1575 train_time:27576ms step_avg:41.16ms
+step:671/1575 train_time:27639ms step_avg:41.19ms
+step:672/1575 train_time:27698ms step_avg:41.22ms
+step:673/1575 train_time:27761ms step_avg:41.25ms
+step:674/1575 train_time:27821ms step_avg:41.28ms
+step:675/1575 train_time:27885ms step_avg:41.31ms
+step:676/1575 train_time:27944ms step_avg:41.34ms
+step:677/1575 train_time:28007ms step_avg:41.37ms
+step:678/1575 train_time:28067ms step_avg:41.40ms
+step:679/1575 train_time:28130ms step_avg:41.43ms
+step:680/1575 train_time:28189ms step_avg:41.45ms
+step:681/1575 train_time:28253ms step_avg:41.49ms
+step:682/1575 train_time:28312ms step_avg:41.51ms
+step:683/1575 train_time:28376ms step_avg:41.55ms
+step:684/1575 train_time:28435ms step_avg:41.57ms
+step:685/1575 train_time:28499ms step_avg:41.60ms
+step:686/1575 train_time:28558ms step_avg:41.63ms
+step:687/1575 train_time:28621ms step_avg:41.66ms
+step:688/1575 train_time:28680ms step_avg:41.69ms
+step:689/1575 train_time:28743ms step_avg:41.72ms
+step:690/1575 train_time:28803ms step_avg:41.74ms
+step:691/1575 train_time:28867ms step_avg:41.78ms
+step:692/1575 train_time:28926ms step_avg:41.80ms
+step:693/1575 train_time:28990ms step_avg:41.83ms
+step:694/1575 train_time:29048ms step_avg:41.86ms
+step:695/1575 train_time:29111ms step_avg:41.89ms
+step:696/1575 train_time:29170ms step_avg:41.91ms
+step:697/1575 train_time:29233ms step_avg:41.94ms
+step:698/1575 train_time:29293ms step_avg:41.97ms
+step:699/1575 train_time:29357ms step_avg:42.00ms
+step:700/1575 train_time:29416ms step_avg:42.02ms
+step:701/1575 train_time:29479ms step_avg:42.05ms
+step:702/1575 train_time:29538ms step_avg:42.08ms
+step:703/1575 train_time:29602ms step_avg:42.11ms
+step:704/1575 train_time:29661ms step_avg:42.13ms
+step:705/1575 train_time:29725ms step_avg:42.16ms
+step:706/1575 train_time:29784ms step_avg:42.19ms
+step:707/1575 train_time:29848ms step_avg:42.22ms
+step:708/1575 train_time:29907ms step_avg:42.24ms
+step:709/1575 train_time:29970ms step_avg:42.27ms
+step:710/1575 train_time:30029ms step_avg:42.29ms
+step:711/1575 train_time:30094ms step_avg:42.33ms
+step:712/1575 train_time:30153ms step_avg:42.35ms
+step:713/1575 train_time:30217ms step_avg:42.38ms
+step:714/1575 train_time:30276ms step_avg:42.40ms
+step:715/1575 train_time:30339ms step_avg:42.43ms
+step:716/1575 train_time:30399ms step_avg:42.46ms
+step:717/1575 train_time:30462ms step_avg:42.49ms
+step:718/1575 train_time:30522ms step_avg:42.51ms
+step:719/1575 train_time:30588ms step_avg:42.54ms
+step:720/1575 train_time:30646ms step_avg:42.56ms
+step:721/1575 train_time:30708ms step_avg:42.59ms
+step:722/1575 train_time:30768ms step_avg:42.61ms
+step:723/1575 train_time:30832ms step_avg:42.64ms
+step:724/1575 train_time:30891ms step_avg:42.67ms
+step:725/1575 train_time:30954ms step_avg:42.70ms
+step:726/1575 train_time:31014ms step_avg:42.72ms
+step:727/1575 train_time:31078ms step_avg:42.75ms
+step:728/1575 train_time:31137ms step_avg:42.77ms
+step:729/1575 train_time:31201ms step_avg:42.80ms
+step:730/1575 train_time:31260ms step_avg:42.82ms
+step:731/1575 train_time:31322ms step_avg:42.85ms
+step:732/1575 train_time:31381ms step_avg:42.87ms
+step:733/1575 train_time:31445ms step_avg:42.90ms
+step:734/1575 train_time:31505ms step_avg:42.92ms
+step:735/1575 train_time:31567ms step_avg:42.95ms
+step:736/1575 train_time:31627ms step_avg:42.97ms
+step:737/1575 train_time:31690ms step_avg:43.00ms
+step:738/1575 train_time:31749ms step_avg:43.02ms
+step:739/1575 train_time:31812ms step_avg:43.05ms
+step:740/1575 train_time:31872ms step_avg:43.07ms
+step:741/1575 train_time:31934ms step_avg:43.10ms
+step:742/1575 train_time:31994ms step_avg:43.12ms
+step:743/1575 train_time:32057ms step_avg:43.15ms
+step:744/1575 train_time:32117ms step_avg:43.17ms
+step:745/1575 train_time:32180ms step_avg:43.19ms
+step:746/1575 train_time:32241ms step_avg:43.22ms
+step:747/1575 train_time:32303ms step_avg:43.24ms
+step:748/1575 train_time:32364ms step_avg:43.27ms
+step:749/1575 train_time:32427ms step_avg:43.29ms
+step:750/1575 train_time:32485ms step_avg:43.31ms
+step:750/1575 val_loss:3.8823 train_time:32531ms step_avg:43.37ms
+step:751/1575 train_time:32552ms step_avg:43.34ms
+step:752/1575 train_time:32610ms step_avg:43.37ms
+step:753/1575 train_time:32678ms step_avg:43.40ms
+step:754/1575 train_time:32741ms step_avg:43.42ms
+step:755/1575 train_time:32804ms step_avg:43.45ms
+step:756/1575 train_time:32864ms step_avg:43.47ms
+step:757/1575 train_time:32928ms step_avg:43.50ms
+step:758/1575 train_time:32987ms step_avg:43.52ms
+step:759/1575 train_time:33049ms step_avg:43.54ms
+step:760/1575 train_time:33108ms step_avg:43.56ms
+step:761/1575 train_time:33179ms step_avg:43.60ms
+step:762/1575 train_time:33240ms step_avg:43.62ms
+step:763/1575 train_time:33303ms step_avg:43.65ms
+step:764/1575 train_time:33360ms step_avg:43.66ms
+step:765/1575 train_time:33423ms step_avg:43.69ms
+step:766/1575 train_time:33481ms step_avg:43.71ms
+step:767/1575 train_time:33543ms step_avg:43.73ms
+step:768/1575 train_time:33604ms step_avg:43.76ms
+step:769/1575 train_time:33670ms step_avg:43.78ms
+step:770/1575 train_time:33730ms step_avg:43.81ms
+step:771/1575 train_time:33796ms step_avg:43.83ms
+step:772/1575 train_time:33847ms step_avg:43.84ms
+step:773/1575 train_time:33910ms step_avg:43.87ms
+step:774/1575 train_time:33969ms step_avg:43.89ms
+step:775/1575 train_time:34032ms step_avg:43.91ms
+step:776/1575 train_time:34091ms step_avg:43.93ms
+step:777/1575 train_time:34155ms step_avg:43.96ms
+step:778/1575 train_time:34214ms step_avg:43.98ms
+step:779/1575 train_time:34276ms step_avg:44.00ms
+step:780/1575 train_time:34335ms step_avg:44.02ms
+step:781/1575 train_time:34398ms step_avg:44.04ms
+step:782/1575 train_time:34457ms step_avg:44.06ms
+step:783/1575 train_time:34520ms step_avg:44.09ms
+step:784/1575 train_time:34580ms step_avg:44.11ms
+step:785/1575 train_time:34644ms step_avg:44.13ms
+step:786/1575 train_time:34704ms step_avg:44.15ms
+step:787/1575 train_time:34767ms step_avg:44.18ms
+step:788/1575 train_time:34828ms step_avg:44.20ms
+step:789/1575 train_time:34892ms step_avg:44.22ms
+step:790/1575 train_time:34950ms step_avg:44.24ms
+step:791/1575 train_time:35013ms step_avg:44.26ms
+step:792/1575 train_time:35072ms step_avg:44.28ms
+step:793/1575 train_time:35136ms step_avg:44.31ms
+step:794/1575 train_time:35195ms step_avg:44.33ms
+step:795/1575 train_time:35257ms step_avg:44.35ms
+step:796/1575 train_time:35317ms step_avg:44.37ms
+step:797/1575 train_time:35380ms step_avg:44.39ms
+step:798/1575 train_time:35440ms step_avg:44.41ms
+step:799/1575 train_time:35503ms step_avg:44.43ms
+step:800/1575 train_time:35561ms step_avg:44.45ms
+step:801/1575 train_time:35625ms step_avg:44.48ms
+step:802/1575 train_time:35685ms step_avg:44.50ms
+step:803/1575 train_time:35749ms step_avg:44.52ms
+step:804/1575 train_time:35808ms step_avg:44.54ms
+step:805/1575 train_time:35872ms step_avg:44.56ms
+step:806/1575 train_time:35934ms step_avg:44.58ms
+step:807/1575 train_time:35995ms step_avg:44.60ms
+step:808/1575 train_time:36055ms step_avg:44.62ms
+step:809/1575 train_time:36117ms step_avg:44.64ms
+step:810/1575 train_time:36176ms step_avg:44.66ms
+step:811/1575 train_time:36239ms step_avg:44.68ms
+step:812/1575 train_time:36298ms step_avg:44.70ms
+step:813/1575 train_time:36361ms step_avg:44.72ms
+step:814/1575 train_time:36420ms step_avg:44.74ms
+step:815/1575 train_time:36484ms step_avg:44.77ms
+step:816/1575 train_time:36544ms step_avg:44.78ms
+step:817/1575 train_time:36606ms step_avg:44.81ms
+step:818/1575 train_time:36666ms step_avg:44.82ms
+step:819/1575 train_time:36729ms step_avg:44.85ms
+step:820/1575 train_time:36789ms step_avg:44.86ms
+step:821/1575 train_time:36853ms step_avg:44.89ms
+step:822/1575 train_time:36912ms step_avg:44.91ms
+step:823/1575 train_time:36975ms step_avg:44.93ms
+step:824/1575 train_time:37035ms step_avg:44.95ms
+step:825/1575 train_time:37098ms step_avg:44.97ms
+step:826/1575 train_time:37158ms step_avg:44.99ms
+step:827/1575 train_time:37221ms step_avg:45.01ms
+step:828/1575 train_time:37281ms step_avg:45.03ms
+step:829/1575 train_time:37343ms step_avg:45.05ms
+step:830/1575 train_time:37403ms step_avg:45.06ms
+step:831/1575 train_time:37466ms step_avg:45.09ms
+step:832/1575 train_time:37525ms step_avg:45.10ms
+step:833/1575 train_time:37589ms step_avg:45.12ms
+step:834/1575 train_time:37648ms step_avg:45.14ms
+step:835/1575 train_time:37712ms step_avg:45.16ms
+step:836/1575 train_time:37771ms step_avg:45.18ms
+step:837/1575 train_time:37835ms step_avg:45.20ms
+step:838/1575 train_time:37895ms step_avg:45.22ms
+step:839/1575 train_time:37958ms step_avg:45.24ms
+step:840/1575 train_time:38017ms step_avg:45.26ms
+step:841/1575 train_time:38080ms step_avg:45.28ms
+step:842/1575 train_time:38140ms step_avg:45.30ms
+step:843/1575 train_time:38203ms step_avg:45.32ms
+step:844/1575 train_time:38262ms step_avg:45.33ms
+step:845/1575 train_time:38325ms step_avg:45.36ms
+step:846/1575 train_time:38384ms step_avg:45.37ms
+step:847/1575 train_time:38448ms step_avg:45.39ms
+step:848/1575 train_time:38508ms step_avg:45.41ms
+step:849/1575 train_time:38571ms step_avg:45.43ms
+step:850/1575 train_time:38630ms step_avg:45.45ms
+step:851/1575 train_time:38693ms step_avg:45.47ms
+step:852/1575 train_time:38753ms step_avg:45.48ms
+step:853/1575 train_time:38816ms step_avg:45.50ms
+step:854/1575 train_time:38875ms step_avg:45.52ms
+step:855/1575 train_time:38938ms step_avg:45.54ms
+step:856/1575 train_time:38997ms step_avg:45.56ms
+step:857/1575 train_time:39061ms step_avg:45.58ms
+step:858/1575 train_time:39121ms step_avg:45.60ms
+step:859/1575 train_time:39184ms step_avg:45.62ms
+step:860/1575 train_time:39243ms step_avg:45.63ms
+step:861/1575 train_time:39307ms step_avg:45.65ms
+step:862/1575 train_time:39367ms step_avg:45.67ms
+step:863/1575 train_time:39430ms step_avg:45.69ms
+step:864/1575 train_time:39489ms step_avg:45.70ms
+step:865/1575 train_time:39552ms step_avg:45.73ms
+step:866/1575 train_time:39611ms step_avg:45.74ms
+step:867/1575 train_time:39675ms step_avg:45.76ms
+step:868/1575 train_time:39734ms step_avg:45.78ms
+step:869/1575 train_time:39797ms step_avg:45.80ms
+step:870/1575 train_time:39857ms step_avg:45.81ms
+step:871/1575 train_time:39921ms step_avg:45.83ms
+step:872/1575 train_time:39980ms step_avg:45.85ms
+step:873/1575 train_time:40043ms step_avg:45.87ms
+step:874/1575 train_time:40101ms step_avg:45.88ms
+step:875/1575 train_time:40165ms step_avg:45.90ms
+step:876/1575 train_time:40224ms step_avg:45.92ms
+step:877/1575 train_time:40288ms step_avg:45.94ms
+step:878/1575 train_time:40347ms step_avg:45.95ms
+step:879/1575 train_time:40410ms step_avg:45.97ms
+step:880/1575 train_time:40469ms step_avg:45.99ms
+step:881/1575 train_time:40533ms step_avg:46.01ms
+step:882/1575 train_time:40592ms step_avg:46.02ms
+step:883/1575 train_time:40655ms step_avg:46.04ms
+step:884/1575 train_time:40715ms step_avg:46.06ms
+step:885/1575 train_time:40780ms step_avg:46.08ms
+step:886/1575 train_time:40845ms step_avg:46.10ms
+step:887/1575 train_time:40904ms step_avg:46.11ms
+step:888/1575 train_time:40964ms step_avg:46.13ms
+step:889/1575 train_time:41026ms step_avg:46.15ms
+step:890/1575 train_time:41085ms step_avg:46.16ms
+step:891/1575 train_time:41147ms step_avg:46.18ms
+step:892/1575 train_time:41206ms step_avg:46.20ms
+step:893/1575 train_time:41271ms step_avg:46.22ms
+step:894/1575 train_time:41330ms step_avg:46.23ms
+step:895/1575 train_time:41393ms step_avg:46.25ms
+step:896/1575 train_time:41452ms step_avg:46.26ms
+step:897/1575 train_time:41516ms step_avg:46.28ms
+step:898/1575 train_time:41575ms step_avg:46.30ms
+step:899/1575 train_time:41638ms step_avg:46.32ms
+step:900/1575 train_time:41697ms step_avg:46.33ms
+step:901/1575 train_time:41760ms step_avg:46.35ms
+step:902/1575 train_time:41819ms step_avg:46.36ms
+step:903/1575 train_time:41883ms step_avg:46.38ms
+step:904/1575 train_time:41942ms step_avg:46.40ms
+step:905/1575 train_time:42007ms step_avg:46.42ms
+step:906/1575 train_time:42065ms step_avg:46.43ms
+step:907/1575 train_time:42129ms step_avg:46.45ms
+step:908/1575 train_time:42189ms step_avg:46.46ms
+step:909/1575 train_time:42252ms step_avg:46.48ms
+step:910/1575 train_time:42311ms step_avg:46.50ms
+step:911/1575 train_time:42375ms step_avg:46.51ms
+step:912/1575 train_time:42435ms step_avg:46.53ms
+step:913/1575 train_time:42498ms step_avg:46.55ms
+step:914/1575 train_time:42558ms step_avg:46.56ms
+step:915/1575 train_time:42621ms step_avg:46.58ms
+step:916/1575 train_time:42681ms step_avg:46.59ms
+step:917/1575 train_time:42744ms step_avg:46.61ms
+step:918/1575 train_time:42803ms step_avg:46.63ms
+step:919/1575 train_time:42868ms step_avg:46.65ms
+step:920/1575 train_time:42927ms step_avg:46.66ms
+step:921/1575 train_time:42990ms step_avg:46.68ms
+step:922/1575 train_time:43050ms step_avg:46.69ms
+step:923/1575 train_time:43113ms step_avg:46.71ms
+step:924/1575 train_time:43173ms step_avg:46.72ms
+step:925/1575 train_time:43236ms step_avg:46.74ms
+step:926/1575 train_time:43296ms step_avg:46.76ms
+step:927/1575 train_time:43359ms step_avg:46.77ms
+step:928/1575 train_time:43418ms step_avg:46.79ms
+step:929/1575 train_time:43482ms step_avg:46.81ms
+step:930/1575 train_time:43542ms step_avg:46.82ms
+step:931/1575 train_time:43606ms step_avg:46.84ms
+step:932/1575 train_time:43665ms step_avg:46.85ms
+step:933/1575 train_time:43730ms step_avg:46.87ms
+step:934/1575 train_time:43789ms step_avg:46.88ms
+step:935/1575 train_time:43853ms step_avg:46.90ms
+step:936/1575 train_time:43912ms step_avg:46.91ms
+step:937/1575 train_time:43976ms step_avg:46.93ms
+step:938/1575 train_time:44035ms step_avg:46.95ms
+step:939/1575 train_time:44099ms step_avg:46.96ms
+step:940/1575 train_time:44158ms step_avg:46.98ms
+step:941/1575 train_time:44222ms step_avg:46.99ms
+step:942/1575 train_time:44281ms step_avg:47.01ms
+step:943/1575 train_time:44345ms step_avg:47.03ms
+step:944/1575 train_time:44404ms step_avg:47.04ms
+step:945/1575 train_time:44468ms step_avg:47.06ms
+step:946/1575 train_time:44528ms step_avg:47.07ms
+step:947/1575 train_time:44591ms step_avg:47.09ms
+step:948/1575 train_time:44650ms step_avg:47.10ms
+step:949/1575 train_time:44714ms step_avg:47.12ms
+step:950/1575 train_time:44774ms step_avg:47.13ms
+step:951/1575 train_time:44837ms step_avg:47.15ms
+step:952/1575 train_time:44897ms step_avg:47.16ms
+step:953/1575 train_time:44961ms step_avg:47.18ms
+step:954/1575 train_time:45021ms step_avg:47.19ms
+step:955/1575 train_time:45085ms step_avg:47.21ms
+step:956/1575 train_time:45143ms step_avg:47.22ms
+step:957/1575 train_time:45207ms step_avg:47.24ms
+step:958/1575 train_time:45266ms step_avg:47.25ms
+step:959/1575 train_time:45330ms step_avg:47.27ms
+step:960/1575 train_time:45389ms step_avg:47.28ms
+step:961/1575 train_time:45452ms step_avg:47.30ms
+step:962/1575 train_time:45512ms step_avg:47.31ms
+step:963/1575 train_time:45575ms step_avg:47.33ms
+step:964/1575 train_time:45635ms step_avg:47.34ms
+step:965/1575 train_time:45698ms step_avg:47.36ms
+step:966/1575 train_time:45757ms step_avg:47.37ms
+step:967/1575 train_time:45819ms step_avg:47.38ms
+step:968/1575 train_time:45879ms step_avg:47.40ms
+step:969/1575 train_time:45942ms step_avg:47.41ms
+step:970/1575 train_time:46001ms step_avg:47.42ms
+step:971/1575 train_time:46065ms step_avg:47.44ms
+step:972/1575 train_time:46124ms step_avg:47.45ms
+step:973/1575 train_time:46188ms step_avg:47.47ms
+step:974/1575 train_time:46247ms step_avg:47.48ms
+step:975/1575 train_time:46311ms step_avg:47.50ms
+step:976/1575 train_time:46370ms step_avg:47.51ms
+step:977/1575 train_time:46434ms step_avg:47.53ms
+step:978/1575 train_time:46493ms step_avg:47.54ms
+step:979/1575 train_time:46556ms step_avg:47.55ms
+step:980/1575 train_time:46615ms step_avg:47.57ms
+step:981/1575 train_time:46679ms step_avg:47.58ms
+step:982/1575 train_time:46739ms step_avg:47.60ms
+step:983/1575 train_time:46802ms step_avg:47.61ms
+step:984/1575 train_time:46861ms step_avg:47.62ms
+step:985/1575 train_time:46924ms step_avg:47.64ms
+step:986/1575 train_time:46983ms step_avg:47.65ms
+step:987/1575 train_time:47047ms step_avg:47.67ms
+step:988/1575 train_time:47106ms step_avg:47.68ms
+step:989/1575 train_time:47171ms step_avg:47.70ms
+step:990/1575 train_time:47230ms step_avg:47.71ms
+step:991/1575 train_time:47293ms step_avg:47.72ms
+step:992/1575 train_time:47353ms step_avg:47.73ms
+step:993/1575 train_time:47417ms step_avg:47.75ms
+step:994/1575 train_time:47476ms step_avg:47.76ms
+step:995/1575 train_time:47539ms step_avg:47.78ms
+step:996/1575 train_time:47598ms step_avg:47.79ms
+step:997/1575 train_time:47661ms step_avg:47.80ms
+step:998/1575 train_time:47720ms step_avg:47.82ms
+step:999/1575 train_time:47784ms step_avg:47.83ms
+step:1000/1575 train_time:47844ms step_avg:47.84ms
+step:1000/1575 val_loss:3.5812 train_time:47889ms step_avg:47.89ms
+step:1001/1575 train_time:47910ms step_avg:47.86ms
+step:1002/1575 train_time:47969ms step_avg:47.87ms
+step:1003/1575 train_time:48035ms step_avg:47.89ms
+step:1004/1575 train_time:48097ms step_avg:47.91ms
+step:1005/1575 train_time:48159ms step_avg:47.92ms
+step:1006/1575 train_time:48218ms step_avg:47.93ms
+step:1007/1575 train_time:48281ms step_avg:47.95ms
+step:1008/1575 train_time:48341ms step_avg:47.96ms
+step:1009/1575 train_time:48404ms step_avg:47.97ms
+step:1010/1575 train_time:48462ms step_avg:47.98ms
+step:1011/1575 train_time:48525ms step_avg:48.00ms
+step:1012/1575 train_time:48584ms step_avg:48.01ms
+step:1013/1575 train_time:48648ms step_avg:48.02ms
+step:1014/1575 train_time:48705ms step_avg:48.03ms
+step:1015/1575 train_time:48768ms step_avg:48.05ms
+step:1016/1575 train_time:48827ms step_avg:48.06ms
+step:1017/1575 train_time:48891ms step_avg:48.07ms
+step:1018/1575 train_time:48952ms step_avg:48.09ms
+step:1019/1575 train_time:49017ms step_avg:48.10ms
+step:1020/1575 train_time:49077ms step_avg:48.11ms
+step:1021/1575 train_time:49142ms step_avg:48.13ms
+step:1022/1575 train_time:49200ms step_avg:48.14ms
+step:1023/1575 train_time:49265ms step_avg:48.16ms
+step:1024/1575 train_time:49324ms step_avg:48.17ms
+step:1025/1575 train_time:49396ms step_avg:48.19ms
+step:1026/1575 train_time:49477ms step_avg:48.22ms
+step:1027/1575 train_time:49567ms step_avg:48.26ms
+step:1028/1575 train_time:49653ms step_avg:48.30ms
+step:1029/1575 train_time:49741ms step_avg:48.34ms
+step:1030/1575 train_time:49826ms step_avg:48.38ms
+step:1031/1575 train_time:49917ms step_avg:48.42ms
+step:1032/1575 train_time:50003ms step_avg:48.45ms
+step:1033/1575 train_time:50096ms step_avg:48.50ms
+step:1034/1575 train_time:50182ms step_avg:48.53ms
+step:1035/1575 train_time:50271ms step_avg:48.57ms
+step:1036/1575 train_time:50357ms step_avg:48.61ms
+step:1037/1575 train_time:50447ms step_avg:48.65ms
+step:1038/1575 train_time:50531ms step_avg:48.68ms
+step:1039/1575 train_time:50620ms step_avg:48.72ms
+step:1040/1575 train_time:50705ms step_avg:48.75ms
+step:1041/1575 train_time:50794ms step_avg:48.79ms
+step:1042/1575 train_time:50880ms step_avg:48.83ms
+step:1043/1575 train_time:50971ms step_avg:48.87ms
+step:1044/1575 train_time:51057ms step_avg:48.90ms
+step:1045/1575 train_time:51148ms step_avg:48.95ms
+step:1046/1575 train_time:51233ms step_avg:48.98ms
+step:1047/1575 train_time:51322ms step_avg:49.02ms
+step:1048/1575 train_time:51408ms step_avg:49.05ms
+step:1049/1575 train_time:51498ms step_avg:49.09ms
+step:1050/1575 train_time:51584ms step_avg:49.13ms
+step:1051/1575 train_time:51672ms step_avg:49.16ms
+step:1052/1575 train_time:51757ms step_avg:49.20ms
+step:1053/1575 train_time:51846ms step_avg:49.24ms
+step:1054/1575 train_time:51933ms step_avg:49.27ms
+step:1055/1575 train_time:52023ms step_avg:49.31ms
+step:1056/1575 train_time:52111ms step_avg:49.35ms
+step:1057/1575 train_time:52200ms step_avg:49.39ms
+step:1058/1575 train_time:52286ms step_avg:49.42ms
+step:1059/1575 train_time:52376ms step_avg:49.46ms
+step:1060/1575 train_time:52463ms step_avg:49.49ms
+step:1061/1575 train_time:52552ms step_avg:49.53ms
+step:1062/1575 train_time:52637ms step_avg:49.56ms
+step:1063/1575 train_time:52725ms step_avg:49.60ms
+step:1064/1575 train_time:52811ms step_avg:49.63ms
+step:1065/1575 train_time:52900ms step_avg:49.67ms
+step:1066/1575 train_time:52987ms step_avg:49.71ms
+step:1067/1575 train_time:53076ms step_avg:49.74ms
+step:1068/1575 train_time:53163ms step_avg:49.78ms
+step:1069/1575 train_time:53252ms step_avg:49.82ms
+step:1070/1575 train_time:53339ms step_avg:49.85ms
+step:1071/1575 train_time:53429ms step_avg:49.89ms
+step:1072/1575 train_time:53514ms step_avg:49.92ms
+step:1073/1575 train_time:53603ms step_avg:49.96ms
+step:1074/1575 train_time:53689ms step_avg:49.99ms
+step:1075/1575 train_time:53778ms step_avg:50.03ms
+step:1076/1575 train_time:53864ms step_avg:50.06ms
+step:1077/1575 train_time:53954ms step_avg:50.10ms
+step:1078/1575 train_time:54040ms step_avg:50.13ms
+step:1079/1575 train_time:54131ms step_avg:50.17ms
+step:1080/1575 train_time:54216ms step_avg:50.20ms
+step:1081/1575 train_time:54306ms step_avg:50.24ms
+step:1082/1575 train_time:54393ms step_avg:50.27ms
+step:1083/1575 train_time:54482ms step_avg:50.31ms
+step:1084/1575 train_time:54568ms step_avg:50.34ms
+step:1085/1575 train_time:54657ms step_avg:50.38ms
+step:1086/1575 train_time:54743ms step_avg:50.41ms
+step:1087/1575 train_time:54832ms step_avg:50.44ms
+step:1088/1575 train_time:54920ms step_avg:50.48ms
+step:1089/1575 train_time:55008ms step_avg:50.51ms
+step:1090/1575 train_time:55094ms step_avg:50.55ms
+step:1091/1575 train_time:55185ms step_avg:50.58ms
+step:1092/1575 train_time:55270ms step_avg:50.61ms
+step:1093/1575 train_time:55359ms step_avg:50.65ms
+step:1094/1575 train_time:55445ms step_avg:50.68ms
+step:1095/1575 train_time:55536ms step_avg:50.72ms
+step:1096/1575 train_time:55621ms step_avg:50.75ms
+step:1097/1575 train_time:55710ms step_avg:50.78ms
+step:1098/1575 train_time:55795ms step_avg:50.82ms
+step:1099/1575 train_time:55885ms step_avg:50.85ms
+step:1100/1575 train_time:55971ms step_avg:50.88ms
+step:1101/1575 train_time:56061ms step_avg:50.92ms
+step:1102/1575 train_time:56147ms step_avg:50.95ms
+step:1103/1575 train_time:56236ms step_avg:50.98ms
+step:1104/1575 train_time:56322ms step_avg:51.02ms
+step:1105/1575 train_time:56412ms step_avg:51.05ms
+step:1106/1575 train_time:56497ms step_avg:51.08ms
+step:1107/1575 train_time:56588ms step_avg:51.12ms
+step:1108/1575 train_time:56673ms step_avg:51.15ms
+step:1109/1575 train_time:56762ms step_avg:51.18ms
+step:1110/1575 train_time:56849ms step_avg:51.21ms
+step:1111/1575 train_time:56938ms step_avg:51.25ms
+step:1112/1575 train_time:57029ms step_avg:51.28ms
+step:1113/1575 train_time:57119ms step_avg:51.32ms
+step:1114/1575 train_time:57201ms step_avg:51.35ms
+step:1115/1575 train_time:57290ms step_avg:51.38ms
+step:1116/1575 train_time:57375ms step_avg:51.41ms
+step:1117/1575 train_time:57465ms step_avg:51.45ms
+step:1118/1575 train_time:57550ms step_avg:51.48ms
+step:1119/1575 train_time:57639ms step_avg:51.51ms
+step:1120/1575 train_time:57726ms step_avg:51.54ms
+step:1121/1575 train_time:57814ms step_avg:51.57ms
+step:1122/1575 train_time:57900ms step_avg:51.60ms
+step:1123/1575 train_time:57990ms step_avg:51.64ms
+step:1124/1575 train_time:58075ms step_avg:51.67ms
+step:1125/1575 train_time:58165ms step_avg:51.70ms
+step:1126/1575 train_time:58251ms step_avg:51.73ms
+step:1127/1575 train_time:58340ms step_avg:51.77ms
+step:1128/1575 train_time:58426ms step_avg:51.80ms
+step:1129/1575 train_time:58515ms step_avg:51.83ms
+step:1130/1575 train_time:58601ms step_avg:51.86ms
+step:1131/1575 train_time:58691ms step_avg:51.89ms
+step:1132/1575 train_time:58776ms step_avg:51.92ms
+step:1133/1575 train_time:58865ms step_avg:51.96ms
+step:1134/1575 train_time:58950ms step_avg:51.98ms
+step:1135/1575 train_time:59040ms step_avg:52.02ms
+step:1136/1575 train_time:59127ms step_avg:52.05ms
+step:1137/1575 train_time:59217ms step_avg:52.08ms
+step:1138/1575 train_time:59302ms step_avg:52.11ms
+step:1139/1575 train_time:59392ms step_avg:52.14ms
+step:1140/1575 train_time:59477ms step_avg:52.17ms
+step:1141/1575 train_time:59568ms step_avg:52.21ms
+step:1142/1575 train_time:59653ms step_avg:52.24ms
+step:1143/1575 train_time:59743ms step_avg:52.27ms
+step:1144/1575 train_time:59828ms step_avg:52.30ms
+step:1145/1575 train_time:59918ms step_avg:52.33ms
+step:1146/1575 train_time:60008ms step_avg:52.36ms
+step:1147/1575 train_time:60096ms step_avg:52.39ms
+step:1148/1575 train_time:60183ms step_avg:52.42ms
+step:1149/1575 train_time:60272ms step_avg:52.46ms
+step:1150/1575 train_time:60358ms step_avg:52.48ms
+step:1151/1575 train_time:60447ms step_avg:52.52ms
+step:1152/1575 train_time:60533ms step_avg:52.55ms
+step:1153/1575 train_time:60622ms step_avg:52.58ms
+step:1154/1575 train_time:60708ms step_avg:52.61ms
+step:1155/1575 train_time:60797ms step_avg:52.64ms
+step:1156/1575 train_time:60884ms step_avg:52.67ms
+step:1157/1575 train_time:60973ms step_avg:52.70ms
+step:1158/1575 train_time:61059ms step_avg:52.73ms
+step:1159/1575 train_time:61150ms step_avg:52.76ms
+step:1160/1575 train_time:61236ms step_avg:52.79ms
+step:1161/1575 train_time:61326ms step_avg:52.82ms
+step:1162/1575 train_time:61412ms step_avg:52.85ms
+step:1163/1575 train_time:61501ms step_avg:52.88ms
+step:1164/1575 train_time:61587ms step_avg:52.91ms
+step:1165/1575 train_time:61676ms step_avg:52.94ms
+step:1166/1575 train_time:61763ms step_avg:52.97ms
+step:1167/1575 train_time:61851ms step_avg:53.00ms
+step:1168/1575 train_time:61937ms step_avg:53.03ms
+step:1169/1575 train_time:62027ms step_avg:53.06ms
+step:1170/1575 train_time:62113ms step_avg:53.09ms
+step:1171/1575 train_time:62203ms step_avg:53.12ms
+step:1172/1575 train_time:62288ms step_avg:53.15ms
+step:1173/1575 train_time:62378ms step_avg:53.18ms
+step:1174/1575 train_time:62464ms step_avg:53.21ms
+step:1175/1575 train_time:62553ms step_avg:53.24ms
+step:1176/1575 train_time:62639ms step_avg:53.26ms
+step:1177/1575 train_time:62729ms step_avg:53.30ms
+step:1178/1575 train_time:62814ms step_avg:53.32ms
+step:1179/1575 train_time:62904ms step_avg:53.35ms
+step:1180/1575 train_time:62990ms step_avg:53.38ms
+step:1181/1575 train_time:63079ms step_avg:53.41ms
+step:1182/1575 train_time:63166ms step_avg:53.44ms
+step:1183/1575 train_time:63253ms step_avg:53.47ms
+step:1184/1575 train_time:63340ms step_avg:53.50ms
+step:1185/1575 train_time:63430ms step_avg:53.53ms
+step:1186/1575 train_time:63515ms step_avg:53.55ms
+step:1187/1575 train_time:63604ms step_avg:53.58ms
+step:1188/1575 train_time:63691ms step_avg:53.61ms
+step:1189/1575 train_time:63780ms step_avg:53.64ms
+step:1190/1575 train_time:63865ms step_avg:53.67ms
+step:1191/1575 train_time:63955ms step_avg:53.70ms
+step:1192/1575 train_time:64041ms step_avg:53.73ms
+step:1193/1575 train_time:64131ms step_avg:53.76ms
+step:1194/1575 train_time:64216ms step_avg:53.78ms
+step:1195/1575 train_time:64307ms step_avg:53.81ms
+step:1196/1575 train_time:64393ms step_avg:53.84ms
+step:1197/1575 train_time:64483ms step_avg:53.87ms
+step:1198/1575 train_time:64568ms step_avg:53.90ms
+step:1199/1575 train_time:64660ms step_avg:53.93ms
+step:1200/1575 train_time:64745ms step_avg:53.95ms
+step:1201/1575 train_time:64833ms step_avg:53.98ms
+step:1202/1575 train_time:64919ms step_avg:54.01ms
+step:1203/1575 train_time:65009ms step_avg:54.04ms
+step:1204/1575 train_time:65096ms step_avg:54.07ms
+step:1205/1575 train_time:65185ms step_avg:54.10ms
+step:1206/1575 train_time:65270ms step_avg:54.12ms
+step:1207/1575 train_time:65360ms step_avg:54.15ms
+step:1208/1575 train_time:65446ms step_avg:54.18ms
+step:1209/1575 train_time:65535ms step_avg:54.21ms
+step:1210/1575 train_time:65622ms step_avg:54.23ms
+step:1211/1575 train_time:65712ms step_avg:54.26ms
+step:1212/1575 train_time:65797ms step_avg:54.29ms
+step:1213/1575 train_time:65887ms step_avg:54.32ms
+step:1214/1575 train_time:65972ms step_avg:54.34ms
+step:1215/1575 train_time:66062ms step_avg:54.37ms
+step:1216/1575 train_time:66148ms step_avg:54.40ms
+step:1217/1575 train_time:66238ms step_avg:54.43ms
+step:1218/1575 train_time:66325ms step_avg:54.45ms
+step:1219/1575 train_time:66413ms step_avg:54.48ms
+step:1220/1575 train_time:66499ms step_avg:54.51ms
+step:1221/1575 train_time:66588ms step_avg:54.54ms
+step:1222/1575 train_time:66675ms step_avg:54.56ms
+step:1223/1575 train_time:66764ms step_avg:54.59ms
+step:1224/1575 train_time:66850ms step_avg:54.62ms
+step:1225/1575 train_time:66939ms step_avg:54.64ms
+step:1226/1575 train_time:67024ms step_avg:54.67ms
+step:1227/1575 train_time:67114ms step_avg:54.70ms
+step:1228/1575 train_time:67200ms step_avg:54.72ms
+step:1229/1575 train_time:67291ms step_avg:54.75ms
+step:1230/1575 train_time:67376ms step_avg:54.78ms
+step:1231/1575 train_time:67465ms step_avg:54.81ms
+step:1232/1575 train_time:67551ms step_avg:54.83ms
+step:1233/1575 train_time:67641ms step_avg:54.86ms
+step:1234/1575 train_time:67727ms step_avg:54.88ms
+step:1235/1575 train_time:67816ms step_avg:54.91ms
+step:1236/1575 train_time:67902ms step_avg:54.94ms
+step:1237/1575 train_time:67991ms step_avg:54.96ms
+step:1238/1575 train_time:68077ms step_avg:54.99ms
+step:1239/1575 train_time:68168ms step_avg:55.02ms
+step:1240/1575 train_time:68252ms step_avg:55.04ms
+step:1241/1575 train_time:68342ms step_avg:55.07ms
+step:1242/1575 train_time:68427ms step_avg:55.09ms
+step:1243/1575 train_time:68516ms step_avg:55.12ms
+step:1244/1575 train_time:68603ms step_avg:55.15ms
+step:1245/1575 train_time:68693ms step_avg:55.17ms
+step:1246/1575 train_time:68779ms step_avg:55.20ms
+step:1247/1575 train_time:68868ms step_avg:55.23ms
+step:1248/1575 train_time:68954ms step_avg:55.25ms
+step:1249/1575 train_time:69043ms step_avg:55.28ms
+step:1250/1575 train_time:69129ms step_avg:55.30ms
+step:1250/1575 val_loss:3.4043 train_time:69202ms step_avg:55.36ms
+step:1251/1575 train_time:69223ms step_avg:55.33ms
+step:1252/1575 train_time:69310ms step_avg:55.36ms
+step:1253/1575 train_time:69402ms step_avg:55.39ms
+step:1254/1575 train_time:69489ms step_avg:55.41ms
+step:1255/1575 train_time:69578ms step_avg:55.44ms
+step:1256/1575 train_time:69662ms step_avg:55.46ms
+step:1257/1575 train_time:69749ms step_avg:55.49ms
+step:1258/1575 train_time:69835ms step_avg:55.51ms
+step:1259/1575 train_time:69924ms step_avg:55.54ms
+step:1260/1575 train_time:70009ms step_avg:55.56ms
+step:1261/1575 train_time:70098ms step_avg:55.59ms
+step:1262/1575 train_time:70184ms step_avg:55.61ms
+step:1263/1575 train_time:70275ms step_avg:55.64ms
+step:1264/1575 train_time:70363ms step_avg:55.67ms
+step:1265/1575 train_time:70453ms step_avg:55.69ms
+step:1266/1575 train_time:70540ms step_avg:55.72ms
+step:1267/1575 train_time:70628ms step_avg:55.74ms
+step:1268/1575 train_time:70713ms step_avg:55.77ms
+step:1269/1575 train_time:70803ms step_avg:55.79ms
+step:1270/1575 train_time:70888ms step_avg:55.82ms
+step:1271/1575 train_time:70976ms step_avg:55.84ms
+step:1272/1575 train_time:71062ms step_avg:55.87ms
+step:1273/1575 train_time:71150ms step_avg:55.89ms
+step:1274/1575 train_time:71238ms step_avg:55.92ms
+step:1275/1575 train_time:71328ms step_avg:55.94ms
+step:1276/1575 train_time:71415ms step_avg:55.97ms
+step:1277/1575 train_time:71506ms step_avg:56.00ms
+step:1278/1575 train_time:71592ms step_avg:56.02ms
+step:1279/1575 train_time:71681ms step_avg:56.04ms
+step:1280/1575 train_time:71766ms step_avg:56.07ms
+step:1281/1575 train_time:71855ms step_avg:56.09ms
+step:1282/1575 train_time:71940ms step_avg:56.12ms
+step:1283/1575 train_time:72029ms step_avg:56.14ms
+step:1284/1575 train_time:72114ms step_avg:56.16ms
+step:1285/1575 train_time:72204ms step_avg:56.19ms
+step:1286/1575 train_time:72292ms step_avg:56.21ms
+step:1287/1575 train_time:72381ms step_avg:56.24ms
+step:1288/1575 train_time:72467ms step_avg:56.26ms
+step:1289/1575 train_time:72557ms step_avg:56.29ms
+step:1290/1575 train_time:72643ms step_avg:56.31ms
+step:1291/1575 train_time:72732ms step_avg:56.34ms
+step:1292/1575 train_time:72818ms step_avg:56.36ms
+step:1293/1575 train_time:72907ms step_avg:56.39ms
+step:1294/1575 train_time:72992ms step_avg:56.41ms
+step:1295/1575 train_time:73083ms step_avg:56.43ms
+step:1296/1575 train_time:73168ms step_avg:56.46ms
+step:1297/1575 train_time:73257ms step_avg:56.48ms
+step:1298/1575 train_time:73344ms step_avg:56.51ms
+step:1299/1575 train_time:73434ms step_avg:56.53ms
+step:1300/1575 train_time:73520ms step_avg:56.55ms
+step:1301/1575 train_time:73609ms step_avg:56.58ms
+step:1302/1575 train_time:73696ms step_avg:56.60ms
+step:1303/1575 train_time:73787ms step_avg:56.63ms
+step:1304/1575 train_time:73871ms step_avg:56.65ms
+step:1305/1575 train_time:73961ms step_avg:56.68ms
+step:1306/1575 train_time:74048ms step_avg:56.70ms
+step:1307/1575 train_time:74136ms step_avg:56.72ms
+step:1308/1575 train_time:74222ms step_avg:56.74ms
+step:1309/1575 train_time:74312ms step_avg:56.77ms
+step:1310/1575 train_time:74399ms step_avg:56.79ms
+step:1311/1575 train_time:74488ms step_avg:56.82ms
+step:1312/1575 train_time:74574ms step_avg:56.84ms
+step:1313/1575 train_time:74664ms step_avg:56.86ms
+step:1314/1575 train_time:74750ms step_avg:56.89ms
+step:1315/1575 train_time:74840ms step_avg:56.91ms
+step:1316/1575 train_time:74925ms step_avg:56.93ms
+step:1317/1575 train_time:75014ms step_avg:56.96ms
+step:1318/1575 train_time:75100ms step_avg:56.98ms
+step:1319/1575 train_time:75190ms step_avg:57.01ms
+step:1320/1575 train_time:75276ms step_avg:57.03ms
+step:1321/1575 train_time:75367ms step_avg:57.05ms
+step:1322/1575 train_time:75453ms step_avg:57.07ms
+step:1323/1575 train_time:75543ms step_avg:57.10ms
+step:1324/1575 train_time:75629ms step_avg:57.12ms
+step:1325/1575 train_time:75719ms step_avg:57.15ms
+step:1326/1575 train_time:75804ms step_avg:57.17ms
+step:1327/1575 train_time:75894ms step_avg:57.19ms
+step:1328/1575 train_time:75980ms step_avg:57.21ms
+step:1329/1575 train_time:76069ms step_avg:57.24ms
+step:1330/1575 train_time:76155ms step_avg:57.26ms
+step:1331/1575 train_time:76244ms step_avg:57.28ms
+step:1332/1575 train_time:76330ms step_avg:57.30ms
+step:1333/1575 train_time:76420ms step_avg:57.33ms
+step:1334/1575 train_time:76505ms step_avg:57.35ms
+step:1335/1575 train_time:76595ms step_avg:57.37ms
+step:1336/1575 train_time:76681ms step_avg:57.40ms
+step:1337/1575 train_time:76770ms step_avg:57.42ms
+step:1338/1575 train_time:76855ms step_avg:57.44ms
+step:1339/1575 train_time:76945ms step_avg:57.46ms
+step:1340/1575 train_time:77031ms step_avg:57.49ms
+step:1341/1575 train_time:77122ms step_avg:57.51ms
+step:1342/1575 train_time:77207ms step_avg:57.53ms
+step:1343/1575 train_time:77296ms step_avg:57.56ms
+step:1344/1575 train_time:77381ms step_avg:57.58ms
+step:1345/1575 train_time:77471ms step_avg:57.60ms
+step:1346/1575 train_time:77559ms step_avg:57.62ms
+step:1347/1575 train_time:77648ms step_avg:57.64ms
+step:1348/1575 train_time:77734ms step_avg:57.67ms
+step:1349/1575 train_time:77823ms step_avg:57.69ms
+step:1350/1575 train_time:77909ms step_avg:57.71ms
+step:1351/1575 train_time:77999ms step_avg:57.73ms
+step:1352/1575 train_time:78084ms step_avg:57.75ms
+step:1353/1575 train_time:78174ms step_avg:57.78ms
+step:1354/1575 train_time:78260ms step_avg:57.80ms
+step:1355/1575 train_time:78349ms step_avg:57.82ms
+step:1356/1575 train_time:78435ms step_avg:57.84ms
+step:1357/1575 train_time:78525ms step_avg:57.87ms
+step:1358/1575 train_time:78615ms step_avg:57.89ms
+step:1359/1575 train_time:78703ms step_avg:57.91ms
+step:1360/1575 train_time:78789ms step_avg:57.93ms
+step:1361/1575 train_time:78877ms step_avg:57.96ms
+step:1362/1575 train_time:78963ms step_avg:57.98ms
+step:1363/1575 train_time:79052ms step_avg:58.00ms
+step:1364/1575 train_time:79141ms step_avg:58.02ms
+step:1365/1575 train_time:79228ms step_avg:58.04ms
+step:1366/1575 train_time:79313ms step_avg:58.06ms
+step:1367/1575 train_time:79403ms step_avg:58.09ms
+step:1368/1575 train_time:79489ms step_avg:58.11ms
+step:1369/1575 train_time:79579ms step_avg:58.13ms
+step:1370/1575 train_time:79664ms step_avg:58.15ms
+step:1371/1575 train_time:79754ms step_avg:58.17ms
+step:1372/1575 train_time:79840ms step_avg:58.19ms
+step:1373/1575 train_time:79929ms step_avg:58.21ms
+step:1374/1575 train_time:80014ms step_avg:58.23ms
+step:1375/1575 train_time:80103ms step_avg:58.26ms
+step:1376/1575 train_time:80189ms step_avg:58.28ms
+step:1377/1575 train_time:80279ms step_avg:58.30ms
+step:1378/1575 train_time:80364ms step_avg:58.32ms
+step:1379/1575 train_time:80453ms step_avg:58.34ms
+step:1380/1575 train_time:80540ms step_avg:58.36ms
+step:1381/1575 train_time:80629ms step_avg:58.38ms
+step:1382/1575 train_time:80715ms step_avg:58.40ms
+step:1383/1575 train_time:80805ms step_avg:58.43ms
+step:1384/1575 train_time:80891ms step_avg:58.45ms
+step:1385/1575 train_time:80980ms step_avg:58.47ms
+step:1386/1575 train_time:81065ms step_avg:58.49ms
+step:1387/1575 train_time:81156ms step_avg:58.51ms
+step:1388/1575 train_time:81242ms step_avg:58.53ms
+step:1389/1575 train_time:81331ms step_avg:58.55ms
+step:1390/1575 train_time:81417ms step_avg:58.57ms
+step:1391/1575 train_time:81507ms step_avg:58.60ms
+step:1392/1575 train_time:81595ms step_avg:58.62ms
+step:1393/1575 train_time:81684ms step_avg:58.64ms
+step:1394/1575 train_time:81770ms step_avg:58.66ms
+step:1395/1575 train_time:81860ms step_avg:58.68ms
+step:1396/1575 train_time:81945ms step_avg:58.70ms
+step:1397/1575 train_time:82034ms step_avg:58.72ms
+step:1398/1575 train_time:82120ms step_avg:58.74ms
+step:1399/1575 train_time:82209ms step_avg:58.76ms
+step:1400/1575 train_time:82296ms step_avg:58.78ms
+step:1401/1575 train_time:82385ms step_avg:58.80ms
+step:1402/1575 train_time:82471ms step_avg:58.82ms
+step:1403/1575 train_time:82561ms step_avg:58.85ms
+step:1404/1575 train_time:82647ms step_avg:58.87ms
+step:1405/1575 train_time:82737ms step_avg:58.89ms
+step:1406/1575 train_time:82822ms step_avg:58.91ms
+step:1407/1575 train_time:82912ms step_avg:58.93ms
+step:1408/1575 train_time:82998ms step_avg:58.95ms
+step:1409/1575 train_time:83088ms step_avg:58.97ms
+step:1410/1575 train_time:83175ms step_avg:58.99ms
+step:1411/1575 train_time:83263ms step_avg:59.01ms
+step:1412/1575 train_time:83349ms step_avg:59.03ms
+step:1413/1575 train_time:83438ms step_avg:59.05ms
+step:1414/1575 train_time:83524ms step_avg:59.07ms
+step:1415/1575 train_time:83614ms step_avg:59.09ms
+step:1416/1575 train_time:83700ms step_avg:59.11ms
+step:1417/1575 train_time:83789ms step_avg:59.13ms
+step:1418/1575 train_time:83875ms step_avg:59.15ms
+step:1419/1575 train_time:83965ms step_avg:59.17ms
+step:1420/1575 train_time:84053ms step_avg:59.19ms
+step:1421/1575 train_time:84140ms step_avg:59.21ms
+step:1422/1575 train_time:84228ms step_avg:59.23ms
+step:1423/1575 train_time:84316ms step_avg:59.25ms
+step:1424/1575 train_time:84401ms step_avg:59.27ms
+step:1425/1575 train_time:84491ms step_avg:59.29ms
+step:1426/1575 train_time:84577ms step_avg:59.31ms
+step:1427/1575 train_time:84667ms step_avg:59.33ms
+step:1428/1575 train_time:84753ms step_avg:59.35ms
+step:1429/1575 train_time:84843ms step_avg:59.37ms
+step:1430/1575 train_time:84929ms step_avg:59.39ms
+step:1431/1575 train_time:85019ms step_avg:59.41ms
+step:1432/1575 train_time:85104ms step_avg:59.43ms
+step:1433/1575 train_time:85193ms step_avg:59.45ms
+step:1434/1575 train_time:85279ms step_avg:59.47ms
+step:1435/1575 train_time:85368ms step_avg:59.49ms
+step:1436/1575 train_time:85455ms step_avg:59.51ms
+step:1437/1575 train_time:85546ms step_avg:59.53ms
+step:1438/1575 train_time:85632ms step_avg:59.55ms
+step:1439/1575 train_time:85723ms step_avg:59.57ms
+step:1440/1575 train_time:85809ms step_avg:59.59ms
+step:1441/1575 train_time:85898ms step_avg:59.61ms
+step:1442/1575 train_time:85983ms step_avg:59.63ms
+step:1443/1575 train_time:86073ms step_avg:59.65ms
+step:1444/1575 train_time:86159ms step_avg:59.67ms
+step:1445/1575 train_time:86249ms step_avg:59.69ms
+step:1446/1575 train_time:86334ms step_avg:59.71ms
+step:1447/1575 train_time:86424ms step_avg:59.73ms
+step:1448/1575 train_time:86510ms step_avg:59.74ms
+step:1449/1575 train_time:86600ms step_avg:59.77ms
+step:1450/1575 train_time:86686ms step_avg:59.78ms
+step:1451/1575 train_time:86775ms step_avg:59.80ms
+step:1452/1575 train_time:86860ms step_avg:59.82ms
+step:1453/1575 train_time:86949ms step_avg:59.84ms
+step:1454/1575 train_time:87036ms step_avg:59.86ms
+step:1455/1575 train_time:87126ms step_avg:59.88ms
+step:1456/1575 train_time:87212ms step_avg:59.90ms
+step:1457/1575 train_time:87303ms step_avg:59.92ms
+step:1458/1575 train_time:87387ms step_avg:59.94ms
+step:1459/1575 train_time:87477ms step_avg:59.96ms
+step:1460/1575 train_time:87563ms step_avg:59.97ms
+step:1461/1575 train_time:87652ms step_avg:59.99ms
+step:1462/1575 train_time:87738ms step_avg:60.01ms
+step:1463/1575 train_time:87826ms step_avg:60.03ms
+step:1464/1575 train_time:87913ms step_avg:60.05ms
+step:1465/1575 train_time:88003ms step_avg:60.07ms
+step:1466/1575 train_time:88088ms step_avg:60.09ms
+step:1467/1575 train_time:88178ms step_avg:60.11ms
+step:1468/1575 train_time:88263ms step_avg:60.12ms
+step:1469/1575 train_time:88352ms step_avg:60.14ms
+step:1470/1575 train_time:88438ms step_avg:60.16ms
+step:1471/1575 train_time:88528ms step_avg:60.18ms
+step:1472/1575 train_time:88614ms step_avg:60.20ms
+step:1473/1575 train_time:88705ms step_avg:60.22ms
+step:1474/1575 train_time:88790ms step_avg:60.24ms
+step:1475/1575 train_time:88880ms step_avg:60.26ms
+step:1476/1575 train_time:88966ms step_avg:60.27ms
+step:1477/1575 train_time:89055ms step_avg:60.29ms
+step:1478/1575 train_time:89140ms step_avg:60.31ms
+step:1479/1575 train_time:89229ms step_avg:60.33ms
+step:1480/1575 train_time:89315ms step_avg:60.35ms
+step:1481/1575 train_time:89407ms step_avg:60.37ms
+step:1482/1575 train_time:89491ms step_avg:60.39ms
+step:1483/1575 train_time:89581ms step_avg:60.40ms
+step:1484/1575 train_time:89666ms step_avg:60.42ms
+step:1485/1575 train_time:89755ms step_avg:60.44ms
+step:1486/1575 train_time:89841ms step_avg:60.46ms
+step:1487/1575 train_time:89931ms step_avg:60.48ms
+step:1488/1575 train_time:90017ms step_avg:60.50ms
+step:1489/1575 train_time:90107ms step_avg:60.51ms
+step:1490/1575 train_time:90194ms step_avg:60.53ms
+step:1491/1575 train_time:90283ms step_avg:60.55ms
+step:1492/1575 train_time:90369ms step_avg:60.57ms
+step:1493/1575 train_time:90458ms step_avg:60.59ms
+step:1494/1575 train_time:90543ms step_avg:60.60ms
+step:1495/1575 train_time:90632ms step_avg:60.62ms
+step:1496/1575 train_time:90719ms step_avg:60.64ms
+step:1497/1575 train_time:90810ms step_avg:60.66ms
+step:1498/1575 train_time:90895ms step_avg:60.68ms
+step:1499/1575 train_time:90986ms step_avg:60.70ms
+step:1500/1575 train_time:91071ms step_avg:60.71ms
+step:1500/1575 val_loss:3.2986 train_time:91144ms step_avg:60.76ms
+step:1501/1575 train_time:91165ms step_avg:60.74ms
+step:1502/1575 train_time:91253ms step_avg:60.75ms
+step:1503/1575 train_time:91345ms step_avg:60.78ms
+step:1504/1575 train_time:91435ms step_avg:60.79ms
+step:1505/1575 train_time:91524ms step_avg:60.81ms
+step:1506/1575 train_time:91608ms step_avg:60.83ms
+step:1507/1575 train_time:91696ms step_avg:60.85ms
+step:1508/1575 train_time:91781ms step_avg:60.86ms
+step:1509/1575 train_time:91870ms step_avg:60.88ms
+step:1510/1575 train_time:91956ms step_avg:60.90ms
+step:1511/1575 train_time:92045ms step_avg:60.92ms
+step:1512/1575 train_time:92131ms step_avg:60.93ms
+step:1513/1575 train_time:92223ms step_avg:60.95ms
+step:1514/1575 train_time:92310ms step_avg:60.97ms
+step:1515/1575 train_time:92402ms step_avg:60.99ms
+step:1516/1575 train_time:92487ms step_avg:61.01ms
+step:1517/1575 train_time:92577ms step_avg:61.03ms
+step:1518/1575 train_time:92662ms step_avg:61.04ms
+step:1519/1575 train_time:92750ms step_avg:61.06ms
+step:1520/1575 train_time:92835ms step_avg:61.08ms
+step:1521/1575 train_time:92924ms step_avg:61.09ms
+step:1522/1575 train_time:93009ms step_avg:61.11ms
+step:1523/1575 train_time:93098ms step_avg:61.13ms
+step:1524/1575 train_time:93187ms step_avg:61.15ms
+step:1525/1575 train_time:93277ms step_avg:61.17ms
+step:1526/1575 train_time:93366ms step_avg:61.18ms
+step:1527/1575 train_time:93456ms step_avg:61.20ms
+step:1528/1575 train_time:93541ms step_avg:61.22ms
+step:1529/1575 train_time:93632ms step_avg:61.24ms
+step:1530/1575 train_time:93717ms step_avg:61.25ms
+step:1531/1575 train_time:93805ms step_avg:61.27ms
+step:1532/1575 train_time:93890ms step_avg:61.29ms
+step:1533/1575 train_time:93979ms step_avg:61.30ms
+step:1534/1575 train_time:94065ms step_avg:61.32ms
+step:1535/1575 train_time:94155ms step_avg:61.34ms
+step:1536/1575 train_time:94249ms step_avg:61.36ms
+step:1537/1575 train_time:94338ms step_avg:61.38ms
+step:1538/1575 train_time:94425ms step_avg:61.39ms
+step:1539/1575 train_time:94515ms step_avg:61.41ms
+step:1540/1575 train_time:94601ms step_avg:61.43ms
+step:1541/1575 train_time:94690ms step_avg:61.45ms
+step:1542/1575 train_time:94776ms step_avg:61.46ms
+step:1543/1575 train_time:94864ms step_avg:61.48ms
+step:1544/1575 train_time:94950ms step_avg:61.50ms
+step:1545/1575 train_time:95040ms step_avg:61.51ms
+step:1546/1575 train_time:95126ms step_avg:61.53ms
+step:1547/1575 train_time:95217ms step_avg:61.55ms
+step:1548/1575 train_time:95303ms step_avg:61.57ms
+step:1549/1575 train_time:95395ms step_avg:61.58ms
+step:1550/1575 train_time:95481ms step_avg:61.60ms
+step:1551/1575 train_time:95572ms step_avg:61.62ms
+step:1552/1575 train_time:95659ms step_avg:61.64ms
+step:1553/1575 train_time:95747ms step_avg:61.65ms
+step:1554/1575 train_time:95833ms step_avg:61.67ms
+step:1555/1575 train_time:95924ms step_avg:61.69ms
+step:1556/1575 train_time:96010ms step_avg:61.70ms
+step:1557/1575 train_time:96100ms step_avg:61.72ms
+step:1558/1575 train_time:96187ms step_avg:61.74ms
+step:1559/1575 train_time:96278ms step_avg:61.76ms
+step:1560/1575 train_time:96364ms step_avg:61.77ms
+step:1561/1575 train_time:96453ms step_avg:61.79ms
+step:1562/1575 train_time:96540ms step_avg:61.81ms
+step:1563/1575 train_time:96630ms step_avg:61.82ms
+step:1564/1575 train_time:96716ms step_avg:61.84ms
+step:1565/1575 train_time:96806ms step_avg:61.86ms
+step:1566/1575 train_time:96892ms step_avg:61.87ms
+step:1567/1575 train_time:96983ms step_avg:61.89ms
+step:1568/1575 train_time:97068ms step_avg:61.91ms
+step:1569/1575 train_time:97162ms step_avg:61.93ms
+step:1570/1575 train_time:97247ms step_avg:61.94ms
+step:1571/1575 train_time:97337ms step_avg:61.96ms
+step:1572/1575 train_time:97422ms step_avg:61.97ms
+step:1573/1575 train_time:97512ms step_avg:61.99ms
+step:1574/1575 train_time:97598ms step_avg:62.01ms
+step:1575/1575 train_time:97688ms step_avg:62.02ms
+step:1575/1575 val_loss:3.2771 train_time:97755ms step_avg:62.07ms
+peak memory allocated: 31016 MiB reserved: 46918 MiB

--- a/records/track_1_short/2026-01-26-UntieValueEmbeddings/f58d3a2f-73e6-4722-923c-7f3ad02d4627.txt
+++ b/records/track_1_short/2026-01-26-UntieValueEmbeddings/f58d3a2f-73e6-4722-923c-7f3ad02d4627.txt
@@ -1,0 +1,4119 @@
+import os
+import sys
+
+# Read the current file and the kernels file code ASAP, for logging
+with open(sys.argv[0], 'r') as f: 
+    code = f.read()
+with open(os.path.join(os.path.dirname(sys.argv[0]), 'triton_kernels.py'), 'r') as f:
+    code += f"\n\n{'-'*40}\n# triton_kernels.py\n{'-'*40}\n\n" 
+    code += f.read()
+
+import copy
+import glob
+import math
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from itertools import accumulate
+from pathlib import Path
+import gc
+
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+import torch
+import triton
+
+torch.empty(
+    1, device=f"cuda:{os.environ['LOCAL_RANK']}", requires_grad=True
+).backward()  # prevents a bug on some systems
+import torch._dynamo as dynamo
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# torch._inductor.config.coordinate_descent_tuning = True # we have banned this flag for new records because it causes compilation to take 30min
+from kernels import get_kernel
+from torch import Tensor, nn
+
+from triton_kernels import XXT, ba_plus_cAA, FusedLinearReLUSquareFunction, FusedSoftcappedCrossEntropy
+
+dynamo.config.recompile_limit = 64
+
+# -----------------------------------------------------------------------------
+# Custom operators: FP8 matmul by @YouJiacheng
+# Transposed layout by @ChrisJMcCormick allows for faster gradient accumulation.
+
+@torch.library.custom_op("nanogpt::mm_t", mutates_args=())
+def mm_t_op(x: Tensor, w: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor, Tensor]:
+    """Computes y = x @ w with F8 weights stored as (in_features, out_features)."""
+    @torch.compile
+    def impl(x: Tensor, w: Tensor):
+        assert x.is_contiguous() and w.is_contiguous()
+        assert x.shape[1] == w.shape[0]  # x: (batch, in), w: (in, out)
+
+        x_f8 = x.div(x_s).to(torch.float8_e4m3fn)
+        w_f8 = w.div(w_s).to(torch.float8_e4m3fn)
+
+        # _scaled_mm requires column-major B. w_f8 is row-major (in, out).
+        # .T.contiguous().T creates a column-major view without changing logical shape.
+        w_f8_col_major = w_f8.T.contiguous().T
+
+        out = torch._scaled_mm(
+            x_f8,
+            w_f8_col_major,
+            out_dtype=torch.bfloat16,
+            scale_a=x.new_tensor(x_s, dtype=torch.float32),
+            scale_b=x.new_tensor(w_s, dtype=torch.float32),
+            use_fast_accum=True,
+        )
+        return out, x_f8, w_f8
+
+    return impl(x, w)
+
+@mm_t_op.register_fake
+def _(x: Tensor, w: Tensor, *_):
+    assert x.ndim == w.ndim == 2
+    assert x.shape[1] == w.shape[0]
+    assert x.device == w.device
+    assert x.is_contiguous() and w.is_contiguous()
+    return x @ w, x.to(torch.float8_e4m3fn), w.to(torch.float8_e4m3fn)
+
+@torch.library.custom_op("nanogpt::mm_t_backward", mutates_args=())
+def mm_t_backward_op(g: Tensor, x_f8: Tensor, w_f8: Tensor, x_s: float, w_s: float, grad_s: float) -> tuple[Tensor, Tensor]:
+    @torch.compile
+    def impl(grad: Tensor, x_f8: Tensor, w_f8: Tensor):
+        assert grad.is_contiguous()
+        
+        x_scale = grad.new_tensor(x_s, dtype=torch.float32)
+        w_scale = grad.new_tensor(w_s, dtype=torch.float32)
+        grad_scale = grad.new_tensor(grad_s, dtype=torch.float32)
+        grad_f8 = grad.div(grad_s).to(torch.float8_e5m2)
+        
+        # grad_x = grad @ w.T
+        grad_x = torch._scaled_mm(
+            grad_f8,
+            w_f8.T, 
+            out_dtype=torch.bfloat16,
+            scale_a=grad_scale,
+            scale_b=w_scale,
+            use_fast_accum=False,
+        )
+        
+        # grad_w = x.T @ grad
+        # Result is (in, out), naturally matching weight storage. No final .T needed.
+        grad_w = torch._scaled_mm(
+            x_f8.T.contiguous(),
+            grad_f8.T.contiguous().T,
+            out_dtype=torch.float32,
+            scale_a=x_scale,
+            scale_b=grad_scale,
+            use_fast_accum=False,
+        )
+        
+        return grad_x, grad_w
+
+    grad_x, grad_w = impl(g, x_f8, w_f8)
+
+    return grad_x, grad_w
+
+@mm_t_backward_op.register_fake
+def _(g: Tensor, x_f8: Tensor, w_f8: Tensor, *_):
+    return x_f8.to(torch.bfloat16), w_f8.to(torch.float32)
+
+def backward_t(ctx, grad_out: Tensor, *_):
+    x_f8, w_f8 = ctx.saved_tensors
+    x_s, w_s, grad_s = ctx.scales
+    grad_x, grad_w = torch.ops.nanogpt.mm_t_backward(
+        grad_out, x_f8, w_f8, x_s, w_s, grad_s
+    )
+    return grad_x, grad_w, None, None, None
+
+def setup_context_t(ctx: torch.autograd.function.FunctionCtx, inputs, output):
+    *_, x_s, w_s, grad_s = inputs
+    _, x_f8, w_f8 = output
+    ctx.save_for_backward(x_f8, w_f8)
+    ctx.scales = x_s, w_s, grad_s
+    ctx.set_materialize_grads(False)
+
+mm_t_op.register_autograd(backward_t, setup_context=setup_context_t)
+
+# -----------------------------------------------------------------------------
+# Polar Express
+
+# Computed for num_iters=5, safety_factor=2e-2, cushion=2
+polar_express_coeffs = [
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323)
+]
+
+@torch.compile(dynamic=False, fullgraph=True) # Must use dynamic=False or else it's much slower
+def polar_express(G: torch.Tensor, split_baddbmm: bool = False):
+    """
+    Polar Express Sign Method: https://arxiv.org/pdf/2505.16932
+    by Noah Amsel, David Persson, Christopher Musco, Robert M. Gower.
+    """
+    X = G.bfloat16()
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+
+    # Ensure spectral norm is at most 1
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * (1 + 2e-2) + 1e-6)
+
+    # Allocate buffers
+    X = X.contiguous()
+    A = torch.empty((*X.shape[:-1], X.size(-2)), device=X.device, dtype=X.dtype)
+    B = torch.empty_like(A)
+    C = torch.empty_like(X)
+
+    # Select batched vs unbatched
+    if split_baddbmm:
+        BX_matmul = torch.bmm if X.ndim > 2 else torch.mm
+    else:
+        aX_plus_BX = torch.baddbmm if X.ndim > 2 else torch.addmm
+
+    # Perform the iterations
+    for a, b, c in polar_express_coeffs:
+        XXT(X, out=A)  # A = X @ X.mT
+        ba_plus_cAA(A, alpha=c, beta=b, out=B)  # B = b * A + c * A @ A
+
+        # Referencing X twice causes pytorch to make a defensive copy,
+        # resulting in a cudaMemcpyAsync in baddbmm.
+        # For large matrices (i.e., the mlp weights), it's faster to split
+        # the operation into two kernels to avoid this.
+        if split_baddbmm:
+            BX_matmul(B, X, out=C)  # C = B @ X
+            C.add_(X, alpha=a)      # C = C + a*X  (in-place, X only read)
+        else:
+            aX_plus_BX(X, B, X, beta=a, out=C)  # C = a * X + B @ X
+
+        X, C = C, X  # Swap references to avoid unnecessary copies
+
+    if G.size(-2) > G.size(-1):
+        X = X.mT
+    return X
+
+
+# -----------------------------------------------------------------------------
+# Combined NorMuon + Adam Optimizer
+
+@dataclass
+class ParamConfig:
+    """Per-parameter configuration for NorMuonAndAdam optimizer."""
+    label: str
+    optim: str  # "adam" or "normuon"
+    comms: str  # "none", "replicated", or "sharded"
+    adam_betas: tuple[float, float] | None
+    lr_mul: float
+    wd_mul: float
+    lr: float
+    initial_lr: float
+    weight_decay: float
+    # Adam-specific
+    eps: float | None = None
+    # NorMuon-specific
+    reshape: tuple | None = None
+    chunk_size: int | None = None
+    momentum: float | None = None
+    beta2: float | None = None
+    per_matrix_lr_mul: list[float] | None = None
+
+
+class NorMuonAndAdam:
+    """
+    Combined optimizer that handles both NorMuon (for projection matrices) and 
+    Adam (for embeddings/scalars/gate weights).
+
+    Muon - MomentUm Orthogonalized by Newton-schulz
+
+    https://kellerjordan.github.io/posts/muon/
+
+    Muon internally runs standard SGD-momentum, and then performs an orthogonalization post-
+    processing step, in which each 2D parameter's update is replaced with the nearest orthogonal
+    matrix. To efficiently orthogonalize each update, Muon uses a Newton-Schulz iteration (replaced
+    here with Polar Express), which has the advantage that it can be stably run in bfloat16 on the GPU.
+
+    Muon is applied only to the projection matrices in the attention and MLP layers, and is not recommended
+    for embeddings, scalars, or individual weight vectors (e.g., bias terms or gate weights). 
+
+    Differences from standard Muon:
+    - Newton-Shulz is replaced with Polar Express for the orthogonalization step
+    - NorMuon adds a low-rank variance estimator similar to Adafactor. https://arxiv.org/pdf/2510.05491
+    - Cautious weight decay, a gated version of decoupled weight decay
+    - Mantissa tracking for precision
+    
+    Adam (for embeddings/scalars/gates):
+    - Standard Adam with bias correction
+    - Cautious weight decay
+
+    Configuration:
+    Unlike torch.optim.Optimizer, this class uses per-parameter configs from a `param_table` dict
+    and does not include parameter "groups". All parameters require a .label attribute, and a 
+    corresponding entry in the param_table to specify their hyperparameters (lr_mul, wd_mul, adam_betas, etc.).
+
+    Communication and ordering:
+    Gradient communication is explicitly scheduled rather than hook-driven.
+    Reductions are launched in `scatter_order`, while update math and final
+    gathers are executed in `work_order`. These orders are independent and
+    must each contain every parameter label exactly once.
+
+    Two communication modes are supported per parameter:
+    - 'replicated': Gradients are all-reduced and each rank computes the full update.
+    - 'sharded': Gradients are reduce-scattered, each rank updates its shard,
+      and results are all-gathered.
+
+    Adam parameters may be freely sharded. NorMuon operates on full matrices; sharding is 
+    supported by grouping matrices into parameter banks. NorMuon parameters must have a
+    `.reshape` attribute that reshapes the bank so that the leading dimension is divisible 
+    by world_size.
+
+    # Contributors include @YouJiacheng, @KonstantinWilleke, @alexrgilbert, @adricarda,
+    # @tuttyfrutyee, @vdlad, @ryanyang0, @vagrawal, @varunneal, @chrisjmccormick
+    """
+    def __init__(self, named_params, param_table: dict, scatter_order: list, work_order: list,
+                 adam_defaults: dict, normuon_defaults: dict):
+        self.world_size = dist.get_world_size() if dist.is_initialized() else 1
+        
+        # Store defaults for each optimizer type
+        self.adam_defaults = adam_defaults
+        self.normuon_defaults = normuon_defaults
+        self.param_table = param_table
+        self.scatter_order = scatter_order
+        self.work_order = work_order
+        
+        # Collect params by label and build config
+        self.param_cfgs: dict[nn.Parameter, ParamConfig] = {}
+        self.param_states: dict[nn.Parameter, dict] = {}
+        self._param_by_label: dict[str, nn.Parameter] = {}
+        for name, param in named_params:
+            label = getattr(param, "label", None)
+            assert label is not None and label in param_table  # all params must have valid label
+            assert label not in self._param_by_label  # exactly one param per label
+            self._param_by_label[label] = param
+            self._build_param_cfg(param, label)
+        
+        # Assert scatter_order and work_order match present labels exactly
+        present = set(self._param_by_label.keys())
+        assert set(scatter_order) == present and set(work_order) == present
+        
+        # Handle world_size=1: overwrite comms to "none"
+        if self.world_size == 1:
+            for p_cfg in self.param_cfgs.values():
+                p_cfg.comms = "none"
+        
+        # Initialize state for all params
+        self._init_state()
+        
+        # 0-D CPU tensors to avoid recompilation
+        self._step_size_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        self._eff_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+        
+        # Track async operations
+        self._reduce_futures: dict[nn.Parameter, tuple] = {}
+        
+        # Embed/lm_head tying state
+        self.split_embed = False
+        self._lm_head_param = self._param_by_label.get("lm_head")
+        self._embed_param = self._param_by_label.get("embed")
+    
+    def _build_param_cfg(self, param: nn.Parameter, label: str):
+        """Build config for a single parameter from param_table."""
+        table_entry = self.param_table[label]
+        optim = table_entry["optim"]
+        comms = table_entry["comms"]
+        adam_betas = table_entry.get("adam_betas")
+        lr_mul = table_entry.get("lr_mul", 1.0)
+        wd_mul = table_entry.get("wd_mul", 1.0)
+        
+        if optim == "adam":
+            chunk_size = param.shape[0] // self.world_size if comms == "sharded" else None
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.adam_defaults["lr"],
+                initial_lr=self.adam_defaults["lr"],
+                weight_decay=self.adam_defaults["weight_decay"],
+                eps=self.adam_defaults["eps"],
+                chunk_size=chunk_size,
+            )
+        elif optim == "normuon":
+            reshape = getattr(param, "reshape", None)
+            if reshape is None:
+                raise ValueError(f"NorMuon param {label} must have .reshape attribute")
+            if reshape[0] % self.world_size != 0:
+                raise ValueError(f"reshape[0]={reshape[0]} must be divisible by world_size")
+            
+            chunk_size = reshape[0] // self.world_size
+            chunk_shape = (chunk_size, *reshape[1:])
+            # Shape-based LR multiplier for NorMuon
+            shape_mult = max(1.0, chunk_shape[-2] / chunk_shape[-1]) ** 0.5 if len(chunk_shape) >= 2 else 1.0
+            lr_mul = shape_mult * lr_mul
+            
+            # Per-matrix LR multipliers for MLP c_proj (2x LR on odd indices)
+            per_matrix_lr_mul = None
+            if label == "mlp":
+                rank = dist.get_rank() if dist.is_initialized() else 0
+                start_idx = rank * chunk_size
+                per_matrix_lr_mul = []
+                for i in range(chunk_size):
+                    global_idx = start_idx + i
+                    is_c_proj = (global_idx % 2 == 1)
+                    per_matrix_lr_mul.append(2.0 if is_c_proj else 1.0)
+            
+            p_cfg = ParamConfig(
+                label=label,
+                optim=optim,
+                comms=comms,
+                adam_betas=tuple(adam_betas) if adam_betas else None,
+                lr_mul=lr_mul,
+                wd_mul=wd_mul,
+                lr=self.normuon_defaults["lr"],
+                initial_lr=self.normuon_defaults["lr"],
+                weight_decay=self.normuon_defaults["weight_decay"],
+                reshape=reshape,
+                chunk_size=chunk_size,
+                momentum=self.normuon_defaults["momentum"],
+                beta2=self.normuon_defaults["beta2"],
+                per_matrix_lr_mul=per_matrix_lr_mul,
+            )
+        else:
+            raise ValueError(f"Unknown optim type: {optim}")
+        
+        self.param_cfgs[param] = p_cfg
+    
+    def _init_state(self):
+        """Initialize optimizer state for all parameters."""
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam":
+                # Sharded params use chunk state, replicated use full state
+                if p_cfg.comms == "sharded":
+                    chunk = param[:p_cfg.chunk_size]
+                else:
+                    chunk = param
+                exp_avg = torch.zeros_like(chunk, dtype=torch.float32, device=param.device)
+                self.param_states[param] = dict(step=0, exp_avg=exp_avg, exp_avg_sq=torch.zeros_like(exp_avg))
+            
+            elif p_cfg.optim == "normuon":
+                chunk_shape = (p_cfg.chunk_size, *p_cfg.reshape[1:])
+                
+                # Momentum buffer (FP32 for precision)
+                momentum_buffer = torch.zeros(
+                    chunk_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Second momentum buffer - reduced along one dimension
+                if chunk_shape[-2] >= chunk_shape[-1]:
+                    second_mom_shape = (*chunk_shape[:-1], 1)
+                else:
+                    second_mom_shape = (*chunk_shape[:-2], 1, chunk_shape[-1])
+                second_momentum_buffer = torch.zeros(
+                    second_mom_shape, dtype=torch.float32, device=param.device
+                )
+                
+                # Mantissa buffer for precision tracking
+                mantissa = torch.zeros(
+                    chunk_shape, dtype=torch.uint16, device=param.device
+                )
+                
+                self.param_states[param] = dict(
+                    momentum_buffer=momentum_buffer,
+                    second_momentum_buffer=second_momentum_buffer,
+                    mantissa=mantissa,
+                )
+
+    # -----------------------------------
+    # Reduce/Gather operations
+    
+    def _launch_reduce(self, param: nn.Parameter, grad: Tensor):
+        """Launch async reduce for a parameter based on its comms policy."""
+        p_cfg = self.param_cfgs[param]
+        
+        if p_cfg.comms == "none":
+            if p_cfg.optim == "normuon":
+                # NorMuon needs reshaped gradient even without communication
+                grad = grad.view(p_cfg.reshape)
+            self._reduce_futures[param] = (None, grad)
+        elif p_cfg.comms == "replicated":
+            future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
+            self._reduce_futures[param] = (future, grad)
+        elif p_cfg.comms == "sharded":
+            if p_cfg.optim == "normuon":
+                # NorMuon: reshape before reduce_scatter
+                grad_reshaped = grad.view(p_cfg.reshape)
+                grad_chunk = torch.empty(
+                    (p_cfg.chunk_size, *grad_reshaped.shape[1:]),
+                    dtype=grad.dtype,
+                    device=grad.device
+                )
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad_reshaped.contiguous(), op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+            else:
+                # Adam: simple reduce_scatter
+                grad_chunk = torch.empty_like(grad[:p_cfg.chunk_size])
+                future = dist.reduce_scatter_tensor(
+                    grad_chunk, grad, op=dist.ReduceOp.AVG, async_op=True
+                ).get_future()
+                self._reduce_futures[param] = (future, grad_chunk)
+
+    def _launch_gather(self, param: nn.Parameter, p_slice: Tensor) -> "torch.futures.Future":
+        """Launch async all_gather for a sharded parameter."""
+        p_cfg = self.param_cfgs[param]
+        if p_cfg.optim == "normuon":
+            full_param = param.data.view(p_cfg.reshape)
+            assert full_param.is_contiguous()
+            return dist.all_gather_into_tensor(
+                full_param, p_slice.contiguous(), async_op=True
+            ).get_future()
+        else:
+            return dist.all_gather_into_tensor(
+                param, p_slice.contiguous(), async_op=True
+            ).get_future()
+
+    # -----------------------------------
+    # State management
+    
+    def reset(self):
+        """Reset NorMuon momentum buffers and split_embed state (called on training reset)."""
+        self.split_embed = False
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "normuon":
+                p_state = self.param_states[param]
+                p_state["momentum_buffer"].zero_()
+                p_state["mantissa"].zero_()
+                p_state["second_momentum_buffer"].zero_()
+    
+    def copy_lm_state_to_embed(self):
+        """
+        Copy the optimizer state from the lm_head to the embed at the untie point.
+        This requires an all-gather + reshard because of different sharding:
+        - lm_head (768, 50304) is sharded to (96, 50304) per rank (along model_dim)
+        - embed (50304, 768) is sharded to (6288, 768) per rank (along vocab_size)
+        
+        We all-gather the lm_head momentum, transpose it, then each rank takes their
+        embed shard to get the correct momentum state.
+        """
+        lm_head = self._lm_head_param
+        embed = self._embed_param        
+        lm_state = self.param_states[lm_head]
+        embed_state = self.param_states[embed]
+        lm_cfg = self.param_cfgs[lm_head]
+        embed_cfg = self.param_cfgs[embed]
+        
+        embed_state['step'] = lm_state['step'] # Preserve step count for bias correction        
+        
+        # Copy optimizer state with all-gather + transpose + reshard
+        if self.world_size > 1:
+            rank = dist.get_rank()
+            lm_chunk_size = lm_cfg.chunk_size  # 96
+            embed_chunk_size = embed_cfg.chunk_size  # 6288
+            
+            # All-gather lm_head momentum to get full (768, 50304) tensor
+            for key in ["exp_avg", "exp_avg_sq"]:
+                lm_chunk = lm_state[key]  # (96, 50304)
+                full_lm = torch.empty(lm_head.shape[0], lm_head.shape[1], dtype=lm_chunk.dtype, device=lm_chunk.device)
+                dist.all_gather_into_tensor(full_lm, lm_chunk.contiguous())
+                embed_state[key].copy_(full_lm.T[rank * embed_chunk_size:(rank + 1) * embed_chunk_size])
+        else:
+            # Single GPU: simple transpose
+            for key in ["exp_avg", "exp_avg_sq"]:
+                embed_state[key].copy_(lm_state[key].T)
+        
+        # Mark as split
+        self.split_embed = True
+    
+    def state_dict(self):
+        """Return the optimizer state as a dict."""
+        return {
+            "param_states": {id(p): s for p, s in self.param_states.items()},
+            "param_cfgs": {id(p): s for p, s in self.param_cfgs.items()},
+        }
+    
+    def load_state_dict(self, state_dict):
+        """Load optimizer state from a dict."""
+        # Build id->param mapping
+        id_to_param = {id(p): p for p in self.param_cfgs.keys()}
+        
+        # Load state, preserving dtypes
+        for param_id, saved_p_state in state_dict["param_states"].items():
+            if param_id in id_to_param:
+                param = id_to_param[param_id]
+                p_state = self.param_states[param]
+                for k, v in saved_p_state.items():
+                    if isinstance(v, torch.Tensor) and k in p_state:
+                        target_dtype = p_state[k].dtype
+                        p_state[k] = v.to(dtype=target_dtype, device=p_state[k].device)
+                    else:
+                        p_state[k] = v
+
+    # -----------------------------------
+    # Unified optimizer step with explicit ordering
+
+    @torch.no_grad()
+    def step(self, do_adam: bool = True):
+        """
+        Combined optimizer step with explicit ordering.
+        
+        Args:
+            do_adam: If True, update Adam params. NorMuon params always updated.
+        
+        Flow:
+        1. Scatter phase: Launch reduces in scatter_order
+        2. Work phase: Process updates in work_order
+           - Wait for reduce, compute update, launch gather
+        3. Finalize phase: Wait for gathers
+        
+        While the embeddings are tied:
+        - Comms and update math are only done on lm_head.
+        - We add embed.grad.T into lm_head.grad before comms.
+        - After lm_head gather, we copy lm_head.data.T --> embed.data        
+        """
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        lm_param, embed_param = self._lm_head_param, self._embed_param
+        
+        # ===== Phase 1: Launch reduces in scatter_order =====
+        for label in self.scatter_order:
+            param = self._param_by_label[label]
+            p_cfg = self.param_cfgs[param]
+            
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            if param.grad is None:
+                continue
+            
+            # lm_head when tied: aggregate embed.grad.T (transposed shapes)
+            if label == "lm_head" and do_adam and not self.split_embed:
+                if embed_param is not None and embed_param.grad is not None:
+                    param.grad.add_(embed_param.grad.T)
+            
+            # Skip embed when tied (copied from lm_head after gather)
+            if label == "embed" and not self.split_embed:
+                continue
+            
+            self._launch_reduce(param, param.grad)
+        
+        # ===== Phase 2: Process updates in work_order =====
+        gather_futures = []
+        lm_head_gather_future = None
+        
+        for label in self.work_order:
+            param = self._param_by_label[label]
+            if param not in self._reduce_futures:
+                continue
+            
+            p_cfg = self.param_cfgs[param]
+            if p_cfg.optim == "adam" and not do_adam:
+                continue
+            # Wait for reduce
+            future, grad_chunk = self._reduce_futures[param]
+            if future is not None:
+                future.wait()
+            # Apply update based on optim type
+            if p_cfg.optim == "adam":
+                p_slice = self._adam_update(param, grad_chunk, p_cfg, rank)
+            else:
+                p_slice = self._normuon_update(param, grad_chunk, p_cfg, rank)
+            # Launch gather for sharded params
+            if p_cfg.comms == "sharded" and self.world_size > 1:
+                gather_fut = self._launch_gather(param, p_slice)
+                if label == "lm_head":
+                    lm_head_gather_future = gather_fut
+                else:
+                    gather_futures.append(gather_fut)
+        
+        # ===== Phase 3: Wait for gathers, sync embed if tied =====
+        # Wait for lm_head gather first so we can copy to embed while other gathers complete
+        if lm_head_gather_future is not None:
+            lm_head_gather_future.wait()
+        
+        # When tied: copy lm_head.T to embed
+        if do_adam and not self.split_embed and embed_param is not None and lm_param is not None:
+            embed_param.data.copy_(lm_param.data.T)
+        
+        # Wait for remaining gathers
+        for fut in gather_futures:
+            fut.wait()
+        
+        self._reduce_futures.clear()
+        
+        # Clear grads for updated params
+        for param, p_cfg in self.param_cfgs.items():
+            if p_cfg.optim == "adam" and not do_adam:
+                continue  # Don't clear Adam grads on even steps
+            param.grad = None
+
+    # -----------------------------------
+    # Adam update
+
+    def _adam_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply Adam update to a parameter. Returns the updated p_slice."""
+        beta1, beta2 = p_cfg.adam_betas
+        lr = p_cfg.lr * p_cfg.lr_mul
+        
+        # Get parameter slice
+        if p_cfg.comms == "sharded":
+            p_slice = param[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        else:
+            p_slice = param
+        
+        p_state = self.param_states[param]
+        p_state["step"] += 1
+        t = p_state["step"]
+        
+        bias1, bias2 = 1 - beta1 ** t, 1 - beta2 ** t
+        self._step_size_t.fill_(lr * (bias2 ** 0.5 / bias1))
+        self._eff_wd_t.fill_(lr * lr * p_cfg.weight_decay * p_cfg.wd_mul)
+        
+        NorMuonAndAdam._adam_update_step(
+            p_slice, grad_chunk, p_state["exp_avg"], p_state["exp_avg_sq"],
+            beta1, beta2, p_cfg.eps, self._step_size_t, self._eff_wd_t
+        )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _adam_update_step(p_slice, g_slice, exp_avg, exp_avg_sq, beta1, beta2, eps, step_size_t, eff_wd_t):
+        """Compiled Adam update step."""
+        exp_avg.mul_(beta1).add_(g_slice, alpha=1 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g_slice, g_slice, value=1 - beta2)
+        update = exp_avg.div(exp_avg_sq.sqrt().add_(eps)).mul_(step_size_t)
+        # Cautious weight decay
+        mask = (update * p_slice) > 0
+        update.addcmul_(p_slice, mask, value=eff_wd_t)
+        p_slice.add_(other=update, alpha=-1.0)
+
+    # -----------------------------------
+    # NorMuon update
+
+    def _normuon_update(self, param: nn.Parameter, grad_chunk: Tensor, p_cfg: ParamConfig, rank: int) -> Tensor:
+        """Apply NorMuon update to a parameter. Returns the updated p_slice."""
+        chunk_shape = grad_chunk.shape
+        
+        p_state = self.param_states[param]
+        grad_chunk = grad_chunk.float()  # FP32 for momentum
+        
+        # Momentum update
+        momentum_buffer = p_state["momentum_buffer"]
+        momentum_buffer.lerp_(grad_chunk, 1 - p_cfg.momentum)
+        updated_grads = grad_chunk.lerp_(momentum_buffer, p_cfg.momentum)
+        
+        self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.lr)
+        self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+        
+        # Polar Express orthogonalization
+        is_large_matrix = chunk_shape[-2] > 1024
+        v_chunk = polar_express(updated_grads, split_baddbmm=is_large_matrix)
+        
+        # Variance reduction
+        red_dim = -1 if chunk_shape[-2] >= chunk_shape[-1] else -2
+        v_chunk = NorMuonAndAdam._apply_normuon_variance_reduction(
+            v_chunk, p_state["second_momentum_buffer"], p_cfg.beta2, red_dim
+        )
+        
+        # Update parameter, in place, with cautious weight decay
+        param_view = param.data.view(p_cfg.reshape)
+        p_slice = param_view[rank * p_cfg.chunk_size:(rank + 1) * p_cfg.chunk_size]
+        
+        # MLP has per-matrix LR multipliers (c_proj gets 2x LR)
+        if p_cfg.per_matrix_lr_mul is not None:
+            for mat_idx in range(p_cfg.chunk_size):
+                self._eff_lr_t.fill_(p_cfg.lr_mul * p_cfg.per_matrix_lr_mul[mat_idx] * p_cfg.lr)
+                self._eff_wd_t.fill_(p_cfg.wd_mul * p_cfg.weight_decay * p_cfg.lr)
+                NorMuonAndAdam._cautious_wd_and_update_inplace(
+                    p_slice[mat_idx].view(torch.uint16), p_state["mantissa"][mat_idx], v_chunk[mat_idx],
+                    self._eff_wd_t, self._eff_lr_t
+                )
+        else:
+            NorMuonAndAdam._cautious_wd_and_update_inplace(
+                p_slice.view(torch.uint16), p_state["mantissa"], v_chunk,
+                self._eff_wd_t, self._eff_lr_t
+            )
+        
+        return p_slice
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _cautious_wd_and_update_inplace(p, mantissa, grad, wd_tensor, lr_tensor):
+        """
+        Cautious weight decay + parameter update. wd_tensor and lr_tensor are 0-D CPU tensors.
+        Mantissa is tracked to enable higher precision updates on bfloat16 parameters.
+        bfloat16 format: 1 sign bit + 8 exponent bits + 7 mantissa bits = 16 bits total
+        float32 format: 1 sign bit + 8 exponent bits + 23 mantissa bits = 32 bits total
+        """
+        assert p.dtype == mantissa.dtype == torch.uint16
+        grad = grad.float()
+        wd_factor = wd_tensor.to(torch.float32)
+        lr_factor = lr_tensor.to(torch.float32)
+        p_precise_raw = (p.to(torch.uint32) << 16) | mantissa.to(torch.uint32)
+        p_precise = p_precise_raw.view(torch.float32)
+        mask = (grad * p_precise) >= 0
+        p_precise.copy_(p_precise - (p_precise * mask * wd_factor * lr_factor) - (grad * lr_factor))
+        p.copy_((p_precise_raw >> 16).to(torch.uint16))
+        mantissa.copy_(p_precise_raw.to(torch.uint16))
+
+    @staticmethod
+    @torch.compile(dynamic=False, fullgraph=True)
+    def _apply_normuon_variance_reduction(v_chunk, second_momentum_buffer, beta2, red_dim):
+        """NorMuon variance reduction. Algebraically fuses the normalization steps to minimize memory ops."""
+        v_mean = v_chunk.float().square().mean(dim=red_dim, keepdim=True)
+        red_dim_size = v_chunk.size(red_dim)
+        v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True).mul_(red_dim_size)
+        v_norm = v_norm_sq.sqrt_()
+        second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+        step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt_()
+        scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+        v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt_()
+        final_scale = step_size * (v_norm / v_norm_new.clamp_min_(1e-10))
+        return v_chunk.mul_(final_scale.type_as(v_chunk))
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+def norm(x: Tensor):
+    return F.rms_norm(x, (x.size(-1),))
+
+
+class CastedLinearT(nn.Module):
+    """
+    Linear layer with transposed weight storage (in_features, out_features) which
+    addresses the slow kernel that was used for gradient accumulation. @chrisjmccormick
+    """
+    def __init__(self, in_features: int, out_features: int, use_fp8=False, x_s=1.0, w_s=1.0, grad_s=1.0):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_fp8 = use_fp8
+        self.x_s = x_s
+        self.w_s = w_s
+        self.grad_s = grad_s
+        
+        self.weight = nn.Parameter(torch.empty(in_features, out_features, dtype=torch.bfloat16))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        with torch.no_grad():
+            nn.init.zeros_(self.weight) # @Grad62304977 and others
+
+    def forward(self, x: Tensor):
+        if self.use_fp8 and self.training:
+            _x = x.flatten(0, -2)
+            out = torch.ops.nanogpt.mm_t(_x, self.weight, x_s=self.x_s, w_s=self.w_s, grad_s=self.grad_s)[0]
+            return out.reshape(*x.shape[:-1], -1)
+        else:
+            return x @ self.weight.type_as(x)
+
+# -----------------------------------------------------------------------------
+# PyTorch nn.Module definitions for the model
+
+class Yarn(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        # half-truncate RoPE by @YouJiacheng (w/ base freq tuning)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        theta = torch.outer(t, angular_freq)
+        self.factor1 = nn.Buffer(
+            theta.cos().to(torch.bfloat16), persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            theta.sin().to(torch.bfloat16), persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        theta = torch.outer(t, self.angular_freq)
+        self.factor1.copy_(theta.cos())
+        self.factor2.copy_(theta.sin())
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+class YarnPairedHead(nn.Module):
+    def __init__(self, head_dim, max_seq_len):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.reset()
+
+    def rotary(self, x_BTHD):
+        assert self.factor1.size(0) >= x_BTHD.size(-3)
+        factor1, factor2 = (
+            self.factor1[None, : x_BTHD.size(-3), None, :],
+            self.factor2[None, : x_BTHD.size(-3), None, :],
+        )
+        x_flip = x_BTHD.view(*x_BTHD.shape[:-1], x_BTHD.shape[-1] // 2, 2).flip(-1).view(x_BTHD.shape)
+        return factor1 * x_BTHD + factor2 * x_flip
+
+    def reset(self):
+        angular_freq = (1 / 1024) ** torch.linspace(0, 1, steps=self.head_dim//4, dtype=torch.float32, device=device)
+        angular_freq = angular_freq.repeat_interleave(2)
+        angular_freq = torch.cat([angular_freq, angular_freq.new_zeros(self.head_dim//2)])
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, angular_freq)
+        theta2 = torch.outer(t_odd, angular_freq)
+        self.factor1 = nn.Buffer(
+            torch.cat((theta1.cos(),theta2.cos()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2 = nn.Buffer(
+            torch.cat((theta1.sin(),theta2.sin()), dim=-1).to(torch.bfloat16), 
+            persistent=False
+        )
+        self.factor2[..., 1::2] *= -1
+        self.angular_freq = angular_freq
+        # start with 0.1, inspired by 0.12 from @leloykun and learnable scalars used by @brendanh0gan https://x.com/hi_tysam/status/1879693583898591283
+        self.attn_scale = 0.1
+
+    def apply(self, old_window: int, new_window: int, alpha: int=1, beta: int=32):
+        rotations = args.block_size * old_window * self.angular_freq / (2 * torch.pi)
+        scaling_factor = old_window / new_window
+        interpolation_weight = torch.clamp((rotations - alpha) / (beta - alpha), 0, 1)
+        self.angular_freq *= scaling_factor + interpolation_weight * (1 - scaling_factor)
+        t = torch.arange(2*self.max_seq_len, dtype=torch.float32, device=self.angular_freq.device)
+        t_even = 2 * t
+        t_odd = 2 * t + 1
+        theta1 = torch.outer(t_even, self.angular_freq)
+        theta2 = torch.outer(t_odd, self.angular_freq)
+        self.factor1.copy_(torch.cat((theta1.cos(),theta2.cos()), dim=-1))
+        self.factor2.copy_( torch.cat((theta1.sin(),theta2.sin()), dim=-1))
+        self.factor2[..., 1::2] *= -1
+        self.attn_scale *= 0.2 * math.log(new_window / old_window) + 1
+
+@dataclass
+class AttnArgs:
+    ve: torch.Tensor
+    sa_lambdas: torch.Tensor
+    seqlens: torch.Tensor
+    bm_size: int
+    yarn: Yarn
+    key_offset: bool
+    attn_gate_w: torch.Tensor
+    ve_gate_w: torch.Tensor
+
+flash_attn_interface = get_kernel('varunneal/flash-attention-3').flash_attn_interface
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas, key_offset = attn_args.ve, attn_args.sa_lambdas, attn_args.key_offset
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        # sparse gated attention to enable context based no-op by @classiclarryd
+        # only include gates on layers with value embeds used on forward pass
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k) # QK norm @Grad62304977
+        q, k = yarn.rotary(q), yarn.rotary(k)
+        if key_offset:
+            # shift keys forward for the stationary head dims. Enables 1-layer induction.
+            k[:, 1:, :, self.head_dim // 2:] = k[:, :-1, :, self.head_dim // 2:]
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T, self.num_heads, 1)
+            v = v + ve_gate_out * ve.view_as(v) # @ KoszarskyB & @Grad62304977
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # use flash_attn over flex_attn @varunneal. flash_attn_varlen suggested by @YouJiacheng
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim) # re-assemble all head outputs side by side
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))  # sa_lambdas[1] pre-multiplied to O @shenberg
+        return y
+
+class PairedHeadCausalSelfAttention(nn.Module):
+    """
+    Pairs up attention heads such that queries from head 1 can attend to keys in head 2, and vice-versa.
+    Implemented by interleaving the k, q, and v for pairs of heads to form twice as long sequences
+    EG [k1_h1, k2_h1, k3_h1], [k1_h2, k2_h2, k3_h2] -> [k1_h1, k1_h2, k2_h1, k2_h2, k3_h1, k3_h2], repeat for q and v
+    """
+    def __init__(self, dim: int, head_dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.dim = dim
+        self.hdim = num_heads * head_dim
+        assert self.hdim == self.dim, "num_heads * head_dim must equal model_dim"
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor):
+        B, T = x.size(0), x.size(1) # batch size, sequence length
+        assert B == 1, "varlen sequences requires B == 1"
+        assert T % 16 == 0
+        # unpack attention args
+        yarn = attn_args.yarn
+        ve, sa_lambdas = attn_args.ve, attn_args.sa_lambdas
+        seqlens, bm_size = attn_args.seqlens, attn_args.bm_size
+        attn_gate_w, ve_gate_w = attn_args.attn_gate_w, attn_args.ve_gate_w
+
+        q, k, v = F.linear(x, sa_lambdas[0] * qkvo_w[:self.dim * 3].type_as(x)).view(B, T, 3 * self.num_heads, self.head_dim).chunk(3, dim=-2)
+        q, k = norm(q), norm(k)
+
+        # delay q,k reshape until rotary makes data contiguous, to enable view (non-copy)
+        q = q.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        k = k.view(B, T, self.num_heads // 2, self.head_dim * 2)
+        v = v.reshape(B, T*2, self.num_heads//2, self.head_dim)
+
+        q, k = yarn.rotary(q), yarn.rotary(k)
+
+        q = q.view(B, T*2, self.num_heads//2, self.head_dim)
+        k = k.view(B, T*2, self.num_heads//2, self.head_dim)
+
+        if ve is not None:
+            ve_gate_out = 2 * torch.sigmoid(F.linear(x[..., :12], ve_gate_w)).view(B, T*2, self.num_heads//2, 1)
+            v = v + ve_gate_out * ve.view_as(v)
+
+        max_len = args.train_max_seq_len if self.training else (args.val_batch_size // (grad_accum_steps * world_size))
+
+        # paired head correction
+        seqlens = 2 * seqlens
+        max_len = 2 * max_len
+
+        y = flash_attn_interface.flash_attn_varlen_func(q[0], k[0], v[0], cu_seqlens_q=seqlens, cu_seqlens_k=seqlens,
+                                                        max_seqlen_q=max_len, max_seqlen_k=max_len,
+                                                        causal=True, softmax_scale=yarn.attn_scale, window_size=(bm_size, 0))
+        y = y.view(B, T, self.num_heads, self.head_dim)
+        y = y * torch.sigmoid(F.linear(x[..., :12], attn_gate_w)).view(B, T, self.num_heads, 1)
+        y = y.contiguous().view(B, T, self.num_heads * self.head_dim)
+        y = F.linear(y, sa_lambdas[1] * qkvo_w[self.dim * 3:].type_as(y))
+        return y
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Weights are stored in parameter banks and passed via forward()
+
+    def forward(self, x: Tensor, c_fc: Tensor, c_proj: Tensor):
+        # relu(x)^2:
+        # https://arxiv.org/abs/2109.08668v2; ~1-2% better than GELU; suggested by @SKYLINEZ007 and @Grad62304977
+        # Fused triton kernel for relu(x @ W1.T)^2 @ W2.T
+        return FusedLinearReLUSquareFunction.apply(x, c_fc, c_proj)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, head_dim: int, num_heads: int, has_attn: bool, has_mlp: bool, use_paired_head: bool):
+        super().__init__()
+        # skip attention of blocks.6 (the 7th layer) by @YouJiacheng
+        if has_attn:
+            if use_paired_head:
+                self.attn = PairedHeadCausalSelfAttention(dim, head_dim, num_heads)
+            else:
+                self.attn = CausalSelfAttention(dim, head_dim, num_heads)
+        else:
+            self.attn = None
+        # skip MLP blocks for first MLP layer by @EmelyanenkoK
+        self.mlp = MLP() if has_mlp else None
+
+    def forward(self, x: Tensor, attn_args: AttnArgs, qkvo_w: Tensor = None, c_fc: Tensor = None, c_proj: Tensor = None):
+        if self.attn is not None:
+            x = x + self.attn(norm(x), attn_args, qkvo_w)
+        if self.mlp is not None:
+            x = x + self.mlp(norm(x), c_fc, c_proj)
+        return x
+
+# -----------------------------------------------------------------------------
+# The main model
+
+def next_multiple_of_n(v: float | int, *, n: int):
+    return next(x for x in range(n, int(v) + 1 + n, n) if x >= v)
+
+@dataclass
+class ForwardScheduleConfig:
+    mtp_weights: torch.Tensor
+    ws_short: int
+    ws_long: int
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, num_heads: int, head_dim: int, model_dim: int, max_seq_len: int):
+        super().__init__()
+        self.num_layers = num_layers
+        vocab_size = next_multiple_of_n(vocab_size, n=128)
+
+        self.smear_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.smear_gate.weight)
+        self.smear_gate.weight.label = 'smear_gate'
+
+        self.skip_gate = nn.Linear(12, 1, bias=False)
+        nn.init.zeros_(self.skip_gate.weight)
+        self.skip_gate.weight.label = 'skip_gate'
+
+        # token value embeddings by @KoszarskyB - inspired by @Grad62304977's value residual implementation following https://arxiv.org/abs/2410.17897
+        # value embedding code simplification inspired by @ragulpr https://github.com/KellerJordan/modded-nanogpt/pull/78
+        self.value_embeds = nn.ModuleList([nn.Embedding(vocab_size, model_dim) for _ in range(3)])
+        for embed in self.value_embeds:
+            nn.init.zeros_(embed.weight)
+        for i, ve in enumerate(self.value_embeds):
+            ve.weight.label = f've{i}'  # ve0, ve1, ve2
+        
+        # parameter banks for attention and value embedding gate weights
+        self.attn_gate_bank = nn.Parameter(torch.zeros(10, num_heads, 12)) # 10 layers
+        self.attn_gate_bank.label = 'attn_gate_bank'
+        self.ve_gate_bank = nn.Parameter(torch.zeros(5, num_heads, 12)) # 5 layers
+        self.ve_gate_bank.label = 've_gate_bank'
+
+        # -----------------------------------
+        # Parameter banks for sharded optimization, by @chrisjmccormick
+
+        # Identify which layers have attention/MLP
+        # Attention is skipped in layer 6 by @YouJiacheng
+        self.attn_layer_indices = [i for i in range(num_layers) if i != 6]
+        # All layers have MLP (At 11 layers--dropped first layer @EmelyanenkoK)
+        self.mlp_layer_indices = list(range(num_layers))
+
+        hdim = num_heads * head_dim
+        mlp_hdim = 4 * model_dim
+
+        # Create index mappings: layer_idx -> bank_idx
+        self.layer_to_attn_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.attn_layer_indices)}
+        self.layer_to_mlp_idx = {layer_idx: bank_idx for bank_idx, layer_idx in enumerate(self.mlp_layer_indices)}
+
+        # Attention bank: stores QKVO weights for all attention layers
+        # merged QKVO weights: suggested by many, implemented by @fernbear.bsky.social, and further improved by @YouJiacheng
+        # https://x.com/hi_tysam/status/1879699187107033311
+        # Simplified layout by @chrisjmccormick
+        # Shape: (num_attn_layers, 4*model_dim, hdim) = (10, 3072, 768)
+        # Reshape for sharding: (40, 768, 768) for even distribution across 8 GPUs
+        self.attn_bank = nn.Parameter(torch.empty(len(self.attn_layer_indices), 4 * model_dim, hdim))
+        self.attn_bank.label = 'attn'
+        self.attn_bank.reshape = (len(self.attn_layer_indices) * 4, hdim, hdim)  # (40, 768, 768)
+
+        # MLP bank: stores c_fc and c_proj for all MLP layers
+        # Shape: (num_mlp_layers + padding, 2, mlp_hdim, model_dim) = (12, 2, 3072, 768)
+        # We add 1 padding layer (index 11) to get 12*2=24 matrices for even distribution across 8 GPUs
+        # Reshape for sharding: (24, 3072, 768)
+        num_mlp_with_padding = len(self.mlp_layer_indices) + 1  # 11 + 1 = 12
+        self.mlp_bank = nn.Parameter(torch.empty(num_mlp_with_padding, 2, mlp_hdim, model_dim))
+        self.mlp_bank.label = 'mlp'
+        self.mlp_bank.reshape = (num_mlp_with_padding * 2, mlp_hdim, model_dim)  # (24, 3072, 768)
+
+        # improved init scale by @YouJiacheng
+        # Attention uses dim^-0.5, MLP uses 0.5 * dim^-0.5
+        attn_std = model_dim ** -0.5
+        attn_bound = (3 ** 0.5) * attn_std
+        mlp_std = 0.5 * (model_dim ** -0.5)
+        mlp_bound = (3 ** 0.5) * mlp_std
+        with torch.no_grad():
+            # Init attention bank (QKV uniform, O zero)
+            self.attn_bank[:, :model_dim * 3, :].uniform_(-attn_bound, attn_bound)
+            self.attn_bank[:, model_dim * 3:, :].zero_()
+            # Init MLP bank (c_fc uniform, c_proj zero) 
+            self.mlp_bank[:, 0, :, :].uniform_(-mlp_bound, mlp_bound)  # c_fc
+            self.mlp_bank[:, 1, :, :].zero_()  # c_proj - zero init suggested by @Grad62304977
+
+        # Create blocks with has_attn/has_mlp flags
+        self.paired_head_layers = [0, 2, 5, 9]
+        self.blocks = nn.ModuleList([
+            Block(model_dim, head_dim, num_heads, 
+                  has_attn=(i in self.layer_to_attn_idx), 
+                  has_mlp=(i in self.layer_to_mlp_idx),
+                  use_paired_head=(i in self.paired_head_layers))
+            for i in range(num_layers)
+        ])
+        self.yarn = Yarn(head_dim, max_seq_len)
+        self.yarn_paired_head = YarnPairedHead(head_dim, max_seq_len)
+        # there are only 50257 unique GPT-2 tokens; we extend to nearest multiple of 128 for efficiency.
+        # suggested to me by @Grad62304977. this originates from Karpathy's experiments.
+        use_fp8 = not os.environ.get("DISABLE_FP8", False)
+        # Transposed weight storage for faster gradient accumulation
+        self.lm_head = CastedLinearT(model_dim, vocab_size, use_fp8=use_fp8, x_s=100/448, w_s=1.6/448, grad_s=0.75/448)
+
+        nn.init.normal_(self.lm_head.weight, mean=0, std=0.005)
+        self.lm_head.weight.label = 'lm_head'
+
+        self.embed = nn.Embedding(vocab_size, model_dim)
+        self.embed.weight.label = 'embed'
+        with torch.no_grad():
+            self.embed.weight.copy_(self.lm_head.weight.T)
+
+        self.bigram_embed = nn.Embedding(args.bigram_vocab_size, model_dim)
+        self.bigram_embed.weight.label = 'bigram_embed'
+        nn.init.zeros_(self.bigram_embed.weight)
+
+        # x0_lambdas separated out for different optimizer treatment (no beta smoothing)
+        self.x0_lambdas = nn.Parameter(torch.zeros(num_layers))
+        self.x0_lambdas.label = 'x0_lambdas'
+
+        pad = (-num_layers * 3 - 3) % dist.get_world_size()  # updated: 3*num_layers instead of 4*
+        self.scalars = nn.Parameter(
+            torch.cat(
+                [
+                    1.1 * torch.ones(num_layers),  # resid lambdas. 1.1 init such that layer i weight is i^(num_layers-i).
+                    *[torch.tensor([0.5, 1.0]) for _ in range(num_layers)],  # SA lambdas
+                    0.1 * torch.ones(num_layers), # bigram lambdas
+                    torch.zeros(1), # smear_lambda
+                    0.5*torch.ones(1), # backout_lambda
+                    -1.5 * torch.ones(1),  # skip_lambda -> σ(-1.5) ≈ 0.18
+                    torch.ones(pad),
+                ]
+            )
+        )
+        self.scalars.label = 'scalars'
+
+    def forward(self, input_seq: Tensor, target_seq: Tensor, seqlens: Tensor, bigram_input_seq: Tensor, schedule_cfg: ForwardScheduleConfig):
+        assert input_seq.ndim == 1
+
+        # unpack schedule_cfg
+        mtp_weights, ws_short, ws_long = schedule_cfg.mtp_weights, schedule_cfg.ws_short, schedule_cfg.ws_long
+
+        # set configs
+        skip_connections = []
+        skip_in = [3] # long attention window on layer 3
+        skip_out = [6] # no attn op on layer 6
+        x_backout = None
+        backout_layer = 7
+
+        # set lambdas
+        resid_lambdas = self.scalars[: 1 * self.num_layers]
+        x0_lambdas = self.x0_lambdas
+        sa_lambdas = self.scalars[1 * self.num_layers: 3 * self.num_layers].view(-1, 2)
+        bigram_lambdas = self.scalars[3 * self.num_layers: 4 * self.num_layers]
+        smear_lambda = self.scalars[4 * self.num_layers]
+        backout_lambda = self.scalars[4 * self.num_layers+1]
+        skip_lambda = self.scalars[4 * self.num_layers+2]
+
+        # set block masks and key shift
+        short_bm = ws_short * args.block_size
+        long_bm = ws_long * args.block_size
+        bm_sizes = [short_bm, short_bm, short_bm, long_bm, short_bm, short_bm, None, short_bm, short_bm, short_bm, long_bm]
+        assert len(bm_sizes) == self.num_layers
+        key_offset = [b==long_bm for b in bm_sizes] # apply partial key offset to long windows
+
+        # Embedding lookup - embed is synced from lm_head during tied phase by optimizer
+        x = self.embed(input_seq)
+        x0_bigram = self.bigram_embed(bigram_input_seq)[None]
+        
+        # Value embeddings - always computed (not precomputed)
+        ve = [value_embed(input_seq) for value_embed in self.value_embeds]
+        # 012 ... 012 structure on token value embeddings by @YouJiacheng, improved on @leloykun's U-net structure
+        # dropping first layer updates this to .12 ... 012
+        ve = [ve[1], ve[2]] + [None] * (self.num_layers - 5) + [ve[0], ve[1], ve[2]]
+        assert len(ve) == self.num_layers
+
+        # smear token embed forward 1 position @classiclarryd
+        smear_gate_out = smear_lambda * torch.sigmoid(self.smear_gate(x[1:, :self.smear_gate.weight.size(-1)]))
+        x = torch.cat([x[:1], x[1:] + smear_gate_out * x[:-1]])
+        x = x0 = norm(x[None])
+
+        # unbind gate banks to avoid select_backwards kernel
+        ag = [w.bfloat16() for w in self.attn_gate_bank.unbind(0)] 
+        veg = [w.bfloat16() for w in self.ve_gate_bank.unbind(0)]
+        attn_gates = ag[:6] + [None] + ag[6:]
+        ve_gates = [veg[0], veg[1]] + [None] * (self.num_layers - 5) + [veg[2], veg[3], veg[4]]
+        assert len(attn_gates) == self.num_layers
+        assert len(ve_gates) == self.num_layers
+
+        # unbind weight banks to avoid select_backwards kernel
+        attn_weights = self.attn_bank.unbind(0)  # tuple of [4*dim, hdim] tensors
+        mlp_fcs = self.mlp_bank[:, 0, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+        mlp_projs = self.mlp_bank[:, 1, :, :].unbind(0)  # tuple of [mlp_hdim, dim] tensors
+
+        for i in range(self.num_layers):
+            yarn = self.yarn_paired_head if i in self.paired_head_layers else self.yarn
+            attn_args = AttnArgs(
+                ve=ve[i],
+                sa_lambdas=sa_lambdas[i],
+                seqlens=seqlens,
+                bm_size=bm_sizes[i],
+                yarn=yarn,
+                key_offset=key_offset[i],
+                attn_gate_w=attn_gates[i],
+                ve_gate_w=ve_gates[i]
+            )
+            if i in skip_out:
+                skip_gate_out = torch.sigmoid(skip_lambda) * 2 * torch.sigmoid(self.skip_gate(x0[..., :self.skip_gate.weight.size(-1)]))
+                x = x + skip_gate_out * skip_connections.pop()
+            if i == 0:
+                x = (resid_lambdas[0] + x0_lambdas[0]) * x + bigram_lambdas[0] * x0_bigram
+            else:
+                x = resid_lambdas[i] * x + x0_lambdas[i] * x0 + bigram_lambdas[i] * x0_bigram
+            
+            # Get weights for this layer from banks
+            qkvo_w = attn_weights[self.layer_to_attn_idx[i]] if i in self.layer_to_attn_idx else None
+            c_fc = mlp_fcs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            c_proj = mlp_projs[self.layer_to_mlp_idx[i]] if i in self.layer_to_mlp_idx else None
+            
+            x = self.blocks[i](x, attn_args, qkvo_w, c_fc, c_proj)
+            if i in skip_in:
+                skip_connections.append(x)
+            if i == backout_layer:
+                x_backout = x
+
+        # back out contributions from first 7 layers that are only required for downstream context and not direct prediction
+        x -= backout_lambda * x_backout
+        x = norm(x)
+        logits = self.lm_head(x)
+        # @Grad62304977 added tanh softcapping following Gemma 2 paper, @KoszarskyB reduced it from 30 to 15
+        # @YouJiacheng shifted it by +15 (2*sigmoid(2*x)=tanh(x)+1). @classiclarryd updated to 23*sigmoid((logits+5)/7.5)
+        if self.training:
+            losses = FusedSoftcappedCrossEntropy.apply(logits.view(-1, logits.size(-1)), target_seq, mtp_weights)
+            loss = losses.sum()
+        else:
+            logits = 23 * torch.sigmoid((logits + 5) / 7.5)
+            logits_for_loss = logits.float()
+            loss = F.cross_entropy(logits_for_loss.view(-1, logits_for_loss.size(-1)), target_seq, reduction="mean")
+        return loss
+# -----------------------------------------------------------------------------
+# Distributed data loader
+
+def _load_data_shard(file: Path):
+    header = torch.from_file(str(file), False, 256, dtype=torch.int32) # header is 256 int32
+    assert header[0] == 20240520, "magic number mismatch in the data .bin file"
+    assert header[1] == 1, "unsupported version"
+    num_tokens = int(header[2]) # number of tokens (claimed)
+    with file.open("rb", buffering=0) as f:
+        tokens = torch.empty(num_tokens, dtype=torch.uint16, pin_memory=True) # avoid pin_memory copy by @YouJiacheng
+        f.seek(256 * 4)
+        nbytes = f.readinto(tokens.numpy()) # avoid bytes->array copy by @YouJiacheng
+        assert nbytes == 2 * num_tokens, "number of tokens read does not match header"
+    return tokens
+
+BOS_ID = 50256
+
+class BOSFinder:
+    # Helper for getting sequences that start at the beginning of documents by @varunneal based on work by @classiclarryd
+    def __init__(self, tokens: Tensor, world_size: int = 1, quickload: bool = False):
+        # Precompute BOS positions once per shard
+        self.tokens=tokens
+        self.size = tokens.numel()
+        self.quickload = quickload
+        if quickload:
+            # only scan first 4 million tokens, then kickoff async thread to scan rest
+            self.bos_idx = (tokens[:4_000_000] == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+            self.thread = None
+            self.ready = threading.Event()
+            self.start()
+        else:
+            self.bos_idx = (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.i = 0
+        self.world_size = world_size
+        self.batch_iter = 0
+
+    def _load(self):
+        self.bos_idx_async = (self.tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        self.bos_idx = self.bos_idx_async
+
+    def next_batch(self, num_tokens_local: int, max_seq_len: int):
+        # if quickload was used, repoint to the full dataset after 5 batches
+        if self.quickload and self.batch_iter==5:
+            self.get()
+        n = len(self.bos_idx)
+        starts = [[] for _ in range(self.world_size)]
+        ends = [[] for _ in range(self.world_size)]
+
+        idx = self.i
+        for r in range(self.world_size):
+            cur_len = 0
+            while cur_len <= num_tokens_local:
+                if idx >= n:
+                    raise StopIteration(f"Insufficient BOS ahead; hit tail of shard.")
+                cur = self.bos_idx[idx]
+                starts[r].append(cur)
+                end = min(self.bos_idx[idx + 1] if idx + 1 < n else self.size,
+                          cur + max_seq_len,
+                          cur + num_tokens_local - cur_len + 1)
+                ends[r].append(end)
+                cur_len += end - cur
+                idx += 1
+
+            assert cur_len == num_tokens_local + 1
+        self.i = idx
+        self.batch_iter+=1
+        return starts, ends
+
+class DataPreloader:
+    # Helper for asynchronously loading next shard and indexing bos tokens
+    def __init__(self, file_iter, world_size: int = 1):
+        self.file_iter = file_iter
+        self.world_size = world_size
+        self.thread = None
+        self.data = None
+        self.ready = threading.Event()
+
+    def _load(self):
+        tokens = _load_data_shard(next(self.file_iter))
+        self.data = (tokens, BOSFinder(tokens, self.world_size))
+        self.ready.set()
+
+    def start(self):
+        self.ready.clear()
+        self.thread = threading.Thread(target=self._load)
+        self.thread.start()
+
+    def get(self):
+        if self.thread:
+            self.ready.wait()
+            self.thread.join()
+        return self.data
+
+def get_bigram_hash(x):
+    """
+    Computes bigram hash for each position using [prev_token, curr_token].
+    Multiply by arbitary large ints to get even spread over int32 range.
+    Position 0 is mapped to the reserved index (vocab_size - 1).
+    BOS_tokens within the batch will hash based on last token of prior doc. Masking this ran slower and showed no improvement.
+    """
+    rand_int_1 = 36313
+    rand_int_2 = 27191
+    mod = args.bigram_vocab_size-1
+    x = x.to(torch.int32).clone()
+    x[0] = mod
+    x[1:] = torch.bitwise_xor(rand_int_1 * x[1:], rand_int_2 * x[:-1]) % mod
+    return x
+
+def distributed_data_generator(filename_pattern: str, num_tokens: int, max_seq_len: int, grad_accum_steps: int = 1, align_to_bos: bool = True):
+    # align_to_bos: each sequence begins with Beginning of Sequence token, sequences truncated to max_seq_len
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    assert num_tokens % (world_size * grad_accum_steps) == 0, "Batch size must be divisible by world size"
+    num_tokens = num_tokens // grad_accum_steps
+
+    files = [Path(file) for file in sorted(glob.glob(filename_pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {filename_pattern}")
+
+    file_iter = iter(files)  # Use itertools.cycle(files) for multi-epoch training
+    tokens = _load_data_shard(next(file_iter))
+    if align_to_bos:
+        finder = BOSFinder(tokens, world_size=world_size, quickload=True)
+        preloader = DataPreloader(file_iter, world_size)
+        preloader.start()
+    else:
+        pos = 0  # for unaligned case
+
+    while True:
+        num_tokens_local = num_tokens // world_size
+        max_num_docs = next_multiple_of_n(num_tokens_local // 300, n=128)  # median doc length is ~400
+
+        if align_to_bos:
+            try:
+                seq_starts, seq_ends = finder.next_batch(num_tokens_local, max_seq_len)
+                start_idxs, end_idxs = torch.tensor(seq_starts[rank]), torch.tensor(seq_ends[rank])
+            except StopIteration:
+                # This shard is exhausted, load the next one in the next loop iteration.
+                tokens, finder = preloader.get()
+                preloader.start()
+                continue
+
+            buf = torch.cat([tokens[i:j] for i, j in zip(start_idxs, end_idxs)])
+            _inputs = buf[:-1]
+            _targets = buf[1:]
+            end_idxs[-1] -= 1  # last document was too long to account for _targets offset
+            cum_lengths = (end_idxs - start_idxs).cumsum(0)
+
+        else:
+            if pos + num_tokens + 1 >= len(tokens):  # should not occur for val data
+                tokens, pos = _load_data_shard(next(file_iter)), 0
+
+            pos_local = pos + rank * num_tokens_local
+            buf = tokens[pos_local: pos_local + num_tokens_local + 1]
+            _inputs = buf[:-1].view(num_tokens_local, )
+            _targets = buf[1:].view(num_tokens_local, )
+
+            cum_lengths = torch.nonzero(_inputs == BOS_ID)[:, 0]
+            pos += num_tokens
+
+
+        _cum_lengths = torch.full((max_num_docs,), num_tokens_local)
+        _cum_lengths[0] = 0
+        _cum_lengths[1:len(cum_lengths) + 1] = cum_lengths
+
+        # Cast to int32 on CPU before transfer to avoid dtype conversion during .to()
+        _inputs = _inputs.to(dtype=torch.int32)
+        _targets = _targets.to(dtype=torch.int64)
+        _cum_lengths = _cum_lengths.to(dtype=torch.int32)
+        _bigram_inputs = get_bigram_hash(_inputs)
+
+        new_params = yield (
+            _inputs.to(device="cuda", non_blocking=True),
+            _targets.to(device="cuda", non_blocking=True),
+            _cum_lengths.to(device="cuda", non_blocking=True),
+            _bigram_inputs.to(device="cuda", non_blocking=True)
+        )
+
+        if new_params is not None:
+            # makes it possible for generator to receive new (num_tokens, max_seq_len, grad_accum_steps) via .send()
+            new_num_tokens, new_max_seq_len, new_grad_accum_steps = new_params
+            assert new_num_tokens % (world_size * new_grad_accum_steps) == 0, "Num tokens must be divisible by world size"
+            num_tokens = new_num_tokens // new_grad_accum_steps
+            max_seq_len = new_max_seq_len
+
+# -----------------------------------------------------------------------------
+# Training Management
+ 
+def get_bs(step: int):
+    if step >= args.num_scheduled_iterations:
+        return args.train_bs_extension
+    x = step / args.num_scheduled_iterations
+    bs_idx = int(len(args.train_bs_schedule) * x)
+    return args.train_bs_schedule[bs_idx]
+
+def get_ws(step: int):
+    # set short window size to half of long window size
+    # Higher ws on "extension" steps
+    if step >= args.num_scheduled_iterations:
+        return args.ws_final // 2, args.ws_final
+    x = step / args.num_scheduled_iterations
+    assert 0 <= x < 1
+    ws_idx = int(len(args.ws_schedule) * x)
+    return args.ws_schedule[ws_idx] // 2, args.ws_schedule[ws_idx]
+
+# learning rate schedule: tied to batch size schedule, with cooldown at the end.
+def get_lr(step: int):
+    if step > args.num_scheduled_iterations:
+        return 0.1
+    lr_max = 1.0
+    x = step / args.num_scheduled_iterations
+    if x > 1/3:
+       lr_max = 1.52  # (16/8)**0.6
+    if x > 2/3:
+        lr_max = 1.73  # (24/8)**0.5
+    if x >= 1 - args.cooldown_frac:
+        w = (1 - x) / args.cooldown_frac
+        lr = lr_max * w + (1 - w) * 0.1
+        return lr
+    return lr_max
+
+def get_muon_momentum(step: int, muon_warmup_steps=300, muon_cooldown_steps=50, momentum_min=0.85, momentum_max=0.95):
+    # warmup phase: linearly increase momentum from min to max
+    # cooldown phase: linearly decrease momentum from max to min
+    momentum_cd_start = args.num_iterations - muon_cooldown_steps
+    if step < muon_warmup_steps:
+        frac = step / muon_warmup_steps
+        momentum = momentum_min + frac * (momentum_max - momentum_min)
+    elif step > momentum_cd_start:
+        frac = (step - momentum_cd_start) / muon_cooldown_steps
+        momentum = momentum_max - frac * (momentum_max - momentum_min)
+    else:
+        momentum = momentum_max
+    return momentum
+
+class TrainingManager():
+    """
+    Manages the NorMuonAndAdam for all parameters with explicit ordering.
+    Notable Features:
+        1. Scalars are given higher momentum terms to smooth learning @ChrisJMcCormick
+        2. Adam optimizers are only stepped on odd steps @classiclarryd
+        3. Explicit scatter_order and work_order for communication scheduling (no backward hooks)
+        4. Muon has a linear momentum warmup and cooldown schedule
+        5. Learning rates follow a linear decay schedule
+        6. Embed is tied to lm_head until split step (2/3 of training), then untied @classiclarryd
+
+    Manages model architecture, data, and target that changes during training
+    Notable Features:
+        1. Multi Token Prediction schedule of [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1] @varunneal
+        2. Sliding Attention window schedule of [1,3] -> [3,7] -> [5,11] -> [6,13]
+        3. YaRN updates to RoPE on window changes
+        4. Split embed and lm_head at 2/3 of training (weights and optimizer state copied)
+        5. Batch size schedule of 8 -> 16 -> 24
+        6. Post training extension of long windows from 13 to 20
+    """
+    def __init__(self, model):
+        self.mtp_weights_schedule = self._build_mtp_schedule()
+        self.model = model
+        
+        # - Ordering dictates when to launch reduce/reduce_scatter operations
+        # - "sharded" parameters use reduce_scatter/all_gather and "replicated" ones use all_reduce
+        # - lr_mul and wd_mul are per-parameter learning rate and weight decay multipliers
+        self.param_table = {
+            "attn":           {"optim": "normuon", "comms": "sharded",    "adam_betas": None},
+            "mlp":            {"optim": "normuon", "comms": "sharded",    "adam_betas": None},         
+            "scalars":        {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "ve0":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve1":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "ve2":            {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "bigram_embed":   {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.75, 0.95], "lr_mul": 75.,  "wd_mul": 5.0},
+            "smear_gate":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.01, "wd_mul": 0.0},
+            "skip_gate":      {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99], "lr_mul": 0.05, "wd_mul": 0.0},
+            "attn_gate_bank": {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "ve_gate_bank":   {"optim": "adam",    "comms": "replicated", "adam_betas": [0.9,  0.99]},
+            "x0_lambdas":     {"optim": "adam",    "comms": "replicated", "adam_betas": [0.65, 0.95], "lr_mul": 5.0,  "wd_mul": 0.0},
+            "lm_head":        {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+            "embed":          {"optim": "adam",    "comms": "sharded",    "adam_betas": [0.5,  0.95], "wd_mul": 150.},
+        }
+
+        # - Process smaller/faster params first while large reduces complete
+        # - lm_head must complete before embed sync (when tied)
+        self.work_order = [
+            "scalars", "smear_gate", "skip_gate", "attn_gate_bank", "ve_gate_bank", "x0_lambdas",  # Small, fast
+            "ve0", "ve1", "ve2", "bigram_embed",  # Medium
+            "lm_head", "embed",   # lm_head must complete before embed sync (when tied)
+            "attn", "mlp",        # Large, polar express - process last to maximize overlap
+        ]
+
+        adam_defaults = dict(
+            lr=0.008,
+            eps=1e-10,
+            weight_decay=0.005,
+        )
+        
+        normuon_defaults = dict(
+            lr=0.023,
+            momentum=0.95,
+            beta2=0.95,
+            weight_decay=1.2,
+        )
+        
+        self.optimizer = NorMuonAndAdam(
+            model.named_parameters(),
+            param_table=self.param_table,
+            scatter_order=list(self.param_table.keys()),  # Dict order defines scatter priority
+            work_order=self.work_order,
+            adam_defaults=adam_defaults,
+            normuon_defaults=normuon_defaults,
+        )
+
+        # Split embed from lm_head at 2/3 of training (on an odd step so Adam updates)
+        self.split_step = math.ceil(args.split_embed_frac * args.num_scheduled_iterations) | 1
+
+        self.reset()
+
+    def _build_mtp_schedule(self):
+        # Precompute MTP weights for all steps to avoid tensor allocation during training
+        # Schedule: [1, 0.5, 0.25->0] -> [1, 0.5->0] -> [1]
+        mtp_weights_schedule = []
+        for s in range(args.num_iterations + 1):
+            x = s / args.num_scheduled_iterations
+            if x < 1/3:
+                w = [1.0, 0.5, 0.25 * (1 - 3*x)]
+            elif x < 2/3:
+                w = [1.0, 0.5 * (1 - (3*x - 1))]
+            else:
+                w = [1.0]
+            mtp_weights_schedule.append(torch.tensor(w, device=device))
+        return mtp_weights_schedule
+
+    def apply_final_ws_ext(self):
+        self.ws_long = args.ws_validate_post_yarn_ext
+
+    def get_forward_args(self):
+        return ForwardScheduleConfig(
+            mtp_weights = self.mtp_weights,
+            ws_short = self.ws_short,
+            ws_long = self.ws_long
+        )
+    
+    def _is_adam_step(self, step: int):
+        """Adam params are only updated on odd steps."""
+        return step % 2 == 1
+
+    def get_transition_steps(self):
+        transition_steps = []
+        ws_short, ws_long = get_ws(0)
+        for step in range(1, args.num_iterations):
+            ws_short, new_ws_long = get_ws(step)
+            if new_ws_long != ws_long:
+                transition_steps.append(step)
+                ws_long = new_ws_long
+        return transition_steps
+
+    def advance_schedule(self, step: int):
+        self.ws_short, new_ws_long = get_ws(step)
+        if new_ws_long != self.ws_long:
+            self.model.yarn.apply(self.ws_long, new_ws_long)
+            self.model.yarn_paired_head.apply(self.ws_long, new_ws_long)
+
+        new_batch_size = get_bs(step)
+        if new_batch_size != self.batch_size:
+            self.train_loader_send_args = (new_batch_size, args.train_max_seq_len, grad_accum_steps)
+            self.batch_size = new_batch_size
+        else:
+            self.train_loader_send_args = None
+
+        self.ws_long = new_ws_long
+        self.mtp_weights = self.mtp_weights_schedule[step]
+    
+    def step_optimizers(self, step: int):
+        step_lr = get_lr(step)
+        muon_momentum = get_muon_momentum(step)
+        do_adam = self._is_adam_step(step)
+        
+        # Update learning rates and momentum for all params
+        for param, p_cfg in self.optimizer.param_cfgs.items():
+            p_cfg.lr = p_cfg.initial_lr * step_lr
+            if p_cfg.optim == "normuon":
+                p_cfg.momentum = muon_momentum
+        
+        # Step optimizer with do_adam flag
+        self.optimizer.step(do_adam=do_adam)
+        
+        # At split step: copy lm_head optimizer state to embed and mark as split
+        if step == self.split_step:
+            self.optimizer.copy_lm_state_to_embed()
+
+    def reset(self, state=None):
+        if state is not None:
+            self.optimizer.load_state_dict(state)
+
+        # Reset NorMuon momentum buffers and split_embed state
+        self.optimizer.reset()
+
+        self.ws_short, self.ws_long = get_ws(0)
+        self.batch_size = get_bs(0)
+        self.model.yarn.reset()
+        self.model.yarn_paired_head.reset()
+
+    def get_state(self):
+        return copy.deepcopy(self.optimizer.state_dict())
+
+# -----------------------------------------------------------------------------
+# int main
+
+@dataclass
+class Hyperparameters:
+    # data
+    train_files: str = "data/fineweb10B/fineweb_train_*.bin" # input .bin to train on
+    val_files: str = "data/fineweb10B/fineweb_val_*.bin" # input .bin to eval validation loss on
+    val_tokens: int = 10485760 # how many tokens of validation data? it's important to keep this fixed for consistent comparisons
+    # batch sizes
+    train_bs_schedule: tuple = (8 * 2048 * 8, 16 * 2048 * 8, 24 * 2048 * 8)
+    train_bs_extension: int = 24 * 2048 * 8
+    train_max_seq_len: int = 128 * 16
+    val_batch_size: int = 4 * 64 * 1024 * 8
+    # optimization
+    num_scheduled_iterations: int = 1560  # number of steps to complete lr and ws schedule
+    num_extension_iterations: int = 40  # number of steps to continue training at final lr and ws
+    num_iterations: int = num_scheduled_iterations + num_extension_iterations
+    cooldown_frac: float = 0.55  # fraction of num_scheduled_iterations spent cooling down the learning rate
+    split_embed_frac: float = 2/3  # fraction of training when embeddings split from lm_head
+    # evaluation and logging
+    run_id: str = f"{uuid.uuid4()}"
+    val_loss_every: int = 250  # every how many steps to evaluate val loss? 0 for only at the end
+    save_checkpoint: bool = False
+    # attention masking
+    block_size: int = 128
+    ws_schedule: tuple = (3, 7, 11)
+    ws_final: int = 13 # increase final validation ws, used for YaRN extension and short window size @classiclarryd
+    ws_validate_post_yarn_ext: int = 20 # extend long windows out even further after applying YaRN
+    # bigram hash embedding
+    bigram_vocab_size = 50304 * 5
+
+args = Hyperparameters()
+
+data_path = os.environ.get("DATA_PATH", ".")
+args.train_files = os.path.join(data_path, args.train_files)
+args.val_files = os.path.join(data_path, args.val_files)
+
+# torchrun sets these env variables
+rank = int(os.environ["RANK"])
+world_size = int(os.environ["WORLD_SIZE"])
+assert 8 % world_size == 0, "world_size must be a divisor of 8"
+grad_accum_steps = 8 // world_size
+assert torch.cuda.is_available()
+device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+torch.cuda.set_device(device)
+dist.init_process_group(backend="nccl", device_id=device)
+dist.barrier()
+master_process = (rank == 0) # this process will do logging, checkpointing etc.
+
+# begin logging
+logfile = None
+if master_process:
+    run_id = args.run_id
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+    print(logfile)
+def print0(s, console=False):
+    if master_process:
+        with open(logfile, "a") as f:
+            if console:
+                print(s)
+            print(s, file=f)
+
+# begin by printing this file (the Python code)
+print0(code)
+print0("="*100)
+# log information about the hardware/software environment this is running on
+print0(f"Running Python {sys.version}")
+print0(f"Running PyTorch {torch.version.__version__} compiled for CUDA {torch.version.cuda}")
+print0(f"Running Triton version {triton.__version__}")
+
+def nvidia_smi():
+    import subprocess  # avoid top level import
+    return subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+print0(nvidia_smi())
+print0("="*100)
+
+model: nn.Module = GPT(
+    vocab_size=50257,
+    num_layers=11,
+    num_heads=6,
+    head_dim=128,
+    model_dim=768,
+    max_seq_len=args.val_batch_size // (grad_accum_steps * world_size)
+).cuda()
+for m in model.modules():
+    if isinstance(m, (nn.Embedding, nn.Linear)):
+        m.weight.data = m.weight.data.bfloat16()
+model.attn_gate_bank.data = model.attn_gate_bank.data.bfloat16()
+model.ve_gate_bank.data = model.ve_gate_bank.data.bfloat16()
+model.attn_bank.data = model.attn_bank.data.bfloat16()
+model.mlp_bank.data = model.mlp_bank.data.bfloat16()
+for param in model.parameters():
+    dist.broadcast(param.detach(), 0)
+
+model: nn.Module = torch.compile(model, dynamic=False, fullgraph=True)
+training_manager = TrainingManager(model)
+
+########################################
+#            Warmup kernels            #
+########################################
+print0("Compiling model and warming up kernels (~7 minutes on first execution)", console=True)
+# Warmup the training kernels, then re-initialize the state so we aren't cheating
+initial_state = dict(model=copy.deepcopy(model.state_dict()),
+                     optimizer=training_manager.get_state()) # save the initial state
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+
+transition_steps = training_manager.get_transition_steps()
+# first few steps plus transitions
+warmup_steps = sorted({0, 1, 2} | set(s + offset for s in transition_steps for offset in [-1, 0, 1] if s + offset >= 0)) 
+print0(f"Sampling steps {warmup_steps} for warmup", console=True)
+for step in warmup_steps:
+    training_manager.advance_schedule(step)
+    model.eval()
+    with torch.no_grad():
+        inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+        model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+    model.train()
+    for idx in range(grad_accum_steps):
+        send_args = training_manager.train_loader_send_args
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+print0("Resetting Model", console=True)
+model.zero_grad(set_to_none=True)
+model.load_state_dict(initial_state["model"])
+training_manager.reset(initial_state["optimizer"])
+del val_loader, train_loader, initial_state
+model.train()
+
+########################################
+#        Training and validation       #
+########################################
+train_loader = distributed_data_generator(args.train_files, args.train_bs_schedule[0], args.train_max_seq_len, grad_accum_steps=grad_accum_steps)
+
+gc.collect()
+
+training_time_ms = 0
+# start the clock
+torch.cuda.synchronize()
+t0 = time.perf_counter()
+# begin training
+train_steps = args.num_iterations
+for step in range(train_steps + 1):
+    last_step = (step == train_steps)
+    training_manager.advance_schedule(step)
+    # --------------- VALIDATION SECTION -----------------
+    if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+        if last_step:
+            training_manager.apply_final_ws_ext()
+        # stop the clock
+        torch.cuda.synchronize()
+        training_time_ms += 1000 * (time.perf_counter() - t0)
+        model.eval()
+        assert args.val_tokens % args.val_batch_size == 0
+        val_steps = grad_accum_steps * args.val_tokens // args.val_batch_size
+        val_loader = distributed_data_generator(args.val_files, args.val_batch_size, -1, grad_accum_steps=grad_accum_steps, align_to_bos=False)
+        val_loss = 0
+        with torch.no_grad():
+            for _ in range(val_steps):
+                inputs, targets, cum_seqlens, bigram_inputs = next(val_loader)
+                val_loss += model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args())
+        val_loss /= val_steps
+        del val_loader
+        dist.reduce(val_loss, 0, op=dist.ReduceOp.AVG)
+        print0(f"step:{step}/{train_steps} val_loss:{val_loss:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step, 1):.2f}ms", console=True)
+        model.train()
+        # start the clock again
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+
+    if last_step:
+        if master_process and args.save_checkpoint:
+            log = dict(step=step, code=code, model=model.state_dict(), optimizer=training_manager.get_state())
+            os.makedirs(f"logs/{run_id}", exist_ok=True)
+            torch.save(log, f"logs/{run_id}/state_step{step:06d}.pt")
+        # the last step only has the validation loop, so break to avoid training
+        break
+
+    # --------------- TRAINING SECTION -----------------
+    for idx in range(grad_accum_steps):
+        inputs, targets, cum_seqlens, bigram_inputs = train_loader.send(training_manager.train_loader_send_args)
+        (model(inputs, targets, cum_seqlens, bigram_inputs, training_manager.get_forward_args()) / grad_accum_steps).backward()
+    training_manager.step_optimizers(step)
+
+    # logging
+    approx_training_time_ms = training_time_ms + 1000 * (time.perf_counter() - t0)
+    print0(f"step:{step+1}/{train_steps} train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms/(step + 1):.2f}ms", console=True)
+
+print0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+       f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB", console=True)
+dist.destroy_process_group()
+
+----------------------------------------
+# triton_kernels.py
+----------------------------------------
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# -----------------------------------------------------------------------------
+# Triton kernel for symmetric matrix multiplication by @byronxu99
+
+def _get_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 8,
+                "LOWER_UPPER": 1,
+            },
+            num_stages=stages,
+            num_warps=warps,
+        )
+        for bm in [64, 128]
+        for bn in [64, 128, 256]
+        for bk in [64, 128]
+        for stages, warps in [(3, 4), (3, 8), (4, 4)]
+        if bm // bn <= 2 and bn // bm <= 2
+    ]
+
+@triton.jit
+def _pid_to_block(
+    pid,
+    M,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Split output matrix into blocks of size (BLOCK_SIZE_M, BLOCK_SIZE_N)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(M, BLOCK_SIZE_N)
+
+    # Map PID to a single matrix in batch
+    batch_idx = pid // (num_pid_m * num_pid_n)
+    pid = pid % (num_pid_m * num_pid_n)
+
+    # Map PID to 2D grid of blocks
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    pid_m, pid_n = tl.swizzle2d(pid_m, pid_n, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    m_idx = pid_m * BLOCK_SIZE_M
+    n_idx = pid_n * BLOCK_SIZE_N
+    return batch_idx, m_idx, n_idx
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "K", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def XXT_kernel(
+    A_ptr, C_ptr,
+    M, K,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def XXT(A: torch.Tensor, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = A @ A.T
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert out.size(-2) == M, "Output matrix has incorrect shape"
+    assert out.size(-1) == M, "Output matrix has incorrect shape"
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    XXT_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        K=K,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+    )
+    return out
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "a_stride_r", "a_stride_c", "c_stride_r", "c_stride_c"],
+)
+@triton.jit
+def ba_plus_cAA_kernel(
+    A_ptr, C_ptr,
+    M,
+    a_stride_b, a_stride_r, a_stride_c,
+    c_stride_b, c_stride_r, c_stride_c,
+    alpha, beta,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    LOWER_UPPER: tl.constexpr,
+):
+    # This is mostly duplicated from XXT_kernel, but also loads and adds a block of A
+    # Performance is slightly slower than XXT_kernel, so we use two separate kernels
+    pid = tl.program_id(axis=0)
+    batch_idx, m_idx, n_idx = _pid_to_block(
+        pid, M, BLOCK_SIZE_M, BLOCK_SIZE_N, GROUP_SIZE_M
+    )
+
+    # Skip blocks that don't need to be computed
+    skip_block_below_diag = (LOWER_UPPER == 0) and (n_idx + BLOCK_SIZE_N <= m_idx)
+    skip_block_above_diag = (LOWER_UPPER != 0) and (m_idx + BLOCK_SIZE_M <= n_idx)
+    if skip_block_below_diag or skip_block_above_diag:
+        return
+
+    # Index into one matrix of batch
+    A_ptr += batch_idx * a_stride_b
+    C_ptr += batch_idx * c_stride_b
+
+    # Create pointer arrays for A and A.T
+    offs_m = (m_idx + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_n = (n_idx + tl.arange(0, BLOCK_SIZE_N)) % M
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_m[:, None] * a_stride_r + offs_k[None, :] * a_stride_c)
+    at_ptrs = A_ptr + (offs_k[:, None] * a_stride_c + offs_n[None, :] * a_stride_r)
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    # Accumulate over blocks of K
+    for k in tl.range(0, tl.cdiv(M, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < M - k * BLOCK_SIZE_K, other=0.0)
+        at = tl.load(at_ptrs, mask=offs_k[:, None] < M - k * BLOCK_SIZE_K, other=0.0)
+        accumulator = tl.dot(a, at, accumulator)
+        a_ptrs += BLOCK_SIZE_K * a_stride_c
+        at_ptrs += BLOCK_SIZE_K * a_stride_c
+
+    # Load block of A to add (corresponds to the current block of C)
+    offs_am = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_an = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    a_add_ptrs = A_ptr + (offs_am[:, None] * a_stride_r + offs_an[None, :] * a_stride_c)
+    a_add_mask = (offs_am[:, None] < M) & (offs_an[None, :] < M)
+    a_add = tl.load(a_add_ptrs, mask=a_add_mask, other=0.0).to(tl.float32)
+
+    # Apply alpha and beta
+    accumulator *= alpha
+    accumulator += a_add * beta
+
+    out_dtype = C_ptr.dtype.element_ty
+    output = accumulator.to(out_dtype)
+
+    # Store block of C
+    offs_cm = m_idx + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = n_idx + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + (offs_cm[:, None] * c_stride_r + offs_cn[None, :] * c_stride_c)
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < M)
+    tl.store(c_ptrs, output, mask=c_mask)
+
+    # Store block of C mirrored across the diagonal
+    c_ptrs_t = C_ptr + (offs_cn[:, None] * c_stride_r + offs_cm[None, :] * c_stride_c)
+    c_mask_t = (offs_cn[:, None] < M) & (offs_cm[None, :] < M)
+    tl.store(c_ptrs_t, output.T, mask=c_mask_t)
+
+def ba_plus_cAA(A: torch.Tensor, alpha: float, beta: float, out: torch.Tensor):
+    """
+    Launch Triton kernel to compute C = alpha * A @ A.T + beta * A
+    """
+    assert A.ndim == 2 or A.ndim == 3
+    M, K = A.shape[-2:]
+    assert M == K, "Input matrix must be square"
+    assert out.size(-2) == M
+    assert out.size(-1) == M
+
+    batch_size = A.size(0) if A.ndim == 3 else 1
+    input_batch_stride = A.stride(0) if A.ndim == 3 else 0
+    output_batch_stride = out.stride(0) if out.ndim == 3 else 0
+
+    grid = lambda meta: (
+        batch_size * triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(M, meta["BLOCK_SIZE_N"]),
+    )
+    ba_plus_cAA_kernel[grid](
+        A_ptr=A,
+        C_ptr=out,
+        M=M,
+        a_stride_b=input_batch_stride,
+        a_stride_r=A.stride(-2),
+        a_stride_c=A.stride(-1),
+        c_stride_b=output_batch_stride,
+        c_stride_r=out.stride(-2),
+        c_stride_c=out.stride(-1),
+        alpha=alpha,
+        beta=beta,
+    )
+    return out
+
+# -----------------------------------------------------------------------------
+# Triton kernel for MLP: relu(x @ W1.T)^2, by @andrewbriand, @jrauvola
+
+@triton.jit
+def linear_relu_square_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                 M, N, K,
+                                 BLOCK_SIZE_M: tl.constexpr,
+                                 BLOCK_SIZE_N: tl.constexpr,
+                                 BLOCK_SIZE_K: tl.constexpr,
+                                 GROUP_SIZE_M: tl.constexpr,
+                                 NUM_SMS: tl.constexpr,
+                                 FORWARD: tl.constexpr,
+                                 ):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        tile_id_c += NUM_SMS
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am_c = pid_m * BLOCK_SIZE_M
+        offs_bn_c = pid_n * BLOCK_SIZE_N
+
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+
+        c0 = acc0.to(dtype)
+        if not FORWARD:
+            c0_pre = aux_desc.load([offs_am_c, offs_bn_c])
+            c0 = 2 * c0 * tl.where(c0_pre > 0, c0_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+
+        if FORWARD:
+            c0_post = tl.maximum(c0, 0)
+            c0_post = c0_post * c0_post
+            aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            c1_pre = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c1 = 2 * c1 * tl.where(c1_pre > 0, c1_pre, 0)
+
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+
+        if FORWARD:
+            c1_post = tl.maximum(c1, 0)
+            c1_post = c1_post * c1_post
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+
+def linear_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K = b.shape
+    dtype = a.dtype
+
+    c = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    FORWARD = False
+    if aux is None:
+        FORWARD = True
+        aux = torch.empty((M, N), device=a.device, dtype=dtype)
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 256
+    BLOCK_SIZE_K = 64
+    num_stages = 4 if FORWARD else 3
+    num_warps = 8
+
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        ), )
+
+    linear_relu_square_kernel[grid](
+        a_desc, b_desc, c_desc, aux_desc,
+        M, N, K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=1,
+        NUM_SMS=NUM_SMS,
+        FORWARD=FORWARD,
+        num_stages=num_stages,
+        num_warps=num_warps
+    )
+
+    if FORWARD:
+        return c, aux
+    else:
+        return c
+
+class FusedLinearReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, W1, W2):
+        pre, post = linear_relu_square(x.view((-1, x.shape[-1])), W1)
+        x3 = post @ W2
+        ctx.save_for_backward(x, W1, W2, pre, post)
+        return x3.view(x.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, W1, W2, pre, post = ctx.saved_tensors
+        dW2 = post.T @ grad_output
+        dpre = linear_relu_square(grad_output.view((-1, grad_output.shape[-1])), W2, aux=pre)
+        dW1 = dpre.T @ x
+        dx = dpre @ W1
+        return dx.view(x.shape), dW1, dW2
+
+# -----------------------------------------------------------------------------
+# Fused Softcapped Cross Entropy
+
+
+@triton.jit
+def fused_softcapped_entropy_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    
+    max_val = -float('inf')
+    sum_exp = 0.0
+    
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=-float('inf')).to(tl.float32)
+        z = A * tl.sigmoid((val + B) / C)
+        z = tl.where(mask, z, -float('inf'))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    
+    total_loss = 0.0
+    for k in range(n_predict):
+        target_idx = row_idx + k
+        if target_idx < n_rows:
+            weight = tl.load(mtp_weights_ptr + k)
+            if weight > 0:
+                target = tl.load(targets_ptr + target_idx).to(tl.int32)
+                if target >= 0 and target < n_cols:
+                    val_target = tl.load(logits_row_ptr + target).to(tl.float32)
+                    z_target = A * tl.sigmoid((val_target + B) / C)
+                    total_loss += weight * (lse - z_target)
+    
+    tl.store(losses_ptr + row_idx, total_loss)
+
+@triton.jit
+def fused_softcapped_entropy_bwd_kernel(
+    grad_input_ptr, grad_output_ptr, lse_ptr, logits_ptr, targets_ptr, mtp_weights_ptr,
+    stride_logits_n, stride_logits_v, stride_grad_n, stride_grad_v,
+    n_rows, n_cols, n_predict,
+    A, B, C,
+    BLOCK_SIZE: tl.constexpr
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_input_ptr + row_idx * stride_grad_n
+    
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_output_ptr + row_idx)
+    
+    S_w = 0.0
+    for k in range(n_predict):
+        if row_idx + k < n_rows:
+            S_w += tl.load(mtp_weights_ptr + k)
+            
+    for off in range(0, n_cols, BLOCK_SIZE):
+        cols = off + tl.arange(0, BLOCK_SIZE)
+        mask = cols < n_cols
+        val = tl.load(logits_row_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        u = (val + B) / C
+        sigmoid_u = tl.sigmoid(u)
+        z = A * sigmoid_u
+        p = tl.exp(z - lse)
+        
+        term1 = S_w * p
+        term2 = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for k in range(n_predict):
+            if row_idx + k < n_rows:
+                target = tl.load(targets_ptr + row_idx + k).to(tl.int32)
+                weight = tl.load(mtp_weights_ptr + k)
+                term2 += tl.where(cols == target, weight, 0.0)
+        
+        grad_z = grad_loss * (term1 - term2)
+        dz_dx = (1.0 / C) * z * (1.0 - sigmoid_u)
+        grad_x = grad_z * dz_dx
+        tl.store(grad_row_ptr + cols, grad_x.to(tl.bfloat16), mask=mask)
+
+class FusedSoftcappedCrossEntropy(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets, mtp_weights, A=23.0, B=5.0, C=7.5):
+        n_rows, n_cols = logits.shape
+        if mtp_weights is None:
+             mtp_weights = torch.tensor([1.0], device=logits.device, dtype=torch.float32)
+        n_predict = mtp_weights.shape[0]
+
+        losses = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        lse = torch.empty(n_rows, dtype=torch.float32, device=logits.device)
+        
+        logits = logits.contiguous()
+        targets = targets.contiguous()
+        mtp_weights = mtp_weights.contiguous()
+
+        grid = (n_rows,)
+        fused_softcapped_entropy_fwd_kernel[grid](
+            logits, losses, lse, targets, mtp_weights,
+            logits.stride(0), logits.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        
+        ctx.save_for_backward(logits, targets, mtp_weights, lse)
+        ctx.params = (A, B, C)
+        return losses
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, targets, mtp_weights, lse = ctx.saved_tensors
+        A, B, C = ctx.params
+        n_rows, n_cols = logits.shape
+        n_predict = mtp_weights.shape[0]
+        
+        grad_input = torch.empty((n_rows, n_cols), dtype=torch.bfloat16, device=logits.device)
+        grad_output = grad_output.contiguous()
+        
+        grid = (n_rows,)
+        fused_softcapped_entropy_bwd_kernel[grid](
+            grad_input, grad_output, lse, logits, targets, mtp_weights,
+            logits.stride(0), logits.stride(1), grad_input.stride(0), grad_input.stride(1),
+            n_rows, n_cols, n_predict,
+            A, B, C,
+            BLOCK_SIZE=1024,
+            num_warps=8,
+            num_stages=4
+        )
+        return grad_input, None, None, None, None, None
+====================================================================================================
+Running Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
+Running PyTorch 2.10.0.dev20251210+cu126 compiled for CUDA 12.6
+Running Triton version 3.6.0
+Mon Jan 26 03:16:38 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:61:00.0 Off |                    0 |
+| N/A   35C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:62:00.0 Off |                    0 |
+| N/A   39C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:63:00.0 Off |                    0 |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:64:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:6A:00.0 Off |                    0 |
+| N/A   35C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:6B:00.0 Off |                    0 |
+| N/A   42C    P0            133W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:6C:00.0 Off |                    0 |
+| N/A   40C    P0            125W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:6D:00.0 Off |                    0 |
+| N/A   36C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A          295628      C   /usr/bin/python3                       1510MiB |
+|    1   N/A  N/A          295629      C   /usr/bin/python3                       1510MiB |
+|    2   N/A  N/A          295630      C   /usr/bin/python3                       1510MiB |
+|    3   N/A  N/A          295631      C   /usr/bin/python3                       1510MiB |
+|    4   N/A  N/A          295632      C   /usr/bin/python3                       1510MiB |
+|    5   N/A  N/A          295633      C   /usr/bin/python3                       1510MiB |
+|    6   N/A  N/A          295634      C   /usr/bin/python3                       1510MiB |
+|    7   N/A  N/A          295635      C   /usr/bin/python3                       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+Compiling model and warming up kernels (~7 minutes on first execution)
+Sampling steps [0, 1, 2, 519, 520, 521, 1039, 1040, 1041, 1559, 1560, 1561] for warmup
+Resetting Model
+step:0/1600 val_loss:10.8305 train_time:0ms step_avg:0.03ms
+step:1/1600 train_time:79ms step_avg:79.10ms
+step:2/1600 train_time:103ms step_avg:51.45ms
+step:3/1600 train_time:122ms step_avg:40.65ms
+step:4/1600 train_time:146ms step_avg:36.41ms
+step:5/1600 train_time:176ms step_avg:35.29ms
+step:6/1600 train_time:358ms step_avg:59.72ms
+step:7/1600 train_time:378ms step_avg:54.06ms
+step:8/1600 train_time:399ms step_avg:49.86ms
+step:9/1600 train_time:424ms step_avg:47.15ms
+step:10/1600 train_time:461ms step_avg:46.14ms
+step:11/1600 train_time:492ms step_avg:44.74ms
+step:12/1600 train_time:529ms step_avg:44.07ms
+step:13/1600 train_time:560ms step_avg:43.04ms
+step:14/1600 train_time:596ms step_avg:42.60ms
+step:15/1600 train_time:628ms step_avg:41.85ms
+step:16/1600 train_time:665ms step_avg:41.56ms
+step:17/1600 train_time:696ms step_avg:40.93ms
+step:18/1600 train_time:732ms step_avg:40.69ms
+step:19/1600 train_time:764ms step_avg:40.20ms
+step:20/1600 train_time:801ms step_avg:40.05ms
+step:21/1600 train_time:832ms step_avg:39.62ms
+step:22/1600 train_time:869ms step_avg:39.52ms
+step:23/1600 train_time:900ms step_avg:39.15ms
+step:24/1600 train_time:938ms step_avg:39.06ms
+step:25/1600 train_time:969ms step_avg:38.74ms
+step:26/1600 train_time:1006ms step_avg:38.68ms
+step:27/1600 train_time:1037ms step_avg:38.39ms
+step:28/1600 train_time:1073ms step_avg:38.33ms
+step:29/1600 train_time:1104ms step_avg:38.08ms
+step:30/1600 train_time:1141ms step_avg:38.04ms
+step:31/1600 train_time:1172ms step_avg:37.81ms
+step:32/1600 train_time:1209ms step_avg:37.78ms
+step:33/1600 train_time:1240ms step_avg:37.58ms
+step:34/1600 train_time:1278ms step_avg:37.59ms
+step:35/1600 train_time:1309ms step_avg:37.40ms
+step:36/1600 train_time:1346ms step_avg:37.40ms
+step:37/1600 train_time:1377ms step_avg:37.22ms
+step:38/1600 train_time:1414ms step_avg:37.21ms
+step:39/1600 train_time:1445ms step_avg:37.05ms
+step:40/1600 train_time:1482ms step_avg:37.06ms
+step:41/1600 train_time:1513ms step_avg:36.91ms
+step:42/1600 train_time:1550ms step_avg:36.91ms
+step:43/1600 train_time:1581ms step_avg:36.77ms
+step:44/1600 train_time:1618ms step_avg:36.78ms
+step:45/1600 train_time:1649ms step_avg:36.65ms
+step:46/1600 train_time:1687ms step_avg:36.66ms
+step:47/1600 train_time:1717ms step_avg:36.54ms
+step:48/1600 train_time:1754ms step_avg:36.55ms
+step:49/1600 train_time:1785ms step_avg:36.43ms
+step:50/1600 train_time:1822ms step_avg:36.45ms
+step:51/1600 train_time:1853ms step_avg:36.34ms
+step:52/1600 train_time:1890ms step_avg:36.35ms
+step:53/1600 train_time:1921ms step_avg:36.24ms
+step:54/1600 train_time:1958ms step_avg:36.25ms
+step:55/1600 train_time:1988ms step_avg:36.15ms
+step:56/1600 train_time:2025ms step_avg:36.17ms
+step:57/1600 train_time:2056ms step_avg:36.07ms
+step:58/1600 train_time:2093ms step_avg:36.09ms
+step:59/1600 train_time:2124ms step_avg:36.00ms
+step:60/1600 train_time:2161ms step_avg:36.02ms
+step:61/1600 train_time:2192ms step_avg:35.94ms
+step:62/1600 train_time:2229ms step_avg:35.96ms
+step:63/1600 train_time:2261ms step_avg:35.88ms
+step:64/1600 train_time:2298ms step_avg:35.90ms
+step:65/1600 train_time:2328ms step_avg:35.82ms
+step:66/1600 train_time:2366ms step_avg:35.85ms
+step:67/1600 train_time:2396ms step_avg:35.77ms
+step:68/1600 train_time:2433ms step_avg:35.78ms
+step:69/1600 train_time:2464ms step_avg:35.71ms
+step:70/1600 train_time:2501ms step_avg:35.73ms
+step:71/1600 train_time:2532ms step_avg:35.67ms
+step:72/1600 train_time:2570ms step_avg:35.69ms
+step:73/1600 train_time:2601ms step_avg:35.63ms
+step:74/1600 train_time:2638ms step_avg:35.64ms
+step:75/1600 train_time:2669ms step_avg:35.59ms
+step:76/1600 train_time:2706ms step_avg:35.61ms
+step:77/1600 train_time:2737ms step_avg:35.55ms
+step:78/1600 train_time:2774ms step_avg:35.57ms
+step:79/1600 train_time:2805ms step_avg:35.51ms
+step:80/1600 train_time:2843ms step_avg:35.53ms
+step:81/1600 train_time:2874ms step_avg:35.48ms
+step:82/1600 train_time:2911ms step_avg:35.50ms
+step:83/1600 train_time:2942ms step_avg:35.44ms
+step:84/1600 train_time:2979ms step_avg:35.46ms
+step:85/1600 train_time:3010ms step_avg:35.41ms
+step:86/1600 train_time:3048ms step_avg:35.44ms
+step:87/1600 train_time:3079ms step_avg:35.39ms
+step:88/1600 train_time:3115ms step_avg:35.40ms
+step:89/1600 train_time:3146ms step_avg:35.35ms
+step:90/1600 train_time:3184ms step_avg:35.38ms
+step:91/1600 train_time:3215ms step_avg:35.33ms
+step:92/1600 train_time:3252ms step_avg:35.35ms
+step:93/1600 train_time:3283ms step_avg:35.30ms
+step:94/1600 train_time:3319ms step_avg:35.31ms
+step:95/1600 train_time:3351ms step_avg:35.27ms
+step:96/1600 train_time:3389ms step_avg:35.30ms
+step:97/1600 train_time:3420ms step_avg:35.25ms
+step:98/1600 train_time:3456ms step_avg:35.27ms
+step:99/1600 train_time:3487ms step_avg:35.23ms
+step:100/1600 train_time:3525ms step_avg:35.25ms
+step:101/1600 train_time:3556ms step_avg:35.20ms
+step:102/1600 train_time:3592ms step_avg:35.22ms
+step:103/1600 train_time:3624ms step_avg:35.19ms
+step:104/1600 train_time:3661ms step_avg:35.20ms
+step:105/1600 train_time:3692ms step_avg:35.16ms
+step:106/1600 train_time:3729ms step_avg:35.18ms
+step:107/1600 train_time:3760ms step_avg:35.14ms
+step:108/1600 train_time:3797ms step_avg:35.16ms
+step:109/1600 train_time:3828ms step_avg:35.12ms
+step:110/1600 train_time:3866ms step_avg:35.14ms
+step:111/1600 train_time:3896ms step_avg:35.10ms
+step:112/1600 train_time:3934ms step_avg:35.12ms
+step:113/1600 train_time:3965ms step_avg:35.09ms
+step:114/1600 train_time:4002ms step_avg:35.11ms
+step:115/1600 train_time:4033ms step_avg:35.07ms
+step:116/1600 train_time:4070ms step_avg:35.09ms
+step:117/1600 train_time:4101ms step_avg:35.05ms
+step:118/1600 train_time:4138ms step_avg:35.07ms
+step:119/1600 train_time:4169ms step_avg:35.03ms
+step:120/1600 train_time:4206ms step_avg:35.05ms
+step:121/1600 train_time:4237ms step_avg:35.02ms
+step:122/1600 train_time:4274ms step_avg:35.03ms
+step:123/1600 train_time:4305ms step_avg:35.00ms
+step:124/1600 train_time:4342ms step_avg:35.01ms
+step:125/1600 train_time:4373ms step_avg:34.98ms
+step:126/1600 train_time:4410ms step_avg:35.00ms
+step:127/1600 train_time:4441ms step_avg:34.97ms
+step:128/1600 train_time:4478ms step_avg:34.98ms
+step:129/1600 train_time:4509ms step_avg:34.96ms
+step:130/1600 train_time:4547ms step_avg:34.98ms
+step:131/1600 train_time:4578ms step_avg:34.95ms
+step:132/1600 train_time:4615ms step_avg:34.96ms
+step:133/1600 train_time:4646ms step_avg:34.93ms
+step:134/1600 train_time:4683ms step_avg:34.95ms
+step:135/1600 train_time:4713ms step_avg:34.91ms
+step:136/1600 train_time:4750ms step_avg:34.93ms
+step:137/1600 train_time:4781ms step_avg:34.90ms
+step:138/1600 train_time:4818ms step_avg:34.91ms
+step:139/1600 train_time:4849ms step_avg:34.88ms
+step:140/1600 train_time:4886ms step_avg:34.90ms
+step:141/1600 train_time:4917ms step_avg:34.87ms
+step:142/1600 train_time:4954ms step_avg:34.89ms
+step:143/1600 train_time:4985ms step_avg:34.86ms
+step:144/1600 train_time:5022ms step_avg:34.87ms
+step:145/1600 train_time:5053ms step_avg:34.85ms
+step:146/1600 train_time:5090ms step_avg:34.86ms
+step:147/1600 train_time:5121ms step_avg:34.84ms
+step:148/1600 train_time:5158ms step_avg:34.85ms
+step:149/1600 train_time:5189ms step_avg:34.83ms
+step:150/1600 train_time:5226ms step_avg:34.84ms
+step:151/1600 train_time:5257ms step_avg:34.82ms
+step:152/1600 train_time:5294ms step_avg:34.83ms
+step:153/1600 train_time:5325ms step_avg:34.80ms
+step:154/1600 train_time:5362ms step_avg:34.82ms
+step:155/1600 train_time:5393ms step_avg:34.79ms
+step:156/1600 train_time:5430ms step_avg:34.81ms
+step:157/1600 train_time:5461ms step_avg:34.78ms
+step:158/1600 train_time:5498ms step_avg:34.80ms
+step:159/1600 train_time:5529ms step_avg:34.77ms
+step:160/1600 train_time:5566ms step_avg:34.79ms
+step:161/1600 train_time:5597ms step_avg:34.76ms
+step:162/1600 train_time:5634ms step_avg:34.78ms
+step:163/1600 train_time:5665ms step_avg:34.75ms
+step:164/1600 train_time:5702ms step_avg:34.77ms
+step:165/1600 train_time:5733ms step_avg:34.75ms
+step:166/1600 train_time:5770ms step_avg:34.76ms
+step:167/1600 train_time:5801ms step_avg:34.74ms
+step:168/1600 train_time:5838ms step_avg:34.75ms
+step:169/1600 train_time:5869ms step_avg:34.73ms
+step:170/1600 train_time:5906ms step_avg:34.74ms
+step:171/1600 train_time:5937ms step_avg:34.72ms
+step:172/1600 train_time:5974ms step_avg:34.73ms
+step:173/1600 train_time:6004ms step_avg:34.71ms
+step:174/1600 train_time:6041ms step_avg:34.72ms
+step:175/1600 train_time:6072ms step_avg:34.70ms
+step:176/1600 train_time:6110ms step_avg:34.71ms
+step:177/1600 train_time:6140ms step_avg:34.69ms
+step:178/1600 train_time:6177ms step_avg:34.70ms
+step:179/1600 train_time:6208ms step_avg:34.68ms
+step:180/1600 train_time:6245ms step_avg:34.70ms
+step:181/1600 train_time:6276ms step_avg:34.68ms
+step:182/1600 train_time:6313ms step_avg:34.69ms
+step:183/1600 train_time:6344ms step_avg:34.67ms
+step:184/1600 train_time:6381ms step_avg:34.68ms
+step:185/1600 train_time:6412ms step_avg:34.66ms
+step:186/1600 train_time:6449ms step_avg:34.67ms
+step:187/1600 train_time:6479ms step_avg:34.65ms
+step:188/1600 train_time:6516ms step_avg:34.66ms
+step:189/1600 train_time:6547ms step_avg:34.64ms
+step:190/1600 train_time:6584ms step_avg:34.66ms
+step:191/1600 train_time:6615ms step_avg:34.64ms
+step:192/1600 train_time:6653ms step_avg:34.65ms
+step:193/1600 train_time:6684ms step_avg:34.63ms
+step:194/1600 train_time:6721ms step_avg:34.65ms
+step:195/1600 train_time:6752ms step_avg:34.63ms
+step:196/1600 train_time:6789ms step_avg:34.64ms
+step:197/1600 train_time:6820ms step_avg:34.62ms
+step:198/1600 train_time:6856ms step_avg:34.63ms
+step:199/1600 train_time:6888ms step_avg:34.61ms
+step:200/1600 train_time:6925ms step_avg:34.62ms
+step:201/1600 train_time:6956ms step_avg:34.61ms
+step:202/1600 train_time:6993ms step_avg:34.62ms
+step:203/1600 train_time:7024ms step_avg:34.60ms
+step:204/1600 train_time:7061ms step_avg:34.61ms
+step:205/1600 train_time:7092ms step_avg:34.60ms
+step:206/1600 train_time:7129ms step_avg:34.61ms
+step:207/1600 train_time:7160ms step_avg:34.59ms
+step:208/1600 train_time:7196ms step_avg:34.60ms
+step:209/1600 train_time:7227ms step_avg:34.58ms
+step:210/1600 train_time:7265ms step_avg:34.59ms
+step:211/1600 train_time:7296ms step_avg:34.58ms
+step:212/1600 train_time:7333ms step_avg:34.59ms
+step:213/1600 train_time:7364ms step_avg:34.57ms
+step:214/1600 train_time:7401ms step_avg:34.58ms
+step:215/1600 train_time:7432ms step_avg:34.57ms
+step:216/1600 train_time:7470ms step_avg:34.58ms
+step:217/1600 train_time:7500ms step_avg:34.56ms
+step:218/1600 train_time:7537ms step_avg:34.57ms
+step:219/1600 train_time:7568ms step_avg:34.56ms
+step:220/1600 train_time:7605ms step_avg:34.57ms
+step:221/1600 train_time:7636ms step_avg:34.55ms
+step:222/1600 train_time:7673ms step_avg:34.56ms
+step:223/1600 train_time:7703ms step_avg:34.54ms
+step:224/1600 train_time:7740ms step_avg:34.55ms
+step:225/1600 train_time:7771ms step_avg:34.54ms
+step:226/1600 train_time:7808ms step_avg:34.55ms
+step:227/1600 train_time:7839ms step_avg:34.53ms
+step:228/1600 train_time:7876ms step_avg:34.54ms
+step:229/1600 train_time:7906ms step_avg:34.53ms
+step:230/1600 train_time:7944ms step_avg:34.54ms
+step:231/1600 train_time:7974ms step_avg:34.52ms
+step:232/1600 train_time:8011ms step_avg:34.53ms
+step:233/1600 train_time:8042ms step_avg:34.52ms
+step:234/1600 train_time:8079ms step_avg:34.53ms
+step:235/1600 train_time:8110ms step_avg:34.51ms
+step:236/1600 train_time:8148ms step_avg:34.52ms
+step:237/1600 train_time:8179ms step_avg:34.51ms
+step:238/1600 train_time:8215ms step_avg:34.52ms
+step:239/1600 train_time:8247ms step_avg:34.50ms
+step:240/1600 train_time:8284ms step_avg:34.52ms
+step:241/1600 train_time:8315ms step_avg:34.50ms
+step:242/1600 train_time:8352ms step_avg:34.51ms
+step:243/1600 train_time:8383ms step_avg:34.50ms
+step:244/1600 train_time:8420ms step_avg:34.51ms
+step:245/1600 train_time:8451ms step_avg:34.49ms
+step:246/1600 train_time:8488ms step_avg:34.51ms
+step:247/1600 train_time:8519ms step_avg:34.49ms
+step:248/1600 train_time:8556ms step_avg:34.50ms
+step:249/1600 train_time:8587ms step_avg:34.49ms
+step:250/1600 train_time:8625ms step_avg:34.50ms
+step:250/1600 val_loss:4.5740 train_time:8673ms step_avg:34.69ms
+step:251/1600 train_time:8691ms step_avg:34.62ms
+step:252/1600 train_time:8709ms step_avg:34.56ms
+step:253/1600 train_time:8727ms step_avg:34.49ms
+step:254/1600 train_time:8765ms step_avg:34.51ms
+step:255/1600 train_time:8798ms step_avg:34.50ms
+step:256/1600 train_time:8836ms step_avg:34.51ms
+step:257/1600 train_time:8867ms step_avg:34.50ms
+step:258/1600 train_time:8904ms step_avg:34.51ms
+step:259/1600 train_time:8935ms step_avg:34.50ms
+step:260/1600 train_time:8972ms step_avg:34.51ms
+step:261/1600 train_time:9003ms step_avg:34.50ms
+step:262/1600 train_time:9040ms step_avg:34.50ms
+step:263/1600 train_time:9071ms step_avg:34.49ms
+step:264/1600 train_time:9107ms step_avg:34.50ms
+step:265/1600 train_time:9138ms step_avg:34.48ms
+step:266/1600 train_time:9175ms step_avg:34.49ms
+step:267/1600 train_time:9206ms step_avg:34.48ms
+step:268/1600 train_time:9243ms step_avg:34.49ms
+step:269/1600 train_time:9273ms step_avg:34.47ms
+step:270/1600 train_time:9310ms step_avg:34.48ms
+step:271/1600 train_time:9341ms step_avg:34.47ms
+step:272/1600 train_time:9378ms step_avg:34.48ms
+step:273/1600 train_time:9409ms step_avg:34.46ms
+step:274/1600 train_time:9445ms step_avg:34.47ms
+step:275/1600 train_time:9476ms step_avg:34.46ms
+step:276/1600 train_time:9513ms step_avg:34.47ms
+step:277/1600 train_time:9544ms step_avg:34.46ms
+step:278/1600 train_time:9581ms step_avg:34.46ms
+step:279/1600 train_time:9612ms step_avg:34.45ms
+step:280/1600 train_time:9649ms step_avg:34.46ms
+step:281/1600 train_time:9680ms step_avg:34.45ms
+step:282/1600 train_time:9717ms step_avg:34.46ms
+step:283/1600 train_time:9748ms step_avg:34.45ms
+step:284/1600 train_time:9786ms step_avg:34.46ms
+step:285/1600 train_time:9817ms step_avg:34.44ms
+step:286/1600 train_time:9854ms step_avg:34.45ms
+step:287/1600 train_time:9884ms step_avg:34.44ms
+step:288/1600 train_time:9922ms step_avg:34.45ms
+step:289/1600 train_time:9953ms step_avg:34.44ms
+step:290/1600 train_time:9990ms step_avg:34.45ms
+step:291/1600 train_time:10021ms step_avg:34.43ms
+step:292/1600 train_time:10057ms step_avg:34.44ms
+step:293/1600 train_time:10088ms step_avg:34.43ms
+step:294/1600 train_time:10125ms step_avg:34.44ms
+step:295/1600 train_time:10156ms step_avg:34.43ms
+step:296/1600 train_time:10193ms step_avg:34.44ms
+step:297/1600 train_time:10224ms step_avg:34.42ms
+step:298/1600 train_time:10261ms step_avg:34.43ms
+step:299/1600 train_time:10291ms step_avg:34.42ms
+step:300/1600 train_time:10328ms step_avg:34.43ms
+step:301/1600 train_time:10359ms step_avg:34.41ms
+step:302/1600 train_time:10396ms step_avg:34.42ms
+step:303/1600 train_time:10427ms step_avg:34.41ms
+step:304/1600 train_time:10464ms step_avg:34.42ms
+step:305/1600 train_time:10495ms step_avg:34.41ms
+step:306/1600 train_time:10532ms step_avg:34.42ms
+step:307/1600 train_time:10563ms step_avg:34.41ms
+step:308/1600 train_time:10599ms step_avg:34.41ms
+step:309/1600 train_time:10630ms step_avg:34.40ms
+step:310/1600 train_time:10667ms step_avg:34.41ms
+step:311/1600 train_time:10698ms step_avg:34.40ms
+step:312/1600 train_time:10735ms step_avg:34.41ms
+step:313/1600 train_time:10765ms step_avg:34.39ms
+step:314/1600 train_time:10802ms step_avg:34.40ms
+step:315/1600 train_time:10833ms step_avg:34.39ms
+step:316/1600 train_time:10870ms step_avg:34.40ms
+step:317/1600 train_time:10901ms step_avg:34.39ms
+step:318/1600 train_time:10938ms step_avg:34.40ms
+step:319/1600 train_time:10970ms step_avg:34.39ms
+step:320/1600 train_time:11006ms step_avg:34.39ms
+step:321/1600 train_time:11037ms step_avg:34.38ms
+step:322/1600 train_time:11074ms step_avg:34.39ms
+step:323/1600 train_time:11105ms step_avg:34.38ms
+step:324/1600 train_time:11142ms step_avg:34.39ms
+step:325/1600 train_time:11173ms step_avg:34.38ms
+step:326/1600 train_time:11210ms step_avg:34.39ms
+step:327/1600 train_time:11241ms step_avg:34.38ms
+step:328/1600 train_time:11278ms step_avg:34.38ms
+step:329/1600 train_time:11309ms step_avg:34.37ms
+step:330/1600 train_time:11346ms step_avg:34.38ms
+step:331/1600 train_time:11377ms step_avg:34.37ms
+step:332/1600 train_time:11414ms step_avg:34.38ms
+step:333/1600 train_time:11445ms step_avg:34.37ms
+step:334/1600 train_time:11482ms step_avg:34.38ms
+step:335/1600 train_time:11512ms step_avg:34.37ms
+step:336/1600 train_time:11550ms step_avg:34.38ms
+step:337/1600 train_time:11580ms step_avg:34.36ms
+step:338/1600 train_time:11618ms step_avg:34.37ms
+step:339/1600 train_time:11648ms step_avg:34.36ms
+step:340/1600 train_time:11685ms step_avg:34.37ms
+step:341/1600 train_time:11716ms step_avg:34.36ms
+step:342/1600 train_time:11753ms step_avg:34.37ms
+step:343/1600 train_time:11784ms step_avg:34.36ms
+step:344/1600 train_time:11821ms step_avg:34.36ms
+step:345/1600 train_time:11852ms step_avg:34.35ms
+step:346/1600 train_time:11890ms step_avg:34.36ms
+step:347/1600 train_time:11921ms step_avg:34.35ms
+step:348/1600 train_time:11958ms step_avg:34.36ms
+step:349/1600 train_time:11989ms step_avg:34.35ms
+step:350/1600 train_time:12026ms step_avg:34.36ms
+step:351/1600 train_time:12057ms step_avg:34.35ms
+step:352/1600 train_time:12094ms step_avg:34.36ms
+step:353/1600 train_time:12125ms step_avg:34.35ms
+step:354/1600 train_time:12161ms step_avg:34.35ms
+step:355/1600 train_time:12193ms step_avg:34.35ms
+step:356/1600 train_time:12230ms step_avg:34.35ms
+step:357/1600 train_time:12261ms step_avg:34.34ms
+step:358/1600 train_time:12298ms step_avg:34.35ms
+step:359/1600 train_time:12328ms step_avg:34.34ms
+step:360/1600 train_time:12365ms step_avg:34.35ms
+step:361/1600 train_time:12397ms step_avg:34.34ms
+step:362/1600 train_time:12434ms step_avg:34.35ms
+step:363/1600 train_time:12465ms step_avg:34.34ms
+step:364/1600 train_time:12502ms step_avg:34.35ms
+step:365/1600 train_time:12532ms step_avg:34.34ms
+step:366/1600 train_time:12569ms step_avg:34.34ms
+step:367/1600 train_time:12600ms step_avg:34.33ms
+step:368/1600 train_time:12637ms step_avg:34.34ms
+step:369/1600 train_time:12668ms step_avg:34.33ms
+step:370/1600 train_time:12705ms step_avg:34.34ms
+step:371/1600 train_time:12735ms step_avg:34.33ms
+step:372/1600 train_time:12772ms step_avg:34.33ms
+step:373/1600 train_time:12803ms step_avg:34.32ms
+step:374/1600 train_time:12839ms step_avg:34.33ms
+step:375/1600 train_time:12870ms step_avg:34.32ms
+step:376/1600 train_time:12907ms step_avg:34.33ms
+step:377/1600 train_time:12938ms step_avg:34.32ms
+step:378/1600 train_time:12975ms step_avg:34.33ms
+step:379/1600 train_time:13005ms step_avg:34.32ms
+step:380/1600 train_time:13042ms step_avg:34.32ms
+step:381/1600 train_time:13073ms step_avg:34.31ms
+step:382/1600 train_time:13110ms step_avg:34.32ms
+step:383/1600 train_time:13142ms step_avg:34.31ms
+step:384/1600 train_time:13179ms step_avg:34.32ms
+step:385/1600 train_time:13210ms step_avg:34.31ms
+step:386/1600 train_time:13247ms step_avg:34.32ms
+step:387/1600 train_time:13277ms step_avg:34.31ms
+step:388/1600 train_time:13314ms step_avg:34.31ms
+step:389/1600 train_time:13345ms step_avg:34.31ms
+step:390/1600 train_time:13382ms step_avg:34.31ms
+step:391/1600 train_time:13412ms step_avg:34.30ms
+step:392/1600 train_time:13450ms step_avg:34.31ms
+step:393/1600 train_time:13480ms step_avg:34.30ms
+step:394/1600 train_time:13517ms step_avg:34.31ms
+step:395/1600 train_time:13548ms step_avg:34.30ms
+step:396/1600 train_time:13585ms step_avg:34.30ms
+step:397/1600 train_time:13615ms step_avg:34.30ms
+step:398/1600 train_time:13652ms step_avg:34.30ms
+step:399/1600 train_time:13683ms step_avg:34.29ms
+step:400/1600 train_time:13720ms step_avg:34.30ms
+step:401/1600 train_time:13751ms step_avg:34.29ms
+step:402/1600 train_time:13788ms step_avg:34.30ms
+step:403/1600 train_time:13819ms step_avg:34.29ms
+step:404/1600 train_time:13856ms step_avg:34.30ms
+step:405/1600 train_time:13886ms step_avg:34.29ms
+step:406/1600 train_time:13923ms step_avg:34.29ms
+step:407/1600 train_time:13954ms step_avg:34.29ms
+step:408/1600 train_time:13991ms step_avg:34.29ms
+step:409/1600 train_time:14022ms step_avg:34.28ms
+step:410/1600 train_time:14059ms step_avg:34.29ms
+step:411/1600 train_time:14090ms step_avg:34.28ms
+step:412/1600 train_time:14127ms step_avg:34.29ms
+step:413/1600 train_time:14158ms step_avg:34.28ms
+step:414/1600 train_time:14195ms step_avg:34.29ms
+step:415/1600 train_time:14226ms step_avg:34.28ms
+step:416/1600 train_time:14263ms step_avg:34.29ms
+step:417/1600 train_time:14294ms step_avg:34.28ms
+step:418/1600 train_time:14331ms step_avg:34.28ms
+step:419/1600 train_time:14362ms step_avg:34.28ms
+step:420/1600 train_time:14399ms step_avg:34.28ms
+step:421/1600 train_time:14429ms step_avg:34.27ms
+step:422/1600 train_time:14467ms step_avg:34.28ms
+step:423/1600 train_time:14498ms step_avg:34.27ms
+step:424/1600 train_time:14535ms step_avg:34.28ms
+step:425/1600 train_time:14565ms step_avg:34.27ms
+step:426/1600 train_time:14602ms step_avg:34.28ms
+step:427/1600 train_time:14633ms step_avg:34.27ms
+step:428/1600 train_time:14670ms step_avg:34.28ms
+step:429/1600 train_time:14701ms step_avg:34.27ms
+step:430/1600 train_time:14738ms step_avg:34.27ms
+step:431/1600 train_time:14768ms step_avg:34.27ms
+step:432/1600 train_time:14805ms step_avg:34.27ms
+step:433/1600 train_time:14836ms step_avg:34.26ms
+step:434/1600 train_time:14873ms step_avg:34.27ms
+step:435/1600 train_time:14903ms step_avg:34.26ms
+step:436/1600 train_time:14940ms step_avg:34.27ms
+step:437/1600 train_time:14971ms step_avg:34.26ms
+step:438/1600 train_time:15008ms step_avg:34.27ms
+step:439/1600 train_time:15039ms step_avg:34.26ms
+step:440/1600 train_time:15076ms step_avg:34.26ms
+step:441/1600 train_time:15107ms step_avg:34.26ms
+step:442/1600 train_time:15143ms step_avg:34.26ms
+step:443/1600 train_time:15174ms step_avg:34.25ms
+step:444/1600 train_time:15212ms step_avg:34.26ms
+step:445/1600 train_time:15243ms step_avg:34.25ms
+step:446/1600 train_time:15280ms step_avg:34.26ms
+step:447/1600 train_time:15310ms step_avg:34.25ms
+step:448/1600 train_time:15347ms step_avg:34.26ms
+step:449/1600 train_time:15378ms step_avg:34.25ms
+step:450/1600 train_time:15416ms step_avg:34.26ms
+step:451/1600 train_time:15447ms step_avg:34.25ms
+step:452/1600 train_time:15483ms step_avg:34.25ms
+step:453/1600 train_time:15514ms step_avg:34.25ms
+step:454/1600 train_time:15551ms step_avg:34.25ms
+step:455/1600 train_time:15582ms step_avg:34.25ms
+step:456/1600 train_time:15620ms step_avg:34.25ms
+step:457/1600 train_time:15650ms step_avg:34.25ms
+step:458/1600 train_time:15687ms step_avg:34.25ms
+step:459/1600 train_time:15718ms step_avg:34.24ms
+step:460/1600 train_time:15755ms step_avg:34.25ms
+step:461/1600 train_time:15785ms step_avg:34.24ms
+step:462/1600 train_time:15822ms step_avg:34.25ms
+step:463/1600 train_time:15854ms step_avg:34.24ms
+step:464/1600 train_time:15891ms step_avg:34.25ms
+step:465/1600 train_time:15922ms step_avg:34.24ms
+step:466/1600 train_time:15959ms step_avg:34.25ms
+step:467/1600 train_time:15989ms step_avg:34.24ms
+step:468/1600 train_time:16026ms step_avg:34.24ms
+step:469/1600 train_time:16057ms step_avg:34.24ms
+step:470/1600 train_time:16094ms step_avg:34.24ms
+step:471/1600 train_time:16125ms step_avg:34.24ms
+step:472/1600 train_time:16162ms step_avg:34.24ms
+step:473/1600 train_time:16193ms step_avg:34.23ms
+step:474/1600 train_time:16229ms step_avg:34.24ms
+step:475/1600 train_time:16260ms step_avg:34.23ms
+step:476/1600 train_time:16297ms step_avg:34.24ms
+step:477/1600 train_time:16328ms step_avg:34.23ms
+step:478/1600 train_time:16365ms step_avg:34.24ms
+step:479/1600 train_time:16395ms step_avg:34.23ms
+step:480/1600 train_time:16432ms step_avg:34.23ms
+step:481/1600 train_time:16463ms step_avg:34.23ms
+step:482/1600 train_time:16500ms step_avg:34.23ms
+step:483/1600 train_time:16531ms step_avg:34.23ms
+step:484/1600 train_time:16568ms step_avg:34.23ms
+step:485/1600 train_time:16599ms step_avg:34.23ms
+step:486/1600 train_time:16637ms step_avg:34.23ms
+step:487/1600 train_time:16668ms step_avg:34.23ms
+step:488/1600 train_time:16705ms step_avg:34.23ms
+step:489/1600 train_time:16736ms step_avg:34.22ms
+step:490/1600 train_time:16773ms step_avg:34.23ms
+step:491/1600 train_time:16804ms step_avg:34.22ms
+step:492/1600 train_time:16840ms step_avg:34.23ms
+step:493/1600 train_time:16871ms step_avg:34.22ms
+step:494/1600 train_time:16907ms step_avg:34.23ms
+step:495/1600 train_time:16938ms step_avg:34.22ms
+step:496/1600 train_time:16976ms step_avg:34.23ms
+step:497/1600 train_time:17006ms step_avg:34.22ms
+step:498/1600 train_time:17043ms step_avg:34.22ms
+step:499/1600 train_time:17074ms step_avg:34.22ms
+step:500/1600 train_time:17112ms step_avg:34.22ms
+step:500/1600 val_loss:4.2580 train_time:17160ms step_avg:34.32ms
+step:501/1600 train_time:17179ms step_avg:34.29ms
+step:502/1600 train_time:17200ms step_avg:34.26ms
+step:503/1600 train_time:17219ms step_avg:34.23ms
+step:504/1600 train_time:17251ms step_avg:34.23ms
+step:505/1600 train_time:17283ms step_avg:34.22ms
+step:506/1600 train_time:17322ms step_avg:34.23ms
+step:507/1600 train_time:17354ms step_avg:34.23ms
+step:508/1600 train_time:17390ms step_avg:34.23ms
+step:509/1600 train_time:17421ms step_avg:34.23ms
+step:510/1600 train_time:17459ms step_avg:34.23ms
+step:511/1600 train_time:17490ms step_avg:34.23ms
+step:512/1600 train_time:17527ms step_avg:34.23ms
+step:513/1600 train_time:17558ms step_avg:34.23ms
+step:514/1600 train_time:17595ms step_avg:34.23ms
+step:515/1600 train_time:17626ms step_avg:34.22ms
+step:516/1600 train_time:17663ms step_avg:34.23ms
+step:517/1600 train_time:17693ms step_avg:34.22ms
+step:518/1600 train_time:17730ms step_avg:34.23ms
+step:519/1600 train_time:17760ms step_avg:34.22ms
+step:520/1600 train_time:17797ms step_avg:34.23ms
+step:521/1600 train_time:17867ms step_avg:34.29ms
+step:522/1600 train_time:17926ms step_avg:34.34ms
+step:523/1600 train_time:17986ms step_avg:34.39ms
+step:524/1600 train_time:18045ms step_avg:34.44ms
+step:525/1600 train_time:18105ms step_avg:34.49ms
+step:526/1600 train_time:18163ms step_avg:34.53ms
+step:527/1600 train_time:18228ms step_avg:34.59ms
+step:528/1600 train_time:18288ms step_avg:34.64ms
+step:529/1600 train_time:18350ms step_avg:34.69ms
+step:530/1600 train_time:18409ms step_avg:34.73ms
+step:531/1600 train_time:18471ms step_avg:34.79ms
+step:532/1600 train_time:18530ms step_avg:34.83ms
+step:533/1600 train_time:18594ms step_avg:34.88ms
+step:534/1600 train_time:18653ms step_avg:34.93ms
+step:535/1600 train_time:18714ms step_avg:34.98ms
+step:536/1600 train_time:18772ms step_avg:35.02ms
+step:537/1600 train_time:18834ms step_avg:35.07ms
+step:538/1600 train_time:18893ms step_avg:35.12ms
+step:539/1600 train_time:18956ms step_avg:35.17ms
+step:540/1600 train_time:19014ms step_avg:35.21ms
+step:541/1600 train_time:19076ms step_avg:35.26ms
+step:542/1600 train_time:19134ms step_avg:35.30ms
+step:543/1600 train_time:19197ms step_avg:35.35ms
+step:544/1600 train_time:19257ms step_avg:35.40ms
+step:545/1600 train_time:19320ms step_avg:35.45ms
+step:546/1600 train_time:19379ms step_avg:35.49ms
+step:547/1600 train_time:19442ms step_avg:35.54ms
+step:548/1600 train_time:19501ms step_avg:35.59ms
+step:549/1600 train_time:19564ms step_avg:35.64ms
+step:550/1600 train_time:19623ms step_avg:35.68ms
+step:551/1600 train_time:19686ms step_avg:35.73ms
+step:552/1600 train_time:19745ms step_avg:35.77ms
+step:553/1600 train_time:19809ms step_avg:35.82ms
+step:554/1600 train_time:19867ms step_avg:35.86ms
+step:555/1600 train_time:19930ms step_avg:35.91ms
+step:556/1600 train_time:19989ms step_avg:35.95ms
+step:557/1600 train_time:20051ms step_avg:36.00ms
+step:558/1600 train_time:20110ms step_avg:36.04ms
+step:559/1600 train_time:20172ms step_avg:36.09ms
+step:560/1600 train_time:20231ms step_avg:36.13ms
+step:561/1600 train_time:20293ms step_avg:36.17ms
+step:562/1600 train_time:20353ms step_avg:36.21ms
+step:563/1600 train_time:20415ms step_avg:36.26ms
+step:564/1600 train_time:20473ms step_avg:36.30ms
+step:565/1600 train_time:20536ms step_avg:36.35ms
+step:566/1600 train_time:20595ms step_avg:36.39ms
+step:567/1600 train_time:20657ms step_avg:36.43ms
+step:568/1600 train_time:20717ms step_avg:36.47ms
+step:569/1600 train_time:20781ms step_avg:36.52ms
+step:570/1600 train_time:20839ms step_avg:36.56ms
+step:571/1600 train_time:20901ms step_avg:36.60ms
+step:572/1600 train_time:20960ms step_avg:36.64ms
+step:573/1600 train_time:21027ms step_avg:36.70ms
+step:574/1600 train_time:21085ms step_avg:36.73ms
+step:575/1600 train_time:21146ms step_avg:36.78ms
+step:576/1600 train_time:21205ms step_avg:36.81ms
+step:577/1600 train_time:21268ms step_avg:36.86ms
+step:578/1600 train_time:21327ms step_avg:36.90ms
+step:579/1600 train_time:21389ms step_avg:36.94ms
+step:580/1600 train_time:21448ms step_avg:36.98ms
+step:581/1600 train_time:21511ms step_avg:37.02ms
+step:582/1600 train_time:21569ms step_avg:37.06ms
+step:583/1600 train_time:21632ms step_avg:37.10ms
+step:584/1600 train_time:21691ms step_avg:37.14ms
+step:585/1600 train_time:21752ms step_avg:37.18ms
+step:586/1600 train_time:21812ms step_avg:37.22ms
+step:587/1600 train_time:21873ms step_avg:37.26ms
+step:588/1600 train_time:21932ms step_avg:37.30ms
+step:589/1600 train_time:21993ms step_avg:37.34ms
+step:590/1600 train_time:22053ms step_avg:37.38ms
+step:591/1600 train_time:22115ms step_avg:37.42ms
+step:592/1600 train_time:22174ms step_avg:37.46ms
+step:593/1600 train_time:22237ms step_avg:37.50ms
+step:594/1600 train_time:22296ms step_avg:37.54ms
+step:595/1600 train_time:22359ms step_avg:37.58ms
+step:596/1600 train_time:22418ms step_avg:37.61ms
+step:597/1600 train_time:22481ms step_avg:37.66ms
+step:598/1600 train_time:22540ms step_avg:37.69ms
+step:599/1600 train_time:22602ms step_avg:37.73ms
+step:600/1600 train_time:22661ms step_avg:37.77ms
+step:601/1600 train_time:22724ms step_avg:37.81ms
+step:602/1600 train_time:22784ms step_avg:37.85ms
+step:603/1600 train_time:22847ms step_avg:37.89ms
+step:604/1600 train_time:22906ms step_avg:37.92ms
+step:605/1600 train_time:22969ms step_avg:37.96ms
+step:606/1600 train_time:23028ms step_avg:38.00ms
+step:607/1600 train_time:23090ms step_avg:38.04ms
+step:608/1600 train_time:23149ms step_avg:38.07ms
+step:609/1600 train_time:23212ms step_avg:38.11ms
+step:610/1600 train_time:23271ms step_avg:38.15ms
+step:611/1600 train_time:23333ms step_avg:38.19ms
+step:612/1600 train_time:23391ms step_avg:38.22ms
+step:613/1600 train_time:23453ms step_avg:38.26ms
+step:614/1600 train_time:23512ms step_avg:38.29ms
+step:615/1600 train_time:23574ms step_avg:38.33ms
+step:616/1600 train_time:23633ms step_avg:38.37ms
+step:617/1600 train_time:23695ms step_avg:38.40ms
+step:618/1600 train_time:23754ms step_avg:38.44ms
+step:619/1600 train_time:23817ms step_avg:38.48ms
+step:620/1600 train_time:23877ms step_avg:38.51ms
+step:621/1600 train_time:23939ms step_avg:38.55ms
+step:622/1600 train_time:23998ms step_avg:38.58ms
+step:623/1600 train_time:24061ms step_avg:38.62ms
+step:624/1600 train_time:24120ms step_avg:38.65ms
+step:625/1600 train_time:24183ms step_avg:38.69ms
+step:626/1600 train_time:24242ms step_avg:38.73ms
+step:627/1600 train_time:24305ms step_avg:38.76ms
+step:628/1600 train_time:24365ms step_avg:38.80ms
+step:629/1600 train_time:24428ms step_avg:38.84ms
+step:630/1600 train_time:24487ms step_avg:38.87ms
+step:631/1600 train_time:24549ms step_avg:38.91ms
+step:632/1600 train_time:24608ms step_avg:38.94ms
+step:633/1600 train_time:24671ms step_avg:38.97ms
+step:634/1600 train_time:24729ms step_avg:39.00ms
+step:635/1600 train_time:24791ms step_avg:39.04ms
+step:636/1600 train_time:24850ms step_avg:39.07ms
+step:637/1600 train_time:24912ms step_avg:39.11ms
+step:638/1600 train_time:24970ms step_avg:39.14ms
+step:639/1600 train_time:25032ms step_avg:39.17ms
+step:640/1600 train_time:25091ms step_avg:39.21ms
+step:641/1600 train_time:25154ms step_avg:39.24ms
+step:642/1600 train_time:25215ms step_avg:39.28ms
+step:643/1600 train_time:25278ms step_avg:39.31ms
+step:644/1600 train_time:25335ms step_avg:39.34ms
+step:645/1600 train_time:25400ms step_avg:39.38ms
+step:646/1600 train_time:25458ms step_avg:39.41ms
+step:647/1600 train_time:25521ms step_avg:39.44ms
+step:648/1600 train_time:25579ms step_avg:39.47ms
+step:649/1600 train_time:25643ms step_avg:39.51ms
+step:650/1600 train_time:25702ms step_avg:39.54ms
+step:651/1600 train_time:25764ms step_avg:39.58ms
+step:652/1600 train_time:25824ms step_avg:39.61ms
+step:653/1600 train_time:25886ms step_avg:39.64ms
+step:654/1600 train_time:25945ms step_avg:39.67ms
+step:655/1600 train_time:26008ms step_avg:39.71ms
+step:656/1600 train_time:26066ms step_avg:39.73ms
+step:657/1600 train_time:26129ms step_avg:39.77ms
+step:658/1600 train_time:26188ms step_avg:39.80ms
+step:659/1600 train_time:26253ms step_avg:39.84ms
+step:660/1600 train_time:26312ms step_avg:39.87ms
+step:661/1600 train_time:26372ms step_avg:39.90ms
+step:662/1600 train_time:26430ms step_avg:39.92ms
+step:663/1600 train_time:26492ms step_avg:39.96ms
+step:664/1600 train_time:26551ms step_avg:39.99ms
+step:665/1600 train_time:26612ms step_avg:40.02ms
+step:666/1600 train_time:26671ms step_avg:40.05ms
+step:667/1600 train_time:26732ms step_avg:40.08ms
+step:668/1600 train_time:26791ms step_avg:40.11ms
+step:669/1600 train_time:26854ms step_avg:40.14ms
+step:670/1600 train_time:26913ms step_avg:40.17ms
+step:671/1600 train_time:26976ms step_avg:40.20ms
+step:672/1600 train_time:27035ms step_avg:40.23ms
+step:673/1600 train_time:27098ms step_avg:40.26ms
+step:674/1600 train_time:27156ms step_avg:40.29ms
+step:675/1600 train_time:27219ms step_avg:40.33ms
+step:676/1600 train_time:27280ms step_avg:40.35ms
+step:677/1600 train_time:27341ms step_avg:40.39ms
+step:678/1600 train_time:27401ms step_avg:40.41ms
+step:679/1600 train_time:27462ms step_avg:40.44ms
+step:680/1600 train_time:27521ms step_avg:40.47ms
+step:681/1600 train_time:27583ms step_avg:40.50ms
+step:682/1600 train_time:27642ms step_avg:40.53ms
+step:683/1600 train_time:27705ms step_avg:40.56ms
+step:684/1600 train_time:27764ms step_avg:40.59ms
+step:685/1600 train_time:27826ms step_avg:40.62ms
+step:686/1600 train_time:27886ms step_avg:40.65ms
+step:687/1600 train_time:27949ms step_avg:40.68ms
+step:688/1600 train_time:28007ms step_avg:40.71ms
+step:689/1600 train_time:28069ms step_avg:40.74ms
+step:690/1600 train_time:28129ms step_avg:40.77ms
+step:691/1600 train_time:28192ms step_avg:40.80ms
+step:692/1600 train_time:28250ms step_avg:40.82ms
+step:693/1600 train_time:28312ms step_avg:40.85ms
+step:694/1600 train_time:28371ms step_avg:40.88ms
+step:695/1600 train_time:28434ms step_avg:40.91ms
+step:696/1600 train_time:28493ms step_avg:40.94ms
+step:697/1600 train_time:28555ms step_avg:40.97ms
+step:698/1600 train_time:28613ms step_avg:40.99ms
+step:699/1600 train_time:28676ms step_avg:41.02ms
+step:700/1600 train_time:28735ms step_avg:41.05ms
+step:701/1600 train_time:28798ms step_avg:41.08ms
+step:702/1600 train_time:28857ms step_avg:41.11ms
+step:703/1600 train_time:28919ms step_avg:41.14ms
+step:704/1600 train_time:28978ms step_avg:41.16ms
+step:705/1600 train_time:29041ms step_avg:41.19ms
+step:706/1600 train_time:29100ms step_avg:41.22ms
+step:707/1600 train_time:29163ms step_avg:41.25ms
+step:708/1600 train_time:29222ms step_avg:41.27ms
+step:709/1600 train_time:29285ms step_avg:41.30ms
+step:710/1600 train_time:29344ms step_avg:41.33ms
+step:711/1600 train_time:29407ms step_avg:41.36ms
+step:712/1600 train_time:29466ms step_avg:41.38ms
+step:713/1600 train_time:29529ms step_avg:41.41ms
+step:714/1600 train_time:29588ms step_avg:41.44ms
+step:715/1600 train_time:29650ms step_avg:41.47ms
+step:716/1600 train_time:29709ms step_avg:41.49ms
+step:717/1600 train_time:29771ms step_avg:41.52ms
+step:718/1600 train_time:29830ms step_avg:41.55ms
+step:719/1600 train_time:29892ms step_avg:41.57ms
+step:720/1600 train_time:29952ms step_avg:41.60ms
+step:721/1600 train_time:30013ms step_avg:41.63ms
+step:722/1600 train_time:30072ms step_avg:41.65ms
+step:723/1600 train_time:30135ms step_avg:41.68ms
+step:724/1600 train_time:30194ms step_avg:41.70ms
+step:725/1600 train_time:30257ms step_avg:41.73ms
+step:726/1600 train_time:30317ms step_avg:41.76ms
+step:727/1600 train_time:30379ms step_avg:41.79ms
+step:728/1600 train_time:30438ms step_avg:41.81ms
+step:729/1600 train_time:30500ms step_avg:41.84ms
+step:730/1600 train_time:30559ms step_avg:41.86ms
+step:731/1600 train_time:30622ms step_avg:41.89ms
+step:732/1600 train_time:30681ms step_avg:41.91ms
+step:733/1600 train_time:30745ms step_avg:41.94ms
+step:734/1600 train_time:30804ms step_avg:41.97ms
+step:735/1600 train_time:30867ms step_avg:42.00ms
+step:736/1600 train_time:30926ms step_avg:42.02ms
+step:737/1600 train_time:30990ms step_avg:42.05ms
+step:738/1600 train_time:31048ms step_avg:42.07ms
+step:739/1600 train_time:31110ms step_avg:42.10ms
+step:740/1600 train_time:31168ms step_avg:42.12ms
+step:741/1600 train_time:31231ms step_avg:42.15ms
+step:742/1600 train_time:31290ms step_avg:42.17ms
+step:743/1600 train_time:31357ms step_avg:42.20ms
+step:744/1600 train_time:31415ms step_avg:42.22ms
+step:745/1600 train_time:31474ms step_avg:42.25ms
+step:746/1600 train_time:31533ms step_avg:42.27ms
+step:747/1600 train_time:31597ms step_avg:42.30ms
+step:748/1600 train_time:31655ms step_avg:42.32ms
+step:749/1600 train_time:31717ms step_avg:42.35ms
+step:750/1600 train_time:31776ms step_avg:42.37ms
+step:750/1600 val_loss:3.8892 train_time:31824ms step_avg:42.43ms
+step:751/1600 train_time:31843ms step_avg:42.40ms
+step:752/1600 train_time:31902ms step_avg:42.42ms
+step:753/1600 train_time:31965ms step_avg:42.45ms
+step:754/1600 train_time:32028ms step_avg:42.48ms
+step:755/1600 train_time:32091ms step_avg:42.50ms
+step:756/1600 train_time:32151ms step_avg:42.53ms
+step:757/1600 train_time:32212ms step_avg:42.55ms
+step:758/1600 train_time:32271ms step_avg:42.57ms
+step:759/1600 train_time:32333ms step_avg:42.60ms
+step:760/1600 train_time:32392ms step_avg:42.62ms
+step:761/1600 train_time:32454ms step_avg:42.65ms
+step:762/1600 train_time:32514ms step_avg:42.67ms
+step:763/1600 train_time:32575ms step_avg:42.69ms
+step:764/1600 train_time:32634ms step_avg:42.72ms
+step:765/1600 train_time:32697ms step_avg:42.74ms
+step:766/1600 train_time:32756ms step_avg:42.76ms
+step:767/1600 train_time:32819ms step_avg:42.79ms
+step:768/1600 train_time:32879ms step_avg:42.81ms
+step:769/1600 train_time:32942ms step_avg:42.84ms
+step:770/1600 train_time:33001ms step_avg:42.86ms
+step:771/1600 train_time:33064ms step_avg:42.88ms
+step:772/1600 train_time:33123ms step_avg:42.91ms
+step:773/1600 train_time:33186ms step_avg:42.93ms
+step:774/1600 train_time:33245ms step_avg:42.95ms
+step:775/1600 train_time:33308ms step_avg:42.98ms
+step:776/1600 train_time:33367ms step_avg:43.00ms
+step:777/1600 train_time:33429ms step_avg:43.02ms
+step:778/1600 train_time:33488ms step_avg:43.04ms
+step:779/1600 train_time:33552ms step_avg:43.07ms
+step:780/1600 train_time:33609ms step_avg:43.09ms
+step:781/1600 train_time:33671ms step_avg:43.11ms
+step:782/1600 train_time:33730ms step_avg:43.13ms
+step:783/1600 train_time:33794ms step_avg:43.16ms
+step:784/1600 train_time:33854ms step_avg:43.18ms
+step:785/1600 train_time:33919ms step_avg:43.21ms
+step:786/1600 train_time:33978ms step_avg:43.23ms
+step:787/1600 train_time:34041ms step_avg:43.25ms
+step:788/1600 train_time:34099ms step_avg:43.27ms
+step:789/1600 train_time:34162ms step_avg:43.30ms
+step:790/1600 train_time:34221ms step_avg:43.32ms
+step:791/1600 train_time:34283ms step_avg:43.34ms
+step:792/1600 train_time:34342ms step_avg:43.36ms
+step:793/1600 train_time:34404ms step_avg:43.38ms
+step:794/1600 train_time:34463ms step_avg:43.40ms
+step:795/1600 train_time:34525ms step_avg:43.43ms
+step:796/1600 train_time:34584ms step_avg:43.45ms
+step:797/1600 train_time:34647ms step_avg:43.47ms
+step:798/1600 train_time:34705ms step_avg:43.49ms
+step:799/1600 train_time:34769ms step_avg:43.52ms
+step:800/1600 train_time:34829ms step_avg:43.54ms
+step:801/1600 train_time:34893ms step_avg:43.56ms
+step:802/1600 train_time:34952ms step_avg:43.58ms
+step:803/1600 train_time:35016ms step_avg:43.61ms
+step:804/1600 train_time:35075ms step_avg:43.63ms
+step:805/1600 train_time:35138ms step_avg:43.65ms
+step:806/1600 train_time:35198ms step_avg:43.67ms
+step:807/1600 train_time:35260ms step_avg:43.69ms
+step:808/1600 train_time:35319ms step_avg:43.71ms
+step:809/1600 train_time:35381ms step_avg:43.73ms
+step:810/1600 train_time:35440ms step_avg:43.75ms
+step:811/1600 train_time:35502ms step_avg:43.78ms
+step:812/1600 train_time:35561ms step_avg:43.79ms
+step:813/1600 train_time:35626ms step_avg:43.82ms
+step:814/1600 train_time:35686ms step_avg:43.84ms
+step:815/1600 train_time:35746ms step_avg:43.86ms
+step:816/1600 train_time:35805ms step_avg:43.88ms
+step:817/1600 train_time:35868ms step_avg:43.90ms
+step:818/1600 train_time:35928ms step_avg:43.92ms
+step:819/1600 train_time:35991ms step_avg:43.95ms
+step:820/1600 train_time:36051ms step_avg:43.96ms
+step:821/1600 train_time:36113ms step_avg:43.99ms
+step:822/1600 train_time:36173ms step_avg:44.01ms
+step:823/1600 train_time:36236ms step_avg:44.03ms
+step:824/1600 train_time:36295ms step_avg:44.05ms
+step:825/1600 train_time:36358ms step_avg:44.07ms
+step:826/1600 train_time:36417ms step_avg:44.09ms
+step:827/1600 train_time:36479ms step_avg:44.11ms
+step:828/1600 train_time:36538ms step_avg:44.13ms
+step:829/1600 train_time:36601ms step_avg:44.15ms
+step:830/1600 train_time:36659ms step_avg:44.17ms
+step:831/1600 train_time:36722ms step_avg:44.19ms
+step:832/1600 train_time:36782ms step_avg:44.21ms
+step:833/1600 train_time:36846ms step_avg:44.23ms
+step:834/1600 train_time:36905ms step_avg:44.25ms
+step:835/1600 train_time:36967ms step_avg:44.27ms
+step:836/1600 train_time:37026ms step_avg:44.29ms
+step:837/1600 train_time:37089ms step_avg:44.31ms
+step:838/1600 train_time:37148ms step_avg:44.33ms
+step:839/1600 train_time:37211ms step_avg:44.35ms
+step:840/1600 train_time:37270ms step_avg:44.37ms
+step:841/1600 train_time:37333ms step_avg:44.39ms
+step:842/1600 train_time:37393ms step_avg:44.41ms
+step:843/1600 train_time:37455ms step_avg:44.43ms
+step:844/1600 train_time:37514ms step_avg:44.45ms
+step:845/1600 train_time:37576ms step_avg:44.47ms
+step:846/1600 train_time:37636ms step_avg:44.49ms
+step:847/1600 train_time:37698ms step_avg:44.51ms
+step:848/1600 train_time:37757ms step_avg:44.53ms
+step:849/1600 train_time:37820ms step_avg:44.55ms
+step:850/1600 train_time:37879ms step_avg:44.56ms
+step:851/1600 train_time:37941ms step_avg:44.58ms
+step:852/1600 train_time:38001ms step_avg:44.60ms
+step:853/1600 train_time:38063ms step_avg:44.62ms
+step:854/1600 train_time:38125ms step_avg:44.64ms
+step:855/1600 train_time:38185ms step_avg:44.66ms
+step:856/1600 train_time:38244ms step_avg:44.68ms
+step:857/1600 train_time:38307ms step_avg:44.70ms
+step:858/1600 train_time:38367ms step_avg:44.72ms
+step:859/1600 train_time:38430ms step_avg:44.74ms
+step:860/1600 train_time:38489ms step_avg:44.75ms
+step:861/1600 train_time:38551ms step_avg:44.78ms
+step:862/1600 train_time:38611ms step_avg:44.79ms
+step:863/1600 train_time:38673ms step_avg:44.81ms
+step:864/1600 train_time:38733ms step_avg:44.83ms
+step:865/1600 train_time:38796ms step_avg:44.85ms
+step:866/1600 train_time:38855ms step_avg:44.87ms
+step:867/1600 train_time:38919ms step_avg:44.89ms
+step:868/1600 train_time:38978ms step_avg:44.91ms
+step:869/1600 train_time:39040ms step_avg:44.93ms
+step:870/1600 train_time:39099ms step_avg:44.94ms
+step:871/1600 train_time:39162ms step_avg:44.96ms
+step:872/1600 train_time:39221ms step_avg:44.98ms
+step:873/1600 train_time:39283ms step_avg:45.00ms
+step:874/1600 train_time:39342ms step_avg:45.01ms
+step:875/1600 train_time:39404ms step_avg:45.03ms
+step:876/1600 train_time:39462ms step_avg:45.05ms
+step:877/1600 train_time:39525ms step_avg:45.07ms
+step:878/1600 train_time:39585ms step_avg:45.08ms
+step:879/1600 train_time:39647ms step_avg:45.10ms
+step:880/1600 train_time:39707ms step_avg:45.12ms
+step:881/1600 train_time:39769ms step_avg:45.14ms
+step:882/1600 train_time:39830ms step_avg:45.16ms
+step:883/1600 train_time:39893ms step_avg:45.18ms
+step:884/1600 train_time:39952ms step_avg:45.19ms
+step:885/1600 train_time:40016ms step_avg:45.22ms
+step:886/1600 train_time:40075ms step_avg:45.23ms
+step:887/1600 train_time:40139ms step_avg:45.25ms
+step:888/1600 train_time:40198ms step_avg:45.27ms
+step:889/1600 train_time:40260ms step_avg:45.29ms
+step:890/1600 train_time:40324ms step_avg:45.31ms
+step:891/1600 train_time:40383ms step_avg:45.32ms
+step:892/1600 train_time:40442ms step_avg:45.34ms
+step:893/1600 train_time:40503ms step_avg:45.36ms
+step:894/1600 train_time:40562ms step_avg:45.37ms
+step:895/1600 train_time:40624ms step_avg:45.39ms
+step:896/1600 train_time:40684ms step_avg:45.41ms
+step:897/1600 train_time:40748ms step_avg:45.43ms
+step:898/1600 train_time:40807ms step_avg:45.44ms
+step:899/1600 train_time:40868ms step_avg:45.46ms
+step:900/1600 train_time:40927ms step_avg:45.47ms
+step:901/1600 train_time:40990ms step_avg:45.49ms
+step:902/1600 train_time:41050ms step_avg:45.51ms
+step:903/1600 train_time:41113ms step_avg:45.53ms
+step:904/1600 train_time:41173ms step_avg:45.54ms
+step:905/1600 train_time:41236ms step_avg:45.56ms
+step:906/1600 train_time:41295ms step_avg:45.58ms
+step:907/1600 train_time:41358ms step_avg:45.60ms
+step:908/1600 train_time:41420ms step_avg:45.62ms
+step:909/1600 train_time:41482ms step_avg:45.63ms
+step:910/1600 train_time:41539ms step_avg:45.65ms
+step:911/1600 train_time:41601ms step_avg:45.66ms
+step:912/1600 train_time:41660ms step_avg:45.68ms
+step:913/1600 train_time:41723ms step_avg:45.70ms
+step:914/1600 train_time:41782ms step_avg:45.71ms
+step:915/1600 train_time:41845ms step_avg:45.73ms
+step:916/1600 train_time:41904ms step_avg:45.75ms
+step:917/1600 train_time:41967ms step_avg:45.77ms
+step:918/1600 train_time:42026ms step_avg:45.78ms
+step:919/1600 train_time:42089ms step_avg:45.80ms
+step:920/1600 train_time:42148ms step_avg:45.81ms
+step:921/1600 train_time:42212ms step_avg:45.83ms
+step:922/1600 train_time:42272ms step_avg:45.85ms
+step:923/1600 train_time:42335ms step_avg:45.87ms
+step:924/1600 train_time:42394ms step_avg:45.88ms
+step:925/1600 train_time:42457ms step_avg:45.90ms
+step:926/1600 train_time:42516ms step_avg:45.91ms
+step:927/1600 train_time:42579ms step_avg:45.93ms
+step:928/1600 train_time:42638ms step_avg:45.95ms
+step:929/1600 train_time:42700ms step_avg:45.96ms
+step:930/1600 train_time:42760ms step_avg:45.98ms
+step:931/1600 train_time:42822ms step_avg:46.00ms
+step:932/1600 train_time:42881ms step_avg:46.01ms
+step:933/1600 train_time:42943ms step_avg:46.03ms
+step:934/1600 train_time:43002ms step_avg:46.04ms
+step:935/1600 train_time:43065ms step_avg:46.06ms
+step:936/1600 train_time:43124ms step_avg:46.07ms
+step:937/1600 train_time:43187ms step_avg:46.09ms
+step:938/1600 train_time:43247ms step_avg:46.11ms
+step:939/1600 train_time:43310ms step_avg:46.12ms
+step:940/1600 train_time:43370ms step_avg:46.14ms
+step:941/1600 train_time:43433ms step_avg:46.16ms
+step:942/1600 train_time:43492ms step_avg:46.17ms
+step:943/1600 train_time:43554ms step_avg:46.19ms
+step:944/1600 train_time:43614ms step_avg:46.20ms
+step:945/1600 train_time:43677ms step_avg:46.22ms
+step:946/1600 train_time:43737ms step_avg:46.23ms
+step:947/1600 train_time:43799ms step_avg:46.25ms
+step:948/1600 train_time:43859ms step_avg:46.26ms
+step:949/1600 train_time:43921ms step_avg:46.28ms
+step:950/1600 train_time:43980ms step_avg:46.29ms
+step:951/1600 train_time:44042ms step_avg:46.31ms
+step:952/1600 train_time:44101ms step_avg:46.32ms
+step:953/1600 train_time:44163ms step_avg:46.34ms
+step:954/1600 train_time:44222ms step_avg:46.35ms
+step:955/1600 train_time:44285ms step_avg:46.37ms
+step:956/1600 train_time:44343ms step_avg:46.38ms
+step:957/1600 train_time:44406ms step_avg:46.40ms
+step:958/1600 train_time:44465ms step_avg:46.41ms
+step:959/1600 train_time:44529ms step_avg:46.43ms
+step:960/1600 train_time:44588ms step_avg:46.45ms
+step:961/1600 train_time:44651ms step_avg:46.46ms
+step:962/1600 train_time:44710ms step_avg:46.48ms
+step:963/1600 train_time:44772ms step_avg:46.49ms
+step:964/1600 train_time:44832ms step_avg:46.51ms
+step:965/1600 train_time:44895ms step_avg:46.52ms
+step:966/1600 train_time:44955ms step_avg:46.54ms
+step:967/1600 train_time:45019ms step_avg:46.56ms
+step:968/1600 train_time:45078ms step_avg:46.57ms
+step:969/1600 train_time:45140ms step_avg:46.58ms
+step:970/1600 train_time:45199ms step_avg:46.60ms
+step:971/1600 train_time:45261ms step_avg:46.61ms
+step:972/1600 train_time:45320ms step_avg:46.63ms
+step:973/1600 train_time:45383ms step_avg:46.64ms
+step:974/1600 train_time:45442ms step_avg:46.65ms
+step:975/1600 train_time:45504ms step_avg:46.67ms
+step:976/1600 train_time:45563ms step_avg:46.68ms
+step:977/1600 train_time:45627ms step_avg:46.70ms
+step:978/1600 train_time:45686ms step_avg:46.71ms
+step:979/1600 train_time:45749ms step_avg:46.73ms
+step:980/1600 train_time:45810ms step_avg:46.75ms
+step:981/1600 train_time:45875ms step_avg:46.76ms
+step:982/1600 train_time:45935ms step_avg:46.78ms
+step:983/1600 train_time:45995ms step_avg:46.79ms
+step:984/1600 train_time:46054ms step_avg:46.80ms
+step:985/1600 train_time:46117ms step_avg:46.82ms
+step:986/1600 train_time:46176ms step_avg:46.83ms
+step:987/1600 train_time:46239ms step_avg:46.85ms
+step:988/1600 train_time:46301ms step_avg:46.86ms
+step:989/1600 train_time:46361ms step_avg:46.88ms
+step:990/1600 train_time:46420ms step_avg:46.89ms
+step:991/1600 train_time:46481ms step_avg:46.90ms
+step:992/1600 train_time:46540ms step_avg:46.92ms
+step:993/1600 train_time:46603ms step_avg:46.93ms
+step:994/1600 train_time:46661ms step_avg:46.94ms
+step:995/1600 train_time:46723ms step_avg:46.96ms
+step:996/1600 train_time:46783ms step_avg:46.97ms
+step:997/1600 train_time:46845ms step_avg:46.99ms
+step:998/1600 train_time:46906ms step_avg:47.00ms
+step:999/1600 train_time:46968ms step_avg:47.02ms
+step:1000/1600 train_time:47028ms step_avg:47.03ms
+step:1000/1600 val_loss:3.5991 train_time:47075ms step_avg:47.08ms
+step:1001/1600 train_time:47094ms step_avg:47.05ms
+step:1002/1600 train_time:47152ms step_avg:47.06ms
+step:1003/1600 train_time:47217ms step_avg:47.08ms
+step:1004/1600 train_time:47281ms step_avg:47.09ms
+step:1005/1600 train_time:47342ms step_avg:47.11ms
+step:1006/1600 train_time:47401ms step_avg:47.12ms
+step:1007/1600 train_time:47462ms step_avg:47.13ms
+step:1008/1600 train_time:47521ms step_avg:47.14ms
+step:1009/1600 train_time:47584ms step_avg:47.16ms
+step:1010/1600 train_time:47642ms step_avg:47.17ms
+step:1011/1600 train_time:47704ms step_avg:47.18ms
+step:1012/1600 train_time:47762ms step_avg:47.20ms
+step:1013/1600 train_time:47823ms step_avg:47.21ms
+step:1014/1600 train_time:47882ms step_avg:47.22ms
+step:1015/1600 train_time:47944ms step_avg:47.24ms
+step:1016/1600 train_time:48003ms step_avg:47.25ms
+step:1017/1600 train_time:48066ms step_avg:47.26ms
+step:1018/1600 train_time:48127ms step_avg:47.28ms
+step:1019/1600 train_time:48191ms step_avg:47.29ms
+step:1020/1600 train_time:48251ms step_avg:47.30ms
+step:1021/1600 train_time:48314ms step_avg:47.32ms
+step:1022/1600 train_time:48372ms step_avg:47.33ms
+step:1023/1600 train_time:48435ms step_avg:47.35ms
+step:1024/1600 train_time:48494ms step_avg:47.36ms
+step:1025/1600 train_time:48557ms step_avg:47.37ms
+step:1026/1600 train_time:48615ms step_avg:47.38ms
+step:1027/1600 train_time:48677ms step_avg:47.40ms
+step:1028/1600 train_time:48737ms step_avg:47.41ms
+step:1029/1600 train_time:48799ms step_avg:47.42ms
+step:1030/1600 train_time:48858ms step_avg:47.44ms
+step:1031/1600 train_time:48921ms step_avg:47.45ms
+step:1032/1600 train_time:48980ms step_avg:47.46ms
+step:1033/1600 train_time:49044ms step_avg:47.48ms
+step:1034/1600 train_time:49103ms step_avg:47.49ms
+step:1035/1600 train_time:49167ms step_avg:47.50ms
+step:1036/1600 train_time:49226ms step_avg:47.52ms
+step:1037/1600 train_time:49288ms step_avg:47.53ms
+step:1038/1600 train_time:49347ms step_avg:47.54ms
+step:1039/1600 train_time:49409ms step_avg:47.55ms
+step:1040/1600 train_time:49468ms step_avg:47.57ms
+step:1041/1600 train_time:49539ms step_avg:47.59ms
+step:1042/1600 train_time:49622ms step_avg:47.62ms
+step:1043/1600 train_time:49712ms step_avg:47.66ms
+step:1044/1600 train_time:49796ms step_avg:47.70ms
+step:1045/1600 train_time:49885ms step_avg:47.74ms
+step:1046/1600 train_time:49970ms step_avg:47.77ms
+step:1047/1600 train_time:50061ms step_avg:47.81ms
+step:1048/1600 train_time:50146ms step_avg:47.85ms
+step:1049/1600 train_time:50233ms step_avg:47.89ms
+step:1050/1600 train_time:50318ms step_avg:47.92ms
+step:1051/1600 train_time:50408ms step_avg:47.96ms
+step:1052/1600 train_time:50494ms step_avg:48.00ms
+step:1053/1600 train_time:50582ms step_avg:48.04ms
+step:1054/1600 train_time:50667ms step_avg:48.07ms
+step:1055/1600 train_time:50755ms step_avg:48.11ms
+step:1056/1600 train_time:50840ms step_avg:48.14ms
+step:1057/1600 train_time:50929ms step_avg:48.18ms
+step:1058/1600 train_time:51014ms step_avg:48.22ms
+step:1059/1600 train_time:51102ms step_avg:48.25ms
+step:1060/1600 train_time:51188ms step_avg:48.29ms
+step:1061/1600 train_time:51277ms step_avg:48.33ms
+step:1062/1600 train_time:51362ms step_avg:48.36ms
+step:1063/1600 train_time:51450ms step_avg:48.40ms
+step:1064/1600 train_time:51534ms step_avg:48.43ms
+step:1065/1600 train_time:51623ms step_avg:48.47ms
+step:1066/1600 train_time:51709ms step_avg:48.51ms
+step:1067/1600 train_time:51798ms step_avg:48.55ms
+step:1068/1600 train_time:51884ms step_avg:48.58ms
+step:1069/1600 train_time:51972ms step_avg:48.62ms
+step:1070/1600 train_time:52057ms step_avg:48.65ms
+step:1071/1600 train_time:52146ms step_avg:48.69ms
+step:1072/1600 train_time:52231ms step_avg:48.72ms
+step:1073/1600 train_time:52320ms step_avg:48.76ms
+step:1074/1600 train_time:52405ms step_avg:48.79ms
+step:1075/1600 train_time:52494ms step_avg:48.83ms
+step:1076/1600 train_time:52578ms step_avg:48.86ms
+step:1077/1600 train_time:52668ms step_avg:48.90ms
+step:1078/1600 train_time:52752ms step_avg:48.94ms
+step:1079/1600 train_time:52840ms step_avg:48.97ms
+step:1080/1600 train_time:52926ms step_avg:49.01ms
+step:1081/1600 train_time:53014ms step_avg:49.04ms
+step:1082/1600 train_time:53099ms step_avg:49.08ms
+step:1083/1600 train_time:53188ms step_avg:49.11ms
+step:1084/1600 train_time:53274ms step_avg:49.15ms
+step:1085/1600 train_time:53362ms step_avg:49.18ms
+step:1086/1600 train_time:53448ms step_avg:49.22ms
+step:1087/1600 train_time:53536ms step_avg:49.25ms
+step:1088/1600 train_time:53621ms step_avg:49.28ms
+step:1089/1600 train_time:53710ms step_avg:49.32ms
+step:1090/1600 train_time:53795ms step_avg:49.35ms
+step:1091/1600 train_time:53883ms step_avg:49.39ms
+step:1092/1600 train_time:53969ms step_avg:49.42ms
+step:1093/1600 train_time:54058ms step_avg:49.46ms
+step:1094/1600 train_time:54144ms step_avg:49.49ms
+step:1095/1600 train_time:54232ms step_avg:49.53ms
+step:1096/1600 train_time:54317ms step_avg:49.56ms
+step:1097/1600 train_time:54405ms step_avg:49.59ms
+step:1098/1600 train_time:54490ms step_avg:49.63ms
+step:1099/1600 train_time:54579ms step_avg:49.66ms
+step:1100/1600 train_time:54665ms step_avg:49.70ms
+step:1101/1600 train_time:54753ms step_avg:49.73ms
+step:1102/1600 train_time:54838ms step_avg:49.76ms
+step:1103/1600 train_time:54926ms step_avg:49.80ms
+step:1104/1600 train_time:55011ms step_avg:49.83ms
+step:1105/1600 train_time:55099ms step_avg:49.86ms
+step:1106/1600 train_time:55187ms step_avg:49.90ms
+step:1107/1600 train_time:55274ms step_avg:49.93ms
+step:1108/1600 train_time:55358ms step_avg:49.96ms
+step:1109/1600 train_time:55447ms step_avg:50.00ms
+step:1110/1600 train_time:55532ms step_avg:50.03ms
+step:1111/1600 train_time:55620ms step_avg:50.06ms
+step:1112/1600 train_time:55706ms step_avg:50.10ms
+step:1113/1600 train_time:55794ms step_avg:50.13ms
+step:1114/1600 train_time:55878ms step_avg:50.16ms
+step:1115/1600 train_time:55967ms step_avg:50.19ms
+step:1116/1600 train_time:56052ms step_avg:50.23ms
+step:1117/1600 train_time:56140ms step_avg:50.26ms
+step:1118/1600 train_time:56227ms step_avg:50.29ms
+step:1119/1600 train_time:56315ms step_avg:50.33ms
+step:1120/1600 train_time:56400ms step_avg:50.36ms
+step:1121/1600 train_time:56489ms step_avg:50.39ms
+step:1122/1600 train_time:56573ms step_avg:50.42ms
+step:1123/1600 train_time:56662ms step_avg:50.46ms
+step:1124/1600 train_time:56747ms step_avg:50.49ms
+step:1125/1600 train_time:56836ms step_avg:50.52ms
+step:1126/1600 train_time:56921ms step_avg:50.55ms
+step:1127/1600 train_time:57009ms step_avg:50.59ms
+step:1128/1600 train_time:57095ms step_avg:50.62ms
+step:1129/1600 train_time:57184ms step_avg:50.65ms
+step:1130/1600 train_time:57272ms step_avg:50.68ms
+step:1131/1600 train_time:57357ms step_avg:50.71ms
+step:1132/1600 train_time:57452ms step_avg:50.75ms
+step:1133/1600 train_time:57537ms step_avg:50.78ms
+step:1134/1600 train_time:57622ms step_avg:50.81ms
+step:1135/1600 train_time:57710ms step_avg:50.85ms
+step:1136/1600 train_time:57794ms step_avg:50.88ms
+step:1137/1600 train_time:57883ms step_avg:50.91ms
+step:1138/1600 train_time:57967ms step_avg:50.94ms
+step:1139/1600 train_time:58051ms step_avg:50.97ms
+step:1140/1600 train_time:58136ms step_avg:51.00ms
+step:1141/1600 train_time:58225ms step_avg:51.03ms
+step:1142/1600 train_time:58312ms step_avg:51.06ms
+step:1143/1600 train_time:58399ms step_avg:51.09ms
+step:1144/1600 train_time:58484ms step_avg:51.12ms
+step:1145/1600 train_time:58572ms step_avg:51.15ms
+step:1146/1600 train_time:58657ms step_avg:51.18ms
+step:1147/1600 train_time:58745ms step_avg:51.22ms
+step:1148/1600 train_time:58831ms step_avg:51.25ms
+step:1149/1600 train_time:58919ms step_avg:51.28ms
+step:1150/1600 train_time:59004ms step_avg:51.31ms
+step:1151/1600 train_time:59092ms step_avg:51.34ms
+step:1152/1600 train_time:59177ms step_avg:51.37ms
+step:1153/1600 train_time:59266ms step_avg:51.40ms
+step:1154/1600 train_time:59355ms step_avg:51.43ms
+step:1155/1600 train_time:59441ms step_avg:51.46ms
+step:1156/1600 train_time:59527ms step_avg:51.49ms
+step:1157/1600 train_time:59615ms step_avg:51.53ms
+step:1158/1600 train_time:59700ms step_avg:51.55ms
+step:1159/1600 train_time:59788ms step_avg:51.59ms
+step:1160/1600 train_time:59874ms step_avg:51.62ms
+step:1161/1600 train_time:59961ms step_avg:51.65ms
+step:1162/1600 train_time:60047ms step_avg:51.68ms
+step:1163/1600 train_time:60135ms step_avg:51.71ms
+step:1164/1600 train_time:60220ms step_avg:51.74ms
+step:1165/1600 train_time:60312ms step_avg:51.77ms
+step:1166/1600 train_time:60395ms step_avg:51.80ms
+step:1167/1600 train_time:60482ms step_avg:51.83ms
+step:1168/1600 train_time:60569ms step_avg:51.86ms
+step:1169/1600 train_time:60657ms step_avg:51.89ms
+step:1170/1600 train_time:60742ms step_avg:51.92ms
+step:1171/1600 train_time:60831ms step_avg:51.95ms
+step:1172/1600 train_time:60915ms step_avg:51.98ms
+step:1173/1600 train_time:61004ms step_avg:52.01ms
+step:1174/1600 train_time:61089ms step_avg:52.03ms
+step:1175/1600 train_time:61178ms step_avg:52.07ms
+step:1176/1600 train_time:61264ms step_avg:52.09ms
+step:1177/1600 train_time:61352ms step_avg:52.13ms
+step:1178/1600 train_time:61437ms step_avg:52.15ms
+step:1179/1600 train_time:61525ms step_avg:52.18ms
+step:1180/1600 train_time:61610ms step_avg:52.21ms
+step:1181/1600 train_time:61699ms step_avg:52.24ms
+step:1182/1600 train_time:61785ms step_avg:52.27ms
+step:1183/1600 train_time:61874ms step_avg:52.30ms
+step:1184/1600 train_time:61958ms step_avg:52.33ms
+step:1185/1600 train_time:62047ms step_avg:52.36ms
+step:1186/1600 train_time:62131ms step_avg:52.39ms
+step:1187/1600 train_time:62220ms step_avg:52.42ms
+step:1188/1600 train_time:62305ms step_avg:52.45ms
+step:1189/1600 train_time:62394ms step_avg:52.48ms
+step:1190/1600 train_time:62478ms step_avg:52.50ms
+step:1191/1600 train_time:62567ms step_avg:52.53ms
+step:1192/1600 train_time:62651ms step_avg:52.56ms
+step:1193/1600 train_time:62740ms step_avg:52.59ms
+step:1194/1600 train_time:62825ms step_avg:52.62ms
+step:1195/1600 train_time:62913ms step_avg:52.65ms
+step:1196/1600 train_time:62998ms step_avg:52.67ms
+step:1197/1600 train_time:63087ms step_avg:52.70ms
+step:1198/1600 train_time:63174ms step_avg:52.73ms
+step:1199/1600 train_time:63262ms step_avg:52.76ms
+step:1200/1600 train_time:63347ms step_avg:52.79ms
+step:1201/1600 train_time:63435ms step_avg:52.82ms
+step:1202/1600 train_time:63520ms step_avg:52.85ms
+step:1203/1600 train_time:63609ms step_avg:52.87ms
+step:1204/1600 train_time:63693ms step_avg:52.90ms
+step:1205/1600 train_time:63781ms step_avg:52.93ms
+step:1206/1600 train_time:63866ms step_avg:52.96ms
+step:1207/1600 train_time:63956ms step_avg:52.99ms
+step:1208/1600 train_time:64042ms step_avg:53.01ms
+step:1209/1600 train_time:64131ms step_avg:53.04ms
+step:1210/1600 train_time:64216ms step_avg:53.07ms
+step:1211/1600 train_time:64304ms step_avg:53.10ms
+step:1212/1600 train_time:64389ms step_avg:53.13ms
+step:1213/1600 train_time:64478ms step_avg:53.16ms
+step:1214/1600 train_time:64564ms step_avg:53.18ms
+step:1215/1600 train_time:64652ms step_avg:53.21ms
+step:1216/1600 train_time:64737ms step_avg:53.24ms
+step:1217/1600 train_time:64825ms step_avg:53.27ms
+step:1218/1600 train_time:64911ms step_avg:53.29ms
+step:1219/1600 train_time:65000ms step_avg:53.32ms
+step:1220/1600 train_time:65086ms step_avg:53.35ms
+step:1221/1600 train_time:65175ms step_avg:53.38ms
+step:1222/1600 train_time:65260ms step_avg:53.40ms
+step:1223/1600 train_time:65349ms step_avg:53.43ms
+step:1224/1600 train_time:65437ms step_avg:53.46ms
+step:1225/1600 train_time:65526ms step_avg:53.49ms
+step:1226/1600 train_time:65609ms step_avg:53.51ms
+step:1227/1600 train_time:65697ms step_avg:53.54ms
+step:1228/1600 train_time:65782ms step_avg:53.57ms
+step:1229/1600 train_time:65870ms step_avg:53.60ms
+step:1230/1600 train_time:65954ms step_avg:53.62ms
+step:1231/1600 train_time:66043ms step_avg:53.65ms
+step:1232/1600 train_time:66127ms step_avg:53.67ms
+step:1233/1600 train_time:66216ms step_avg:53.70ms
+step:1234/1600 train_time:66300ms step_avg:53.73ms
+step:1235/1600 train_time:66389ms step_avg:53.76ms
+step:1236/1600 train_time:66475ms step_avg:53.78ms
+step:1237/1600 train_time:66562ms step_avg:53.81ms
+step:1238/1600 train_time:66648ms step_avg:53.83ms
+step:1239/1600 train_time:66736ms step_avg:53.86ms
+step:1240/1600 train_time:66821ms step_avg:53.89ms
+step:1241/1600 train_time:66909ms step_avg:53.92ms
+step:1242/1600 train_time:66994ms step_avg:53.94ms
+step:1243/1600 train_time:67082ms step_avg:53.97ms
+step:1244/1600 train_time:67166ms step_avg:53.99ms
+step:1245/1600 train_time:67255ms step_avg:54.02ms
+step:1246/1600 train_time:67340ms step_avg:54.04ms
+step:1247/1600 train_time:67429ms step_avg:54.07ms
+step:1248/1600 train_time:67514ms step_avg:54.10ms
+step:1249/1600 train_time:67603ms step_avg:54.13ms
+step:1250/1600 train_time:67687ms step_avg:54.15ms
+step:1250/1600 val_loss:3.4164 train_time:67761ms step_avg:54.21ms
+step:1251/1600 train_time:67781ms step_avg:54.18ms
+step:1252/1600 train_time:67868ms step_avg:54.21ms
+step:1253/1600 train_time:67960ms step_avg:54.24ms
+step:1254/1600 train_time:68046ms step_avg:54.26ms
+step:1255/1600 train_time:68133ms step_avg:54.29ms
+step:1256/1600 train_time:68218ms step_avg:54.31ms
+step:1257/1600 train_time:68304ms step_avg:54.34ms
+step:1258/1600 train_time:68388ms step_avg:54.36ms
+step:1259/1600 train_time:68475ms step_avg:54.39ms
+step:1260/1600 train_time:68560ms step_avg:54.41ms
+step:1261/1600 train_time:68648ms step_avg:54.44ms
+step:1262/1600 train_time:68733ms step_avg:54.46ms
+step:1263/1600 train_time:68825ms step_avg:54.49ms
+step:1264/1600 train_time:68913ms step_avg:54.52ms
+step:1265/1600 train_time:69002ms step_avg:54.55ms
+step:1266/1600 train_time:69088ms step_avg:54.57ms
+step:1267/1600 train_time:69176ms step_avg:54.60ms
+step:1268/1600 train_time:69260ms step_avg:54.62ms
+step:1269/1600 train_time:69348ms step_avg:54.65ms
+step:1270/1600 train_time:69432ms step_avg:54.67ms
+step:1271/1600 train_time:69520ms step_avg:54.70ms
+step:1272/1600 train_time:69606ms step_avg:54.72ms
+step:1273/1600 train_time:69697ms step_avg:54.75ms
+step:1274/1600 train_time:69782ms step_avg:54.77ms
+step:1275/1600 train_time:69871ms step_avg:54.80ms
+step:1276/1600 train_time:69956ms step_avg:54.82ms
+step:1277/1600 train_time:70046ms step_avg:54.85ms
+step:1278/1600 train_time:70131ms step_avg:54.88ms
+step:1279/1600 train_time:70219ms step_avg:54.90ms
+step:1280/1600 train_time:70304ms step_avg:54.92ms
+step:1281/1600 train_time:70392ms step_avg:54.95ms
+step:1282/1600 train_time:70477ms step_avg:54.97ms
+step:1283/1600 train_time:70565ms step_avg:55.00ms
+step:1284/1600 train_time:70650ms step_avg:55.02ms
+step:1285/1600 train_time:70738ms step_avg:55.05ms
+step:1286/1600 train_time:70824ms step_avg:55.07ms
+step:1287/1600 train_time:70913ms step_avg:55.10ms
+step:1288/1600 train_time:70999ms step_avg:55.12ms
+step:1289/1600 train_time:71088ms step_avg:55.15ms
+step:1290/1600 train_time:71173ms step_avg:55.17ms
+step:1291/1600 train_time:71261ms step_avg:55.20ms
+step:1292/1600 train_time:71346ms step_avg:55.22ms
+step:1293/1600 train_time:71434ms step_avg:55.25ms
+step:1294/1600 train_time:71518ms step_avg:55.27ms
+step:1295/1600 train_time:71607ms step_avg:55.29ms
+step:1296/1600 train_time:71691ms step_avg:55.32ms
+step:1297/1600 train_time:71780ms step_avg:55.34ms
+step:1298/1600 train_time:71866ms step_avg:55.37ms
+step:1299/1600 train_time:71956ms step_avg:55.39ms
+step:1300/1600 train_time:72041ms step_avg:55.42ms
+step:1301/1600 train_time:72130ms step_avg:55.44ms
+step:1302/1600 train_time:72215ms step_avg:55.46ms
+step:1303/1600 train_time:72303ms step_avg:55.49ms
+step:1304/1600 train_time:72388ms step_avg:55.51ms
+step:1305/1600 train_time:72475ms step_avg:55.54ms
+step:1306/1600 train_time:72560ms step_avg:55.56ms
+step:1307/1600 train_time:72648ms step_avg:55.58ms
+step:1308/1600 train_time:72733ms step_avg:55.61ms
+step:1309/1600 train_time:72821ms step_avg:55.63ms
+step:1310/1600 train_time:72907ms step_avg:55.65ms
+step:1311/1600 train_time:72995ms step_avg:55.68ms
+step:1312/1600 train_time:73082ms step_avg:55.70ms
+step:1313/1600 train_time:73170ms step_avg:55.73ms
+step:1314/1600 train_time:73255ms step_avg:55.75ms
+step:1315/1600 train_time:73343ms step_avg:55.77ms
+step:1316/1600 train_time:73427ms step_avg:55.80ms
+step:1317/1600 train_time:73515ms step_avg:55.82ms
+step:1318/1600 train_time:73600ms step_avg:55.84ms
+step:1319/1600 train_time:73687ms step_avg:55.87ms
+step:1320/1600 train_time:73772ms step_avg:55.89ms
+step:1321/1600 train_time:73861ms step_avg:55.91ms
+step:1322/1600 train_time:73946ms step_avg:55.94ms
+step:1323/1600 train_time:74035ms step_avg:55.96ms
+step:1324/1600 train_time:74121ms step_avg:55.98ms
+step:1325/1600 train_time:74209ms step_avg:56.01ms
+step:1326/1600 train_time:74294ms step_avg:56.03ms
+step:1327/1600 train_time:74383ms step_avg:56.05ms
+step:1328/1600 train_time:74467ms step_avg:56.07ms
+step:1329/1600 train_time:74555ms step_avg:56.10ms
+step:1330/1600 train_time:74640ms step_avg:56.12ms
+step:1331/1600 train_time:74729ms step_avg:56.14ms
+step:1332/1600 train_time:74814ms step_avg:56.17ms
+step:1333/1600 train_time:74902ms step_avg:56.19ms
+step:1334/1600 train_time:74987ms step_avg:56.21ms
+step:1335/1600 train_time:75076ms step_avg:56.24ms
+step:1336/1600 train_time:75162ms step_avg:56.26ms
+step:1337/1600 train_time:75250ms step_avg:56.28ms
+step:1338/1600 train_time:75335ms step_avg:56.30ms
+step:1339/1600 train_time:75424ms step_avg:56.33ms
+step:1340/1600 train_time:75508ms step_avg:56.35ms
+step:1341/1600 train_time:75596ms step_avg:56.37ms
+step:1342/1600 train_time:75682ms step_avg:56.39ms
+step:1343/1600 train_time:75771ms step_avg:56.42ms
+step:1344/1600 train_time:75855ms step_avg:56.44ms
+step:1345/1600 train_time:75944ms step_avg:56.46ms
+step:1346/1600 train_time:76029ms step_avg:56.49ms
+step:1347/1600 train_time:76117ms step_avg:56.51ms
+step:1348/1600 train_time:76203ms step_avg:56.53ms
+step:1349/1600 train_time:76292ms step_avg:56.55ms
+step:1350/1600 train_time:76377ms step_avg:56.58ms
+step:1351/1600 train_time:76465ms step_avg:56.60ms
+step:1352/1600 train_time:76549ms step_avg:56.62ms
+step:1353/1600 train_time:76637ms step_avg:56.64ms
+step:1354/1600 train_time:76724ms step_avg:56.66ms
+step:1355/1600 train_time:76812ms step_avg:56.69ms
+step:1356/1600 train_time:76897ms step_avg:56.71ms
+step:1357/1600 train_time:76987ms step_avg:56.73ms
+step:1358/1600 train_time:77071ms step_avg:56.75ms
+step:1359/1600 train_time:77160ms step_avg:56.78ms
+step:1360/1600 train_time:77245ms step_avg:56.80ms
+step:1361/1600 train_time:77334ms step_avg:56.82ms
+step:1362/1600 train_time:77419ms step_avg:56.84ms
+step:1363/1600 train_time:77507ms step_avg:56.87ms
+step:1364/1600 train_time:77591ms step_avg:56.89ms
+step:1365/1600 train_time:77680ms step_avg:56.91ms
+step:1366/1600 train_time:77770ms step_avg:56.93ms
+step:1367/1600 train_time:77856ms step_avg:56.95ms
+step:1368/1600 train_time:77942ms step_avg:56.98ms
+step:1369/1600 train_time:78031ms step_avg:57.00ms
+step:1370/1600 train_time:78116ms step_avg:57.02ms
+step:1371/1600 train_time:78205ms step_avg:57.04ms
+step:1372/1600 train_time:78290ms step_avg:57.06ms
+step:1373/1600 train_time:78378ms step_avg:57.09ms
+step:1374/1600 train_time:78463ms step_avg:57.11ms
+step:1375/1600 train_time:78551ms step_avg:57.13ms
+step:1376/1600 train_time:78636ms step_avg:57.15ms
+step:1377/1600 train_time:78725ms step_avg:57.17ms
+step:1378/1600 train_time:78810ms step_avg:57.19ms
+step:1379/1600 train_time:78898ms step_avg:57.21ms
+step:1380/1600 train_time:78984ms step_avg:57.23ms
+step:1381/1600 train_time:79072ms step_avg:57.26ms
+step:1382/1600 train_time:79157ms step_avg:57.28ms
+step:1383/1600 train_time:79247ms step_avg:57.30ms
+step:1384/1600 train_time:79333ms step_avg:57.32ms
+step:1385/1600 train_time:79421ms step_avg:57.34ms
+step:1386/1600 train_time:79505ms step_avg:57.36ms
+step:1387/1600 train_time:79593ms step_avg:57.38ms
+step:1388/1600 train_time:79680ms step_avg:57.41ms
+step:1389/1600 train_time:79768ms step_avg:57.43ms
+step:1390/1600 train_time:79853ms step_avg:57.45ms
+step:1391/1600 train_time:79942ms step_avg:57.47ms
+step:1392/1600 train_time:80029ms step_avg:57.49ms
+step:1393/1600 train_time:80117ms step_avg:57.51ms
+step:1394/1600 train_time:80202ms step_avg:57.53ms
+step:1395/1600 train_time:80290ms step_avg:57.56ms
+step:1396/1600 train_time:80375ms step_avg:57.58ms
+step:1397/1600 train_time:80463ms step_avg:57.60ms
+step:1398/1600 train_time:80548ms step_avg:57.62ms
+step:1399/1600 train_time:80636ms step_avg:57.64ms
+step:1400/1600 train_time:80724ms step_avg:57.66ms
+step:1401/1600 train_time:80811ms step_avg:57.68ms
+step:1402/1600 train_time:80896ms step_avg:57.70ms
+step:1403/1600 train_time:80985ms step_avg:57.72ms
+step:1404/1600 train_time:81071ms step_avg:57.74ms
+step:1405/1600 train_time:81159ms step_avg:57.76ms
+step:1406/1600 train_time:81244ms step_avg:57.78ms
+step:1407/1600 train_time:81332ms step_avg:57.81ms
+step:1408/1600 train_time:81418ms step_avg:57.83ms
+step:1409/1600 train_time:81507ms step_avg:57.85ms
+step:1410/1600 train_time:81593ms step_avg:57.87ms
+step:1411/1600 train_time:81681ms step_avg:57.89ms
+step:1412/1600 train_time:81766ms step_avg:57.91ms
+step:1413/1600 train_time:81854ms step_avg:57.93ms
+step:1414/1600 train_time:81940ms step_avg:57.95ms
+step:1415/1600 train_time:82029ms step_avg:57.97ms
+step:1416/1600 train_time:82113ms step_avg:57.99ms
+step:1417/1600 train_time:82201ms step_avg:58.01ms
+step:1418/1600 train_time:82287ms step_avg:58.03ms
+step:1419/1600 train_time:82374ms step_avg:58.05ms
+step:1420/1600 train_time:82460ms step_avg:58.07ms
+step:1421/1600 train_time:82549ms step_avg:58.09ms
+step:1422/1600 train_time:82633ms step_avg:58.11ms
+step:1423/1600 train_time:82722ms step_avg:58.13ms
+step:1424/1600 train_time:82808ms step_avg:58.15ms
+step:1425/1600 train_time:82896ms step_avg:58.17ms
+step:1426/1600 train_time:82981ms step_avg:58.19ms
+step:1427/1600 train_time:83070ms step_avg:58.21ms
+step:1428/1600 train_time:83155ms step_avg:58.23ms
+step:1429/1600 train_time:83244ms step_avg:58.25ms
+step:1430/1600 train_time:83329ms step_avg:58.27ms
+step:1431/1600 train_time:83417ms step_avg:58.29ms
+step:1432/1600 train_time:83502ms step_avg:58.31ms
+step:1433/1600 train_time:83590ms step_avg:58.33ms
+step:1434/1600 train_time:83675ms step_avg:58.35ms
+step:1435/1600 train_time:83764ms step_avg:58.37ms
+step:1436/1600 train_time:83849ms step_avg:58.39ms
+step:1437/1600 train_time:83938ms step_avg:58.41ms
+step:1438/1600 train_time:84023ms step_avg:58.43ms
+step:1439/1600 train_time:84114ms step_avg:58.45ms
+step:1440/1600 train_time:84199ms step_avg:58.47ms
+step:1441/1600 train_time:84287ms step_avg:58.49ms
+step:1442/1600 train_time:84372ms step_avg:58.51ms
+step:1443/1600 train_time:84460ms step_avg:58.53ms
+step:1444/1600 train_time:84545ms step_avg:58.55ms
+step:1445/1600 train_time:84635ms step_avg:58.57ms
+step:1446/1600 train_time:84721ms step_avg:58.59ms
+step:1447/1600 train_time:84808ms step_avg:58.61ms
+step:1448/1600 train_time:84892ms step_avg:58.63ms
+step:1449/1600 train_time:84980ms step_avg:58.65ms
+step:1450/1600 train_time:85068ms step_avg:58.67ms
+step:1451/1600 train_time:85154ms step_avg:58.69ms
+step:1452/1600 train_time:85239ms step_avg:58.70ms
+step:1453/1600 train_time:85328ms step_avg:58.73ms
+step:1454/1600 train_time:85413ms step_avg:58.74ms
+step:1455/1600 train_time:85501ms step_avg:58.76ms
+step:1456/1600 train_time:85586ms step_avg:58.78ms
+step:1457/1600 train_time:85674ms step_avg:58.80ms
+step:1458/1600 train_time:85760ms step_avg:58.82ms
+step:1459/1600 train_time:85848ms step_avg:58.84ms
+step:1460/1600 train_time:85933ms step_avg:58.86ms
+step:1461/1600 train_time:86022ms step_avg:58.88ms
+step:1462/1600 train_time:86108ms step_avg:58.90ms
+step:1463/1600 train_time:86196ms step_avg:58.92ms
+step:1464/1600 train_time:86282ms step_avg:58.94ms
+step:1465/1600 train_time:86371ms step_avg:58.96ms
+step:1466/1600 train_time:86456ms step_avg:58.97ms
+step:1467/1600 train_time:86544ms step_avg:58.99ms
+step:1468/1600 train_time:86629ms step_avg:59.01ms
+step:1469/1600 train_time:86717ms step_avg:59.03ms
+step:1470/1600 train_time:86802ms step_avg:59.05ms
+step:1471/1600 train_time:86891ms step_avg:59.07ms
+step:1472/1600 train_time:86976ms step_avg:59.09ms
+step:1473/1600 train_time:87065ms step_avg:59.11ms
+step:1474/1600 train_time:87150ms step_avg:59.12ms
+step:1475/1600 train_time:87238ms step_avg:59.14ms
+step:1476/1600 train_time:87323ms step_avg:59.16ms
+step:1477/1600 train_time:87412ms step_avg:59.18ms
+step:1478/1600 train_time:87497ms step_avg:59.20ms
+step:1479/1600 train_time:87585ms step_avg:59.22ms
+step:1480/1600 train_time:87671ms step_avg:59.24ms
+step:1481/1600 train_time:87760ms step_avg:59.26ms
+step:1482/1600 train_time:87845ms step_avg:59.27ms
+step:1483/1600 train_time:87935ms step_avg:59.30ms
+step:1484/1600 train_time:88020ms step_avg:59.31ms
+step:1485/1600 train_time:88108ms step_avg:59.33ms
+step:1486/1600 train_time:88193ms step_avg:59.35ms
+step:1487/1600 train_time:88282ms step_avg:59.37ms
+step:1488/1600 train_time:88367ms step_avg:59.39ms
+step:1489/1600 train_time:88455ms step_avg:59.41ms
+step:1490/1600 train_time:88540ms step_avg:59.42ms
+step:1491/1600 train_time:88628ms step_avg:59.44ms
+step:1492/1600 train_time:88714ms step_avg:59.46ms
+step:1493/1600 train_time:88804ms step_avg:59.48ms
+step:1494/1600 train_time:88888ms step_avg:59.50ms
+step:1495/1600 train_time:88976ms step_avg:59.52ms
+step:1496/1600 train_time:89062ms step_avg:59.53ms
+step:1497/1600 train_time:89150ms step_avg:59.55ms
+step:1498/1600 train_time:89235ms step_avg:59.57ms
+step:1499/1600 train_time:89324ms step_avg:59.59ms
+step:1500/1600 train_time:89409ms step_avg:59.61ms
+step:1500/1600 val_loss:3.3067 train_time:89482ms step_avg:59.65ms
+step:1501/1600 train_time:89503ms step_avg:59.63ms
+step:1502/1600 train_time:89585ms step_avg:59.64ms
+step:1503/1600 train_time:89678ms step_avg:59.67ms
+step:1504/1600 train_time:89763ms step_avg:59.68ms
+step:1505/1600 train_time:89850ms step_avg:59.70ms
+step:1506/1600 train_time:89934ms step_avg:59.72ms
+step:1507/1600 train_time:90022ms step_avg:59.74ms
+step:1508/1600 train_time:90108ms step_avg:59.75ms
+step:1509/1600 train_time:90195ms step_avg:59.77ms
+step:1510/1600 train_time:90280ms step_avg:59.79ms
+step:1511/1600 train_time:90368ms step_avg:59.81ms
+step:1512/1600 train_time:90455ms step_avg:59.82ms
+step:1513/1600 train_time:90547ms step_avg:59.85ms
+step:1514/1600 train_time:90633ms step_avg:59.86ms
+step:1515/1600 train_time:90723ms step_avg:59.88ms
+step:1516/1600 train_time:90809ms step_avg:59.90ms
+step:1517/1600 train_time:90897ms step_avg:59.92ms
+step:1518/1600 train_time:90981ms step_avg:59.93ms
+step:1519/1600 train_time:91068ms step_avg:59.95ms
+step:1520/1600 train_time:91152ms step_avg:59.97ms
+step:1521/1600 train_time:91240ms step_avg:59.99ms
+step:1522/1600 train_time:91324ms step_avg:60.00ms
+step:1523/1600 train_time:91412ms step_avg:60.02ms
+step:1524/1600 train_time:91499ms step_avg:60.04ms
+step:1525/1600 train_time:91588ms step_avg:60.06ms
+step:1526/1600 train_time:91674ms step_avg:60.07ms
+step:1527/1600 train_time:91763ms step_avg:60.09ms
+step:1528/1600 train_time:91848ms step_avg:60.11ms
+step:1529/1600 train_time:91936ms step_avg:60.13ms
+step:1530/1600 train_time:92020ms step_avg:60.14ms
+step:1531/1600 train_time:92107ms step_avg:60.16ms
+step:1532/1600 train_time:92192ms step_avg:60.18ms
+step:1533/1600 train_time:92280ms step_avg:60.20ms
+step:1534/1600 train_time:92364ms step_avg:60.21ms
+step:1535/1600 train_time:92453ms step_avg:60.23ms
+step:1536/1600 train_time:92539ms step_avg:60.25ms
+step:1537/1600 train_time:92628ms step_avg:60.27ms
+step:1538/1600 train_time:92714ms step_avg:60.28ms
+step:1539/1600 train_time:92803ms step_avg:60.30ms
+step:1540/1600 train_time:92889ms step_avg:60.32ms
+step:1541/1600 train_time:92976ms step_avg:60.33ms
+step:1542/1600 train_time:93060ms step_avg:60.35ms
+step:1543/1600 train_time:93148ms step_avg:60.37ms
+step:1544/1600 train_time:93232ms step_avg:60.38ms
+step:1545/1600 train_time:93320ms step_avg:60.40ms
+step:1546/1600 train_time:93405ms step_avg:60.42ms
+step:1547/1600 train_time:93493ms step_avg:60.44ms
+step:1548/1600 train_time:93579ms step_avg:60.45ms
+step:1549/1600 train_time:93669ms step_avg:60.47ms
+step:1550/1600 train_time:93754ms step_avg:60.49ms
+step:1551/1600 train_time:93844ms step_avg:60.51ms
+step:1552/1600 train_time:93929ms step_avg:60.52ms
+step:1553/1600 train_time:94017ms step_avg:60.54ms
+step:1554/1600 train_time:94102ms step_avg:60.55ms
+step:1555/1600 train_time:94191ms step_avg:60.57ms
+step:1556/1600 train_time:94275ms step_avg:60.59ms
+step:1557/1600 train_time:94366ms step_avg:60.61ms
+step:1558/1600 train_time:94453ms step_avg:60.62ms
+step:1559/1600 train_time:94539ms step_avg:60.64ms
+step:1560/1600 train_time:94625ms step_avg:60.66ms
+step:1561/1600 train_time:94721ms step_avg:60.68ms
+step:1562/1600 train_time:94805ms step_avg:60.69ms
+step:1563/1600 train_time:94893ms step_avg:60.71ms
+step:1564/1600 train_time:94978ms step_avg:60.73ms
+step:1565/1600 train_time:95066ms step_avg:60.75ms
+step:1566/1600 train_time:95152ms step_avg:60.76ms
+step:1567/1600 train_time:95240ms step_avg:60.78ms
+step:1568/1600 train_time:95325ms step_avg:60.79ms
+step:1569/1600 train_time:95415ms step_avg:60.81ms
+step:1570/1600 train_time:95501ms step_avg:60.83ms
+step:1571/1600 train_time:95590ms step_avg:60.85ms
+step:1572/1600 train_time:95675ms step_avg:60.86ms
+step:1573/1600 train_time:95765ms step_avg:60.88ms
+step:1574/1600 train_time:95851ms step_avg:60.90ms
+step:1575/1600 train_time:95939ms step_avg:60.91ms
+step:1576/1600 train_time:96026ms step_avg:60.93ms
+step:1577/1600 train_time:96117ms step_avg:60.95ms
+step:1578/1600 train_time:96201ms step_avg:60.96ms
+step:1579/1600 train_time:96289ms step_avg:60.98ms
+step:1580/1600 train_time:96374ms step_avg:61.00ms
+step:1581/1600 train_time:96462ms step_avg:61.01ms
+step:1582/1600 train_time:96548ms step_avg:61.03ms
+step:1583/1600 train_time:96638ms step_avg:61.05ms
+step:1584/1600 train_time:96723ms step_avg:61.06ms
+step:1585/1600 train_time:96812ms step_avg:61.08ms
+step:1586/1600 train_time:96898ms step_avg:61.10ms
+step:1587/1600 train_time:96986ms step_avg:61.11ms
+step:1588/1600 train_time:97072ms step_avg:61.13ms
+step:1589/1600 train_time:97160ms step_avg:61.15ms
+step:1590/1600 train_time:97246ms step_avg:61.16ms
+step:1591/1600 train_time:97335ms step_avg:61.18ms
+step:1592/1600 train_time:97420ms step_avg:61.19ms
+step:1593/1600 train_time:97509ms step_avg:61.21ms
+step:1594/1600 train_time:97595ms step_avg:61.23ms
+step:1595/1600 train_time:97684ms step_avg:61.24ms
+step:1596/1600 train_time:97770ms step_avg:61.26ms
+step:1597/1600 train_time:97860ms step_avg:61.28ms
+step:1598/1600 train_time:97945ms step_avg:61.29ms
+step:1599/1600 train_time:98034ms step_avg:61.31ms
+step:1600/1600 train_time:98120ms step_avg:61.32ms
+step:1600/1600 val_loss:3.2772 train_time:98193ms step_avg:61.37ms
+peak memory allocated: 30264 MiB reserved: 46240 MiB

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torch
 huggingface-hub
 kernels
 setuptools
+typing-extensions==4.15.0


### PR DESCRIPTION
Updates in PR, building off latest #201 
- Untie value embeddings to replace pattern of `VE[.12...012]` with `VE[.01...345]`.

Also suggest we close #198 by pinning `typing-extensions==4.15.0` for housekeeping.

## Ideas

The latest idea is inspired by the principle of Bigram/Engram Hash embeddings to allow more uncontextualised information into the architecture. I believe there's further room in adding sparsity to be explored, i.e. Meta's STEM and optimizing the bwd to not communicate unaccessed indices in sparse embeddings.

I tried these ablations:
- Same weights but more tied layers: `ve[012...012]` (1) 
- Fewer VE tied layers: `ve[01…01]`
- Different layers: `ve[.01…01.]`
- Apply VE to all layers
Surprisingly, the old finding in #194 that adding VE to the first layer no longer held up -- there was no loss delta at all compared to before. I hypothesize that improvements in between (Partial Key Offset, Bigram Hash) removed the need for this somehow, but I'm not quite sure why.

Unrelated to this VE idea, I tried to optimize the bwd with `torch.Embedding(..., sparse=True)`, but I'm running into 2 issues: 1) the metadata overhead of keeping count of the accessed indices complicates the Adam step, especially when distributed, and 2) Full CUDA graphs aren't preserved under sparse embeddings in [2.10](https://github.com/pytorch/pytorch/issues/150656).

## Timing

The timings (-25 steps) hold up to the latest PR, and are significant (p<0.001).
- H0: Control is latest WR at 1600 steps.
- H1: Untie VE at 1575 steps.

```
                   Runs   Time μ  Time σ  Time +/-  Time p  Loss μ  Loss σ  Loss +/-      p
H0                   10  98.1066  0.0904    0.0000     NaN  3.2778  0.0010    0.0000 0.0000
H1                   10  97.7141  0.0533   -0.3925  0.0000  3.2784  0.0009    0.0006 0.0002

H0:
  losses = [3.2776, 3.2785, 3.277, 3.2772, 3.2788, 3.2764, 3.2763, 3.2784, 3.2788, 3.2791]
  times  = [98.081, 98.053, 97.895, 98.193, 98.136, 98.093, 98.11, 98.124, 98.156, 98.225]
  (n = 10)

H1:
  losses = [3.2784, 3.2778, 3.2792, 3.2799, 3.2776, 3.2782, 3.2771, 3.2786, 3.2775, 3.2794]
  times  = [97.715, 97.704, 97.725, 97.666, 97.725, 97.632, 97.755, 97.831, 97.697, 97.691]
  (n = 10)
```

The 3 extra embedding weights in H1 added to the average step time, compared to H0. I suggest we time this improvement `time delta = 98.1-97.7 = 0.4s`.